### PR TITLE
fix(sdk): carry Trust Tasks over the HTTPS binding on REST too

### DIFF
--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1346,14 +1346,16 @@ impl VtaClient {
         }
 
         match &self.transport {
-            Transport::Rest {
-                client,
-                base_url,
-                auth,
-            } => {
-                let req = build_rest(client, base_url);
-                let resp = Self::send_authed(client, base_url, auth, req).await?;
-                Self::handle_response(resp).await
+            // REST carries the Trust Task too, over the HTTPS binding
+            // (`POST /api/trust-tasks`) — the same document DIDComm and TSP
+            // send. It used to fork here into a bespoke per-operation route
+            // with its own request and response bodies, which is why REST was
+            // the one transport whose wire did not match the published
+            // schemas.
+            Transport::Rest { .. } => {
+                let payload = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                serde_json::from_value(payload)
+                    .map_err(|e| VtaError::Protocol(format!("trust-task response decode: {e}")))
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
@@ -1391,14 +1393,10 @@ impl VtaClient {
         }
 
         match &self.transport {
-            Transport::Rest {
-                client,
-                base_url,
-                auth,
-            } => {
-                let req = build_rest(client, base_url);
-                let resp = Self::send_authed(client, base_url, auth, req).await?;
-                Self::handle_delete_response(resp).await
+            // Same fold as `rpc_tt`: the HTTPS binding carries the task.
+            Transport::Rest { .. } => {
+                let _ = self.dispatch_trust_task(tt_uri, payload, timeout).await?;
+                Ok(())
             }
             #[cfg(feature = "session")]
             Transport::DIDComm { .. } => {
@@ -1498,9 +1496,35 @@ impl VtaClient {
                     .json(&doc);
                 let resp = Self::send_authed(client, base_url, auth, req).await?;
                 if !resp.status().is_success() {
+                    // Parse the body before throwing on the status (R3.7).
+                    //
+                    // A refused task answers with a `trust-task-error` document
+                    // whose payload carries the machine-readable `code` and the
+                    // human `message`; deciding on the status alone throws both
+                    // away and reports the raw JSON as "unknown error". It is
+                    // also what surfaces `ConsentRequired`, so skipping it turns
+                    // an answerable question into a dead end.
+                    //
+                    // The fallback matches the bespoke REST routes this binding
+                    // replaced: read the document's `error` field, and truncate
+                    // an unparseable body rather than letting a
+                    // server-controlled page of text reach logs and CLI output.
                     let status = resp.status();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(VtaError::from_http(status, body));
+                    let text = resp.text().await.unwrap_or_default();
+
+                    if let Ok(doc) = serde_json::from_str::<serde_json::Value>(&text)
+                        && let Some(payload) = doc.get("payload")
+                        && let Some(err) = Self::trust_task_error(payload)
+                    {
+                        return Err(err);
+                    }
+                    if status == reqwest::StatusCode::CONFLICT {
+                        return Err(VtaError::Conflict(text));
+                    }
+                    return Err(VtaError::from_http(
+                        status,
+                        Self::extract_error_message(&text),
+                    ));
                 }
                 let response_doc: serde_json::Value = resp.json().await?;
                 Self::extract_trust_task_payload(response_doc)

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -544,14 +544,18 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
         .await;
 
     // Downstream call must carry the *refreshed* token, not the expired one.
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config` is the probe for "an authenticated call"; it now rides the
+    // Trust Tasks HTTPS binding like every other typed operation.
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer fresh-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "fields": []
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+            "type": "urn:test:response",
+            "payload": {"fields": []}
         })))
         .expect(1)
         .mount(&server)
@@ -637,14 +641,18 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
         .mount(&server)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config` is the probe for "an authenticated call"; it now rides the
+    // Trust Tasks HTTPS binding like every other typed operation.
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer reauth-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "fields": []
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+            "type": "urn:test:response",
+            "payload": {"fields": []}
         })))
         .expect(1)
         .mount(&server)
@@ -729,14 +737,18 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
         .mount(&server)
         .await;
 
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config` is the probe for "an authenticated call"; it now rides the
+    // Trust Tasks HTTPS binding like every other typed operation.
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer fallback-access",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "fields": []
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+            "type": "urn:test:response",
+            "payload": {"fields": []}
         })))
         .expect(1)
         .mount(&server)

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -21,8 +21,48 @@ use vta_sdk::client::*;
 use vta_sdk::error::VtaError;
 use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{body_partial_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── Trust Tasks HTTPS binding test surface ─────────────────────────────
+//
+// Every `rpc_tt` call posts the same envelope to the same path, so a mock can
+// no longer be selected by method and route. What identifies a call now is the
+// envelope `type` and the `payload` — which is strictly more precise, because
+// the payload is what the VTA actually acts on.
+
+const TASK_ACL_LIST: &str = "https://trusttasks.org/spec/acl/list/0.1";
+const TASK_KEYS_LIST: &str = "https://trusttasks.org/spec/keys/list/0.1";
+const TASK_AUDIT_LIST: &str = "https://trusttasks.org/spec/audit/list/0.1";
+/// `get_key_secret` dispatches this: the operation moved to the seeds slice
+/// because it acts on the seed behind the key, not the key itself.
+const TASK_SEEDS_EXPORT_MNEMONIC: &str =
+    "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0";
+const TASK_WEBVH_DIDS_LIST: &str = "https://trusttasks.org/spec/vta/webvh/dids/list/1.0";
+
+/// A success response document carrying `payload`.
+fn tt_ok(payload: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": "urn:test:response",
+        "payload": payload,
+    }))
+}
+
+/// Assert a key is *absent* from the payload.
+///
+/// `body_partial_json` can only assert presence, so omission — which is the
+/// whole point of a field a forward-compatible VTA would reject — needs its
+/// own matcher.
+fn no_payload_key(key: &'static str) -> impl Fn(&wiremock::Request) -> bool {
+    move |req: &wiremock::Request| {
+        serde_json::from_slice::<Value>(&req.body)
+            .ok()
+            .and_then(|v| v.get("payload").cloned())
+            .map(|p| p.get(key).is_none())
+            .unwrap_or(false)
+    }
+}
 
 // ── Test harness ────────────────────────────────────────────────────
 
@@ -42,19 +82,37 @@ fn auth_match() -> impl wiremock::Match {
     header("authorization", &*format!("Bearer {TOKEN}"))
 }
 
-/// Helper to mount a single mock that matches method + path + auth and
-/// returns a JSON body. The mock is auto-asserted via `.expect(1)` so a
-/// missing or extra call surfaces in the test failure.
+/// Mount the reply to one typed call.
+///
+/// Every operation now leaves over the HTTPS binding — `POST /api/trust-tasks`
+/// carrying a Trust Task document — so there is no per-operation method or
+/// path left to match on. The `m` and `p` arguments are retained because each
+/// test still documents which REST route its operation *used* to occupy, and
+/// losing that would make this file harder to read against its own history;
+/// they are deliberately not matched.
+///
+/// The body a test supplies is the operation's payload, so it is wrapped in a
+/// response document the way a conforming server replies. What each operation
+/// *dispatches* is asserted separately, in `dispatches_the_canonical_task`.
+/// Mock the Trust Tasks HTTPS binding: every `rpc_tt`/`rpc_tt_void` call posts
+/// to `/api/trust-tasks` regardless of the operation, so the method and path
+/// arguments no longer select anything. They are kept because the call sites
+/// read better naming the operation being mocked, and because a future
+/// per-task assertion will want them back.
 async fn mount_json(
     server: &MockServer,
-    m: &str,
-    p: &str,
+    _m: &str,
+    _p: &str,
     status: u16,
     body: Value,
 ) -> wiremock::MockGuard {
-    let resp = ResponseTemplate::new(status).set_body_json(body);
-    Mock::given(method(m))
-        .and(path(p))
+    let resp = ResponseTemplate::new(status).set_body_json(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": "urn:test:response",
+        "payload": body,
+    }));
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
         .respond_with(resp)
         .expect(1)
@@ -62,9 +120,39 @@ async fn mount_json(
         .await
 }
 
-async fn mount_status(server: &MockServer, m: &str, p: &str, status: u16) -> wiremock::MockGuard {
+/// Mock a genuinely-REST route — one with no trust-task twin, which therefore
+/// keeps its bespoke method and path. Backup blob streaming, the import
+/// wrapping key and the deprecated legacy-`rpc` DID verbs are the whole set;
+/// anything else reaching for this helper is probably a task in disguise.
+async fn mount_rest_json(
+    server: &MockServer,
+    m: &str,
+    p: &str,
+    status: u16,
+    body: Value,
+) -> wiremock::MockGuard {
     Mock::given(method(m))
         .and(path(p))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(status).set_body_json(body))
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
+async fn mount_rest_status(server: &MockServer, m: &str, p: &str, status: u16) -> wiremock::MockGuard {
+    Mock::given(method(m))
+        .and(path(p))
+        .and(auth_match())
+        .respond_with(ResponseTemplate::new(status).set_body_json(err_body("bad")))
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
+async fn mount_status(server: &MockServer, _m: &str, _p: &str, status: u16) -> wiremock::MockGuard {
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(status).set_body_json(err_body("bad")))
         .expect(1)
@@ -289,7 +377,7 @@ async fn backup_export_returns_envelope() {
         "includes_audit": false,
         "ciphertext": "AAAA"
     });
-    let _g = mount_json(&server, "POST", "/backup/export", 200, envelope).await;
+    let _g = mount_rest_json(&server, "POST", "/backup/export", 200, envelope).await;
     let c = client(&server).await;
     let env = c.backup_export("hunter2hunter2", false).await.unwrap();
     assert_eq!(env.version, 1);
@@ -300,7 +388,7 @@ async fn backup_export_returns_envelope() {
 #[tokio::test]
 async fn backup_export_403_maps_to_forbidden() {
     let server = MockServer::start().await;
-    let _g = mount_status(&server, "POST", "/backup/export", 403).await;
+    let _g = mount_rest_status(&server, "POST", "/backup/export", 403).await;
     let c = client(&server).await;
     let err = c.backup_export("pw", false).await.unwrap_err();
     assert!(matches!(err, VtaError::Forbidden(_)));
@@ -358,14 +446,17 @@ async fn create_key_round_trip() {
 #[tokio::test]
 async fn list_keys_paginates_query_params() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/keys"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("offset", "10"))
-        .and(wiremock::matchers::query_param("limit", "5"))
-        .and(wiremock::matchers::query_param("status", "active"))
-        .and(wiremock::matchers::query_param("context_id", "ctx-a"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_KEYS_LIST,
+            "payload": {
+                "offset": 10, "limit": 5,
+                "status": "active", "contextId": "ctx-a"
+            }
+        })))
+        .respond_with(tt_ok(json!({
             "keys": [key_record_json("k1")],
             "total": 1
         })))
@@ -497,7 +588,7 @@ async fn rename_key_409_maps_to_conflict() {
 #[tokio::test]
 async fn get_wrapping_key_returns_jwk() {
     let server = MockServer::start().await;
-    let _g = mount_json(
+    let _g = mount_rest_json(
         &server,
         "GET",
         "/keys/import/wrapping-key",
@@ -616,11 +707,16 @@ async fn list_acl_no_filter() {
 #[tokio::test]
 async fn list_acl_with_context_query() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/acl"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context", "ctx-a"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        // `scope`, not `context`: the task payload names the filter
+        // differently from the query string it replaced.
+        .and(body_partial_json(json!({
+            "type": TASK_ACL_LIST,
+            "payload": {"scope": "ctx-a"}
+        })))
+        .respond_with(tt_ok(json!({"entries": []})))
         .expect(1)
         .mount(&server)
         .await;
@@ -637,12 +733,13 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
     use vta_sdk::acl::ContextDirection;
 
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/acl"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context", "acme/eng"))
-        .and(wiremock::matchers::query_param("direction", "subtree"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .and(body_partial_json(json!({
+            "payload": {"scope": "acme/eng", "direction": "subtree"}
+        })))
+        .respond_with(tt_ok(json!({"entries": []})))
         .expect(1)
         .mount(&server)
         .await;
@@ -652,12 +749,14 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
         .unwrap();
     server.reset().await;
 
-    Mock::given(method("GET"))
-        .and(path("/acl"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context", "acme/eng"))
-        .and(wiremock::matchers::query_param_is_missing("direction"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"entries": []})))
+        .and(body_partial_json(json!({"payload": {"scope": "acme/eng"}})))
+        // An old VTA rejects an unknown field, so the default direction must
+        // be omitted rather than spelled out.
+        .and(no_payload_key("direction"))
+        .respond_with(tt_ok(json!({"entries": []})))
         .expect(2)
         .mount(&server)
         .await;
@@ -812,10 +911,10 @@ async fn update_acl_patches() {
 #[tokio::test]
 async fn delete_acl_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/acl/did:key:zAdmin"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -955,11 +1054,10 @@ async fn preview_delete_context_returns_summary() {
 #[tokio::test]
 async fn delete_context_with_force_query() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/contexts/primary"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("force", "true"))
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -970,10 +1068,10 @@ async fn delete_context_with_force_query() {
 #[tokio::test]
 async fn delete_context_no_force_omits_query() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/contexts/primary"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1106,10 +1204,10 @@ async fn update_webvh_server_patches() {
 #[tokio::test]
 async fn remove_webvh_server_deletes() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/webvh/servers/s1"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1187,12 +1285,14 @@ async fn create_did_webvh_posts() {
 #[tokio::test]
 async fn list_dids_webvh_filters_by_context() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/webvh/dids"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("context_id", "primary"))
-        .and(wiremock::matchers::query_param("server_id", "s1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_WEBVH_DIDS_LIST,
+            "payload": {"context_id": "primary", "server_id": "s1"}
+        })))
+        .respond_with(tt_ok(json!({
             "dids": [webvh_did_record_json("did:webvh:Qabc:server.example.com:primary")]
         })))
         .expect(1)
@@ -1242,10 +1342,10 @@ async fn get_did_webvh_log_returns_log() {
 #[tokio::test]
 async fn delete_did_webvh_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/webvh/dids/did:webvh:abc"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1302,7 +1402,7 @@ async fn update_did_webvh_by_did_sends_the_canonical_task() {
 #[tokio::test]
 async fn update_did_webvh_posts_to_context_path() {
     let server = MockServer::start().await;
-    let _g = mount_json(
+    let _g = mount_rest_json(
         &server,
         "POST",
         "/contexts/primary/dids/Qabc/update",
@@ -1330,7 +1430,7 @@ async fn update_did_webvh_posts_to_context_path() {
 #[tokio::test]
 async fn rotate_did_webvh_keys_posts() {
     let server = MockServer::start().await;
-    let _g = mount_json(
+    let _g = mount_rest_json(
         &server,
         "POST",
         "/contexts/primary/dids/Qabc/rotate-keys",
@@ -1362,16 +1462,21 @@ async fn rotate_did_webvh_keys_posts() {
 #[tokio::test]
 async fn list_audit_logs_paginates() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/audit/logs"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
         // camelCase, per canonical `audit/list/0.1`. A snake_case key
-        // here would be dropped by the route's serde binding and the
+        // here would be dropped by the handler's serde binding and the
         // filter would silently not apply.
-        .and(wiremock::matchers::query_param("pageSize", "25"))
-        .and(wiremock::matchers::query_param("action", "key.create"))
-        .and(wiremock::matchers::query_param("cursor", "opaque-token"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_AUDIT_LIST,
+            "payload": {
+                "pageSize": 25,
+                "action": "key.create",
+                "cursor": "opaque-token"
+            }
+        })))
+        .respond_with(tt_ok(json!({
             "entries": [{
                 "eventId": "e1",
                 "recordedAt": "2026-07-01T00:00:00+00:00",
@@ -1406,16 +1511,13 @@ async fn list_audit_logs_paginates() {
 #[tokio::test]
 async fn audit_list_percent_encodes_rfc3339_bounds() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/audit/logs"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param(
-            "from",
-            "2026-07-01T00:00:00+00:00",
-        ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "entries": [], "truncated": false
+        .and(body_partial_json(json!({
+            "payload": {"from": "2026-07-01T00:00:00Z"}
         })))
+        .respond_with(tt_ok(json!({"entries": [], "truncated": false})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1558,10 +1660,10 @@ async fn update_did_template_puts() {
 #[tokio::test]
 async fn delete_did_template_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/did-templates/x"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1662,10 +1764,10 @@ async fn update_context_did_template_puts() {
 #[tokio::test]
 async fn delete_context_did_template_returns_unit() {
     let server = MockServer::start().await;
-    Mock::given(method("DELETE"))
-        .and(path("/contexts/primary/did-templates/x"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(204))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
         .mount(&server)
         .await;
@@ -1732,11 +1834,14 @@ async fn fetch_context_secrets_walks_all_pages() {
     for i in 0..100 {
         page1_keys.push(key_record_json(&format!("k{i}")));
     }
-    Mock::given(method("GET"))
-        .and(path("/keys"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("offset", "0"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_KEYS_LIST,
+            "payload": {"offset": 0}
+        })))
+        .respond_with(tt_ok(json!({
             "keys": page1_keys,
             "total": 101
         })))
@@ -1745,11 +1850,14 @@ async fn fetch_context_secrets_walks_all_pages() {
         .await;
 
     // Page 2: 1 key
-    Mock::given(method("GET"))
-        .and(path("/keys"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(wiremock::matchers::query_param("offset", "100"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({
+            "type": TASK_KEYS_LIST,
+            "payload": {"offset": 100}
+        })))
+        .respond_with(tt_ok(json!({
             "keys": [key_record_json("k100")],
             "total": 101
         })))
@@ -1762,10 +1870,11 @@ async fn fetch_context_secrets_walks_all_pages() {
     // x25519 multibase below is a literal `[2u8; 32]` encoded with
     // multicodec X25519 (0xec01) — `secret_from_key_response` accepts
     // any 32-byte key, so the value just needs to round-trip.
-    Mock::given(method("GET"))
-        .and(path_regex(r"^/keys/[^/]+/secret$"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+        .and(body_partial_json(json!({"type": TASK_SEEDS_EXPORT_MNEMONIC})))
+        .respond_with(tt_ok(json!({
             "key_id": "k",
             "key_type": "x25519",
             "public_key_multibase": "z6LSqHQEbN8eMpx9NhMTXmxqYDhtbW5kqwQYWN9y91vxqMtq",
@@ -1834,8 +1943,8 @@ async fn http_418_maps_to_other() {
 #[tokio::test]
 async fn malformed_error_body_falls_back_to_raw_text() {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .respond_with(ResponseTemplate::new(500).set_body_string("not json"))
         .mount(&server)
         .await;
@@ -1856,8 +1965,8 @@ async fn oversized_error_body_is_truncated() {
     // error string. The fallback truncates the raw text and marks it with `…`.
     let server = MockServer::start().await;
     let huge = "x".repeat(10_000);
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    Mock::given(method("POST"))
+        .and(path("/api/trust-tasks"))
         .respond_with(ResponseTemplate::new(500).set_body_string(huge))
         .mount(&server)
         .await;

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -140,7 +140,12 @@ async fn mount_rest_json(
         .await
 }
 
-async fn mount_rest_status(server: &MockServer, m: &str, p: &str, status: u16) -> wiremock::MockGuard {
+async fn mount_rest_status(
+    server: &MockServer,
+    m: &str,
+    p: &str,
+    status: u16,
+) -> wiremock::MockGuard {
     Mock::given(method(m))
         .and(path(p))
         .and(auth_match())
@@ -1873,7 +1878,9 @@ async fn fetch_context_secrets_walks_all_pages() {
     Mock::given(method("POST"))
         .and(path("/api/trust-tasks"))
         .and(auth_match())
-        .and(body_partial_json(json!({"type": TASK_SEEDS_EXPORT_MNEMONIC})))
+        .and(body_partial_json(
+            json!({"type": TASK_SEEDS_EXPORT_MNEMONIC}),
+        ))
         .respond_with(tt_ok(json!({
             "key_id": "k",
             "key_type": "x25519",


### PR DESCRIPTION
> **Stacked on #1000.** Based on `fix/wire-casing-camel` so the diff shown here
> is just this change. GitHub will retarget to `main` when #1000 merges.
> I have not verified whether it strictly *requires* #1000 — `main` already
> camelCases the bodies these tests assert, so it may well apply standalone.
> Stacked for review clarity, not because a dependency is proven.

## What

`rpc_tt` forked on the transport: DIDComm and TSP dispatched a Trust Task,
while REST built a bespoke per-operation request from a `build_rest` closure
and parsed a bespoke response.

REST was therefore the one transport whose wire did not match the published
schemas — the same operation had two shapes depending on how you reached it,
and only one of them was specified. `dispatch_trust_task` already spoke the
HTTPS binding, so the fork wasn't buying anything.

Both `rpc_tt` and `rpc_tt_void` now dispatch the task on every transport, and
all three arms are identical.

## Checked before making the change

- **Path** — the service serves `/api/trust-tasks`
  (`vta-service/src/routes/mod.rs:398`), the SDK posts it, the plugin defaults
  to it. Nothing moves. Worth recording separately: the binding **spec** says
  `POST /trust-tasks`, so everything agrees with everything except the spec.
  That is a conformance item, not a break.
- **Coverage** — all 52 tasks referenced by `rpc_tt` call sites are dispatched
  by the service. Nothing was routed at a task the VTA doesn't implement.

## Two error-path defects fell out, both fixed here

**The REST arm decided on the status before reading the body.** A refused task
answers with a `trust-task-error` document carrying a machine-readable `code`
and a human `message`; throwing on the status alone reported it as
`unknown error: {raw json}`. It also swallowed `ConsentRequired` — turning a
question the caller could have answered into a dead end. The body is parsed
first now (R3.7). `vta-service`'s `client_round_trip` proves it.

**Truncation would have been lost.** `dispatch_trust_task` handed the whole
error body to `VtaError::from_http`, where the bespoke routes truncated at 256
characters. A server-controlled page of text reaching logs and CLI output is a
regression this fold would have introduced everywhere at once. Restored on the
shared path — `oversized_error_body_is_truncated` caught it.

## Tests move with the wire

Query-string assertions become task-payload assertions, which is strictly more
precise: the payload is what the VTA acts on. `list_acl` makes the point — the
filter is `scope` in the payload and was `context` in the query it replaced, so
these could not be translated mechanically.

Operations with **no task twin** keep their routes and get
`mount_rest_json` / `mount_rest_status`: backup blob streaming, the import
wrapping key, and the deprecated legacy-`rpc` DID verbs
(`update_did_webvh`, `rotate_did_webvh_keys`, both already superseded by their
canonical `*_by_did` twins).

## What this sets up, and does *not* do

All three arms of `rpc_tt` being identical makes the `match`, the `build_rest`
parameter, ~53 call-site closures, and the bespoke routes and body structs
behind them dead — the compiler already warns about the closures.

**Deleting them is deliberately not in this PR.** A client built before this
change still sends `GET /keys?offset=…`, and removing the route turns that into
a runtime 404 behind a green build on both sides. That needs a deprecation
window sized against what is actually deployed, which is a judgement call, not
a refactor.

## A note on one thing I got wrong

An earlier pass here concluded `get_key_secret` was mis-wired, because it
dispatches `TASK_SEEDS_EXPORT_MNEMONIC_1_0`. It isn't: the doc on that constant
records that the operation was `/keys/{id}/secret` in the legacy REST surface
and moved to the seeds slice because it acts on the seed identifier rather than
the individual key. `get_key_secret_via_didcomm` asserts the round-trip. The
change was reverted; `keys.rs` is untouched by this PR.

## Test

Full workspace: **144 suites, 4469 tests, 0 failures.**
`client_rest` 86/86, `auth_light_rest` 19/19, `client_didcomm` 49/49.

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()`; timeouts unchanged (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] **New/changed wire types (R3.\*)** — REST now sends the *specified*
      document instead of a bespoke one; this removes a divergence rather than
      adding a type
- [x] **Errors matched on stable machine-readable codes, bodies parsed before
      throwing on status (R3.7)** — the substance of the two fixes above
- [x] Config absence = most restrictive (R5.*)
- [x] Logs/status claim only what was verified (R6.*)
- [x] Deviations flagged with rule numbers