### PR TITLE
security(deps): clear four Dependabot alerts by moving the edges that carry them

### DIFF
--- a/deploy/nitro/enclave-proxy/Cargo.lock
+++ b/deploy/nitro/enclave-proxy/Cargo.lock
@@ -3246,9 +3246,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -37,9 +37,18 @@ utoipa = { workspace = true }
 rand = { workspace = true }
 bip39 = "2"
 hmac = "0.13"
-aws-sdk-kms = "1"
-aws-sdk-dynamodb = "1"
-aws-config = { version = "1", features = ["behavior-version-latest"] }
+# `default-features = false` drops the SDKs' `rustls` feature, which is not
+# "use rustls" but `aws-smithy-runtime/tls-rustls` -> the smithy client's
+# `legacy-rustls-ring` -> **rustls 0.21.8** -> rustls-webpki 0.101.7, the
+# stale copy behind three Dependabot alerts. The modern stack is already in
+# the tree (`rustls-aws-lc`, rustls 0.23) via `default-https-client`, so the
+# legacy pull was redundant as well as vulnerable. Nothing in this workspace
+# names rustls-webpki, so a direct bump cannot move it — the feature edge is
+# the only lever. Re-adding a default-featured `aws-sdk-*` dependency
+# reintroduces all three alerts.
+aws-sdk-kms = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-dynamodb = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
 aws-lc-rs = "1"
 aes = "0.9"
 cbc = "0.2"


### PR DESCRIPTION
Four open alerts on the default branch, two high. Neither is a version bump,
and neither means quite what the severity implies — so both are diagnosed to
the edge that carries them rather than bumped and hoped.

## `quinn-proto` 0.11.14 (high) — real pin, no exposure

Remote memory exhaustion from unbounded out-of-order buffering; patched in
0.11.15. It lives in `deploy/nitro/enclave-proxy/Cargo.lock`, which is a
separate lockfile from the workspace — that is how it drifted.

**It is never compiled.** It arrives as an optional dependency of `reqwest`'s
HTTP/3 support, which this crate does not enable:

```
cargo tree -i quinn-proto              -> nothing to print
cargo tree -i quinn-proto --target all -> nothing to print
cargo build --locked                   -> quinn never compiles
```

Cargo records optional dependencies in the lockfile whether or not the
feature selecting them is on, and Dependabot reads the lockfile rather than
the build graph. The alert is accurate about the pin and silent about the
fact that nothing links it.

Bumped anyway. The pin is what the alert is about, and leaving a
known-vulnerable version pinned so that a future feature flip can quietly
link it is worse than a one-line lock change. It also clears a high alert
that would otherwise keep drawing attention away from ones that bite.

## `rustls-webpki` ×3 — a misleadingly-named feature, not a stale version

All three alerts resolve to a single `0.101.7`, **not** to the `0.103.14` the
workspace also carries. Nothing in this tree names `rustls-webpki`, so no
bump can move it. Worth stating plainly, because "two high alerts, one is
just a patch" invites someone to try the bump, watch the alert survive, and
conclude the tooling is wrong.

The copy arrives through a feature edge:

```
aws-sdk-{kms,dynamodb} default features -> "rustls"
  -> aws-smithy-runtime/tls-rustls
  -> aws-smithy-http-client/legacy-rustls-ring
  -> rustls 0.21.8 -> rustls-webpki 0.101.7
```

**The `rustls` feature on those SDK crates does not mean "use rustls".** It
selects the *legacy* ring-backed rustls 0.21 client. The modern stack was
already in the tree — `rustls-aws-lc` on rustls 0.23, reached via
`default-https-client` — so the legacy pull was redundant as well as
vulnerable, and this workspace has been compiling both TLS stacks.

`default-features = false` plus the features actually wanted removes it.
Afterwards neither `rustls@0.21.12` nor `rustls-webpki@0.101.7` is in the
resolved graph on any target; only `0.23.43` / `0.103.14` remain.

### The lockfile does not change

Zero churn, and that is the evidence the legacy client was never needed —
nothing else in the tree was reaching it.

It also means **the alerts may not close**, for the same reason as
`quinn-proto`: the optional-dependency entries persist in the lock, and
Dependabot reads the lock. What changes is that the code is no longer
compiled or linked. Flagging so nobody reads a surviving alert as this change
having failed.

## Verification

The change touches the KMS/DynamoDB path used by the enclave, so it is
verified against the exact CI invocations that reach `vta-tee`:

| run | result |
|---|---|
| `cargo test --workspace` | exit 0, 145 suites, 0 failed |
| `cargo test -p vta-tee --features tenant-overlay tenant_overlay` | exit 0 |
| `cargo test -p vta-service --no-default-features --features tee,rest,didcomm --lib routes::bootstrap` | exit 0 |

## Unrelated, found while verifying — not fixed here

`cargo test --workspace --all-features` does not compile on a clean `main`:
six `E0609`s in `vta-sdk/tests/provision_client_e2e.rs`, reading `.nonce` and
`.holder` off a `serde_json::Value`. Confirmed pre-existing by stashing this
change and reproducing. CI runs `cargo test --workspace` (ci.yml:203) plus
targeted feature combos and never `--all-features`, so nothing covers it.
Reported rather than folded in.

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types (R3.*) — none
- [x] Config absence = most restrictive (R5.*) — `default-features = false`
      is exactly this: nothing is pulled that is not named
- [x] **Logs/status claim only what was verified (R6.\*)** — states that the
      alerts may survive the fix, rather than implying they close