### PR TITLE
feat(vta)!: dedup keyed Trust Tasks on an idempotency key

### DIFF
--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -126,6 +126,19 @@ pub const TASK_CONSENT: &str = "task_consent";
 /// not backed up.
 pub const OUTBOX: &str = "outbox";
 
+/// Idempotency records for keyed Trust Tasks — one row per
+/// `(actor, idempotency-key)`, holding the request digest and, for tasks whose
+/// response may be replayed, the original response. Lets a client's retry of a
+/// lost reply converge on the first execution instead of producing a second
+/// durable effect.
+///
+/// Persistent rather than in-memory (unlike the `(actor, envelope-id)` replay
+/// cache it sits beside) because the window that matters is exactly the one a
+/// restart falls inside: the VTA processed the request, the reply was lost, and
+/// the client is still retrying. Swept on TTL by
+/// `vta_sweepers::idempotency_sweeper`. Runtime state, not backed up.
+pub const IDEMPOTENCY: &str = "idempotency";
+
 /// Every production keyspace. Partitioned by [`BACKED_UP`] +
 /// [`EXCLUDED_FROM_BACKUP`]; the [`tests::backup_partition_is_total`] guard
 /// asserts the partition stays exhaustive so a newly-added keyspace can't be
@@ -156,6 +169,7 @@ pub const ALL: &[&str] = &[
     POLICY,
     TASK_CONSENT,
     OUTBOX,
+    IDEMPOTENCY,
 ];
 
 /// Keyspaces whose contents a full `export_backup` captures (as typed
@@ -209,6 +223,11 @@ pub const EXCLUDED_FROM_BACKUP: &[&str] = &[
     // Reliable-messaging outbox: runtime delivery state, re-driven from live
     // sends, not part of a state backup.
     OUTBOX,
+    // Trust-Task idempotency records. Short-lived by construction (a retry
+    // window, not durable state) and scoped to the VTA that served the original
+    // request — restoring one elsewhere would claim to have already performed
+    // operations that instance never did.
+    IDEMPOTENCY,
 ];
 
 #[cfg(test)]

--- a/vta-service/src/lib.rs
+++ b/vta-service/src/lib.rs
@@ -22,7 +22,7 @@ pub use vta_audit as audit;
 /// soft-deleted-vault purge), extracted to the `vta-sweepers` crate and
 /// re-exported so every `crate::{acl_sweeper,consent_sweeper,vault_sweeper}::…`
 /// path (the storage-thread sweep loop, provision-integration) is unchanged.
