### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.11.24"
+version = "0.12.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6295,7 +6295,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.12.8"
+version = "0.13.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9222,7 +9222,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "tracing",
  "uuid",
@@ -9232,7 +9232,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9261,7 +9261,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9319,7 +9319,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9402,7 +9402,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "hex",
  "multibase",
@@ -9422,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9588,7 +9588,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9658,7 +9658,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9692,7 +9692,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9713,7 +9713,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9810,7 +9810,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9884,7 +9884,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.16"
+version = "0.2.0"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.24...cnm-cli-v0.12.0) — 2026-08-21
+
+
+### Fixed
+
+- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))
+
+All four binaries treated an unavailable OS credential store as a warning
+  and carried on. What happened next was worse than a silent fallback:
+  `KeyringBackend` stayed registered, every `Entry::new` returned
+  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
+  `None` — so the tool behaved exactly as though the user had never logged
+  in. A silent fallback at least stores something; this silently forgets.
+  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
+  keyring did not survive a reboot, and the error told the user to check
+  their network.
+
+  The four call sites are byte-identical, but their consequences are not,
+  so the fix is not:
+
+  - `pnm` and `cnm` keep their session — the admin DID and its private key
+    — in the credential store and nowhere else. They now exit at startup
+    via `keyring_init::install_default_store_or_exit`, which is the whole
+    point: there is nothing they can usefully do next.
+  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
+    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
+    store, one of eight `[secrets] backend` options. Which one is in play
+    is not known until config loads, long after `main` starts, so hard
+    failing there would break every deployment on aws/gcp/azure/vault/k8s
+    running on a host with no credential store — the normal server shape.
+    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
+    already failed closed — now says which subsystem broke rather than
+    "failed to create keyring entry".
+
+  The second half is `FileBackend`. `default_backend` ended in an
+  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
+  was enabled, writing the admin private key to `sessions.json` as
+  plaintext at the process umask, announced by a WARNING on every access —
+  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
+  used 0600; the inconsistency was inside one tool.
+
+  That fallback is gone. A build with no session store gets `RefusingBackend`,
+  which refuses to save rather than inventing somewhere to put a private
+  key. `FileBackend` is now reachable only by explicit choice — the
+  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
+  creates its file at 0600 inside a 0700 directory *before* writing, since
+  writing and then hardening leaves a window at the umask. An existing
+  world-readable file from an older build is re-hardened on the next write.
+
+  The runtime override exists because requiring a rebuild to run on a
+  headless host creates pressure to disable the check rather than make a
+  choice. It parses strictly: `os` or `file`, and anything else — including
+  a near-miss like `plaintext` — resolves to neither and refuses. Asking
+  for `os` on a build with no `keyring` feature refuses too, rather than
+  quietly substituting a file.
+
+  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
+  the error as `Display` so it is available without the `keyring` feature —
+  OpenVTC renders the same text and honours the same override, which was
+  the stated goal: identical secret handling across vta, pnm, openvtc and
+  vtc, hard failure rather than a fallback to open text files.
+
+
+
 ## [0.11.24](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.23...cnm-cli-v0.11.24) — 2026-08-20
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.11.24"
+version = "0.12.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.11", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.8...pnm-cli-v0.13.0) — 2026-08-21
+
+
+### Fixed
+
+- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))
+
+All four binaries treated an unavailable OS credential store as a warning
+  and carried on. What happened next was worse than a silent fallback:
+  `KeyringBackend` stayed registered, every `Entry::new` returned
+  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
+  `None` — so the tool behaved exactly as though the user had never logged
+  in. A silent fallback at least stores something; this silently forgets.
+  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
+  keyring did not survive a reboot, and the error told the user to check
+  their network.
+
+  The four call sites are byte-identical, but their consequences are not,
+  so the fix is not:
+
+  - `pnm` and `cnm` keep their session — the admin DID and its private key
+    — in the credential store and nowhere else. They now exit at startup
+    via `keyring_init::install_default_store_or_exit`, which is the whole
+    point: there is nothing they can usefully do next.
+  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
+    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
+    store, one of eight `[secrets] backend` options. Which one is in play
+    is not known until config loads, long after `main` starts, so hard
+    failing there would break every deployment on aws/gcp/azure/vault/k8s
+    running on a host with no credential store — the normal server shape.
+    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
+    already failed closed — now says which subsystem broke rather than
+    "failed to create keyring entry".
+
+  The second half is `FileBackend`. `default_backend` ended in an
+  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
+  was enabled, writing the admin private key to `sessions.json` as
+  plaintext at the process umask, announced by a WARNING on every access —
+  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
+  used 0600; the inconsistency was inside one tool.
+
+  That fallback is gone. A build with no session store gets `RefusingBackend`,
+  which refuses to save rather than inventing somewhere to put a private
+  key. `FileBackend` is now reachable only by explicit choice — the
+  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
+  creates its file at 0600 inside a 0700 directory *before* writing, since
+  writing and then hardening leaves a window at the umask. An existing
+  world-readable file from an older build is re-hardened on the next write.
+
+  The runtime override exists because requiring a rebuild to run on a
+  headless host creates pressure to disable the check rather than make a
+  choice. It parses strictly: `os` or `file`, and anything else — including
+  a near-miss like `plaintext` — resolves to neither and refuses. Asking
+  for `os` on a build with no `keyring` feature refuses too, rather than
+  quietly substituting a file.
+
+  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
+  the error as `Display` so it is available without the `keyring` feature —
+  OpenVTC renders the same text and honours the same override, which was
+  the stated goal: identical secret handling across vta, pnm, openvtc and
+  vtc, hard failure rather than a fallback to open text files.
+
+
+
 ## [0.12.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.7...pnm-cli-v0.12.8) — 2026-08-20
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.12.8"
+version = "0.13.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.8...vta-audit-v0.1.9) — 2026-08-21
+
+
 ## [0.1.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.7...vta-audit-v0.1.8) — 2026-08-20
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,6 +21,6 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.13" }
-vta-sdk = { path = "../vta-sdk", version = "0.26" }
+vta-sdk = { path = "../vta-sdk", version = "0.27" }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.13](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.12...vta-backup-v0.1.13) — 2026-08-21
+
+
 ## [0.1.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.11...vta-backup-v0.1.12) — 2026-08-20
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.12"
+version = "0.1.13"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -28,7 +28,7 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.13" }
-vta-sdk = { path = "../vta-sdk", version = "0.26" }
+vta-sdk = { path = "../vta-sdk", version = "0.27" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.2...vta-cli-common-v0.11.3) — 2026-08-21
+
+
 ## [0.11.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.1...vta-cli-common-v0.11.2) — 2026-08-20
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.10...vta-config-v0.3.11) — 2026-08-21
+
+
 ## [0.3.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.9...vta-config-v0.3.10) — 2026-08-20
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.3.10"
+version = "0.3.11"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,10 +27,10 @@ tee = []
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.13" }
-vti-secrets = { path = "../vti-secrets", version = "0.1" }
+vti-secrets = { path = "../vti-secrets", version = "0.2" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.26", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.27", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,7 +34,7 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.18", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.19", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.7...vta-keys-v0.2.8) — 2026-08-21
+
+
 ## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.6...vta-keys-v0.2.7) — 2026-08-20
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -37,8 +37,8 @@ tee = ["vti-secrets/tee"]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vti-common = { path = "../vti-common", version = "0.13" }
-vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["sealed-transfer"] }
+vti-secrets = { path = "../vti-secrets", version = "0.2" }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.9...vta-policy-v0.2.10) — 2026-08-21
+
+
 ## [0.2.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.8...vta-policy-v0.2.9) — 2026-08-20
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.26", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.27", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,138 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.27.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.26.0...vta-sdk-v0.27.0) — 2026-08-21
+
+
+### Fixed
+
+- **sdk**: Decode the Trust-Task responses the agent actually sends ([#1033](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1033))
+
+`pnm contexts create` fails against any agent built since #1000:
+
+      Protocol error: trust-task response decode: missing field `base_path`
+
+  #1000 folded Trust Task payloads to lowerCamelCase per SPEC §4.10 and excluded
+  `client/types.rs` as REST bodies whose casing "no published schema pins". The
+  exclusion was drawn by file path, and the path was stale: `rpc_tt` carries the
+  same Trust-Task document over REST, DIDComm and TSP alike, so `ContextResponse`
+  is a Trust-Task decode target and a published schema does pin it. The agent moved
+  to `basePath`; the client went on demanding `base_path`.
+
+  Eleven call sites across eight types, every one a required field with no
+  `default`, so they fail hard on every transport rather than degrading:
+
+  - contexts create / get / update / update-did / list — all of `pnm contexts`
+  - keys sign / rename / revoke / export-secret
+  - seeds rotate / list (`activeSeedId` only)
+
+  `vta-cli-common` and `vta-mcp` consume these, so `pnm`/`cnm` key management and
+  the MCP tool surface are equally affected. The user who reported it hit contexts
+  first and would have hit `keys sign` next.
+
+  Aliases rather than `rename_all`: this is the same Postel fold #1000 used, it
+  changes nothing about what the SDK emits, and it keeps working against an agent
+  that has not taken the change. `SeedInfoResponse` gets aliases it does not yet
+  need, because its counterpart `SeedInfo` is the one payload struct #1000 left
+  unfolded — when that lands, this type should not be what breaks.
+
+  The casing is the symptom. The defect is that one wire has two structs, so
+  either end can move alone; the 50 Trust-Task call sites that did NOT break are
+  exactly those where client and agent decode the same type. Collapsing each pair
+  onto one type is the real repair and is not attempted here — it changes public
+  type identity for two downstream crates. The module note records that.
+
+  ## Why no test caught a total outage
+
+  Three layers each stopped one step short of the join. The conformance harness
+  checks the agent against the published schema — green, its witness correctly
+  said `basePath`. The SDK's client tests check the client against a hand-written
+  mock — also green, because the mock still said `base_path`. Nothing compared the
+  two fixtures, so they disagreed for two days while both suites passed.
+
+  `vta-sdk/tests/trust_task_decode.rs` is that missing seam: it constructs the
+  agent's own body type, serializes it as the agent would, and requires the
+  client's own decode type to accept the bytes. No JSON literal appears in the
+  derived cases, so there is no third spelling to drift. Verified non-vacuous —
+  with the aliases reverted, 9 of 9 derived cases fail, each naming the CLI surface
+  that is broken and printing the exact wire.
+
+  The stale fixtures are re-cut to what an agent really sends, including the
+  asymmetry a uniform pass would have got wrong: `seeds[]` stays snake_case inside
+  a camelCase `activeSeedId`, because that is what the half-folded type emits.
+  Re-cutting them would have silently retired the only coverage of the snake_case
+  intake aliases, so that direction is now asserted explicitly by name —
+  `a_legacy_agent_snake_case_response_still_decodes` — rather than left implicit in
+  a fixture someone would later tidy.
+
+  Conformance witnesses stay hand-written: they anchor the types to the spec, and
+  deriving them from the types they check would make them vacuous.
+
+  Two adjacent findings, left alone as neither is a break: `CapabilitiesResponse`
+  and `SeedInfo` both received `alias` attributes in #1000 without the
+  `rename_all` that would give them meaning, so both still emit snake_case and
+  their aliases are inert. Filed rather than folded in, since fixing them changes
+  the wire.
+
+- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))
+
+All four binaries treated an unavailable OS credential store as a warning
+  and carried on. What happened next was worse than a silent fallback:
+  `KeyringBackend` stayed registered, every `Entry::new` returned
+  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
+  `None` — so the tool behaved exactly as though the user had never logged
+  in. A silent fallback at least stores something; this silently forgets.
+  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
+  keyring did not survive a reboot, and the error told the user to check
+  their network.
+
+  The four call sites are byte-identical, but their consequences are not,
+  so the fix is not:
+
+  - `pnm` and `cnm` keep their session — the admin DID and its private key
+    — in the credential store and nowhere else. They now exit at startup
+    via `keyring_init::install_default_store_or_exit`, which is the whole
+    point: there is nothing they can usefully do next.
+  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
+    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
+    store, one of eight `[secrets] backend` options. Which one is in play
+    is not known until config loads, long after `main` starts, so hard
+    failing there would break every deployment on aws/gcp/azure/vault/k8s
+    running on a host with no credential store — the normal server shape.
+    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
+    already failed closed — now says which subsystem broke rather than
+    "failed to create keyring entry".
+
+  The second half is `FileBackend`. `default_backend` ended in an
+  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
+  was enabled, writing the admin private key to `sessions.json` as
+  plaintext at the process umask, announced by a WARNING on every access —
+  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
+  used 0600; the inconsistency was inside one tool.
+
+  That fallback is gone. A build with no session store gets `RefusingBackend`,
+  which refuses to save rather than inventing somewhere to put a private
+  key. `FileBackend` is now reachable only by explicit choice — the
+  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
+  creates its file at 0600 inside a 0700 directory *before* writing, since
+  writing and then hardening leaves a window at the umask. An existing
+  world-readable file from an older build is re-hardened on the next write.
+
+  The runtime override exists because requiring a rebuild to run on a
+  headless host creates pressure to disable the check rather than make a
+  choice. It parses strictly: `os` or `file`, and anything else — including
+  a near-miss like `plaintext` — resolves to neither and refuses. Asking
+  for `os` on a build with no `keyring` feature refuses too, rather than
+  quietly substituting a file.
+
+  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
+  the error as `Display` so it is available without the `keyring` feature —
+  OpenVTC renders the same text and honours the same override, which was
+  the stated goal: identical secret handling across vta, pnm, openvtc and
+  vtc, hard failure rather than a fallback to open text files.
+
+
+
 ## [0.26.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.25.1...vta-sdk-v0.26.0) — 2026-08-20
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.26.0"
+version = "0.27.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,116 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.19.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.18.0...vta-service-v0.19.0) — 2026-08-21
+
+
+### Fixed
+
+- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))
+
+All four binaries treated an unavailable OS credential store as a warning
+  and carried on. What happened next was worse than a silent fallback:
+  `KeyringBackend` stayed registered, every `Entry::new` returned
+  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
+  `None` — so the tool behaved exactly as though the user had never logged
+  in. A silent fallback at least stores something; this silently forgets.
+  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
+  keyring did not survive a reboot, and the error told the user to check
+  their network.
+
+  The four call sites are byte-identical, but their consequences are not,
+  so the fix is not:
+
+  - `pnm` and `cnm` keep their session — the admin DID and its private key
+    — in the credential store and nowhere else. They now exit at startup
+    via `keyring_init::install_default_store_or_exit`, which is the whole
+    point: there is nothing they can usefully do next.
+  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
+    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
+    store, one of eight `[secrets] backend` options. Which one is in play
+    is not known until config loads, long after `main` starts, so hard
+    failing there would break every deployment on aws/gcp/azure/vault/k8s
+    running on a host with no credential store — the normal server shape.
+    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
+    already failed closed — now says which subsystem broke rather than
+    "failed to create keyring entry".
+
+  The second half is `FileBackend`. `default_backend` ended in an
+  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
+  was enabled, writing the admin private key to `sessions.json` as
+  plaintext at the process umask, announced by a WARNING on every access —
+  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
+  used 0600; the inconsistency was inside one tool.
+
+  That fallback is gone. A build with no session store gets `RefusingBackend`,
+  which refuses to save rather than inventing somewhere to put a private
+  key. `FileBackend` is now reachable only by explicit choice — the
+  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
+  creates its file at 0600 inside a 0700 directory *before* writing, since
+  writing and then hardening leaves a window at the umask. An existing
+  world-readable file from an older build is re-hardened on the next write.
+
+  The runtime override exists because requiring a rebuild to run on a
+  headless host creates pressure to disable the check rather than make a
+  choice. It parses strictly: `os` or `file`, and anything else — including
+  a near-miss like `plaintext` — resolves to neither and refuses. Asking
+  for `os` on a build with no `keyring` feature refuses too, rather than
+  quietly substituting a file.
+
+  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
+  the error as `Display` so it is available without the `keyring` feature —
+  OpenVTC renders the same text and honours the same override, which was
+  the stated goal: identical secret handling across vta, pnm, openvtc and
+  vtc, hard failure rather than a fallback to open text files.
+
+- **service**: Make AppState non-exhaustive so adding a field stops being a break ([#1024](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1024))
+
+`AppState` is 46 public fields, no private field, no constructor guard. Any
+  crate could write an `AppState { .. }` literal, which made *adding a field* a
+  source-breaking change under `constructible_struct_adds_field`. Twenty-nine
+  commits have added at least one field; c93c7b57 added five.
+
+  That break has never once been reported. `cargo semver-checks` cannot build
+  this crate's baseline — the published ranges resolve two `trust-tasks-rs`
+  versions into one graph — and a crate whose baseline fails to build is
+  silently not compared rather than reported as unchecked.
+
+  The version numbers came out right anyway, and it is worth recording why,
+  because the reason is two coincidences rather than a working process:
+
+    - at 0.x a break needs a MINOR bump, and conventional commits already force
+      one for `feat:`;
+    - every field addition since release-plz adoption happened to be a `feat:`.
+
+  Neither holds in general. `refactor:`, `fix:`, `perf:` and `chore:` all yield
+  a patch and can add fields just as easily — c93c7b57 is a `refactor:` and
+  added five, which is the largest single addition in the file's history.
+  Moving state between structs is what a refactor does, so the commit type most
+  likely to add public fields is one of the types that yields a patch. And the
+  alignment fails completely at 1.0, where a break needs a MAJOR and `feat:`
+  gives only a MINOR: the cover expires exactly when the consequences become
+  external.
+
+  `#[non_exhaustive]` closes the class permanently instead of relying on any of
+  that continuing to hold.
+
+  Nothing outside the crate is affected. Both construction sites are in-crate
+  (`build_app_state` and `test_support`), `MockVta` is the supported entry
+  point for consumers, and `tests/app_state_single_construction.rs` already
+  goes through `build_app_state` rather than a literal — that test is from the
+  P1.1 work in c93c7b57, so a single canonical constructor was already the
+  crate's intent. This makes it enforceable from outside rather than
+  conventional.
+
+  Marked `!` because it is one: outside this crate, `AppState { .. }` and
+  exhaustive destructuring stop compiling. That is the point — it is the last
+  such break this struct can have.
+
+  cargo test --workspace: 145 suites, 0 failed. cargo check --all-features
+  clean, zero warnings.
+
+
+
 ## [0.18.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.17.1...vta-service-v0.18.0) — 2026-08-20
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -143,7 +143,7 @@ vti-common = { path = "../vti-common", version = "0.13", features = ["encryption
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
-vti-secrets = { path = "../vti-secrets", version = "0.1" }
+vti-secrets = { path = "../vti-secrets", version = "0.2" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Structured audit logging (the `audit!` macro + audit-keyspace helpers),
 # extracted and re-exported as `crate::audit`.
@@ -179,7 +179,7 @@ vta-policy = { path = "../vta-policy", version = "0.2" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -375,7 +375,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.9...vta-support-v0.2.10) — 2026-08-21
+
+
 ## [0.2.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.8...vta-support-v0.2.9) — 2026-08-20
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.2...vta-vault-v0.3.3) — 2026-08-21
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.1...vta-vault-v0.3.2) — 2026-08-20
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -34,7 +34,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.11...vta-webvh-v0.1.12) — 2026-08-21
+
+
 ## [0.1.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.10...vta-webvh-v0.1.11) — 2026-08-20
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.11"
+version = "0.1.12"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -22,7 +22,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.13" }
-vta-sdk = { path = "../vta-sdk", version = "0.26" }
+vta-sdk = { path = "../vta-sdk", version = "0.27" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.9...vtc-client-v0.3.10) — 2026-08-21
+
+
 ## [0.3.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.8...vtc-client-v0.3.9) — 2026-08-20
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -133,8 +133,8 @@ vti-common = { path = "../vti-common", version = "0.13", features = [
 # Shared secret-store backend implementations (the VTC's `create_secret_store`
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
-vti-secrets = { path = "../vti-secrets", version = "0.1" }
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
+vti-secrets = { path = "../vti-secrets", version = "0.2" }
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.13.0...vti-common-v0.13.1) — 2026-08-21
+
+
 ## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.12.2...vti-common-v0.13.0) — 2026-08-20
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.26", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.27", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.16...vti-secrets-v0.2.0) — 2026-08-21
+
+
+### Fixed
+
+- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))
+
+All four binaries treated an unavailable OS credential store as a warning
+  and carried on. What happened next was worse than a silent fallback:
+  `KeyringBackend` stayed registered, every `Entry::new` returned
+  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
+  `None` — so the tool behaved exactly as though the user had never logged
+  in. A silent fallback at least stores something; this silently forgets.
+  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
+  keyring did not survive a reboot, and the error told the user to check
+  their network.
+
+  The four call sites are byte-identical, but their consequences are not,
+  so the fix is not:
+
+  - `pnm` and `cnm` keep their session — the admin DID and its private key
+    — in the credential store and nowhere else. They now exit at startup
+    via `keyring_init::install_default_store_or_exit`, which is the whole
+    point: there is nothing they can usefully do next.
+  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
+    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
+    store, one of eight `[secrets] backend` options. Which one is in play
+    is not known until config loads, long after `main` starts, so hard
+    failing there would break every deployment on aws/gcp/azure/vault/k8s
+    running on a host with no credential store — the normal server shape.
+    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
+    already failed closed — now says which subsystem broke rather than
+    "failed to create keyring entry".
+
+  The second half is `FileBackend`. `default_backend` ended in an
+  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
+  was enabled, writing the admin private key to `sessions.json` as
+  plaintext at the process umask, announced by a WARNING on every access —
+  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
+  used 0600; the inconsistency was inside one tool.
+
+  That fallback is gone. A build with no session store gets `RefusingBackend`,
+  which refuses to save rather than inventing somewhere to put a private
+  key. `FileBackend` is now reachable only by explicit choice — the
+  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
+  creates its file at 0600 inside a 0700 directory *before* writing, since
+  writing and then hardening leaves a window at the umask. An existing
+  world-readable file from an older build is re-hardened on the next write.
+
+  The runtime override exists because requiring a rebuild to run on a
+  headless host creates pressure to disable the check rather than make a
+  choice. It parses strictly: `os` or `file`, and anything else — including
+  a near-miss like `plaintext` — resolves to neither and refuses. Asking
+  for `os` on a build with no `keyring` feature refuses too, rather than
+  quietly substituting a file.
+
+  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
+  the error as `Display` so it is available without the `keyring` feature —
+  OpenVTC renders the same text and honours the same override, which was
+  the stated goal: identical secret handling across vta, pnm, openvtc and
+  vtc, hard failure rather than a fallback to open text files.
+
+
+
 ## [0.1.16](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.15...vti-secrets-v0.1.16) — 2026-08-20
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.1.16"
+version = "0.2.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -54,7 +54,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.26", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.27", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.26.0 -> 0.27.0 (✓ API compatible changes)
* `cnm-cli`: 0.11.24 -> 0.12.0
* `pnm-cli`: 0.12.8 -> 0.13.0
* `vti-secrets`: 0.1.16 -> 0.2.0 (✓ API compatible changes)
* `vta-service`: 0.18.0 -> 0.19.0 (✓ API compatible changes)
* `vti-common`: 0.13.0 -> 0.13.1
* `vta-cli-common`: 0.11.2 -> 0.11.3
* `vta-audit`: 0.1.8 -> 0.1.9
* `vta-config`: 0.3.10 -> 0.3.11
* `vta-keys`: 0.2.7 -> 0.2.8
* `vta-support`: 0.2.9 -> 0.2.10
* `vta-backup`: 0.1.12 -> 0.1.13
* `vta-policy`: 0.2.9 -> 0.2.10
* `vta-vault`: 0.3.2 -> 0.3.3
* `vta-webvh`: 0.1.11 -> 0.1.12
* `vtc-client`: 0.3.9 -> 0.3.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.27.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.26.0...vta-sdk-v0.27.0) — 2026-08-21

