### PR TITLE
fix(sdk/service): take trust-tasks-rs 0.11, and fix the four defects it exposes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.9.0",
  "url",
  "uuid",
 ]
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954fe9bbc880aa008e9f01eeac117ab45419df00fddc40541c975fc70b3de506"
+checksum = "6cd4c9f5aaf47ef876e858a80e1a4c396a04f19a2301f2b0eb4ec4af45ea7180"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -502,7 +502,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "uuid",
 ]
 
@@ -8675,7 +8675,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.9.0",
  "uuid",
 ]
 
@@ -8689,7 +8689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.9.0",
  "uuid",
 ]
 
@@ -8708,7 +8708,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.9.0",
  "uuid",
 ]
 
@@ -8726,7 +8726,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.9.0",
 ]
 
 [[package]]
@@ -8734,6 +8734,21 @@ name = "trust-tasks-rs"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fafd737292481f82d012e197981c7955d2f3f00a7c45708aa46916c4bdd0a9d"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "regress",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "trust-tasks-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ef4e7aa42a0b93315fb08645270f1b0677f046c50f1ab29063c2a12cb61fbb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9395,7 +9410,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "uniffi",
  "vta-sdk",
 ]
@@ -9472,7 +9487,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "url",
  "utoipa",
  "uuid",
@@ -9556,7 +9571,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "url",
  "urlencoding",
  "utoipa",
@@ -9721,7 +9736,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "vta-sdk",
 ]
 
@@ -9790,7 +9805,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -9845,7 +9860,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.0",
  "url",
  "utoipa",
  "utoipa-axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c566099c0d490d74c836d1008eabb2da3bafc0acd9653d802893893134e91bff"
+checksum = "6baa61c2753f158f246e9b5b5c15d2ec989c8694e7ab550bee817db8d776ade8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.18"
+version = "0.18.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01857ae34f9931c8d0335d17a8f69917f22ae8e6fb3f09e1c7bfa56bb1343b62"
+checksum = "ab9d65f2641d3df7aef6687abd2bd0788d7f9e725755baed7460449303b42dee"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -413,7 +413,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.9.0",
+ "trust-tasks-rs",
  "url",
  "uuid",
 ]
@@ -502,15 +502,15 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.51"
+version = "0.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004ee041b061e9b91f440fee6db14ca003f0881933faab17ba05d2442eb8910"
+checksum = "5727932e3b6db173056fd0faa74b21c3000db7b7e718aedf237611107e0f699f"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b84deea82515fc558c7c663986060b227b7604612e48fe31ce8cde688fc3ed"
+checksum = "0f0bb62312c455dce9dc7e4899bacecea4b0abb2bb2b11f4b2269d85dcfbd630"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
@@ -1273,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.120.0"
+version = "1.121.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578638cafe182113da770e9798e7063d6de96cbbfe06f647d0026f197c9b97c"
+checksum = "8de999e21177c7513e70b4adfdc6656f438651b2de2c6690e058073da3a3082c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.114.0"
+version = "1.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
+checksum = "d5b034f8b7ceadb873d0bc607c30bb4b0be68e09a84c837174e7c2c6878ff882"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.111.0"
+version = "1.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f840fd8a79900661ca05e9af1f4e2b3c74386e9fc1b4a9dd58745faf689f0"
+checksum = "5230ecd791109507f2bec2f907ed605a5c9fbd37033736943f06c9a09ad3914d"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.105.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+checksum = "2d0efcee834347b6705eca3eea2defd88242f43774f55d7326604222e3c86260"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
+checksum = "a59312a04cf19c962cfee32b64ecfee758f8786407ff6da5b30fff46ae96f201"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.110.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+checksum = "120e7eb63457a9e547f9986fe3b273f77c43679da4d04f46359fa881c5e19b6e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1485,15 +1485,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.16",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -4216,9 +4216,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4536,7 +4536,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.16",
+ "h2 0.4.17",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -6496,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6839,18 +6839,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6964,7 +6964,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.16",
+ "h2 0.4.17",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -8481,7 +8481,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.16",
+ "h2 0.4.17",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -8667,37 +8667,37 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9544464e98ff02398134df574ae40caf193146c8db44cc3a774255931b3a8b"
+checksum = "8c744c8389d63e3e4d6bf89a44df0fa6429cc449cf24c70e33bb3f6ef0a10f37"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.9.0",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001ffbb2589cc5626f2eb2bcf006cd0da4bd37ce0f45143a9ceb7821f1758393"
+checksum = "4dcb2a620b363ca38771125868e36a0e4204a13ea0ca1a756fcd441f5a341330"
 dependencies = [
  "affinidi-messaging-didcomm",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.9.0",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283761acdbaeec3c82db38c7ecf750847d89098a1a7e2a83becb26b1eddc20d4"
+checksum = "5b05af8774339d7c1fb29bde5ab5c37893221b9b5e95429bdd3db8f4404ae650"
 dependencies = [
  "axum",
  "chrono",
@@ -8708,15 +8708,15 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.9.0",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e14b624ab8fb95442a6183d756f9416ff4b931790bff45ebc59f4a9a8fb576a"
+checksum = "69ac669b4bcaa91fd640e2630a4791fc1fb5fe4b38d1d22ab1e4e34d3e8cad9e"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8726,29 +8726,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.9.0",
+ "trust-tasks-rs",
 ]
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fafd737292481f82d012e197981c7955d2f3f00a7c45708aa46916c4bdd0a9d"
-dependencies = [
- "async-trait",
- "chrono",
- "regress",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "trust-tasks-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ef4e7aa42a0b93315fb08645270f1b0677f046c50f1ab29063c2a12cb61fbb"
+checksum = "8480433b7122652533d7c76f5378196f3be02ed295d124174ef36c6968af54cc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9410,7 +9395,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "uniffi",
  "vta-sdk",
 ]
@@ -9487,7 +9472,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "uuid",
@@ -9571,7 +9556,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "url",
  "urlencoding",
  "utoipa",
@@ -9736,7 +9721,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "vta-sdk",
 ]
 
