### PR TITLE
feat(service): retire an orphaned webvh slot, on evidence rather than assertion

### DIFF
--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -66,6 +66,34 @@ impl VtaClient {
     /// host credentials, and the host has no view of the VTA's records — which
     /// is why this is a VTA task rather than something the caller assembles
     /// from two listings.
+    /// Retire an orphaned slot on a hosting server — one the host serves and
+    /// this VTA has no record of.
+    ///
+    /// Obtain `slot_id` (and `expected_did`, when the slot has one) from a
+    /// [`Self::reconcile_webvh_server_dids`] report rather than constructing
+    /// them. The VTA re-derives orphanhood itself and refuses if it holds any
+    /// record for the slot, so naming a live DID here is refused rather than
+    /// obeyed — but `expected_did` is what turns a *stale* report into a
+    /// refusal instead of retiring something the caller never saw.
+    ///
+    /// Destructive and irreversible: the DID stops resolving, and every relying
+    /// party that held it sees that without being able to tell retirement from
+    /// compromise.
+    pub async fn retire_orphan_slot(
+        &self,
+        body: &crate::protocols::did_management::servers::RetireOrphanSlotBody,
+    ) -> Result<crate::protocols::did_management::servers::RetireOrphanSlotResultBody, VtaError>
+    {
+        self.rpc_tt(
+            crate::trust_tasks::TASK_WEBVH_SERVERS_RETIRE_ORPHAN_0_1,
+            serde_json::to_value(body)?,
+            // As reconcile: this reads the host's full listing to prove
+            // orphanhood before it removes anything.
+            60,
+        )
+        .await
+    }
+
     pub async fn reconcile_webvh_server_dids(
         &self,
         server_id: &str,

--- a/vta-sdk/src/protocols/did_management/servers.rs
+++ b/vta-sdk/src/protocols/did_management/servers.rs
@@ -212,3 +212,62 @@ pub struct RegisterDidWithServerResultBody {
     #[serde(alias = "log_entry_count")]
     pub log_entry_count: u32,
 }
+
+/// Retire an **orphaned** slot on a hosting server — one the host serves for
+/// this VTA and the VTA holds no record of.
+///
+/// The gap this closes is structural. Every ordinary delete addresses a DID
+/// through its local record, which is what says which server to talk to and
+/// which keys to sign with; an orphan is defined by that record's absence, so
+/// the lookup fails before a request leaves the VTA. And the caller cannot go
+/// around it, because the VTA holds the host credentials.
+///
+/// The safety of an operation with no undo rests on one inversion: **the VTA
+/// decides whether the slot is orphaned, and the caller does not get to claim
+/// it.** A live DID has a record, and the record is what makes the refusal
+/// automatic. See `vta/webvh/servers/retire-orphan/0.1`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct RetireOrphanSlotBody {
+    #[serde(alias = "server_id")]
+    pub server_id: String,
+    /// The slot to retire, as a [`ReconcileWebvhServerDidsResultBody::host_only`]
+    /// entry reports it. The slot rather than the DID, because a slot reserved
+    /// but never published to has none and is exactly as orphaned.
+    #[serde(alias = "slot_id")]
+    pub slot_id: String,
+    /// The DID the caller believes the slot serves, echoed back from the
+    /// reconcile report it acted on.
+    ///
+    /// A reconcile response is a comparison at an instant, and a slot may be
+    /// published to between the report and this request. Naming what was seen
+    /// turns a stale report into a refusal rather than a surprise.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "expected_did"
+    )]
+    pub expected_did: Option<String>,
+    /// Operator rationale, recorded in the audit trail. The act has no undo, so
+    /// why it was done outlives the record of what was done.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct RetireOrphanSlotResultBody {
+    #[serde(alias = "server_id")]
+    pub server_id: String,
+    #[serde(alias = "slot_id")]
+    pub slot_id: String,
+    /// Whether the slot is no longer served. Reported, never inferred: a VTA
+    /// that could not confirm removal with the host must not claim it.
+    pub retired: bool,
+    /// The DID the slot was serving, echoed so the record of what was retired
+    /// survives the slot's disappearance. Absent where it was never published.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub did: Option<String>,
+}

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -316,6 +316,13 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_WEBVH_SERVERS_REMOVE_1_0, RetrySafe),
     (trust_tasks::TASK_WEBVH_SERVERS_DOMAINS_0_1, ReadOnly),
     (trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1, RetrySafe),
