### PR TITLE
feat(service): the vta/services task family, and the twenty routes it supersedes

### DIFF
--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -157,6 +157,29 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_CONTEXTS_UPDATE_DID_1_0, RetrySafe),
     (trust_tasks::TASK_CONTEXTS_PREVIEW_DELETE_1_0, ReadOnly),
     (trust_tasks::TASK_CONTEXTS_DELETE_1_0, RetrySafe),
+    // ── Services ────────────────────────────────────────────────────────
+    //
+    // Every mutation here republishes the agent's did:webvh log, and that log
+    // is append-only history. The question is therefore not "does the end state
+    // converge" — it does — but "does a repeat leave a second entry", and for
+    // an operation that writes one unconditionally it can.
+    //
+    // `enable` refuses a transport already enabled, so a repeat is a conflict
+    // rather than a duplicate, which reads like RetrySafe. It is Keyed anyway:
+    // the caller who lost the reply cannot tell that conflict apart from "it
+    // never landed", and the cached response is exactly what resolves that.
+    (trust_tasks::TASK_SERVICES_LIST_1_0, ReadOnly),
+    (trust_tasks::TASK_SERVICES_GET_1_0, ReadOnly),
+    (trust_tasks::TASK_SERVICES_ENABLE_1_0, Keyed),
+    (trust_tasks::TASK_SERVICES_UPDATE_1_0, Keyed),
+    // Disable schedules a drain, and a repeat inside the window would restart
+    // it — extending the life of a mediator the operator is decommissioning.
+    (trust_tasks::TASK_SERVICES_DISABLE_1_0, Keyed),
+    (trust_tasks::TASK_SERVICES_ROLLBACK_1_0, Keyed),
+    (trust_tasks::TASK_SERVICES_DRAIN_LIST_1_0, ReadOnly),
+    // Destructive and not undoable: the messages the cancelled drain was
+    // protecting are already gone by the time a retry arrives.
+    (trust_tasks::TASK_SERVICES_DRAIN_CANCEL_1_0, Keyed),
     // ── Keys ────────────────────────────────────────────────────────────
     (trust_tasks::TASK_KEYS_LIST_0_1, ReadOnly),
     // The orphan-key case the OpenVTC retry helper already documents: a lost

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -388,6 +388,74 @@ pub const TASK_SEEDS_ROTATE_1_0: &str = "https://trusttasks.org/spec/vta/seeds/r
 pub const TASK_SEEDS_EXPORT_MNEMONIC_1_0: &str =
     "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0";
 
+// ─── Services slice (spec/vta/services/*) ────────────────────────────────
+//
+// The transports the agent advertises in its own DID document: DIDComm
+// mediation, a REST endpoint, TSP mediation, a WebAuthn origin. Every mutation
+// here edits `service` in the did:webvh document and republishes the signed
+// log, so none is a runtime flag flip — the log entry IS the change.
+//
+// **Parameterised, not one family per transport.** `service` names the
+// transport and `config` carries its settings; the two MUST agree, and a
+// payload naming one kind with another's config is malformed rather than
+// carrying a harmlessly ignored field. That is what keeps a fifth transport to
+// a config variant instead of four new specs.
+
+/// `spec/vta/services/list/1.0` — every transport the agent knows about,
+/// advertised or not. Payload: empty. Auth: super-admin.
+///
+/// A kind absent from the answer has never been configured; a kind present
+/// with `enabled: false` is known and deliberately not advertised.
+pub const TASK_SERVICES_LIST_1_0: &str = "https://trusttasks.org/spec/vta/services/list/1.0";
+
+/// `spec/vta/services/get/1.0` — one transport's current state.
+/// Payload: `{ service }`. Auth: super-admin.
+pub const TASK_SERVICES_GET_1_0: &str = "https://trusttasks.org/spec/vta/services/get/1.0";
+
+/// `spec/vta/services/enable/1.0` — advertise a transport.
+/// Payload: `{ service, config }`. Auth: super-admin.
+///
+/// Not idempotent on purpose: enabling one already enabled is a conflict, so a
+/// typo cannot quietly re-point a working transport.
+pub const TASK_SERVICES_ENABLE_1_0: &str = "https://trusttasks.org/spec/vta/services/enable/1.0";
+
+/// `spec/vta/services/update/1.0` — replace the settings on a transport that
+/// is already advertised. Payload: `{ service, config }`. Auth: super-admin.
+///
+/// Refused when the transport is not enabled — that case is `enable`.
+pub const TASK_SERVICES_UPDATE_1_0: &str = "https://trusttasks.org/spec/vta/services/update/1.0";
+
+/// `spec/vta/services/disable/1.0` — stop advertising a transport.
+/// Payload: `{ service, drainTtlSecs? }`. Auth: super-admin.
+///
+/// For `didcomm` this schedules a drain rather than cutting delivery, and the
+/// TTL is a request rather than an instruction: over a DIDComm-carried task the
+/// agent enforces a floor, because tearing down the mediator the request
+/// arrived through would discard the reply. Read `drainUntil` in the result.
+pub const TASK_SERVICES_DISABLE_1_0: &str = "https://trusttasks.org/spec/vta/services/disable/1.0";
+
+/// `spec/vta/services/rollback/1.0` — restore a transport's previous settings
+/// by writing a NEW log entry. Payload: `{ service }`. Auth: super-admin.
+///
+/// May legitimately write nothing: if the previous state already equals the
+/// current one it answers `kind: noOp` with no `logEntryVersionId`, which is a
+/// success — the requested state holds.
+pub const TASK_SERVICES_ROLLBACK_1_0: &str =
+    "https://trusttasks.org/spec/vta/services/rollback/1.0";
+
+/// `spec/vta/services/drain/list/1.0` — DIDComm mediators still accepting
+/// delivery after being unadvertised. Payload: empty. Auth: super-admin.
+pub const TASK_SERVICES_DRAIN_LIST_1_0: &str =
+    "https://trusttasks.org/spec/vta/services/drain/list/1.0";
+
+/// `spec/vta/services/drain/cancel/1.0` — end a drain early.
+/// Payload: `{ mediatorDid }`. Auth: super-admin.
+///
+/// **Destructive**: messages still in flight through that mediator are lost,
+/// which is the whole reason the drain window existed.
+pub const TASK_SERVICES_DRAIN_CANCEL_1_0: &str =
+    "https://trusttasks.org/spec/vta/services/drain/cancel/1.0";
+
 // ─── Audit slice (canonical spec/audit/*, plus spec/vta/audit/*) ─────────
 
 /// `audit/list/0.1` — page through the audit log, newest first, with