### Fixed

- **sdk**: Decode the Trust-Task responses the agent actually sends ([#1033](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1033))

`pnm contexts create` fails against any agent built since #1000:

      Protocol error: trust-task response decode: missing field `base_path`

  #1000 folded Trust Task payloads to lowerCamelCase per SPEC §4.10 and excluded
  `client/types.rs` as REST bodies whose casing "no published schema pins". The
  exclusion was drawn by file path, and the path was stale: `rpc_tt` carries the
  same Trust-Task document over REST, DIDComm and TSP alike, so `ContextResponse`
  is a Trust-Task decode target and a published schema does pin it. The agent moved
  to `basePath`; the client went on demanding `base_path`.

  Eleven call sites across eight types, every one a required field with no
  `default`, so they fail hard on every transport rather than degrading:

  - contexts create / get / update / update-did / list — all of `pnm contexts`
  - keys sign / rename / revoke / export-secret
  - seeds rotate / list (`activeSeedId` only)

  `vta-cli-common` and `vta-mcp` consume these, so `pnm`/`cnm` key management and
  the MCP tool surface are equally affected. The user who reported it hit contexts
  first and would have hit `keys sign` next.

  Aliases rather than `rename_all`: this is the same Postel fold #1000 used, it
  changes nothing about what the SDK emits, and it keeps working against an agent
  that has not taken the change. `SeedInfoResponse` gets aliases it does not yet
  need, because its counterpart `SeedInfo` is the one payload struct #1000 left
  unfolded — when that lands, this type should not be what breaks.

  The casing is the symptom. The defect is that one wire has two structs, so
  either end can move alone; the 50 Trust-Task call sites that did NOT break are
  exactly those where client and agent decode the same type. Collapsing each pair
  onto one type is the real repair and is not attempted here — it changes public
  type identity for two downstream crates. The module note records that.
</blockquote>

## `cnm-cli`

<blockquote>

## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.11.24...cnm-cli-v0.12.0) — 2026-08-21

### Fixed

- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))

