### PR TITLE
feat(sdk)!: hold one idempotency key across every attempt of an operation

### DIFF
--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1449,6 +1449,75 @@ impl VtaClient {
         })
     }
 
+    /// Run `op` as **one logical operation**, under one idempotency key, with
+    /// bounded retry on transient faults.
+    ///
+    /// This is the piece that makes the VTA's idempotency actually engage. A
+    /// retry loop written around a client method cannot carry a stable key,
+    /// because each call builds a fresh document — so the VTA sees an unrelated
+    /// request and the second durable effect happens anyway. Scoping the key
+    /// outside the call is the only place it can be held.
+    ///
+    /// ```no_run
+    /// # async fn f(
+    /// #     client: &vta_sdk::client::VtaClient,
+    /// #     build: impl Fn() -> vta_sdk::client::CreateKeyRequest,
+    /// # ) -> Result<(), vta_sdk::error::VtaError> {
+    /// let key = client.idempotent(|| client.create_key(build())).await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// `op` is re-invoked from scratch per attempt, so it must rebuild any
+    /// by-value request — but every attempt carries the *same* key, so a lost
+    /// reply converges on the first execution's result instead of repeating it.
+    ///
+    /// # Use this instead of your own retry loop, not around one
+    ///
+    /// Retry layers compose badly. The messaging delivery layer already retries
+    /// a durable outbox with backoff underneath this, so an application loop on
+    /// top multiplies attempts. This method is the application-layer owner:
+    /// bounded at [`MAX_ATTEMPTS`](crate::idempotency::MAX_ATTEMPTS), backed
+    /// off, and honouring the server's `retryAfter` hint up to a cap.
+    ///
+    /// Only transient faults are repeated
+    /// ([`is_transient`](crate::idempotency::is_transient)) — a validation
+    /// error or a conflict is returned immediately, because re-sending cannot
+    /// change it.
+    pub async fn idempotent<F, Fut, T>(&self, mut op: F) -> Result<T, VtaError>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<T, VtaError>>,
+    {
+        use crate::idempotency::{IDEMPOTENCY_KEY, MAX_ATTEMPTS, backoff_for, is_transient};
+        let key = crate::idempotency::new_key();
+        IDEMPOTENCY_KEY
+            .scope(key.clone(), async move {
+                let mut attempt = 1usize;
+                loop {
+                    match op().await {
+                        Ok(v) => return Ok(v),
+                        Err(e) if attempt < MAX_ATTEMPTS && is_transient(&e) => {
+                            let wait = backoff_for(&e, attempt);
+                            #[cfg(feature = "client")]
+                            tracing::warn!(
+                                idempotency_key = %key,
+                                attempt,
+                                max = MAX_ATTEMPTS,
+                                error = %e,
+                                "VTA call failed; retrying under the same idempotency key in {wait:?}"
+                            );
+                            if !wait.is_zero() {
+                                tokio::time::sleep(wait).await;
+                            }
+                            attempt += 1;
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            })
+            .await
+    }
+
     pub async fn dispatch_trust_task(
         &self,
         type_uri: &str,
@@ -1464,11 +1533,7 @@ impl VtaClient {
             return sink.dispatch(type_uri, &payload);
         }
 
-        let doc = serde_json::json!({
-            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-            "type": type_uri,
-            "payload": payload,
-        });
+        let doc = build_task_document(type_uri, payload);
         match &self.transport {
             Transport::Rest {
                 client,
@@ -1688,6 +1753,21 @@ impl VtaClient {
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(true),
             });
+        }
+
+        // `unavailable` is the one rejection that means "ask again" rather
+        // than "this failed" — the idempotency layer answers with it while a
+        // first attempt on the same key is still running. Collapsing it into
+        // `Protocol` would leave a retry loop unable to tell it apart from a
+        // terminal error, so it gets its own variant carrying the server's
+        // `retryAfter` hint.
+        if code == "unavailable" {
+            let retry_after = payload
+                .get("retryAfter")
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|t| t.with_timezone(&chrono::Utc));
+            return Some(VtaError::Unavailable { retry_after });
         }
 
         Some(VtaError::Protocol(format!(
@@ -2423,5 +2503,105 @@ mod tests {
         assert_eq!(SurfaceTransport::Tsp.to_string(), "TSP");
         assert_eq!(SurfaceTransport::Didcomm.to_string(), "DIDComm");
         assert_eq!(SurfaceTransport::Rest.to_string(), "REST");
+    }
+}
+
+/// Build the Trust Task document a dispatch sends.
+///
+/// Split out of [`VtaClient::dispatch_trust_task`] so the one interesting thing
+/// it does — deciding whether to attach an idempotency key — is testable without
+/// a transport.
+///
+/// The key is attached only when one is in scope
+/// ([`crate::idempotency::current_key`], set by
+/// [`VtaClient::idempotent`]) **and** the task is one a second execution would
+/// actually harm ([`crate::retry_safety`]). Attaching it to a read or a
+/// convergent mutation would cost the VTA a dedup record and buy nothing.
+///
+/// It goes top-level, beside `id`, for two reasons: the VTA reads it from
+/// `TrustTask::extra`, and a Data-Integrity proof covers every member but
+/// `proof` — so a signed document's key cannot be rewritten in transit to split
+/// one operation into two.
+fn build_task_document(type_uri: &str, payload: serde_json::Value) -> serde_json::Value {
+    let mut doc = serde_json::json!({
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        "type": type_uri,
+        "payload": payload,
+    });
+    if let Some(key) = crate::idempotency::current_key()
+        && crate::retry_safety::retry_safety(type_uri).is_some_and(|s| s.needs_key())
+        && let Some(obj) = doc.as_object_mut()
+    {
+        obj.insert("idempotencyKey".to_string(), serde_json::json!(key));
+    }
+    doc
+}
+
+#[cfg(test)]
+mod idempotency_document_tests {
+    use super::build_task_document;
+    use crate::idempotency::IDEMPOTENCY_KEY;
+    use crate::trust_tasks;
+
+    fn key_in(doc: &serde_json::Value) -> Option<String> {
+        doc.get("idempotencyKey")?.as_str().map(str::to_string)
+    }
+
+    #[tokio::test]
+    async fn a_keyed_task_carries_the_scoped_key() {
+        IDEMPOTENCY_KEY
+            .scope("urn:uuid:k".to_string(), async {
+                let doc = build_task_document(
+                    trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
+                    serde_json::json!({}),
+                );
+                assert_eq!(key_in(&doc).as_deref(), Some("urn:uuid:k"));
+            })
+            .await;
+    }
+
+    /// A read costs the VTA a dedup record and buys nothing, so it gets no key
+    /// even inside a scope.
+    #[tokio::test]
+    async fn a_retry_safe_task_carries_no_key_even_in_scope() {
+        IDEMPOTENCY_KEY
+            .scope("urn:uuid:k".to_string(), async {
+                let doc = build_task_document(
+                    trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
+                    serde_json::json!({}),
+                );
+                assert_eq!(key_in(&doc), None);
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn outside_a_scope_no_document_carries_a_key() {
+        let doc = build_task_document(
+            trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
+            serde_json::json!({}),
+        );
+        assert_eq!(key_in(&doc), None);
+    }
+
+    /// The whole point: two dispatches inside one scope are the *same*
+    /// operation, so they must carry the same key even though their envelope
+    /// ids differ.
+    #[tokio::test]
+    async fn two_attempts_in_one_scope_share_a_key_but_not_an_envelope_id() {
+        IDEMPOTENCY_KEY
+            .scope("urn:uuid:k".to_string(), async {
+                let a =
+                    build_task_document(trust_tasks::TASK_KEYS_CREATE_0_1, serde_json::json!({}));
+                let b =
+                    build_task_document(trust_tasks::TASK_KEYS_CREATE_0_1, serde_json::json!({}));
+                assert_eq!(key_in(&a), key_in(&b), "the retry must reuse the key");
+                assert_ne!(
+                    a.get("id"),
+                    b.get("id"),
+                    "envelope ids stay per-attempt — which is exactly why the key is needed"
+                );
+            })
+            .await;
     }
 }

--- a/vta-sdk/src/error.rs
+++ b/vta-sdk/src/error.rs
@@ -173,6 +173,26 @@ pub enum VtaError {
         theirs: Vec<crate::protocol::matching::Protocol>,
     },
 
+    /// The VTA is temporarily unable to process this task — the standard
+    /// `unavailable` rejection (HTTP 503).
+    ///
+    /// Typed rather than folded into [`VtaError::Protocol`] because it is the
+    /// one wire rejection that means **"ask again"** rather than "this failed".
+    /// The idempotency layer returns it when a first attempt on the same key is
+    /// still running, so a retry loop that reads it as a terminal error gives up
+    /// on the one answer it was supposed to wait for.
+    ///
+    /// `retry_after` carries the server's hint verbatim when it supplied one. A
+    /// client should honour it and cap it — an unbounded wait on a
+    /// server-controlled value is a denial of service the server can trigger.
+    #[error("temporarily unavailable{}", match .retry_after {
+        Some(t) => format!(" (retry after {t})"),
+        None => String::new(),
+    })]
+    Unavailable {
+        retry_after: Option<chrono::DateTime<chrono::Utc>>,
+    },
+
     #[error("{0}")]
     Other(String),
 }
@@ -377,6 +397,12 @@ impl VtaError {
             Self::Conflict(_) => Some(
                 "The resource already exists. Use the corresponding `update` or \
                  `delete-then-create` flow rather than `create`.",
+            ),
+            Self::Unavailable { .. } => Some(
+                "The VTA is temporarily busy — this is a wait, not a failure. If the \
+                 request carried an idempotency key, an earlier attempt on that key is \
+                 still running: retry with the same key and the original result will be \
+                 returned rather than the operation repeated.",
             ),
             Self::Validation(_) => Some(
                 "The request body or parameters were rejected by the VTA's schema. \

--- a/vta-sdk/src/idempotency.rs
+++ b/vta-sdk/src/idempotency.rs
@@ -1,0 +1,211 @@
+//! Client-side idempotency: one key held across every attempt of one operation.
+//!
+//! The VTA deduplicates keyed Trust Tasks on an `idempotencyKey`
+//! ([`crate::retry_safety`] says which tasks). That only helps if the *retry*
+//! carries the *same* key as the attempt it is retrying — and that is precisely
+//! what a hand-rolled retry loop cannot do, because it re-invokes a client
+//! method that builds a fresh document each time.
+//!
+//! That is not a hypothetical. Every dispatch mints a new `urn:uuid:` envelope
+//! id, so the VTA's `(actor, envelope-id)` replay dedup never fires on a genuine
+//! retry either. A key minted inside the client method has exactly the same
+//! problem: attempt two gets a new one, the VTA sees an unrelated request, and
+//! the second durable effect happens anyway.
+//!
+//! So the key has to be scoped *outside* the call. [`VtaClient::idempotent`]
+//! does that: it mints one key, holds it in a task-local for the duration of a
+//! closure, and retries transient faults inside that scope. Every dispatch the
+//! closure makes carries the same key.
+//!
+//! ```no_run
+//! # async fn f(
+//! #     client: &vta_sdk::client::VtaClient,
+//! #     build: impl Fn() -> vta_sdk::client::CreateKeyRequest,
+//! # ) -> Result<(), vta_sdk::error::VtaError> {
+//! // One key across all attempts, so a lost reply converges on the first
+//! // result instead of minting a second key. The request is rebuilt inside
+//! // the closure because each attempt re-invokes it from scratch.
+//! let key = client.idempotent(|| client.create_key(build())).await?;
+//! # Ok(()) }
+//! ```
+//!
+//! # One retry owner
+//!
+//! Retry layers compose badly: the messaging delivery layer already retries a
+//! durable outbox with backoff, so an application loop on top multiplies
+//! attempts against a server that dedups at neither. [`VtaClient::idempotent`]
+//! is the application-layer owner — callers should use it *instead of* their own
+//! loop, not around one.
+//!
+//! It also refuses to guess. A task the classification marks
+//! [`RetrySafety::Keyed`](crate::retry_safety::RetrySafety::Keyed) is only
+//! retried because the key makes the retry safe; a task with no classification
+//! is treated as unsafe rather than assumed benign.
+
+use std::time::Duration;
+
+use crate::error::VtaError;
+
+/// Attempts made in total, including the first. Bounded low on purpose: the
+/// fault this recovers from is a stale socket that reconnects almost
+/// immediately, and beyond a couple of attempts the useful signal is "this is
+/// down", not "try harder".
+pub const MAX_ATTEMPTS: usize = 3;
+
+/// Base backoff, doubled per attempt (0.5s, then 1s).
+pub const RETRY_BASE: Duration = Duration::from_millis(500);
+
+/// Ceiling on a server-supplied `retryAfter`.
+///
+/// The hint is honoured, but not unconditionally: an unbounded wait on a value
+/// the server chooses is a stall the server can trigger at will. Beyond this
+/// the client falls back to its own backoff and lets the attempt budget run
+/// out, which surfaces as an error the caller can see rather than a hang.
+pub const MAX_RETRY_AFTER: Duration = Duration::from_secs(30);
+
+tokio::task_local! {
+    /// The idempotency key in scope for the current operation, set by
+    /// [`VtaClient::idempotent`](crate::client::VtaClient::idempotent) and read
+    /// by the dispatcher when it builds each Trust Task document.
+    ///
+    /// A task-local rather than a parameter because it has to reach *every*
+    /// typed client method — `create_key`, `create_did_webvh`, and the twenty
+    /// others — without changing twenty signatures, and because it is
+    /// genuinely ambient: it belongs to the operation, not to the call.
+    pub(crate) static IDEMPOTENCY_KEY: String;
+}
+
+/// The key in scope, if any.
+pub fn current_key() -> Option<String> {
+    IDEMPOTENCY_KEY.try_with(|k| k.clone()).ok()
+}
+
+/// A fresh idempotency key.
+///
+/// A UUID: the key needs to be unguessable and unique per operation, and
+/// nothing reads structure out of it. Deliberately *not* derived from the
+/// request — two genuinely separate creates of the same thing are two
+/// operations, and a content-derived key would silently merge them.
+pub fn new_key() -> String {
+    format!("urn:uuid:{}", uuid::Uuid::new_v4())
+}
+
+/// Whether a failed attempt is worth repeating.
+///
+/// True for faults where the request most likely never arrived, or where the
+/// VTA has explicitly said "ask again":
+///
+/// - transport and network faults — the motivating case is a stale always-on
+///   DIDComm socket that the messaging layer reconnects underneath, so the next
+///   send lands on a live one;
+/// - 5xx, transient in the same way;
+/// - [`VtaError::Unavailable`], which the VTA's idempotency layer returns while
+///   a first attempt on this key is still running. Treating that as terminal
+///   would abandon the one answer the caller was told to wait for.
+///
+/// Deterministic faults — validation, conflict, not-found, auth, gone — are
+/// never retried. Re-sending cannot change them.
+pub fn is_transient(e: &VtaError) -> bool {
+    matches!(
+        e,
+        VtaError::DidcommTransport(_)
+            | VtaError::TspTransport(_)
+            | VtaError::Network(_)
+            | VtaError::Server { .. }
+            | VtaError::Unavailable { .. }
+    )
+}
+
+/// How long to wait before the next attempt.
+///
+/// Prefers the server's hint when it gave one, capped by [`MAX_RETRY_AFTER`];
+/// otherwise exponential backoff from [`RETRY_BASE`].
+pub(crate) fn backoff_for(e: &VtaError, attempt: usize) -> Duration {
+    if let VtaError::Unavailable {
+        retry_after: Some(at),
+    } = e
+    {
+        let delta = *at - chrono::Utc::now();
+        if let Ok(d) = delta.to_std() {
+            return d.min(MAX_RETRY_AFTER);
+        }
+        // Already in the past, or unrepresentable: retry promptly rather than
+        // treating a stale hint as a reason to wait.
+        return Duration::ZERO;
+    }
+    RETRY_BASE * (1 << (attempt.saturating_sub(1)) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_are_unique() {
+        assert_ne!(new_key(), new_key());
+    }
+
+    #[test]
+    fn transient_faults_are_retried_and_deterministic_ones_are_not() {
+        assert!(is_transient(&VtaError::DidcommTransport("stale".into())));
+        assert!(is_transient(&VtaError::Server {
+            status: 502,
+            body: String::new()
+        }));
+        assert!(is_transient(&VtaError::Unavailable { retry_after: None }));
+
+        assert!(!is_transient(&VtaError::Validation("bad".into())));
+        assert!(!is_transient(&VtaError::Conflict("exists".into())));
+        assert!(!is_transient(&VtaError::NotFound("gone".into())));
+        assert!(!is_transient(&VtaError::Auth("expired".into())));
+        assert!(!is_transient(&VtaError::Gone("consumed".into())));
+    }
+
+    #[test]
+    fn backoff_doubles_without_a_server_hint() {
+        let e = VtaError::DidcommTransport("x".into());
+        assert_eq!(backoff_for(&e, 1), RETRY_BASE);
+        assert_eq!(backoff_for(&e, 2), RETRY_BASE * 2);
+    }
+
+    #[test]
+    fn a_server_hint_is_honoured_but_capped() {
+        let far = VtaError::Unavailable {
+            retry_after: Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+        };
+        assert_eq!(
+            backoff_for(&far, 1),
+            MAX_RETRY_AFTER,
+            "an unbounded server-chosen wait is a stall the server can trigger"
+        );
+
+        let soon = VtaError::Unavailable {
+            retry_after: Some(chrono::Utc::now() + chrono::Duration::seconds(2)),
+        };
+        let d = backoff_for(&soon, 1);
+        assert!(
+            d <= Duration::from_secs(2) && d > Duration::from_millis(500),
+            "{d:?}"
+        );
+    }
+
+    #[test]
+    fn a_stale_hint_retries_promptly_rather_than_waiting() {
+        let past = VtaError::Unavailable {
+            retry_after: Some(chrono::Utc::now() - chrono::Duration::seconds(30)),
+        };
+        assert_eq!(backoff_for(&past, 1), Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn a_key_is_visible_only_inside_its_scope() {
+        assert_eq!(current_key(), None);
+        let k = new_key();
+        IDEMPOTENCY_KEY
+            .scope(k.clone(), async {
+                assert_eq!(current_key().as_deref(), Some(k.as_str()));
+            })
+            .await;
+        assert_eq!(current_key(), None);
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -134,6 +134,10 @@ pub mod http;
 #[cfg(feature = "keyring")]
 pub mod keyring_init;
 pub mod keys;
+// Client-side idempotency: one key held across every attempt of one operation.
+// Needs the async runtime for its task-local + backoff, so it rides `client`.
+#[cfg(feature = "client")]
+pub mod idempotency;
 pub mod prelude;
 // What a lost reply costs each Trust Task. Always-on and dependency-free (it
 // classifies `trust_tasks`' URI catalog), so a retry layer can consult it


### PR DESCRIPTION
Third of five PRs closing #1009, and the one that makes the rest actually
engage. Independent of #1011 — SDK-only, branched from main — but inert until
#1011 lands, since nothing server-side reads the key yet.

## The problem this solves

#1011 makes the VTA dedup keyed Trust Tasks on an `idempotencyKey`. That only
helps if the **retry carries the same key as the attempt it is retrying**, and a
hand-rolled retry loop structurally cannot do that: it re-invokes a client method
that builds a fresh document each time.

Minting the key *inside* the client method has the identical failure the envelope
id already has — attempt two gets a new one, the VTA sees an unrelated request,
and the second durable effect happens anyway. This is exactly why OpenVTC's
`vta_retry` cannot be fixed in OpenVTC.

So the key has to be scoped **outside** the call.

```rust
let key = client.idempotent(|| client.create_key(req.clone())).await?;
```

`idempotent` mints one key, holds it in a task-local for the closure's duration,
and retries transient faults inside that scope. Every dispatch the closure makes
carries the same key; envelope ids still differ per attempt, which is the point.

A task-local rather than a parameter because it has to reach all twenty-odd typed
methods without changing twenty signatures, and because it is genuinely ambient —
it belongs to the operation, not the call. Same pattern as `WIRE_VERSION` in
`vta-service`.

## Where the key is attached

Only when the task is one a second execution would actually harm
(`retry_safety`). A read or a convergent mutation gets nothing — attaching a key
there costs the VTA a dedup record and buys nothing. Pinned by
`a_retry_safe_task_carries_no_key_even_in_scope`.

Top-level beside `id`, where the VTA reads it from `TrustTask::extra` and a
Data-Integrity proof covers it, so a relayer cannot rewrite it to split one
operation into two.

I pulled the document construction out of `dispatch_trust_task` into
`build_task_document` purely so this decision is testable without standing up a
transport.

## One retry owner (remediation item 4)

Retry layers compose badly. The messaging delivery layer already retries a
durable outbox with backoff underneath this, so an application loop on top
multiplies attempts against a server that dedups at neither.

`idempotent` is the application-layer owner: 3 attempts, exponential backoff, and
it honours the server's `retryAfter` **capped at 30s** — an unbounded wait on a
server-chosen value is a stall the server can trigger at will. A stale hint
(already in the past) retries promptly rather than treating it as a reason to
wait.

Callers should use this *instead of* their own loop, not around one. The OpenVTC
side of that migration is a follow-up in the other repo.

## BREAKING CHANGE — `VtaError::Unavailable`

Flagged by cargo-semver-checks (advisory `continue-on-error` job, so a 0.x break
is *known* rather than shipped as a patch). Title carries `!`.

Typed rather than folded into `Protocol(String)` because it is the one wire
rejection meaning **"ask again"** rather than "this failed" — #1011's idempotency
layer returns it while a first attempt on the same key is still running, and a
retry loop reading it as terminal gives up on exactly the answer it was told to
wait for.

Worth knowing *why* it needed a variant at all: `unavailable` maps to HTTP 503,
and `VtaError::Server` (already retryable) would have covered it — except the
REST leg parses the error document **before** the status (R3.7), so the code
collapsed to a string and the 503 never surfaced. The DIDComm leg drops status
entirely.

## Scope

No behaviour changes for existing callers. `idempotent` is opt-in; a call made
outside it builds a byte-identical document to today. Nothing in this repo calls
it yet.

Refs #1009.

## Pre-merge

- [x] `cargo fmt --all`
- [x] `cargo clippy -p vta-sdk --all-targets` — clean (the 5 `unused variable`
      warnings under `--features client` are pre-existing on main; verified by
      stashing)
- [x] `cargo test -p vta-sdk --features client` — 368 + 19 + 86 + 3 + 2 passed
- [x] No `version =` edits, no changelog file