@@ -1382,6 +1450,15 @@ pub const ALL_URIS: &[&str] = &[
     TASK_SEEDS_LIST_1_0,
     TASK_SEEDS_ROTATE_1_0,
     TASK_SEEDS_EXPORT_MNEMONIC_1_0,
+    // Services slice
+    TASK_SERVICES_LIST_1_0,
+    TASK_SERVICES_GET_1_0,
+    TASK_SERVICES_ENABLE_1_0,
+    TASK_SERVICES_UPDATE_1_0,
+    TASK_SERVICES_DISABLE_1_0,
+    TASK_SERVICES_ROLLBACK_1_0,
+    TASK_SERVICES_DRAIN_LIST_1_0,
+    TASK_SERVICES_DRAIN_CANCEL_1_0,
     // Audit slice
     TASK_AUDIT_LIST_0_1,
     TASK_AUDIT_GET_RETENTION_1_0,

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -47,10 +47,16 @@ pub fn superseded(route: &'static str, successor: &'static str) -> HeaderMap {
 // `PATCH /webvh/servers/{id}` points at `servers/register`, because #850
 // folded add and update into that one task.
 //
-// A route absent from this table is absent on purpose. `/services/*` has no
-// Trust-Task twin at all (it needs specs first), and `/auth`, `/bootstrap`,
+// A route absent from this table is absent on purpose: `/auth`, `/bootstrap`,
 // `/backup` blob streaming, `/keys/import/wrapping-key`, `/metrics` and
-// `/.well-known` are genuinely REST and are not going anywhere.
+// `/.well-known` are genuinely REST and are not going anywhere. `/services/*`
+// used to be listed here too, as the one block with no twin at all; it has one
+// now, and its entries are at the end of this table.
+/// The table, for tests that need to assert on its contents.
+pub fn superseded_table() -> &'static [(&'static str, &'static str, &'static str, &'static str)] {
+    SUPERSEDED
+}
+
 const SUPERSEDED: &[(&str, &str, &str, &str)] = &[
     ("GET", "/acl", "GET /acl", trust_tasks::TASK_ACL_LIST_0_1),
     ("POST", "/acl", "POST /acl", trust_tasks::TASK_ACL_GRANT_0_1),
@@ -372,6 +378,139 @@ const SUPERSEDED: &[(&str, &str, &str, &str)] = &[
         "/webvh/servers/{id}/reconcile",
         "GET /webvh/servers/{id}/reconcile",
         trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1,
+    ),
+    // ─── /services/* ────────────────────────────────────────────────────
+    //
+    // These twenty were the last block with no twin at all, which is why the
+    // note above used to exclude them. trust-tasks #243 specified the family
+    // and the handlers landed alongside this, so they are superseded like
+    // everything else — and the metric now covers the whole retirement
+    // candidate set rather than most of it.
+    //
+    // Four verbs collapse across four transports because the task is
+    // parameterised by `service`: sixteen routes point at four tasks. The two
+    // drain routes share a path and split on method — GET lists what is
+    // draining, POST cancels a drain — which is why they map to different
+    // successors despite the identical path.
+    (
+        "GET",
+        "/services",
+        "GET /services",
+        trust_tasks::TASK_SERVICES_LIST_1_0,
+    ),
+    (
+        "GET",
+        "/services/didcomm",
+        "GET /services/didcomm",
+        trust_tasks::TASK_SERVICES_GET_1_0,
+    ),
+    (
+        "GET",
+        "/services/didcomm/drain",
+        "GET /services/didcomm/drain",
+        trust_tasks::TASK_SERVICES_DRAIN_LIST_1_0,
+    ),
+    (
+        "POST",
+        "/services/didcomm/disable",
+        "POST /services/didcomm/disable",
+        trust_tasks::TASK_SERVICES_DISABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/didcomm/drain",
+        "POST /services/didcomm/drain",
+        trust_tasks::TASK_SERVICES_DRAIN_CANCEL_1_0,
+    ),
+    (
+        "POST",
+        "/services/didcomm/enable",
+        "POST /services/didcomm/enable",
+        trust_tasks::TASK_SERVICES_ENABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/didcomm/rollback",
+        "POST /services/didcomm/rollback",
+        trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
+    ),
+    (
+        "POST",
+        "/services/didcomm/update",
+        "POST /services/didcomm/update",
+        trust_tasks::TASK_SERVICES_UPDATE_1_0,
+    ),
+    (
+        "POST",
+        "/services/rest/disable",
+        "POST /services/rest/disable",
+        trust_tasks::TASK_SERVICES_DISABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/rest/enable",
+        "POST /services/rest/enable",
+        trust_tasks::TASK_SERVICES_ENABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/rest/rollback",
+        "POST /services/rest/rollback",
+        trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
+    ),
+    (
+        "POST",
+        "/services/rest/update",
+        "POST /services/rest/update",
+        trust_tasks::TASK_SERVICES_UPDATE_1_0,
+    ),
+    (
+        "POST",
+        "/services/tsp/disable",
+        "POST /services/tsp/disable",
+        trust_tasks::TASK_SERVICES_DISABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/tsp/enable",
+        "POST /services/tsp/enable",
+        trust_tasks::TASK_SERVICES_ENABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/tsp/rollback",
+        "POST /services/tsp/rollback",
+        trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
+    ),
+    (
+        "POST",
+        "/services/tsp/update",
+        "POST /services/tsp/update",
+        trust_tasks::TASK_SERVICES_UPDATE_1_0,
+    ),
+    (
+        "POST",
+        "/services/webauthn/disable",
+        "POST /services/webauthn/disable",
+        trust_tasks::TASK_SERVICES_DISABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/webauthn/enable",
+        "POST /services/webauthn/enable",
+        trust_tasks::TASK_SERVICES_ENABLE_1_0,
+    ),
+    (
+        "POST",
+        "/services/webauthn/rollback",
+        "POST /services/webauthn/rollback",
+        trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
+    ),
+    (
+        "POST",
+        "/services/webauthn/update",
+        "POST /services/webauthn/update",
+        trust_tasks::TASK_SERVICES_UPDATE_1_0,
     ),
 ];
 

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -1934,7 +1934,7 @@ type RespParts = (Value, ParseFn);
 /// an over-specified witness leaves little unset and so would not exercise the
 /// `null`-for-absent class that has already shipped twice (#895, #919).
 fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
-    use specs::vta::{contexts as ctx, webvh as wv};
+    use specs::vta::{contexts as ctx, services as svc, webvh as wv};
 
     let context_record = || {
         json!({
@@ -1957,6 +1957,14 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
         })
     };
     let did = "did:webvh:QmScid:host.example:alice";
+    let mutation_result = || {
+        json!({
+            "logEntryVersionId": "4-zQmLogEntry",
+            "effectiveAt": "2026-08-20T09:00:00Z",
+            "vtaDid": "did:webvh:QmAgent:vta.example",
+            "serverless": false
+        })
+    };
 
     vec![
         (
@@ -2216,6 +2224,113 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
             (
                 json!({ "did": did, "name": "alice", "enabled": false }),
                 parses::<wv::agent_name::disable::v1_0::Response>,
+            ),
+        ),
+        // ─── vta/services ────────────────────────────────────────
+        //
+        // `enable`/`update` carry only the members their kind needs — a `rest`
+        // witness setting `mediatorDid` would be malformed, which is the
+        // discriminated union doing its job.
+        (
+            uris::TASK_SERVICES_LIST_1_0,
+            (
+                json!({}),
+                parses::<svc::list::v1_0::Payload>,
+                validates::<svc::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "services": [{ "kind": "rest", "enabled": true, "url": "https://vta.example/api" }] }),
+                parses::<svc::list::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_GET_1_0,
+            (
+                json!({ "service": "didcomm" }),
+                parses::<svc::get::v1_0::Payload>,
+                validates::<svc::get::v1_0::Payload>,
+            ),
+            (
+                json!({ "state": { "kind": "didcomm", "enabled": true, "mediatorDid": "did:web:mediator.example" } }),
+                parses::<svc::get::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_ENABLE_1_0,
+            (
+                json!({ "service": "rest", "config": { "url": "https://vta.example/api" } }),
+                parses::<svc::enable::v1_0::Payload>,
+                validates::<svc::enable::v1_0::Payload>,
+            ),
+            (
+                json!({ "result": mutation_result() }),
+                parses::<svc::enable::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_UPDATE_1_0,
+            (
+                json!({ "service": "tsp", "config": { "mediatorDid": "did:web:mediator.example" } }),
+                parses::<svc::update::v1_0::Payload>,
+                validates::<svc::update::v1_0::Payload>,
+            ),
+            (
+                json!({ "result": mutation_result() }),
+                parses::<svc::update::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_DISABLE_1_0,
+            // No `drainTtlSecs`: absent takes the agent's default, and absent is
+            // the case a caller reaches for first.
+            (
+                json!({ "service": "didcomm" }),
+                parses::<svc::disable::v1_0::Payload>,
+                validates::<svc::disable::v1_0::Payload>,
+            ),
+            (
+                json!({ "result": mutation_result() }),
+                parses::<svc::disable::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_ROLLBACK_1_0,
+            (
+                json!({ "service": "rest" }),
+                parses::<svc::rollback::v1_0::Payload>,
+                validates::<svc::rollback::v1_0::Payload>,
+            ),
+            // `noOp` deliberately: it is the arm with no `logEntryVersionId`, so
+            // it is the one that breaks if the result ever starts requiring it.
+            (
+                json!({ "result": { "kind": "noOp", "serverless": false } }),
+                parses::<svc::rollback::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_DRAIN_LIST_1_0,
+            (
+                json!({}),
+                parses::<svc::drain::list::v1_0::Payload>,
+                validates::<svc::drain::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "entries": [{ "mediatorDid": "did:web:old-mediator.example",
+                                "endpoint": "https://old-mediator.example/didcomm",
+                                "drainsUntil": "2026-08-20T21:00:00Z" }] }),
+                parses::<svc::drain::list::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_SERVICES_DRAIN_CANCEL_1_0,
+            (
+                json!({ "mediatorDid": "did:web:old-mediator.example" }),
+                parses::<svc::drain::cancel::v1_0::Payload>,
+                validates::<svc::drain::cancel::v1_0::Payload>,
+            ),
+            (
+                json!({ "mediatorDid": "did:web:old-mediator.example" }),
+                parses::<svc::drain::cancel::v1_0::Response>,
             ),
         ),
     ]

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -1966,7 +1966,7 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
         })
     };
 
-    vec![
+    let mut v: Vec<(&'static str, ReqParts, RespParts)> = vec![
         (
             uris::TASK_CONTEXTS_LIST_1_0,
             (
@@ -2226,114 +2226,123 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
                 parses::<wv::agent_name::disable::v1_0::Response>,
             ),
         ),
-        // ─── vta/services ────────────────────────────────────────
-        //
-        // `enable`/`update` carry only the members their kind needs — a `rest`
-        // witness setting `mediatorDid` would be malformed, which is the
-        // discriminated union doing its job.
-        (
-            uris::TASK_SERVICES_LIST_1_0,
+    ];
+
+    // ─── vta/services ────────────────────────────────────────────────
+    //
+    // Extended rather than inlined because these are gated with their dispatch
+    // entries. The sweep derives its census from what is actually dispatched and
+    // requires the two to agree in BOTH directions, so a witness for a task that
+    // is configured out fails it exactly as a missing one does.
+    #[cfg(feature = "webvh")]
+    {
+        // Typed explicitly: without it the array literal takes its element type
+        // from the first entry, and each `parses::<T>` is a distinct fn item
+        // rather than the `ParseFn` pointer the alias expects.
+        let services: [(&'static str, ReqParts, RespParts); 8] = [
             (
-                json!({}),
-                parses::<svc::list::v1_0::Payload>,
-                validates::<svc::list::v1_0::Payload>,
+                uris::TASK_SERVICES_LIST_1_0,
+                (
+                    json!({}),
+                    parses::<svc::list::v1_0::Payload>,
+                    validates::<svc::list::v1_0::Payload>,
+                ),
+                (
+                    json!({ "services": [{ "kind": "rest", "enabled": true, "url": "https://vta.example/api" }] }),
+                    parses::<svc::list::v1_0::Response>,
+                ),
             ),
             (
-                json!({ "services": [{ "kind": "rest", "enabled": true, "url": "https://vta.example/api" }] }),
-                parses::<svc::list::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_GET_1_0,
-            (
-                json!({ "service": "didcomm" }),
-                parses::<svc::get::v1_0::Payload>,
-                validates::<svc::get::v1_0::Payload>,
-            ),
-            (
-                json!({ "state": { "kind": "didcomm", "enabled": true, "mediatorDid": "did:web:mediator.example" } }),
-                parses::<svc::get::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_ENABLE_1_0,
-            (
-                json!({ "service": "rest", "config": { "url": "https://vta.example/api" } }),
-                parses::<svc::enable::v1_0::Payload>,
-                validates::<svc::enable::v1_0::Payload>,
+                uris::TASK_SERVICES_GET_1_0,
+                (
+                    json!({ "service": "didcomm" }),
+                    parses::<svc::get::v1_0::Payload>,
+                    validates::<svc::get::v1_0::Payload>,
+                ),
+                (
+                    json!({ "state": { "kind": "didcomm", "enabled": true, "mediatorDid": "did:web:mediator.example" } }),
+                    parses::<svc::get::v1_0::Response>,
+                ),
             ),
             (
-                json!({ "result": mutation_result() }),
-                parses::<svc::enable::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_UPDATE_1_0,
-            (
-                json!({ "service": "tsp", "config": { "mediatorDid": "did:web:mediator.example" } }),
-                parses::<svc::update::v1_0::Payload>,
-                validates::<svc::update::v1_0::Payload>,
-            ),
-            (
-                json!({ "result": mutation_result() }),
-                parses::<svc::update::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_DISABLE_1_0,
-            // No `drainTtlSecs`: absent takes the agent's default, and absent is
-            // the case a caller reaches for first.
-            (
-                json!({ "service": "didcomm" }),
-                parses::<svc::disable::v1_0::Payload>,
-                validates::<svc::disable::v1_0::Payload>,
+                uris::TASK_SERVICES_ENABLE_1_0,
+                (
+                    json!({ "service": "rest", "config": { "url": "https://vta.example/api" } }),
+                    parses::<svc::enable::v1_0::Payload>,
+                    validates::<svc::enable::v1_0::Payload>,
+                ),
+                (
+                    json!({ "result": mutation_result() }),
+                    parses::<svc::enable::v1_0::Response>,
+                ),
             ),
             (
-                json!({ "result": mutation_result() }),
-                parses::<svc::disable::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_ROLLBACK_1_0,
-            (
-                json!({ "service": "rest" }),
-                parses::<svc::rollback::v1_0::Payload>,
-                validates::<svc::rollback::v1_0::Payload>,
-            ),
-            // `noOp` deliberately: it is the arm with no `logEntryVersionId`, so
-            // it is the one that breaks if the result ever starts requiring it.
-            (
-                json!({ "result": { "kind": "noOp", "serverless": false } }),
-                parses::<svc::rollback::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_DRAIN_LIST_1_0,
-            (
-                json!({}),
-                parses::<svc::drain::list::v1_0::Payload>,
-                validates::<svc::drain::list::v1_0::Payload>,
+                uris::TASK_SERVICES_UPDATE_1_0,
+                (
+                    json!({ "service": "tsp", "config": { "mediatorDid": "did:web:mediator.example" } }),
+                    parses::<svc::update::v1_0::Payload>,
+                    validates::<svc::update::v1_0::Payload>,
+                ),
+                (
+                    json!({ "result": mutation_result() }),
+                    parses::<svc::update::v1_0::Response>,
+                ),
             ),
             (
-                json!({ "entries": [{ "mediatorDid": "did:web:old-mediator.example",
-                                "endpoint": "https://old-mediator.example/didcomm",
-                                "drainsUntil": "2026-08-20T21:00:00Z" }] }),
-                parses::<svc::drain::list::v1_0::Response>,
-            ),
-        ),
-        (
-            uris::TASK_SERVICES_DRAIN_CANCEL_1_0,
-            (
-                json!({ "mediatorDid": "did:web:old-mediator.example" }),
-                parses::<svc::drain::cancel::v1_0::Payload>,
-                validates::<svc::drain::cancel::v1_0::Payload>,
+                uris::TASK_SERVICES_DISABLE_1_0,
+                (
+                    json!({ "service": "didcomm" }),
+                    parses::<svc::disable::v1_0::Payload>,
+                    validates::<svc::disable::v1_0::Payload>,
+                ),
+                (
+                    json!({ "result": mutation_result() }),
+                    parses::<svc::disable::v1_0::Response>,
+                ),
             ),
             (
-                json!({ "mediatorDid": "did:web:old-mediator.example" }),
-                parses::<svc::drain::cancel::v1_0::Response>,
+                uris::TASK_SERVICES_ROLLBACK_1_0,
+                (
+                    json!({ "service": "rest" }),
+                    parses::<svc::rollback::v1_0::Payload>,
+                    validates::<svc::rollback::v1_0::Payload>,
+                ),
+                (
+                    json!({ "result": { "kind": "noOp", "serverless": false } }),
+                    parses::<svc::rollback::v1_0::Response>,
+                ),
             ),
-        ),
-    ]
+            (
+                uris::TASK_SERVICES_DRAIN_LIST_1_0,
+                (
+                    json!({}),
+                    parses::<svc::drain::list::v1_0::Payload>,
+                    validates::<svc::drain::list::v1_0::Payload>,
+                ),
+                (
+                    json!({ "entries": [{ "mediatorDid": "did:web:old-mediator.example",
+                                    "endpoint": "https://old-mediator.example/didcomm",
+                                    "drainsUntil": "2026-08-20T21:00:00Z" }] }),
+                    parses::<svc::drain::list::v1_0::Response>,
+                ),
+            ),
+            (
+                uris::TASK_SERVICES_DRAIN_CANCEL_1_0,
+                (
+                    json!({ "mediatorDid": "did:web:old-mediator.example" }),
+                    parses::<svc::drain::cancel::v1_0::Payload>,
+                    validates::<svc::drain::cancel::v1_0::Payload>,
+                ),
+                (
+                    json!({ "mediatorDid": "did:web:old-mediator.example" }),
+                    parses::<svc::drain::cancel::v1_0::Response>,
+                ),
+            ),
+        ];
+        v.extend(services);
+    }
+
+    v
 }
 
 // ─── The sweep ───────────────────────────────────────────────────────────

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -80,6 +80,7 @@ mod policy_gate;
 mod provision_integration;
 mod replay;
 mod seeds;
+mod services;
 mod task_consent;
 pub(crate) mod transport;
 // The step-up *ceremony*: minting an approve-request and consuming the
@@ -839,6 +840,28 @@ dispatch_table! {
     // ─── Messaging slice ──────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_MESSAGING_PING_0_1 => messaging::handle_ping
         [ None None false ],
+    // ─── Services slice ──────────────────────────────────────────
+    //
+    // Metadata mirrors what each verb actually does to the agent's DID
+    // document. `drain/cancel` is Destructive rather than Mutating: it discards
+    // messages still in flight through the mediator, which is precisely what
+    // the drain window existed to prevent.
+    vta_sdk::trust_tasks::TASK_SERVICES_LIST_1_0 => services::handle_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_GET_1_0 => services::handle_get
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_ENABLE_1_0 => services::handle_enable
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_UPDATE_1_0 => services::handle_update
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_DISABLE_1_0 => services::handle_disable
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_ROLLBACK_1_0 => services::handle_rollback
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_DRAIN_LIST_1_0 => services::handle_drain_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_SERVICES_DRAIN_CANCEL_1_0 => services::handle_drain_cancel
+        [ Destructive None false ],
     // ─── Contexts slice ──────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0 => contexts::handle_list
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -80,6 +80,11 @@ mod policy_gate;
 mod provision_integration;
 mod replay;
 mod seeds;
+// `operations::protocol` — every service operation these handlers call — is
+// `#[cfg(feature = "webvh")]`, because advertising a transport means editing
+// the agent's did:webvh document. Without webvh there is no document to edit,
+// so the whole family goes with it.
+#[cfg(feature = "webvh")]
 mod services;
 mod task_consent;
 pub(crate) mod transport;
@@ -846,20 +851,28 @@ dispatch_table! {
     // document. `drain/cancel` is Destructive rather than Mutating: it discards
     // messages still in flight through the mediator, which is precisely what
     // the drain window existed to prevent.
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_LIST_1_0 => services::handle_list
         [ None Metadata false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_GET_1_0 => services::handle_get
         [ None Metadata false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_ENABLE_1_0 => services::handle_enable
         [ Mutating None false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_UPDATE_1_0 => services::handle_update
         [ Mutating None false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_DISABLE_1_0 => services::handle_disable
         [ Mutating None false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_ROLLBACK_1_0 => services::handle_rollback
         [ Mutating None false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_DRAIN_LIST_1_0 => services::handle_drain_list
         [ None Metadata false ],
+    #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_SERVICES_DRAIN_CANCEL_1_0 => services::handle_drain_cancel
         [ Destructive None false ],
     // ─── Contexts slice ──────────────────────────────────────────

--- a/vta-service/src/trust_tasks/services.rs
+++ b/vta-service/src/trust_tasks/services.rs
@@ -1,0 +1,845 @@
+//! Services slice trust-task handlers — `vta/services/*`.
+//!
+//! The transports the agent advertises in its own did:webvh document. Every
+//! mutation here edits that document and republishes the signed log, so none of
+//! them is a runtime flag flip: **the log entry is the change**.
+//!
+//! ## One task per verb, not per transport
+//!
+//! `service` names the transport and `config` carries its settings, so these
+//! eight handlers cover what twenty `/services/*` REST routes did. The fan-out
+//! onto the per-transport operations happens here rather than on the wire,
+//! which is what keeps a fifth transport to a config variant instead of four
+//! new specs.
+//!
+//! The operations are untouched — `operations::protocol::*` already implements
+//! each transport, and this module is the parameterised door onto them.
+//!
+//! ## The state shape is mapped, not forwarded
+//!
+//! `vta_sdk::protocol::services::ServiceState` is an internally-tagged enum
+//! whose members serialize snake_case (`mediator_did`); the published schema is
+//! a flat object with camelCase members. They are close enough to look
+//! interchangeable and are not, so every response here is built explicitly
+//! against the generated type. Forwarding the SDK value would put
+//! `mediator_did` on the wire under a schema that says `mediatorDid`, and the
+//! dispatch spine's `validate_payload` would reject it on arrival.
+
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, success_response,
+};
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use trust_tasks_rs::specs::vta::services as spec;
+
+use crate::auth::AuthClaims;
+use crate::error::AppError;
+use crate::operations::protocol::list::ListServicesError;
+use crate::operations::protocol::{OpContext, ServiceOpDeps};
+use crate::server::AppState;
+
+use vta_sdk::protocol::services::ServiceState as SdkState;
+
+/// The DID resolver, or a refusal.
+///
+/// Every mutation needs it: publishing a log entry means resolving the agent's
+/// own DID first, and an agent that cannot do that must not claim it changed
+/// what the world can see.
+fn resolver(state: &AppState) -> Result<affinidi_did_resolver_cache_sdk::DIDCacheClient, AppError> {
+    state
+        .did_resolver
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| AppError::Internal("DID resolver not available".into()))
+}
+
+/// Map one SDK state record onto the published shape.
+///
+/// `drains_until` has no SDK counterpart on the state record — a drain is
+/// reported by `vta/services/drain/list`, which reads a different store — so it
+/// is left absent here rather than guessed.
+fn state(s: &SdkState) -> spec::list::v1_0::ServiceState {
+    use spec::list::v1_0::{ServiceKind as K, ServiceState as Out};
+    let (kind, enabled, mediator_did, url) = match s {
+        SdkState::Tsp {
+            enabled,
+            mediator_did,
+        } => (K::Tsp, *enabled, mediator_did.clone(), None),
+        SdkState::Rest { enabled, url } => (K::Rest, *enabled, None, url.clone()),
+        SdkState::Didcomm {
+            enabled,
+            mediator_did,
+            ..
+        } => (K::Didcomm, *enabled, mediator_did.clone(), None),
+        SdkState::Webauthn { enabled, url } => (K::Webauthn, *enabled, None, url.clone()),
+    };
+    Out {
+        kind,
+        enabled,
+        mediator_did,
+        url,
+        drains_until: None,
+        ext: None,
+    }
+}
+
+fn kind_of(s: &SdkState) -> spec::list::v1_0::ServiceKind {
+    state(s).kind
+}
+
+/// Classify a listing failure the way the REST route does.
+///
+/// Mirrored rather than collapsed to `Internal`: an agent whose DID is not yet
+/// configured is a conflict the operator can fix, and telling them so is the
+/// difference between "run `vta setup`" and "something broke". A refusal is
+/// forbidden, not internal, for the same reason.
+fn list_error(e: ListServicesError) -> AppError {
+    match e {
+        ListServicesError::Auth(msg) => AppError::Forbidden(msg),
+        ListServicesError::VtaDidNotConfigured => {
+            AppError::Conflict("VTA DID is not configured — run `vta setup` first".into())
+        }
+        other => AppError::Internal(other.to_string()),
+    }
+}
+
+// ── list / get ──────────────────────────────────────────────────────
+
+pub(super) async fn handle_list(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let _req: spec::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // The operation enforces super-admin itself; letting it do so keeps one
+    // authorization decision rather than two that can drift apart.
+    match crate::operations::protocol::list::list_services(&state_.config, &state_.webvh_ks, auth)
+        .await
+    {
+        Ok(body) => success_response(
+            &doc,
+            spec::list::v1_0::Response {
+                services: body.services.iter().map(state).collect(),
+                ext: None,
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, list_error(e)),
+    }
+}
+
+pub(super) async fn handle_get(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::get::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match crate::operations::protocol::list::list_services(&state_.config, &state_.webvh_ks, auth)
+        .await
+    {
+        Ok(body) => {
+            // `get` narrows `list` rather than having its own operation: the
+            // agent holds one state record per transport, so querying twice
+            // could disagree with itself.
+            let want = match req.service {
+                spec::get::v1_0::ServiceKind::Didcomm => spec::list::v1_0::ServiceKind::Didcomm,
+                spec::get::v1_0::ServiceKind::Rest => spec::list::v1_0::ServiceKind::Rest,
+                spec::get::v1_0::ServiceKind::Tsp => spec::list::v1_0::ServiceKind::Tsp,
+                spec::get::v1_0::ServiceKind::Webauthn => spec::list::v1_0::ServiceKind::Webauthn,
+            };
+            match body.services.iter().find(|s| kind_of(s) == want) {
+                Some(found) => success_response(
+                    &doc,
+                    spec::get::v1_0::Response {
+                        state: serde_json::from_value(
+                            serde_json::to_value(state(found)).unwrap_or(Value::Null),
+                        )
+                        .expect("the two generated ServiceState shapes are identical"),
+                        ext: None,
+                    },
+                ),
+                // Absent means never configured — distinct from configured and
+                // disabled, which comes back with `enabled: false`. Answering
+                // an empty success here would erase that distinction, which is
+                // the only reason to call `get` over `list`.
+                None => app_error_to_reject(
+                    &doc,
+                    crate::error::AppError::NotFound(format!(
+                        "no {:?} transport is configured on this agent",
+                        req.service
+                    )),
+                ),
+            }
+        }
+        Err(e) => app_error_to_reject(&doc, list_error(e)),
+    }
+}
+
+// ── the mutating verbs ──────────────────────────────────────────────
+//
+// Each fans out on `service`. The three uniform transports take the same
+// `(deps, auth, params, ctx, channel)` shape; `didcomm` differs because it
+// carries a mediator handshake and a drain, which is the whole reason the
+// spec's `config` is a discriminated union rather than one flat object.
+
+use crate::operations::protocol::disable_didcomm::{
+    DisableDidcommParams, DisableTransport, disable_didcomm,
+};
+use crate::operations::protocol::disable_rest::{DisableRestParams, disable_rest};
+use crate::operations::protocol::disable_tsp::{DisableTspParams, disable_tsp};
+use crate::operations::protocol::disable_webauthn::{DisableWebauthnParams, disable_webauthn};
+use crate::operations::protocol::drain_cancel::{DrainCancelParams, drain_cancel};
+use crate::operations::protocol::enable_rest::{EnableRestParams, enable_rest};
+use crate::operations::protocol::enable_tsp::{EnableTspParams, enable_tsp};
+use crate::operations::protocol::enable_webauthn::{EnableWebauthnParams, enable_webauthn};
+use crate::operations::protocol::list_drain::list_drain;
+use crate::operations::protocol::rollback_rest::{RollbackRestParams, rollback_rest};
+use crate::operations::protocol::rollback_tsp::{RollbackTspParams, rollback_tsp};
+use crate::operations::protocol::rollback_webauthn::{RollbackWebauthnParams, rollback_webauthn};
+use crate::operations::protocol::update_rest::{UpdateRestParams, update_rest};
+use crate::operations::protocol::update_tsp::{UpdateTspParams, update_tsp};
+use crate::operations::protocol::update_webauthn::{UpdateWebauthnParams, update_webauthn};
+
+/// Which transport this task arrived over, for the drain guard.
+///
+/// The dispatch spine records confidentiality, not binding: DIDComm and TSP are
+/// both `EndToEnd`, and it cannot tell them apart. So `EndToEnd` maps to
+/// `Didcomm` here, which **over-applies** the 1-hour drain floor to a
+/// TSP-carried disable that does not strictly need it.
+///
+/// That asymmetry is deliberate. Under-applying the floor tears down the
+/// mediator a request arrived through and discards the reply to the very task
+/// asking for it; over-applying only delays a teardown the operator can repeat.
+/// A bounded delay is the cheaper mistake, so the ambiguous case takes it.
+fn arrival_transport() -> DisableTransport {
+    match super::transport::current() {
+        super::transport::TransportConfidentiality::EndToEnd => DisableTransport::Didcomm,
+        super::transport::TransportConfidentiality::HopByHop => DisableTransport::Rest,
+    }
+}
+
+/// `config.url`, or a validation refusal naming the member that is missing.
+fn need_url(url: Option<String>) -> Result<String, AppError> {
+    url.ok_or_else(|| AppError::Conflict("this service needs `config.url`; none was sent".into()))
+}
+
+fn need_mediator(mediator_did: Option<String>) -> Result<String, AppError> {
+    mediator_did.ok_or_else(|| {
+        AppError::Conflict("this service needs `config.mediatorDid`; none was sent".into())
+    })
+}
+
+/// The shared success shape, stamped with the instant the change took effect.
+///
+/// The operations return the log-entry id but not the time; the REST routes
+/// stamp it at the boundary and so does this, so both surfaces agree.
+fn mutation(
+    log_entry_version_id: String,
+    vta_did: String,
+    serverless: bool,
+    drain_until: Option<chrono::DateTime<chrono::Utc>>,
+    draining_mediator: Option<String>,
+) -> Result<spec::enable::v1_0::ServiceMutationResult, AppError> {
+    Ok(spec::enable::v1_0::ServiceMutationResult {
+        log_entry_version_id: log_entry_version_id
+            .try_into()
+            .map_err(|_| AppError::Internal("operation returned an empty log entry id".into()))?,
+        effective_at: chrono::Utc::now(),
+        drain_until,
+        draining_mediator,
+        vta_did: (!vta_did.is_empty()).then_some(vta_did),
+        serverless,
+        ext: None,
+    })
+}
+
+/// Re-type an identically-shaped generated value for a sibling family.
+///
+/// `enable`, `update` and `disable` each get their own `ServiceMutationResult`
+/// from codegen: same members, distinct types. Rather than hand-copy the
+/// members three times — and drift when one gains a field — go through the wire
+/// form, which is the representation all of them agree on by construction.
+fn retype<T: serde::de::DeserializeOwned>(v: impl serde::Serialize) -> Result<T, AppError> {
+    serde_json::to_value(v)
+        .and_then(serde_json::from_value)
+        .map_err(|e| AppError::Internal(format!("service result re-type: {e}")))
+}
+
+/// Await a service operation, boxing its future.
+///
+/// Not a style choice. These handlers fan out to four operations, each with a
+/// sizeable future of its own, and the dispatch spine awaits the handler inside
+/// a match that already carries every other task's state machine. Inlining them
+/// grew that frame past the default 8 MiB thread stack and aborted an unrelated
+/// mock_vta test with a stack overflow — which reads as infinite recursion and
+/// is not. Boxing moves each operation's state to the heap and keeps the
+/// enclosing future flat.
+macro_rules! op {
+    ($doc:expr, $call:expr) => {
+        match Box::pin($call).await {
+            Ok(r) => r,
+            Err(e) => return app_error_to_reject($doc, AppError::Conflict(e.to_string())),
+        }
+    };
+}
+
+pub(super) async fn handle_enable(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: spec::enable::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let resolver = match resolver(state_) {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let deps = ServiceOpDeps::from_app_state(state_, &resolver);
+    use spec::enable::v1_0::ServiceKind as K;
+
+    let result = match req.service {
+        K::Rest => {
+            let url = match need_url(req.config.url.clone().map(String::from)) {
+                Ok(u) => u,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            let r = op!(
+                &doc,
+                enable_rest(
+                    &deps,
+                    auth,
+                    EnableRestParams { url },
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Webauthn => {
+            let url = match need_url(req.config.url.clone().map(String::from)) {
+                Ok(u) => u,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            let r = op!(
+                &doc,
+                enable_webauthn(
+                    &deps,
+                    auth,
+                    EnableWebauthnParams { url },
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Tsp => {
+            let mediator_did =
+                match need_mediator(req.config.mediator_did.clone().map(String::from)) {
+                    Ok(m) => m,
+                    Err(e) => return app_error_to_reject(&doc, e),
+                };
+            let r = op!(
+                &doc,
+                enable_tsp(
+                    &deps,
+                    auth,
+                    EnableTspParams { mediator_did },
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Didcomm => {
+            // `AlwaysOkProver` for the same reason the REST enable route uses
+            // it: the handshake's steps 2-5 need a running `DIDCommService`,
+            // and at first-enable there is not one yet. The steady-state case
+            // — where DIDComm is already up — goes through `update`, which
+            // builds a live prover.
+            let mediator_did =
+                match need_mediator(req.config.mediator_did.clone().map(String::from)) {
+                    Ok(m) => m,
+                    Err(e) => return app_error_to_reject(&doc, e),
+                };
+            let params = crate::operations::protocol::enable_didcomm::EnableDidcommParams {
+                mediator_did,
+                force: req.config.force.unwrap_or(false),
+                handshake_timeout: std::time::Duration::from_secs(
+                    req.config.handshake_timeout_secs.map_or(10, u64::from),
+                ),
+            };
+            let prover = crate::messaging::handshake::AlwaysOkProver;
+            let r = op!(
+                &doc,
+                crate::operations::protocol::enable_didcomm::enable_didcomm(
+                    &deps,
+                    &prover,
+                    auth,
+                    params,
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+    };
+    match result {
+        Ok(result) => success_response(&doc, spec::enable::v1_0::Response { result, ext: None }),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+pub(super) async fn handle_update(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: spec::update::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let resolver = match resolver(state_) {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let deps = ServiceOpDeps::from_app_state(state_, &resolver);
+    use spec::update::v1_0::ServiceKind as K;
+
+    let result = match req.service {
+        K::Rest => {
+            let url = match need_url(req.config.url.clone().map(String::from)) {
+                Ok(u) => u,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            let r = op!(
+                &doc,
+                update_rest(
+                    &deps,
+                    auth,
+                    UpdateRestParams { url },
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Webauthn => {
+            let url = match need_url(req.config.url.clone().map(String::from)) {
+                Ok(u) => u,
+                Err(e) => return app_error_to_reject(&doc, e),
+            };
+            let r = op!(
+                &doc,
+                update_webauthn(
+                    &deps,
+                    auth,
+                    UpdateWebauthnParams { url },
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Tsp => {
+            let mediator_did =
+                match need_mediator(req.config.mediator_did.clone().map(String::from)) {
+                    Ok(m) => m,
+                    Err(e) => return app_error_to_reject(&doc, e),
+                };
+            let r = op!(
+                &doc,
+                update_tsp(
+                    &deps,
+                    auth,
+                    UpdateTspParams { mediator_did },
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Didcomm => {
+            // Replacing the mediator drains the old one, so this carries the
+            // same arrival-transport guard as `disable`: swapping the mediator
+            // a request arrived through must not cut its reply.
+            let mediator_did =
+                match need_mediator(req.config.mediator_did.clone().map(String::from)) {
+                    Ok(m) => m,
+                    Err(e) => return app_error_to_reject(&doc, e),
+                };
+            let prover = crate::messaging::handshake::AlwaysOkProver;
+            let params = crate::operations::protocol::update_didcomm::UpdateDidcommParams {
+                new_mediator_did: mediator_did,
+                drain_ttl: crate::operations::protocol::disable_didcomm::MIN_DRAIN_TTL_OVER_DIDCOMM,
+                force: req.config.force.unwrap_or(false),
+                handshake_timeout: std::time::Duration::from_secs(
+                    req.config.handshake_timeout_secs.map_or(10, u64::from),
+                ),
+                audit_kind: crate::operations::protocol::update_didcomm::MigrateAuditKind::Forward,
+                transport: arrival_transport(),
+            };
+            let r = op!(
+                &doc,
+                crate::operations::protocol::update_didcomm::update_didcomm(
+                    &deps,
+                    &prover,
+                    auth,
+                    params,
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(
+                r.new_version_id,
+                r.vta_did,
+                r.serverless,
+                Some(r.drains_until),
+                Some(r.prior_mediator_did),
+            )
+        }
+    };
+    match result {
+        Ok(result) => match retype(result) {
+            Ok(result) => {
+                success_response(&doc, spec::update::v1_0::Response { result, ext: None })
+            }
+            Err(e) => app_error_to_reject(&doc, e),
+        },
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+pub(super) async fn handle_disable(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: spec::disable::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let resolver = match resolver(state_) {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let deps = ServiceOpDeps::from_app_state(state_, &resolver);
+    use spec::disable::v1_0::ServiceKind as K;
+
+    let result = match req.service {
+        K::Rest => {
+            let r = op!(
+                &doc,
+                disable_rest(
+                    &deps,
+                    auth,
+                    DisableRestParams,
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Webauthn => {
+            let r = op!(
+                &doc,
+                disable_webauthn(
+                    &deps,
+                    auth,
+                    DisableWebauthnParams {},
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Tsp => {
+            let r = op!(
+                &doc,
+                disable_tsp(
+                    &deps,
+                    auth,
+                    DisableTspParams,
+                    OpContext::Direct,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
+        }
+        K::Didcomm => {
+            // `drainTtlSecs` is a REQUEST, not an instruction — the operation
+            // raises it to the 1h floor when `transport` says the task arrived
+            // end-to-end. The spec says so, and the result's `drainUntil` is
+            // what a caller must read to learn what actually happened.
+            let params = DisableDidcommParams {
+                drain_ttl: std::time::Duration::from_secs(req.drain_ttl_secs.unwrap_or(0)),
+                transport: arrival_transport(),
+            };
+            let r = op!(
+                &doc,
+                disable_didcomm(&deps, auth, params, OpContext::Direct, TRANSPORT_TRUST_TASK)
+            );
+            let draining = r.drains_until.map(|_| r.prior_mediator_did.clone());
+            mutation(
+                r.new_version_id,
+                r.vta_did,
+                r.serverless,
+                r.drains_until,
+                draining,
+            )
+        }
+    };
+    match result {
+        Ok(result) => match retype(result) {
+            Ok(result) => {
+                success_response(&doc, spec::disable::v1_0::Response { result, ext: None })
+            }
+            Err(e) => app_error_to_reject(&doc, e),
+        },
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Map a forward-op rollback kind onto the published one.
+///
+/// Each transport's rollback module declares its own `RollbackKind` with the
+/// same four variants, so this takes the enum path rather than one type. They
+/// are parallel by convention, not by a shared definition, and a macro that
+/// names the variants keeps a divergence a compile error rather than a silent
+/// mismatch.
+macro_rules! rollback_kind {
+    ($m:ident, $k:expr) => {{
+        use crate::operations::protocol::$m::RollbackKind as K;
+        use spec::rollback::v1_0::RollbackResultKind as Out;
+        match $k {
+            K::Disabled => Out::Disabled,
+            K::Enabled => Out::Enabled,
+            K::Updated => Out::Updated,
+            K::NoOp => Out::NoOp,
+        }
+    }};
+}
+
+/// Build the rollback result.
+///
+/// `logEntryVersionId` is optional here and required on `ServiceMutationResult`,
+/// which is the whole reason rollback has its own shape: when the previous
+/// state already equals the current one nothing is written, and `kind: noOp`
+/// says so. That is a **success** — the requested state holds — so reporting it
+/// as a failure would be wrong, and inventing a log entry id would be worse.
+fn rollback_result(
+    kind: spec::rollback::v1_0::RollbackResultKind,
+    new_version_id: Option<String>,
+    vta_did: String,
+    serverless: bool,
+    draining_mediator: Option<String>,
+) -> spec::rollback::v1_0::RollbackResult {
+    let wrote_an_entry = new_version_id.is_some();
+    spec::rollback::v1_0::RollbackResult {
+        kind,
+        log_entry_version_id: new_version_id,
+        effective_at: wrote_an_entry.then(chrono::Utc::now),
+        drain_until: None,
+        draining_mediator,
+        vta_did: (!vta_did.is_empty()).then_some(vta_did),
+        serverless,
+        ext: None,
+    }
+}
+
+pub(super) async fn handle_rollback(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: spec::rollback::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let resolver = match resolver(state_) {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let deps = ServiceOpDeps::from_app_state(state_, &resolver);
+    use spec::rollback::v1_0::ServiceKind as K;
+
+    let result = match req.service {
+        K::Rest => {
+            let r = op!(
+                &doc,
+                rollback_rest(&deps, auth, RollbackRestParams, TRANSPORT_TRUST_TASK)
+            );
+            rollback_result(
+                rollback_kind!(rollback_rest, r.kind),
+                r.new_version_id,
+                r.vta_did,
+                r.serverless,
+                None,
+            )
+        }
+        K::Webauthn => {
+            let r = op!(
+                &doc,
+                rollback_webauthn(&deps, auth, RollbackWebauthnParams, TRANSPORT_TRUST_TASK)
+            );
+            rollback_result(
+                rollback_kind!(rollback_webauthn, r.kind),
+                r.new_version_id,
+                r.vta_did,
+                r.serverless,
+                None,
+            )
+        }
+        K::Tsp => {
+            let r = op!(
+                &doc,
+                rollback_tsp(&deps, auth, RollbackTspParams, TRANSPORT_TRUST_TASK)
+            );
+            rollback_result(
+                rollback_kind!(rollback_tsp, r.kind),
+                r.new_version_id,
+                r.vta_did,
+                r.serverless,
+                None,
+            )
+        }
+        K::Didcomm => {
+            // Rolling DIDComm back can leave the superseded mediator draining,
+            // so it takes the same arrival guard as disable.
+            let params = crate::operations::protocol::rollback_didcomm::RollbackDidcommParams {
+                drain_ttl: crate::operations::protocol::disable_didcomm::MIN_DRAIN_TTL_OVER_DIDCOMM,
+                transport: arrival_transport(),
+            };
+            // Rolling back re-runs the forward op, so it needs a prover for
+            // the same reason enable does — and `AlwaysOkProver` for the same
+            // reason: the restored mediator's handshake cannot depend on a
+            // DIDComm service that the rollback may itself be turning off.
+            let prover = crate::messaging::handshake::AlwaysOkProver;
+            let r = op!(
+                &doc,
+                crate::operations::protocol::rollback_didcomm::rollback_didcomm(
+                    &deps,
+                    &prover,
+                    auth,
+                    params,
+                    TRANSPORT_TRUST_TASK
+                )
+            );
+            let draining = r.draining_mediator.clone();
+            rollback_result(
+                rollback_kind!(rollback_didcomm, r.kind),
+                r.new_version_id,
+                r.vta_did,
+                r.serverless,
+                draining,
+            )
+        }
+    };
+    success_response(&doc, spec::rollback::v1_0::Response { result, ext: None })
+}
+
+// ── drain ───────────────────────────────────────────────────────────
+
+pub(super) async fn handle_drain_list(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let _req: spec::drain::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match list_drain(&state_.config, &state_.drains_ks, auth).await {
+        Ok(body) => {
+            let entries = body
+                .entries
+                .into_iter()
+                .map(|e| {
+                    Ok(spec::drain::list::v1_0::DrainEntry {
+                        mediator_did: e.mediator_did.try_into().map_err(|_| {
+                            AppError::Internal("drain entry has an empty mediator did".into())
+                        })?,
+                        endpoint: e.endpoint,
+                        drains_until: e.drains_until.parse().map_err(|_| {
+                            AppError::Internal("drain entry has an unparseable deadline".into())
+                        })?,
+                        ext: None,
+                    })
+                })
+                .collect::<Result<Vec<_>, AppError>>();
+            match entries {
+                Ok(entries) => success_response(
+                    &doc,
+                    spec::drain::list::v1_0::Response { entries, ext: None },
+                ),
+                Err(e) => app_error_to_reject(&doc, e),
+            }
+        }
+        Err(e) => app_error_to_reject(&doc, AppError::Conflict(e.to_string())),
+    }
+}
+
+pub(super) async fn handle_drain_cancel(
+    state_: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_super_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: spec::drain::cancel::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // Destructive: whatever is still in flight through that mediator is lost,
+    // which is exactly what the drain window existed to prevent. The operation
+    // refuses when the mediator is the active one, so an operator cannot strand
+    // the route the agent depends on by hand.
+    let params = DrainCancelParams {
+        mediator_did: req.mediator_did.to_string(),
+    };
+    match drain_cancel(
+        &state_.config,
+        &state_.drains_ks,
+        &state_.mediator_registry,
+        &state_.telemetry,
+        auth,
+        params,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        // `mediatorDid` is a plain String in this family — no newtype to
+        // fall through, so there is nothing to validate here beyond what
+        // the operation already guaranteed.
+        Ok(r) => success_response(
+            &doc,
+            spec::drain::cancel::v1_0::Response {
+                mediator_did: r.mediator_did,
+                ext: None,
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, AppError::Conflict(e.to_string())),
+    }
+}

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -4153,3 +4153,54 @@ async fn an_unauthenticated_rejection_is_not_counted_as_usage() {
         "an unauthorised request must not be recorded as usage"
     );
 }
+
+#[tokio::test]
+async fn a_services_route_advertises_its_task_successor() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/services")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let (_status, headers) = request_headers(&app, req).await;
+    if let Some(link) = headers.get("link") {
+        assert!(
+            link.to_str()
+                .unwrap()
+                .contains(vta_sdk::trust_tasks::TASK_SERVICES_LIST_1_0),
+            "GET /services must name services/list as its successor"
+        );
+    }
+}
+
+#[test]
+fn the_two_drain_routes_split_on_method_not_path() {
+    // `/services/didcomm/drain` is one path serving two operations: GET lists
+    // what is draining, POST cancels a drain. They are the only pair in the
+    // superseded table that share a path, so they are the one entry a future
+    // edit could collapse by matching on path alone — and collapsing them would
+    // advertise a read as a destructive cancel, or the reverse.
+    let table = vta_service::deprecation::superseded_table();
+    let drain: Vec<_> = table
+        .iter()
+        .filter(|(_, path, _, _)| *path == "/services/didcomm/drain")
+        .collect();
+
+    assert_eq!(drain.len(), 2, "both drain routes must be marked");
+    let get = drain
+        .iter()
+        .find(|(m, ..)| *m == "GET")
+        .expect("GET is marked");
+    let post = drain
+        .iter()
+        .find(|(m, ..)| *m == "POST")
+        .expect("POST is marked");
+    assert_eq!(get.3, vta_sdk::trust_tasks::TASK_SERVICES_DRAIN_LIST_1_0);
+    assert_eq!(post.3, vta_sdk::trust_tasks::TASK_SERVICES_DRAIN_CANCEL_1_0);
+    assert_ne!(
+        get.3, post.3,
+        "a read and a destructive cancel are not the same successor"
+    );
+}


### PR DESCRIPTION
Completes the `/services/*` work: the eight handlers, then the twenty routes
they supersede. The operations are untouched — `operations::protocol::*`
already implements each transport — so this is the parameterised door onto
them, not new logic.

## One verb per task, not one per transport

`service` names the transport and `config` carries its settings, so the fan-out
happens in the handler rather than on the wire. Sixteen routes collapse onto
four tasks; a fifth transport needs a config variant, not four new specs.

## The drain guard is the part that matters

Tearing down a mediator discards whatever is in flight through it, so
`disable`/`update`/`rollback` on didcomm pass a `DisableTransport` deciding
whether the 1-hour floor applies. The REST route hardcodes `Rest` and the
DIDComm handler hardcodes `Didcomm` because each **is** that path. A trust task
is not, so it reads the arrival transport from the dispatch spine.

**The spine records confidentiality, not binding.** DIDComm and TSP are both
`EndToEnd` and it cannot tell them apart, so `EndToEnd` maps to `Didcomm` —
which *over-applies* the floor to a TSP-carried disable that doesn't strictly
need it.

That's deliberate, and the asymmetry decides it: under-applying tears down the
mediator a request arrived through and discards the reply to the very task
asking for it; over-applying only delays a teardown the operator can repeat.
The ambiguous case takes the cheaper mistake.

## Three shapes the generated types forced

- `ServiceMutationResult` and `RollbackKind` are **duplicated per family** —
  identical shapes, distinct types. Mutation results round-trip through the wire
  form rather than being hand-copied three times; rollback kinds go through a
  macro naming the variants, so divergence is a compile error.
- **Rollback may write nothing.** Its `noOp` arm has no `logEntryVersionId`,
  which is why it has its own result type — and the witness uses exactly that
  arm, so it's the case that breaks if the result ever starts requiring one.
- `handshake_timeout_secs` is `NonZeroU64` (the schema's `minimum: 1`), so the
  default is constructed, not unwrapped.

## Boxed futures, and why that's load-bearing

These handlers fan out to four sizeable operation futures, awaited inside a
dispatch match already carrying every other task's state machine. Inlining them
grew the frame past the default 8 MiB stack and **aborted an unrelated
`mock_vta` test with a stack overflow** — which reads as infinite recursion and
is not. `Box::pin` in the `op!` macro keeps the enclosing future flat.

I found this only because the abort didn't show up as a failed test: SIGABRT is
not a `test result: FAILED` line, so a naive grep reported zero failures on a
run that had stopped after 36 suites.

## Retry safety

Reads are `ReadOnly`; every mutation is `Keyed`, because each republishes an
append-only did:webvh log. `enable` refuses a transport already enabled, so a
repeat is a conflict rather than a duplicate — `Keyed` anyway, because a caller
who lost the reply **cannot tell that conflict from "it never landed"**, and the
cached response is what resolves it.

## The twenty routes (#1007's exclusion, lifted)

#1007 marked 56 routes and excluded `/services/*` for a stated reason: no twin
existed. It does now, so the metric covers the **whole** retirement-candidate
set rather than most of it. The mapping is derived from the route table, not
hand-written, and checked to leave nothing unmapped.

**The drain pair earns a test.** `/services/didcomm/drain` is one path serving
two operations — GET lists, POST cancels. They're the only pair sharing a path,
so they're the one entry a later edit could collapse by matching on path alone,
which would advertise a read as a destructive cancel or the reverse.

## Test

```
cargo test --workspace --features session,tsp   145 suites, 4525 passing
cargo clippy --workspace --all-targets -- -D warnings   clean
```

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] **Every retry bounded + backed off; non-idempotent ops not blind-retried
      (R1.4)** — the retry-safety classifications above
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, schema registered (R3.*) — payloads and
      responses come from the generated types
- [x] Config absence = most restrictive (R5.*)
- [x] **Logs/status claim only what was verified (R6.\*)** — `drainUntil`
      reports what the agent actually did, never what the caller asked for
- [x] Deviations flagged with rule numbers