### PR TITLE
ci: guard the release workflows too, minus the cancellation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
     # after the Release PR merges. An ordinary feature merge is a no-op.
     name: Release-plz release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: read
@@ -58,7 +59,42 @@ jobs:
           persist-credentials: false
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -81,6 +117,7 @@ jobs:
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -96,7 +133,42 @@ jobs:
           persist-credentials: false
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: |
+          # `apt-get update` is the operation that hangs here — three runs
+          # stalled on it, and once each attempt was bounded the timings showed
+          # every failure landing on the 90s `update` ceiling, never on the
+          # install. The mirror is unresponsive; retrying it harder does not
+          # help.
+          #
+          # So don't run it unless it is actually needed. The runner image ships
+          # a usable package index, and pkg-config is already present on
+          # ubuntu-24.04, so the fast path is to check what is missing and
+          # install straight from the shipped index. Refreshing the index is the
+          # fallback, still bounded and retried, for the case where the package
+          # genuinely is not in it.
+          pkgs=""
+          for p in libdbus-1-dev pkg-config; do
+            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+          done
+          if [ -z "$pkgs" ]; then
+            echo "libdbus-1-dev and pkg-config already present; nothing to do"
+            exit 0
+          fi
+          echo "missing:$pkgs"
+          if sudo timeout 120 apt-get install -y $pkgs; then
+            exit 0
+          fi
+          echo "::warning::install from the shipped index failed; refreshing"
+          for attempt in 1 2 3; do
+            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+            sleep 10
+          done
+          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
+          exit 1
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release-mobile-ios.yml
+++ b/.github/workflows/release-mobile-ios.yml
@@ -21,6 +21,7 @@ jobs:
   ios-xcframework:
     name: Package + publish iOS xcframework
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Why now

#1002 hardened `ci.yml` and deliberately left the release workflows alone, on
the grounds that they needed someone looking at the release path rather than a
blanket sweep. Having looked, one of them has the same bug — in a worse place.

## `publish.yml` carries the unhardened apt step, twice

```yaml
run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
```

That is the exact step that hung for up to an hour on **five separate CI runs**
this morning, and here it sits in front of publishing crates. The failure mode
isn't a slow build — it's a release that never happens, with nothing saying
why.

It now uses the same block `ci.yml` proved on main: check what's missing with
`dpkg -s`, install from the index the runner image already ships (`pkg-config`
is present on ubuntu-24.04), and fall back to a bounded, retried `apt-get
update` only if the package genuinely isn't there. On CI that took the step
from a 20–60 minute hang to **5 seconds**.

## Timeouts on all three jobs

From observed durations, not guesses:

| Job | Observed | Ceiling |
|---|---|---|
| Release-plz PR | 9m | 30 |
| iOS xcframework | 27m | 60 |
| Release-plz release | (no-op on last run) | 60 |

The release job gets the most headroom **on purpose**. A ceiling that fires
part-way through publishing a workspace of crates leaves a partial release —
worse than the hang it guards against. It is set to catch a wedged job and
nothing tighter.

## No `concurrency` group, deliberately

This is why the release workflows warranted their own PR rather than riding
#1002. `cancel-in-progress` on a workflow that publishes crates or ships an
xcframework could kill it mid-flight and leave a partial release. These want
**bounding, not cancellation** — so they get timeouts and the apt fix, and no
concurrency group.

## Verification

- Both files parse as YAML; every job carries `timeout-minutes`
- The apt block is copied from `ci.yml` rather than re-written, and passes
  `bash -n`
- Neither file gained a concurrency group (asserted, not assumed)