### PR TITLE
fix(service)!: make AppState non-exhaustive so adding a field stops being a break

### DIFF
--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -69,7 +69,32 @@ pub fn trigger_restart(restart_tx: &watch::Sender<bool>) {
     });
 }
 
+/// Shared handle graph for every route, task handler and sweeper.
+///
+/// **`#[non_exhaustive]` is load-bearing, not decoration.** This struct is 46
+/// public fields with no private field and no constructor guard, so before
+/// this attribute any crate could write an `AppState { .. }` literal — which
+/// made *adding a field* a source-breaking change under
+/// `constructible_struct_adds_field`. Twenty-nine commits have added at least
+/// one field to it; one added five.
+///
+/// That break was never reported, because `cargo semver-checks` cannot build
+/// this crate's baseline (its published dependency ranges resolve two
+/// `trust-tasks-rs` versions into one graph) and a crate whose baseline fails
+/// to build is silently not compared. Version numbers stayed correct anyway
+/// — at 0.x a break needs a minor bump and conventional commits already force
+/// one for `feat:`, which every field addition since release-plz happened to
+/// be. Both of those are coincidences: `refactor:`/`fix:`/`perf:`/`chore:`
+/// yield a patch and can add fields just as easily (c93c7b57 added five under
+/// `refactor:`), and the alignment disappears entirely at 1.0, where a break
+/// needs a major and `feat:` gives only a minor.
+///
+/// Marking it non-exhaustive closes the class permanently rather than relying
+/// on any of that holding. Construction inside this crate is unaffected —
+/// both sites (`build_state` below and `test_support`) are in-crate, and
+/// `MockVta` is the supported entry point for consumers.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct AppState {
     pub keys_ks: KeyspaceHandle,
     pub sessions_ks: KeyspaceHandle,


### PR DESCRIPTION
## The problem

`AppState` is **46 public fields, zero private fields, no constructor guard**.
Before this, any crate could write an `AppState { .. }` literal — which makes
*adding a field* a source-breaking change under
`constructible_struct_adds_field`.

Twenty-nine commits have added at least one field to it. `c93c7b57` added five
in one go.

**That break has never once been reported.** `cargo semver-checks` cannot build
this crate's baseline, and a crate whose baseline fails to build is silently not
compared — indistinguishable from a crate that was compared and found clean.
(That baseline failure turned out to be a real defect in the published crate,
not a tooling artifact; it is being handled separately.)

## Why the version numbers were right anyway

They were, and it is worth recording *why*, because the reason is two
coincidences rather than a process:

1. At `0.x` a breaking change needs a **minor** bump, and conventional commits
   already force a minor for `feat:`.
2. Every field addition since release-plz adoption happened to be a `feat:`.

So the correct bump was demanded by commit classification, not by the semver
check — which never ran. Something was incidentally standing where the dead
check stood.

**Neither coincidence holds in general:**

| | |
|---|---|
| `refactor:` / `fix:` / `perf:` / `chore:` | all yield a **patch**, all can add fields |
| `c93c7b57` | a `refactor:` that added **five** fields — the largest single addition in the file's history |
| at 1.0 | a break needs a **major**, `feat:` gives only a minor — the alignment fails entirely |

Moving state between structs is what a refactor *is*, so the commit type most
likely to add public fields is one of the types that yields a patch. That is a
structural pairing, not bad luck. And the cover expires precisely when the
consequences become external.

`#[non_exhaustive]` closes the class permanently rather than relying on any of
that continuing to hold.

## Why this is safe

Nothing outside the crate is affected:

- both construction sites are in-crate — `build_app_state` and `test_support`
- `MockVta` is the supported entry point for external consumers
- `tests/app_state_single_construction.rs` already goes through
  `build_app_state` rather than a literal

That last one matters: the test is from the **P1.1 work in `c93c7b57`** — the
same commit that added five fields. A single canonical constructor was already
the crate's intent. This makes it enforceable from outside rather than
conventional.

## The `!`

Marked breaking because it is: outside this crate, `AppState { .. }` and
exhaustive destructuring stop compiling. **That is the point.** It is one final
break, and it is the last one this struct can have.

## Verification

- `cargo test --workspace` — 145 suites, 0 failed
- `cargo check -p vta-service --all-features` — clean, zero warnings

## Checklist (stack guide §9)

- [x] No new `reqwest::Client::new()` / bare `fetch()` (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types (R3.*) — none; this is a Rust source-level
      constructibility change with no wire effect
- [x] Config absence = most restrictive (R5.*)
- [x] **Logs/status claim only what was verified (R6.\*)** — the doc comment
      states the version numbers were correct and says plainly that this was
      coincidence, rather than implying the check was working