### PR TITLE
feat(service): signal every superseded REST route, from one layer

### DIFF
--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1899,10 +1899,6 @@ async fn fetch_context_secrets_walks_all_pages() {
     assert_eq!(secrets.len(), 101);
 }
 
-// `path_regex` is in `wiremock::matchers` — re-exported here for
-// readability above.
-use wiremock::matchers::path_regex;
-
 // ── Error-mapping coverage (status → typed variant) ─────────────────
 
 #[tokio::test]

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -11,8 +11,12 @@
 //! dispatched as a Trust-Task via `POST /api/trust-tasks` (reachable over REST,
 //! DIDComm, and TSP through the shared `dispatch_trust_task_core` spine).
 
+use axum::extract::{MatchedPath, Request};
 use axum::http::{HeaderMap, HeaderValue};
+use axum::middleware::Next;
+use axum::response::Response;
 use metrics::counter;
+use vta_sdk::trust_tasks;
 
 /// Build the deprecation response headers for a legacy `route`, pointing at the
 /// successor Trust-Task URI, and record a hit for that route.
@@ -28,4 +32,380 @@ pub fn superseded(route: &'static str, successor: &'static str) -> HeaderMap {
         headers.insert("link", link);
     }
     headers
+}
+
+// ─── The superseded-route table ────────────────────────────────────────────
+//
+// `(method, matched-path, metric label, successor Trust-Task URI)`.
+//
+// Recovered from the `build_rest` closures the SDK carried before #1000
+// deleted them: each paired a Trust-Task constant with the exact REST route it
+// fell back to, so this mapping is what the client itself used rather than a
+// guess from matching names. Two entries look wrong at a glance and are not —
+// `GET /webvh/dids/{scid}/log` points at `dids/get`, because the dedicated
+// get-log task folded into it behind `includeLog`; and
+// `PATCH /webvh/servers/{id}` points at `servers/register`, because #850
+// folded add and update into that one task.
+//
+// A route absent from this table is absent on purpose. `/services/*` has no
+// Trust-Task twin at all (it needs specs first), and `/auth`, `/bootstrap`,
+// `/backup` blob streaming, `/keys/import/wrapping-key`, `/metrics` and
+// `/.well-known` are genuinely REST and are not going anywhere.
+const SUPERSEDED: &[(&str, &str, &str, &str)] = &[
+    ("GET", "/acl", "GET /acl", trust_tasks::TASK_ACL_LIST_0_1),
+    ("POST", "/acl", "POST /acl", trust_tasks::TASK_ACL_GRANT_0_1),
+    (
+        "DELETE",
+        "/acl/{did}",
+        "DELETE /acl/{did}",
+        trust_tasks::TASK_ACL_REVOKE_0_1,
+    ),
+    (
+        "GET",
+        "/acl/{did}",
+        "GET /acl/{did}",
+        trust_tasks::TASK_ACL_SHOW_0_1,
+    ),
+    (
+        "PATCH",
+        "/acl/{did}",
+        "PATCH /acl/{did}",
+        trust_tasks::TASK_ACL_UPDATE_0_1,
+    ),
+    (
+        "POST",
+        "/acl/{did}/change-role",
+        "POST /acl/{did}/change-role",
+        trust_tasks::TASK_ACL_CHANGE_ROLE_0_1,
+    ),
+    (
+        "GET",
+        "/audit/logs",
+        "GET /audit/logs",
+        trust_tasks::TASK_AUDIT_LIST_0_1,
+    ),
+    (
+        "GET",
+        "/audit/retention",
+        "GET /audit/retention",
+        trust_tasks::TASK_AUDIT_GET_RETENTION_1_0,
+    ),
+    (
+        "PATCH",
+        "/audit/retention",
+        "PATCH /audit/retention",
+        trust_tasks::TASK_AUDIT_UPDATE_RETENTION_1_0,
+    ),
+    (
+        "GET",
+        "/capabilities",
+        "GET /capabilities",
+        trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
+    ),
+    (
+        "GET",
+        "/config",
+        "GET /config",
+        trust_tasks::TASK_CONFIG_SHOW_0_1,
+    ),
+    (
+        "PATCH",
+        "/config",
+        "PATCH /config",
+        trust_tasks::TASK_CONFIG_PATCH_0_1,
+    ),
+    (
+        "GET",
+        "/contexts",
+        "GET /contexts",
+        trust_tasks::TASK_CONTEXTS_LIST_1_0,
+    ),
+    (
+        "POST",
+        "/contexts",
+        "POST /contexts",
+        trust_tasks::TASK_CONTEXTS_CREATE_1_0,
+    ),
+    (
+        "DELETE",
+        "/contexts/{id}",
+        "DELETE /contexts/{id}",
+        trust_tasks::TASK_CONTEXTS_DELETE_1_0,
+    ),
+    (
+        "GET",
+        "/contexts/{id}",
+        "GET /contexts/{id}",
+        trust_tasks::TASK_CONTEXTS_GET_1_0,
+    ),
+    (
+        "PATCH",
+        "/contexts/{id}",
+        "PATCH /contexts/{id}",
+        trust_tasks::TASK_CONTEXTS_UPDATE_1_0,
+    ),
+    (
+        "GET",
+        "/contexts/{id}/delete-preview",
+        "GET /contexts/{id}/delete-preview",
+        trust_tasks::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
+    ),
+    (
+        "PUT",
+        "/contexts/{id}/did",
+        "PUT /contexts/{id}/did",
+        trust_tasks::TASK_CONTEXTS_UPDATE_DID_1_0,
+    ),
+    (
+        "GET",
+        "/contexts/{id}/did-templates",
+        "GET /contexts/{id}/did-templates",
+        trust_tasks::TASK_DID_TEMPLATES_LIST_2_0,
+    ),
+    (
+        "POST",
+        "/contexts/{id}/did-templates",
+        "POST /contexts/{id}/did-templates",
+        trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0,
+    ),
+    (
+        "DELETE",
+        "/contexts/{id}/did-templates/{name}",
+        "DELETE /contexts/{id}/did-templates/{name}",
+        trust_tasks::TASK_DID_TEMPLATES_DELETE_2_0,
+    ),
+    (
+        "GET",
+        "/contexts/{id}/did-templates/{name}",
+        "GET /contexts/{id}/did-templates/{name}",
+        trust_tasks::TASK_DID_TEMPLATES_GET_2_0,
+    ),
+    (
+        "PUT",
+        "/contexts/{id}/did-templates/{name}",
+        "PUT /contexts/{id}/did-templates/{name}",
+        trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0,
+    ),
+    (
+        "POST",
+        "/contexts/{id}/did-templates/{name}/render",
+        "POST /contexts/{id}/did-templates/{name}/render",
+        trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0,
+    ),
+    (
+        "GET",
+        "/did-templates",
+        "GET /did-templates",
+        trust_tasks::TASK_DID_TEMPLATES_LIST_2_0,
+    ),
+    (
+        "POST",
+        "/did-templates",
+        "POST /did-templates",
+        trust_tasks::TASK_DID_TEMPLATES_CREATE_2_0,
+    ),
+    (
+        "DELETE",
+        "/did-templates/{name}",
+        "DELETE /did-templates/{name}",
+        trust_tasks::TASK_DID_TEMPLATES_DELETE_2_0,
+    ),
+    (
+        "GET",
+        "/did-templates/{name}",
+        "GET /did-templates/{name}",
+        trust_tasks::TASK_DID_TEMPLATES_GET_2_0,
+    ),
+    (
+        "PUT",
+        "/did-templates/{name}",
+        "PUT /did-templates/{name}",
+        trust_tasks::TASK_DID_TEMPLATES_UPDATE_2_0,
+    ),
+    (
+        "POST",
+        "/did-templates/{name}/render",
+        "POST /did-templates/{name}/render",
+        trust_tasks::TASK_DID_TEMPLATES_RENDER_2_0,
+    ),
+    ("GET", "/keys", "GET /keys", trust_tasks::TASK_KEYS_LIST_0_1),
+    (
+        "POST",
+        "/keys",
+        "POST /keys",
+        trust_tasks::TASK_KEYS_CREATE_0_1,
+    ),
+    (
+        "POST",
+        "/keys/derive-and-sign",
+        "POST /keys/derive-and-sign",
+        trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1,
+    ),
+    (
+        "POST",
+        "/keys/derive-and-sign-document",
+        "POST /keys/derive-and-sign-document",
+        trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
+    ),
+    (
+        "POST",
+        "/keys/import",
+        "POST /keys/import",
+        trust_tasks::TASK_KEYS_IMPORT_0_1,
+    ),
+    (
+        "GET",
+        "/keys/seeds",
+        "GET /keys/seeds",
+        trust_tasks::TASK_SEEDS_LIST_1_0,
+    ),
+    (
+        "POST",
+        "/keys/seeds/rotate",
+        "POST /keys/seeds/rotate",
+        trust_tasks::TASK_SEEDS_ROTATE_1_0,
+    ),
+    (
+        "DELETE",
+        "/keys/{key_id}",
+        "DELETE /keys/{key_id}",
+        trust_tasks::TASK_KEYS_REVOKE_0_1,
+    ),
+    (
+        "GET",
+        "/keys/{key_id}",
+        "GET /keys/{key_id}",
+        trust_tasks::TASK_KEYS_SHOW_0_1,
+    ),
+    (
+        "PATCH",
+        "/keys/{key_id}",
+        "PATCH /keys/{key_id}",
+        trust_tasks::TASK_KEYS_RENAME_0_1,
+    ),
+    (
+        "GET",
+        "/keys/{key_id}/secret",
+        "GET /keys/{key_id}/secret",
+        trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
+    ),
+    (
+        "POST",
+        "/keys/{key_id}/sign",
+        "POST /keys/{key_id}/sign",
+        trust_tasks::TASK_KEYS_SIGN_0_1,
+    ),
+    (
+        "POST",
+        "/vta/restart",
+        "POST /vta/restart",
+        trust_tasks::TASK_MANAGEMENT_RELOAD_SERVICES_1_0,
+    ),
+    (
+        "GET",
+        "/webvh/dids",
+        "GET /webvh/dids",
+        trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
+    ),
+    (
+        "POST",
+        "/webvh/dids",
+        "POST /webvh/dids",
+        trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
+    ),
+    (
+        "DELETE",
+        "/webvh/dids/{did}",
+        "DELETE /webvh/dids/{did}",
+        trust_tasks::TASK_WEBVH_DIDS_DELETE_1_0,
+    ),
+    (
+        "GET",
+        "/webvh/dids/{did}",
+        "GET /webvh/dids/{did}",
+        trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
+    ),
+    (
+        "GET",
+        "/webvh/dids/{did}/log",
+        "GET /webvh/dids/{did}/log",
+        trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
+    ),
+    (
+        "POST",
+        "/webvh/dids/{did}/register-server",
+        "POST /webvh/dids/{did}/register-server",
+        trust_tasks::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+    ),
+    (
+        "GET",
+        "/webvh/servers",
+        "GET /webvh/servers",
+        trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0,
+    ),
+    (
+        "POST",
+        "/webvh/servers",
+        "POST /webvh/servers",
+        trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
+    ),
+    (
+        "DELETE",
+        "/webvh/servers/{id}",
+        "DELETE /webvh/servers/{id}",
+        trust_tasks::TASK_WEBVH_SERVERS_REMOVE_1_0,
+    ),
+    (
+        "PATCH",
+        "/webvh/servers/{id}",
+        "PATCH /webvh/servers/{id}",
+        trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0,
+    ),
+    (
+        "GET",
+        "/webvh/servers/{id}/domains",
+        "GET /webvh/servers/{id}/domains",
+        trust_tasks::TASK_WEBVH_SERVERS_DOMAINS_0_1,
+    ),
+    (
+        "GET",
+        "/webvh/servers/{id}/reconcile",
+        "GET /webvh/servers/{id}/reconcile",
+        trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1,
+    ),
+];
+
+/// Middleware: tag any response served by a superseded REST route.
+///
+/// A layer rather than a call inside each of the 56 handlers, because the
+/// per-handler form has to thread a `HeaderMap` back through the return type —
+/// and a handler with several `Ok(...)` arms only has to miss one for its route
+/// to go quiet and read as "nobody calls this any more". Since the whole point
+/// is to delete routes on the strength of a zero reading, a signal that can be
+/// half-applied is worse than none. Matching on [`MatchedPath`] cannot be.
+pub async fn mark_superseded(req: Request, next: Next) -> Response {
+    let hit = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .and_then(|path| {
+            let method = req.method().as_str();
+            SUPERSEDED
+                .iter()
+                .find(|(m, p, _, _)| *m == method && *p == path)
+        })
+        .copied();
+
+    let mut resp = next.run(req).await;
+
+    if let Some((_, _, label, successor)) = hit {
+        // Only a response the route actually produced counts as usage. A 404,
+        // or a request rejected before it reached the handler, says nothing
+        // about a client depending on this route — counting those would hold
+        // the metric off zero forever and the route could never be retired.
+        if resp.status().is_success() {
+            resp.headers_mut().extend(superseded(label, successor));
+        }
+    }
+    resp
 }

