### PR TITLE
fix(sdk/service): serve and use the Trust-Task path the binding asks for

### DIFF
--- a/vta-sdk/src/client/backup_descriptors.rs
+++ b/vta-sdk/src/client/backup_descriptors.rs
@@ -18,7 +18,7 @@
 //! pieces separately:
 //!
 //! - [`VtaClient::post_trust_task`] — POST a typed trust-task
-//!   envelope to `/api/trust-tasks` and deserialize the response.
+//!   envelope to `/trust-tasks` and deserialize the response.
 //! - [`VtaClient::download_blob`] / [`VtaClient::upload_blob`] —
 //!   raw byte transport against the descriptor's
 //!   `transport_url`, carrying the `X-Backup-Token` header.
@@ -173,7 +173,7 @@ impl VtaClient {
 
     // ─── Low-level: building blocks ─────────────────────────────────────
 
-    /// POST a typed trust-task envelope to `/api/trust-tasks` and
+    /// POST a typed trust-task envelope to `/trust-tasks` and
     /// deserialise the response payload as `R`. Used by the descriptor
     /// flows above; exposed in case external integrators want to
     /// drive the slice manually.
@@ -227,7 +227,10 @@ impl VtaClient {
             "payload": payload_value,
         });
 
-        let url = format!("{}/api/trust-tasks", base_url);
+        // `<base>/trust-tasks` — the same contract `rpc_tt` uses. This is a
+        // second hand-built call site rather than a shared helper, which is
+        // exactly why it carried the legacy prefix after the shared one moved.
+        let url = format!("{}/trust-tasks", base_url);
         let req = client.post(url).json(&doc);
         let resp = Self::with_auth_token(req, &token).send().await?;
 

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1332,7 +1332,7 @@ impl VtaClient {
 
         match &self.transport {
             // REST carries the Trust Task too, over the HTTPS binding
-            // (`POST /api/trust-tasks`) — the same document DIDComm and TSP
+            // (`POST /trust-tasks`) — the same document DIDComm and TSP
             // send. It used to fork here into a bespoke per-operation route
             // with its own request and response bodies, which is why REST was
             // the one transport whose wire did not match the published
@@ -1402,7 +1402,7 @@ impl VtaClient {
     ///
     /// The wire envelope is identical on both transports — `{ id, type,
     /// payload }`:
-    /// - **REST** → `POST /api/trust-tasks` with the envelope; the HTTP status
+    /// - **REST** → `POST /trust-tasks` with the envelope; the HTTP status
     ///   signals success/failure and the response body's `payload` is returned.
     /// - **DIDComm** → a message of type [`TRUST_TASK_ENVELOPE_TYPE`] carrying
     ///   the envelope as its body; the reply is itself a trust-task document
@@ -1541,7 +1541,17 @@ impl VtaClient {
                 auth,
             } => {
                 let req = client
-                    .post(format!("{base_url}/api/trust-tasks"))
+                    // `<base>/trust-tasks`, matching the published HTTPS
+                    // binding. `base_url` is the Trust-Task base — the
+                    // `#vta-rest` serviceEndpoint when discovered from the DID
+                    // document, else `--url`. This appended `/trust-tasks`
+                    // and worked only because the service happened to serve the
+                    // same prefix; a third-party client built from the binding
+                    // asked for `/trust-tasks` and got a 404. The service now
+                    // serves both, so this move is safe against any VTA that
+                    // has taken it, and the legacy path is marked superseded so
+                    // the usual metric decides when it goes.
+                    .post(format!("{base_url}/trust-tasks"))
                     .json(&doc);
                 let resp = Self::send_authed(client, base_url, auth, req).await?;
                 if !resp.status().is_success() {

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -339,7 +339,7 @@ impl VtaClient {
     // the VTA rather than talking to the host directly: only the VTA can sign.
     //
     // These are trust-task-only by design — there is no bespoke REST route,
-    // and none is needed: `dispatch_trust_task` posts to `/api/trust-tasks`
+    // and none is needed: `dispatch_trust_task` posts to `/trust-tasks`
     // on a REST transport and rides the DIDComm envelope otherwise, so both
     // transports reach the same handler.
 

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -2,7 +2,7 @@
 //!
 //! One `pub const` per registered URI; grep `TASK_*` to enumerate the
 //! full wire surface. Each URI is routed both on REST (via the
-//! trust-task envelope's `type` field on `POST /api/trust-tasks` or
+//! trust-task envelope's `type` field on `POST /trust-tasks` or
 //! a dedicated unauth route) and on DIDComm (via the inbound message
 //! `type`).
 //!
@@ -1581,7 +1581,7 @@ pub const ALL_URIS: &[&str] = &[
 ];
 
 /// The subset of [`ALL_URIS`] served by **dedicated REST routes** rather than
-/// the `/api/trust-tasks` dispatcher: pre-login auth (challenge / authenticate /
+/// the `/trust-tasks` dispatcher: pre-login auth (challenge / authenticate /
 /// refresh), passkey-login, and TEE attestation.
 ///
 /// These are **not** reachable through the generic dispatcher
@@ -1605,7 +1605,7 @@ pub const REST_ROUTED_URIS: &[&str] = &[
     TASK_ATTESTATION_REPORT_1_0,
 ];
 
-/// The operations reachable through the generic `/api/trust-tasks` dispatcher —
+/// The operations reachable through the generic `/trust-tasks` dispatcher —
 /// [`ALL_URIS`] minus [`REST_ROUTED_URIS`]. Use this to drive a generic
 /// "invoke any operation" surface so the advertised catalog matches what the
 /// dispatcher can actually route.

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -547,7 +547,7 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
     // `get_config` is the probe for "an authenticated call"; it now rides the
     // Trust Tasks HTTPS binding like every other typed operation.
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer fresh-access",
@@ -644,7 +644,7 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
     // `get_config` is the probe for "an authenticated call"; it now rides the
     // Trust Tasks HTTPS binding like every other typed operation.
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer reauth-access",
@@ -740,7 +740,7 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
     // `get_config` is the probe for "an authenticated call"; it now rides the
     // Trust Tasks HTTPS binding like every other typed operation.
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer fallback-access",

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -112,7 +112,7 @@ async fn mount_json(
         "payload": body,
     }));
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(resp)
         .expect(1)
@@ -157,7 +157,7 @@ async fn mount_rest_status(
 
 async fn mount_status(server: &MockServer, _m: &str, _p: &str, status: u16) -> wiremock::MockGuard {
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(status).set_body_json(err_body("bad")))
         .expect(1)
@@ -452,7 +452,7 @@ async fn create_key_round_trip() {
 async fn list_keys_paginates_query_params() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({
             "type": TASK_KEYS_LIST,
@@ -713,7 +713,7 @@ async fn list_acl_no_filter() {
 async fn list_acl_with_context_query() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         // `scope`, not `context`: the task payload names the filter
         // differently from the query string it replaced.
@@ -739,7 +739,7 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
 
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({
             "payload": {"scope": "acme/eng", "direction": "subtree"}
@@ -755,7 +755,7 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
     server.reset().await;
 
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({"payload": {"scope": "acme/eng"}})))
         // An old VTA rejects an unknown field, so the default direction must
@@ -780,7 +780,7 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
 async fn swap_acl_sends_the_canonical_task_over_rest() {
     let server = MockServer::start().await;
     let _g = Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(wiremock::matchers::body_partial_json(json!({
             "type": "https://trusttasks.org/spec/acl/swap-key/0.1",
@@ -917,7 +917,7 @@ async fn update_acl_patches() {
 async fn delete_acl_returns_unit() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1060,7 +1060,7 @@ async fn preview_delete_context_returns_summary() {
 async fn delete_context_with_force_query() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1074,7 +1074,7 @@ async fn delete_context_with_force_query() {
 async fn delete_context_no_force_omits_query() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1210,7 +1210,7 @@ async fn update_webvh_server_patches() {
 async fn remove_webvh_server_deletes() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1291,7 +1291,7 @@ async fn create_did_webvh_posts() {
 async fn list_dids_webvh_filters_by_context() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({
             "type": TASK_WEBVH_DIDS_LIST,
@@ -1351,7 +1351,7 @@ async fn get_did_webvh_log_returns_log() {
 async fn delete_did_webvh_returns_unit() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1369,7 +1369,7 @@ async fn delete_did_webvh_returns_unit() {
 async fn update_did_webvh_by_did_sends_the_canonical_task() {
     let server = MockServer::start().await;
     let _g = Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(wiremock::matchers::body_partial_json(json!({
             "type": "https://trusttasks.org/spec/vta/webvh/dids/update/1.0",
@@ -1471,7 +1471,7 @@ async fn rotate_did_webvh_keys_posts() {
 async fn list_audit_logs_paginates() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         // camelCase, per canonical `audit/list/0.1`. A snake_case key
         // here would be dropped by the handler's serde binding and the
@@ -1520,7 +1520,7 @@ async fn list_audit_logs_paginates() {
 async fn audit_list_percent_encodes_rfc3339_bounds() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({
             "payload": {"from": "2026-07-01T00:00:00Z"}
@@ -1669,7 +1669,7 @@ async fn update_did_template_puts() {
 async fn delete_did_template_returns_unit() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1773,7 +1773,7 @@ async fn update_context_did_template_puts() {
 async fn delete_context_did_template_returns_unit() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
         .expect(1)
@@ -1843,7 +1843,7 @@ async fn fetch_context_secrets_walks_all_pages() {
         page1_keys.push(key_record_json(&format!("k{i}")));
     }
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({
             "type": TASK_KEYS_LIST,
@@ -1859,7 +1859,7 @@ async fn fetch_context_secrets_walks_all_pages() {
 
     // Page 2: 1 key
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(json!({
             "type": TASK_KEYS_LIST,
@@ -1879,7 +1879,7 @@ async fn fetch_context_secrets_walks_all_pages() {
     // multicodec X25519 (0xec01) — `secret_from_key_response` accepts
     // any 32-byte key, so the value just needs to round-trip.
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .and(auth_match())
         .and(body_partial_json(
             json!({"type": TASK_SEEDS_EXPORT_MNEMONIC}),
@@ -1950,7 +1950,7 @@ async fn http_418_maps_to_other() {
 async fn malformed_error_body_falls_back_to_raw_text() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .respond_with(ResponseTemplate::new(500).set_body_string("not json"))
         .mount(&server)
         .await;
@@ -1972,7 +1972,7 @@ async fn oversized_error_body_is_truncated() {
     let server = MockServer::start().await;
     let huge = "x".repeat(10_000);
     Mock::given(method("POST"))
-        .and(path("/api/trust-tasks"))
+        .and(path("/trust-tasks"))
         .respond_with(ResponseTemplate::new(500).set_body_string(huge))
         .mount(&server)
         .await;

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -379,6 +379,30 @@ const SUPERSEDED: &[(&str, &str, &str, &str)] = &[
         "GET /webvh/servers/{id}/reconcile",
         trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1,
     ),
+    // ─── the Trust-Task endpoint itself ─────────────────────────────────
+    //
+    // `/api/trust-tasks` is not superseded by a *task* — it IS the task
+    // endpoint. What supersedes it is the conformant spelling served beside
+    // it, `POST /trust-tasks`, which is what the published HTTPS binding asks
+    // for. The successor URI below is the envelope type rather than an
+    // operation, because there is no operation: the successor is the same
+    // dispatcher at the path the binding actually uses.
+    //
+    // The successor is a PATH, not a task URI — every other row here names the
+    // task that replaced an operation, and this one names the endpoint that
+    // replaced a spelling. `Link: rel="successor-version"` takes a URI either
+    // way, so the header stays meaningful; the row is simply the one place in
+    // this table where the successor is not a `trusttasks.org` URI.
+    //
+    // Marked so the existing metric governs its retirement like everything
+    // else. It cannot go until deployed clients stop asking for it, and those
+    // clients are our own SDK until it takes the change beside this one.
+    (
+        "POST",
+        "/api/trust-tasks",
+        "POST /api/trust-tasks",
+        "/trust-tasks",
+    ),
     // ─── /services/* ────────────────────────────────────────────────────
     //
     // These twenty were the last block with no twin at all, which is why the

--- a/vta-service/src/routes/mod.rs
+++ b/vta-service/src/routes/mod.rs
@@ -394,6 +394,27 @@ fn build_api_router(trust_xff: bool, interval_secs: u64, burst: u32) -> OpenApiR
         // docs/05-design-notes/trust-task-uri-registry.md). Phase 2
         // scaffold; handlers register per Phase 3 slice. Not yet documented
         // in OpenAPI (dynamic envelope payload).
+        // Two paths, one dispatcher, and the second is the conformant one.
+        //
+        // The HTTPS binding POSTs to `<serviceEndpoint>/trust-tasks`, where
+        // `serviceEndpoint` is what the VTA advertises on its Trust-Task
+        // service entry. Every deployment example advertises an ORIGIN
+        // (`https://trust.example.com`), so a client built from the published
+        // binding asks for `/trust-tasks` and, until now, got a 404 — while
+        // `vta-sdk` worked only because it hardcodes the same `/api` prefix
+        // this service happens to serve. Two implementations agreeing by
+        // convention is not a contract; it just hides its absence from the
+        // people who wrote both ends.
+        //
+        // Serving both makes every existing advertisement conformant without
+        // an operator touching it: for an origin-advertising VTA the
+        // Trust-Task base IS the origin. `/api/trust-tasks` stays for deployed
+        // clients and is marked superseded, so the same metric that governs
+        // every other retired route decides when it goes.
+        .route(
+            "/trust-tasks",
+            post(crate::trust_tasks::dispatch_trust_task),
+        )
         .route(
             "/api/trust-tasks",
             post(crate::trust_tasks::dispatch_trust_task),

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -4210,3 +4210,65 @@ fn the_two_drain_routes_split_on_method_not_path() {
         "a read and a destructive cancel are not the same successor"
     );
 }
+
+// ─── the Trust-Task endpoint contract ──────────────────────────────────────
+
+#[tokio::test]
+async fn both_trust_task_paths_reach_the_same_dispatcher() {
+    // `POST /trust-tasks` is what the published HTTPS binding asks for:
+    // `<serviceEndpoint>/trust-tasks`, where serviceEndpoint is the Trust-Task
+    // base a VTA advertises. Every deployment example advertises an origin, so
+    // the binding's request lands unprefixed — and until this route existed it
+    // got a 404 while `vta-sdk` worked, because both ends of ours hardcoded
+    // `/api`. Two implementations agreeing by convention is not a contract.
+    //
+    // Both must reach the same dispatcher, and must fail the same way when
+    // unauthenticated: a difference in either is a difference in behaviour
+    // between a conformant client and ours.
+    let (app, _ctx) = TestApp::new().await;
+    let body = r#"{"id":"urn:uuid:00000000-0000-4000-8000-000000000000","type":"urn:test:none","payload":{}}"#;
+
+    let mut seen = Vec::new();
+    for path in ["/trust-tasks", "/api/trust-tasks"] {
+        let req = Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _) = app.request(req).await;
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "{path} must be served — the binding uses the unprefixed spelling"
+        );
+        seen.push(status);
+    }
+    assert_eq!(
+        seen[0], seen[1],
+        "the two spellings must behave identically"
+    );
+}
+
+#[tokio::test]
+async fn the_legacy_trust_task_path_advertises_the_conformant_one() {
+    let (app, ctx) = TestApp::new().await;
+    let token = ctx.auth_token("did:key:z6MkSuper", "admin", vec![]).await;
+    let body = r#"{"id":"urn:uuid:00000000-0000-4000-8000-000000000000","type":"urn:test:none","payload":{}}"#;
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let (_status, headers) = request_headers(&app, req).await;
+    // Only a successful response is marked — a rejected envelope says nothing
+    // about a client depending on the path.
+    if let Some(link) = headers.get("link") {
+        assert!(
+            link.to_str().unwrap().contains("/trust-tasks"),
+            "the legacy path must name the conformant one as its successor"
+        );
+    }
+}


### PR DESCRIPTION
## The bug

`trust-tasks-https` — our own published HTTPS binding — POSTs to
`<serviceEndpoint>/trust-tasks`. Every deployment example advertises an
**origin**:

```
docs/02-vta/examples/vta-setup.example.toml   public_url = "https://trust.example.com"
local-dev/vta-pathful-webvh-setup.toml        public_url = "http://localhost:3000"
deploy/nitro/config.toml                    # public_url = "https://vta.example.com"
```

So a client built from the binding asked for `/trust-tasks` and **got a 404**.
Ours worked only because `vta-sdk` hardcoded `/api/trust-tasks` and this service
happened to serve the same prefix.

Two implementations agreeing by convention isn't a contract. It hides the
absence of one from the only people positioned to notice — which is why this
survived until someone read the binding instead of the code.

## The underlying defect was never the path

Nothing defined what the advertised endpoint **denotes**, so the two clients
composed it differently and both could not be right:

| client | composes |
|---|---|
| `vta-sdk` | `<serviceEndpoint>` + `/api/trust-tasks` |
| `trust-tasks-https` | `<serviceEndpoint>` + `/trust-tasks` |

Against an origin advertisement the SDK works and the binding 404s. Against a
`.../api` advertisement the binding works and the SDK **doubles the prefix**.

Settled: **`serviceEndpoint` is the Trust-Task base**, and the binding's suffix
is the contract.

## Why this doesn't break anyone

**The service serves both paths from one dispatcher.** That's the move that
makes it safe: for an origin-advertising VTA the Trust-Task base *is* the
origin, so **every existing advertisement becomes conformant with no operator
action**.

The SDK then moves to `<base>/trust-tasks` — the half that makes the contract
real rather than aspirational — and is safe against any VTA that has taken the
service change.

`/api/trust-tasks` is marked superseded, so the metric governing every other
retired route decides when it goes. It can't go while deployed clients ask for
it, and those clients are our own SDK until this ships.

## One oddity in the superseded table

That row's successor is a **path**, not a task URI. Every other row names the
task that replaced an operation; this one names the endpoint that replaced a
spelling. `Link: rel="successor-version"` takes a URI either way, so the header
stays meaningful — flagged in the comment rather than left looking like an
oversight.

## A second hand-built call site

Moving the SDK surfaced `client/backup_descriptors.rs` formatting
`{base}/api/trust-tasks` itself instead of going through `rpc_tt` — which is
precisely why it kept the legacy prefix after the shared path moved. Same class
as the `update_context` literal in #1015: a payload or URL built by hand drifts
from the one built centrally.

## Tests

Both spellings must reach the same dispatcher **and fail identically when
unauthenticated** — a divergence there means a conformant client and ours behave
differently, which is the thing being fixed. 26 mocks across `client_rest` and
`auth_light_rest` move with the client.

## Not in this PR, on purpose

Specifying what the Trust-Task service entry *means*, so this is a contract
rather than a second convention. That's a spec-registry change and wants its own
review — including whether it deserves a dedicated service `type` rather than
reusing `VTARest`, since "the REST API" and "where Trust Tasks are accepted" are
different claims that merely coincide today.

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] **New/changed wire types (R3.\*)** — no type changed; the endpoint's
      *meaning* is what moved, and the legacy spelling keeps working
- [x] Config absence = most restrictive (R5.*)
- [x] **Logs/status claim only what was verified (R6.\*)** — the superseded row
      says its successor is a path, rather than dressing it as a task
- [x] Deviations flagged with rule numbers