@@ -9805,7 +9790,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -9860,7 +9845,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.11.0",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -10726,9 +10711,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -10737,9 +10722,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,7 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.9", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.8"
 trust-tasks-https = { version = "0.9", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,8 +236,8 @@ aws-lc-rs = "1.16"
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
 trust-tasks-rs = { version = "0.11", default-features = false, features = ["validate"] }
-trust-tasks-capability-client = "0.8"
-trust-tasks-https = { version = "0.9", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-capability-client = "0.9"
+trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -248,8 +248,8 @@ trust-tasks-https = { version = "0.9", default-features = false, features = ["se
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.9", default-features = false }
-trust-tasks-proof = { version = "0.9", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.10", default-features = false }
+trust-tasks-proof = { version = "0.10", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/vta-sdk/src/client/contexts.rs
+++ b/vta-sdk/src/client/contexts.rs
@@ -45,17 +45,28 @@ impl VtaClient {
         id: &str,
         req: UpdateContextRequest,
     ) -> Result<ContextResponse, VtaError> {
-        self.rpc_tt(
-            crate::trust_tasks::TASK_CONTEXTS_UPDATE_1_0,
-            serde_json::json!({
-                "id": id,
-                "name": &req.name,
-                "did": &req.did,
-                "description": &req.description,
-            }),
-            30,
-        )
-        .await
+        // Built from the request struct rather than a `json!` literal, for two
+        // reasons the literal got wrong.
+        //
+        // It named the members by hand and omitted `contextPolicy`, so a caller
+        // setting a policy had it silently dropped — the field was accepted and
+        // never sent. And it read `req.name`/`req.did`/`req.description`
+        // directly, which bypasses their `skip_serializing_if` and emits
+        // `null` for every unset one; the agent rejects that as
+        // `malformedRequest`, since an absent optional must be ABSENT.
+        let mut payload = serde_json::to_value(&req)?;
+        match payload.as_object_mut() {
+            Some(obj) => {
+                obj.insert("id".into(), serde_json::Value::String(id.to_string()));
+            }
+            None => {
+                return Err(VtaError::Protocol(
+                    "update-context request did not serialize to an object".into(),
+                ));
+            }
+        }
+        self.rpc_tt(crate::trust_tasks::TASK_CONTEXTS_UPDATE_1_0, payload, 30)
+            .await
     }
 
     /// Update the DID for a context. Requires Admin role with access to the context.

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -209,7 +209,11 @@ impl CreateContextRequest {
     }
 }
 
+/// Sent as the `vta/contexts/update/1.0` payload, so it is bound by that
+/// schema's lowerCamelCase members — `contextPolicy`, not `context_policy`.
+/// Serialize-only: nothing reads this back, so it needs no intake alias.
 #[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateContextRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -676,7 +680,13 @@ pub struct UpdateWebvhServerRequest {
 
 // ── WebVH DID types ─────────────────────────────────────────────────
 
+/// Sent as the `vta/webvh/dids/create/1.0` payload. That schema was published
+/// in trust-tasks #240 and this struct predates it, which is why it carried
+/// snake_case members the agent would have rejected as `malformedRequest`;
+/// client-side validation only started catching it once trust-tasks-rs 0.11
+/// brought the schema into the index.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateDidWebvhRequest {
     pub context_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -24,15 +24,23 @@ use serde::{Deserialize, Serialize};
 /// server — that is the serverless case (selected by the absence of a
 /// `server_id`, where the DID location comes from the `URL` itself).
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(tag = "mode", content = "path", rename_all = "snake_case")]
+// camelCase, because the discriminator VALUE is part of the wire contract just
+// as much as a member name is. `vta/webvh/dids/create/1.0` spells the variants
+// `wellKnown` / `explicit` / `autoAssign`, and a `oneOf` keyed on `mode` refuses
+// `auto_assign` outright — it matches no branch, so the whole payload is
+// malformed rather than merely oddly-spelled. `alias` keeps the previous
+// spelling readable on intake for a producer that has not migrated.
+#[serde(tag = "mode", content = "path", rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum WebvhPathMode {
     /// Root DID at the host: resolves at `<host>/.well-known/did.jsonl`.
+    #[serde(alias = "well_known")]
     WellKnown,
     /// Operator-chosen path label: `<host>/<path>/did.jsonl`.
     Explicit(String),
     /// Let the hosting server allocate the path.
     #[default]
+    #[serde(alias = "auto_assign")]
     AutoAssign,
 }
 
@@ -354,8 +362,18 @@ mod webvh_path_mode_tests {
         );
         assert_eq!(
             serde_json::to_value(WebvhPathMode::AutoAssign).unwrap(),
-            serde_json::json!({ "mode": "auto_assign" })
+            serde_json::json!({ "mode": "autoAssign" })
         );
+
+        // Postel: the previous spelling still parses, so a producer that has
+        // not migrated keeps working. It is accepted, never emitted — the
+        // assertion above is what the wire actually carries.
+        let legacy: WebvhPathMode =
+            serde_json::from_value(serde_json::json!({ "mode": "auto_assign" })).unwrap();
+        assert_eq!(legacy, WebvhPathMode::AutoAssign);
+        let legacy: WebvhPathMode =
+            serde_json::from_value(serde_json::json!({ "mode": "well_known" })).unwrap();
+        assert_eq!(legacy, WebvhPathMode::WellKnown);
     }
 }
 

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -1895,7 +1895,330 @@ fn table() -> Vec<(&'static str, Conformance)> {
         ));
     }
 