-pub use vta_sweepers::{acl_sweeper, consent_sweeper, vault_sweeper};
+pub use vta_sweepers::{acl_sweeper, consent_sweeper, idempotency_sweeper, vault_sweeper};
 pub mod auth;
 /// Backup/restore subsystem, extracted to the `vta-backup` crate. The sealed
 /// backup-bundle store + its TTL sweeper are re-exported so every

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -95,6 +95,11 @@ pub struct AppState {
     /// Anti-replay log for sealed-bootstrap `bundle_id`s. One row per seal;
     /// `PersistentNonceStore` refuses duplicates.
     pub sealed_nonces_ks: KeyspaceHandle,
+    /// Idempotency records for keyed Trust Tasks (`trust_tasks::idempotency`).
+    /// One row per `(actor, idempotency-key)`, so a client's retry of a lost
+    /// reply converges on the first execution instead of producing a second
+    /// durable effect.
+    pub idempotency_ks: KeyspaceHandle,
     /// In-flight backup-bundle records for the descriptor-pattern
     /// export/import slice (see
     /// `docs/05-design-notes/backup-descriptor-pattern.md`). Holds
@@ -315,6 +320,10 @@ pub async fn build_app_state(
     // row is a one-byte sentinel, so the keyspace is intentionally
     // unencrypted — saves a decrypt hop on every request.
     let sealed_nonces_ks = apply_encryption(store.keyspace(crate::keyspaces::SEALED_NONCES)?);
+    // Trust-Task idempotency records. Encrypted like every other keyspace that
+    // may hold response bodies — a `Keyed` record carries the original response
+    // verbatim, which is caller data even when it is not secret material.
+    let idempotency_ks = apply_encryption(store.keyspace(crate::keyspaces::IDEMPOTENCY)?);
     let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
     // Stage `.vtabak` blobs under `{data_dir}/backups`. Created lazily
     // by the op layer at first `initiate-*` call (so a VTA that never
@@ -391,6 +400,7 @@ pub async fn build_app_state(
         vault_ks,
         service_state_ks,
         sealed_nonces_ks,
+        idempotency_ks,
         backup_bundles_ks,
         backup_blob_dir,
         #[cfg(feature = "webvh")]
@@ -696,6 +706,7 @@ pub async fn run(
         let acl_ks = apply_encryption(store.keyspace(crate::keyspaces::ACL)?);
         let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
         let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
+        let idempotency_ks = apply_encryption(store.keyspace(crate::keyspaces::IDEMPOTENCY)?);
         let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
         let vault_ks = apply_encryption(store.keyspace(crate::keyspaces::VAULT)?);
         let backup_bundles_ks = apply_encryption(store.keyspace(crate::keyspaces::BACKUP_BUNDLES)?);
@@ -780,6 +791,7 @@ pub async fn run(
         let storage_audit_ks = audit_ks.clone();
         let storage_acl_ks = acl_ks.clone();
         let storage_consent_ks = consent_ks.clone();
+        let storage_idempotency_ks = idempotency_ks.clone();
         let storage_task_consent_ks = task_consent_ks.clone();
         let storage_vault_ks = vault_ks.clone();
         let storage_backup_bundles_ks = backup_bundles_ks.clone();
@@ -1083,6 +1095,7 @@ pub async fn run(
                     storage_audit_ks,
                     storage_acl_ks,
                     storage_consent_ks,
+                    storage_idempotency_ks,
                     storage_task_consent_ks,
                     storage_vault_ks,
                     storage_backup_bundles_ks,
@@ -1192,6 +1205,7 @@ fn run_storage_thread(
     audit_ks: KeyspaceHandle,
     acl_ks: KeyspaceHandle,
     consent_ks: KeyspaceHandle,
+    idempotency_ks: KeyspaceHandle,
     task_consent_ks: KeyspaceHandle,
     vault_ks: KeyspaceHandle,
     backup_bundles_ks_storage: KeyspaceHandle,
@@ -1245,6 +1259,11 @@ fn run_storage_thread(
                         {
                             warn!("consent sweeper error: {e}");
                         }
+                        // Idempotency records are read-through-expiry, so a
+                        // missed pass costs space and nothing else — that is why
+                        // this one logs rather than propagating, and why it is
+                        // not audited (retry bookkeeping, not a security event).
+                        crate::idempotency_sweeper::sweep_expired_logged(&idempotency_ks).await;
                         // Same for task-execution consent: an unanswered pending
                         // would otherwise sit in the keyspace forever, since the
                         // gate only expires one lazily when its digest is re-read.

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1009,6 +1009,7 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
     let policy_ks = store.keyspace(crate::keyspaces::POLICY).unwrap();
     let state = crate::server::AppState {
         internal_ks: store.keyspace(crate::keyspaces::INTERNAL_KEYS).unwrap(),
+        idempotency_ks: store.keyspace(crate::keyspaces::IDEMPOTENCY).unwrap(),
         // Empty by default: a test VTA trusts no mdoc issuer until one is
         // configured, matching the fail-closed production default. A test that
         // needs mdoc receive builds its own anchors and swaps this out.

--- a/vta-service/src/trust_tasks/idempotency.rs
+++ b/vta-service/src/trust_tasks/idempotency.rs
@@ -1,0 +1,429 @@
+//! Idempotency for keyed Trust Tasks.
+//!
+//! The mechanism is [`vti_common::idempotency`] — the same store the VTC's
+//! `Idempotency-Key` middleware uses. This module is only the *policy*: which
+//! tasks get a record, where the key comes from, and how each claim outcome is
+//! phrased as a Trust-Task rejection.
+//!
+//! # What this adds over [`super::replay`]
+//!
+//! That layer asks "have I seen this exact envelope before" and refuses it if
+//! so — at-most-once, in memory, keyed on `(actor, envelope-id)`. It is right
+//! for a cross-transport fallback re-sending byte-identical bytes, and it
+//! cannot help with the case that actually hurts.
+//!
+//! A request times out. Usually it never arrived, so retrying is correct.
+//! Sometimes the VTA processed it and only the reply was lost — and then the
+//! retry produces a *second durable effect*. `webvh/dids/create` is the sharp
+//! example: production callers use `WebvhPathMode::AutoAssign`, so the retry is
+//! assigned a different path and the first DID stays published in the log with
+//! nobody holding a reference to it.
+//!
+//! `replay` cannot catch that, because the retry is not the same envelope —
+//! every SDK path mints a fresh `urn:uuid:` per attempt. What it needs is a key
+//! stable *across* attempts of one logical operation, which is what
+//! `idempotencyKey` is. The two layers are complementary and both stay.
+//!
+//! # Where the key lives, and why it is trustworthy
+//!
+//! A top-level `idempotencyKey` member on the Trust Task document. It lands in
+//! `TrustTask::extra` (which is `#[serde(flatten)]`), so the upstream document
+//! type needs no change — and because a Data-Integrity proof covers every
+//! member but `proof`, **the key is signed**. A relayer cannot alter it to
+//! split one operation into two or merge two into one.
+//!
+//! # Backwards compatibility
+//!
+//! A request with no `idempotencyKey` takes none of these paths and is
+//! dispatched exactly as it is today. Nothing that works now can begin failing
+//! because this module exists.
+
+use trust_tasks_rs::{RejectReason, TrustTask};
+use vta_sdk::retry_safety::{RetrySafety, retry_safety};
+use vti_common::idempotency::{
+    CacheEntry, ClaimOutcome, CompletedResponse, IdempotencyStore, Principal,
+};
+
+use super::helpers::{TrustTaskOutcome, reject_with};
+
+/// The document member carrying the key.
+pub(crate) const IDEMPOTENCY_KEY_MEMBER: &str = "idempotencyKey";
+
+/// How long an in-flight claim is honoured before a retry may reclaim it.
+///
+/// Only reached when a process died between claiming and completing — a live
+/// request is bounded by its own handler timeout, and the longest of those is
+/// 60s. Too short and a slow-but-live operation gets double-dispatched, which
+/// is the failure this module exists to prevent; too long and a genuine crash
+/// blocks the retry that would have recovered from it.
+const IN_FLIGHT_GRACE_MINS: i64 = 10;
+
+/// Largest response body kept for replay, in bytes.
+///
+/// A cap, not a promise: the record's job is to stop the second durable effect,
+/// and it does that whether or not the body fits. Without a cap, one large
+/// listing response would let a caller size a dedup record with whatever it
+/// asked for. Over the cap, the record degrades to the same answer a
+/// secret-bearing task gets — it happened, the result is not retained.
+const MAX_CACHED_BODY: usize = 64 * 1024;
+
+/// Suggested wait before retrying a request whose first attempt is running.
+const IN_FLIGHT_RETRY_AFTER_SECS: i64 = 2;
+
+/// The class every keyed Trust Task is recorded under.
+///
+/// Always `NonDestructive`, including for tasks that destroy something. The
+/// `Destructive` class exists for HTTP routes whose idempotency key *is* the
+/// target's UUID, where a long TTL would silently no-op a later intentional
+/// re-create under that same UUID. A Trust-Task key is per-attempt-group and
+/// carries no resource identity, so re-creating the same resource later means a
+/// new key and that hazard cannot arise. The 24h window is what serves the case
+/// this exists for: an operator re-running a failed provisioning step.
+const CLASS: vti_common::idempotency::IdempotencyClass =
+    vti_common::idempotency::IdempotencyClass::NonDestructive;
+
+/// The `idempotencyKey` a document carries, if any and if usable.
+///
+/// A malformed key reads as absent rather than as an error: the request is then
+/// dispatched exactly as an unkeyed one, which is what it would have done
+/// before this module existed. Rejecting it instead would break callers to
+/// enforce a convenience.
+pub(crate) fn key_of(doc: &TrustTask<serde_json::Value>) -> Option<String> {
+    let raw = doc.extra.get(IDEMPOTENCY_KEY_MEMBER)?.as_str()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > 255 {
+        tracing::debug!(
+            len = trimmed.len(),
+            "ignoring unusable idempotencyKey (empty, or over 255 chars)"
+        );
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// SHA-256 over the request payload.
+///
+/// `serde_json::Value` maps are `BTreeMap`s in this workspace (`preserve_order`
+/// is off), so serialisation is already key-ordered and two encodings of the
+/// same logical payload hash alike.
+fn payload_hash(doc: &TrustTask<serde_json::Value>) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    // Bound the hash to the task as well as the payload, so one key cannot be
+    // reused across two different operations that happen to share a body.
+    h.update(doc.type_uri.to_string().as_bytes());
+    h.update([0u8]);
+    h.update(serde_json::to_vec(&doc.payload).unwrap_or_default());
+    h.finalize().into()
+}
+
+/// What the dispatcher should do with a keyed request.
+pub(crate) enum Claim {
+    /// This attempt owns the key. Run the handler, then call
+    /// [`record_outcome`].
+    Proceed { key: String, safety: RetrySafety },
+    /// Answer with this instead of dispatching.
+    Answer(Box<TrustTaskOutcome>),
+    /// Not keyed, not a task worth keying, or the store is unavailable.
+    /// Dispatch normally and record nothing.
+    Skip,
+}
+
+/// Claim `(actor, key)` for this request, or report what already happened to it.
+///
+/// A store error never blocks the request. Idempotency is an improvement on the
+/// status quo, not a precondition for it — failing closed here would turn a
+/// storage blip into an outage of every keyed operation, in order to prevent a
+/// duplicate that only matters when a reply is *also* lost.
+pub(crate) async fn claim(
+    ks: &vti_common::store::KeyspaceHandle,
+    actor: &str,
+    doc: &TrustTask<serde_json::Value>,
+) -> Claim {
+    let type_uri = doc.type_uri.to_string();
+
+    // `None` is an unknown task — the dispatcher rejects it on the type URI in
+    // a moment, so there is nothing to claim. Not-keyed tasks are skipped
+    // because a repeat is harmless, so a record would cost a write and buy
+    // nothing.
+    let Some(safety) = retry_safety(&type_uri).filter(|s| s.needs_key()) else {
+        return Claim::Skip;
+    };
+    let Some(key) = key_of(doc) else {
+        return Claim::Skip;
+    };
+
+    let store = IdempotencyStore::new(ks.clone());
+    let principal = Principal::Did(actor.to_string()).hash();
+    let grace = chrono::Duration::minutes(IN_FLIGHT_GRACE_MINS);
+
+    let outcome = match store
+        .claim(&principal, &key, payload_hash(doc), CLASS, grace)
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(error = %e, actor, key, "idempotency claim failed; dispatching unguarded");
+            return Claim::Skip;
+        }
+    };
+
+    match outcome {
+        ClaimOutcome::Claimed => {
+            tracing::debug!(actor, key, %type_uri, "idempotency key claimed");
+            Claim::Proceed { key, safety }
+        }
+        ClaimOutcome::InFlight => {
+            // Nobody knows the outcome yet, so the honest answer is "ask
+            // again", not "duplicate".
+            let retry_after =
+                chrono::Utc::now() + chrono::Duration::seconds(IN_FLIGHT_RETRY_AFTER_SECS);
+            Claim::Answer(Box::new(reject_with(
+                doc,
+                RejectReason::Unavailable {
+                    retry_after: Some(retry_after),
+                },
+            )))
+        }
+        ClaimOutcome::Conflict => Claim::Answer(Box::new(reject_with(
+            doc,
+            RejectReason::TaskFailed {
+                reason: "idempotency key reused for a different request".to_string(),
+                details: Some(serde_json::json!({
+                    "idempotencyKey": key,
+                    "task": type_uri,
+                    "reason": "this key was already used for a different task or payload; \
+                               answering it from the first request's result would answer the \
+                               wrong question. Use a fresh key, or re-send the original \
+                               request unchanged",
+                })),
+            },
+        ))),
+        ClaimOutcome::Completed(entry) => {
+            Claim::Answer(Box::new(replay(doc, &entry, &key, &type_uri)))
+        }
+    }
+}
+
+/// Answer a retry from a completed record.
+fn replay(
+    doc: &TrustTask<serde_json::Value>,
+    entry: &CacheEntry,
+    key: &str,
+    type_uri: &str,
+) -> TrustTaskOutcome {
+    if !entry.has_replayable_response() {
+        return reject_with(
+            doc,
+            RejectReason::TaskFailed {
+                reason: "already performed; the result is not replayable".to_string(),
+                details: Some(serde_json::json!({
+                    "idempotencyKey": key,
+                    "task": type_uri,
+                    "completedAt": entry.created_at.to_rfc3339(),
+                    "reason": "this request was already performed and its effect is not \
+                               duplicated. The original response is deliberately not retained \
+                               — it carried secret material, or exceeded the replay size cap \
+                               — so retrieve the result with the corresponding read operation",
+                })),
+            },
+        );
+    }
+    let Ok(status) = axum::http::StatusCode::from_u16(entry.response_status) else {
+        return reject_with(
+            doc,
+            RejectReason::InternalError {
+                reason: "recorded idempotent response has an unusable status".to_string(),
+            },
+        );
+    };
+    tracing::info!(key, %type_uri, "replaying recorded response");
+    TrustTaskOutcome {
+        status,
+        body: entry.response_body.clone(),
+    }
+}
+
+/// Record the outcome of a claimed request, so a later retry converges on it.
+///
+/// A failed outcome *releases* the claim rather than recording it: the effect
+/// this exists to deduplicate never happened, so the retry should be allowed to
+/// actually run. Caching failures would turn one transient error into a sticky
+/// one for the lifetime of the record.
+pub(crate) async fn record_outcome(
+    ks: &vti_common::store::KeyspaceHandle,
+    actor: &str,
+    key: &str,
+    safety: RetrySafety,
+    outcome: &TrustTaskOutcome,
+) {
+    let store = IdempotencyStore::new(ks.clone());
+    let principal = Principal::Did(actor.to_string()).hash();
+
+    if !outcome.status.is_success() {
+        if let Err(e) = store.release(&principal, key).await {
+            tracing::warn!(error = %e, actor, key, "failed to release an idempotency claim after a failed task");
+        }
+        return;
+    }
+
+    let too_large = outcome.body.len() > MAX_CACHED_BODY;
+    if too_large && safety.response_is_replayable() {
+        tracing::debug!(
+            actor,
+            key,
+            bytes = outcome.body.len(),
+            cap = MAX_CACHED_BODY,
+            "response too large to retain for replay; recording completion only"
+        );
+    }
+    let response = (safety.response_is_replayable() && !too_large).then(|| CompletedResponse {
+        status: outcome.status.as_u16(),
+        // Trust-Task outcomes are status + body; the content type is fixed by
+        // `TrustTaskOutcome::into_response`, so there is nothing to carry here.
+        headers: Vec::new(),
+        body: outcome.body.clone(),
+    });
+
+    if let Err(e) = store.complete(&principal, key, response).await {
+        tracing::warn!(error = %e, actor, key, "failed to record an idempotent outcome; a retry may re-run this task");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use trust_tasks_rs::TypeUri;
+    use vta_sdk::trust_tasks;
+
+    fn doc_with(type_uri: &str, payload: Value, key: Option<&str>) -> TrustTask<Value> {
+        let uri: TypeUri = type_uri.parse().expect("type uri");
+        let mut d = TrustTask::new("urn:uuid:test", uri, payload);
+        if let Some(k) = key {
+            d.extra.insert(
+                IDEMPOTENCY_KEY_MEMBER.to_string(),
+                serde_json::json!(k.to_string()),
+            );
+        }
+        d
+    }
+
+    #[test]
+    fn the_key_is_read_from_the_flattened_extra_member() {
+        let d = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::json!({}),
+            Some("abc"),
+        );
+        assert_eq!(key_of(&d).as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn an_unusable_key_reads_as_absent_not_as_an_error() {
+        for bad in ["", "   ", &"x".repeat(256)] {
+            let d = doc_with(
+                trust_tasks::TASK_KEYS_CREATE_0_1,
+                serde_json::json!({}),
+                Some(bad),
+            );
+            assert_eq!(key_of(&d), None, "{bad:?} should read as absent");
+        }
+        let none = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::json!({}),
+            None,
+        );
+        assert_eq!(key_of(&none), None);
+    }
+
+    /// The key has to be a top-level member for the proof to cover it. If it
+    /// ever serialises inside `payload`, a relayer could rewrite it.
+    #[test]
+    fn the_key_survives_the_json_round_trip_it_takes_on_the_wire() {
+        let d = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::json!({"a": 1}),
+            Some("k-1"),
+        );
+        let wire = serde_json::to_string(&d).expect("serialise");
+        assert!(
+            wire.contains(r#""idempotencyKey":"k-1""#),
+            "key must be top-level so the proof covers it: {wire}"
+        );
+        let back: TrustTask<Value> = serde_json::from_str(&wire).expect("deserialise");
+        assert_eq!(key_of(&back).as_deref(), Some("k-1"));
+    }
+
+    #[test]
+    fn the_request_hash_is_stable_across_member_ordering() {
+        let a = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::from_str(r#"{"b":2,"a":1}"#).unwrap(),
+            None,
+        );
+        let b = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::from_str(r#"{"a":1,"b":2}"#).unwrap(),
+            None,
+        );
+        assert_eq!(payload_hash(&a), payload_hash(&b));
+    }
+
+    #[test]
+    fn the_request_hash_separates_different_payloads() {
+        let a = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::json!({"label": "one"}),
+            None,
+        );
+        let b = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::json!({"label": "two"}),
+            None,
+        );
+        assert_ne!(payload_hash(&a), payload_hash(&b));
+    }
+
+    /// The same body under two different tasks must not hash alike, or one key
+    /// could carry a `keys/create` answer to a `dids/create` retry.
+    #[test]
+    fn the_request_hash_separates_different_tasks() {
+        let a = doc_with(
+            trust_tasks::TASK_KEYS_CREATE_0_1,
+            serde_json::json!({}),
+            None,
+        );
+        let b = doc_with(
+            trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
+            serde_json::json!({}),
+            None,
+        );
+        assert_ne!(payload_hash(&a), payload_hash(&b));
+    }
+
+    /// The classification decides whether a record is kept at all; this pins
+    /// both ends so a table edit shows up here too.
+    #[test]
+    fn only_keyed_tasks_are_worth_a_record() {
+        assert!(
+            retry_safety(trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0)
+                .expect("classified")
+                .needs_key()
+        );
+        assert!(
+            !retry_safety(trust_tasks::TASK_WEBVH_DIDS_LIST_1_0)
+                .expect("classified")
+                .needs_key()
+        );
+    }
+
+    #[test]
+    fn secret_bearing_tasks_are_never_recorded_with_a_body() {
+        assert!(
+            !retry_safety(trust_tasks::TASK_PROVISION_INTEGRATION_0_2)
+                .expect("classified")
+                .response_is_replayable()
+        );
+    }
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -66,6 +66,7 @@ mod device;
 mod did_templates;
 mod discovery;
 mod helpers;
+mod idempotency;
 mod keys;
 mod management;
 mod memory;
@@ -620,6 +621,28 @@ async fn dispatch_trust_task_inner(
         return reject;
     }
 
+    // Idempotency claim. Only bites when the document carries an
+    // `idempotencyKey` *and* the task is one where a second execution leaves a
+    // second durable artefact (`vta_sdk::retry_safety`) — everything else
+    // returns `Skip` and dispatches exactly as before.
+    //
+    // Placed after payload validation so a malformed request never consumes a
+    // key, and before the policy gate so a *denied* request releases its claim
+    // through the same `record_outcome` path every other failure takes. The
+    // claim is written before the handler runs, which is what makes two
+    // concurrent attempts safe: `insert_if_absent` is atomic, so one proceeds
+    // and the other is told to wait rather than both passing a check.
+    //
+    // This is the layer `replay` (2b above) cannot be. That one keys on the
+    // envelope id and so only catches a byte-identical resubmission; every SDK
+    // path mints a fresh `urn:uuid:` per attempt, so a genuine retry sails past
+    // it. The key here is stable across attempts of the same logical operation.
+    let idem_claim = match idempotency::claim(&state.idempotency_ks, &auth.did, &doc).await {
+        idempotency::Claim::Answer(outcome) => return *outcome,
+        idempotency::Claim::Proceed { key, safety } => Some((key, safety)),
+        idempotency::Claim::Skip => None,
+    };
+
     // Policy Decision Point gate — evaluated before dispatch. A no-op unless
     // `config.policy.enforcement` is on; when a policy denies (or demands
     // step-up/consent), the task is rejected here and never reaches its handler.
@@ -657,6 +680,14 @@ async fn dispatch_trust_task_inner(
                 }
             }
         };
+
+    // Record what happened, so a retry carrying the same key converges on it.
+    // A failed outcome *releases* the claim instead of recording it — the
+    // effect this exists to deduplicate never happened, so the retry should be
+    // allowed to actually run.
+    if let Some((key, safety)) = idem_claim {
+        idempotency::record_outcome(&state.idempotency_ks, &auth.did, &key, safety, &outcome).await;
+    }
 
     if let Some((action, resource, context_id, detail)) = vault_audit {
         let label = vault_audit_outcome_label(&outcome);

--- a/vta-sweepers/src/idempotency_sweeper.rs
+++ b/vta-sweepers/src/idempotency_sweeper.rs
@@ -1,0 +1,168 @@
+//! Background pruning of expired idempotency records.
+//!
+//! Called from the storage thread's interval loop. The records
+//! (`vti_common::idempotency`) are read-through-expiry — a stale one is already
+//! treated as absent at lookup time, so nothing incorrect is served between
+//! sweeps. This exists purely to reclaim the space, which without it grows with
+//! every keyed request forever.
+//!
+//! Deliberately **not** audited, unlike the ACL and consent sweepers. Those
+//! remove a *grant* — the expiry is a security event an operator may need to
+//! reconstruct. An idempotency record is retry bookkeeping; a row per expiry
+//! would bury the audit log in noise carrying no security meaning.
+
+use tracing::{debug, info, warn};
+
+use vti_common::error::AppError;
+use vti_common::idempotency::CacheEntry;
+use vti_common::store::KeyspaceHandle;
+
+/// Storage-key prefix every idempotency record shares. Must match
+/// `vti_common::idempotency::store::storage_key`.
+const RECORD_PREFIX: &str = "idem:";
+
+/// Delete every record past its `expires_at`.
+///
+/// An unreadable row is deleted rather than skipped. A record whose shape no
+/// longer parses can never be served — `get` deserialises before it can filter
+/// — so leaving it in place keeps a row that is permanently dead weight *and*
+/// permanently blocks its key, because a claim on that key reads it, fails to
+/// decode, and surfaces as a store error.
+pub async fn sweep_expired(idempotency_ks: &KeyspaceHandle) -> Result<(), AppError> {
+    let now = chrono::Utc::now();
+    let mut pruned = 0usize;
+    let mut unreadable = 0usize;
+
+    for (key, value) in idempotency_ks.prefix_iter_raw(RECORD_PREFIX).await? {
+        match serde_json::from_slice::<CacheEntry>(&value) {
+            Ok(entry) => {
+                if entry.is_expired(now) {
+                    idempotency_ks.remove(key).await?;
+                    pruned += 1;
+                }
+            }
+            Err(e) => {
+                debug!(error = %e, "idempotency sweeper: removing an unreadable record");
+                idempotency_ks.remove(key).await?;
+                unreadable += 1;
+            }
+        }
+    }
+
+    if pruned > 0 || unreadable > 0 {
+        info!(pruned, unreadable, "idempotency sweeper pruned records");
+    }
+    Ok(())
+}
+
+/// Sweep, logging rather than propagating a failure.
+///
+/// The interval loop must not stop because one pass failed: the records expire
+/// on read regardless, so a missed sweep costs space and nothing else.
+pub async fn sweep_expired_logged(idempotency_ks: &KeyspaceHandle) {
+    if let Err(e) = sweep_expired(idempotency_ks).await {
+        warn!(error = %e, "idempotency sweep failed; retrying next tick");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use vti_common::config::StoreConfig;
+    use vti_common::idempotency::{EntryState, IdempotencyClass};
+    use vti_common::store::Store;
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        let ks = store.keyspace("idempotency-sweeper-test").expect("ks");
+        (ks, dir)
+    }
+
+    fn entry(key: &str, expires_in: Duration) -> CacheEntry {
+        let now = chrono::Utc::now();
+        CacheEntry {
+            state: EntryState::Completed,
+            idempotency_key: key.into(),
+            request_hash: [7u8; 32],
+            response_status: 200,
+            response_headers: vec![],
+            response_body: b"{}".to_vec(),
+            class: IdempotencyClass::NonDestructive,
+            created_at: now,
+            expires_at: now + expires_in,
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_records_go_and_live_ones_stay() {
+        let (ks, _d) = temp_ks();
+        ks.insert(
+            format!("{RECORD_PREFIX}aa:live").into_bytes(),
+            &entry("live", Duration::hours(1)),
+        )
+        .await
+        .expect("insert");
+        ks.insert(
+            format!("{RECORD_PREFIX}aa:dead").into_bytes(),
+            &entry("dead", -Duration::hours(1)),
+        )
+        .await
+        .expect("insert");
+
+        sweep_expired(&ks).await.expect("sweep");
+
+        let remaining = ks.prefix_iter_raw(RECORD_PREFIX).await.expect("iter");
+        assert_eq!(remaining.len(), 1, "only the live record should survive");
+        let survivor: CacheEntry = serde_json::from_slice(&remaining[0].1).expect("decode");
+        assert_eq!(survivor.idempotency_key, "live");
+    }
+
+    /// An undecodable row blocks its key forever if left in place — a claim on
+    /// it reads, fails to decode, and errors out. Removing it frees the key.
+    #[tokio::test]
+    async fn unreadable_records_are_removed_rather_than_skipped() {
+        let (ks, _d) = temp_ks();
+        ks.insert_raw(
+            format!("{RECORD_PREFIX}aa:junk").into_bytes(),
+            b"not a cache entry".to_vec(),
+        )
+        .await
+        .expect("insert");
+
+        sweep_expired(&ks).await.expect("sweep");
+
+        assert!(
+            ks.prefix_iter_raw(RECORD_PREFIX)
+                .await
+                .expect("iter")
+                .is_empty()
+        );
+    }
+
+    /// The sweep must not walk rows that are not its own.
+    #[tokio::test]
+    async fn records_outside_the_prefix_are_untouched() {
+        let (ks, _d) = temp_ks();
+        ks.insert_raw(b"other:row".to_vec(), b"keep me".to_vec())
+            .await
+            .expect("insert");
+
+        sweep_expired(&ks).await.expect("sweep");
+
+        assert_eq!(
+            ks.get_raw(b"other:row".to_vec()).await.expect("get"),
+            Some(b"keep me".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_keyspace_sweeps_cleanly() {
+        let (ks, _d) = temp_ks();
+        sweep_expired(&ks).await.expect("sweep");
+    }
+}

--- a/vta-sweepers/src/lib.rs
+++ b/vta-sweepers/src/lib.rs
@@ -6,6 +6,7 @@
 //! - [`consent_sweeper`] — expires stale pending-consent rows and consumed
 //!   consent grants (the DTTE ceremony state).
 //! - [`vault_sweeper`] — hard-purges grace-expired soft-deleted vault entries.
+//! - [`idempotency_sweeper`] — reclaims expired Trust-Task idempotency records.
 //!
 //! Each depends only on the foundation/leaf crates (`vti-common`, `vta-audit`,
 //! `vta-keyspaces`, and — for the vault sweeper — `vta-vault`), never on
@@ -18,4 +19,5 @@
 
 pub mod acl_sweeper;
 pub mod consent_sweeper;
+pub mod idempotency_sweeper;
 pub mod vault_sweeper;

--- a/vti-common/src/idempotency/middleware.rs
+++ b/vti-common/src/idempotency/middleware.rs
@@ -159,6 +159,9 @@ async fn run(
 
     let now = Utc::now();
     let entry = CacheEntry {
+        // The HTTP path has no claim stage: it caches a response it already
+        // has, so the record is complete the moment it is written.
+        state: super::EntryState::Completed,
         idempotency_key: idempotency_key.clone(),
         request_hash,
         response_status: resp_parts.status.as_u16(),

--- a/vti-common/src/idempotency/mod.rs
+++ b/vti-common/src/idempotency/mod.rs
@@ -52,4 +52,7 @@ pub use class::IdempotencyClass;
 pub use middleware::{
     IDEMPOTENCY_HEADER, IdempotencyLayerState, MAX_BODY_BYTES, idempotency_middleware,
 };
-pub use store::{CacheEntry, IdempotencyStore, Principal, principal_from_request};
+pub use store::{
+    CacheEntry, ClaimOutcome, CompletedResponse, EntryState, IdempotencyStore, Principal,
+    principal_from_request,
+};

--- a/vti-common/src/idempotency/store.rs
+++ b/vti-common/src/idempotency/store.rs
@@ -28,6 +28,19 @@ pub enum Principal {
     /// the IP-scoping prevents one IP's idempotent retry returning
     /// another IP's cached response.
     Ip(IpAddr),
+    /// Authenticated request scoped to the caller's **DID**.
+    ///
+    /// Preferred over [`Principal::AuthToken`] wherever the DID is known,
+    /// for two reasons. It survives token rotation, so a retry that
+    /// straddles a refresh still lands in the same namespace — with the
+    /// token as the principal, rotating mid-retry silently starts a fresh
+    /// cache and re-runs the operation, which is the failure the cache
+    /// exists to prevent. And it is the *only* identity the DIDComm and
+    /// TSP transports have: neither carries a bearer token, so a
+    /// Trust-Task caller on either transport would otherwise collapse to
+    /// [`Principal::Anonymous`] and share a namespace with every other
+    /// caller.
+    Did(String),
     /// Fallback when neither Authorization nor `ConnectInfo` is
     /// available (e.g. unit tests). Cache is effectively shared
     /// across anonymous callers — acceptable because no Phase-0
@@ -44,6 +57,10 @@ impl Principal {
             Principal::AuthToken(bytes) => {
                 hasher.update(b"auth-token:");
                 hasher.update(bytes);
+            }
+            Principal::Did(did) => {
+                hasher.update(b"did:");
+                hasher.update(did.as_bytes());
             }
             Principal::Ip(ip) => {
                 hasher.update(b"ip:");
@@ -80,10 +97,39 @@ pub fn principal_from_request(parts: &Parts) -> Principal {
 // Cache entry
 // ---------------------------------------------------------------------------
 
+/// What stage of its life a [`CacheEntry`] is in.
+///
+/// The HTTP middleware only ever writes [`EntryState::Completed`], which is
+/// why that is the serde default: a record written before this enum existed
+/// reads back as a completed one, unchanged.
+///
+/// The other two variants exist for callers that claim a key *before* running
+/// the operation — see [`IdempotencyStore::claim`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EntryState {
+    /// Claimed, but the outcome is not known yet — the first attempt is still
+    /// running. A concurrent attempt seeing this must wait, not proceed.
+    InFlight,
+    /// Finished. The response fields hold the original response verbatim.
+    #[default]
+    Completed,
+    /// Finished, and the response deliberately **not** retained — because it
+    /// carried secret material, or exceeded the caller's size cap. The effect
+    /// is still deduplicated; only the replay is unavailable, and a caller
+    /// seeing this should say so rather than answer with an empty body.
+    CompletedNotRetained,
+}
+
 /// Persisted cache record. The response is held in full so a retry
 /// reproduces every header + body byte the original delivered.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CacheEntry {
+    /// Which stage this record is in. Defaults to [`EntryState::Completed`]
+    /// so records written by the HTTP middleware — which has no in-flight
+    /// stage — deserialize unchanged.
+    #[serde(default)]
+    pub state: EntryState,
     pub idempotency_key: String,
     /// SHA-256 over the request body. Differing hashes for the same
     /// `(principal, key)` cause [`AppError::IdempotencyKeyConflict`].
@@ -99,6 +145,20 @@ pub struct CacheEntry {
 impl CacheEntry {
     pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
         self.expires_at <= now
+    }
+
+    /// Whether the outcome is still unknown.
+    pub fn is_in_flight(&self) -> bool {
+        self.state == EntryState::InFlight
+    }
+
+    /// Whether [`Self::response_body`] holds the original response.
+    ///
+    /// False for an in-flight claim (no outcome yet) and for a deliberately
+    /// unretained one — in both cases the body field is empty, and answering
+    /// a retry with it would be answering with a lie.
+    pub fn has_replayable_response(&self) -> bool {
+        self.state == EntryState::Completed
     }
 }
 
@@ -138,6 +198,152 @@ impl IdempotencyStore {
         let storage_key = storage_key(principal_hash, &entry.idempotency_key);
         self.ks.insert(storage_key, entry).await
     }
+
+    /// Claim `(principal, key)` **before** running the operation.
+    ///
+    /// This is the difference between deduplicating a *finished* request and
+    /// deduplicating a request at all. [`Self::get`] followed by
+    /// [`Self::put`] leaves a window: two concurrent attempts both read
+    /// `None`, both run, and both produce the effect the cache exists to
+    /// prevent. Claiming closes it — the write is `insert_if_absent`, so
+    /// exactly one attempt wins and the other is told to wait.
+    ///
+    /// It also survives a crash. An attempt that dies between claiming and
+    /// completing leaves an [`EntryState::InFlight`] record, which
+    /// [`ClaimOutcome`] reports as stale once `in_flight_grace` has passed so
+    /// the retry can reclaim it rather than being blocked forever.
+    ///
+    /// The caller must finish with [`Self::complete`] or [`Self::release`];
+    /// a claim left dangling blocks retries until it goes stale.
+    pub async fn claim(
+        &self,
+        principal_hash: &[u8; 32],
+        key: &str,
+        request_hash: [u8; 32],
+        class: IdempotencyClass,
+        in_flight_grace: chrono::Duration,
+    ) -> Result<ClaimOutcome, AppError> {
+        let now = Utc::now();
+        let pending = CacheEntry {
+            state: EntryState::InFlight,
+            idempotency_key: key.to_string(),
+            request_hash,
+            response_status: 0,
+            response_headers: Vec::new(),
+            response_body: Vec::new(),
+            class,
+            created_at: now,
+            expires_at: now + chrono::Duration::seconds(class.ttl_seconds() as i64),
+        };
+        let sk = storage_key(principal_hash, key);
+
+        if self.ks.insert_if_absent(sk.clone(), &pending).await? {
+            return Ok(ClaimOutcome::Claimed);
+        }
+
+        let Some(existing): Option<CacheEntry> = self.ks.get(sk.clone()).await? else {
+            // Raced the sweeper, or another attempt completing and being
+            // reclaimed. Nothing holds the key now.
+            self.ks.insert(sk, &pending).await?;
+            return Ok(ClaimOutcome::Claimed);
+        };
+
+        if existing.is_expired(now) {
+            self.ks.insert(sk, &pending).await?;
+            return Ok(ClaimOutcome::Claimed);
+        }
+
+        // Checked before the in-flight branch: a mismatched body is a caller
+        // error whichever stage the first attempt is in, and reporting "wait
+        // and try again" to a request that will never be accepted would send
+        // the caller round a loop it cannot exit.
+        if existing.request_hash != request_hash {
+            return Ok(ClaimOutcome::Conflict);
+        }
+
+        if existing.is_in_flight() {
+            if now - existing.created_at > in_flight_grace {
+                // The claiming attempt cannot still be running; it died.
+                self.ks.insert(sk, &pending).await?;
+                return Ok(ClaimOutcome::Claimed);
+            }
+            return Ok(ClaimOutcome::InFlight);
+        }
+
+        Ok(ClaimOutcome::Completed(Box::new(existing)))
+    }
+
+    /// Record the outcome of a claimed key.
+    ///
+    /// `response` is `None` when the body must not be retained — a
+    /// secret-bearing or oversized response. The record still marks the
+    /// operation done, so the duplicate effect is still prevented; only the
+    /// replay is given up, and [`EntryState::CompletedNotRetained`] says so
+    /// explicitly rather than leaving an empty body to be misread as one.
+    pub async fn complete(
+        &self,
+        principal_hash: &[u8; 32],
+        key: &str,
+        response: Option<CompletedResponse>,
+    ) -> Result<(), AppError> {
+        let sk = storage_key(principal_hash, key);
+        let Some(mut entry): Option<CacheEntry> = self.ks.get(sk.clone()).await? else {
+            // The claim went away underneath us. Nothing to complete, and
+            // writing a fresh record here would resurrect a key the sweeper
+            // (or a reclaim) deliberately dropped.
+            return Ok(());
+        };
+        match response {
+            Some(r) => {
+                entry.state = EntryState::Completed;
+                entry.response_status = r.status;
+                entry.response_headers = r.headers;
+                entry.response_body = r.body;
+            }
+            None => {
+                entry.state = EntryState::CompletedNotRetained;
+                entry.response_status = 0;
+                entry.response_headers = Vec::new();
+                entry.response_body = Vec::new();
+            }
+        }
+        self.ks.insert(sk, &entry).await
+    }
+
+    /// Drop a claim without recording an outcome.
+    ///
+    /// For the case where the operation *failed*: the effect never happened,
+    /// so a retry should be allowed to actually run rather than be answered
+    /// with the failure. Caching failures would turn one transient error into
+    /// a sticky one for the lifetime of the record.
+    pub async fn release(&self, principal_hash: &[u8; 32], key: &str) -> Result<(), AppError> {
+        self.ks.remove(storage_key(principal_hash, key)).await
+    }
+}
+
+/// The response fields to record against a completed claim.
+#[derive(Debug, Clone)]
+pub struct CompletedResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+/// What [`IdempotencyStore::claim`] found.
+#[derive(Debug)]
+pub enum ClaimOutcome {
+    /// The key is ours. Run the operation, then `complete` or `release`.
+    Claimed,
+    /// An attempt with the same request is still running. Answer "try again"
+    /// — not "duplicate", because at this instant nobody knows the outcome.
+    InFlight,
+    /// The request already ran. Replay it if
+    /// [`CacheEntry::has_replayable_response`], otherwise say it happened and
+    /// the result is not retained.
+    Completed(Box<CacheEntry>),
+    /// This key was already used for a *different* request. Answering it with
+    /// the first request's result would be answering the wrong question.
+    Conflict,
 }
 
 fn storage_key(principal_hash: &[u8; 32], key: &str) -> Vec<u8> {
@@ -178,6 +384,7 @@ mod tests {
     fn sample_entry() -> CacheEntry {
         let now = Utc::now();
         CacheEntry {
+            state: EntryState::Completed,
             idempotency_key: "key-1".into(),
             request_hash: [0xAB; 32],
             response_status: 201,
@@ -228,6 +435,232 @@ mod tests {
         let got_b = store.get(&b, &entry.idempotency_key).await.unwrap();
         assert!(got_a.is_some());
         assert!(got_b.is_none(), "principal scoping leaked");
+    }
+
+    const GRACE: chrono::Duration = chrono::Duration::minutes(10);
+
+    /// The property `get` + `put` cannot provide: two concurrent attempts, one
+    /// winner. Without this, both read `None` and both run the operation.
+    #[tokio::test]
+    async fn a_second_claim_on_the_same_request_does_not_also_win() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+
+        let first = store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        assert!(matches!(first, ClaimOutcome::Claimed));
+
+        let second = store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        assert!(
+            matches!(second, ClaimOutcome::InFlight),
+            "a concurrent attempt must be told to wait, got {second:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_completed_claim_replays_its_response() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+        store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        store
+            .complete(
+                &p,
+                "k",
+                Some(CompletedResponse {
+                    status: 201,
+                    headers: vec![],
+                    body: b"body".to_vec(),
+                }),
+            )
+            .await
+            .expect("complete");
+
+        match store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim")
+        {
+            ClaimOutcome::Completed(e) => {
+                assert!(e.has_replayable_response());
+                assert_eq!(e.response_status, 201);
+                assert_eq!(e.response_body, b"body".to_vec());
+            }
+            other => panic!("expected a completed replay, got {other:?}"),
+        }
+    }
+
+    /// The secret-bearing case: the effect is still deduplicated, but the
+    /// record must not be mistaken for a real empty response.
+    #[tokio::test]
+    async fn an_unretained_completion_dedups_without_offering_a_body() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+        store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        store.complete(&p, "k", None).await.expect("complete");
+
+        match store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim")
+        {
+            ClaimOutcome::Completed(e) => {
+                assert_eq!(e.state, EntryState::CompletedNotRetained);
+                assert!(!e.has_replayable_response());
+                assert!(e.response_body.is_empty());
+            }
+            other => panic!("expected a completed record, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn the_same_key_with_a_different_request_conflicts() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+        store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        let other = store
+            .claim(&p, "k", [2u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        assert!(
+            matches!(other, ClaimOutcome::Conflict),
+            "a different body under the same key must conflict, got {other:?}"
+        );
+    }
+
+    /// A mismatched body conflicts even while the first attempt is still
+    /// running — telling that caller to "try again" would loop it forever on a
+    /// request that can never be accepted.
+    #[tokio::test]
+    async fn conflict_is_reported_ahead_of_in_flight() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+        store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        // First attempt deliberately left in flight.
+        let other = store
+            .claim(&p, "k", [9u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        assert!(matches!(other, ClaimOutcome::Conflict), "got {other:?}");
+    }
+
+    /// A process that dies between claiming and completing must not block the
+    /// retry that would recover it.
+    #[tokio::test]
+    async fn a_stale_in_flight_claim_is_reclaimed() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+        store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        // Zero grace: any in-flight claim is already stale.
+        let again = store
+            .claim(
+                &p,
+                "k",
+                [1u8; 32],
+                IdempotencyClass::NonDestructive,
+                chrono::Duration::zero(),
+            )
+            .await
+            .expect("claim");
+        assert!(matches!(again, ClaimOutcome::Claimed), "got {again:?}");
+    }
+
+    /// A failed operation releases its key, so the retry actually runs rather
+    /// than being answered with a cached failure.
+    #[tokio::test]
+    async fn releasing_a_claim_frees_the_key() {
+        let (store, _d) = temp_store();
+        let p = Principal::Did("did:web:alice".into()).hash();
+        store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        store.release(&p, "k").await.expect("release");
+        let again = store
+            .claim(&p, "k", [1u8; 32], IdempotencyClass::NonDestructive, GRACE)
+            .await
+            .expect("claim");
+        assert!(matches!(again, ClaimOutcome::Claimed), "got {again:?}");
+    }
+
+    #[tokio::test]
+    async fn claims_are_scoped_by_principal() {
+        let (store, _d) = temp_store();
+        let alice = Principal::Did("did:web:alice".into()).hash();
+        let bob = Principal::Did("did:web:bob".into()).hash();
+        store
+            .claim(
+                &alice,
+                "k",
+                [1u8; 32],
+                IdempotencyClass::NonDestructive,
+                GRACE,
+            )
+            .await
+            .expect("claim");
+        let bobs = store
+            .claim(
+                &bob,
+                "k",
+                [1u8; 32],
+                IdempotencyClass::NonDestructive,
+                GRACE,
+            )
+            .await
+            .expect("claim");
+        assert!(
+            matches!(bobs, ClaimOutcome::Claimed),
+            "one caller's key must not block another's, got {bobs:?}"
+        );
+    }
+
+    /// A DID principal is stable across token rotation — the reason it exists.
+    #[test]
+    fn did_principals_are_distinct_and_stable() {
+        let a = Principal::Did("did:web:alice".into());
+        assert_eq!(a.hash(), Principal::Did("did:web:alice".into()).hash());
+        assert_ne!(a.hash(), Principal::Did("did:web:bob".into()).hash());
+        assert_ne!(
+            a.hash(),
+            Principal::AuthToken(b"did:web:alice".to_vec()).hash()
+        );
+    }
+
+    /// Records written before `state` existed must still read as completed.
+    #[test]
+    fn a_record_without_a_state_member_reads_as_completed() {
+        let json = serde_json::json!({
+            "idempotency_key": "k",
+            "request_hash": vec![0u8; 32],
+            "response_status": 200,
+            "response_headers": [],
+            "response_body": [],
+            "class": "NonDestructive",
+            "created_at": "2026-01-01T00:00:00Z",
+            "expires_at": "2036-01-01T00:00:00Z",
+        });
+        let e: CacheEntry = serde_json::from_value(json).expect("legacy record decodes");
+        assert_eq!(e.state, EntryState::Completed);
+        assert!(e.has_replayable_response());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Second of five PRs closing #1009. Rebased onto main now that #1010 (the
classification) has merged, so this diff is its own work only.

## Breaking change, deliberately — `semver checks` is reporting it correctly

Two API breaks in `vti-common`, both flagged by cargo-semver-checks (an advisory
`continue-on-error` job, by design, so a 0.x break is *known* rather than shipped
as a patch):

- `Principal` gains a `Did` variant — exhaustive enum.
- `CacheEntry` gains a `state` field — exhaustively constructible struct.

**No stored-record break.** `state` is `#[serde(default)]`, so a record written
before it existed reads back as `Completed`; the module's 13 pre-existing tests
pass unchanged. The only source break is an exhaustive `match` on `Principal` or a
struct literal for `CacheEntry`, and nothing outside `vti-common` did either — the
module had no consumers. Title carries `!` so release-plz moves the compatibility
field.

## The headline: I did not write a new store

`vti_common::idempotency` **already exists** — a persistent
`(principal, key) → response` cache with class-based TTLs, request-hash conflict
detection and an Axum middleware, written for the VTC's `Idempotency-Key` header
and never wired to a consumer. I started building a parallel implementation
before finding it. This PR extends that one instead and makes the VTA its first
consumer, so the VTC's HTTP path inherits the additions when it wires up.

The 13 existing tests pass unchanged; the middleware needed a one-field
construction fix and nothing else.

## What the shared store was missing

**1. `Principal::Did`.** `AuthToken` scopes the cache to the bearer credential,
and its own doc comment notes that "token rotation resets the cache namespace
(conservatively)". For a *retry* that is not conservative, it is wrong — a retry
straddling a token refresh starts a fresh namespace and re-runs the operation,
which is precisely what the cache exists to prevent. It is also the only identity
DIDComm and TSP have; without a DID variant, every Trust-Task caller on those
transports collapses to `Anonymous` and shares one namespace.

**2. An in-flight claim.** `get` then `put` leaves a real window: two concurrent
attempts both read `None`, both run, both produce the effect. `claim()` closes it
with `insert_if_absent`, so exactly one wins. The loser gets `Unavailable` with a
retry hint rather than "duplicate" — at that instant nobody knows the outcome, and
saying "duplicate" would assert something untrue.

A claim orphaned by a crash goes stale after a grace window (10 min, past the
longest handler timeout of 60s) so a retry can reclaim it instead of being blocked
forever.

One ordering detail worth checking in review: **conflict is reported ahead of
in-flight**. A mismatched body under a live claim gets `Conflict`, not "try
again" — telling that caller to retry would loop it forever on a request that can
never be accepted.

**3. `CompletedNotRetained`.** This is the part I'd most like scrutinised.

Result-caching idempotency wants to replay the stored response. For
`seeds/export-mnemonic`, `backup/complete-export` and `provision/integration`
that means persisting a mnemonic / a sealed bundle / the whole VTA under a
passphrase, a second time, indefinitely, in a keyspace that exists for retry
bookkeeping. The workspace already has a standing invariant that the mnemonic
plaintext is never cached anywhere; a naive result cache would violate it.

So those record completion **without** the body. The duplicate effect is still
prevented — which is the actual goal — and the retry receives an error saying the
result is not replayable, naming the read operation that can fetch it. An empty
body would have been silently misread as a real response, hence the explicit
state rather than a `None`-shaped absence.

Oversized responses (>64 KiB) take the same path, so one large listing task can't
let a caller size a dedup record with whatever it asked for.

## Wire format

A top-level `idempotencyKey` member. It lands in `TrustTask::extra`
(`#[serde(flatten)]`), so **no change to the upstream `trust-tasks-rs` document
type is needed** — and because a DI proof covers every member except `proof`, the
key is signed. A relayer cannot rewrite it to split one operation into two.

The request hash binds the **type URI as well as the payload**, so one key cannot
carry a `keys/create` answer to a `dids/create` retry.

## Blast radius

Deliberately small:

- No `idempotencyKey` → none of this runs. Dispatch is byte-identical to today.
- Only tasks the classification marks `Keyed`/`KeyedSecret` are recorded.
- A store error **logs and dispatches unguarded**. Failing closed would turn a
  storage blip into an outage of every keyed operation, to prevent a duplicate
  that only matters when a reply is *also* lost. Deliberate; argue if you disagree.
- A failed task **releases** its claim rather than recording it — caching failures
  would make one transient error sticky for 24h.

The claim sits after payload validation (a malformed request must not consume a
key) and before the policy gate (a denial releases through the same path every
other failure takes).

## Also

- New `IDEMPOTENCY` keyspace, in `EXCLUDED_FROM_BACKUP` — short-lived retry state,
  and scoped to the VTA that served the original request, so restoring it
  elsewhere would claim to have already performed operations that instance never
  did. Census test passes.
- `idempotency_sweeper`, alongside acl/consent/vault. Not audited, unlike those —
  they remove a *grant* (a security event); this removes retry bookkeeping, and a
  row per expiry would bury the audit log. Unreadable rows are deleted rather than
  skipped: a row that cannot decode can never be served, and leaving it in place
  permanently blocks its key.

## Not in this PR

Nothing sends a key yet — the SDK change is PR 3, and until it lands this is
inert in production. Retry-ownership and the orphan reconciliation sweeper are
PRs 4 and 5.

Refs #1009.

## Pre-merge

- [x] `cargo fmt --all`
- [x] `cargo clippy` on all four touched crates, `--all-targets` — clean
- [x] `cargo test -p vta-service --lib` — 831 passed
- [x] `cargo test -p vti-common` — 408 passed (13 pre-existing idempotency tests unchanged, 10 new)
- [x] `cargo test -p vta-sweepers -p vta-keyspaces` — passed
- [x] No `version =` edits, no changelog file
