### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6295,7 +6295,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "tracing",
  "uuid",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9261,7 +9261,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9319,7 +9319,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9352,7 +9352,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "vti-common",
 ]
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "hex",
  "multibase",
@@ -9422,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9588,7 +9588,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9608,7 +9608,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9624,7 +9624,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm",
@@ -9658,7 +9658,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9692,7 +9692,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9713,7 +9713,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9810,7 +9810,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.24](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.23...cnm-cli-v0.11.24) — 2026-08-20
+
+
 ## [0.11.23](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.22...cnm-cli-v0.11.23) — 2026-08-18
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.23"
+version = "0.11.24"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.11", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }
@@ -26,7 +26,7 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 # SLIP-0010 key derivation (`vti_common::slip10`) — the harness re-derives the
 # same keys the VTA does, from the same seed and paths.
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 
 [lints]
 workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.7...pnm-cli-v0.12.8) — 2026-08-20
+
+
+### Documentation
+
+- **pnm-cli**: Document the tsp and azure-secrets build features ([#1016](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1016))
+
+The README's Feature Flags table listed two of the crate's four features.
+  Both omissions changed what an operator ends up with:
+
+  `tsp` is a default (`default = ["keyring", "tsp"]`) and gates the round-trip
+  TSP probe in `pnm health`. The keyring-free build the README recommended,
+  `--no-default-features --features config-session`, silently dropped it, after
+  which `pnm health` reports an advertised TSPTransport service without ever
+  exercising it. The build examples now re-add `tsp` and say why.
+
+  `azure-secrets` is off by default and inert unless `keyring` is also off --
+  the backend's Azure arm is gated `not(feature = "keyring")` -- so adding it to
+  a default build selects nothing and reports no error.
+
+  The section also claimed "at least one of keyring or config-session must be
+  enabled". Nothing enforces that. With neither, the backend falls through to
+  the plaintext file store and warns on every access, which is a materially
+  different guarantee from the build-time gate the sentence implied. Replaced
+  with the real selection order, keyring -> azure-secrets -> config-session ->
+  plaintext fallback, and the warning verbatim.
+
+
+
 ## [0.12.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.6...pnm-cli-v0.12.7) — 2026-08-18
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.7"
+version = "0.12.8"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.7...vta-audit-v0.1.8) — 2026-08-20
+
+
 ## [0.1.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.6...vta-audit-v0.1.7) — 2026-08-18
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12" }
-vta-sdk = { path = "../vta-sdk", version = "0.25" }
+vti-common = { path = "../vti-common", version = "0.13" }
+vta-sdk = { path = "../vta-sdk", version = "0.26" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.11...vta-backup-v0.1.12) — 2026-08-20
+
+
+### Fixed
+
+- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))
+
+* fix(tee): retry transient ENOTCONN on first vsock config-overlay read
+
+  tokio-vsock can report a stream connected just before Nitro finishes the
+  nonblocking handshake, so the very first read on a fresh vsock:5800
+  connection to the parent config server can return ENOTCONN even though
+  the parent is listening and ready. Retry only that specific transient
+  error kind with a short delay; any other I/O error still fails closed
+  immediately, and the existing overall READ_TIMEOUT deadline still
+  bounds the whole fetch.
+
+  Adds positive (retries ENOTCONN then succeeds) and negative (does not
+  retry PermissionDenied) unit tests against the inner read loop.
+
+
+
 ## [0.1.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.10...vta-backup-v0.1.11) — 2026-08-18
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,9 +27,9 @@ webvh = ["vta-keyspaces/webvh"]
 tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12" }