+    // Destructive, but convergent: once the slot is gone a repeat removes
+    // nothing — the same reasoning as `dids/delete` below. The one hazard is a
+    // host that re-allocates the slot id, and two guards already close it: the
+    // VTA re-derives orphanhood (a re-allocated slot with a local record is
+    // refused outright), and `expectedDid` refuses a slot that no longer serves
+    // what the caller saw.
+    (trust_tasks::TASK_WEBVH_SERVERS_RETIRE_ORPHAN_0_1, RetrySafe),
     // ── WebVH DIDs ──────────────────────────────────────────────────────
     (trust_tasks::TASK_WEBVH_DIDS_LIST_1_0, ReadOnly),
     // The finding that opened all of this. Production callers use

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -316,6 +316,21 @@ pub const TASK_KEYS_SHOW_0_1: &str = "https://trusttasks.org/spec/keys/show/0.1"
 pub const TASK_WEBVH_SERVERS_RECONCILE_0_1: &str =
     "https://trusttasks.org/spec/vta/webvh/servers/reconcile/0.1";
 
+/// `vta/webvh/servers/retire-orphan/0.1` — remove a slot the hosting server
+/// serves for this VTA and the VTA holds no record of.
+///
+/// The remedy for the one divergence
+/// [`TASK_WEBVH_SERVERS_RECONCILE_0_1`] can name but nothing could repair. No
+/// ordinary delete reaches an orphan: every delete addresses a DID through its
+/// local record, so the lookup fails before a request leaves the VTA.
+///
+/// The VTA re-derives orphanhood itself and refuses if it holds any record for
+/// the slot — the caller does not get to assert it. Destructive, no undo, and
+/// never performed on a sweep.
+/// Payload: [`crate::protocols::did_management::servers::RetireOrphanSlotBody`].
+pub const TASK_WEBVH_SERVERS_RETIRE_ORPHAN_0_1: &str =
+    "https://trusttasks.org/spec/vta/webvh/servers/retire-orphan/0.1";
+
 pub const TASK_WEBVH_SERVERS_DOMAINS_0_1: &str =
     "https://trusttasks.org/spec/vta/webvh/servers/domains/0.1";
 
@@ -1527,6 +1542,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_WEBVH_SERVERS_REMOVE_1_0,
     TASK_WEBVH_SERVERS_DOMAINS_0_1,
     TASK_WEBVH_SERVERS_RECONCILE_0_1,
+    TASK_WEBVH_SERVERS_RETIRE_ORPHAN_0_1,
     TASK_WEBVH_DIDS_LIST_1_0,
     TASK_WEBVH_DIDS_CREATE_1_0,
     TASK_WEBVH_DIDS_GET_1_0,

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -33,7 +33,7 @@ pub use register_server::{
 };
 pub use servers::{
     list_webvh_server_domains, list_webvh_servers, reconcile_webvh_server_dids,
-    register_webvh_server, remove_webvh_server,
+    register_webvh_server, remove_webvh_server, retire_orphan_slot,
 };
 pub use update::{
     AgentNameVerb, RotateDidWebvhKeysOptions, UpdateDidWebvhError, UpdateDidWebvhOptions,

--- a/vta-service/src/operations/did_webvh/servers.rs
+++ b/vta-service/src/operations/did_webvh/servers.rs
@@ -546,3 +546,460 @@ mod reconcile_tests {
         assert_eq!(order, ["alpha", "mike", "zulu"]);
     }
 }