All four binaries treated an unavailable OS credential store as a warning
  and carried on. What happened next was worse than a silent fallback:
  `KeyringBackend` stayed registered, every `Entry::new` returned
  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
  `None` — so the tool behaved exactly as though the user had never logged
  in. A silent fallback at least stores something; this silently forgets.
  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
  keyring did not survive a reboot, and the error told the user to check
  their network.

  The four call sites are byte-identical, but their consequences are not,
  so the fix is not:

  - `pnm` and `cnm` keep their session — the admin DID and its private key
    — in the credential store and nowhere else. They now exit at startup
    via `keyring_init::install_default_store_or_exit`, which is the whole
    point: there is nothing they can usefully do next.
  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
    store, one of eight `[secrets] backend` options. Which one is in play
    is not known until config loads, long after `main` starts, so hard
    failing there would break every deployment on aws/gcp/azure/vault/k8s
    running on a host with no credential store — the normal server shape.
    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
    already failed closed — now says which subsystem broke rather than
    "failed to create keyring entry".

  The second half is `FileBackend`. `default_backend` ended in an
  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
  was enabled, writing the admin private key to `sessions.json` as
  plaintext at the process umask, announced by a WARNING on every access —
  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
  used 0600; the inconsistency was inside one tool.

  That fallback is gone. A build with no session store gets `RefusingBackend`,
  which refuses to save rather than inventing somewhere to put a private
  key. `FileBackend` is now reachable only by explicit choice — the
  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
  creates its file at 0600 inside a 0700 directory *before* writing, since
  writing and then hardening leaves a window at the umask. An existing
  world-readable file from an older build is re-hardened on the next write.

  The runtime override exists because requiring a rebuild to run on a
  headless host creates pressure to disable the check rather than make a
  choice. It parses strictly: `os` or `file`, and anything else — including
  a near-miss like `plaintext` — resolves to neither and refuses. Asking
  for `os` on a build with no `keyring` feature refuses too, rather than
  quietly substituting a file.

  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
  the error as `Display` so it is available without the `keyring` feature —
  OpenVTC renders the same text and honours the same override, which was
  the stated goal: identical secret handling across vta, pnm, openvtc and
  vtc, hard failure rather than a fallback to open text files.
