### PR TITLE
fix(tee): bootstrap 410 and vsock enotconn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,16 @@ jobs:
           cargo test -p vta-service --bin vta --features config-seed setup::interactive
           cargo test -p vta-service --bin vta --features config-seed,vault-secrets,k8s-secrets setup::interactive
 
+      # The TEE Mode B carve-out. `tee` is not a default feature of
+      # `vta-service`, so `cargo test --workspace` never builds
+      # `routes::bootstrap::tests` — and the `cargo check` step above builds
+      # the lib only, so it does not even TYPE-CHECK them. That module holds
+      # the two properties CLAUDE.md calls load-bearing: exactly one admin is
+      # ever minted, and a consumed carve-out refuses with 410 rather than a
+      # code that invites a retry. Both were unrunnable in CI. Run them.
+      - name: vta-service TEE Mode B carve-out
+        run: cargo test -p vta-service --no-default-features --features tee,rest,didcomm --lib routes::bootstrap
+
       # The fleet (`BAKE_CONFIG=false`) tenant-overlay path. `tenant-overlay` is
       # not a default feature of `vta-tee` and nothing in the default workspace
       # graph turns it on, so `cargo test --workspace` never even COMPILES

--- a/vta-backup/src/ops/blob.rs
+++ b/vta-backup/src/ops/blob.rs
@@ -32,9 +32,9 @@ use vti_common::store::KeyspaceHandle;
 /// - bundle_id not found → `NotFound`
 /// - token doesn't match the stored hash → `Forbidden`
 /// - bundle is an import bundle, or already-downloaded / aborted /
