### PR TITLE
fix(sdk): build these two task payloads from their typed bodies

### DIFF
--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -143,7 +143,9 @@ impl VtaClient {
     pub async fn get_key_secret(&self, key_id: &str) -> Result<GetKeySecretResponse, VtaError> {
         self.rpc_tt(
             trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
-            serde_json::json!({ "key_id": key_id }),
+            serde_json::to_value(crate::protocols::key_management::secret::GetKeySecretBody {
+                key_id: key_id.to_string(),
+            })?,
             30,
         )
         .await

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -165,10 +165,10 @@ impl VtaClient {
     ) -> Result<crate::protocols::did_management::list::ListDidsWebvhResultBody, VtaError> {
         self.rpc_tt(
             crate::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
-            serde_json::json!({
-                "context_id": context_id,
-                "server_id": server_id,
-            }),
+            serde_json::to_value(crate::protocols::did_management::list::ListDidsWebvhBody {
+                context_id: context_id.map(str::to_string),
+                server_id: server_id.map(str::to_string),
+            })?,
             30,
         )
         .await

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1295,7 +1295,10 @@ async fn list_dids_webvh_filters_by_context() {
         .and(auth_match())
         .and(body_partial_json(json!({
             "type": TASK_WEBVH_DIDS_LIST,
-            "payload": {"context_id": "primary", "server_id": "s1"}
+            // camelCase: the payload is built from `ListDidsWebvhBody`, which
+            // emits the canonical spelling rather than whatever a hand-written
+            // literal happened to say.
+            "payload": {"contextId": "primary", "serverId": "s1"}
         })))
         .respond_with(tt_ok(json!({
             "dids": [webvh_did_record_json("did:webvh:Qabc:server.example.com:primary")]


### PR DESCRIPTION
## What

`get_key_secret` and `list_dids_webvh` were the last two `rpc_tt` call sites
building their payload as a hand-written `serde_json::json!` literal, so they
emitted `key_id`, `context_id` and `server_id` — snake_case, against a
SPEC §4.10 contract that says lowerCamelCase.

Both now build the typed body (`GetKeySecretBody`, `ListDidsWebvhBody`).

## Why the earlier casing fold missed them

#1000's fold rewrote **structs** via `rename_all`. A `json!` literal has no
struct to fold, so it kept whatever spelling was typed — this was called out as
the "known gap" in that PR and this closes it.

Nothing was broken: both structs carry `#[serde(alias = "…")]` for the old
spelling, so the VTA accepted what the SDK sent. But the SDK was emitting a
non-canonical spelling of its own published contract, and a consumer generated
from the schemas would not have recognised it.

Building from the typed body means the wire spelling now comes from the same
struct the schema is generated from, so the two cannot drift again — which is
the actual fix, rather than correcting three strings.

## A second, smaller win

`list_dids_webvh`'s literal emitted `"context_id": null` for an absent filter.
`ListDidsWebvhBody` carries `skip_serializing_if = "Option::is_none"`, so the
key is now omitted entirely.

## Verification

`list_dids_webvh_filters_by_context` asserted the old spelling and now asserts
`contextId` / `serverId` — the test is the proof the **emitted wire** changed,
not merely the source.

A sweep confirms none are left:

```
snake_case keys left in rpc_tt payloads: none
```

- `cargo clippy --workspace -- -D warnings` — 0 errors
- `cargo test --workspace --features session,tsp` — **4469 passing, 0 failures**

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] **New/changed wire types: camelCase, schema registered, consumers updated
      (R3.\*)** — this is the whole PR; the receiving structs already accepted
      both spellings, so no consumer needs a lockstep change
- [x] Config absence = most restrictive (R5.*)
- [x] Logs/status claim only what was verified (R6.*)
- [x] Deviations flagged with rule numbers