+    // ─── vta/contexts + vta/webvh ────────────────────────────────────
+    //
+    // These 22 were dispatched against unpublished URIs until trust-tasks #240
+    // specified them, so `schema_index` could not resolve a schema and the
+    // sweep skipped them entirely — they sat in `UNSPECCED_DISPATCHED_URIS`
+    // instead. Taking trust-tasks-rs 0.11 makes them resolvable, so they move
+    // out of that debt list and into here, which is the whole point of the
+    // list: the debt shrinks monotonically as specs land.
+    //
+    // The witnesses are written as raw JSON rather than through the producer
+    // types on purpose. Two of those producer types were WRONG when the schemas
+    // arrived — `CreateDidWebvhRequest` emitted snake_case and `update_context`
+    // emitted `null` for unset members — so building a witness from them would
+    // have encoded the defect and passed. The schema is the authority here.
+    for (uri, req, resp) in webvh_and_context_witnesses() {
+        t.push((
+            uri,
+            Conformance::Checked(Witness {
+                request: req.0,
+                parse_request: req.1,
+                validate_request: req.2,
+                response: resp.0,
+                parse_response: resp.1,
+            }),
+        ));
+    }
+
     t
+}
+
+type ReqParts = (Value, ParseFn, ValidateFn);
+type RespParts = (Value, ParseFn);
+
+/// Witnesses for the families trust-tasks #240 published.
+///
+/// Each request carries exactly its schema's required members and nothing else:
+/// an over-specified witness leaves little unset and so would not exercise the
+/// `null`-for-absent class that has already shipped twice (#895, #919).
+fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
+    use specs::vta::{contexts as ctx, webvh as wv};
+
+    let context_record = || {
+        json!({
+            "id": "personal", "name": "Personal", "basePath": "personal",
+            "createdAt": "2026-08-19T09:00:00Z", "updatedAt": "2026-08-19T09:00:00Z"
+        })
+    };
+    let did_record = || {
+        json!({
+            "did": "did:webvh:QmScid:host.example:alice", "serverId": "prod",
+            "mnemonic": "alice", "scid": "QmScid", "contextId": "personal",
+            "portable": true, "logEntryCount": 4,
+            "createdAt": "2026-08-19T09:00:00Z", "updatedAt": "2026-08-19T09:00:00Z"
+        })
+    };
+    let server_record = || {
+        json!({
+            "id": "prod", "did": "did:web:host.example",
+            "createdAt": "2026-08-19T09:00:00Z", "updatedAt": "2026-08-19T09:00:00Z"
+        })
+    };
+    let did = "did:webvh:QmScid:host.example:alice";
+
+    vec![
+        (
+            uris::TASK_CONTEXTS_LIST_1_0,
+            (
+                json!({}),
+                parses::<ctx::list::v1_0::Payload>,
+                validates::<ctx::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "contexts": [context_record()] }),
+                parses::<ctx::list::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_GET_1_0,
+            (
+                json!({ "id": "personal" }),
+                parses::<ctx::get::v1_0::Payload>,
+                validates::<ctx::get::v1_0::Payload>,
+            ),
+            (context_record(), parses::<ctx::get::v1_0::Response>),
+        ),
+        (
+            uris::TASK_CONTEXTS_CREATE_1_0,
+            (
+                json!({ "id": "personal", "name": "Personal" }),
+                parses::<ctx::create::v1_0::Payload>,
+                validates::<ctx::create::v1_0::Payload>,
+            ),
+            (context_record(), parses::<ctx::create::v1_0::Response>),
+        ),
+        (
+            uris::TASK_CONTEXTS_UPDATE_1_0,
+            (
+                json!({ "id": "personal" }),
+                parses::<ctx::update::v1_0::Payload>,
+                validates::<ctx::update::v1_0::Payload>,
+            ),
+            (context_record(), parses::<ctx::update::v1_0::Response>),
+        ),
+        (
+            uris::TASK_CONTEXTS_UPDATE_DID_1_0,
+            (
+                json!({ "id": "personal", "did": did }),
+                parses::<ctx::update_did::v1_0::Payload>,
+                validates::<ctx::update_did::v1_0::Payload>,
+            ),
+            (context_record(), parses::<ctx::update_did::v1_0::Response>),
+        ),
+        (
+            uris::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
+            (
+                json!({ "id": "personal" }),
+                parses::<ctx::preview_delete::v1_0::Payload>,
+                validates::<ctx::preview_delete::v1_0::Payload>,
+            ),
+            (
+                // These four are arrays of ids, not counts. The names read like
+                // tallies and do not behave like them — precisely what a witness
+                // written by hand gets wrong and the round-trip check exists to catch.
+                json!({ "id": "personal", "keys": ["k-1"], "webvhDids": [],
+                 "aclEntriesRemoved": ["did:key:zRemoved"], "aclEntriesUpdated": [] }),
+                parses::<ctx::preview_delete::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_DELETE_1_0,
+            (
+                json!({ "id": "personal" }),
+                parses::<ctx::delete::v1_0::Payload>,
+                validates::<ctx::delete::v1_0::Payload>,
+            ),
+            (
+                json!({ "id": "personal", "deleted": true }),
+                parses::<ctx::delete::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_LIST_1_0,
+            (
+                json!({}),
+                parses::<wv::dids::list::v1_0::Payload>,
+                validates::<wv::dids::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "dids": [did_record()] }),
+                parses::<wv::dids::list::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_GET_1_0,
+            (
+                json!({ "did": did }),
+                parses::<wv::dids::get::v1_0::Payload>,
+                validates::<wv::dids::get::v1_0::Payload>,
+            ),
+            (
+                json!({ "record": did_record() }),
+                parses::<wv::dids::get::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_CREATE_1_0,
+            (
+                json!({ "contextId": "personal" }),
+                parses::<wv::dids::create::v1_0::Payload>,
+                validates::<wv::dids::create::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "contextId": "personal", "scid": "QmScid", "portable": true,
+                  "signingKeyId": "k-sign", "kaKeyId": "k-ka", "preRotationKeyCount": 2,
+                  "createdAt": "2026-08-19T09:00:00Z" }),
+                parses::<wv::dids::create::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_DELETE_1_0,
+            (
+                json!({ "did": did }),
+                parses::<wv::dids::delete::v1_0::Payload>,
+                validates::<wv::dids::delete::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "deleted": true }),
+                parses::<wv::dids::delete::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
+            (
+                json!({ "did": did }),
+                parses::<wv::dids::rotate_keys::v1_0::Payload>,
+                validates::<wv::dids::rotate_keys::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "newVersionId": "2-zVer", "newScid": "QmScid", "newLogEntry": "{}",
+                  "updateKeysCount": 1, "preRotationKeyCount": 2, "serverless": false }),
+                parses::<wv::dids::rotate_keys::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+            (
+                json!({ "did": did, "serverId": "prod" }),
+                parses::<wv::dids::register_with_server::v1_0::Payload>,
+                validates::<wv::dids::register_with_server::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "serverId": "prod", "logEntryCount": 4 }),
+                parses::<wv::dids::register_with_server::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_SERVERS_LIST_1_0,
+            (
+                json!({}),
+                parses::<wv::servers::list::v1_0::Payload>,
+                validates::<wv::servers::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "servers": [server_record()] }),
+                parses::<wv::servers::list::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_SERVERS_REGISTER_1_0,
+            (
+                json!({ "id": "prod" }),
+                parses::<wv::servers::register::v1_0::Payload>,
+                validates::<wv::servers::register::v1_0::Payload>,
+            ),
+            (
+                server_record(),
+                parses::<wv::servers::register::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_SERVERS_REMOVE_1_0,
+            (
+                json!({ "id": "prod" }),
+                parses::<wv::servers::remove::v1_0::Payload>,
+                validates::<wv::servers::remove::v1_0::Payload>,
+            ),
+            (
+                json!({ "id": "prod", "removed": true }),
+                parses::<wv::servers::remove::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_SET_1_0,
+            (
+                json!({ "did": did, "name": "alice" }),
+                parses::<wv::agent_name::set::v1_0::Payload>,
+                validates::<wv::agent_name::set::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "name": "alice", "enabled": true }),
+                parses::<wv::agent_name::set::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
+            (
+                json!({ "did": did, "name": "alice" }),
+                parses::<wv::agent_name::remove::v1_0::Payload>,
+                validates::<wv::agent_name::remove::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "name": "alice", "enabled": false }),
+                parses::<wv::agent_name::remove::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_LIST_1_0,
+            (
+                json!({ "did": did }),
+                parses::<wv::agent_name::list::v1_0::Payload>,
+                validates::<wv::agent_name::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "names": [{ "name": "alice", "enabled": true }] }),
+                parses::<wv::agent_name::list::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_CHECK_1_0,
+            (
+                json!({ "did": did, "name": "alice" }),
+                parses::<wv::agent_name::check::v1_0::Payload>,
+                validates::<wv::agent_name::check::v1_0::Payload>,
+            ),
+            (
+                json!({ "name": "alice", "domain": "host.example", "available": true, "reserved": false }),
+                parses::<wv::agent_name::check::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
+            (
+                json!({ "did": did, "name": "alice" }),
+                parses::<wv::agent_name::enable::v1_0::Payload>,
+                validates::<wv::agent_name::enable::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "name": "alice", "enabled": true }),
+                parses::<wv::agent_name::enable::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
+            (
+                json!({ "did": did, "name": "alice" }),
+                parses::<wv::agent_name::disable::v1_0::Payload>,
+                validates::<wv::agent_name::disable::v1_0::Payload>,
+            ),
+            (
+                json!({ "did": did, "name": "alice", "enabled": false }),
+                parses::<wv::agent_name::disable::v1_0::Response>,
+            ),
+        ),
+    ]
 }
 
 // ─── The sweep ───────────────────────────────────────────────────────────

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -225,14 +225,6 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
 /// Tracking issue: OpenVTC/verifiable-trust-infrastructure#854.
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
-    // ─ vta/contexts/* — keep-and-spec under `vta/` (reduction plan §E).
-    "https://trusttasks.org/spec/vta/contexts/list/1.0",
-    "https://trusttasks.org/spec/vta/contexts/create/1.0",
-    "https://trusttasks.org/spec/vta/contexts/get/1.0",
-    "https://trusttasks.org/spec/vta/contexts/update/1.0",
-    "https://trusttasks.org/spec/vta/contexts/update-did/1.0",
-    "https://trusttasks.org/spec/vta/contexts/preview-delete/1.0",
-    "https://trusttasks.org/spec/vta/contexts/delete/1.0",
     // ─ vta/seeds/* — keep-and-spec under `vta/` (reduction plan §E).
     "https://trusttasks.org/spec/vta/seeds/list/1.0",
     "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
