### PR TITLE
chore(deps)!: move to trust-tasks-rs 0.11, and fix the wire drift it exposed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.18"
+version = "0.18.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01857ae34f9931c8d0335d17a8f69917f22ae8e6fb3f09e1c7bfa56bb1343b62"
+checksum = "ab9d65f2641d3df7aef6687abd2bd0788d7f9e725755baed7460449303b42dee"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954fe9bbc880aa008e9f01eeac117ab45419df00fddc40541c975fc70b3de506"
+checksum = "6cd4c9f5aaf47ef876e858a80e1a4c396a04f19a2301f2b0eb4ec4af45ea7180"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -2945,7 +2945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4610,7 +4610,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6487,7 +6487,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6526,7 +6526,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -8667,9 +8667,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9544464e98ff02398134df574ae40caf193146c8db44cc3a774255931b3a8b"
+checksum = "8c744c8389d63e3e4d6bf89a44df0fa6429cc449cf24c70e33bb3f6ef0a10f37"
 dependencies = [
  "chrono",
  "serde",
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001ffbb2589cc5626f2eb2bcf006cd0da4bd37ce0f45143a9ceb7821f1758393"
+checksum = "4dcb2a620b363ca38771125868e36a0e4204a13ea0ca1a756fcd441f5a341330"
 dependencies = [
  "affinidi-messaging-didcomm",
  "serde",
@@ -8695,9 +8695,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283761acdbaeec3c82db38c7ecf750847d89098a1a7e2a83becb26b1eddc20d4"
+checksum = "5b05af8774339d7c1fb29bde5ab5c37893221b9b5e95429bdd3db8f4404ae650"
 dependencies = [
  "axum",
  "chrono",
@@ -8714,9 +8714,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e14b624ab8fb95442a6183d756f9416ff4b931790bff45ebc59f4a9a8fb576a"
+checksum = "69ac669b4bcaa91fd640e2630a4791fc1fb5fe4b38d1d22ab1e4e34d3e8cad9e"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8731,9 +8731,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fafd737292481f82d012e197981c7955d2f3f00a7c45708aa46916c4bdd0a9d"
+checksum = "8480433b7122652533d7c76f5378196f3be02ed295d124174ef36c6968af54cc"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,9 +235,9 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.9", default-features = false, features = ["validate"] }
-trust-tasks-capability-client = "0.8"
-trust-tasks-https = { version = "0.9", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-rs = { version = "0.11", default-features = false, features = ["validate"] }
+trust-tasks-capability-client = "0.9"
+trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -248,8 +248,8 @@ trust-tasks-https = { version = "0.9", default-features = false, features = ["se
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.9", default-features = false }
-trust-tasks-proof = { version = "0.9", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.10", default-features = false }
+trust-tasks-proof = { version = "0.10", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/vta-sdk/src/client/contexts.rs
+++ b/vta-sdk/src/client/contexts.rs
@@ -45,14 +45,22 @@ impl VtaClient {
         id: &str,
         req: UpdateContextRequest,
     ) -> Result<ContextResponse, VtaError> {
+        // Built from the canonical body rather than a hand-rolled map. The map
+        // emitted every member unconditionally, so an unset `name`/`did`/
+        // `description` went out as `null` — and the published schema types
+        // them as optional *strings*, which `null` is not. It validated only
+        // while the registry had no schema for this task to check against.
+        // Same defect, same fix, as `keys/create` (#919).
+        let body = crate::protocols::context_management::update::UpdateContextBody {
+            id: id.to_string(),
+            name: req.name.clone(),
+            did: req.did.clone(),
+            description: req.description.clone(),
+            ..Default::default()
+        };
         self.rpc_tt(
             crate::trust_tasks::TASK_CONTEXTS_UPDATE_1_0,
-            serde_json::json!({
-                "id": id,
-                "name": &req.name,
-                "did": &req.did,
-                "description": &req.description,
-            }),
+            serde_json::to_value(&body)?,
             30,
         )
         .await

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -676,7 +676,14 @@ pub struct UpdateWebvhServerRequest {
 
 // ── WebVH DID types ─────────────────────────────────────────────────
 
+/// `rename_all = "camelCase"` because the canonical wire is camelCase (R3.1),
+/// and `vta/webvh/dids/create/1.0`'s published schema is
+/// `additionalProperties: false`. This struct emitted snake_case, which the
+/// server accepted only through the back-compat aliases on
+/// [`crate::protocols::did_management::create::CreateDidWebvhBody`] — so the
+/// drift was invisible until the registry served a schema to check it against.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateDidWebvhRequest {
     pub context_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vta-sdk/src/protocols/context_management/update.rs
+++ b/vta-sdk/src/protocols/context_management/update.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::create::CreateContextResultBody;
 use crate::context_policy::ContextPolicy;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateContextBody {

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -23,16 +23,30 @@ use serde::{Deserialize, Serialize};
 /// absent path has never meant the `.well-known` root on a hosting
 /// server — that is the serverless case (selected by the absence of a
 /// `server_id`, where the DID location comes from the `URL` itself).
+/// # Wire casing
+///
+/// The discriminant values are **camelCase** (`wellKnown` / `autoAssign`),
+/// because that is what `vta/webvh/dids/create/1.0`'s published schema pins
+/// with a `const` in each `oneOf` branch — and, like every other wire type
+/// here, the canonical form is camelCase (R3.1).
+///
+/// This emitted `snake_case` until the registry served a schema to check it
+/// against. Nothing caught it because the discriminant is a *value*, not a
+/// member name, so it slipped past the reviews that watch member casing. The
+/// snake_case forms stay accepted as aliases, so a peer built against the old
+/// spelling keeps working; only what we *emit* changes.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(tag = "mode", content = "path", rename_all = "snake_case")]
+#[serde(tag = "mode", content = "path", rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum WebvhPathMode {
     /// Root DID at the host: resolves at `<host>/.well-known/did.jsonl`.
+    #[serde(alias = "well_known")]
     WellKnown,
     /// Operator-chosen path label: `<host>/<path>/did.jsonl`.
     Explicit(String),
     /// Let the hosting server allocate the path.
     #[default]
+    #[serde(alias = "auto_assign")]
     AutoAssign,
 }
 
@@ -354,8 +368,33 @@ mod webvh_path_mode_tests {
         );
         assert_eq!(
             serde_json::to_value(WebvhPathMode::AutoAssign).unwrap(),
-            serde_json::json!({ "mode": "auto_assign" })
+            serde_json::json!({ "mode": "autoAssign" })
         );
+        assert_eq!(
+            serde_json::to_value(WebvhPathMode::WellKnown).unwrap(),
+            serde_json::json!({ "mode": "wellKnown" })
+        );
+    }
+
+    /// The discriminant used to be snake_case, which the published schema
+    /// rejects — it pins each branch with a camelCase `const`. What we emit
+    /// moved; what we accept did not, so a peer built against the old spelling
+    /// still deserializes.
+    #[test]
+    fn the_retired_snake_case_discriminants_still_deserialize() {
+        for (wire, expected) in [
+            (
+                serde_json::json!({ "mode": "auto_assign" }),
+                WebvhPathMode::AutoAssign,
+            ),
+            (
+                serde_json::json!({ "mode": "well_known" }),
+                WebvhPathMode::WellKnown,
+            ),
+        ] {
+            let got: WebvhPathMode = serde_json::from_value(wire.clone()).expect("alias accepted");
+            assert_eq!(got, expected, "{wire} must still parse");
+        }
     }
 }
 

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -344,6 +344,58 @@ fn acl_entry() -> AclEntry {
     }
 }
 
+/// A `did:webvh` with a real-shaped SCID — several schemas bound `minLength`
+/// on these, and a placeholder like `"did:webvh:x"` satisfies a length check by
+/// accident while testing nothing about the form.
+const WEBVH_DID: &str = "did:webvh:QmZ4rT9xK2mN8vB5cD1sA7wE3fH6jL0pQ:did.example.com:alice";
+/// The DID of a DID-hosting server, as `webvh/servers/register` records it.
+const HOST_DID: &str = "did:web:did.example.com";
+
+/// The shared `ContextRecord` (`vta/_shared/0.1/context.schema.json`) every
+/// context task answers with. One builder because the shape is shared: a
+/// per-witness copy would let four of the five drift apart unnoticed.
+fn context_record_json() -> Value {
+    json!({
+        "id": "ctx1",
+        "name": "Production",
+        "basePath": "m/26'/2'/1'",
+        "createdAt": TS,
+        "updatedAt": TS,
+    })
+}
+
+/// The `WebvhDidRecord` shape `dids/get` and `dids/list` share.
+fn webvh_did_record_json() -> Value {
+    json!({
+        "did": WEBVH_DID,
+        "serverId": "primary-host",
+        "mnemonic": "attract-case",
+        "scid": "QmZ4rT9xK2mN8vB5cD1sA7wE3fH6jL0pQ",
+        "contextId": "ctx1",
+        "portable": true,
+        "logEntryCount": 1,
+        "createdAt": TS,
+        "updatedAt": TS,
+    })
+}
+
+/// The registered-server record `servers/list` and `servers/register` share.
+fn webvh_server_json() -> Value {
+    json!({
+        "id": "primary-host",
+        "did": HOST_DID,
+        "label": "Primary",
+        "createdAt": TS,
+        "updatedAt": TS,
+    })
+}
+
+/// The `{did, name, enabled}` answer every agent-name mutation returns.
+/// `set`/`enable` report `true`; `remove`/`disable` report `false`.
+fn agent_name_state_json(enabled: bool) -> Value {
+    json!({ "did": WEBVH_DID, "name": "alice", "enabled": enabled })
+}
+
 fn to_v<T: serde::Serialize>(t: T) -> Value {
     serde_json::to_value(t).expect("serialize fixture")
 }
@@ -1469,6 +1521,261 @@ fn table() -> Vec<(&'static str, Conformance)> {
                         reason: "immutable".into(),
                     }],
                 })
+            ),
+        ),
+        // ─── contexts (published at 1.0 by the move to trust-tasks-rs 0.11) ──
+        //
+        // These seven were dispatched against unpublished URIs, so
+        // `validate_payload` skipped them on both ends and nothing checked the
+        // wire. The registry now serves their schemas; these witnesses are what
+        // holds them to it.
+        (
+            uris::TASK_CONTEXTS_CREATE_1_0,
+            checked!(
+                specs::vta::contexts::create::v1_0::Payload,
+                specs::vta::contexts::create::v1_0::Response,
+                json!({ "id": "ctx1", "name": "Production", "description": "prod" }),
+                json!(context_record_json())
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_GET_1_0,
+            checked!(
+                specs::vta::contexts::get::v1_0::Payload,
+                specs::vta::contexts::get::v1_0::Response,
+                json!({ "id": "ctx1" }),
+                json!(context_record_json())
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_LIST_1_0,
+            checked!(
+                specs::vta::contexts::list::v1_0::Payload,
+                specs::vta::contexts::list::v1_0::Response,
+                json!({}),
+                json!({ "contexts": [context_record_json()] })
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_UPDATE_1_0,
+            checked!(
+                specs::vta::contexts::update::v1_0::Payload,
+                specs::vta::contexts::update::v1_0::Response,
+                // Only `id` is required, and the optional members are typed as
+                // strings — so an unset one must be ABSENT, not `null`. The
+                // client sent `null` here until this witness existed to say so.
+                json!({ "id": "ctx1", "name": "Renamed" }),
+                json!(context_record_json())
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_UPDATE_DID_1_0,
+            checked!(
+                specs::vta::contexts::update_did::v1_0::Payload,
+                specs::vta::contexts::update_did::v1_0::Response,
+                json!({ "id": "ctx1", "did": SUBJECT }),
+                json!(context_record_json())
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
+            checked!(
+                specs::vta::contexts::preview_delete::v1_0::Payload,
+                specs::vta::contexts::preview_delete::v1_0::Response,
+                json!({ "id": "ctx1" }),
+                json!({
+                    "id": "ctx1",
+                    "keys": ["key-1"],
+                    "webvhDids": [WEBVH_DID],
+                    "aclEntriesRemoved": [SUBJECT],
+                    "aclEntriesUpdated": []
+                })
+            ),
+        ),
+        (
+            uris::TASK_CONTEXTS_DELETE_1_0,
+            checked!(
+                specs::vta::contexts::delete::v1_0::Payload,
+                specs::vta::contexts::delete::v1_0::Response,
+                json!({ "id": "ctx1", "force": true }),
+                json!({ "id": "ctx1", "deleted": true })
+            ),
+        ),
+        // ─── webvh/agent-name ────────────────────────────────────────────
+        (
+            uris::TASK_WEBVH_AGENT_NAME_CHECK_1_0,
+            checked!(
+                specs::vta::webvh::agent_name::check::v1_0::Payload,
+                specs::vta::webvh::agent_name::check::v1_0::Response,
+                json!({ "did": WEBVH_DID, "name": "alice" }),
+                json!({
+                    "name": "alice",
+                    "domain": "did.example.com",
+                    "available": true,
+                    "reserved": false
+                })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_LIST_1_0,
+            checked!(
+                specs::vta::webvh::agent_name::list::v1_0::Payload,
+                specs::vta::webvh::agent_name::list::v1_0::Response,
+                json!({ "did": WEBVH_DID }),
+                json!({
+                    "did": WEBVH_DID,
+                    // `createdAt` here is epoch seconds, not the RFC3339 the context and
+                    // webvh records use — the families genuinely differ, so the
+                    // fixture must too.
+                    "names": [{ "name": "alice", "enabled": true, "createdAt": 1_785_628_800u64 }]
+                })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_SET_1_0,
+            checked!(
+                specs::vta::webvh::agent_name::set::v1_0::Payload,
+                specs::vta::webvh::agent_name::set::v1_0::Response,
+                json!({ "did": WEBVH_DID, "name": "alice" }),
+                json!(agent_name_state_json(true))
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
+            checked!(
+                specs::vta::webvh::agent_name::remove::v1_0::Payload,
+                specs::vta::webvh::agent_name::remove::v1_0::Response,
+                json!({ "did": WEBVH_DID, "name": "alice" }),
+                json!(agent_name_state_json(false))
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
+            checked!(
+                specs::vta::webvh::agent_name::enable::v1_0::Payload,
+                specs::vta::webvh::agent_name::enable::v1_0::Response,
+                json!({ "did": WEBVH_DID, "name": "alice" }),
+                json!(agent_name_state_json(true))
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
+            checked!(
+                specs::vta::webvh::agent_name::disable::v1_0::Payload,
+                specs::vta::webvh::agent_name::disable::v1_0::Response,
+                json!({ "did": WEBVH_DID, "name": "alice" }),
+                json!(agent_name_state_json(false))
+            ),
+        ),
+        // ─── webvh/dids ──────────────────────────────────────────────────
+        (
+            uris::TASK_WEBVH_DIDS_CREATE_1_0,
+            checked!(
+                specs::vta::webvh::dids::create::v1_0::Payload,
+                specs::vta::webvh::dids::create::v1_0::Response,
+                // camelCase, because the schema is `additionalProperties: false`.
+                // The SDK's `CreateDidWebvhRequest` emitted snake_case here and
+                // was only ever accepted through the body type's back-compat
+                // aliases; this witness is what makes that a test failure.
+                json!({
+                    "contextId": "ctx1",
+                    "serverId": "primary-host",
+                    "portable": true,
+                    "addMediatorService": true,
+                    "preRotationCount": 2,
+                    "setPrimary": false
+                }),
+                json!({
+                    "did": WEBVH_DID,
+                    "contextId": "ctx1",
+                    "scid": "QmZ4rT9xK2mN8vB5cD1sA7wE3fH6jL0pQ",
+                    "portable": true,
+                    "signingKeyId": "key-sign",
+                    "kaKeyId": "key-ka",
+                    "preRotationKeyCount": 2,
+                    "createdAt": TS
+                })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_GET_1_0,
+            checked!(
+                specs::vta::webvh::dids::get::v1_0::Payload,
+                specs::vta::webvh::dids::get::v1_0::Response,
+                json!({ "did": WEBVH_DID, "includeLog": false }),
+                json!({ "record": webvh_did_record_json() })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_LIST_1_0,
+            checked!(
+                specs::vta::webvh::dids::list::v1_0::Payload,
+                specs::vta::webvh::dids::list::v1_0::Response,
+                json!({ "contextId": "ctx1" }),
+                json!({ "dids": [webvh_did_record_json()] })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_DELETE_1_0,
+            checked!(
+                specs::vta::webvh::dids::delete::v1_0::Payload,
+                specs::vta::webvh::dids::delete::v1_0::Response,
+                json!({ "did": WEBVH_DID }),
+                json!({ "did": WEBVH_DID, "deleted": true })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_ROTATE_KEYS_1_0,
+            checked!(
+                specs::vta::webvh::dids::rotate_keys::v1_0::Payload,
+                specs::vta::webvh::dids::rotate_keys::v1_0::Response,
+                json!({ "did": WEBVH_DID, "preRotationCount": 2 }),
+                json!({
+                    "did": WEBVH_DID,
+                    "newVersionId": "2-QmNewVersionIdentifierValue",
+                    "newScid": "QmY8nP3bV6xC1kM4hS9dF2gJ5tR7wL0zQ",
+                    "newLogEntry": "{\"versionId\":\"2-Qm\"}",
+                    "updateKeysCount": 1,
+                    "preRotationKeyCount": 2,
+                    "serverless": false
+                })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_DIDS_REGISTER_WITH_SERVER_1_0,
+            checked!(
+                specs::vta::webvh::dids::register_with_server::v1_0::Payload,
+                specs::vta::webvh::dids::register_with_server::v1_0::Response,
+                json!({ "did": WEBVH_DID, "serverId": "primary-host" }),
+                json!({ "did": WEBVH_DID, "serverId": "primary-host", "logEntryCount": 1 })
+            ),
+        ),
+        // ─── webvh/servers ───────────────────────────────────────────────
+        (
+            uris::TASK_WEBVH_SERVERS_LIST_1_0,
+            checked!(
+                specs::vta::webvh::servers::list::v1_0::Payload,
+                specs::vta::webvh::servers::list::v1_0::Response,
+                json!({}),
+                json!({ "servers": [webvh_server_json()] })
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_SERVERS_REGISTER_1_0,
+            checked!(
+                specs::vta::webvh::servers::register::v1_0::Payload,
+                specs::vta::webvh::servers::register::v1_0::Response,
+                json!({ "id": "primary-host", "did": HOST_DID, "label": "Primary" }),
+                json!(webvh_server_json())
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_SERVERS_REMOVE_1_0,
+            checked!(
+                specs::vta::webvh::servers::remove::v1_0::Payload,
+                specs::vta::webvh::servers::remove::v1_0::Response,
+                json!({ "id": "primary-host" }),
+                json!({ "id": "primary-host", "removed": true })
             ),
         ),
     ];

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -226,13 +226,6 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
 #[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
 const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     // ─ vta/contexts/* — keep-and-spec under `vta/` (reduction plan §E).
-    "https://trusttasks.org/spec/vta/contexts/list/1.0",
-    "https://trusttasks.org/spec/vta/contexts/create/1.0",
-    "https://trusttasks.org/spec/vta/contexts/get/1.0",
-    "https://trusttasks.org/spec/vta/contexts/update/1.0",
-    "https://trusttasks.org/spec/vta/contexts/update-did/1.0",
-    "https://trusttasks.org/spec/vta/contexts/preview-delete/1.0",
-    "https://trusttasks.org/spec/vta/contexts/delete/1.0",
     // ─ vta/seeds/* — keep-and-spec under `vta/` (reduction plan §E).
     "https://trusttasks.org/spec/vta/seeds/list/1.0",
     "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
@@ -254,21 +247,6 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     "https://trusttasks.org/spec/vta/attestation/report/1.0",
     // ─ vta/webvh/** — two-ends-of-one-wire decision pending (plan §B).
     //   `dids/update` is published; the rest are not.
-    "https://trusttasks.org/spec/vta/webvh/servers/list/1.0",
-    "https://trusttasks.org/spec/vta/webvh/servers/register/1.0",
-    "https://trusttasks.org/spec/vta/webvh/servers/remove/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/get/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/delete/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/rotate-keys/1.0",
-    "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/list/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/check/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/set/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/remove/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/disable/1.0",
-    "https://trusttasks.org/spec/vta/webvh/agent-name/enable/1.0",
     // ─ Vault archival lifecycle (#540) — generalise with a store
     //   discriminator instead of publishing twelve (reduction plan §C).
     "https://trusttasks.org/spec/vault/archive/0.1",
@@ -1561,13 +1539,26 @@ mod payload_validation_tests {
     #[tokio::test]
     async fn an_unspecced_task_proceeds_by_default_and_can_be_refused() {
         let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
-        // No published spec — one of many. (`vta/memory/list` HAS one, which is
-        // itself the point: the set of validatable tasks is growing.)
-        const UNSPECCED: &str = "https://trusttasks.org/spec/vta/webvh/dids/create/1.0";
+        // Chosen from the tracked-debt list at runtime rather than named, because
+        // naming one is how this test rots: it used to hard-code
+        // `vta/webvh/dids/create/1.0`, which the registry published, and the
+        // test then failed for the best possible reason — the debt shrank.
+        // Deriving it means the test follows the debt down instead of breaking
+        // each time a spec lands.
+        let Some(unspecced) = super::UNSPECCED_DISPATCHED_URIS
+            .iter()
+            .copied()
+            .find(|u| trust_tasks_rs::schema_index::schema_for(u).is_none())
+        else {
+            // Every dispatched task is specced. That is the goal, and when it
+            // arrives this test has nothing left to say — delete it, and the
+            // `require_payload_schema` escape hatch with it.
+            return;
+        };
         let d = doc(json!({ "contextId": "default" }));
 
         assert!(
-            super::validate_payload(&state, UNSPECCED, &d)
+            super::validate_payload(&state, unspecced, &d)
                 .await
                 .is_none(),
             "by default an unvalidatable task still dispatches — refusing it would \
@@ -1576,7 +1567,7 @@ mod payload_validation_tests {
 
         state.config.write().await.policy.require_payload_schema = true;
         assert!(
-            super::validate_payload(&state, UNSPECCED, &d)
+            super::validate_payload(&state, unspecced, &d)
                 .await
                 .is_some(),
             "an operator who would rather fail closed can"

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1897,6 +1897,12 @@ async fn create_did_webvh_accepts_path_mode_field() {
         .request(post_auth(
             "/webvh/dids",
             &token,
+            // Deliberately the **retired** snake_case spelling, on both the
+            // member names and the `mode` discriminant. The canonical wire is
+            // camelCase and that is what the SDK now emits; this is the
+            // back-compat coverage proving a caller built against the old
+            // shape still works. Do not "modernise" it — that would delete the
+            // only test of the aliases.
             json!({
                 "context_id": "test-path-mode",
                 "url": "https://example.com/.well-known/did/did.jsonl",

--- a/vta-service/tests/producer_payload_conformance.rs
+++ b/vta-service/tests/producer_payload_conformance.rs
@@ -87,14 +87,6 @@ const UNPUBLISHED: &[(&str, &str)] = &[
         "The canonical `keys/*` fold (#888) did not reach the seed family.",
     ),
     (
-        "https://trusttasks.org/spec/vta/webvh/dids/register-with-server/1.0",
-        "The webvh fold reached `dids/update` (#885) but not registration.",
-    ),
-    (
-        "https://trusttasks.org/spec/vta/webvh/dids/list/1.0",
-        "As `register-with-server` — same family, same unfolded half.",
-    ),
-    (
         "https://trusttasks.org/spec/vault/credentials/receive/0.1",
         "The `vault/*` fold published query/get/upsert/delete but not \
          `credentials/receive`.",

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,7 +437,7 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        36,
+        14,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
@@ -454,7 +454,12 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
          trust-tasks-rs 0.6.1. It is the first entry this list has gained and \
          lost, and the round trip is the point — the number went up when a URI \
          was bound ahead of its spec, and came back down when the registry \
-         served it. That is the whole mechanism working, not an exception to it",
+         served it. That is the whole mechanism working, not an exception to it. \
+         Then 36 → 14 in one step, on the move to trust-tasks-rs 0.11: \
+         twenty-two of these were authored upstream while this workspace sat \
+         on 0.9, so bumping the registry crate is what revealed them as \
+         published — nothing here was rebound. The debt shrinks when the \
+         registry catches up, which is the direction it is meant to move",
     ),
 ];
 


### PR DESCRIPTION
Started as "did the sibling release fix the duplicate `trust-tasks-rs`?" — yes.
But the upgrade turns on schema validation for 22 tasks that previously had
none, and **three of them were sending non-conforming payloads**.

## The graph

`trust-tasks-https` / `-didcomm` / `-proof` / `-tsp` / `-capability-client` /
`-didcomm-v1` now all require `^0.11`, and `affinidi-messaging-sdk` 0.19.9 /
`-mediator` 0.18.20 followed. Until every one agreed, bumping the direct
dependency put **two** `trust-tasks-rs` nodes in the graph and the types crossed:

```
error[E0308]: expected `MediatorAcl`, found a different `MediatorAcl`
note: there are multiple different versions of crate `trust_tasks_rs`
```

Refreshing the lock to the versions that agree collapses it to one node.

## Three live defects, all the same class as #919

They were shipping before this PR. Nothing failed only because neither end had a
schema to check against.

1. **`CreateDidWebvhRequest` serialized snake_case.** Canonical wire is camelCase
   (R3.1) and the schema is `additionalProperties: false`. It worked solely
   through `CreateDidWebvhBody`'s back-compat aliases — which is exactly what made
   it invisible.
2. **`update_context` sent `null`** for unset members, where the schema types them
   as optional *strings*. Now built from `UpdateContextBody`, which skips `None`.
3. **`WebvhPathMode` emitted `auto_assign`** where the schema pins `autoAssign`
   with a `const` per `oneOf` branch.

**Number 3 is the one worth your attention.** The drift was in a *discriminant
value*, not a member name — so it slipped past every review and every convention
that watches member casing. And it was only reachable after fixing #1: the payload
had to get past the field-name check before the value check could fail. One drift
was hiding another.

Aliases keep the retired spellings accepted, so a peer built against the old shape
still parses; only what we **emit** moves. A round-trip test pins both directions,
and the REST test that posts the old spelling is annotated as the back-compat
coverage it now is — please don't let anyone "modernise" it.

## Four census guards, all shrinking

Every debt list in the workspace fired, each in the good direction:

| Guard | Change |
|---|---|
| manifest debt (`UNPUBLISHED_CANONICAL_OK`) | 36 → 14 |
| conformance witnesses | +22, each schema-validated with the mandatory non-vacuity check |
| `UNSPECCED_DISPATCHED_URIS` | −22 |
| producer-payload `UNPUBLISHED` | −2 |

I **de-rotted one test rather than re-pinning it**. `an_unspecced_task_proceeds_by_default`
hard-coded `webvh/dids/create` as its unspecced example — which this PR publishes,
so it failed for the best possible reason. It now derives one from the debt list at
runtime, so it follows the debt down instead of breaking every time a spec lands,
and returns early with a note to delete itself when the list empties.

## Follow-up I'd propose rather than bolt on

The 22 new witnesses use hand-written `json!`, which proves *the schema accepts a
shape*. Where a typed body exists (`CreateDidWebvhBody`, `UpdateContextBody`, …),
`to_v(typed)` is strictly stronger — it asserts **our types** conform, which is
what caught all three defects here. That's a second audit pass and will likely
surface more drift, so it deserves its own PR.

## BREAKING CHANGE

`WebvhPathMode` serializes as `wellKnown` / `autoAssign` instead of `well_known` /
`auto_assign`. Deserialization accepts both, so this breaks only a consumer that
string-matches on what we emit. Title carries `!`; expect the advisory semver job
to report it.

## Pre-merge

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo test --workspace --no-fail-fast` — **4514 passed, 0 failed** across 145 binaries
- [x] No `version =` edits, no changelog file
