### PR TITLE
ci: lint test targets too, and fix the one warning that hid there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
 
-      - run: cargo clippy --workspace -- -D warnings
+      # `--all-targets` so tests, benches and examples are linted too. Without
+      # it clippy sees only the lib/bin targets, and dead code in `tests/`
+      # accumulates unseen — a dead import sat on main after #1000 and only
+      # surfaced when someone ran this flag by hand.
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   fmt:
     name: Format
@@ -600,7 +604,7 @@ jobs:
       # this combination had accumulated six dead imports/constants whose only
       # consumers were behind `didcomm`; nothing built it, so nothing said so.
       - name: vta-service rest only
-        run: cargo clippy -p vta-service --no-default-features --features rest -- -D warnings
+        run: cargo clippy -p vta-service --no-default-features --features rest --all-targets -- -D warnings
       # TSP *without* DIDComm — the combination the `tsp = ["didcomm"]` feature
       # edge used to make unbuildable. `-D warnings` for the same reason as the
       # REST-only step above: the dead code this build exposes (DIDComm-only

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -1128,6 +1128,13 @@ async fn delete_did_webvh_via_didcomm() {
 // ── Backup ──────────────────────────────────────────────────────────
 
 /// The `backup/*` pair is twinless, so it stays on the legacy message (#861).
+//
+// `backup_export` is `#[deprecated]` in favour of the descriptor flow, and this
+// test calls it on purpose: the legacy inline path is exactly what it covers,
+// and it needs to keep working for as long as it ships. Allowing the lint here
+// — rather than silencing it globally or dropping the test — keeps the warning
+// live for every *other* caller, which is who it is aimed at.
+#[allow(deprecated)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn backup_export_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, _body| {


### PR DESCRIPTION
## The gap

`cargo clippy --workspace -- -D warnings` lints only lib and bin targets.
Anything under `tests/` is never checked, so dead code accumulates there unseen.

Concretely: a dead `wiremock::matchers::path_regex` import left behind by
#1000 sat on main until I happened to run `--all-targets` by hand while working
on #1007. Nothing would have caught it. Closing the gap is what stops the next
one lasting as long.

## What it surfaces

Exactly one further warning, in `backup_export_via_didcomm` — a call to the
`#[deprecated]` `backup_export`.

That call is **deliberate**: the `backup/*` pair is twinless (#861), the legacy
inline path is precisely what the test covers, and it has to keep working for
as long as it ships. So the fix is `#[allow(deprecated)]` scoped to that single
test with the reason recorded — silencing the lint globally, or deleting the
test, would each throw the warning away for the callers it's actually aimed at.

## Also

The `vta-service` rest-only feature-combo step gets `--all-targets` too, so it
matches the tsp-without-didcomm step beside it, which already had it. I checked
that combination is clean under the flag before changing the workflow rather
than after.

## Verification

```
cargo clippy --workspace --all-targets -- -D warnings   → clean
cargo clippy -p vta-service --no-default-features --features rest --all-targets -- -D warnings   → clean
```

Note the workspace was already only *two* warnings from clean under this flag —
this is a cheap change that permanently closes a class of blind spot rather
than one instance of it.