-///   expired → `NotFound` / `Conflict` (see [`enforce_export_ready`])
-/// - bundle expired by clock → `Conflict` (410-style, via [`gone`])
-/// - blob bytes missing on disk → `Conflict` (already swept)
+///   expired → `NotFound` / `Conflict` / `Gone` (see [`enforce_export_ready`])
+/// - bundle expired by clock → `Gone` (410, via [`gone`])
+/// - blob bytes missing on disk → `Gone` (already swept)
 pub async fn read_export_blob(
     bundles_ks: &KeyspaceHandle,
     bundle_id: Uuid,
@@ -240,13 +240,13 @@ fn enforce_import_pending(record: &BundleRecord) -> Result<(), AppError> {
 }
 
 fn gone(message: String) -> AppError {
-    // `AppError` doesn't have a `Gone` variant. The blob endpoints
-    // want 410 specifically so the operator CLI can distinguish
-    // "this slot was valid but is now consumed/expired" from
-    // "this slot never existed" (404). Map via `Conflict` for now —
-    // a follow-on can add a typed variant if the CLI surface
-    // requires it.
-    AppError::Conflict(message)
+    // 410, not 409: the blob endpoints need the operator CLI to be able to
+    // distinguish "this slot was valid but is now consumed/expired" from
+    // "this slot never existed" (404). Both route annotations have declared
+    // `410` since they were written; until `AppError::Gone` existed this
+    // helper had to approximate it with `Conflict`, which rendered 409 and
+    // quietly contradicted the documented contract.
+    AppError::Gone(message)
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {

--- a/vta-cli-common/src/render.rs
+++ b/vta-cli-common/src/render.rs
@@ -200,14 +200,34 @@ pub fn print_cli_error(err: &(dyn std::error::Error + 'static)) {
                 );
             }
             VtaError::Gone(msg) => {
-                let bin = bin_name();
-                eprintln!("{RED}\u{2717}{RESET} Resource is gone: {msg}");
-                eprintln!(
-                    "  {DIM}This usually means the bootstrap carve-out has already been used. \
-                     For a second admin, run `{bin} bootstrap provision-request` from the new \
-                     operator's host and have an existing admin run \
-                     `{bin} bootstrap provision-integration` against this VTA.{RESET}"
-                );
+                // Same treatment as the `Conflict` arm below: the SDK keeps
+                // the full 410 body, so surface the human field rather than
+                // dumping raw JSON at the operator.
+                let human = extract_human_message(msg);
+                eprintln!("{RED}\u{2717}{RESET} Resource is gone: {human}");
+                // 410 has more than one producer — the TEE bootstrap carve-out
+                // and the one-shot backup blob slots — so the carve-out
+                // walkthrough only prints when the refusal is actually about
+                // the carve-out. Unconditionally, it would send a backup
+                // operator down the admin-provisioning path for a bundle that
+                // simply expired. The marker is the server's own wording in
+                // `routes::bootstrap::carve_out_closed_error`; a miss costs
+                // the generic hint, never a wrong one.
+                if human.contains(CARVE_OUT_MARKER) {
+                    let bin = bin_name();
+                    eprintln!(
+                        "  {DIM}This usually means the bootstrap carve-out has already been \
+                         used. For a second admin, run `{bin} bootstrap provision-request` from \
+                         the new operator's host and have an existing admin run \
+                         `{bin} bootstrap provision-integration` against this VTA.{RESET}"
+                    );
+                } else {
+                    eprintln!(
+                        "  {DIM}This resource was single-use or time-limited, and has been \
+                         consumed or has expired. Retrying will not help — restart the \
+                         operation to get a fresh one.{RESET}"
+                    );
+                }
             }
             VtaError::Validation(msg) => {
                 eprintln!("{RED}\u{2717}{RESET} Invalid request: {msg}");
@@ -320,6 +340,12 @@ pub fn print_cli_error(err: &(dyn std::error::Error + 'static)) {
 /// output we don't want to dump JSON at the operator, so prefer the body's
 /// `message` field, then its `error` field, and only fall back to the raw
 /// text when the body isn't the expected JSON shape.
+/// Substring that marks a 410 as the TEE first-boot bootstrap carve-out
+/// rather than one of the other single-use resources that now render as
+/// `Gone` (the backup blob slots). Mirrors the server's wording in
+/// `vta_service::routes::bootstrap::carve_out_closed_error`.
+const CARVE_OUT_MARKER: &str = "carve-out";
+
 fn extract_human_message(body: &str) -> String {
     serde_json::from_str::<serde_json::Value>(body)
         .ok()

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -370,9 +370,9 @@ impl VtaError {
                  the ACL entry for your DID against the target context.",
             ),
             Self::Gone(_) => Some(
-                "The resource has been permanently consumed. The single-use bootstrap \
-                 carve-out has likely already been used; ask an existing admin to \
-                 provision-integration a new operator instead.",
+                "The resource was single-use or time-limited and has been consumed or has \
+                 expired — retrying will not succeed. If this was the bootstrap carve-out, \
+                 ask an existing admin to provision-integration a new operator instead.",
             ),
             Self::Conflict(_) => Some(
                 "The resource already exists. Use the corresponding `update` or \

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -52,7 +52,13 @@ fn handler_err(e: impl std::fmt::Display) -> DIDCommServiceError {
 /// body is `pub(crate)` in the transport crate and not inspectable here).
 fn app_err_to_problem_report(e: &AppError) -> ProblemReport {
     match e {
-        AppError::Conflict(msg) => ProblemReport::conflict(msg.clone()),
+        // No `gone` code exists in the affinidi taxonomy, and no DIDComm
+        // surface produces `Gone` today (its producers — the TEE bootstrap
+        // carve-out and the one-shot backup blob slots — are REST-only). Ride
+        // with `conflict` rather than the `internal-error` fallback, which
+        // would tell the caller a permanently-consumed resource was a server
+        // bug worth retrying.
+        AppError::Conflict(msg) | AppError::Gone(msg) => ProblemReport::conflict(msg.clone()),
         AppError::NotFound(msg) => ProblemReport::not_found(msg.clone()),
         AppError::Authentication(msg) | AppError::Unauthorized(msg) => {
             ProblemReport::unauthorized(msg.clone())
@@ -2123,6 +2129,9 @@ mod tests {
     fn app_error_maps_to_byte_identical_codes() {
         let cases = [
             (AppError::Conflict("c".into()), codes::CONFLICT, "c"),
+            // The taxonomy has no `gone`; what matters is that it does not
+            // land in the `internal-error` fallback and read as a server bug.
+            (AppError::Gone("g".into()), codes::CONFLICT, "g"),
             (AppError::NotFound("n".into()), codes::NOT_FOUND, "n"),
             (
                 AppError::Authentication("a".into()),

--- a/vta-service/src/routes/backup_blob.rs
+++ b/vta-service/src/routes/backup_blob.rs
@@ -113,7 +113,7 @@ pub async fn get_blob(
         (status = 401, description = "Missing or malformed x-backup-token header"),
         (status = 403, description = "Token does not match"),
         (status = 404, description = "Bundle not found"),
-        (status = 410, description = "Bundle expired or already received"),
+        (status = 410, description = "Bundle expired or aborted"),
     ),
 )]
 pub async fn post_blob(
@@ -315,8 +315,11 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        // gone() maps to AppError::Conflict → 409
-        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        // A consumed single-use slot is 410, not 409 — the status this
+        // route's `utoipa` annotation has always declared. `gone()` renders
+        // `AppError::Gone`; 409 stays for "wrong bundle kind / wrong state",
+        // which a differently-shaped request could still satisfy.
+        assert_eq!(resp.status(), StatusCode::GONE);
     }
 
     #[tokio::test]

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -107,7 +107,8 @@ pub struct BootstrapResponseBody {
     responses(
         (status = 200, description = "Armored sealed admin bundle + digest", body = BootstrapResponseBody),
         (status = 400, description = "Unsupported version or malformed client_did/nonce"),
-        (status = 403, description = "Carve-out already used or TEE first-boot unavailable"),
+        (status = 403, description = "TEE first-boot unavailable on this VTA build"),
+        (status = 410, description = "Carve-out already used — this VTA already has an admin"),
     ),
 )]
 pub async fn request(
@@ -186,12 +187,14 @@ pub async fn request(
 #[cfg(feature = "tee")]
 static MODE_B_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// Mode B: TEE first-boot sealed bootstrap. No token; the attestation quote
+/// Mint Mode B: TEE first-boot sealed bootstrap. No token; the attestation quote
 /// is the sole authorization anchor.
 ///
 /// On success, closes the first-boot carve-out permanently by writing the
 /// `BOOTSTRAP_CARVEOUT_CLOSED_KEY` sentinel. Any subsequent request is
-/// rejected.
+/// rejected with [`carve_out_closed_error`] (410 Gone) — the carve-out is
+/// consumed, not merely disallowed for this caller, which is what
+/// distinguishes it from a 403.
 #[cfg(feature = "tee")]
 async fn mint_mode_b(
     state: &AppState,
@@ -228,9 +231,7 @@ async fn mint_mode_b(
             .await?
             .is_some()
     {
-        return Err(AppError::Forbidden(
-            "TEE first-boot carve-out has already been used".into(),
-        ));
+        return Err(carve_out_closed_error());
     }
 
     let cfg = state.config.read().await;
@@ -335,9 +336,7 @@ async fn mint_mode_b(
         // bypassed). Roll back the ACL we just wrote so it does not
         // linger as an admin entry for an undeliverable DID, and refuse.
         let _ = delete_acl_entry(&state.acl_ks, &did).await;
-        return Err(AppError::Forbidden(
-            "TEE first-boot carve-out has already been used".into(),
-        ));
+        return Err(carve_out_closed_error());
     }
 
     // Durability barrier: do not return the bundle until the carve-out
@@ -352,6 +351,20 @@ async fn mint_mode_b(
 
     info!("TEE first-boot carve-out consumed — closed for good");
     Ok(bundle)
+}
+
+/// The consumed-carve-out refusal, shared by both places `mint_mode_b` can
+/// discover the sentinel is already set (the up-front check, and the
+/// defensive `insert_raw_if_absent` loss on the commit path).
+///
+/// Rendered as **410 Gone**, not 403: the carve-out is not a permission this
+/// caller lacks (a 403 would suggest a *different* caller or a *later*
+/// retry might succeed) — it is a single-use resource that has been
+/// permanently, irreversibly consumed for this VTA. `vta_sdk::error::VtaError`
+/// keys its `Gone` variant (and CLI hint) off this exact status.
+#[cfg(feature = "tee")]
+fn carve_out_closed_error() -> AppError {
+    AppError::Gone("TEE first-boot carve-out has already been used".into())
 }
 
 /// Decode the consumer's `did:key` (Ed25519) to its raw 32-byte pubkey.
@@ -530,6 +543,61 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "sentinel must be set after the run"
+        );
+    }
+
+    /// The API-contract regression this module exists to close: a consumed
+    /// Mode B carve-out must render **410 Gone**, not 403. A 403 tells the
+    /// caller "you specifically are not authorized" — which is wrong here,
+    /// since *no* caller, with *any* credentials, can ever succeed again.
+    /// Drives the real `mint_mode_b` end-to-end (simulated TEE provider,
+    /// real keyspaces) twice: the first mints an admin and closes the
+    /// carve-out; the second — from an entirely different client key and
+    /// nonce, so this isn't a replay-detection false positive — must be
+    /// refused as `AppError::Gone`, rendering HTTP 410.
+    #[tokio::test]
+    async fn consumed_carveout_returns_410_gone_not_403() {
+        use crate::config::{TeeConfig, TeeMode};
+        use crate::server::TeeContext;
+
+        let (_app, ctx) = crate::test_support::build_test_app().await;
+
+        let tee_state = crate::tee::init_tee(&TeeConfig {
+            mode: TeeMode::Simulated,
+            ..Default::default()
+        })
+        .expect("init simulated tee")
+        .expect("simulated tee state present");
+
+        let mut state = ctx.state.clone();
+        state.tee = Some(TeeContext {
+            state: tee_state,
+            mnemonic_guard: None,
+        });
+
+        let now = now_epoch();
+
+        // First request succeeds and closes the carve-out.
+        let (_seed_a, pub_a) = generate_ed25519_keypair();
+        mint_mode_b(&state, &pub_a, [1u8; 16], now)
+            .await
+            .expect("first bootstrap mints an admin");
+
+        // Second request — different client key, different nonce — must be
+        // refused. The carve-out is consumed, not merely "not for you".
+        let (_seed_b, pub_b) = generate_ed25519_keypair();
+        let err = mint_mode_b(&state, &pub_b, [2u8; 16], now)
+            .await
+            .expect_err("second bootstrap must be refused");
+
+        assert!(
+            matches!(err, AppError::Gone(_)),
+            "consumed carve-out must map to AppError::Gone, got {err:?}"
+        );
+        assert_eq!(
+            err.into_response().status(),
+            axum::http::StatusCode::GONE,
+            "consumed carve-out must render as HTTP 410, not 403/409"
         );
     }
 }

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -187,7 +187,7 @@ pub async fn request(
 #[cfg(feature = "tee")]
 static MODE_B_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// Mint Mode B: TEE first-boot sealed bootstrap. No token; the attestation quote
+/// Mode B: TEE first-boot sealed bootstrap. No token; the attestation quote
 /// is the sole authorization anchor.
 ///
 /// On success, closes the first-boot carve-out permanently by writing the

--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -86,7 +86,7 @@ pub(super) fn parse_payload<T: serde::de::DeserializeOwned>(
 ///
 /// - `Authentication` / `Unauthorized` / `Forbidden` → `permission_denied`
 /// - `Validation` / `TrustTaskMalformed` / `InvalidCursor` → `malformed_request`
-/// - `NotFound` / `Conflict` → `task_failed`
+/// - `NotFound` / `Conflict` / `Gone` → `task_failed`
 /// - everything else → `internal_error`
 pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> TrustTaskOutcome {
     let message = err.to_string();
@@ -101,10 +101,18 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Trus
         AppError::Validation(_) | AppError::TrustTaskMalformed(_) | AppError::InvalidCursor => {
             RejectReason::MalformedRequest { reason: message }
         }
-        AppError::NotFound(_) | AppError::Conflict(_) => RejectReason::TaskFailed {
-            reason: message,
-            details: None,
-        },
+        // `Gone` rides with these rather than the `internal_error`
+        // fallback. No task produces it today (its producers are REST-only),
+        // but the fallback is the wrong default for it: a consumed single-use
+        // resource is a terminal *caller-visible* outcome, and reporting it as
+        // an internal error tells the client to retry something that can never
+        // succeed again.
+        AppError::NotFound(_) | AppError::Conflict(_) | AppError::Gone(_) => {
+            RejectReason::TaskFailed {
+                reason: message,
+                details: None,
+            }
+        }
         // Hand the framework the *cause*, not the rendered error. Both
         // `AppError::Internal` and `RejectReason::InternalError` render as
         // "internal error: {…}", so passing the outer `Display` in put the
@@ -330,5 +338,25 @@ mod tests {
             AppError::NotFound("SCID QmNope not found".into()),
         ));
         assert!(message.contains("SCID QmNope not found"), "{message}");
+    }
+
+    /// `Gone` must not fall through to the `internal_error` catch-all. A
+    /// consumed single-use resource is a terminal outcome the *caller* has to
+    /// act on; `internal_error` reads as "server bug, try again", which is the
+    /// one instruction that can never work here.
+    #[test]
+    fn a_gone_is_a_task_failure_not_an_internal_error() {
+        let message = message_of(app_error_to_reject(
+            &doc(),
+            AppError::Gone("carve-out has already been used".into()),
+        ));
+        assert!(
+            message.contains("carve-out has already been used"),
+            "{message}"
+        );
+        assert!(
+            !message.starts_with("internal error"),
+            "a consumed resource must not report as a server fault: {message}"
+        );
     }
 }

--- a/vta-tee/src/tenant_overlay.rs
+++ b/vta-tee/src/tenant_overlay.rs
@@ -51,6 +51,10 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// hangs in `fetch_and_apply_overlay` instead of producing the fail-closed error
 /// the caller is written to act on.
 const READ_TIMEOUT: Duration = Duration::from_secs(10);
+/// `tokio-vsock` can report a stream connected just before Nitro finishes the
+/// nonblocking handshake, making the first read return `ENOTCONN`. Retry only
+/// that transient state; the outer [`READ_TIMEOUT`] remains the hard deadline.
+const NOT_CONNECTED_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 /// Failure fetching or applying the tenant-config overlay. Every variant is
 /// fail-closed: on real Nitro the caller aborts the boot rather than continue
@@ -190,14 +194,21 @@ async fn read_envelope(stream: &mut VsockStream) -> Result<Vec<u8>, OverlayFetch
 
 /// The unbounded-in-time inner read. Only ever called under the
 /// [`read_envelope`] deadline.
-async fn read_envelope_to_eof(stream: &mut VsockStream) -> Result<Vec<u8>, OverlayFetchError> {
+async fn read_envelope_to_eof<R>(stream: &mut R) -> Result<Vec<u8>, OverlayFetchError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
     let mut buf = Vec::new();
     let mut chunk = [0u8; 8192];
     loop {
-        let n = stream
-            .read(&mut chunk)
-            .await
-            .map_err(|e| OverlayFetchError::Read(e.to_string()))?;
+        let n = match stream.read(&mut chunk).await {
+            Ok(n) => n,
+            Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
+                tokio::time::sleep(NOT_CONNECTED_RETRY_DELAY).await;
+                continue;
+            }
+            Err(e) => return Err(OverlayFetchError::Read(e.to_string())),
+        };
         if n == 0 {
             break; // EOF — parent finished and shut the connection.
         }
@@ -233,8 +244,68 @@ pub async fn fetch_and_apply_overlay(config: &mut AppConfig) -> Result<(), Overl
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use tokio::io::{AsyncRead, ReadBuf};
 
     const GOOD_ARN: &str = "arn:aws:kms:us-east-1:111122223333:key/abcd-ef01";
+
+    struct FirstReadError {
+        kind: std::io::ErrorKind,
+        payload: &'static [u8],
+        state: u8,
+    }
+
+    impl AsyncRead for FirstReadError {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            match self.state {
+                0 => {
+                    self.state = 1;
+                    Poll::Ready(Err(std::io::Error::from(self.kind)))
+                }
+                1 => {
+                    self.state = 2;
+                    buf.put_slice(self.payload);
+                    Poll::Ready(Ok(()))
+                }
+                _ => Poll::Ready(Ok(())),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_transient_not_connected_read() {
+        let mut reader = FirstReadError {
+            kind: std::io::ErrorKind::NotConnected,
+            payload: b"config envelope",
+            state: 0,
+        };
+
+        assert_eq!(
+            read_envelope_to_eof(&mut reader).await.unwrap(),
+            b"config envelope"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_non_transient_read_error() {
+        let mut reader = FirstReadError {
+            kind: std::io::ErrorKind::PermissionDenied,
+            payload: b"must not be read",
+            state: 0,
+        };
+
+        assert!(matches!(
+            read_envelope_to_eof(&mut reader).await,
+            Err(OverlayFetchError::Read(_))
+        ));
+        assert_eq!(reader.state, 1);
+    }
 
     #[test]
     fn parses_a_well_formed_v1_envelope() {

--- a/vta-tee/src/tenant_overlay.rs
+++ b/vta-tee/src/tenant_overlay.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use tokio::io::AsyncReadExt;
 use tokio_vsock::{VsockAddr, VsockStream};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use vta_config::AppConfig;
 use vta_config::tenant_overlay::{TenantConfigOverlay, TenantOverlayError, apply_tenant_overlay};
@@ -145,6 +145,13 @@ fn parse_envelope(bytes: &[u8]) -> Result<TenantConfigOverlay, OverlayFetchError
     Ok(envelope.overlay)
 }
 
+/// Whether `bytes` contains exactly one complete JSON value. This answers only
+/// the transport-framing question; [`parse_envelope`] performs the strict
+/// version and allowlist checks after the read completes.
+fn is_complete_json(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde::de::IgnoredAny>(bytes).is_ok()
+}
+
 /// Connect to the parent config server, retrying with bounded backoff so a
 /// cold-boot ordering race (enclave up before the parent binds vsock:5800)
 /// isn't an outage. Gives up after ~30 attempts.
@@ -197,12 +204,12 @@ async fn read_envelope(stream: &mut VsockStream) -> Result<Vec<u8>, OverlayFetch
 /// The unbounded-in-time inner read. Only ever called under the
 /// [`read_envelope`] deadline.
 ///
-/// `ENOTCONN` is retried **only while the buffer is still empty** — that is
-/// the handshake race [`NOT_CONNECTED_RETRY_DELAY`] describes, and it can only
-/// occur before the parent has sent anything. Once a byte has arrived the
-/// connection demonstrably completed, so a later `ENOTCONN` is a real
-/// mid-stream teardown: retrying it would burn the rest of [`READ_TIMEOUT`]
-/// and then report a timeout instead of the errno that actually happened.
+/// `ENOTCONN` while the buffer is empty is the handshake race
+/// [`NOT_CONNECTED_RETRY_DELAY`] describes. Linux AF_VSOCK may also report
+/// `ENOTCONN` instead of EOF after the peer has sent its complete payload and
+/// shut down. In that second case the bytes are accepted as framed only if they
+/// contain one complete JSON value. A partial or malformed buffer still fails
+/// closed immediately; the normal strict envelope parse follows the read.
 async fn read_envelope_to_eof<R>(stream: &mut R) -> Result<Vec<u8>, OverlayFetchError>
 where
     R: tokio::io::AsyncRead + Unpin,
@@ -227,6 +234,13 @@ where
                 }
                 tokio::time::sleep(NOT_CONNECTED_RETRY_DELAY).await;
                 continue;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotConnected && is_complete_json(&buf) => {
+                debug!(
+                    "config server closed vsock with ENOTCONN after a complete {}-byte envelope; treating it as EOF",
+                    buf.len()
+                );
+                break;
             }
             Err(e) => return Err(OverlayFetchError::Read(e.to_string())),
         };
@@ -340,13 +354,44 @@ mod tests {
         assert_eq!(reader.polls, 1, "a hard error must not be retried");
     }
 
-    /// The retry is for the *handshake* race, which by definition happens
-    /// before the parent has sent anything. An `ENOTCONN` after bytes have
-    /// arrived is a real mid-stream teardown: retrying it would spin out the
-    /// whole `READ_TIMEOUT` and then report "not fully received within 10s",
-    /// hiding the errno that actually explains the failure.
+    /// A post-payload `ENOTCONN` is Linux AF_VSOCK's observable close behavior
+    /// in some parent/enclave timing windows. It is equivalent to EOF only when
+    /// the buffered bytes are already one complete JSON value.
     #[tokio::test]
-    async fn does_not_retry_not_connected_once_bytes_have_arrived() {
+    async fn accepts_not_connected_after_complete_envelope() {
+        const ENVELOPE: &[u8] = br#"{"version":1,"overlay":{},"integrity":null}"#;
+        let mut reader = ScriptedReader::new(vec![
+            Step::Bytes(ENVELOPE),
+            Step::Err(std::io::ErrorKind::NotConnected),
+            Step::Bytes(b"must not be read"),
+        ]);
+
+        assert_eq!(read_envelope_to_eof(&mut reader).await.unwrap(), ENVELOPE);
+        assert_eq!(
+            reader.polls, 2,
+            "a complete envelope must terminate at ENOTCONN"
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_complete_invalid_envelope() {
+        const ENVELOPE: &[u8] = br#"{"version":2,"overlay":{"future_field":true}}"#;
+        let mut reader = ScriptedReader::new(vec![
+            Step::Bytes(ENVELOPE),
+            Step::Err(std::io::ErrorKind::NotConnected),
+        ]);
+
+        let bytes = read_envelope_to_eof(&mut reader)
+            .await
+            .expect("a complete JSON value is transport-complete");
+        assert!(matches!(
+            parse_envelope(&bytes),
+            Err(OverlayFetchError::UnsupportedVersion(2))
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_not_connected_after_partial_envelope() {
         let mut reader = ScriptedReader::new(vec![
             Step::Bytes(b"{\"version\":1,"),
             Step::Err(std::io::ErrorKind::NotConnected),
@@ -359,7 +404,7 @@ mod tests {
         ));
         assert_eq!(
             reader.polls, 2,
-            "mid-stream ENOTCONN must fail fast, not retry"
+            "partial-envelope ENOTCONN must fail fast, not retry"
         );
     }
 

--- a/vta-tee/src/tenant_overlay.rs
+++ b/vta-tee/src/tenant_overlay.rs
@@ -53,7 +53,9 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const READ_TIMEOUT: Duration = Duration::from_secs(10);
 /// `tokio-vsock` can report a stream connected just before Nitro finishes the
 /// nonblocking handshake, making the first read return `ENOTCONN`. Retry only
-/// that transient state; the outer [`READ_TIMEOUT`] remains the hard deadline.
+/// that transient state, and only *before any byte has arrived* — see
+/// [`read_envelope_to_eof`]. The outer [`READ_TIMEOUT`] remains the hard
+/// deadline.
 const NOT_CONNECTED_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 /// Failure fetching or applying the tenant-config overlay. Every variant is
@@ -194,16 +196,35 @@ async fn read_envelope(stream: &mut VsockStream) -> Result<Vec<u8>, OverlayFetch
 
 /// The unbounded-in-time inner read. Only ever called under the
 /// [`read_envelope`] deadline.
+///
+/// `ENOTCONN` is retried **only while the buffer is still empty** — that is
+/// the handshake race [`NOT_CONNECTED_RETRY_DELAY`] describes, and it can only
+/// occur before the parent has sent anything. Once a byte has arrived the
+/// connection demonstrably completed, so a later `ENOTCONN` is a real
+/// mid-stream teardown: retrying it would burn the rest of [`READ_TIMEOUT`]
+/// and then report a timeout instead of the errno that actually happened.
 async fn read_envelope_to_eof<R>(stream: &mut R) -> Result<Vec<u8>, OverlayFetchError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut buf = Vec::new();
     let mut chunk = [0u8; 8192];
+    let mut warned_not_connected = false;
     loop {
         let n = match stream.read(&mut chunk).await {
             Ok(n) => n,
-            Err(e) if e.kind() == std::io::ErrorKind::NotConnected => {
+            Err(e) if e.kind() == std::io::ErrorKind::NotConnected && buf.is_empty() => {
+                // Log once, not once per 10ms tick: a boot that spent most of
+                // READ_TIMEOUT here must not look identical to one that read
+                // immediately, but ~1000 identical lines is not an improvement.
+                if !warned_not_connected {
+                    warned_not_connected = true;
+                    warn!(
+                        "config server accepted but the vsock handshake is not complete yet \
+                         (ENOTCONN); retrying every {NOT_CONNECTED_RETRY_DELAY:?} until the \
+                         {READ_TIMEOUT:?} read deadline"
+                    );
+                }
                 tokio::time::sleep(NOT_CONNECTED_RETRY_DELAY).await;
                 continue;
             }
@@ -251,40 +272,53 @@ mod tests {
 
     const GOOD_ARN: &str = "arn:aws:kms:us-east-1:111122223333:key/abcd-ef01";
 
-    struct FirstReadError {
-        kind: std::io::ErrorKind,
-        payload: &'static [u8],
-        state: u8,
+    /// One scripted `poll_read` outcome. A `ScriptedReader` walks these in
+    /// order; running off the end is EOF, which is how the read loop
+    /// terminates.
+    enum Step {
+        Err(std::io::ErrorKind),
+        Bytes(&'static [u8]),
     }
 
-    impl AsyncRead for FirstReadError {
+    /// A reader that replays a fixed script of `poll_read` outcomes, counting
+    /// how many polls it served so a test can pin "the loop stopped here".
+    struct ScriptedReader {
+        steps: Vec<Step>,
+        polls: usize,
+    }
+
+    impl ScriptedReader {
+        fn new(steps: Vec<Step>) -> Self {
+            Self { steps, polls: 0 }
+        }
+    }
+
+    impl AsyncRead for ScriptedReader {
         fn poll_read(
             mut self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
-            match self.state {
-                0 => {
-                    self.state = 1;
-                    Poll::Ready(Err(std::io::Error::from(self.kind)))
-                }
-                1 => {
-                    self.state = 2;
-                    buf.put_slice(self.payload);
+            let idx = self.polls;
+            self.polls += 1;
+            match self.steps.get(idx) {
+                Some(Step::Err(kind)) => Poll::Ready(Err(std::io::Error::from(*kind))),
+                Some(Step::Bytes(payload)) => {
+                    buf.put_slice(payload);
                     Poll::Ready(Ok(()))
                 }
-                _ => Poll::Ready(Ok(())),
+                // Off the end of the script: EOF.
+                None => Poll::Ready(Ok(())),
             }
         }
     }
 
     #[tokio::test]
     async fn retries_transient_not_connected_read() {
-        let mut reader = FirstReadError {
-            kind: std::io::ErrorKind::NotConnected,
-            payload: b"config envelope",
-            state: 0,
-        };
+        let mut reader = ScriptedReader::new(vec![
+            Step::Err(std::io::ErrorKind::NotConnected),
+            Step::Bytes(b"config envelope"),
+        ]);
 
         assert_eq!(
             read_envelope_to_eof(&mut reader).await.unwrap(),
@@ -294,17 +328,39 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_non_transient_read_error() {
-        let mut reader = FirstReadError {
-            kind: std::io::ErrorKind::PermissionDenied,
-            payload: b"must not be read",
-            state: 0,
-        };
+        let mut reader = ScriptedReader::new(vec![
+            Step::Err(std::io::ErrorKind::PermissionDenied),
+            Step::Bytes(b"must not be read"),
+        ]);
 
         assert!(matches!(
             read_envelope_to_eof(&mut reader).await,
             Err(OverlayFetchError::Read(_))
         ));
-        assert_eq!(reader.state, 1);
+        assert_eq!(reader.polls, 1, "a hard error must not be retried");
+    }
+
+    /// The retry is for the *handshake* race, which by definition happens
+    /// before the parent has sent anything. An `ENOTCONN` after bytes have
+    /// arrived is a real mid-stream teardown: retrying it would spin out the
+    /// whole `READ_TIMEOUT` and then report "not fully received within 10s",
+    /// hiding the errno that actually explains the failure.
+    #[tokio::test]
+    async fn does_not_retry_not_connected_once_bytes_have_arrived() {
+        let mut reader = ScriptedReader::new(vec![
+            Step::Bytes(b"{\"version\":1,"),
+            Step::Err(std::io::ErrorKind::NotConnected),
+            Step::Bytes(b"must not be read"),
+        ]);
+
+        assert!(matches!(
+            read_envelope_to_eof(&mut reader).await,
+            Err(OverlayFetchError::Read(_))
+        ));
+        assert_eq!(
+            reader.polls, 2,
+            "mid-stream ENOTCONN must fail fast, not retry"
+        );
     }
 
     #[test]

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -804,7 +804,14 @@ pub(crate) fn app_error_code(err: &AppError) -> &'static str {
         AppError::Forbidden(_) | AppError::StepUpRequired(_) => codes::FORBIDDEN,
         AppError::Unauthorized(_) | AppError::Authentication(_) => codes::UNAUTHORIZED,
         AppError::NotFound(_) => codes::NOT_FOUND,
-        AppError::Conflict(_) | AppError::IdempotencyKeyConflict => codes::CONFLICT,
+        // The affinidi taxonomy has no `gone` code, and inventing a wire code
+        // for a variant no DIDComm surface produces would be worse than
+        // approximating. `conflict` ("your request conflicts with the
+        // resource's state") is the closest caller-fault code; the
+        // `internal-error` fallback would be an outright wrong signal.
+        AppError::Conflict(_) | AppError::Gone(_) | AppError::IdempotencyKeyConflict => {
+            codes::CONFLICT
+        }
         AppError::Validation(_)
         | AppError::TrustTaskMalformed(_)
         | AppError::TrustTaskMissing
@@ -1502,6 +1509,17 @@ mod tests {
         assert_eq!(
             app_error_code(&AppError::Validation("bad".into())),
             codes::BAD_REQUEST
+        );
+        // A consumed single-use resource is a caller-visible terminal
+        // outcome. The taxonomy has no `gone` code, so it rides with
+        // `conflict` — the one thing it must not be is `internal-error`.
+        assert_eq!(
+            app_error_code(&AppError::Gone("consumed".into())),
+            codes::CONFLICT
+        );
+        assert_ne!(
+            app_error_code(&AppError::Gone("consumed".into())),
+            codes::INTERNAL
         );
         // Genuine infra faults stay internal.
         assert_eq!(

--- a/vtc-service/src/trust_tasks/helpers.rs
+++ b/vtc-service/src/trust_tasks/helpers.rs
@@ -90,12 +90,16 @@ pub(crate) fn app_error_to_reject(doc: &TrustTask<Value>, err: &AppError) -> Tru
         | AppError::TrustTaskMalformed(_)
         | AppError::TrustTaskMissing
         | AppError::InvalidCursor => RejectReason::MalformedRequest { reason: message },
-        AppError::NotFound(_) | AppError::Conflict(_) | AppError::IdempotencyKeyConflict => {
-            RejectReason::TaskFailed {
-                reason: message,
-                details: None,
-            }
-        }
+        // `Gone` is a terminal caller-visible outcome, not a server fault —
+        // keep it out of the `internal_error` fallback, which would tell the
+        // client to retry a permanently-consumed resource.
+        AppError::NotFound(_)
+        | AppError::Conflict(_)
+        | AppError::Gone(_)
+        | AppError::IdempotencyKeyConflict => RejectReason::TaskFailed {
+            reason: message,
+            details: None,
+        },
         _ => RejectReason::InternalError { reason: message },
     };
     reject_with(doc, reason)

--- a/vti-common/src/error.rs
+++ b/vti-common/src/error.rs
@@ -29,6 +29,18 @@ pub enum AppError {
     #[error("conflict: {0}")]
     Conflict(String),
 
+    /// The resource existed but has been permanently, irreversibly consumed
+    /// or removed — rendered as **410 Gone**, distinct from [`Self::NotFound`]
+    /// (never existed / not visible to this caller) and [`Self::Conflict`]
+    /// (a transient state mismatch a retry or different request could
+    /// resolve). Canonical use: the TEE Mode B bootstrap carve-out after it
+    /// has been claimed — a second `/bootstrap/request` cannot succeed no
+    /// matter what the caller sends, ever again for this VTA. The SDK's
+    /// `vta_sdk::error::VtaError::Gone` mirrors this on the client side
+    /// (`from_http` maps 410 → `Gone`) with an operator-facing hint.
+    #[error("gone: {0}")]
+    Gone(String),
+
     #[error("secrets error: {0}")]
     Secrets(#[from] SecretsResolverError),
 
@@ -208,6 +220,7 @@ impl IntoResponse for AppError {
             AppError::SecretStore(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::NotFound(_) => StatusCode::NOT_FOUND,
             AppError::Conflict(_) => StatusCode::CONFLICT,
+            AppError::Gone(_) => StatusCode::GONE,
             AppError::Secrets(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::Authentication(_) => StatusCode::UNAUTHORIZED,
             AppError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
@@ -386,5 +399,31 @@ mod approval_required_tests {
         }
         .into_response();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}
+
+#[cfg(test)]
+mod gone_tests {
+    use super::*;
+
+    /// The whole point of the variant: a consumed single-use resource (the
+    /// canonical example being the TEE Mode B bootstrap carve-out) must
+    /// render 410, not 403/409 — the SDK's `VtaError::from_http` keys its
+    /// `Gone` mapping off exactly this status code.
+    #[test]
+    fn renders_as_410_gone() {
+        let resp =
+            AppError::Gone("TEE first-boot carve-out has already been used".into()).into_response();
+        assert_eq!(resp.status(), StatusCode::GONE);
+    }
+
+    #[tokio::test]
+    async fn body_carries_the_message() {
+        use axum::body::to_bytes;
+
+        let resp = AppError::Gone("carve-out closed".into()).into_response();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+        assert_eq!(body["error"], "gone: carve-out closed");
     }
 }


### PR DESCRIPTION
tokio-vsock can report a stream connected just before Nitro finishes the
nonblocking handshake, so the very first read on a fresh vsock:5800
connection to the parent config server can return ENOTCONN even though
the parent is listening and ready. Retry only that specific transient
error kind with a short delay; any other I/O error still fails closed
immediately, and the existing overall READ_TIMEOUT deadline still
bounds the whole fetch.

Adds positive (retries ENOTCONN then succeeds) and negative (does not
retry PermissionDenied) unit tests against the inner read loop.

`POST /bootstrap/request` returned 403 Forbidden once the TEE first-boot
carve-out had already been claimed, but the documented API contract
requires 410 Gone. A 403 tells the caller "you specifically are not
authorized", which is the wrong signal for a single-use resource that no
caller, with any credentials, can ever claim again — 410 is what tells a
client the retry itself is pointless rather than "try different
credentials".

Adds `AppError::Gone` (renders as HTTP 410) to `vti-common`, alongside the
existing `Conflict`/`NotFound` variants, and switches both closed-carve-out
branches in `mint_mode_b` (the normal "sentinel already exists" check, and
the defensive concurrent-claim-loss path) onto a single
`carve_out_closed_error()` helper that returns it. This is a wire
compatibility fix, not a security fix — the carve-out was already correctly
refusing the second request; only the status code was wrong. The SDK's
`vta_sdk::error::VtaError::Gone` (mapped from HTTP 410 via `from_http`, with
an operator-facing "provision-integration a new operator instead" hint) was
already written expecting this status, so this closes the gap on the server
side.

Adds regression tests: `vti-common` pins the 410 status + body for the new
variant, and `vta-service` drives the real `mint_mode_b` end-to-end twice
against a simulated TEE provider (first call mints an admin and closes the
carve-out; second call, with a different client key and nonce, asserts
`AppError::Gone` / HTTP 410).