### PR TITLE
test(vta): derive the unspecced fixture instead of naming one

### DIFF
--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1545,13 +1545,27 @@ mod payload_validation_tests {
         // half of this test stopped proving anything. That is the growth the
         // comment here has always pointed at, arriving.
         //
-        // When `vta/seeds/*` is specified too, move this to whatever is still
-        // in `UNSPECCED_DISPATCHED_URIS` rather than weakening the assertion.
-        const UNSPECCED: &str = "https://trusttasks.org/spec/vta/seeds/rotate/1.0";
-        let d = doc(json!({ "mnemonic": "correct horse battery staple" }));
+        // So the fixture is now *derived* rather than named: whatever is still
+        // unspecced at run time. Naming one is what rotted twice, and the fix
+        // both times was to name a different one — which only sets the next
+        // failure. Deriving it means the test follows the debt down instead of
+        // breaking each time a spec lands, and the assertion never weakens.
+        let Some(unspecced) = super::UNSPECCED_DISPATCHED_URIS
+            .iter()
+            .copied()
+            .find(|u| trust_tasks_rs::schema_index::schema_for(u).is_none())
+        else {
+            // Every dispatched task is specced. That is the goal, and when it
+            // arrives this test has nothing left to say — delete it, and the
+            // `require_payload_schema` escape hatch it exercises with it.
+            return;
+        };
+        // Payload shape is irrelevant: the task is unvalidatable by definition,
+        // which is the property under test.
+        let d = doc(json!({}));
 
         assert!(
-            super::validate_payload(&state, UNSPECCED, &d)
+            super::validate_payload(&state, unspecced, &d)
                 .await
                 .is_none(),
             "by default an unvalidatable task still dispatches — refusing it would \
@@ -1560,7 +1574,7 @@ mod payload_validation_tests {
 
         state.config.write().await.policy.require_payload_schema = true;
         assert!(
-            super::validate_payload(&state, UNSPECCED, &d)
+            super::validate_payload(&state, unspecced, &d)
                 .await
                 .is_some(),
             "an operator who would rather fail closed can"

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -1897,6 +1897,12 @@ async fn create_did_webvh_accepts_path_mode_field() {
         .request(post_auth(
             "/webvh/dids",
             &token,
+            // Deliberately the **retired** snake_case spelling, on both the
+            // member names and the `mode` discriminant. The canonical wire is
+            // camelCase and that is what the SDK emits since #1015; this is the
+            // back-compat coverage proving a caller built against the old shape
+            // still works. Do not "modernise" it — that would quietly delete
+            // the only test of the aliases.
             json!({
                 "context_id": "test-path-mode",
                 "url": "https://example.com/.well-known/did/did.jsonl",


### PR DESCRIPTION
The salvage from #1018, which I closed as superseded by #1015. Two small things
that weren't in #1015; everything else there was a parallel rewrite not worth the
review time.

## The fixture that keeps rotting

`an_unspecced_task_proceeds_by_default_and_can_be_refused` needs a task with no
resolvable schema. It has been re-pinned **twice**: it named
`vta/webvh/dids/create/1.0` until trust-tasks #240 specified it, and #1015 moved
it to `vta/seeds/rotate/1.0` — which is itself on the keep-and-spec list, so the
next break is already scheduled.

Naming one is the problem. The fix each time is to name a different one, which
only sets up the next failure. #1015's own comment says exactly what to do:

> When `vta/seeds/*` is specified too, move this to whatever is still in
> `UNSPECCED_DISPATCHED_URIS` rather than weakening the assertion.

This does that mechanically. The fixture is now whatever is still unspecced at run
time, so the test follows the debt down instead of breaking each time a spec lands.

**The failure mode it replaces is the point.** A re-pinned test failing for a good
reason ("the thing you were testing got fixed") looks identical to a broken one,
and the tempting repair is to weaken the assertion — which would silently retire
the check that an operator can choose to fail closed. That warning is in #1015's
comment because the risk is real; this removes the occasion for it.

When the list finally empties, the test returns early with a note to delete it
along with the `require_payload_schema` escape hatch it exercises. That is the
honest end state — better than a fixture hunting for a task that no longer exists.

The payload also drops to `{}`. The task is unvalidatable by definition, so its
shape was never the property under test; a realistic-looking body implied it was.

## One annotation

The `api_integration` case that posts `"path_mode": { "mode": "auto_assign" }` with
snake_case member names. Since #1015 the SDK emits camelCase, which makes that case
**the only remaining test of the intake aliases** — and it now reads as staleness
someone would tidy away. Comment says so.

## Pre-merge

- [x] `cargo fmt --all`
- [x] `cargo clippy -p vta-service --all-targets` — clean
- [x] `cargo test -p vta-service --lib trust_tasks` — 139 passed
- [x] `cargo test -p vta-service --test api_integration` — 122 passed
- [x] No `version =` edits, no changelog file