+
+/// Why a retire-orphan request was refused.
+///
+/// Separate from [`AppError`] because each variant carries the extended error
+/// code its specification defines (`vta/webvh/servers/retire-orphan:*`), and
+/// the caller keys on that rather than on prose. Two of the three are
+/// *uncertainty* rather than contradiction — the VTA does not know the slot is
+/// safe to remove — and refusing on uncertainty is the whole point: the
+/// alternative to a false refusal is a retry, and the alternative to a false
+/// removal is nothing.
+#[derive(Debug)]
+pub enum RetireOrphanRefusal {
+    /// The VTA holds a record for this slot, so it is not an orphan.
+    NotOrphaned {
+        slot_id: String,
+        did: Option<String>,
+    },
+    /// The slot does not serve the DID the caller named — the report they
+    /// acted on is stale.
+    DidMismatch {
+        slot_id: String,
+        expected: String,
+        actual: Option<String>,
+    },
+    /// Orphanhood could not be confirmed, so the VTA will not act on the
+    /// caller's word for it.
+    ListingUnavailable { server_id: String, detail: String },
+}
+
+impl RetireOrphanRefusal {
+    /// The specification's extended code, for `details.reason`.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NotOrphaned { .. } => "vta/webvh/servers/retire-orphan:notOrphaned",
+            Self::DidMismatch { .. } => "vta/webvh/servers/retire-orphan:didMismatch",
+            Self::ListingUnavailable { .. } => "vta/webvh/servers/retire-orphan:listingUnavailable",
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            Self::NotOrphaned { slot_id, .. } => format!(
+                "slot `{slot_id}` has a record in this VTA, so it is not an orphan. \
+                 retire-orphan applies only to slots this VTA has no record of — \
+                 use `webvh/dids/delete` for one it still controls."
+            ),
+            Self::DidMismatch {
+                slot_id, actual, ..
+            } => format!(
+                "slot `{slot_id}` serves {} — not the DID named. Re-run reconcile \
+                 before retiring it.",
+                actual.as_deref().unwrap_or("no DID")
+            ),
+            Self::ListingUnavailable { server_id, detail } => format!(
+                "cannot confirm slot orphanhood on server `{server_id}`: {detail}. \
+                 Refusing rather than removing on the caller's word."
+            ),
+        }
+    }
+}
+
+/// Whether this slot may be retired, and what would go — with the I/O lifted
+/// out so every refusal is testable without a host.
+///
+/// This is the safety property in one function. A slot absent from `host_only`
+/// is either unknown to the host or known to us; both mean retire-orphan is the
+/// wrong instrument, and the local record is what tells them apart in the
+/// message. The caller's request is never evidence of orphanhood — only this
+/// comparison is.
+///
+/// Returns the DID that would stop resolving and the host domain to address, so
+/// the caller has both without re-searching the report.
+#[allow(clippy::type_complexity)]
+fn decide_retirement(
+    report: &vta_sdk::protocols::did_management::servers::ReconcileWebvhServerDidsResultBody,
+    all_local: &[vta_sdk::webvh::WebvhDidRecord],
+    server_key: &str,
+    slot_id: &str,
+    expected_did: Option<&str>,
+) -> Result<(Option<String>, Option<String>), RetireOrphanRefusal> {
+    let Some(orphan) = report.host_only.iter().find(|h| h.slot_id == slot_id) else {
+        let local = all_local
+            .iter()
+            .find(|r| r.mnemonic == slot_id && r.server_id == server_key);
+        return Err(RetireOrphanRefusal::NotOrphaned {
+            slot_id: slot_id.to_string(),
+            did: local.map(|r| r.did.clone()),
+        });
+    };
+
+    // Optimistic concurrency against a stale report: a reconcile response is a
+    // comparison at an instant, so naming what was seen turns a slot published
+    // to in the meantime into a refusal rather than a surprise.
+    if let Some(expected) = expected_did
+        && orphan.did.as_deref() != Some(expected)
+    {
+        return Err(RetireOrphanRefusal::DidMismatch {
+            slot_id: slot_id.to_string(),
+            expected: expected.to_string(),
+            actual: orphan.did.clone(),
+        });
+    }
+
+    Ok((orphan.did.clone(), orphan.domain.clone()))
+}
+
+/// Retire an orphaned slot on a hosting server.
+///
+/// Implements `vta/webvh/servers/retire-orphan/0.1`. See
+/// [`reconcile_webvh_server_dids`] for how the orphan set is derived — this
+/// re-derives it the same way rather than trusting the caller, which is the
+/// property the whole operation rests on.
+///
+/// # Why the caller cannot simply be believed
+///
+/// A slot id is a bare string. If this trusted it, the operation would be
+/// "delete anything on the host, unaudited by the VTA's own state" wearing a
+/// narrower name. Re-deriving means a live DID is refused automatically,
+/// because a live DID has a local record and that record is the refusal.
+///
+/// # Not automatic
+///
+/// Nothing in this service calls it on a timer or as a consequence of another
+/// task, and nothing should. The signal it acts on is an *absence*, and
+/// absences are produced by bugs as readily as by orphaning — a storage read
+/// that fails open, a record written under the wrong server id. Each of those
+/// presents as an orphan, and the response would be to make a published
+/// identifier stop resolving, irreversibly.
+pub async fn retire_orphan_slot(
+    deps: &crate::operations::did_webvh::WebvhDeps<'_>,
+    auth: &AuthClaims,
+    vta_did: Option<&str>,
+    body: &vta_sdk::protocols::did_management::servers::RetireOrphanSlotBody,
+) -> Result<
+    Result<
+        vta_sdk::protocols::did_management::servers::RetireOrphanSlotResultBody,
+        RetireOrphanRefusal,
+    >,
+    AppError,
+> {
+    use vta_sdk::protocols::did_management::servers::RetireOrphanSlotResultBody;
+
+    // At least as broad as reconcile demands. A slot absent from this VTA
+    // belongs to no context here, so there is no scope to narrow to — and this
+    // one writes.
+    auth.require_super_admin()?;
+
+    let server = webvh_store::get_server(deps.webvh_ks, &body.server_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("webvh server not found: {}", body.server_id)))?;
+
+    let vta_did_value = vta_did.ok_or_else(|| {
+        AppError::Validation(
+            "VTA DID is not configured — complete `vta setup` before retiring a slot.".to_string(),
+        )
+    })?;
+
+    let identity = crate::operations::did_webvh::auth_cache::load_vta_webvh_signing_identity(
+        deps.keys_ks,
+        deps.imported_ks,
+        deps.seed_store,
+        deps.audit_ks,
+        vta_did_value,
+    )
+    .await?;
+    let auth_ctx = crate::operations::did_webvh::auth_cache::AuthContext {
+        webvh_ks: deps.webvh_ks,
+        identity: &identity,
+        locks: deps.auth_locks,
+    };
+    let transport = crate::operations::did_webvh::WebvhTransport::from_server_authenticated(
+        &server,
+        deps.did_resolver,
+        deps.didcomm_bridge,
+        &auth_ctx,
+    )
+    .await?;
+
+    let client = match transport {
+        crate::operations::did_webvh::WebvhTransport::Rest(c) => c,
+        crate::operations::did_webvh::WebvhTransport::DIDComm { .. } => {
+            // Same refusal reconcile gives, and for the same reason: the
+            // listing is REST-only, and without it orphanhood is unproven.
+            return Ok(Err(RetireOrphanRefusal::ListingUnavailable {
+                server_id: body.server_id.clone(),
+                detail: "the host's DID listing is REST-only and this server is \
+                         registered over DIDComm"
+                    .to_string(),
+            }));
+        }
+    };
+
+    let hosted = match client.list_dids_for_owner(vta_did_value).await {
+        Ok(h) => h,
+        Err(e) => {
+            return Ok(Err(RetireOrphanRefusal::ListingUnavailable {
+                server_id: body.server_id.clone(),
+                detail: e.to_string(),
+            }));
+        }
+    };
+    let all_local = webvh_store::list_dids(deps.webvh_ks).await?;
+    let report = diff_host_against_local(&hosted, &all_local, &server.id, &body.server_id);
+
+    let (retired_did, domain) = match decide_retirement(
+        &report,
+        &all_local,
+        &server.id,
+        &body.slot_id,
+        body.expected_did.as_deref(),
+    ) {
+        Ok(t) => t,
+        Err(refusal) => return Ok(Err(refusal)),
+    };
+    client
+        .delete_did(&body.slot_id, domain.as_deref())
+        .await
+        .map_err(|e| {
+            AppError::Internal(format!(
+                "host refused to retire slot `{}`: {e}",
+                body.slot_id
+            ))
+        })?;
+
+    // Transport literal rather than the const: `trust_tasks::webvh` is private
+    // to the dispatcher, and an operation should not reach into it.
+    // The slot will not exist to be asked about afterwards, so this row is the
+    // only account of what happened — including why, when the operator said.
+    crate::audit::record_with_detail(
+        deps.audit_ks,
+        "webvh.slot.retire_orphan",
+        &auth.did,
+        Some(&body.slot_id),
+        "success",
+        Some("trust-task"),
+        None,
+        body.reason.as_deref(),
+    )
+    .await
+    .unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "retire-orphan audit record failed");
+    });
+
+    info!(
+        caller = %auth.did,
+        server_id = %body.server_id,
+        slot_id = %body.slot_id,
+        did = retired_did.as_deref().unwrap_or("<unpublished>"),
+        "orphaned webvh slot retired"
+    );
+
+    Ok(Ok(RetireOrphanSlotResultBody {
+        server_id: body.server_id.clone(),
+        slot_id: body.slot_id.clone(),
+        retired: true,
+        did: retired_did,
+    }))
+}
+
+#[cfg(test)]
+mod retire_orphan_tests {
+    use super::*;
+    use crate::webvh_client::HostedDidEntry;
+    use vta_sdk::webvh::WebvhDidRecord;
+
+    const SERVER: &str = "primary-host";
+
+    fn hosted(mnemonic: &str, did: Option<&str>) -> HostedDidEntry {
+        HostedDidEntry {
+            mnemonic: mnemonic.into(),
+            did_id: did.map(str::to_string),
+            domain: Some("webvh.example".into()),
+            disabled: false,
+            updated_at: 0,
+        }
+    }
+
+    fn local(mnemonic: &str) -> WebvhDidRecord {
+        WebvhDidRecord {
+            did: format!("did:webvh:QmScid:webvh.example:{mnemonic}"),
+            server_id: SERVER.into(),
+            mnemonic: mnemonic.into(),
+            scid: "QmScid".into(),
+            context_id: "ctx".into(),
+            portable: false,
+            log_entry_count: 1,
+            pre_rotation_count: 0,
+            next_fragment_id: 2,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn decide(
+        hosted_slots: &[HostedDidEntry],
+        local_records: &[WebvhDidRecord],
+        slot: &str,
+        expected: Option<&str>,
+    ) -> Result<(Option<String>, Option<String>), RetireOrphanRefusal> {
+        let report = diff_host_against_local(hosted_slots, local_records, SERVER, SERVER);
+        decide_retirement(&report, local_records, SERVER, slot, expected)
+    }
+
+    /// The happy path: the host serves it, we have no record, so it goes.
+    #[test]
+    fn an_orphan_is_retirable_and_names_what_would_go() {
+        let did = "did:webvh:QmScid:webvh.example:orphan";
+        let (retired, domain) = decide(&[hosted("orphan", Some(did))], &[], "orphan", None)
+            .expect("an orphan is retirable");
+        assert_eq!(retired.as_deref(), Some(did));
+        assert_eq!(domain.as_deref(), Some("webvh.example"));
+    }
+
+    /// A slot reserved but never published to is exactly as orphaned, and has
+    /// no DID to name — which is why the operation keys on the slot.
+    #[test]
+    fn an_unpublished_slot_is_still_an_orphan() {
+        let (retired, _) =
+            decide(&[hosted("reserved", None)], &[], "reserved", None).expect("still an orphan");
+        assert_eq!(retired, None);
+    }
+
+    /// The property everything rests on: a live DID has a local record, and
+    /// that record is what makes the refusal automatic. A caller cannot
+    /// retire it by naming it.
+    #[test]
+    fn a_slot_we_hold_a_record_for_is_refused() {
+        let did = "did:webvh:QmScid:webvh.example:live";
+        let refusal = decide(&[hosted("live", Some(did))], &[local("live")], "live", None)
+            .expect_err("a live DID must be refused");
+        assert!(
+            refusal.code().ends_with(":notOrphaned"),
+            "the extended code is what a caller keys on"
+        );
+        match &refusal {
+            RetireOrphanRefusal::NotOrphaned { slot_id, did: d } => {
+                assert_eq!(slot_id, "live");
+                assert_eq!(
+                    d.as_deref(),
+                    Some(did),
+                    "the refusal should name what it found, so the operator can see why"
+                );
+            }
+            other => panic!("expected NotOrphaned, got {other:?}"),
+        }
+    }
+
+    /// A slot the host does not serve is not an orphan either — there is
+    /// nothing there to retire, and saying "retired" would be a lie.
+    #[test]
+    fn a_slot_the_host_does_not_serve_is_refused() {
+        let refusal =
+            decide(&[], &[], "ghost", None).expect_err("nothing to retire is not a success");
+        assert!(matches!(refusal, RetireOrphanRefusal::NotOrphaned { .. }));
+    }
+
+    /// A report can go stale between being read and being acted on. Naming the
+    /// DID that was seen is what turns that into a refusal.
+    #[test]
+    fn a_stale_report_is_refused_rather_than_retiring_the_wrong_thing() {
+        let now_serves = "did:webvh:QmScid:webvh.example:published-since";
+        let refusal = decide(
+            &[hosted("attract-case", Some(now_serves))],
+            &[],
+            "attract-case",
+            Some("did:webvh:QmScid:webvh.example:what-the-operator-saw"),
+        )
+        .expect_err("a mismatched DID must refuse");
+        match refusal {
+            RetireOrphanRefusal::DidMismatch { actual, .. } => {
+                assert_eq!(actual.as_deref(), Some(now_serves));
+            }
+            other => panic!("expected DidMismatch, got {other:?}"),
+        }
+    }
+
+    /// The guard also fires the other way: a slot that has since been published
+    /// to, when the operator saw no DID at all.
+    #[test]
+    fn expecting_a_did_on_a_slot_that_has_none_is_refused() {
+        let refusal = decide(
+            &[hosted("reserved", None)],
+            &[],
+            "reserved",
+            Some("did:webvh:QmScid:webvh.example:reserved"),
+        )
+        .expect_err("expected-vs-none must refuse");
+        assert!(matches!(refusal, RetireOrphanRefusal::DidMismatch { .. }));
+    }
+
+    /// Omitting `expectedDid` skips the staleness guard — the caller has
+    /// accepted that risk, and the orphanhood check still stands.
+    #[test]
+    fn omitting_the_expected_did_skips_only_the_staleness_guard() {
+        let did = "did:webvh:QmScid:webvh.example:whatever";
+        assert!(decide(&[hosted("slot", Some(did))], &[], "slot", None).is_ok());
+        // …but not the orphanhood one.
+        assert!(decide(&[hosted("slot", Some(did))], &[local("slot")], "slot", None).is_err());
+    }
+
+    /// A record naming a *different* server does not make this slot ours. The
+    /// reconcile filter already scopes by server; this pins that the refusal
+    /// path uses the same scoping rather than a global search.
+    #[test]
+    fn a_record_on_another_server_does_not_shield_the_slot() {
+        let did = "did:webvh:QmScid:webvh.example:shared-name";
+        let mut elsewhere = local("shared-name");
+        elsewhere.server_id = "some-other-host".into();
+        assert!(
+            decide(
+                &[hosted("shared-name", Some(did))],
+                &[elsewhere],
+                "shared-name",
+                None
+            )
+            .is_ok(),
+            "a slot recorded against another server is still an orphan on this one"
+        );
+    }
+
+    /// Each refusal carries the code its specification defines; a caller keys
+    /// on that rather than on prose, so the mapping is pinned.
+    #[test]
+    fn every_refusal_carries_its_specified_code() {
+        let cases = [
+            (
+                RetireOrphanRefusal::NotOrphaned {
+                    slot_id: "s".into(),
+                    did: None,
+                },
+                "vta/webvh/servers/retire-orphan:notOrphaned",
+            ),
+            (
+                RetireOrphanRefusal::DidMismatch {
+                    slot_id: "s".into(),
+                    expected: "did:webvh:a".into(),
+                    actual: None,
+                },
+                "vta/webvh/servers/retire-orphan:didMismatch",
+            ),
+            (
+                RetireOrphanRefusal::ListingUnavailable {
+                    server_id: "s".into(),
+                    detail: "down".into(),
+                },
+                "vta/webvh/servers/retire-orphan:listingUnavailable",
+            ),
+        ];
+        for (refusal, code) in cases {
+            assert_eq!(refusal.code(), code);
+            assert!(
+                !refusal.message().is_empty(),
+                "{code} must explain itself to an operator"
+            );
+        }
+    }
+}

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -99,7 +99,8 @@ use vta_sdk::protocols::device_management::{
 };
 use vta_sdk::protocols::did_management::servers::{
     AgentOnlyDid, HostOnlyDid, ListWebvhServerDomainsBody, ListWebvhServerDomainsResultBody,
-    ReconcileWebvhServerDidsBody, ReconcileWebvhServerDidsResultBody, WebvhServerDomainEntry,
+    ReconcileWebvhServerDidsBody, ReconcileWebvhServerDidsResultBody, RetireOrphanSlotBody,
+    RetireOrphanSlotResultBody, WebvhServerDomainEntry,
 };
 use vta_sdk::protocols::key_management::create::{
     CreateKeyBody, CreateKeyResponseBody, CreateKeyResultBody,
@@ -2140,6 +2141,38 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
             (
                 server_record(),
                 parses::<wv::servers::register::v1_0::Response>,
+            ),
+        ),
+        (
+            uris::TASK_WEBVH_SERVERS_RETIRE_ORPHAN_0_1,
+            (
+                // From the typed body rather than hand-written JSON, so this
+                // asserts that *our* wire type conforms — the property that
+                // catches drift, rather than merely that the schema accepts a
+                // shape written by hand to match it.
+                to_v(RetireOrphanSlotBody {
+                    server_id: "primary-host".into(),
+                    slot_id: "attract-case".into(),
+                    expected_did: Some(
+                        "did:webvh:QmZ4rT9xK2mN8vB5cD1sA7wE3fH6jL0pQ:did.example.com:attract-case"
+                            .into(),
+                    ),
+                    reason: Some("orphaned by a create whose reply was lost".into()),
+                }),
+                parses::<wv::servers::retire_orphan::v0_1::Payload>,
+                validates::<wv::servers::retire_orphan::v0_1::Payload>,
+            ),
+            (
+                to_v(RetireOrphanSlotResultBody {
+                    server_id: "primary-host".into(),
+                    slot_id: "attract-case".into(),
+                    retired: true,
+                    did: Some(
+                        "did:webvh:QmZ4rT9xK2mN8vB5cD1sA7wE3fH6jL0pQ:did.example.com:attract-case"
+                            .into(),
+                    ),
+                }),
+                parses::<wv::servers::retire_orphan::v0_1::Response>,
             ),
         ),
         (

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1073,6 +1073,14 @@ dispatch_table! {
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_RECONCILE_0_1 => webvh::handle_servers_reconcile
         [ None Metadata false ],
+    // Destructive rather than Mutating: it stops a published identifier
+    // resolving, with no undo, and every relying party that held the DID sees
+    // it go — they cannot distinguish retirement from compromise or an outage.
+    // Reconcile above it is the read that finds these; this is the only write
+    // in the pair, and the asymmetry in class is the point.
+    #[cfg(feature = "webvh")]
+    vta_sdk::trust_tasks::TASK_WEBVH_SERVERS_RETIRE_ORPHAN_0_1 => webvh::handle_servers_retire_orphan
+        [ Destructive None false ],
     #[cfg(feature = "webvh")]
     vta_sdk::trust_tasks::TASK_WEBVH_DIDS_LIST_1_0 => webvh::handle_dids_list
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/webvh.rs
+++ b/vta-service/src/trust_tasks/webvh.rs
@@ -733,6 +733,62 @@ pub(super) async fn handle_servers_reconcile(
     }
 }
 
+/// `spec/vta/webvh/servers/retire-orphan/0.1` — remove a slot the host serves
+/// and this VTA has no record of. Destructive, no undo, super-admin.
+///
+/// The refusals are the interesting half. Three conditions decline, and each
+/// carries the specification's extended code in `details.reason` so a caller
+/// keys on a stable field rather than on prose — the same shape the consent
+/// gate uses. Two of the three are *uncertainty* rather than contradiction,
+/// and refusing on uncertainty is deliberate: the alternative to a false
+/// refusal is a retry, and the alternative to a false removal is nothing.
+pub(super) async fn handle_servers_retire_orphan(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    use vta_sdk::protocols::did_management::servers::RetireOrphanSlotBody;
+    let req: RetireOrphanSlotBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let did_resolver = match state.did_resolver.as_ref() {
+        Some(r) => r,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Internal("DID resolver not available".into()),
+            );
+        }
+    };
+    let vta_did = state.config.read().await.vta_did.clone();
+    let deps = operations::did_webvh::WebvhDeps::from_app_state(state, did_resolver);
+    match operations::did_webvh::retire_orphan_slot(&deps, auth, vta_did.as_deref(), &req).await {
+        Ok(Ok(body)) => success_response(&doc, body),
+        Ok(Err(refusal)) => {
+            tracing::info!(
+                caller = %auth.did,
+                server_id = %req.server_id,
+                slot_id = %req.slot_id,
+                code = refusal.code(),
+                "retire-orphan refused"
+            );
+            super::helpers::reject_with(
+                &doc,
+                trust_tasks_rs::RejectReason::TaskFailed {
+                    reason: refusal.message(),
+                    details: Some(serde_json::json!({
+                        "reason": refusal.code(),
+                        "serverId": req.server_id,
+                        "slotId": req.slot_id,
+                    })),
+                },
+            )
+        }
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
 pub(super) async fn handle_servers_domains(
     state: &AppState,
     auth: &AuthClaims,


### PR DESCRIPTION
Closes the last item on #1009. Implements `vta/webvh/servers/retire-orphan/0.1`
(spec: trustoverip/dtgwg-trust-tasks-tf#249).

## The gap

`vta/webvh/servers/reconcile` reports two divergences and repairs neither,
deliberately, because they want opposite remedies. The `agentOnly` side has one —
retry the publish, or drop the local record. The `hostOnly` side, an **orphan**,
had none, and the reason is structural rather than an oversight:

Every delete addresses a DID *through its local record* — that record is what says
which server to talk to and which keys to sign with. An orphan is defined by that
record's absence, so `get_did(...).ok_or(NotFound)` fails before a request ever
leaves the VTA. And the caller can't go around it: reconcile authenticates to the
host with VTA-held credentials, so the VTA *is* the credential holder.

A slot both parties can see, and neither can remove.

## The one property everything rests on

**The VTA decides whether the slot is orphaned. The caller does not get to claim
it.**

A slot id is a bare string. If this trusted it, the operation would be "delete
anything on the host, unaudited by the VTA's own state" wearing a narrower name.
Instead it re-runs the same comparison `reconcile` performs and refuses if it
holds *any* record for the slot — a live DID has a record, and that record is what
makes the refusal automatic.

If you review one thing, review whether `decide_retirement` actually closes that.

I lifted it out of the I/O, the way `diff_host_against_local` already is in the
same file, so every refusal is testable without a host. Three of the nine tests
exist only because of that: a record naming a **different** server doesn't shield
the slot, and `expectedDid` fires in both directions — expected-a-DID-got-none as
well as got-a-different-one.

## Refusing under uncertainty is deliberate

Three conditions decline. Two are *uncertainty* rather than contradiction — the
listing is unobtainable, or the DID doesn't match — meaning the VTA doesn't know
the slot is safe to remove. The asymmetry settles it: the alternative to a false
refusal is a retry; the alternative to a false removal is nothing.

## Classification

- **`Destructive`** in the dispatch table, not `Mutating`. It stops a published
  identifier resolving, and every relying party that held the DID sees that
  without being able to distinguish retirement from compromise or an outage.
- **`RetrySafe`** in `retry_safety`. Destructive but convergent — once the slot is
  gone a repeat removes nothing. The slot-reuse hazard is closed twice: the
  orphanhood re-derivation, and `expectedDid`.
- **Never automatic.** Nothing calls it on a timer and nothing should. The signal
  is an *absence*, and absences come from bugs as readily as from orphaning — a
  read that fails open, a record written under the wrong server id. Each presents
  as an orphan, and the response would be to make a published identifier stop
  resolving, irreversibly. The spec forbids it; this just doesn't provide one.

## Two judgement calls to check

**No new error-code machinery.** No extended codes exist anywhere in the
dispatcher today, so the spec's (`retire-orphan:notOrphaned` / `:didMismatch` /
`:listingUnavailable`) ride in `details.reason` — the shape the consent gate uses
and `trust_task_error` already keys on. Making them typed first requires deciding
whether a spec's `errorCodes` are *normative* (should the dispatcher refuse to
emit an undeclared code?), which is a contract question that shouldn't be settled
as a side effect of one family landing. Being raised separately.

**The conformance witness is built from the typed bodies**, not raw JSON — sound
here only because the spec preceded the types. Where a type came first and was
reverse-engineered from a schema, a typed witness can encode the defect and pass
green. See #1021, which writes that rule down.

## Seam

One arm in `trust_tasks/mod.rs`, directly after `SERVERS_RECONCILE`. Coordinated
with the session holding `vta/services/*` — no overlap in `mod.rs`,
`conformance.rs`, or `retry_safety.rs`, and no `api/trust-tasks` references, so
this absorbs #1020's endpoint move cleanly whichever lands first.

## Pre-merge

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo test --workspace --no-fail-fast` — 3534 passed, 0 failed
- [x] 9 new unit tests covering every refusal path
- [x] Conformance witness, census, and manifest guards green
- [x] No `version =` edits, no changelog file