--- a/vta-service/src/routes/contexts.rs
+++ b/vta-service/src/routes/contexts.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use serde::Deserialize;
 
 use vta_sdk::protocols::context_management::{
@@ -53,15 +53,9 @@ pub struct DeleteContextQuery {
 pub async fn list_contexts_handler(
     auth: AuthClaims,
     State(state): State<AppState>,
-) -> Result<(HeaderMap, Json<ListContextsResultBody>), AppError> {
+) -> Result<Json<ListContextsResultBody>, AppError> {
     let result = operations::contexts::list_contexts(&state.contexts_ks, &auth, "rest").await?;
-    // Deprecated: superseded by the `contexts/list/1.0` Trust-Task via
-    // /api/trust-tasks. See `crate::deprecation`.
-    let headers = crate::deprecation::superseded(
-        "GET /contexts",
-        vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0,
-    );
-    Ok((headers, Json(result)))
+    Ok(Json(result))
 }
 
 /// POST /contexts — create a context. Auth: **admin** (the operation enforces
@@ -81,7 +75,7 @@ pub async fn create_context_handler(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateContextRequest>,
-) -> Result<(StatusCode, HeaderMap, Json<CreateContextResultBody>), AppError> {
+) -> Result<(StatusCode, Json<CreateContextResultBody>), AppError> {
     let result = operations::contexts::create_context(
         &state.contexts_ks,
         &auth.0,
@@ -92,12 +86,7 @@ pub async fn create_context_handler(
         "rest",
     )
     .await?;
-    // Deprecated: superseded by the `contexts/create/1.0` Trust-Task.
-    let headers = crate::deprecation::superseded(
-        "POST /contexts",
-        vta_sdk::trust_tasks::TASK_CONTEXTS_CREATE_1_0,
-    );
-    Ok((StatusCode::CREATED, headers, Json(result)))
+    Ok((StatusCode::CREATED, Json(result)))
 }
 
 /// GET /contexts/{id} — retrieve a single context by ID. Auth: any authenticated user.

--- a/vta-service/src/routes/did_webvh.rs
+++ b/vta-service/src/routes/did_webvh.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use serde::Deserialize;
 
 use vta_sdk::protocols::did_management::{
@@ -247,7 +247,7 @@ pub async fn create_did_handler(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(body): Json<CreateDidWebvhBody>,
-) -> Result<(StatusCode, HeaderMap, Json<CreateDidWebvhResultBody>), AppError> {
+) -> Result<(StatusCode, Json<CreateDidWebvhResultBody>), AppError> {
     let config = state.config.read().await;
     let params = body.into();
     let did_resolver = state
@@ -257,12 +257,7 @@ pub async fn create_did_handler(
     let deps =
         operations::did_webvh::CreateDidWebvhDeps::from_app_state(&state, &config, did_resolver);
     let result = operations::did_webvh::create_did_webvh(&deps, &auth.0, params, "rest").await?;
-    // Deprecated: superseded by the `vta/webvh/dids/create/1.0` Trust-Task.
-    let headers = crate::deprecation::superseded(
-        "POST /webvh/dids",
-        vta_sdk::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
-    );
-    Ok((StatusCode::CREATED, headers, Json(result)))
+    Ok((StatusCode::CREATED, Json(result)))
 }
 
 /// GET /webvh/dids — list webvh DIDs with optional filters. Auth: any authenticated user.
@@ -279,7 +274,7 @@ pub async fn list_dids_handler(
     auth: AuthClaims,
     State(state): State<AppState>,
     Query(query): Query<ListDidsQuery>,
-) -> Result<(HeaderMap, Json<ListDidsWebvhResultBody>), AppError> {
+) -> Result<Json<ListDidsWebvhResultBody>, AppError> {
     let result = operations::did_webvh::list_dids_webvh(
         &state.webvh_ks,
         &auth,
@@ -288,12 +283,7 @@ pub async fn list_dids_handler(
         "rest",
     )
     .await?;
-    // Deprecated: superseded by the `vta/webvh/dids/list/1.0` Trust-Task.
-    let headers = crate::deprecation::superseded(
-        "GET /webvh/dids",
-        vta_sdk::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
-    );
-    Ok((headers, Json(result)))
+    Ok(Json(result))
 }
 
 /// GET /webvh/dids/{did} — retrieve a single webvh DID record. Auth: any authenticated user.

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -634,6 +634,14 @@ pub fn router_with_cors(
     // connection indefinitely). The blob branch's own 100 MB body limit,
     // applied inner to this 1 MB global one, still wins for that branch
     // (the inner layer sets the limit extension last).
+    // Tag responses from REST routes a Trust-Task has superseded, and count
+    // them. Inside the body-limit and timeout layers so it sees the response a
+    // route actually produced; see `crate::deprecation` for why removal is
+    // gated on this metric reaching zero rather than on a calendar date.
+    let router = router.layer(axum::middleware::from_fn(
+        crate::deprecation::mark_superseded,
+    ));
+
     let router =
         router
             .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -4063,3 +4063,93 @@ async fn body_cap_returns_413_for_oversized_payload() {
          DefaultBodyLimit::max(1 MB) layer appears to be missing"
     );
 }
+
+// ─── Superseded-route signalling ───────────────────────────────────────────
+//
+// `crate::deprecation` gates route removal on `deprecated_route_requests_total`
+// reaching zero. That only works if the signal is actually attached, so these
+// tests assert the middleware fires — a silent middleware would read exactly
+// like "nobody calls this route" and get it deleted out from under a client.
+
+/// Send a request and return the response headers alongside the status.
+async fn request_headers(app: &TestApp, req: Request<Body>) -> (StatusCode, axum::http::HeaderMap) {
+    let resp = app
+        .router
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("request failed");
+    (resp.status(), resp.headers().clone())
+}
+
+#[tokio::test]
+async fn superseded_route_advertises_its_trust_task_successor() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/contexts")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, headers) = request_headers(&app, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    assert_eq!(
+        headers.get("deprecation").map(|v| v.to_str().unwrap()),
+        Some("true"),
+        "a superseded route must say so"
+    );
+    let link = headers
+        .get("link")
+        .expect("successor link")
+        .to_str()
+        .unwrap();
+    assert!(
+        link.contains(vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0),
+        "the link must name the successor task, got: {link}"
+    );
+    assert!(
+        link.contains("rel=\"successor-version\""),
+        "RFC 8288 relation, got: {link}"
+    );
+}
+
+#[tokio::test]
+async fn a_route_with_no_trust_task_twin_is_not_marked() {
+    // `/auth/challenge` is genuinely REST — it is the bootstrap that has to work
+    // before a Trust Task can be authenticated at all — so it must never be
+    // advertised as superseded.
+    let (app, _ctx) = TestApp::new().await;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/auth/challenge")
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"did":"did:key:z6MkSuper"}"#))
+        .unwrap();
+    let (_status, headers) = request_headers(&app, req).await;
+    assert!(
+        headers.get("deprecation").is_none(),
+        "a route with no successor must not be marked deprecated"
+    );
+}
+
+#[tokio::test]
+async fn an_unauthenticated_rejection_is_not_counted_as_usage() {
+    // Removal is gated on the counter reaching zero, so only a response the
+    // route actually produced may count. A rejected request says nothing about
+    // a client depending on the route, and counting it would hold the metric
+    // off zero forever.
+    let (app, _ctx) = TestApp::new().await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/contexts")
+        .body(Body::empty())
+        .unwrap();
+    let (status, headers) = request_headers(&app, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(
+        headers.get("deprecation").is_none(),
+        "an unauthorised request must not be recorded as usage"
+    );
+}


### PR DESCRIPTION
## Why

`crate::deprecation` already sets the policy — removal is gated on
`deprecated_route_requests_total` reaching zero, explicitly **not** on a guessed
calendar date, which is why it emits no `Sunset`. But the signal reached only
**4 routes** out of the ~56 a Trust Task supersedes. A metric covering a twelfth
of the surface can't justify deleting anything.

This makes the metric trustworthy enough to act on.

## The mapping is recovered, not guessed

Before #1000 deleted them, each `build_rest` closure in the SDK paired a
Trust-Task constant with the exact REST route it fell back to. Reading them
back out of git yields **60 route→task pairs with zero ambiguity** — the
mapping the client itself used, rather than one inferred from matching names.

Two entries look wrong at a glance and are not. Both are documented at their
SDK call sites:

| Route | Successor | Why |
|---|---|---|
| `GET /webvh/dids/{scid}/log` | `dids/get/1.0` | the dedicated get-log task folded into it behind `includeLog` |
| `PATCH /webvh/servers/{id}` | `servers/register/1.0` | #850 folded add + update into one task |

## One layer, not 56 handler edits

The per-handler form threads a `HeaderMap` back through the return type. These
handlers have **39 distinct return shapes** — `Result<Json<T>>`,
`Result<(StatusCode, Json<T>)>`, `Result<StatusCode>`, and so on.

A handler with several `Ok(...)` arms only has to miss one for its route to
fall silent — and **a silent route reads exactly like an unused one**. Since
the entire purpose is deleting routes on the strength of a zero reading, a
signal that can be half-applied is worse than no signal at all. Matching on
`MatchedPath` in one place cannot be half-applied.

The four existing per-handler calls are removed with it, so there's one
mechanism rather than two that double-count the same request.

## Only a successful response counts

A 404, or a request rejected before it reached the handler, says nothing about
a client depending on the route. Counting those would hold the metric off zero
forever and the route could never be retired — defeating the point of gating on
it.

## 56 routes are deliberately *not* marked

`/services/*` (21) has no Trust-Task twin at all and needs specs authored
first. `/auth` (8), `/bootstrap`, `/attestation` (7), `passkey_vms` (4), backup
blob streaming, the import wrapping key, `/metrics` and `/.well-known` are
genuinely REST and aren't going anywhere. The table comment records this so the
next reader doesn't have to re-derive it.

## Tests

Three, holding the property that actually matters — that the signal is really
attached, since a silent middleware would look identical to "nobody calls this":

- `superseded_route_advertises_its_trust_task_successor` — right task URI, RFC
  8288 `rel="successor-version"`
- `a_route_with_no_trust_task_twin_is_not_marked` — `/auth/challenge` stays
  unmarked
- `an_unauthenticated_rejection_is_not_counted_as_usage`

`cargo test --workspace --features session,tsp` — **4472 passing, 0 failures**.

## One drive-by, and a gap worth a follow-up

Removes a dead `path_regex` import in `client_rest.rs` left behind by #1000.

It's worth knowing **why that survived**: CI runs `cargo clippy --workspace --
-D warnings`, which does **not** lint test targets. Adding `--all-targets`
would have caught it. The workspace is two warnings away from being clean under
that flag — this import, and a deliberate `#[deprecated]` call in
`vti-e2e-tests` that would want an `#[allow(deprecated)]`. Happy to raise that
separately if you want it.

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types (R3.*) — none; response headers only
- [x] Config absence = most restrictive (R5.*)
- [x] **Logs/status claim only what was verified (R6.\*)** — the substance of
      this PR: the counter must mean "a client used this route", so rejections
      don't count
- [x] Deviations flagged with rule numbers