</blockquote>

## `pnm-cli`

<blockquote>

## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.12.8...pnm-cli-v0.13.0) — 2026-08-21

### Fixed

- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))

All four binaries treated an unavailable OS credential store as a warning
  and carried on. What happened next was worse than a silent fallback:
  `KeyringBackend` stayed registered, every `Entry::new` returned
  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
  `None` — so the tool behaved exactly as though the user had never logged
  in. A silent fallback at least stores something; this silently forgets.
  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
  keyring did not survive a reboot, and the error told the user to check
  their network.

  The four call sites are byte-identical, but their consequences are not,
  so the fix is not:

  - `pnm` and `cnm` keep their session — the admin DID and its private key
    — in the credential store and nowhere else. They now exit at startup
    via `keyring_init::install_default_store_or_exit`, which is the whole
    point: there is nothing they can usefully do next.
  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
    store, one of eight `[secrets] backend` options. Which one is in play
    is not known until config loads, long after `main` starts, so hard
    failing there would break every deployment on aws/gcp/azure/vault/k8s
    running on a host with no credential store — the normal server shape.
    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
    already failed closed — now says which subsystem broke rather than
    "failed to create keyring entry".

  The second half is `FileBackend`. `default_backend` ended in an
  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
  was enabled, writing the admin private key to `sessions.json` as
  plaintext at the process umask, announced by a WARNING on every access —
  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
  used 0600; the inconsistency was inside one tool.

  That fallback is gone. A build with no session store gets `RefusingBackend`,
  which refuses to save rather than inventing somewhere to put a private
  key. `FileBackend` is now reachable only by explicit choice — the
  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
  creates its file at 0600 inside a 0700 directory *before* writing, since
  writing and then hardening leaves a window at the umask. An existing
  world-readable file from an older build is re-hardened on the next write.

  The runtime override exists because requiring a rebuild to run on a
  headless host creates pressure to disable the check rather than make a
  choice. It parses strictly: `os` or `file`, and anything else — including
  a near-miss like `plaintext` — resolves to neither and refuses. Asking
  for `os` on a build with no `keyring` feature refuses too, rather than
  quietly substituting a file.

  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
  the error as `Display` so it is available without the `keyring` feature —
  OpenVTC renders the same text and honours the same override, which was
  the stated goal: identical secret handling across vta, pnm, openvtc and
  vtc, hard failure rather than a fallback to open text files.
