### PR TITLE
fix(sdk/cli)!: a credential store that cannot be opened must not read as "never logged in"

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -943,10 +943,11 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
+    // Same shape as PNM: CNM's session lives in the OS credential store, and a
+    // store that cannot be opened reads as "no session" rather than as an
+    // error. See `install_default_store_or_exit`.
     #[cfg(feature = "keyring")]
-    if let Err(e) = vta_sdk::keyring_init::install_default_store() {
-        eprintln!("warning: OS keyring unavailable: {e}");
-    }
+    vta_sdk::keyring_init::install_default_store_or_exit("cnm");
 
     print_banner();
 

--- a/docs/02-vta/secret-backends.md
+++ b/docs/02-vta/secret-backends.md
@@ -470,6 +470,31 @@ The keyring is **interactive** on macOS — a Keychain unlock prompt
 may appear when `vta` first reads the seed in a fresh terminal
 session. CI / headless environments should use a different backend.
 
+**An unreachable credential store fails closed.** If the platform store
+cannot be opened — no Secret Service on a headless Linux host, a locked
+keychain, a Windows service account with no loaded profile — this backend
+returns an error rather than reporting the seed as absent. `vta` and `vtc`
+print a warning at startup naming the store, and then fail on first seed
+access *if* `backend` resolves to `keyring`; any other backend is
+unaffected, which is why that startup warning is not fatal.
+
+The CLIs behave differently, and deliberately: `pnm` and `cnm` keep their
+session — the admin DID and its private key — in the credential store and
+nowhere else, so an unreachable store leaves them nothing to read. They
+**exit at startup** with an explanation instead of continuing as though
+you had never logged in. On a host that genuinely has no credential
+store, opt into file storage explicitly:
+
+```bash
+VTI_SECURE_STORE=file pnm auth status
+```
+
+That writes sessions as plaintext JSON at mode `0600` in a `0700`
+directory. It is a deliberate choice, never a fallback — a build with no
+session store compiled in refuses to save rather than inventing
+somewhere to put a private key. Only use it where the filesystem itself
+is the trust boundary: an encrypted volume, or a locked-down container.
+
 ### Config-seed
 
 Cargo feature: `config-seed` · File: `vti-secrets/src/seed_store/config.rs`

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -81,10 +81,12 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
+    // PNM's session — the admin DID and its private key — lives in the OS
+    // credential store. If that store cannot be opened, `SessionStore` reads
+    // return `None`, which is indistinguishable from "never logged in": the
+    // tool does not fall back, it forgets. Stop and say so instead.
     #[cfg(feature = "keyring")]
-    if let Err(e) = vta_sdk::keyring_init::install_default_store() {
-        eprintln!("warning: OS keyring unavailable: {e}");
-    }
+    vta_sdk::keyring_init::install_default_store_or_exit("pnm");
 
     print_banner();
 

--- a/vta-sdk/src/keyring_init.rs
+++ b/vta-sdk/src/keyring_init.rs
@@ -41,3 +41,71 @@ compile_error!(
     "vta-sdk `keyring` feature requires target_os in (macos, linux, windows). \
      Disable the feature or build for a supported OS."
 );
