### PR TITLE
ci: bound every job, and stop superseded PR runs racing the new one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,24 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -109,7 +126,24 @@ jobs:
           df -h /
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -140,7 +174,24 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -192,7 +243,24 @@ jobs:
           df -h /
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - name: Read MSRV from Cargo.toml
         id: msrv
@@ -295,7 +363,24 @@ jobs:
           fetch-depth: 0
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-semver-checks
@@ -362,7 +447,24 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -482,7 +584,24 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # The observed failure here is a *hang*, not a clean error: apt sits
+          # on an unresponsive mirror and never returns. Three separate runs
+          # stalled on this step, one of them for a full hour before anyone
+          # looked. A bare retry loop is no use against that — it would wait
+          # forever on the first attempt — so each attempt is bounded with
+          # `timeout`, which turns the hang into a failure the loop can act on.
+          # Acquire::Retries handles the ordinary transient case underneath.
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after 3 bounded attempts"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# One live run per ref. Pushing a fixup to an open PR used to leave the
+# superseded run executing and racing the new one for the same runner pool;
+# a superseded PR run tells you nothing worth waiting for.
+#
+# Cancellation is scoped to pull requests on purpose. A push to main or
+# nightly gates releases and is the record of what that commit did, so those
+# runs are left to finish even when another lands on top.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -42,6 +53,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -75,6 +87,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -122,6 +135,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -147,6 +161,7 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -163,6 +178,7 @@ jobs:
     # newer compiler can silently break consumers on the documented MSRV.
     name: MSRV
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -212,6 +228,7 @@ jobs:
     # with justified ignores; this job just runs it.
     name: cargo-deny
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
@@ -228,6 +245,7 @@ jobs:
     name: commit lint
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Conventional-commit PR title
         env:
@@ -269,6 +287,7 @@ jobs:
     name: semver checks
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -326,6 +345,7 @@ jobs:
     # misattribution happened twice (#706, #711).
     name: lockfile self-pins
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Lockfile self-pin guard
@@ -337,6 +357,7 @@ jobs:
     # builds are covered by the `check` job above.
     name: Feature combos
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 
@@ -456,6 +477,7 @@ jobs:
     # depends on `tokio-vsock` which doesn't build on macOS/Windows.
     name: Enclave build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -491,6 +513,7 @@ jobs:
     # Xcode; the macOS image also ships the Android NDK.
     name: Mobile build
     runs-on: macos-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,22 +59,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - uses: dtolnay/rust-toolchain@stable
@@ -127,22 +145,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - uses: dtolnay/rust-toolchain@stable
@@ -175,22 +211,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - uses: dtolnay/rust-toolchain@stable
@@ -244,22 +298,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - name: Read MSRV from Cargo.toml
@@ -364,22 +436,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - uses: dtolnay/rust-toolchain@stable
@@ -448,22 +538,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - uses: dtolnay/rust-toolchain@stable
@@ -585,22 +693,40 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          # The observed failure here is a *hang*, not a clean error: apt sits
-          # on an unresponsive mirror and never returns. Three separate runs
-          # stalled on this step, one of them for a full hour before anyone
-          # looked. A bare retry loop is no use against that — it would wait
-          # forever on the first attempt — so each attempt is bounded with
-          # `timeout`, which turns the hang into a failure the loop can act on.
-          # Acquire::Retries handles the ordinary transient case underneath.
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
           for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y libdbus-1-dev pkg-config; then
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
               exit 0
             fi
             echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
             sleep 10
           done
-          echo "::error::apt-get failed after 3 bounded attempts"
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Two gaps that surfaced together on #1000, where CI sat for an hour and reported
nothing.

## No job had a timeout

All five long jobs were stuck on the **same step** for sixty minutes:

```
in_progress  Install system dependencies     ← 60 min
pending      Run dtolnay/rust-toolchain@stable
pending      Run actions/cache@v5
pending      Run cargo test --workspace
```

That step is `sudo apt-get update && sudo apt-get install -y libdbus-1-dev
pkg-config`. They never reached the Rust toolchain, let alone the tests — an
apt hang on GitHub's runners.

With no `timeout-minutes`, that hangs indefinitely, and an indefinite hang is
indistinguishable from a slow build until someone reads the step list by hand.
I only found it because I went looking; the PR just looked slow.

Ceilings are ~2× each job's observed p100, taken from real runs rather than
guessed:

| Job | Observed | Ceiling |
|---|---|---|
| Mobile build | 22m | 45 |
| Feature combos | 20m | 45 |
| semver checks | 17–22m | 45 |
| Test | 13m | 30 |
| Clippy | 4m | 20 |
| MSRV / Enclave build / Check | 3m | 20 |
| Format, cargo-deny, lockfile self-pins, commit lint | <1m | 10 |

The headroom is deliberate. These exist to bound a **hang**, not to enforce a
performance budget — a job that fails because a runner had a slow day is worse
than no limit at all.

## No `concurrency` group

Pushing a fixup to an open PR left the superseded run executing and racing the
new one for the same runner pool. #1000 had two full runs live simultaneously,
and the older one was still churning through jobs the newer one had already
finished.

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**Cancellation is scoped to pull requests on purpose.** A push to `main` or
`nightly` gates releases and is the record of what that commit did, so those
runs are left to finish even when another lands on top. Only PR runs — where a
superseded result tells you nothing worth waiting for — get cancelled. This is
slightly more conservative than the unconditional `cancel-in-progress: true`
the browser-plugin repo uses.

## Scope

`ci.yml` only.

- `docker.yml` and `join-didcomm-soak.yml` already carry timeouts.
- **`publish.yml` and `release-mobile-ios.yml` have neither, and are
  deliberately untouched.** `cancel-in-progress` on a workflow that publishes
  crates could kill a publish part-way through — a worse failure than the one
  being fixed here. They want their own change, made by someone looking at the
  release path properly.

## Test

YAML parses; 12 jobs, all now carrying `timeout-minutes`, verified
programmatically rather than by eye:

```
YAML parses; 12 jobs
concurrency: {'group': 'ci-${{ github.ref }}',
              'cancel-in-progress': "${{ github.event_name == 'pull_request' }}"}
no timeout: []
```

The concurrency behaviour proves itself on this PR: pushing again should cancel
the previous run rather than leave it racing.