### PR TITLE
ci(semver): a failed baseline means the published crate is broken, so say that

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,8 +492,34 @@ jobs:
       #
       # `vta-service` is NOT excluded: it has a real consumer, so a silent
       # break there reaches somebody.
+      # A baseline build failure is NOT a CI inconvenience — it is a
+      # production defect, and this step exists to stop the two looking alike.
+      #
+      # cargo-semver-checks builds the baseline the way a consumer gets it:
+      # `cargo add <crate>@<version>` into a fresh crate, resolving from the
+      # published ranges with no lockfile. That makes it the only thing in this
+      # repo that resolves like a consumer — and therefore the only thing that
+      # can notice when a *published* artifact stops building.
+      #
+      # It noticed. `vta-service` 0.17.1 does not build for an external
+      # consumer: `affinidi-tdk 0.8.5` requires `affinidi-messaging-sdk ^0.19`,
+      # which now resolves to 0.19.9 requiring `trust-tasks-rs ^0.11`, while
+      # 0.17.1 and `vta-sdk` 0.25.1 require `^0.9`. Two versions in one graph,
+      # and the types cross in `vta-sdk`'s `acl_setup`. Reproduce in 30s:
+      #
+      #     cargo new --lib x && cd x && echo '[workspace]' >> Cargo.toml
+      #     cargo add vta-service@0.17.1 && cargo build
+      #
+      # Our own builds are fine because `Cargo.lock` pins one of each. Consumers
+      # do not get our lockfile. That is the whole defect in one sentence.
+      #
+      # Crucially, none of those versions were broken when published — they
+      # broke later, together, when a range they each depend on resolved
+      # somewhere new. No amount of care at publish time catches that, which is
+      # why this check has to keep running rather than gate a release.
       - name: Check published crates for API breaks
         run: |
+          set +e
           cargo semver-checks --workspace \
             --exclude vta-audit \
             --exclude vta-backup \
@@ -506,7 +532,34 @@ jobs:
             --exclude vta-tee \
             --exclude vta-vault \
             --exclude vta-webvh \
-            --exclude vti-webauthn
+            --exclude vti-webauthn \
+            2>&1 | tee semver.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          # The distinction that was missing, and the reason a dead check sat
+          # unnoticed: a failed baseline and a clean comparison produced the
+          # same silence, on a job that was already red for a declared break.
+          # One red looked like another.
+          if grep -qE 'failed to build rustdoc|running cargo-doc on crate' semver.log; then
+            broken="$(grep -oE 'failed to build rustdoc for crate [a-z0-9-]+' semver.log \
+              | sed 's/failed to build rustdoc for crate //' | sort -u | tr '\n' ' ')"
+            echo "::error::PUBLISHED CRATE DOES NOT BUILD: ${broken}-- the semver \
+          baseline is the published crate as a consumer receives it, so a \
+          baseline that fails to build means consumers cannot build it either. \
+          This is not 'the check could not run'; it is the check reporting a \
+          broken artifact on crates.io. Reproduce: cargo new --lib x && cd x && \
+          echo '[workspace]' >> Cargo.toml && cargo add ${broken%% *} && cargo build"
+            exit 1
+          fi
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::API breaks reported — expected on a PR marked '!'; \
+          the release moves the compatibility field accordingly."
+          else
+            echo "all baselines built; no API breaks reported"
+          fi
+          exit "$status"
 
   lockfile-self-pins:
     # Sibling guard to release-guards: the version bump can be correct and the


### PR DESCRIPTION
> **Read this first:** `vta-service` does not build on crates.io. That is not
> what I set out to fix — I set out to fix the CI job that reports it, and spent
> most of a day trying to make a true message go away.

## The check was right

`cargo semver-checks` builds its baseline the way a consumer gets it —
`cargo add <crate>@<version>` into a fresh crate, resolved from published ranges
with **no lockfile**. That makes it the only thing in this repo that resolves
like a consumer, and therefore the only thing that can notice when a *published*
artifact stops building.

It noticed. Thirty-second reproduction, nothing of ours in scope:

```
cargo new --lib x && cd x && echo '[workspace]' >> Cargo.toml
cargo add vta-service@0.17.1 && cargo build
→ expected `MediatorAcl`, found a different `MediatorAcl`
→ note: there are multiple different versions of crate `trust_tasks_rs`
```

`affinidi-tdk 0.8.5` → `affinidi-messaging-sdk ^0.19` → resolves to **0.19.9** →
`trust-tasks-rs ^0.11`, while `vta-service` 0.17.1 and `vta-sdk` 0.25.1 require
`^0.9`. The types cross in `vta-sdk`'s `acl_setup`.

**Our builds are fine because `Cargo.lock` pins one of each. Consumers don't get
our lockfile.** That's the whole defect.

| Version | Resolution | Build |
|---|---|---|
| 0.17.1 | split (2) | **fails** — confirmed |
| 0.17.0 | split (2) | not built |
| 0.16.1 | split (3) | **fails** — confirmed |
| 0.15.4 | split (3) | not built |

Blast radius is `vta-service` plus anyone taking `vta-sdk` with the `acl-setup`
feature; default-feature SDK consumers are unaffected.

## Why it hid, which is what this PR changes

Two failures, one expected. The job is `continue-on-error` **by design**, and was
already red for the declared `!` breaks in #1011/#1012 — so a second red looked
like the first. "Baseline failed to build" and "compared, clean" produced the
same silence for that crate.

And the noise **scales with our own output**: every `!` we land raises the floor
and makes the next real finding harder to see. That's a feedback loop, not
ordinary flakiness.

So the step now separates three states that were one:

- **baseline failed to build** → `::error::` naming the crate and the
  reproduction, and saying what it means — not "the check could not run" but
  "consumers cannot build this"
- **compared, breaks reported** → warning (this is what the advisory contract is
  actually about)
- **compared, clean** → says so explicitly

## What this does not do

**It does not gate.** `continue-on-error` is job-level, so `exit 1` is still
soft. The comment says so rather than implying otherwise. Whether "could not
evaluate" should become a real gate is a contract question deserving its own
change — it shouldn't be redefined as a side effect of this.

**It cannot prevent the class.** None of those versions were broken when
published. They broke later, together, when a range they each depend on resolved
somewhere new. No pre-publish check catches a build that breaks two months later,
caused by a release in another repo, on a day nobody touched this one. Only a
check that keeps resolving like a consumer does — which is what this is.

## Rejected alternatives, and why the rejection matters

`--baseline-rev`, `--baseline-root` and `--default-features` were all tried and
all fail identically: the tool always rebuilds the baseline in a fresh isolated
workspace, discarding any lockfile.

That looked like tool inflexibility. **It wasn't.** They were three attempts to
construct a consistent baseline for a crate whose published ranges do not admit
one — and any of them succeeding would have *suppressed a true negative*. The fix
I was reaching for would itself have been the bug.

## Not in this PR — for @stormer78

`vta-service` needs a **release**, and **yank is unavailable**: every published
version splits, and 0.16.1 is confirmed broken by build, so yanking 0.17.1 drops
consumers onto 0.17.0 with nothing good beneath it. Main already requires
`trust-tasks-rs ^0.11` consistently, so the next release fixes it by
construction. That's a lever for you, not for CI.

## Verification

- [x] Reproduced the consumer failure independently (`CONSUMER_BUILD_EXIT=101`)
- [x] Confirmed 0.16.1 by build, not inferred from its resolution
- [x] Confirmed the tag builds under `--locked` (exit 0) — isolating the lockfile as the thing hiding it
- [x] Annotation extraction logic tested against real log output
- [x] `yaml.safe_load` on the workflow