-vta-sdk = { path = "../vta-sdk", version = "0.25" }
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vti-common = { path = "../vti-common", version = "0.13" }
+vta-sdk = { path = "../vta-sdk", version = "0.26" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.1...vta-cli-common-v0.11.2) — 2026-08-20
+
+
+### Fixed
+
+- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))
+
+* fix(tee): retry transient ENOTCONN on first vsock config-overlay read
+
+  tokio-vsock can report a stream connected just before Nitro finishes the
+  nonblocking handshake, so the very first read on a fresh vsock:5800
+  connection to the parent config server can return ENOTCONN even though
+  the parent is listening and ready. Retry only that specific transient
+  error kind with a short delay; any other I/O error still fails closed
+  immediately, and the existing overall READ_TIMEOUT deadline still
+  bounds the whole fetch.
+
+  Adds positive (retries ENOTCONN then succeeds) and negative (does not
+  retry PermissionDenied) unit tests against the inner read loop.
+
+
+
 ## [0.11.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.0...vta-cli-common-v0.11.1) — 2026-08-18
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.11.1"
+version = "0.11.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,13 +18,13 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.9...vta-config-v0.3.10) — 2026-08-20
+
+
 ## [0.3.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.8...vta-config-v0.3.9) — 2026-08-18
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,11 +26,11 @@ default = []
 tee = []
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.25", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.26", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,8 +34,8 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.17", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.12", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.18", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build
 # links no overlay code.

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.6...vta-keys-v0.2.7) — 2026-08-20
+
+
 ## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.5...vta-keys-v0.2.6) — 2026-08-18
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -34,11 +34,11 @@ keyring = ["vti-secrets/keyring"]
 tee = ["vti-secrets/tee"]
 
 [dependencies]
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.5...vta-keyspaces-v0.2.0) — 2026-08-20
+
+
+### Added
+
+- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))
+
+A client that retries a timed-out request is doing the right thing. The
+  dangerous case is the one where the VTA processed it and only the reply
+  was lost, because the retry then produces a second durable effect —
+  `webvh/dids/create` being the sharp example, where auto-assigned paths
+  mean the retry mints a *different* DID and the first stays published
+  with nobody holding a reference to it.
+
+  The existing `trust_tasks::replay` layer cannot catch that. It keys on
+  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
+  attempt, so a genuine retry sails past it. Its own module docs name this
+  work as the deliberate follow-up.
+
+  ## Built on the store that was already here
+
+
+
 ## [0.1.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.4...vta-keyspaces-v0.1.5) — 2026-08-18
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.1.5"
+version = "0.2.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,4 +26,4 @@ webvh = []
 
 [dependencies]
 # For `KeyspaceHandle` in the shared `Keyspaces` handle bundle.
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.8...vta-policy-v0.2.9) — 2026-08-20
+
+
 ## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.7...vta-policy-v0.2.8) — 2026-08-18
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,12 +20,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 vta-config = { path = "../vta-config", version = "0.3" }
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.25", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.26", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,322 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.26.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.25.1...vta-sdk-v0.26.0) — 2026-08-20
+
+
+### Added
+
+- **service**: Retire an orphaned webvh slot, on evidence rather than assertion ([#1022](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1022))
+
+`vta/webvh/servers/reconcile` names two divergences and repairs
+  neither, deliberately — they want opposite remedies. This implements the
+  remedy for one: the orphan, a slot a hosting server serves for this VTA
+  that the VTA has no record of.
+
+  Nothing could repair that state, and the reason is structural. Every
+  delete addresses a DID through its local record, which is what says
+  which server to talk to and which keys to sign with; an orphan is
+  defined by that record's absence, so the lookup fails before a request
+  leaves the VTA. Nor can the caller go around it — the VTA holds the host
+  credentials. A slot both parties can see, and neither can remove.
+
+- **service**: The vta/services task family, and the twenty routes it supersedes ([#1017](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1017))
+
+* feat(service): the vta/services task family, one verb per task
+
+  Eight handlers covering what twenty `/services/*` REST routes did. The
+  operations are untouched — `operations::protocol::*` already implements each
+  transport — so this is the parameterised door onto them, not new logic.
+
+  `service` names the transport and `config` carries its settings, so the fan-out
+  happens here rather than on the wire. That is what keeps a fifth transport to a
+  config variant instead of four new specs.
+
+  **The drain guard is the part that matters.** Tearing down a mediator discards
+  whatever is in flight through it, so `disable`/`update`/`rollback` on didcomm
+  pass a `DisableTransport` that decides whether the 1-hour floor applies. The
+  REST route hardcodes `Rest` and the DIDComm handler hardcodes `Didcomm`,
+  because each IS that path; a trust task is not, so it reads the arrival
+  transport from the dispatch spine.
+
+  The spine records confidentiality, not binding: DIDComm and TSP are both
+  `EndToEnd` and it cannot tell them apart. `EndToEnd` therefore maps to
+  `Didcomm`, which OVER-applies the floor to a TSP-carried disable that does not
+  strictly need it. Deliberate: under-applying tears down the mediator a request
+  arrived through and discards the reply to the very task asking for it, while
+  over-applying only delays a teardown the operator can repeat. The ambiguous
+  case takes the cheaper mistake.
+
+  Three shapes the generated types forced, each documented where it lands:
+
+  - `ServiceMutationResult` and `RollbackKind` are duplicated per family —
+    identical shapes, distinct types. Mutation results round-trip through the wire
+    form rather than being hand-copied three times; rollback kinds go through a
+    macro that names the variants, so a divergence is a compile error.
+  - Rollback may write nothing. Its `noOp` arm has no `logEntryVersionId`, which
+    is why it has its own result type, and the witness uses exactly that arm.
+  - `handshake_timeout_secs` is `NonZeroU64` — the schema's `minimum: 1` — so the
+    default is constructed, not unwrapped.
+
+  **Operation futures are boxed, and that is load-bearing.** These handlers fan
+  out to four sizeable futures, awaited inside a dispatch match that already
+  carries every other task's state machine. Inlining them grew the frame past the
+  default 8 MiB stack and aborted an unrelated mock_vta test with a stack
+  overflow — which reads as infinite recursion and is not.
+
+- **sdk**: Hold one idempotency key across every attempt of an operation ([#1012](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1012))
+
+The VTA deduplicates keyed Trust Tasks on an `idempotencyKey` ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011)).
+  That only helps if the retry carries the *same* key as the attempt it is
+  retrying — and a hand-rolled retry loop structurally cannot do that,
+  because it re-invokes a client method that builds a fresh document each
+  time. Minting the key inside the method has the identical problem the
+  envelope id already has: attempt two gets a new one, the VTA sees an
+  unrelated request, and the second durable effect happens anyway.
+
+  So the key has to be scoped *outside* the call. `VtaClient::idempotent`
+  mints one, holds it in a task-local for the duration of a closure, and
+  retries transient faults inside that scope:
+
+      let key = client.idempotent(|| client.create_key(req.clone())).await?;
+
+  Every dispatch the closure makes carries the same key. A task-local
+  rather than a parameter because it has to reach all twenty-odd typed
+  methods without changing twenty signatures, and because it is genuinely
+  ambient — it belongs to the operation, not the call.
+
+  The key is attached only when the task is one a second execution would
+  actually harm (`retry_safety`); attaching it to a read would cost the
+  VTA a dedup record and buy nothing. It goes top-level beside `id`, where
+  the VTA reads it from `TrustTask::extra` and a Data-Integrity proof
+  covers it — so a relayer cannot rewrite it to split one operation
+  into two.
+
+  ## One retry owner
+
+  Retry layers compose badly. The messaging delivery layer already retries
+  a durable outbox with backoff underneath this, so an application loop on
+  top multiplies attempts against a server that dedups at neither. This is
+  the application-layer owner: bounded at 3 attempts, backed off, and
+  honouring the server's `retryAfter` up to a 30s cap — an unbounded wait
+  on a server-chosen value is a stall the server can trigger at will.
+
+  Callers should use it *instead of* their own loop, not around one.
+
+  ## BREAKING CHANGE
+
+  `VtaError` gains an `Unavailable { retry_after }` variant (exhaustive
+  enum), reported by cargo-semver-checks so the release moves the
+  compatibility field rather than shipping it as a patch.
+
+  It is typed rather than folded into `Protocol(String)` because it is the
+  one wire rejection meaning "ask again" rather than "this failed" — the
+  idempotency layer returns it while a first attempt on the same key is
+  still running. A retry loop reading it as terminal gives up on precisely
+  the answer it was told to wait for. The REST leg parses the error
+  document before the status (R3.7), so without this the `unavailable`
+  code collapsed to a string and its 503 never surfaced.
+
+- **sdk**: Classify what a lost reply costs every Trust Task ([#1010](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1010))
+
+A client that retries a timed-out request is doing the right thing — the
+  dominant transport fault is a request that never arrived. The dangerous
+  case is the other one, where the VTA processed it and only the reply was
+  lost, and whether that is harmful depends entirely on the operation.
+  Deleting an already-deleted DID is free; creating a second auto-assigned
+  `did:webvh` is not, because the first stays published in the log with
+  nobody holding a reference to it.
+
+  Callers currently cannot tell those apart, so they guess. This adds the
+  property as data: `RetrySafety` over all 148 URIs in `ALL_URIS`, with a
+  census test that fails if a task joins the catalog unclassified — the
+  same discipline that pins `REST_ROUTED_URIS`.
+
+  Four classes, drawn around the question a retry layer actually asks:
+
+  - `ReadOnly` — no durable effect.
+  - `RetrySafe` — mutating, but a repeat is harmless: it either converges
+    on the same end state (revoke, disable, delete) or leaves an inert,
+    self-expiring duplicate (a spare auth challenge). Deliberately not
+    named "idempotent", because the second half is not.
+  - `Keyed` — non-convergent: a repeat leaves a second durable artefact
+    that persists and matters. Needs an idempotency key.
+  - `KeyedSecret` — as `Keyed`, but the response carries secret material,
+    so the response must never be cached. Deduping the effect without
+    turning a dedup store into a second place mnemonics and sealed
+    bundles live.
+
+  That last class is the one worth arguing about. Result-caching
+  idempotency wants to replay the stored response, and for
+  `seeds/export-mnemonic`, `backup/complete-export` and
+  `provision/integration` that would mean persisting the secret a second
+  time, indefinitely, to serve a retry. The effect is still deduped; only
+  the replay is refused.
+
+  Where convergence is not obvious from an operation's contract it is
+  classified `Keyed` rather than `RetrySafe`. The asymmetry is nearly
+  free — an over-classified task costs one dedup record, while an
+  under-classified one loses the protection in exactly the rare case the
+  table exists for.
+
+  Classification alone gates nothing: it changes how a *keyed* request is
+  handled, and a request carrying no key behaves exactly as it does today
+  on every task in the table. Nothing consumes this yet; the VTA-side
+  dedup store and the client-side key are the follow-ups.
+
+- **service**: Signal every superseded REST route, from one layer ([#1007](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1007))
+
+
+### Fixed
+
+- **sdk,service**: Serve and use the Trust-Task path the binding asks for ([#1020](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1020))
+
+`trust-tasks-https` POSTs to `<serviceEndpoint>/trust-tasks`, where
+  `serviceEndpoint` is what a VTA advertises on its service entry. Every
+  deployment example advertises an ORIGIN — `https://trust.example.com`,
+  `http://localhost:3000` — so a client built from the published binding asked
+  for `/trust-tasks` and got a 404. Ours worked only because `vta-sdk` hardcoded
+  `/api/trust-tasks` and this service happened to serve the same prefix.
+
+  Two implementations agreeing by convention is not a contract; it hides the
+  absence of one from the only people who would notice — which is why this
+  survived until someone read the binding rather than the code.
+
+  The underlying defect was never the path. Nothing defined what the advertised
+  endpoint DENOTES, so the two clients composed it differently and both could not
+  be right: the SDK appended `/api/trust-tasks`, the binding appended
+  `/trust-tasks`. Settled, per Glenn: **serviceEndpoint is the Trust-Task base**,
+  and the binding's suffix is the contract.
+
+  - **The service serves both.** `/trust-tasks` alongside `/api/trust-tasks`, one
+    dispatcher. This is what makes the change safe: for an origin-advertising VTA
+    the Trust-Task base IS the origin, so every existing advertisement becomes
+    conformant with no operator touching anything.
+  - **The SDK moved to `<base>/trust-tasks`.** That is the half that makes the
+    contract real rather than aspirational, and it is safe against any VTA that
+    has taken the change above.
+  - **`/api/trust-tasks` is marked superseded**, so the metric that governs every
+    other retired route decides when it goes. Its successor is a PATH, not a task
+    URI — the one row in that table where the successor is not a
+    `trusttasks.org` URI, because what replaced it is a spelling rather than an
+    operation.
+
+  Moving the SDK surfaced a second hand-built call site: `backup_descriptors.rs`
+  formatted `{base}/api/trust-tasks` itself instead of going through `rpc_tt`,
+  which is exactly why it kept the legacy prefix after the shared path moved.
+
+  Tests pin that both spellings reach the same dispatcher AND fail identically
+  when unauthenticated — a divergence there would mean a conformant client and
+  ours behave differently, which is the thing being fixed. 26 mocks across
+  client_rest and auth_light_rest move with the client.
+
+  Still to do, and deliberately not here: specifying what the Trust-Task service
+  entry means, so this is a contract rather than a second convention. That is a
+  spec-registry change.
+
+- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))
+
+* fix(tee): retry transient ENOTCONN on first vsock config-overlay read
+
+  tokio-vsock can report a stream connected just before Nitro finishes the
+  nonblocking handshake, so the very first read on a fresh vsock:5800
+  connection to the parent config server can return ENOTCONN even though
+  the parent is listening and ready. Retry only that specific transient
+  error kind with a short delay; any other I/O error still fails closed
+  immediately, and the existing overall READ_TIMEOUT deadline still
+  bounds the whole fetch.
+
+  Adds positive (retries ENOTCONN then succeeds) and negative (does not
+  retry PermissionDenied) unit tests against the inner read loop.
+
+- **sdk/service**: Take trust-tasks-rs 0.11, and fix the four defects it exposes ([#1015](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1015))
+
+* build(deps): move to trust-tasks-rs 0.11 and affinidi-messaging-sdk 0.19.9
+
+  trust-tasks-rs 0.11 carries the vta/services/* families this branch implements.
+  The move needed affinidi-messaging-sdk to go first — acl_setup hands a
+  MediatorAcl to TrustTasks::account_update, so two semver-incompatible copies of
+  trust-tasks-rs made that a type error rather than a link. That landed as
+  affinidi-tdk-rs#717 and published as 0.19.9.
+
+  vta-sdk builds clean on this. The workspace does NOT yet: vtc-service still
+  hits a duplicated TrustTask<Value> because the trust-tasks sibling crates
+  (trust-tasks-didcomm, -https, -proof, -tsp, -capability-client, -didcomm-v1)
+  changed their requirement to 0.11 without moving their own versions, so
+  crates.io still serves tarballs built against 0.9. dtgwg-trust-tasks-tf's
+  release/siblings-on-0.11 fixes that; this branch waits on it.
+
+- **sdk**: Build these two task payloads from their typed bodies ([#1005](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1005))
+
+`get_key_secret` and `list_dids_webvh` were the last two `rpc_tt` call sites
+  constructing their payload as a hand-written `serde_json::json!` literal, so
+  they emitted `key_id`, `context_id` and `server_id` — snake_case, against a
+  SPEC §4.10 contract that says lowerCamelCase.
+
+  The earlier casing fold could not reach them by construction: it rewrote
+  structs via `rename_all`, and a literal has no struct to fold. Nothing was
+  broken, because `GetKeySecretBody` and `ListDidsWebvhBody` both carry
+  `#[serde(alias = "…")]` for the old spelling — but the SDK was emitting a
+  non-canonical spelling of its own published contract, and a consumer generated
+  from the schemas would not have recognised it.
+
+  Building the typed body instead means the wire spelling now comes from the same
+  struct the schema is generated from, so the two cannot drift again. This is
+  what the earlier fold's "known gap" note pointed at.
+
+  `list_dids_webvh` gains a second, smaller correctness win: the literal emitted
+  `"context_id": null` for an absent filter, while `ListDidsWebvhBody` carries
+  `skip_serializing_if = "Option::is_none"` and omits the key entirely.
+
+  `list_dids_webvh_filters_by_context` asserted the old spelling and now asserts
+  `contextId`/`serverId` — the test is the proof the emitted wire actually
+  changed, not just the source.
+
+- **wire**: Emit canonical lowerCamelCase on Trust Task payloads, accept snake_case ([#1000](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1000))
+
+* fix(wire)!: emit canonical lowerCamelCase on Trust Task payloads, accept snake_case
+
+  SPEC §4.10 makes lowerCamelCase the wire contract for Trust Task payload
+  members. 53 wire structs emitted snake_case, so every consumer generated from
+  the published schemas disagreed with what this agent actually sends — and the
+  disagreement was invisible until someone wrote a client against the spec.
+
+  The fold is Postel's. `rename_all = "camelCase"` changes what is emitted;
+  a per-field `alias` keeps the previous spelling accepted on intake, so a
+  producer written against the old wire keeps working while it migrates. 126
+  fields carry an alias.
+
+  **Scope is deliberately narrow, and three exclusions are not oversights:**
+
+  - **Config (`setup/from_toml.rs`)** is TOML, where snake_case is idiomatic and
+    is not a wire at all.
+  - **Persisted stores and the backup file format** (`backup_management/types.rs`,
+    `drain_store.rs`) are read back from disk. Re-casing those would fail to read
+    data already written — a worse bug than the one being fixed. Note that
+    `WebvhDidRecord` *is* both wire and persisted: it is folded, and reads of
+    existing snake_case records keep working precisely because of the aliases.
+  - **`protocols/credential_exchange.rs`** carries OID4VCI and OID4VP structures
+    (`vp_token`, `credential_offer`, `dcql_query`). §4.10 requires externally
+    owned names to be carried verbatim, never re-cased. The conformance harness
+    caught this when a first pass re-cased `vp_token`, which is exactly what that
+    test is for.
+
+  REST request/response bodies (`routes/`, `client/types.rs`, `protocol/`) are a
+  further 54 structs with the same problem. They are left for a separate change:
+  unlike task payloads, no published schema pins their casing, and changing what
+  they emit breaks readers that have no alias to fall back on.
+
+  Thirteen integration assertions read the old spelling and now read the new one.
+  Full suite green: 823 lib, 119 api_integration, 90 conformance, plus the rest.
+
+  * style: wrap the serde attributes the casing fold widened
+
+  Adding a per-field `alias` pushed several `#[serde(...)]` attributes past the
+  line width, so rustfmt wants them broken across lines. No semantic change —
+  `cargo fmt --all` output, nothing hand-edited.
+
+
+
 ## [0.25.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.25.0...vta-sdk-v0.25.1) — 2026-08-18
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.25.1"
+version = "0.26.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,242 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.18.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.17.1...vta-service-v0.18.0) — 2026-08-20
+
+
+### Added
+
+- **service**: Retire an orphaned webvh slot, on evidence rather than assertion ([#1022](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1022))
+
+`vta/webvh/servers/reconcile` names two divergences and repairs
+  neither, deliberately — they want opposite remedies. This implements the
+  remedy for one: the orphan, a slot a hosting server serves for this VTA
+  that the VTA has no record of.
+
+  Nothing could repair that state, and the reason is structural. Every
+  delete addresses a DID through its local record, which is what says
+  which server to talk to and which keys to sign with; an orphan is
+  defined by that record's absence, so the lookup fails before a request
+  leaves the VTA. Nor can the caller go around it — the VTA holds the host
+  credentials. A slot both parties can see, and neither can remove.
+
+- **service**: The vta/services task family, and the twenty routes it supersedes ([#1017](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1017))
+
+* feat(service): the vta/services task family, one verb per task
+
+  Eight handlers covering what twenty `/services/*` REST routes did. The
+  operations are untouched — `operations::protocol::*` already implements each
+  transport — so this is the parameterised door onto them, not new logic.
+
+  `service` names the transport and `config` carries its settings, so the fan-out
+  happens here rather than on the wire. That is what keeps a fifth transport to a
+  config variant instead of four new specs.
+
+  **The drain guard is the part that matters.** Tearing down a mediator discards
+  whatever is in flight through it, so `disable`/`update`/`rollback` on didcomm
+  pass a `DisableTransport` that decides whether the 1-hour floor applies. The
+  REST route hardcodes `Rest` and the DIDComm handler hardcodes `Didcomm`,
+  because each IS that path; a trust task is not, so it reads the arrival
+  transport from the dispatch spine.
+
+  The spine records confidentiality, not binding: DIDComm and TSP are both
+  `EndToEnd` and it cannot tell them apart. `EndToEnd` therefore maps to
+  `Didcomm`, which OVER-applies the floor to a TSP-carried disable that does not
+  strictly need it. Deliberate: under-applying tears down the mediator a request
+  arrived through and discards the reply to the very task asking for it, while
+  over-applying only delays a teardown the operator can repeat. The ambiguous
+  case takes the cheaper mistake.
+
+  Three shapes the generated types forced, each documented where it lands:
+
+  - `ServiceMutationResult` and `RollbackKind` are duplicated per family —
+    identical shapes, distinct types. Mutation results round-trip through the wire
+    form rather than being hand-copied three times; rollback kinds go through a
+    macro that names the variants, so a divergence is a compile error.
+  - Rollback may write nothing. Its `noOp` arm has no `logEntryVersionId`, which
+    is why it has its own result type, and the witness uses exactly that arm.
+  - `handshake_timeout_secs` is `NonZeroU64` — the schema's `minimum: 1` — so the
+    default is constructed, not unwrapped.
+
+  **Operation futures are boxed, and that is load-bearing.** These handlers fan
+  out to four sizeable futures, awaited inside a dispatch match that already
+  carries every other task's state machine. Inlining them grew the frame past the
+  default 8 MiB stack and aborted an unrelated mock_vta test with a stack
+  overflow — which reads as infinite recursion and is not.
+
+- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))
+
+A client that retries a timed-out request is doing the right thing. The
+  dangerous case is the one where the VTA processed it and only the reply
+  was lost, because the retry then produces a second durable effect —
+  `webvh/dids/create` being the sharp example, where auto-assigned paths
+  mean the retry mints a *different* DID and the first stays published
+  with nobody holding a reference to it.
+
+  The existing `trust_tasks::replay` layer cannot catch that. It keys on
+  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
+  attempt, so a genuine retry sails past it. Its own module docs name this
+  work as the deliberate follow-up.
+
+  ## Built on the store that was already here
+
+- **service**: Signal every superseded REST route, from one layer ([#1007](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1007))
+
+
+### Documentation
+
+- **service**: Record why a witness is typed or raw, and when that flips ([#1021](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1021))
+
+The conformance sweep's witnesses are typed for some families and raw JSON
+  for others, and nothing in the module said why. The reasoning lived only in
+  #1015's PR body, where it does not reach anyone reading the table.
+
+  The rule: typed when the spec preceded the type, raw JSON when it did not,
+  and the second case is a debt.
+
+  Typed is the stronger form — it proves our types conform rather than that
+  someone can hand-write an acceptable body — but only when the type did not
+  derive its shape from the same misreading that produced the witness. When
+  the contexts/webvh schemas arrived, create_did_webvh was sending context_id
+  against a schema naming contextId, and update_context was dropping
+  contextPolicy entirely. Witnesses built from those types would have encoded
+  both defects and passed green.
+
+  Same principle scripts/check-bindings-conformance.mjs applies a layer down
+  by re-implementing the binding rules instead of importing them.
+
+  This also makes the retro-fit legible as a real step rather than tidying:
+  converting the 22 to typed bodies is only sound now that #1015 corrected
+  the types, and would have laundered the bugs before that.
+
+  Docs only; no behaviour change.
+
+
+
+### Fixed
+
+- **sdk,service**: Serve and use the Trust-Task path the binding asks for ([#1020](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1020))
+
+`trust-tasks-https` POSTs to `<serviceEndpoint>/trust-tasks`, where
+  `serviceEndpoint` is what a VTA advertises on its service entry. Every
+  deployment example advertises an ORIGIN — `https://trust.example.com`,
+  `http://localhost:3000` — so a client built from the published binding asked
+  for `/trust-tasks` and got a 404. Ours worked only because `vta-sdk` hardcoded
+  `/api/trust-tasks` and this service happened to serve the same prefix.
+
+  Two implementations agreeing by convention is not a contract; it hides the
+  absence of one from the only people who would notice — which is why this
+  survived until someone read the binding rather than the code.
+
+  The underlying defect was never the path. Nothing defined what the advertised
+  endpoint DENOTES, so the two clients composed it differently and both could not
+  be right: the SDK appended `/api/trust-tasks`, the binding appended
+  `/trust-tasks`. Settled, per Glenn: **serviceEndpoint is the Trust-Task base**,
+  and the binding's suffix is the contract.
+
+  - **The service serves both.** `/trust-tasks` alongside `/api/trust-tasks`, one
+    dispatcher. This is what makes the change safe: for an origin-advertising VTA
+    the Trust-Task base IS the origin, so every existing advertisement becomes
+    conformant with no operator touching anything.
+  - **The SDK moved to `<base>/trust-tasks`.** That is the half that makes the
+    contract real rather than aspirational, and it is safe against any VTA that
+    has taken the change above.
+  - **`/api/trust-tasks` is marked superseded**, so the metric that governs every
+    other retired route decides when it goes. Its successor is a PATH, not a task
+    URI — the one row in that table where the successor is not a
+    `trusttasks.org` URI, because what replaced it is a spelling rather than an
+    operation.
+
+  Moving the SDK surfaced a second hand-built call site: `backup_descriptors.rs`
+  formatted `{base}/api/trust-tasks` itself instead of going through `rpc_tt`,
+  which is exactly why it kept the legacy prefix after the shared path moved.
+
+  Tests pin that both spellings reach the same dispatcher AND fail identically
+  when unauthenticated — a divergence there would mean a conformant client and
+  ours behave differently, which is the thing being fixed. 26 mocks across
+  client_rest and auth_light_rest move with the client.
+
+  Still to do, and deliberately not here: specifying what the Trust-Task service
+  entry means, so this is a contract rather than a second convention. That is a
+  spec-registry change.
+
+- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))
+
+* fix(tee): retry transient ENOTCONN on first vsock config-overlay read
+
+  tokio-vsock can report a stream connected just before Nitro finishes the
+  nonblocking handshake, so the very first read on a fresh vsock:5800
+  connection to the parent config server can return ENOTCONN even though
+  the parent is listening and ready. Retry only that specific transient
+  error kind with a short delay; any other I/O error still fails closed
+  immediately, and the existing overall READ_TIMEOUT deadline still
+  bounds the whole fetch.
+
+  Adds positive (retries ENOTCONN then succeeds) and negative (does not
+  retry PermissionDenied) unit tests against the inner read loop.
+
+- **sdk/service**: Take trust-tasks-rs 0.11, and fix the four defects it exposes ([#1015](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1015))
+
+* build(deps): move to trust-tasks-rs 0.11 and affinidi-messaging-sdk 0.19.9
+
+  trust-tasks-rs 0.11 carries the vta/services/* families this branch implements.
+  The move needed affinidi-messaging-sdk to go first — acl_setup hands a
+  MediatorAcl to TrustTasks::account_update, so two semver-incompatible copies of
+  trust-tasks-rs made that a type error rather than a link. That landed as
+  affinidi-tdk-rs#717 and published as 0.19.9.
+
+  vta-sdk builds clean on this. The workspace does NOT yet: vtc-service still
+  hits a duplicated TrustTask<Value> because the trust-tasks sibling crates
+  (trust-tasks-didcomm, -https, -proof, -tsp, -capability-client, -didcomm-v1)
+  changed their requirement to 0.11 without moving their own versions, so
+  crates.io still serves tarballs built against 0.9. dtgwg-trust-tasks-tf's
+  release/siblings-on-0.11 fixes that; this branch waits on it.
+
+- **wire**: Emit canonical lowerCamelCase on Trust Task payloads, accept snake_case ([#1000](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1000))
+
+* fix(wire)!: emit canonical lowerCamelCase on Trust Task payloads, accept snake_case
+
+  SPEC §4.10 makes lowerCamelCase the wire contract for Trust Task payload
+  members. 53 wire structs emitted snake_case, so every consumer generated from
+  the published schemas disagreed with what this agent actually sends — and the
+  disagreement was invisible until someone wrote a client against the spec.
+
+  The fold is Postel's. `rename_all = "camelCase"` changes what is emitted;
+  a per-field `alias` keeps the previous spelling accepted on intake, so a
+  producer written against the old wire keeps working while it migrates. 126
+  fields carry an alias.
+
+  **Scope is deliberately narrow, and three exclusions are not oversights:**
+
+  - **Config (`setup/from_toml.rs`)** is TOML, where snake_case is idiomatic and
+    is not a wire at all.
+  - **Persisted stores and the backup file format** (`backup_management/types.rs`,
+    `drain_store.rs`) are read back from disk. Re-casing those would fail to read
+    data already written — a worse bug than the one being fixed. Note that
+    `WebvhDidRecord` *is* both wire and persisted: it is folded, and reads of
+    existing snake_case records keep working precisely because of the aliases.
+  - **`protocols/credential_exchange.rs`** carries OID4VCI and OID4VP structures
+    (`vp_token`, `credential_offer`, `dcql_query`). §4.10 requires externally
+    owned names to be carried verbatim, never re-cased. The conformance harness
+    caught this when a first pass re-cased `vp_token`, which is exactly what that
+    test is for.
+
+  REST request/response bodies (`routes/`, `client/types.rs`, `protocol/`) are a
+  further 54 structs with the same problem. They are left for a separate change:
+  unlike task payloads, no published schema pins their casing, and changing what
+  they emit breaks readers that have no alias to fall back on.
+
+  Thirteen integration assertions read the old spelling and now read the new one.
+  Full suite green: 823 lib, 119 api_integration, 90 conformance, plus the rest.
+
+  * style: wrap the serde attributes the casing fold widened
+
+  Adding a per-field `alias` pushed several `#[serde(...)]` attributes past the
+  line width, so rustfmt wants them broken across lines. No semantic change —
+  `cargo fmt --all` output, nothing hand-edited.
+
+
+
 ## [0.17.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.17.0...vta-service-v0.17.1) — 2026-08-18
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.17.1"
+version = "0.18.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -139,12 +139,12 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.13", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Structured audit logging (the `audit!` macro + audit-keyspace helpers),
 # extracted and re-exported as `crate::audit`.
 vta-audit = { path = "../vta-audit", version = "0.1" }
@@ -163,7 +163,7 @@ vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-vault = { path = "../vta-vault", version = "0.3" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.
-vta-sweepers = { path = "../vta-sweepers", version = "0.1" }
+vta-sweepers = { path = "../vta-sweepers", version = "0.2" }
 # Backup/restore subsystem (export/import ops + backup-bundle store/sweeper),
 # extracted and re-exported as crate::operations::backup +
 # crate::{backup_bundle_store,backup_bundle_sweeper}. Feature edges: this
@@ -179,7 +179,7 @@ vta-policy = { path = "../vta-policy", version = "0.2" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -375,7 +375,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.8...vta-support-v0.2.9) — 2026-08-20
+
+
 ## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.7...vta-support-v0.2.8) — 2026-08-18
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }
 # `encryption` is REQUIRED, not optional: `seal.rs` calls
 # `KeyspaceHandle::with_encryption`, which is `#[cfg(feature = "encryption")]`.
@@ -29,8 +29,8 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # verifies each crate in isolation, where nothing enables it, so the method
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
-vti-common = { path = "../vti-common", version = "0.12", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.4...vta-sweepers-v0.2.0) — 2026-08-20
+
+
+### Added
+
+- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))
+
+A client that retries a timed-out request is doing the right thing. The
+  dangerous case is the one where the VTA processed it and only the reply
+  was lost, because the retry then produces a second durable effect —
+  `webvh/dids/create` being the sharp example, where auto-assigned paths
+  mean the retry mints a *different* DID and the first stays published
+  with nobody holding a reference to it.
+
+  The existing `trust_tasks::replay` layer cannot catch that. It keys on
+  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
+  attempt, so a genuine retry sails past it. Its own module docs name this
+  work as the deliberate follow-up.
+
+  ## Built on the store that was already here
+
+
+
 ## [0.1.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.3...vta-sweepers-v0.1.4) — 2026-08-18
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,9 +20,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 vta-audit = { path = "../vta-audit", version = "0.1" }
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-vault = { path = "../vta-vault", version = "0.3" }
 tracing = { workspace = true }
 chrono = { workspace = true }

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.8...vta-tee-v0.1.9) — 2026-08-20
+
+
+### Fixed
+
+- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))
+
+* fix(tee): retry transient ENOTCONN on first vsock config-overlay read
+
+  tokio-vsock can report a stream connected just before Nitro finishes the
+  nonblocking handshake, so the very first read on a fresh vsock:5800
+  connection to the parent config server can return ENOTCONN even though
+  the parent is listening and ready. Retry only that specific transient
+  error kind with a short delay; any other I/O error still fails closed
+  immediately, and the existing overall READ_TIMEOUT deadline still
+  bounds the whole fetch.
+
+  Adds positive (retries ENOTCONN then succeeds) and negative (does not
+  retry PermissionDenied) unit tests against the inner read loop.
+
+
+
 ## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.7...vta-tee-v0.1.8) — 2026-08-16
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,8 +27,8 @@ repository.workspace = true
 tenant-overlay = ["dep:tokio-vsock"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12", features = ["encryption", "openapi"] }
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
+vti-common = { path = "../vti-common", version = "0.13", features = ["encryption", "openapi"] }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3", features = ["tee"] }
 vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-support = { path = "../vta-support", version = "0.2" }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.1...vta-vault-v0.3.2) — 2026-08-20
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.0...vta-vault-v0.3.1) — 2026-08-18
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -32,9 +32,9 @@ bbs = ["dep:affinidi-bbs", "affinidi-data-integrity/bbs-2023"]
 webvh = ["dep:reqwest", "vta-sdk/client"]
 
 [dependencies]
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vti-common = { path = "../vti-common", version = "0.12", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["didcomm", "sealed-transfer"] }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
+vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.10...vta-webvh-v0.1.11) — 2026-08-20
+
+
 ## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.9...vta-webvh-v0.1.10) — 2026-08-18
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,9 +20,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vta-keyspaces = { path = "../vta-keyspaces", version = "0.1" }
-vti-common = { path = "../vti-common", version = "0.12" }
-vta-sdk = { path = "../vta-sdk", version = "0.25" }
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
+vti-common = { path = "../vti-common", version = "0.13" }
+vta-sdk = { path = "../vta-sdk", version = "0.26" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.8...vtc-client-v0.3.9) — 2026-08-20
+
+
 ## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.7...vtc-client-v0.3.8) — 2026-08-18
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -117,7 +117,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12", features = [
+vti-common = { path = "../vti-common", version = "0.13", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
@@ -134,7 +134,7 @@ vti-common = { path = "../vti-common", version = "0.12", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.2...vti-common-v0.13.0) — 2026-08-20
+
+
+### Added
+
+- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))
+
+A client that retries a timed-out request is doing the right thing. The
+  dangerous case is the one where the VTA processed it and only the reply
+  was lost, because the retry then produces a second durable effect —
+  `webvh/dids/create` being the sharp example, where auto-assigned paths
+  mean the retry mints a *different* DID and the first stays published
+  with nobody holding a reference to it.
+
+  The existing `trust_tasks::replay` layer cannot catch that. It keys on
+  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
+  attempt, so a genuine retry sails past it. Its own module docs name this
+  work as the deliberate follow-up.
+
+  ## Built on the store that was already here
+
+
+
+### Fixed
+
+- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))
+
+* fix(tee): retry transient ENOTCONN on first vsock config-overlay read
+
+  tokio-vsock can report a stream connected just before Nitro finishes the
+  nonblocking handshake, so the very first read on a fresh vsock:5800
+  connection to the parent config server can return ENOTCONN even though
+  the parent is listening and ready. Retry only that specific transient
+  error kind with a short delay; any other I/O error still fails closed
+  immediately, and the existing overall READ_TIMEOUT deadline still
+  bounds the whole fetch.
+
+  Adds positive (retries ENOTCONN then succeeds) and negative (does not
+  retry PermissionDenied) unit tests against the inner read loop.
+
+
+
 ## [0.12.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.1...vti-common-v0.12.2) — 2026-08-18
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.12.2"
+version = "0.13.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.25", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.26", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.16](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.15...vti-secrets-v0.1.16) — 2026-08-20
+
+
 ## [0.1.15](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.14...vti-secrets-v0.1.15) — 2026-08-18
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.15"
+version = "0.1.16"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,14 +47,14 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.12" }
+vti-common = { path = "../vti-common", version = "0.13" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.25", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.25.1 -> 0.26.0 (⚠ API breaking changes)
* `vti-common`: 0.12.2 -> 0.13.0 (⚠ API breaking changes)
* `vta-cli-common`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `cnm-cli`: 0.11.23 -> 0.11.24
* `pnm-cli`: 0.12.7 -> 0.12.8
* `vta-keyspaces`: 0.1.5 -> 0.2.0
* `vta-backup`: 0.1.11 -> 0.1.12
* `vta-sweepers`: 0.1.4 -> 0.2.0
* `vta-tee`: 0.1.8 -> 0.1.9
* `vta-service`: 0.17.1 -> 0.18.0 (✓ API compatible changes)
* `vtc-client`: 0.3.8 -> 0.3.9 (✓ API compatible changes)
* `vta-audit`: 0.1.7 -> 0.1.8
* `vti-secrets`: 0.1.15 -> 0.1.16
* `vta-config`: 0.3.9 -> 0.3.10
* `vta-keys`: 0.2.6 -> 0.2.7
* `vta-support`: 0.2.8 -> 0.2.9
* `vta-policy`: 0.2.8 -> 0.2.9
* `vta-vault`: 0.3.1 -> 0.3.2
* `vta-webvh`: 0.1.10 -> 0.1.11

### ⚠ `vta-sdk` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant VtaError:Unavailable in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vta-sdk/src/error.rs:192
  variant VtaError:Unavailable in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vta-sdk/src/error.rs:192
```

### ⚠ `vti-common` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CacheEntry.state in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vti-common/src/idempotency/store.rs:132
  field CacheEntry.state in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vti-common/src/idempotency/store.rs:132

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Principal:Did in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vti-common/src/idempotency/store.rs:43
  variant Principal:Did in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vti-common/src/idempotency/store.rs:43
  variant AppError:Gone in /tmp/.tmpLEQKoi/verifiable-trust-infrastructure/vti-common/src/error.rs:42
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.26.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.25.1...vta-sdk-v0.26.0) — 2026-08-20

### Added

- **service**: Retire an orphaned webvh slot, on evidence rather than assertion ([#1022](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1022))

`vta/webvh/servers/reconcile` names two divergences and repairs
  neither, deliberately — they want opposite remedies. This implements the
  remedy for one: the orphan, a slot a hosting server serves for this VTA
  that the VTA has no record of.

  Nothing could repair that state, and the reason is structural. Every
  delete addresses a DID through its local record, which is what says
  which server to talk to and which keys to sign with; an orphan is
  defined by that record's absence, so the lookup fails before a request
  leaves the VTA. Nor can the caller go around it — the VTA holds the host
  credentials. A slot both parties can see, and neither can remove.

- **service**: The vta/services task family, and the twenty routes it supersedes ([#1017](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1017))

* feat(service): the vta/services task family, one verb per task

  Eight handlers covering what twenty `/services/*` REST routes did. The
  operations are untouched — `operations::protocol::*` already implements each
  transport — so this is the parameterised door onto them, not new logic.

  `service` names the transport and `config` carries its settings, so the fan-out
  happens here rather than on the wire. That is what keeps a fifth transport to a
  config variant instead of four new specs.

  **The drain guard is the part that matters.** Tearing down a mediator discards
  whatever is in flight through it, so `disable`/`update`/`rollback` on didcomm
  pass a `DisableTransport` that decides whether the 1-hour floor applies. The
  REST route hardcodes `Rest` and the DIDComm handler hardcodes `Didcomm`,
  because each IS that path; a trust task is not, so it reads the arrival
  transport from the dispatch spine.

  The spine records confidentiality, not binding: DIDComm and TSP are both
  `EndToEnd` and it cannot tell them apart. `EndToEnd` therefore maps to
  `Didcomm`, which OVER-applies the floor to a TSP-carried disable that does not
  strictly need it. Deliberate: under-applying tears down the mediator a request
  arrived through and discards the reply to the very task asking for it, while
  over-applying only delays a teardown the operator can repeat. The ambiguous
  case takes the cheaper mistake.

  Three shapes the generated types forced, each documented where it lands:

  - `ServiceMutationResult` and `RollbackKind` are duplicated per family —
    identical shapes, distinct types. Mutation results round-trip through the wire
    form rather than being hand-copied three times; rollback kinds go through a
    macro that names the variants, so a divergence is a compile error.
  - Rollback may write nothing. Its `noOp` arm has no `logEntryVersionId`, which
    is why it has its own result type, and the witness uses exactly that arm.
  - `handshake_timeout_secs` is `NonZeroU64` — the schema's `minimum: 1` — so the
    default is constructed, not unwrapped.

  **Operation futures are boxed, and that is load-bearing.** These handlers fan
  out to four sizeable futures, awaited inside a dispatch match that already
  carries every other task's state machine. Inlining them grew the frame past the
  default 8 MiB stack and aborted an unrelated mock_vta test with a stack
  overflow — which reads as infinite recursion and is not.

- **sdk**: Hold one idempotency key across every attempt of an operation ([#1012](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1012))

The VTA deduplicates keyed Trust Tasks on an `idempotencyKey` ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011)).
  That only helps if the retry carries the *same* key as the attempt it is
  retrying — and a hand-rolled retry loop structurally cannot do that,
  because it re-invokes a client method that builds a fresh document each
  time. Minting the key inside the method has the identical problem the
  envelope id already has: attempt two gets a new one, the VTA sees an
  unrelated request, and the second durable effect happens anyway.

  So the key has to be scoped *outside* the call. `VtaClient::idempotent`
  mints one, holds it in a task-local for the duration of a closure, and
  retries transient faults inside that scope:

      let key = client.idempotent(|| client.create_key(req.clone())).await?;

  Every dispatch the closure makes carries the same key. A task-local
  rather than a parameter because it has to reach all twenty-odd typed
  methods without changing twenty signatures, and because it is genuinely
  ambient — it belongs to the operation, not the call.

  The key is attached only when the task is one a second execution would
  actually harm (`retry_safety`); attaching it to a read would cost the
  VTA a dedup record and buy nothing. It goes top-level beside `id`, where
  the VTA reads it from `TrustTask::extra` and a Data-Integrity proof
  covers it — so a relayer cannot rewrite it to split one operation
  into two.
</blockquote>

## `vti-common`

<blockquote>

## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.2...vti-common-v0.13.0) — 2026-08-20

### Added

- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))

A client that retries a timed-out request is doing the right thing. The
  dangerous case is the one where the VTA processed it and only the reply
  was lost, because the retry then produces a second durable effect —
  `webvh/dids/create` being the sharp example, where auto-assigned paths
  mean the retry mints a *different* DID and the first stays published
  with nobody holding a reference to it.

  The existing `trust_tasks::replay` layer cannot catch that. It keys on
  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
  attempt, so a genuine retry sails past it. Its own module docs name this
  work as the deliberate follow-up.
</blockquote>

## `vta-cli-common`

<blockquote>

## [0.11.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.1...vta-cli-common-v0.11.2) — 2026-08-20

### Fixed

- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))

* fix(tee): retry transient ENOTCONN on first vsock config-overlay read

  tokio-vsock can report a stream connected just before Nitro finishes the
  nonblocking handshake, so the very first read on a fresh vsock:5800
  connection to the parent config server can return ENOTCONN even though
  the parent is listening and ready. Retry only that specific transient
  error kind with a short delay; any other I/O error still fails closed
  immediately, and the existing overall READ_TIMEOUT deadline still
  bounds the whole fetch.

  Adds positive (retries ENOTCONN then succeeds) and negative (does not
  retry PermissionDenied) unit tests against the inner read loop.
</blockquote>


## `pnm-cli`

<blockquote>

## [0.12.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.7...pnm-cli-v0.12.8) — 2026-08-20

### Documentation

- **pnm-cli**: Document the tsp and azure-secrets build features ([#1016](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1016))

The README's Feature Flags table listed two of the crate's four features.
  Both omissions changed what an operator ends up with:

  `tsp` is a default (`default = ["keyring", "tsp"]`) and gates the round-trip
  TSP probe in `pnm health`. The keyring-free build the README recommended,
  `--no-default-features --features config-session`, silently dropped it, after
  which `pnm health` reports an advertised TSPTransport service without ever
  exercising it. The build examples now re-add `tsp` and say why.

  `azure-secrets` is off by default and inert unless `keyring` is also off --
  the backend's Azure arm is gated `not(feature = "keyring")` -- so adding it to
  a default build selects nothing and reports no error.

  The section also claimed "at least one of keyring or config-session must be
  enabled". Nothing enforces that. With neither, the backend falls through to
  the plaintext file store and warns on every access, which is a materially
  different guarantee from the build-time gate the sentence implied. Replaced
  with the real selection order, keyring -> azure-secrets -> config-session ->
  plaintext fallback, and the warning verbatim.
</blockquote>

## `vta-keyspaces`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.5...vta-keyspaces-v0.2.0) — 2026-08-20

### Added

- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))

A client that retries a timed-out request is doing the right thing. The
  dangerous case is the one where the VTA processed it and only the reply
  was lost, because the retry then produces a second durable effect —
  `webvh/dids/create` being the sharp example, where auto-assigned paths
  mean the retry mints a *different* DID and the first stays published
  with nobody holding a reference to it.

  The existing `trust_tasks::replay` layer cannot catch that. It keys on
  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
  attempt, so a genuine retry sails past it. Its own module docs name this
  work as the deliberate follow-up.
</blockquote>

## `vta-backup`

<blockquote>

## [0.1.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.11...vta-backup-v0.1.12) — 2026-08-20

### Fixed

- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))

* fix(tee): retry transient ENOTCONN on first vsock config-overlay read

  tokio-vsock can report a stream connected just before Nitro finishes the
  nonblocking handshake, so the very first read on a fresh vsock:5800
  connection to the parent config server can return ENOTCONN even though
  the parent is listening and ready. Retry only that specific transient
  error kind with a short delay; any other I/O error still fails closed
  immediately, and the existing overall READ_TIMEOUT deadline still
  bounds the whole fetch.

  Adds positive (retries ENOTCONN then succeeds) and negative (does not
  retry PermissionDenied) unit tests against the inner read loop.
</blockquote>

## `vta-sweepers`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.4...vta-sweepers-v0.2.0) — 2026-08-20

### Added

- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))

A client that retries a timed-out request is doing the right thing. The
  dangerous case is the one where the VTA processed it and only the reply
  was lost, because the retry then produces a second durable effect —
  `webvh/dids/create` being the sharp example, where auto-assigned paths
  mean the retry mints a *different* DID and the first stays published
  with nobody holding a reference to it.

  The existing `trust_tasks::replay` layer cannot catch that. It keys on
  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
  attempt, so a genuine retry sails past it. Its own module docs name this
  work as the deliberate follow-up.
</blockquote>

## `vta-tee`

<blockquote>

## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.8...vta-tee-v0.1.9) — 2026-08-20

### Fixed

- **tee**: Bootstrap 410 and vsock enotconn ([#1003](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1003))

* fix(tee): retry transient ENOTCONN on first vsock config-overlay read

  tokio-vsock can report a stream connected just before Nitro finishes the
  nonblocking handshake, so the very first read on a fresh vsock:5800
  connection to the parent config server can return ENOTCONN even though
  the parent is listening and ready. Retry only that specific transient
  error kind with a short delay; any other I/O error still fails closed
  immediately, and the existing overall READ_TIMEOUT deadline still
  bounds the whole fetch.

  Adds positive (retries ENOTCONN then succeeds) and negative (does not
  retry PermissionDenied) unit tests against the inner read loop.
</blockquote>

## `vta-service`

<blockquote>

## [0.18.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.17.1...vta-service-v0.18.0) — 2026-08-20

### Added

- **service**: Retire an orphaned webvh slot, on evidence rather than assertion ([#1022](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1022))

`vta/webvh/servers/reconcile` names two divergences and repairs
  neither, deliberately — they want opposite remedies. This implements the
  remedy for one: the orphan, a slot a hosting server serves for this VTA
  that the VTA has no record of.

  Nothing could repair that state, and the reason is structural. Every
  delete addresses a DID through its local record, which is what says
  which server to talk to and which keys to sign with; an orphan is
  defined by that record's absence, so the lookup fails before a request
  leaves the VTA. Nor can the caller go around it — the VTA holds the host
  credentials. A slot both parties can see, and neither can remove.

- **service**: The vta/services task family, and the twenty routes it supersedes ([#1017](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1017))

* feat(service): the vta/services task family, one verb per task

  Eight handlers covering what twenty `/services/*` REST routes did. The
  operations are untouched — `operations::protocol::*` already implements each
  transport — so this is the parameterised door onto them, not new logic.

  `service` names the transport and `config` carries its settings, so the fan-out
  happens here rather than on the wire. That is what keeps a fifth transport to a
  config variant instead of four new specs.

  **The drain guard is the part that matters.** Tearing down a mediator discards
  whatever is in flight through it, so `disable`/`update`/`rollback` on didcomm
  pass a `DisableTransport` that decides whether the 1-hour floor applies. The
  REST route hardcodes `Rest` and the DIDComm handler hardcodes `Didcomm`,
  because each IS that path; a trust task is not, so it reads the arrival
  transport from the dispatch spine.

  The spine records confidentiality, not binding: DIDComm and TSP are both
  `EndToEnd` and it cannot tell them apart. `EndToEnd` therefore maps to
  `Didcomm`, which OVER-applies the floor to a TSP-carried disable that does not
  strictly need it. Deliberate: under-applying tears down the mediator a request
  arrived through and discards the reply to the very task asking for it, while
  over-applying only delays a teardown the operator can repeat. The ambiguous
  case takes the cheaper mistake.

  Three shapes the generated types forced, each documented where it lands:

  - `ServiceMutationResult` and `RollbackKind` are duplicated per family —
    identical shapes, distinct types. Mutation results round-trip through the wire
    form rather than being hand-copied three times; rollback kinds go through a
    macro that names the variants, so a divergence is a compile error.
  - Rollback may write nothing. Its `noOp` arm has no `logEntryVersionId`, which
    is why it has its own result type, and the witness uses exactly that arm.
  - `handshake_timeout_secs` is `NonZeroU64` — the schema's `minimum: 1` — so the
    default is constructed, not unwrapped.

  **Operation futures are boxed, and that is load-bearing.** These handlers fan
  out to four sizeable futures, awaited inside a dispatch match that already
  carries every other task's state machine. Inlining them grew the frame past the
  default 8 MiB stack and aborted an unrelated mock_vta test with a stack
  overflow — which reads as infinite recursion and is not.

- **vta**: Dedup keyed Trust Tasks on an idempotency key ([#1011](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1011))

A client that retries a timed-out request is doing the right thing. The
  dangerous case is the one where the VTA processed it and only the reply
  was lost, because the retry then produces a second durable effect —
  `webvh/dids/create` being the sharp example, where auto-assigned paths
  mean the retry mints a *different* DID and the first stays published
  with nobody holding a reference to it.

  The existing `trust_tasks::replay` layer cannot catch that. It keys on
  `(actor, envelope-id)` and every SDK path mints a fresh `urn:uuid:` per
  attempt, so a genuine retry sails past it. Its own module docs name this
  work as the deliberate follow-up.
</blockquote>











</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).