</blockquote>

## `vti-secrets`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.1.16...vti-secrets-v0.2.0) — 2026-08-21

### Fixed

- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))

All four binaries treated an unavailable OS credential store as a warning
  and carried on. What happened next was worse than a silent fallback:
  `KeyringBackend` stayed registered, every `Entry::new` returned
  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
  `None` — so the tool behaved exactly as though the user had never logged
  in. A silent fallback at least stores something; this silently forgets.
  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
  keyring did not survive a reboot, and the error told the user to check
  their network.

  The four call sites are byte-identical, but their consequences are not,
  so the fix is not:

  - `pnm` and `cnm` keep their session — the admin DID and its private key
    — in the credential store and nowhere else. They now exit at startup
    via `keyring_init::install_default_store_or_exit`, which is the whole
    point: there is nothing they can usefully do next.
  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
    store, one of eight `[secrets] backend` options. Which one is in play
    is not known until config loads, long after `main` starts, so hard
    failing there would break every deployment on aws/gcp/azure/vault/k8s
    running on a host with no credential store — the normal server shape.
    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
    already failed closed — now says which subsystem broke rather than
    "failed to create keyring entry".

  The second half is `FileBackend`. `default_backend` ended in an
  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
  was enabled, writing the admin private key to `sessions.json` as
  plaintext at the process umask, announced by a WARNING on every access —
  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
  used 0600; the inconsistency was inside one tool.

  That fallback is gone. A build with no session store gets `RefusingBackend`,
  which refuses to save rather than inventing somewhere to put a private
  key. `FileBackend` is now reachable only by explicit choice — the
  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
  creates its file at 0600 inside a 0700 directory *before* writing, since
  writing and then hardening leaves a window at the umask. An existing
  world-readable file from an older build is re-hardened on the next write.

  The runtime override exists because requiring a rebuild to run on a
  headless host creates pressure to disable the check rather than make a
  choice. It parses strictly: `os` or `file`, and anything else — including
  a near-miss like `plaintext` — resolves to neither and refuses. Asking
  for `os` on a build with no `keyring` feature refuses too, rather than
  quietly substituting a file.

  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
  the error as `Display` so it is available without the `keyring` feature —
  OpenVTC renders the same text and honours the same override, which was
  the stated goal: identical secret handling across vta, pnm, openvtc and
  vtc, hard failure rather than a fallback to open text files.