@@ -254,21 +246,6 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     "https://trusttasks.org/spec/vta/attestation/report/1.0",
     // ─ vta/webvh/** — two-ends-of-one-wire decision pending (plan §B).
     //   `dids/update` is published; the rest are not.
-    "https://trusttasks.org/spec/vta/webvh/servers/list/1.0",
-    "https://trusttasks.org/spec/vta/webvh/servers/register/1.0",
-    "https://trusttasks.org/spec/vta/webvh/servers/remove/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/get/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/delete/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/rotate-keys/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/list/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/check/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/set/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/remove/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/disable/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/enable/1.0",
     // ─ Vault archival lifecycle (#540) — generalise with a store
     //   discriminator instead of publishing twelve (reduction plan §C).
     "https://trusttasks.org/spec/vault/archive/0.1",
@@ -1561,10 +1538,17 @@ mod payload_validation_tests {
     #[tokio::test]
     async fn an_unspecced_task_proceeds_by_default_and_can_be_refused() {
         let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
-        // No published spec — one of many. (`vta/memory/list` HAS one, which is
-        // itself the point: the set of validatable tasks is growing.)
-        const UNSPECCED: &str = "https://trusttasks.org/spec/vta/webvh/dids/create/1.0";
-        let d = doc(json!({ "contextId": "default" }));
+        // No published spec — one of the remaining few, and the set keeps
+        // shrinking. This fixture named `vta/webvh/dids/create/1.0` until
+        // trust-tasks #240 specified it and trust-tasks-rs 0.11 made the schema
+        // resolvable, at which point the task validated and the fail-closed
+        // half of this test stopped proving anything. That is the growth the
+        // comment here has always pointed at, arriving.
+        //
+        // When `vta/seeds/*` is specified too, move this to whatever is still
+        // in `UNSPECCED_DISPATCHED_URIS` rather than weakening the assertion.
+        const UNSPECCED: &str = "https://trusttasks.org/spec/vta/seeds/rotate/1.0";
+        let d = doc(json!({ "mnemonic": "correct horse battery staple" }));
 
         assert!(
             super::validate_payload(&state, UNSPECCED, &d)

--- a/vta-service/tests/producer_payload_conformance.rs
+++ b/vta-service/tests/producer_payload_conformance.rs
@@ -87,14 +87,6 @@ const UNPUBLISHED: &[(&str, &str)] = &[
         "The canonical `keys/*` fold (#888) did not reach the seed family.",
     ),
     (
-        "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0",
-        "The webvh fold reached `dids/update` (#885) but not registration.",
-    ),
-    (
-        "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
-        "As `register-with-server` — same family, same unfolded half.",
-    ),
-    (
         "https://trusttasks.org/spec/vault/credentials/receive/0.1",
         "The `vault/*` fold published query/get/upsert/delete but not \
          `credentials/receive`.",

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,7 +437,7 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        36,
+        14,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
@@ -454,7 +454,15 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
          trust-tasks-rs 0.6.1. It is the first entry this list has gained and \
          lost, and the round trip is the point — the number went up when a URI \
          was bound ahead of its spec, and came back down when the registry \
-         served it. That is the whole mechanism working, not an exception to it",
+         served it. That is the whole mechanism working, not an exception to it. \
+         \
+         36 → 14 is the largest single fall this list has taken: trust-tasks \
+         #240 specified the `vta/contexts/*` and `vta/webvh/*` families — 22 \
+         URIs — and taking trust-tasks-rs 0.11 made the registry serve them. \
+         The same move retired those 22 from UNSPECCED_DISPATCHED_URIS into \
+         real conformance witnesses, so they went from bound-but-unchecked to \
+         validated against a published schema on every request. What is left \
+         is mostly the seeds, backup and attestation families",
     ),
 ];
 


### PR DESCRIPTION
## What this is

Moving to `trust-tasks-rs 0.11` brings the `vta/contexts/*` and `vta/webvh/*`
schemas into `schema_index`. **Everything else in this PR follows from that one
fact** — four separate guards refuse to let a task be dispatched against a
schema the registry now serves without being checked against it.

It also unblocks the `vta/services/*` handlers, which is what I set out to do;
those are a follow-up PR.

## Four real defects, none previously reachable by any test

Client-side `validate_payload` only runs for tasks whose schema resolves. Under
0.9 these four resolved to nothing, so the payloads went out unchecked. Each
would have been rejected by a conforming agent as `malformedRequest`:

| Defect | Why it matters |
|---|---|
| `create_did_webvh` sent `context_id`, `server_id`, `pre_rotation_count`, … | schema names `contextId` and forbids additional properties — **every** create over a task transport was malformed |
| `update_context` omitted `contextPolicy` entirely | a caller setting a policy had it silently accepted and never sent; **it failed by doing nothing** |
| `update_context` emitted `null` for unset members | bypassed `skip_serializing_if` via a hand-written `json!`; same shape as #919 |
| `WebvhPathMode` emitted `{"mode":"auto_assign"}` | schema's `oneOf` spells `autoAssign` |

The last one is worth separating from an ordinary casing slip: it's a
**discriminator value**. A `oneOf` keyed on `mode` matches *no branch*, so the
whole payload is malformed rather than oddly-spelled. It now emits camelCase
and accepts the old spelling via `alias`; its unit test was pinning the wrong
wire and now pins the right one plus the intake path.

Both `update_context` and `create_did_webvh` now build from their typed request
structs, so the wire comes from the same declaration the schema is generated
against and can't drift by hand again.

## 22 conformance witnesses

These families were dispatched against unpublished URIs, so the sweep skipped
them and they sat in `UNSPECCED_DISPATCHED_URIS`. They move out of that list and
into the witness table — which is what the list is *for*: it shrinks
monotonically as specs land.

**Written as raw JSON, not through the producer types, deliberately.** Two of
those producer types were wrong when the schemas arrived, so a witness built
from them would have encoded the defect and passed green. The schema is the
authority here, not the code that feeds it.

## The debt lists shrink

| | before | after |
|---|---|---|
| vtc-service unpublished bound URIs | 36 | **14** |
| `UNSPECCED_DISPATCHED_URIS` (contexts/webvh) | 22 | **0** |
| `producer_payload_conformance` UNPUBLISHED | 4 | **2** |

36 → 14 is the largest single fall that manifest count has taken. Its comment
already carried the history of the number moving, including a URI that went up
and back down in a day with the note *"That is the whole mechanism working, not
an exception to it."* I extended it rather than just editing the digit.

`an_unspecced_task_proceeds_by_default` needed a new fixture for the same
reason: it named `webvh/dids/create` as its example of an unspecced task, and
that task is now validatable, so its fail-closed half had stopped proving
anything.

## One witness I got wrong, caught by the round-trip check

I wrote `aclEntriesRemoved` / `aclEntriesUpdated` as counts. They're arrays of
ids. `every_witnessed_task_round_trips_through_its_generated_types` caught it —
exactly the hand-written-witness error class it exists for.

## Dependency chain behind this

This needed four upstream releases, each blocked on the last:
affinidi-tdk-rs#717 (`affinidi-messaging-sdk 0.19.9`, so `acl_setup`'s
`MediatorAcl` stops being a duplicated type) → trust-tasks #250 (the six
sibling crates, whose manifests required 0.11 while crates.io still served
tarballs built on 0.9).

## Test

```
cargo test --workspace --features session,tsp   4523 passing, 0 failures
cargo clippy --workspace --all-targets -- -D warnings   clean
```

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] **New/changed wire types: camelCase, schema registered, all consumers
      updated (R3.\*)** — the substance of this PR; four wire defects corrected
      against their published schemas, with `alias` on the discriminator so a
      producer mid-migration still parses
- [x] Config absence = most restrictive (R5.*)
- [x] Logs/status claim only what was verified (R6.*)
- [x] Deviations flagged with rule numbers