+
+/// Install the platform store, or terminate the process explaining why not.
+///
+/// For a binary whose **sessions live in the credential store** — `pnm`, `cnm`,
+/// and external consumers with the same shape. Those tools cannot do anything
+/// useful once the store is unreachable: [`crate::session::SessionStore`] reads
+/// through `SessionBackend::load`, which returns `Option`, so a store error is
+/// indistinguishable from "no session" and the tool behaves as though the user
+/// had never logged in. It does not fall back — it *forgets*. Stopping here,
+/// with [`crate::secure_store::unavailable_message`], is the difference between
+/// a diagnosable failure and a user reinstalling their account.
+///
+/// A binary for which the credential store is only *one* of several configured
+/// secret backends must not call this — see [`warn_store_unavailable`]
+/// below. Hard-failing
+/// there would break every deployment using AWS, GCP, Vault or Kubernetes on a
+/// host that has no credential store at all, which is the normal server shape.
+///
+/// Honours `VTI_SECURE_STORE` ([`crate::secure_store::OVERRIDE_ENV`]): an
+/// operator who has explicitly selected `file` has already accepted that the
+/// platform store is not in play, so its absence is not an error.
+pub fn install_default_store_or_exit(tool: &str) {
+    use crate::secure_store::{self, SecureStore};
+
+    let selected = match secure_store::override_from_env() {
+        Ok(v) => v,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            std::process::exit(1);
+        }
+    };
+
+    if selected == Some(SecureStore::File) {
+        // Deliberate opt-out. `default_backend` will pick the file store; there
+        // is no platform store to install and nothing to warn about.
+        return;
+    }
+
+    if let Err(e) = install_default_store() {
+        eprintln!("{}", secure_store::unavailable_message(tool, &e));
+        std::process::exit(1);
+    }
+}
+
+/// Install the platform store, or report that secrets held *in it* will fail.
+///
+/// For a binary where the credential store is one backend among several
+/// (`vta`, `vtc`: `[secrets] backend = ...` also offers AWS, GCP, Azure, Vault,
+/// Kubernetes and TEE-KMS). Which one is in play is not known until config is
+/// loaded, well after this runs, so this cannot decide to be fatal.
+///
+/// It does not need to. The keyring-backed seed store already fails closed —
+/// `vti_secrets::seed_store::KeyringSeedStore` propagates the entry error as
+/// `AppError::SecretStore` rather than reporting an absent seed. The only thing
+/// missing was an operator being told which subsystem broke, which is what this
+/// prints.
+pub fn warn_store_unavailable(tool: &str) {
+    if let Err(e) = install_default_store() {
+        eprintln!(
+            "warning: the OS credential store is unavailable: {e}\n\
+             \n\
+             {tool} will still start. This is fatal only if `[secrets] backend` \
+             resolves to the keyring — that path fails closed and will refuse to \
+             read or write the master seed rather than report it missing. Any \
+             other backend (aws, gcp, azure, vault, k8s, tee-kms) is unaffected."
+        );
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -134,6 +134,11 @@ pub mod http;
 #[cfg(feature = "keyring")]
 pub mod keyring_init;
 pub mod keys;
+// Which store holds a tool's secrets, and the one explanation every tool in the
+// workspace prints when that store cannot be opened. Always compiled — a
+// consumer that does not enable `keyring` still renders the same text and
+// honours the same `VTI_SECURE_STORE` override.
+pub mod secure_store;
 // Client-side idempotency: one key held across every attempt of one operation.
 // Needs the async runtime for its task-local + backoff, so it rides `client`.
 #[cfg(feature = "client")]

--- a/vta-sdk/src/secure_store.rs
+++ b/vta-sdk/src/secure_store.rs
@@ -1,0 +1,164 @@
+//! Where a tool keeps its long-lived secrets, and what it does when that
+//! store cannot be opened.
+//!
+//! Every tool in this workspace — `vta`, `vtc`, `pnm`, `cnm`, and external
+//! consumers such as OpenVTC — resolves the *same* store on the same OS via
+//! [`crate::keyring_init::install_default_store`]. What differed until now was
+//! the failure behaviour: each printed its own warning and carried on, so a
+//! machine whose credential store was unavailable behaved as though the user
+//! had simply never logged in.
+//!
+//! This module holds the two things that behaviour needs to be consistent: one
+//! explanation ([`unavailable_message`]) and one deliberate opt-out
+//! ([`OVERRIDE_ENV`]).
+//!
+//! It is always compiled — no feature gate — so a consumer that does not enable
+//! the `keyring` feature can still render the same text and honour the same
+//! override.
+
+/// Which store a tool was told to use for its sessions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecureStore {
+    /// The platform credential store — Keychain, Credential Manager, or the
+    /// DBus Secret Service. The default, and the only durable one.
+    Os,
+    /// A plaintext JSON file at `0600`, for hosts that have no credential
+    /// store at all. **Chosen explicitly, never fallen back to.**
+    File,
+}
+
+/// Environment variable that overrides store selection.
+///
+/// The only recognised values are `os` and `file`. Anything else is a hard
+/// error rather than a silent default — a typo in this variable must not be the
+/// difference between a keychain entry and a file on disk.
+pub const OVERRIDE_ENV: &str = "VTI_SECURE_STORE";
+
+/// Read [`OVERRIDE_ENV`].
+///
+/// `Ok(None)` means the operator expressed no preference and the compiled
+/// default applies. `Err` carries a ready-to-print explanation of an
+/// unrecognised value.
+pub fn override_from_env() -> Result<Option<SecureStore>, String> {
+    let raw = match std::env::var(OVERRIDE_ENV) {
+        Ok(v) => v,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(format!("{OVERRIDE_ENV} is not valid UTF-8"));
+        }
+    };
+    parse_override(&raw)
+}
+
+/// The value half of [`override_from_env`], split out so it is testable without
+/// mutating process environment shared with every other test in the binary.
+fn parse_override(raw: &str) -> Result<Option<SecureStore>, String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" => Ok(None),
+        "os" | "keyring" => Ok(Some(SecureStore::Os)),
+        "file" => Ok(Some(SecureStore::File)),
+        other => Err(format!(
+            "{OVERRIDE_ENV}={other:?} is not a store. Use `os` for the platform \
+             credential store, or `file` for a plaintext file at 0600."
+        )),
+    }
+}
+
+/// The platform-specific remedy for an unreachable credential store.
+fn remedy() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "Unlock the login keychain, or run this from a session that has one \
+         (an SSH session without `security unlock-keychain` does not)."
+    }
+    #[cfg(target_os = "linux")]
+    {
+        "Start a Secret Service provider — gnome-keyring-daemon, KWallet, or \
+         KeePassXC — and make sure DBus is reachable ($DBUS_SESSION_BUS_ADDRESS). \
+         Headless hosts usually have neither."
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Check that the Credential Manager service is running and that this \
+         account has a loaded user profile (a service account run with \
+         `LoadUserProfile=false` does not)."
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        "This platform has no supported credential store."
+    }
+}
+
+/// The one explanation every tool prints when the credential store cannot be
+/// opened.
+///
+/// `tool` is the binary name, so the suggested command line is copy-pasteable.
+/// `err` is whatever the store returned; it is taken as `Display` rather than a
+/// `keyring_core::Error` so this text is available without the `keyring`
+/// feature — external consumers render it too.
+///
+/// The text deliberately leads with the *consequence*. The failure mode that
+/// motivated this is a user being told their network was broken when in fact
+/// their credential store had evaporated, so the first line has to say what is
+/// actually gone.
+pub fn unavailable_message(tool: &str, err: &dyn std::fmt::Display) -> String {
+    format!(
+        "error: the OS credential store is unavailable, so {tool} cannot read or \
+         write your session.\n\
+         \n\
+           cause: {err}\n\
+         \n\
+         Your credentials are not lost — they are in a store this process cannot \
+         reach. {tool} is stopping rather than continuing as though you had never \
+         logged in, which is what it used to do.\n\
+         \n\
+         {}\n\
+         \n\
+         On a host that genuinely has no credential store, opt in to file storage \
+         deliberately:\n\
+         \n\
+             {OVERRIDE_ENV}=file {tool} ...\n\
+         \n\
+         That writes secrets as plaintext JSON at mode 0600. Only use it where the \
+         filesystem itself is the trust boundary — an encrypted volume, or a \
+         locked-down container.",
+        remedy()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The override parser is the gate between "keychain" and "file on disk",
+    /// so an unrecognised value must not resolve to either.
+    #[test]
+    fn an_unknown_override_is_an_error_not_a_default() {
+        assert!(matches!(parse_override("os"), Ok(Some(SecureStore::Os))));
+        assert!(matches!(
+            parse_override("File"),
+            Ok(Some(SecureStore::File))
+        ));
+        assert!(matches!(
+            parse_override("  file  "),
+            Ok(Some(SecureStore::File))
+        ));
+        assert!(matches!(parse_override(""), Ok(None)));
+
+        // The dangerous direction: a near-miss must not resolve to `File`.
+        assert!(parse_override("plaintext").is_err());
+        assert!(parse_override("fil").is_err());
+        assert!(parse_override("true").is_err());
+    }
+
+    /// The message exists to stop a user diagnosing the wrong subsystem, so the
+    /// consequence and the opt-out both have to be in it.
+    #[test]
+    fn the_message_names_the_consequence_and_the_opt_out() {
+        let msg = unavailable_message("pnm", &"no default store");
+        assert!(msg.contains("cannot read or write your session"));
+        assert!(msg.contains("no default store"));
+        assert!(msg.contains("VTI_SECURE_STORE=file pnm"));
+        assert!(msg.contains("0600"));
+    }
+}

--- a/vta-sdk/src/session/backends/file.rs
+++ b/vta-sdk/src/session/backends/file.rs
@@ -1,10 +1,19 @@
-//! Plaintext on-disk JSON [`SessionBackend`] for development / config-
-//! managed deployments where the OS keyring is not available.
+//! Plaintext on-disk JSON [`SessionBackend`] for hosts with no OS credential
+//! store — an encrypted volume, a locked-down container, CI.
 //!
-//! Sessions live at `<sessions_dir>/sessions.json`. The `warn` flag
-//! emits a runtime warning on every access — used when the file
-//! backend was selected as the silent fallback rather than the
-//! explicit `config-session` feature.
+//! Sessions live at `<sessions_dir>/sessions.json`, written at mode `0600`
+//! inside a `0700` directory. Reachable only by explicit choice: the
+//! `config-session` feature, or `VTI_SECURE_STORE=file`. See
+//! [`super`] for why there is no longer a silent fallback into this backend.
+//!
+//! # Mode is set before content
+//!
+//! The file holds an admin private key. Writing it and then hardening it leaves
+//! a window — however short — in which it is readable at the process umask, and
+//! on a shared host that window is the whole vulnerability. So the file is
+//! created empty with its mode already restrictive, and only then written.
+//! `pnm`'s bootstrap-secrets path has always done this; the session store did
+//! not, which is the inconsistency #1027 names.
 
 use std::path::PathBuf;
 
@@ -12,12 +21,32 @@ use crate::session::SessionBackend;
 
 pub(crate) struct FileBackend {
     pub(crate) sessions_dir: PathBuf,
-    pub(crate) warn: bool,
+    /// How this backend came to be selected, for the one-time notice. Always an
+    /// explicit choice — there is no fallback path into here.
+    pub(crate) reason: &'static str,
 }
 
 impl FileBackend {
     fn sessions_path(&self) -> PathBuf {
         self.sessions_dir.join("sessions.json")
+    }
+
+    /// Announce plaintext storage once per process, not once per access.
+    ///
+    /// The previous implementation printed on every `load` and `save`, which
+    /// trained everyone to ignore it.
+    fn notice_once(&self) {
+        use std::sync::Once;
+        static NOTICE: Once = Once::new();
+        let reason = self.reason;
+        let path = self.sessions_path();
+        NOTICE.call_once(|| {
+            eprintln!(
+                "note: sessions are stored as plaintext at mode 0600 in {} \
+                 (selected by {reason}).",
+                path.display()
+            );
+        });
     }
 
     fn load_map(&self) -> std::collections::HashMap<String, serde_json::Value> {
@@ -47,32 +76,81 @@ impl FileBackend {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let path = self.sessions_path();
         let json = serde_json::to_string_pretty(map)?;
+        create_owner_only(&path)?;
         std::fs::write(&path, json)?;
         Ok(())
     }
 }
 
+/// Create the sessions directory owner-only (`0700`).
+///
+/// A `0600` file inside a world-traversable directory is fine on its own, but
+/// the directory listing leaks which VTAs an operator holds sessions for, and a
+/// group-writable directory lets someone swap the file underneath us.
+fn create_dir_owner_only(dir: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(dir)?.permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(dir, perms)?;
+    }
+    Ok(())
+}
+
+/// Ensure the sessions file exists at mode `0600` *before* anything is written
+/// into it.
+///
+/// `std::fs::write` on a fresh path creates at `0666 & !umask`, which on a
+/// default umask is world-readable. Pre-creating with an explicit mode closes
+/// that, and re-asserting the mode on an existing file repairs one written by
+/// an older build.
+fn create_owner_only(path: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        create_dir_owner_only(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(path)?;
+        // `.mode()` applies only on creation, so an existing file keeps
+        // whatever it had — including a world-readable mode from a build
+        // before this hardening. Re-assert it.
+        let mut perms = std::fs::metadata(path)?.permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Windows: the file inherits the parent directory's ACL, and the
+        // per-user config dir is already user-scoped. `vti_common::secure_file`
+        // holds the explicit-ACL treatment for the paths that need it; the SDK
+        // is a leaf crate and cannot reach it.
+        if !path.exists() {
+            std::fs::File::create(path)?;
+        }
+    }
+
+    Ok(())
+}
+
 impl SessionBackend for FileBackend {
     fn load(&self, key: &str) -> Option<String> {
-        if self.warn {
-            eprintln!("WARNING: No secure session store — using plaintext file storage");
-        }
+        self.notice_once();
         let map = self.load_map();
         map.get(key).map(|v| v.to_string())
     }
 
     fn save(&self, key: &str, value: &str) -> Result<(), Box<dyn std::error::Error>> {
-        if self.warn {
-            eprintln!("WARNING: No secure session store — using plaintext file storage");
-        }
-        if let Some(parent) = self.sessions_dir.parent()
-            && let Err(e) = std::fs::create_dir_all(parent)
-        {
-            tracing::warn!("failed to create sessions parent dir: {e}");
-        }
-        if let Err(e) = std::fs::create_dir_all(&self.sessions_dir) {
-            tracing::warn!("failed to create sessions dir: {e}");
-        }
+        self.notice_once();
         let mut map = self.load_map();
         let parsed: serde_json::Value = serde_json::from_str(value)?;
         map.insert(key.to_string(), parsed);
@@ -83,5 +161,68 @@ impl SessionBackend for FileBackend {
         let mut map = self.load_map();
         map.remove(key);
         let _ = self.save_map(&map);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode_of(p: &std::path::Path) -> u32 {
+        std::fs::metadata(p).unwrap().permissions().mode() & 0o777
+    }
+
+    /// The point of the whole change: an admin private key must never land in a
+    /// world-readable file, not even for the instant between write and chmod.
+    #[test]
+    fn a_saved_session_is_owner_only() {
+        let dir = std::env::temp_dir().join(format!("vta-sdk-file-backend-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let backend = FileBackend {
+            sessions_dir: dir.clone(),
+            reason: "a test",
+        };
+
+        backend.save("k", r#"{"private_key":"secret"}"#).unwrap();
+
+        assert_eq!(
+            mode_of(&backend.sessions_path()),
+            0o600,
+            "file must be 0600"
+        );
+        assert_eq!(mode_of(&dir), 0o700, "directory must be 0700");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A sessions file written by a build from before this hardening is
+    /// repaired on the next write rather than left permanently exposed.
+    #[test]
+    fn an_existing_world_readable_file_is_repaired() {
+        let dir = std::env::temp_dir().join(format!(
+            "vta-sdk-file-backend-legacy-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sessions.json");
+        std::fs::write(&path, "{}").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(mode_of(&path), 0o644, "precondition: starts world-readable");
+
+        let backend = FileBackend {
+            sessions_dir: dir.clone(),
+            reason: "a test",
+        };
+        backend.save("k", r#"{"private_key":"secret"}"#).unwrap();
+
+        assert_eq!(
+            mode_of(&path),
+            0o600,
+            "an existing file must be re-hardened"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/vta-sdk/src/session/backends/mod.rs
+++ b/vta-sdk/src/session/backends/mod.rs
@@ -7,37 +7,98 @@
 //! - [`AzureBackend`] (`azure-secrets` without `keyring`) — Azure
 //!   Key Vault, isolated through a side thread to avoid nesting tokio
 //!   runtimes.
-//! - [`FileBackend`] — plaintext on-disk JSON. Always compiled; used
-//!   either via the explicit `config-session` feature or as the silent
-//!   fallback when no other backend is enabled.
+//! - [`FileBackend`] — plaintext on-disk JSON at mode `0600`. Reachable only
+//!   by explicit choice: the `config-session` feature, or `VTI_SECURE_STORE=file`
+//!   at runtime.
+//! - [`RefusingBackend`] — what a build with no session store at all gets. It
+//!   refuses to save rather than inventing somewhere to put a private key.
 //!
-//! [`default_backend`] picks among them based on compiled features,
-//! preserving the priority order keyring → azure → config-session →
-//! plaintext-fallback that the SDK has always used.
+//! # There is no silent fallback
+//!
+//! [`default_backend`] used to end in an `#[allow(unreachable_code)]`
+//! `FileBackend`, reached whenever no backend feature was enabled. That wrote
+//! the admin private key to `sessions.json` as plaintext JSON at whatever the
+//! umask allowed, announced by a `WARNING:` line on every access — which is to
+//! say, invisible. A store that holds a private key is a decision, so it is now
+//! always made explicitly and never arrived at by omission.
+//!
+//! The runtime override exists because the alternative is worse: an operator on
+//! a headless host with no Secret Service would otherwise have to rebuild the
+//! binary with `--features config-session` to run it at all, and the pressure
+//! that creates is to disable the check rather than to make a choice.
 
 use std::path::PathBuf;
 
 use super::SessionBackend;
+use crate::secure_store::{self, SecureStore};
 
 #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
 mod azure;
 mod file;
 #[cfg(feature = "keyring")]
 mod keyring;
+mod refusing;
 
 #[cfg(all(feature = "azure-secrets", not(feature = "keyring")))]
 pub(super) use azure::AzureBackend;
 pub(super) use file::FileBackend;
 #[cfg(feature = "keyring")]
 pub(super) use keyring::KeyringBackend;
+pub(super) use refusing::RefusingBackend;
 
 /// Create the default session backend based on compiled features.
 ///
-/// Priority: keyring → azure-secrets → config-session → plaintext fallback.
+/// Priority: explicit `VTI_SECURE_STORE=file` → keyring → azure-secrets →
+/// config-session → refuse.
+///
+/// The runtime override is checked *first* on purpose. It is the operator
+/// saying "this host has no credential store"; consulting it after the
+/// compiled default would mean a binary built with `keyring` could never honour
+/// it, which is exactly the case it exists for.
 pub(super) fn default_backend(
     service_name: &str,
     sessions_dir: PathBuf,
 ) -> Box<dyn SessionBackend> {
+    let _ = service_name;
+
+    match secure_store::override_from_env() {
+        Ok(Some(SecureStore::File)) => {
+            return Box::new(FileBackend {
+                sessions_dir,
+                reason: "VTI_SECURE_STORE=file",
+            });
+        }
+        Ok(Some(SecureStore::Os)) => {
+            // Asking for the OS store on a build that has none must not quietly
+            // resolve to a file — that is the substitution this whole change
+            // exists to remove, and an explicit request makes it worse, not
+            // better.
+            #[cfg(not(feature = "keyring"))]
+            return Box::new(RefusingBackend {
+                reason: format!(
+                    "{}=os asks for the OS credential store, but this build has no \
+                     `keyring` feature compiled in. Rebuild with it, or choose \
+                     `file` deliberately.",
+                    secure_store::OVERRIDE_ENV
+                ),
+            });
+        }
+        Ok(None) => {}
+        Err(msg) => {
+            // Selection is the gate between a keychain entry and a file on
+            // disk. An unparseable value resolves to neither.
+            return Box::new(RefusingBackend {
+                reason: format!("{msg} Until it is fixed, no session store is selected."),
+            });
+        }
+    }
+
+    compiled_default(service_name, sessions_dir)
+}
+
+/// The compile-time half of [`default_backend`], after the runtime override has
+/// declined to answer.
+fn compiled_default(service_name: &str, sessions_dir: PathBuf) -> Box<dyn SessionBackend> {
     let _ = service_name;
     let _ = &sessions_dir;
 
@@ -64,13 +125,17 @@ pub(super) fn default_backend(
     {
         return Box::new(FileBackend {
             sessions_dir,
-            warn: false,
+            reason: "the `config-session` feature",
         });
     }
 
     #[allow(unreachable_code)]
-    Box::new(FileBackend {
-        sessions_dir,
-        warn: true,
+    Box::new(RefusingBackend {
+        reason: format!(
+            "this build has no session store compiled in. Rebuild with one of the \
+             `keyring`, `azure-secrets` or `config-session` features, or set \
+             {}=file to accept a plaintext file at mode 0600.",
+            secure_store::OVERRIDE_ENV
+        ),
     })
 }

--- a/vta-sdk/src/session/backends/refusing.rs
+++ b/vta-sdk/src/session/backends/refusing.rs
@@ -1,0 +1,30 @@
+//! The backend a build with no session store gets.
+//!
+//! Its whole job is to be honest. A session store holds an admin private key;
+//! if the build was never told where to put one, the answer is not "a file in
+//! the working directory" — it is that there is nowhere to put it, said out
+//! loud, on the operation that would have persisted it.
+
+use crate::session::SessionBackend;
+
+pub(crate) struct RefusingBackend {
+    /// Why no store was selected, phrased for an operator and carrying the
+    /// remedy. Rendered on every operation that would have touched a store.
+    pub(crate) reason: String,
+}
+
+impl SessionBackend for RefusingBackend {
+    /// There is genuinely nothing stored, so `None` is the truthful answer —
+    /// but it is the answer that hid this whole class of failure, so it is not
+    /// given silently.
+    fn load(&self, _key: &str) -> Option<String> {
+        eprintln!("error: cannot read session — {}", self.reason);
+        None
+    }
+
+    fn save(&self, _key: &str, _value: &str) -> Result<(), Box<dyn std::error::Error>> {
+        Err(format!("cannot store session — {}", self.reason).into())
+    }
+
+    fn clear(&self, _key: &str) {}
+}

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -4,9 +4,12 @@
 //!   1. **Backend ops** — pure storage round-trips with the in-memory
 //!      backend (`store_direct`, `store_pending_rotation`,
 //!      `loaded_session`, `session_status`, `logout`).
-//!   2. **`FileBackend`** — exercise the on-disk plaintext fallback by
-//!      constructing `SessionStore::new(...)` against a tempdir, where
-//!      the SDK's feature-gate cascade lands on `FileBackend`.
+//!   2. **Backend selection** — what `SessionStore::new(...)` resolves to when
+//!      no backend feature is compiled in. There is no longer a silent
+//!      plaintext fallback (#1027), so this asserts a refusal. `FileBackend`'s
+//!      own round-trip and file-mode coverage lives in unit tests beside it in
+//!      `session/backends/file.rs`, where it runs under the workspace's
+//!      unified feature set instead of being cfg'd out of every CI run.
 //!   3. **Network paths** — `login` / `ensure_authenticated` /
 //!      `rotate_key` against a `wiremock` server, using `did:key` DIDs
 //!      so TDK's resolver doesn't need outbound DNS.
@@ -17,7 +20,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use ed25519_dalek::SigningKey;
 use serde_json::json;
-#[cfg(not(any(feature = "keyring", feature = "azure-secrets")))]
+#[cfg(not(any(
+    feature = "keyring",
+    feature = "azure-secrets",
+    feature = "config-session"
+)))]
 use tempfile::tempdir;
 use vta_sdk::credentials::CredentialBundle;
 use vta_sdk::did_key::ed25519_multibase_pubkey;
@@ -112,53 +119,59 @@ fn session_status_none_when_no_token_cached() {
     assert!(matches!(status.token_status, TokenStatus::None));
 }
 
-// ── FileBackend (on-disk plaintext fallback) ────────────────────────
+// ── Backend selection ───────────────────────────────────────────────
 //
-// Only exercised when no other session backend is compiled in. Under
-// workspace cov runs the `keyring` feature is unified on (pnm-cli /
-// cnm-cli enable it), and `default_backend` returns `KeyringBackend`
-// instead — so these tests would no-op against a different code path.
-// Running `cargo test -p vta-sdk --test session_store --features
-// "session test-support"` exercises this path.
+// Under a workspace test run the `keyring` feature is unified on (pnm-cli /
+// cnm-cli enable it), so `default_backend` returns `KeyringBackend` and the
+// tests below are cfg'd out. That was already true of the `FileBackend` tests
+// that used to live here — which is why their round-trip and file-mode coverage
+// moved into unit tests beside the backend, where the workspace's unified
+// feature set actually runs them. What remains here is only the selection
+// contract, which cannot be observed from inside the module.
 
-#[cfg(not(any(feature = "keyring", feature = "azure-secrets")))]
+/// With no backend feature compiled in, a session store must refuse rather than
+/// invent somewhere to put a private key.
+///
+/// This replaces `file_backend_round_trips_via_session_store_new`, which
+/// asserted the opposite: that the feature cascade silently landed on
+/// `FileBackend` and wrote `sessions.json` at the process umask. That fallback
+/// is gone — a store holding an admin key is now always an explicit choice.
+#[cfg(not(any(
+    feature = "keyring",
+    feature = "azure-secrets",
+    feature = "config-session"
+)))]
 #[test]
-fn file_backend_round_trips_via_session_store_new() {
-    // SessionStore::new() with no keyring/azure features compiled
-    // (the default for these tests) lands on FileBackend with
-    // warn=true. Save → load → clear must round-trip through
-    // `<sessions_dir>/sessions.json`.
+fn no_compiled_backend_refuses_to_store_a_session() {
     let dir = tempdir().unwrap();
     let store = SessionStore::new("test-svc", dir.path().to_path_buf());
 
     let (did, pk) = did_key_from_seed(0x30);
     let (vta_did, _) = did_key_from_seed(0x40);
-    store.store_direct("file-k", &did, &pk, &vta_did).unwrap();
 
-    // The on-disk file is created.
-    let sessions_file = dir.path().join("sessions.json");
+    let err = store
+        .store_direct("file-k", &did, &pk, &vta_did)
+        .expect_err("a build with no session store must not persist a private key");
+    let msg = err.to_string();
     assert!(
-        sessions_file.exists(),
-        "FileBackend should create sessions.json"
+        msg.contains("VTI_SECURE_STORE"),
+        "the refusal must name the deliberate opt-out, got: {msg}"
     );
 
-    // Round-trip via a fresh store instance pointing at the same dir.
-    let store2 = SessionStore::new("test-svc", dir.path().to_path_buf());
-    let info = store2.loaded_session("file-k").unwrap();
-    assert_eq!(info.client_did, did);
-    assert_eq!(info.vta_did.as_deref(), Some(vta_did.as_str()));
-
-    store2.logout("file-k");
-    assert!(!store2.has_session("file-k"));
-    // A subsequent load on a fresh store sees the cleared state.
-    let store3 = SessionStore::new("test-svc", dir.path().to_path_buf());
-    assert!(store3.loaded_session("file-k").is_none());
+    assert!(
+        !dir.path().join("sessions.json").exists(),
+        "refusing to store must not leave a plaintext file behind"
+    );
 }
 
-#[cfg(not(any(feature = "keyring", feature = "azure-secrets")))]
+/// Pointing at a non-existent path must not panic; load returns None.
+#[cfg(not(any(
+    feature = "keyring",
+    feature = "azure-secrets",
+    feature = "config-session"
+)))]
 #[test]
-fn file_backend_load_on_missing_dir_returns_none() {
-    // Pointing at a non-existent path must not panic; load returns None.
+fn load_on_missing_dir_returns_none() {
     let store = SessionStore::new(
         "test-svc",
         std::path::PathBuf::from("/tmp/never-created-vta-sdk-tests-xyz"),

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -1501,10 +1501,14 @@ async fn main() {
 
     let cli = Cli::parse();
 
+    // Not fatal here, unlike the CLIs. The VTA's secrets live in whichever
+    // `[secrets] backend` resolves to — aws, gcp, azure, vault, k8s, tee-kms or
+    // keyring — and config is not loaded until well after this point. Hard
+    // failing would break every cloud deployment on a host that has no
+    // credential store, which is most of them. The keyring-backed seed store
+    // fails closed on its own; this only makes it diagnosable.
     #[cfg(feature = "keyring")]
-    if let Err(e) = vta_sdk::keyring_init::install_default_store() {
-        eprintln!("warning: OS keyring unavailable: {e}");
-    }
+    vta_sdk::keyring_init::warn_store_unavailable("vta");
 
     print_banner();
 

--- a/vtc-service/src/main.rs
+++ b/vtc-service/src/main.rs
@@ -170,10 +170,11 @@ async fn main() {
 
     let cli = Cli::parse();
 
+    // Same reasoning as the VTA: `[secrets] backend` picks the store and is not
+    // known this early, so this reports rather than exits. See
+    // `warn_store_unavailable`.
     #[cfg(feature = "keyring")]
-    if let Err(e) = vta_sdk::keyring_init::install_default_store() {
-        eprintln!("warning: OS keyring unavailable: {e}");
-    }
+    vta_sdk::keyring_init::warn_store_unavailable("vtc");
 
     print_banner();
 

--- a/vti-secrets/src/seed_store/keyring.rs
+++ b/vti-secrets/src/seed_store/keyring.rs
@@ -18,15 +18,29 @@ impl KeyringSeedStore {
     }
 }
 
+/// Explain an `Entry::new` failure in terms of the store, not the entry.
+///
+/// The dominant cause is that the platform store was never installed — the
+/// process started on a host with no Secret Service, or with a locked keychain
+/// — and `keyring-core` reports that as an entry-construction error. An
+/// operator reading "failed to create keyring entry" has no way to tell that
+/// apart from a bad service name, so name the likely cause and the choice.
+fn entry_error(e: impl std::fmt::Display) -> AppError {
+    AppError::SecretStore(format!(
+        "the OS credential store is unavailable, so the master seed cannot be \
+         reached: {e}. This is the `keyring` secrets backend; if this host has no \
+         credential store, set `[secrets] backend` to one it does have (aws, gcp, \
+         azure, vault, k8s). Refusing rather than treating the seed as absent."
+    ))
+}
+
 impl super::SeedStore for KeyringSeedStore {
     fn get(&self) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>, AppError>> + Send + '_>> {
         let service = self.service.clone();
         let user = self.user.clone();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
-                let entry = keyring_core::Entry::new(&service, &user).map_err(|e| {
-                    AppError::SecretStore(format!("failed to create keyring entry: {e}"))
-                })?;
+                let entry = keyring_core::Entry::new(&service, &user).map_err(entry_error)?;
                 match entry.get_password() {
                     Ok(hex_seed) => {
                         let bytes = hex::decode(&hex_seed).map_err(|e| {
@@ -53,9 +67,7 @@ impl super::SeedStore for KeyringSeedStore {
         let hex_seed = hex::encode(seed);
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
-                let entry = keyring_core::Entry::new(&service, &user).map_err(|e| {
-                    AppError::SecretStore(format!("failed to create keyring entry: {e}"))
-                })?;
+                let entry = keyring_core::Entry::new(&service, &user).map_err(entry_error)?;
                 entry
                     .set_password(&hex_seed)
                     .map_err(|e| AppError::SecretStore(format!("failed to store seed: {e}")))?;


### PR DESCRIPTION
Closes #1027.

All four binaries treated an unavailable OS credential store as a warning and carried on. What happened next was worse than a silent fallback: `KeyringBackend` stayed registered, every `Entry::new` returned `NoDefaultStore`, and `SessionBackend::load` swallowed it and returned `None` — so the tool behaved exactly as though the user had never logged in. A silent fallback at least stores something; this silently forgets. OpenVTC hit the user-facing end of it: a profile kept in the Linux kernel keyring did not survive a reboot, and the error told the user to check their network.

## The four call sites are byte-identical; their consequences are not

This is the one place the PR deviates from the issue, which asks for all four to be fatal.

- **`pnm` and `cnm`** keep their session — the admin DID and its private key — in the credential store and nowhere else. They now exit at startup via `keyring_init::install_default_store_or_exit`, which is the whole point: there is nothing they can usefully do next.
- **`vta` and `vtc`** never construct an SDK `SessionStore`; they use the fjall-backed `KeyspaceSessionStore`, and their keyring use is the *seed store*, one of eight `[secrets] backend` options. Which one is in play is not known until config loads, long after `main` starts, so hard-failing there would break every deployment on aws/gcp/azure/vault/k8s running on a host with no credential store — the normal server shape. They get `warn_store_unavailable`, and `KeyringSeedStore` — which already failed closed, propagating `AppError::SecretStore` rather than reporting an absent seed — now says which subsystem broke instead of `failed to create keyring entry`.

## FileBackend was the silent default

`default_backend` ended in an `#[allow(unreachable_code)]` fallback into `FileBackend` whenever no backend feature was enabled, writing the admin private key to `sessions.json` as plaintext at the process umask, announced by a `WARNING:` on every access — which is to say, invisible. `pnm`'s own bootstrap-secrets path has always used `0600`; the inconsistency was inside one tool.

That fallback is gone:

- A build with no session store gets `RefusingBackend`, which refuses to save rather than inventing somewhere to put a private key.
- `FileBackend` is reachable only by explicit choice — the `config-session` feature, or `VTI_SECURE_STORE=file` at runtime.
- It creates its file at `0600` inside a `0700` directory **before** writing, since writing and then hardening leaves a window at the umask. An existing world-readable file from an older build is re-hardened on the next write.

The runtime override exists because requiring a rebuild to run on a headless host creates pressure to disable the check rather than make a choice. It parses strictly: `os` or `file`. Anything else — including a near-miss like `plaintext` — resolves to neither and refuses. Asking for `os` on a build with no `keyring` feature refuses too, rather than quietly substituting a file.

## One explanation, shared

`vta_sdk::secure_store` holds the message and the override. It takes the error as `Display` rather than a `keyring_core::Error`, so it is available without the `keyring` feature — OpenVTC renders the same text and honours the same variable. That was the stated goal: identical secret handling across `vta`, `pnm`, `openvtc` and `vtc`, with a hard failure rather than a fallback to open text files.

## The tests this replaces never ran

`FileBackend`'s round-trip coverage in `tests/session_store.rs` was gated on `not(any(keyring, azure-secrets))`, and `keyring` is unified on by pnm-cli and cnm-cli in any workspace run — so it was cfg'd out of every CI run. That is how a plaintext-at-umask write went unnoticed. The round-trip and the new file-mode assertions moved into unit tests beside the backend, where the workspace's unified feature set actually executes them. What remains in the integration test is only the selection contract, which cannot be observed from inside the module.

## Verification

- `cargo check --workspace --all-targets` clean; `cargo fmt --check` clean; clippy clean on the touched crates.
- `vta-sdk` lib 422/422, including the four new tests (override parsing, message content, file mode `0600`/`0700`, re-hardening a legacy world-readable file).
- Live against a real `pnm` build: default keychain path still resolves an existing session; `VTI_SECURE_STORE=bogus` exits 1 naming the bad value; `VTI_SECURE_STORE=file` runs, reports the plaintext path once, and leaves no file behind on a read-only command.
- The 5 failures in `tests/session_store.rs` under `--features session,test-support` are pre-existing — reproduced identically on the unmodified tree by stashing. That config lacks `client`, so the REST mocks 404.

## Note for review

This is a breaking change to `vta-sdk` (the plaintext fallback is removed), flagged as `BREAKING CHANGE:` in the commit body. No `version =` field is touched — release-plz assigns those.