</blockquote>

## `vta-service`

<blockquote>

## [0.19.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.18.0...vta-service-v0.19.0) — 2026-08-21

### Fixed

- **sdk/cli**: A credential store that cannot be opened must not read as "never logged in" ([#1032](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1032))

All four binaries treated an unavailable OS credential store as a warning
  and carried on. What happened next was worse than a silent fallback:
  `KeyringBackend` stayed registered, every `Entry::new` returned
  `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned
  `None` — so the tool behaved exactly as though the user had never logged
  in. A silent fallback at least stores something; this silently forgets.
  OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel
  keyring did not survive a reboot, and the error told the user to check
  their network.

  The four call sites are byte-identical, but their consequences are not,
  so the fix is not:

  - `pnm` and `cnm` keep their session — the admin DID and its private key
    — in the credential store and nowhere else. They now exit at startup
    via `keyring_init::install_default_store_or_exit`, which is the whole
    point: there is nothing they can usefully do next.
  - `vta` and `vtc` never construct an SDK `SessionStore`; they use the
    fjall-backed `KeyspaceSessionStore`, and their keyring use is the seed
    store, one of eight `[secrets] backend` options. Which one is in play
    is not known until config loads, long after `main` starts, so hard
    failing there would break every deployment on aws/gcp/azure/vault/k8s
    running on a host with no credential store — the normal server shape.
    They get `warn_store_unavailable`, and `KeyringSeedStore` — which
    already failed closed — now says which subsystem broke rather than
    "failed to create keyring entry".

  The second half is `FileBackend`. `default_backend` ended in an
  `#[allow(unreachable_code)]` fallback into it whenever no backend feature
  was enabled, writing the admin private key to `sessions.json` as
  plaintext at the process umask, announced by a WARNING on every access —
  which is to say, invisible. `pnm`'s own bootstrap-secrets path has always
  used 0600; the inconsistency was inside one tool.

  That fallback is gone. A build with no session store gets `RefusingBackend`,
  which refuses to save rather than inventing somewhere to put a private
  key. `FileBackend` is now reachable only by explicit choice — the
  `config-session` feature, or `VTI_SECURE_STORE=file` at runtime — and
  creates its file at 0600 inside a 0700 directory *before* writing, since
  writing and then hardening leaves a window at the umask. An existing
  world-readable file from an older build is re-hardened on the next write.

  The runtime override exists because requiring a rebuild to run on a
  headless host creates pressure to disable the check rather than make a
  choice. It parses strictly: `os` or `file`, and anything else — including
  a near-miss like `plaintext` — resolves to neither and refuses. Asking
  for `os` on a build with no `keyring` feature refuses too, rather than
  quietly substituting a file.

  One explanation now serves every tool, in `vta_sdk::secure_store`, taking
  the error as `Display` so it is available without the `keyring` feature —
  OpenVTC renders the same text and honours the same override, which was
  the stated goal: identical secret handling across vta, pnm, openvtc and
  vtc, hard failure rather than a fallback to open text files.

- **service**: Make AppState non-exhaustive so adding a field stops being a break ([#1024](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1024))

`AppState` is 46 public fields, no private field, no constructor guard. Any
  crate could write an `AppState { .. }` literal, which made *adding a field* a
  source-breaking change under `constructible_struct_adds_field`. Twenty-nine
  commits have added at least one field; c93c7b57 added five.

  That break has never once been reported. `cargo semver-checks` cannot build
  this crate's baseline — the published ranges resolve two `trust-tasks-rs`
  versions into one graph — and a crate whose baseline fails to build is
  silently not compared rather than reported as unchecked.

  The version numbers came out right anyway, and it is worth recording why,
  because the reason is two coincidences rather than a working process:

    - at 0.x a break needs a MINOR bump, and conventional commits already force
      one for `feat:`;
    - every field addition since release-plz adoption happened to be a `feat:`.

  Neither holds in general. `refactor:`, `fix:`, `perf:` and `chore:` all yield
  a patch and can add fields just as easily — c93c7b57 is a `refactor:` and
  added five, which is the largest single addition in the file's history.
  Moving state between structs is what a refactor does, so the commit type most
  likely to add public fields is one of the types that yields a patch. And the
  alignment fails completely at 1.0, where a break needs a MAJOR and `feat:`
  gives only a MINOR: the cover expires exactly when the consequences become
  external.

  `#[non_exhaustive]` closes the class permanently instead of relying on any of
  that continuing to hold.

  Nothing outside the crate is affected. Both construction sites are in-crate
  (`build_app_state` and `test_support`), `MockVta` is the supported entry
  point for consumers, and `tests/app_state_single_construction.rs` already
  goes through `build_app_state` rather than a literal — that test is from the
  P1.1 work in c93c7b57, so a single canonical constructor was already the
  crate's intent. This makes it enforceable from outside rather than
  conventional.

  Marked `!` because it is one: outside this crate, `AppState { .. }` and
  exhaustive destructuring stop compiling. That is the point — it is the last
  such break this struct can have.

  cargo test --workspace: 145 suites, 0 failed. cargo check --all-features
  clean, zero warnings.
</blockquote>













</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).