### PR TITLE
fix(sdk): decode the Trust-Task responses the agent actually sends

### DIFF
--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -155,15 +155,21 @@ fn imported_key_envelope(id: &str) -> Value {
     json!({ "key": record })
 }
 
+/// A context as a **current** agent returns it — lowerCamelCase per SPEC §4.10.
+///
+/// Said `base_path` until #1000 folded the agent's body and left this behind, so
+/// the DIDComm transport's context tests described an agent that no longer
+/// existed. The casing is transport-independent: it is the Trust-Task body, not
+/// a REST detail. See `vta-sdk/tests/trust_task_decode.rs`.
 fn context_json(id: &str) -> Value {
     json!({
         "id": id,
         "name": "Primary",
         "did": "did:web:vta.example.com",
         "description": null,
-        "base_path": "m/26'/2'/0'",
-        "created_at": "2026-01-01T00:00:00Z",
-        "updated_at": "2026-01-01T00:00:00Z"
+        "basePath": "m/26'/2'/0'",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z"
     })
 }
 

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -3,6 +3,34 @@
 //! Split out of `client.rs` so the file is mostly methods. All types
 //! re-exported from the parent module, so callers can continue to
 //! import them via `vta_sdk::client::*` (or `vta_sdk::prelude::*`).
+//!
+//! # These are Trust-Task decode targets, not REST bodies
+//!
+//! The name of this file is older than what is in it. Several of the response
+//! types below are the deserialize target of a **Trust Task** — `rpc_tt` carries
+//! the same document over REST, DIDComm and TSP alike, so "the REST types" has
+//! not described this module since the transports converged.
+//!
+//! That mattered once. #1000 folded Trust Task payloads to lowerCamelCase per
+//! SPEC §4.10 and excluded this file as REST bodies whose casing "no published
+//! schema pins". The exclusion was drawn by path, and the path was stale: the
+//! agent moved to `basePath` while [`ContextResponse`] went on demanding
+//! `base_path`, so every `pnm contexts` command failed with `missing field
+//! base_path` — plus `keys sign`/`rename`/`invalidate`, seed rotate/list, and
+//! the MCP surface that wraps them.
+//!
+//! **The casing was the symptom. The defect is that a single wire has two
+//! structs** — this one and the `protocols::**` body the agent serializes — so a
+//! change to either can move one end alone. The 50 Trust-Task call sites that
+//! did *not* break are precisely those where client and agent decode the *same*
+//! struct. Aliases restore compatibility without changing what anything emits;
+//! collapsing each pair onto one type is the real repair, and is deliberately
+//! not attempted here because it changes public type identity for
+//! `vta-cli-common` and `vta-mcp`.
+//!
+//! Until then: **a `#[serde(alias)]` here is load-bearing.** Adding a
+//! multi-word field to any type in this file without one reintroduces the same
+//! outage. `vta-sdk/tests/trust_task_decode.rs` fails if you do.
 
 use crate::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use crate::protocols::key_management::sign::SignAlgorithm;
@@ -232,14 +260,25 @@ pub struct UpdateContextDidRequest {
     pub did: String,
 }
 
+/// Decode target for the `contexts/{create,get,update,update-did}` Trust Tasks.
+///
+/// The agent serializes
+/// [`CreateContextResultBody`](crate::protocols::context_management::create::CreateContextResultBody),
+/// which is lowerCamelCase per SPEC §4.10. This type is a *separate* struct for
+/// the same wire, so the fold in #1000 moved one end and not the other — see the
+/// module note on [`super::types`] about why the aliases below are load-bearing
+/// rather than decoration.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ContextResponse {
     pub id: String,
     pub name: String,
     pub did: Option<String>,
     pub description: Option<String>,
+    #[serde(alias = "basePath")]
     pub base_path: String,
+    #[serde(alias = "createdAt")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "updatedAt")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -270,8 +309,10 @@ fn default_derived_origin() -> KeyOrigin {
 
 #[derive(Debug, Deserialize)]
 pub struct InvalidateKeyResponse {
+    #[serde(alias = "keyId")]
     pub key_id: String,
     pub status: KeyStatus,
+    #[serde(alias = "updatedAt")]
     pub updated_at: DateTime<Utc>,
 }
 
@@ -282,21 +323,28 @@ pub struct RenameKeyRequest {
 
 #[derive(Debug, Deserialize)]
 pub struct RenameKeyResponse {
+    #[serde(alias = "keyId")]
     pub key_id: String,
+    #[serde(alias = "updatedAt")]
     pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct GetKeySecretResponse {
+    #[serde(alias = "keyId")]
     pub key_id: String,
+    #[serde(alias = "keyType")]
     pub key_type: KeyType,
+    #[serde(alias = "publicKeyMultibase")]
     pub public_key_multibase: String,
+    #[serde(alias = "privateKeyMultibase")]
     pub private_key_multibase: String,
 }
 
-/// Response from `POST /keys/{key_id}/sign`.
+/// Response from the `keys/sign` Trust Task.
 #[derive(Debug, Deserialize)]
 pub struct SignResponse {
+    #[serde(alias = "keyId")]
     pub key_id: String,
     pub signature: String,
     pub algorithm: SignAlgorithm,
@@ -315,17 +363,29 @@ pub struct ErrorResponse {
 
 // ── Seed types ──────────────────────────────────────────────────────
 
+/// Nested element of [`ListSeedsResponse`].
+///
+/// The agent's counterpart
+/// ([`SeedInfo`](crate::protocols::seed_management::list::SeedInfo)) is the one
+/// payload struct #1000 left *without* `rename_all`, so it still emits
+/// snake_case and its own `alias = "created_at"` attributes are inert. These
+/// aliases are therefore pre-emptive: they cost nothing today and mean this type
+/// keeps decoding when `SeedInfo` is folded, instead of breaking a release later
+/// for a reason nobody will connect to that change.
 #[derive(Debug, Deserialize)]
 pub struct SeedInfoResponse {
     pub id: u32,
     pub status: String,
+    #[serde(alias = "createdAt")]
     pub created_at: DateTime<Utc>,
+    #[serde(alias = "retiredAt")]
     pub retired_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct ListSeedsResponse {
     pub seeds: Vec<SeedInfoResponse>,
+    #[serde(alias = "activeSeedId")]
     pub active_seed_id: u32,
 }
 
@@ -337,7 +397,9 @@ pub struct RotateSeedRequest {
 
 #[derive(Debug, Deserialize)]
 pub struct RotateSeedResponse {
+    #[serde(alias = "previousSeedId")]
     pub previous_seed_id: u32,
+    #[serde(alias = "newSeedId")]
     pub new_seed_id: u32,
 }
 

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -511,10 +511,10 @@ async fn get_key_secret_returns_multibase() {
         "/keys/k1/secret",
         200,
         json!({
-            "key_id": "k1",
-            "key_type": "ed25519",
-            "public_key_multibase": "z6Mkpub",
-            "private_key_multibase": "zPriv"
+            "keyId": "k1",
+            "keyType": "ed25519",
+            "publicKeyMultibase": "z6Mkpub",
+            "privateKeyMultibase": "zPriv"
         }),
     )
     .await;
@@ -533,7 +533,7 @@ async fn sign_posts_base64url_payload() {
         "/keys/k1/sign",
         200,
         json!({
-            "key_id": "k1",
+            "keyId": "k1",
             "signature": "AQID",
             "algorithm": "eddsa"
         }),
@@ -554,9 +554,9 @@ async fn invalidate_key_deletes() {
         "/keys/k1",
         200,
         json!({
-            "key_id": "k1",
+            "keyId": "k1",
             "status": "revoked",
-            "updated_at": "2026-01-01T00:00:00Z"
+            "updatedAt": "2026-01-01T00:00:00Z"
         }),
     )
     .await;
@@ -573,7 +573,7 @@ async fn rename_key_patches() {
         "PATCH",
         "/keys/old",
         200,
-        json!({"key_id": "new", "updated_at": "2026-01-01T00:00:00Z"}),
+        json!({"keyId": "new", "updatedAt": "2026-01-01T00:00:00Z"}),
     )
     .await;
     let c = client(&server).await;
@@ -642,11 +642,16 @@ async fn list_seeds_returns_active() {
         "GET",
         "/keys/seeds",
         200,
+        // `seeds[]` is deliberately snake_case while `activeSeedId` is not:
+        // that asymmetry is what the agent really emits, because #1000 folded
+        // `ListSeedsResultBody` and left the nested `SeedInfo` alone. Making
+        // this fixture uniformly camelCase would describe an agent that does
+        // not exist. See `tests/trust_task_decode.rs::seeds_list_*`.
         json!({
             "seeds": [
                 {"id": 1, "status": "active", "created_at": "2026-01-01T00:00:00Z", "retired_at": null}
             ],
-            "active_seed_id": 1
+            "activeSeedId": 1
         }),
     )
     .await;
@@ -664,7 +669,7 @@ async fn rotate_seed_with_mnemonic() {
         "POST",
         "/keys/seeds/rotate",
         200,
-        json!({"previous_seed_id": 1, "new_seed_id": 2}),
+        json!({"previousSeedId": 1, "newSeedId": 2}),
     )
     .await;
     let c = client(&server).await;
@@ -938,15 +943,23 @@ async fn delete_acl_404_maps_to_not_found() {
 
 // ── Contexts ────────────────────────────────────────────────────────
 
+/// A context as a **current** agent returns it.
+///
+/// This fixture said `base_path` until #1000 folded the agent's body to
+/// lowerCamelCase and nothing moved it, so every context test here passed
+/// against an agent that no longer existed while `pnm contexts create` failed
+/// for real users. The authoritative check is now
+/// `tests/trust_task_decode.rs`, which serializes the agent's own type instead
+/// of describing it; this fixture is kept in step with it by hand.
 fn context_json(id: &str) -> Value {
     json!({
         "id": id,
         "name": "Primary",
         "did": "did:web:vta.example.com",
         "description": null,
-        "base_path": "m/26'/2'/0'",
-        "created_at": "2026-01-01T00:00:00Z",
-        "updated_at": "2026-01-01T00:00:00Z"
+        "basePath": "m/26'/2'/0'",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z"
     })
 }
 

--- a/vta-sdk/tests/trust_task_decode.rs
+++ b/vta-sdk/tests/trust_task_decode.rs
@@ -1,0 +1,273 @@
+//! The seam nothing tested: does what the **agent serializes** decode into what
+//! the **client deserializes**?
+//!
+//! # Why this file exists
+//!
+//! `pnm contexts create` failed in production with `trust-task response decode:
+//! missing field base_path` while every test was green, because three layers of
+//! coverage each stopped one step short of the join:
+//!
+//! - The conformance harness (`vta-service`) checks the agent's response against
+//!   the *published schema*. It passed — its witness correctly said `basePath`.
+//! - The SDK's client tests check the client against a *hand-written mock*. They
+//!   passed too — the mock said `base_path`, which the agent had stopped
+//!   emitting.
+//! - Nothing compared those two fixtures, so they disagreed for days.
+//!
+//! Both fixtures were hand-written, and only one was maintained. This file takes
+//! the fixtures out of the loop: it constructs the **agent's own body type**,
+//! serializes it exactly as the agent would, and requires the **client's own
+//! decode type** to accept the bytes. No JSON literal appears anywhere below, so
+//! there is no third spelling to drift.
+//!
+//! # What a failure here means
+//!
+//! A red test in this file is a *live outage* for the named CLI command against
+//! any current agent — not a stylistic complaint. Fix the types; do not adjust
+//! the test to agree with them.
+//!
+//! # Scope, stated honestly
+//!
+//! This covers the 11 Trust-Task call sites whose client decode type differs
+//! from the agent's serialize type (all in `client/types.rs`). The other 50
+//! decode the *same* struct both ends and cannot drift this way — that is a
+//! property of the type graph, and `same_type_sites_cannot_drift` below records
+//! why they are excluded rather than leaving the omission to look like an
+//! oversight.
+
+// The decode targets under test live behind `client`; without it there is no
+// client half of the seam to check.
+#![cfg(feature = "client")]
+
+use chrono::{TimeZone, Utc};
+
+use vta_sdk::client::{
+    ContextListResponse, ContextResponse, GetKeySecretResponse, InvalidateKeyResponse,
+    ListSeedsResponse, RenameKeyResponse, RotateSeedResponse, SignResponse,
+};
+use vta_sdk::keys::{KeyStatus, KeyType};
+use vta_sdk::protocols::context_management::create::CreateContextResultBody;
+use vta_sdk::protocols::context_management::list::ListContextsResultBody;
+use vta_sdk::protocols::key_management::rename::RenameKeyResultBody;
+use vta_sdk::protocols::key_management::revoke::RevokeKeyResultBody;
+use vta_sdk::protocols::key_management::secret::GetKeySecretResultBody;
+use vta_sdk::protocols::key_management::sign::{SignAlgorithm, SignResultBody};
+use vta_sdk::protocols::seed_management::list::{ListSeedsResultBody, SeedInfo};
+use vta_sdk::protocols::seed_management::rotate::RotateSeedResultBody;
+
+/// Serialize what the agent returns, then decode it as the client does.
+///
+/// The panic message names the CLI surface that breaks, because that is the
+/// fact a reader needs first — `missing field base_path` on its own sent a real
+/// investigation to the network layer.
+#[track_caller]
+fn agent_to_client<S, C>(surface: &str, agent_body: &S) -> C
+where
+    S: serde::Serialize,
+    C: serde::de::DeserializeOwned,
+{
+    let wire = serde_json::to_string(agent_body).expect("agent body must serialize");
+    match serde_json::from_str::<C>(&wire) {
+        Ok(decoded) => decoded,
+        Err(e) => panic!(
+            "{surface} is BROKEN against a current agent.\n\
+             \n  agent emitted: {wire}\n  client decode: {e}\n\
+             \n\
+             The client's decode type disagrees with the body the agent \
+             serializes. Add the missing `#[serde(alias = \"...\")]` in \
+             vta-sdk/src/client/types.rs — do not change this test.",
+            surface = surface,
+        ),
+    }
+}
+
+fn ts() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 19, 9, 0, 0).unwrap()
+}
+
+fn agent_context() -> CreateContextResultBody {
+    CreateContextResultBody {
+        id: "personal".into(),
+        name: "Personal".into(),
+        did: None,
+        description: None,
+        parent: None,
+        base_path: "m/26'/2'/0'".into(),
+        created_at: ts(),
+        updated_at: ts(),
+    }
+}
+
+// ── Contexts ────────────────────────────────────────────────────────
+
+/// `pnm contexts create` — the one a user actually hit.
+#[test]
+fn contexts_create_decodes() {
+    let got: ContextResponse = agent_to_client("pnm contexts create", &agent_context());
+    assert_eq!(got.base_path, "m/26'/2'/0'");
+    assert_eq!(got.created_at, ts());
+    assert_eq!(got.updated_at, ts());
+}
+
+/// `contexts/get` and `contexts/update{,-did}` return the same body type, so one
+/// case covers the decode for all three call sites.
+#[test]
+fn contexts_get_and_update_decode() {
+    let got: ContextResponse = agent_to_client("pnm contexts show / update", &agent_context());
+    assert_eq!(got.id, "personal");
+}
+
+/// `pnm contexts list` — the nested case. The outer struct has only a
+/// single-word member, so the break lives one level down; decoding the outer
+/// alone would pass while the element still failed.
+#[test]
+fn contexts_list_decodes_including_its_elements() {
+    let agent = ListContextsResultBody {
+        contexts: vec![agent_context()],
+    };
+    let got: ContextListResponse = agent_to_client("pnm contexts list", &agent);
+    assert_eq!(got.contexts.len(), 1, "the element must survive the decode");
+    assert_eq!(got.contexts[0].base_path, "m/26'/2'/0'");
+}
+
+// ── Keys ────────────────────────────────────────────────────────────
+
+#[test]
+fn keys_sign_decodes() {
+    let agent = SignResultBody {
+        key_id: "key-1".into(),
+        signature: "z3sig".into(),
+        algorithm: SignAlgorithm::EdDSA,
+    };
+    let got: SignResponse = agent_to_client("pnm keys sign", &agent);
+    assert_eq!(got.key_id, "key-1");
+}
+
+#[test]
+fn keys_rename_decodes() {
+    let agent = RenameKeyResultBody {
+        key_id: "key-1".into(),
+        updated_at: ts(),
+    };
+    let got: RenameKeyResponse = agent_to_client("pnm keys rename", &agent);
+    assert_eq!(got.key_id, "key-1");
+    assert_eq!(got.updated_at, ts());
+}
+
+#[test]
+fn keys_revoke_decodes() {
+    let agent = RevokeKeyResultBody {
+        key_id: "key-1".into(),
+        status: KeyStatus::Revoked,
+        updated_at: ts(),
+    };
+    let got: InvalidateKeyResponse = agent_to_client("pnm keys revoke", &agent);
+    assert_eq!(got.key_id, "key-1");
+    assert_eq!(got.updated_at, ts());
+}
+
+#[test]
+fn keys_get_secret_decodes() {
+    let agent = GetKeySecretResultBody {
+        key_id: "key-1".into(),
+        key_type: KeyType::Ed25519,
+        public_key_multibase: "z6Mkpub".into(),
+        private_key_multibase: "z3priv".into(),
+    };
+    let got: GetKeySecretResponse = agent_to_client("pnm keys export-secret", &agent);
+    assert_eq!(got.key_id, "key-1");
+    assert_eq!(got.public_key_multibase, "z6Mkpub");
+    assert_eq!(got.private_key_multibase, "z3priv");
+}
+
+// ── Seeds ───────────────────────────────────────────────────────────
+
+#[test]
+fn seeds_rotate_decodes() {
+    let agent = RotateSeedResultBody {
+        previous_seed_id: 1,
+        new_seed_id: 2,
+    };
+    let got: RotateSeedResponse = agent_to_client("pnm seeds rotate", &agent);
+    assert_eq!(got.previous_seed_id, 1);
+    assert_eq!(got.new_seed_id, 2);
+}
+
+/// `seeds/list` is the asymmetric one: the outer body carries `rename_all`, the
+/// nested `SeedInfo` does not. Asserting the nested timestamp as well as the
+/// outer id is what keeps this honest if `SeedInfo` is folded later.
+#[test]
+fn seeds_list_decodes_including_its_elements() {
+    let agent = ListSeedsResultBody {
+        seeds: vec![SeedInfo {
+            id: 1,
+            status: "active".into(),
+            created_at: ts(),
+            retired_at: None,
+        }],
+        active_seed_id: 1,
+    };
+    let got: ListSeedsResponse = agent_to_client("pnm seeds list", &agent);
+    assert_eq!(got.active_seed_id, 1);
+    assert_eq!(got.seeds.len(), 1, "the element must survive the decode");
+    assert_eq!(got.seeds[0].created_at, ts());
+}
+
+// ── The other direction ─────────────────────────────────────────────
+
+/// An agent from **before** #1000 still decodes.
+///
+/// The aliases are Postel's rule: camelCase is what a current agent sends, and
+/// snake_case is what one running an older release sends. The fixtures in
+/// `client_rest.rs` used to be the only thing covering the snake_case half, and
+/// re-cutting them to camelCase would have retired that coverage silently — the
+/// failure mode #1019 called out when it annotated the last such case.
+///
+/// So it is asserted here explicitly, where the name says why it exists. This is
+/// the one place a JSON literal is correct in this file: no current type
+/// *serializes* the retired spelling, so there is nothing to derive it from.
+#[test]
+fn a_legacy_agent_snake_case_response_still_decodes() {
+    let legacy = serde_json::json!({
+        "id": "personal",
+        "name": "Personal",
+        "did": null,
+        "description": null,
+        "base_path": "m/26'/2'/0'",
+        "created_at": "2026-08-19T09:00:00Z",
+        "updated_at": "2026-08-19T09:00:00Z"
+    });
+    let got: ContextResponse = serde_json::from_value(legacy)
+        .expect("a pre-#1000 agent's snake_case response must still decode");
+    assert_eq!(got.base_path, "m/26'/2'/0'");
+    assert_eq!(got.created_at, ts());
+
+    let legacy_key = serde_json::json!({ "key_id": "key-1", "updated_at": "2026-08-19T09:00:00Z" });
+    let got: RenameKeyResponse =
+        serde_json::from_value(legacy_key).expect("legacy key body must still decode");
+    assert_eq!(got.key_id, "key-1");
+}
+
+// ── The exclusion, recorded ─────────────────────────────────────────
+
+/// Why the other 50 Trust-Task call sites are absent.
+///
+/// They decode the **same struct** the agent serializes (`protocols::**`), so a
+/// casing change moves both ends at once and this class of drift is structurally
+/// impossible — not merely untested. Re-serializing a shared type through itself
+/// would assert that `serde` round-trips, which is not a property of this
+/// codebase.
+///
+/// This exists so a reader counting call sites finds the reason here rather than
+/// assuming the coverage was simply incomplete. If a future change gives one of
+/// those sites its own decode type, it belongs in this file.
+#[test]
+fn same_type_sites_cannot_drift() {
+    // A representative of the safe shape: the client's `create_key` decodes
+    // `CreateKeyResponseBody`, which is the very type the agent's handler
+    // returns. One type, one spelling, nothing to disagree about.
+    fn assert_same<T>(_: std::marker::PhantomData<T>) {}
+    assert_same::<vta_sdk::protocols::key_management::create::CreateKeyResponseBody>(
+        std::marker::PhantomData,
+    );
+}


### PR DESCRIPTION
Reported from the field: `pnm contexts create` fails against any agent built since #1000.

```
✗ Protocol error: trust-task response decode: missing field `base_path`
```

## Cause

#1000 folded Trust Task payloads to lowerCamelCase per SPEC §4.10 and excluded `vta-sdk/src/client/types.rs` as REST bodies whose casing "no published schema pins".

The exclusion was drawn by **file path, and the path was stale**. `rpc_tt` carries the same Trust-Task document over REST, DIDComm and TSP alike (#1020), so `ContextResponse` is a Trust-Task decode target and a published schema does pin it. The agent moved to `basePath`; the client went on demanding `base_path`.

## Blast radius

Eleven call sites across eight types — every mismatching field is **required** with no `default`, so these fail hard on **every transport**, not just REST:

| Surface | Broken |
|---|---|
| Contexts | `create`, `get`, `update`, `update-did`, `list` — all of `pnm contexts` |
| Keys | `sign`, `rename`, `revoke`, `export-secret` |
| Seeds | `rotate`, `list` (`activeSeedId` only) |

`vta-cli-common` and `vta-mcp` consume these, so `pnm`/`cnm` **key** management and the **MCP tool surface** are equally broken. The reporter hit contexts first and would have hit `pnm keys sign` next.

Audited all 61 `rpc_tt`/`rpc_tt_void` call sites. The 50 that are safe are safe for one reason: they decode the *same* `protocols::**` struct the agent serializes, so #1000 moved both ends together.

## Fix

Per-field `alias`, not `rename_all` — the same Postel fold #1000 itself used. It changes nothing about what the SDK emits and keeps working against an agent that has not taken the change.

`SeedInfoResponse` gets aliases it does not yet need: its counterpart `SeedInfo` is the one payload struct #1000 left unfolded, and when that lands this type should not be what breaks.

**The casing is the symptom.** The defect is that one wire has two structs, so either end can move alone. Collapsing each pair onto a single type is the real repair; it is deliberately not attempted here because it changes public type identity for two downstream crates. The module note in `client/types.rs` records that, and says plainly that an alias in that file is load-bearing.

## Why nothing caught a total outage

Three layers each stopped one step short of the join:

- **Conformance** (`vta-service`) checks the agent against the published schema. Green — its witness correctly said `basePath`.
- **SDK client tests** check the client against a hand-written mock. Also green — the mock still said `base_path`.
- **Nothing compared the two fixtures.** They disagreed for two days while both suites passed.

`vta-sdk/tests/trust_task_decode.rs` is that missing seam. It constructs the agent's own body type, serializes it as the agent would, and requires the client's own decode type to accept the bytes. No JSON literal appears in the derived cases, so there is no third spelling to drift.

**Verified non-vacuous:** with the aliases reverted, 9 of 9 derived cases fail, each naming the broken CLI surface and printing the exact wire —

```
pnm contexts create is BROKEN against a current agent.
  agent emitted: {"id":"personal","name":"Personal","basePath":"m/26'/2'/0'",...}
  client decode: missing field `base_path` at line 1 column 130
```

## Fixtures

The stale mocks are re-cut to what an agent really sends — including an asymmetry a uniform pass would have got wrong: `seeds[]` stays snake_case inside a camelCase `activeSeedId`, because that is exactly what the half-folded type emits. A tidy-looking uniform fixture would describe an agent that does not exist.

Re-cutting them would have silently retired the only coverage of the snake_case *intake* aliases — the failure mode #1019 called out. That direction is now asserted explicitly by name (`a_legacy_agent_snake_case_response_still_decodes`) rather than left implicit in a fixture someone would later tidy away.

**Conformance witnesses stay hand-written.** They anchor the types to the spec; deriving them from the types they check would make them vacuous, which is the trap `acl/update` fell into (#856).

## Two adjacent findings, filed not folded

Neither is a break, and fixing either changes the wire:

- `CapabilitiesResponse` (`protocols/discovery.rs:21`) received `alias` attributes in #1000 **without** the `rename_all` that would give them meaning — so it still emits snake_case and its aliases are inert. A §4.10 conformance gap the fold intended to close.
- `SeedInfo` has the same dead-alias shape.

## Verification

- `cargo check --workspace --all-targets` clean; `cargo fmt --check` clean; `cargo clippy --workspace --all-targets` clean.
- New seam test 11/11, and confirmed it runs under CI's feature set (`cargo test --workspace`), not just under an explicit `--features client`.
- `client_rest` 86/86 with the re-cut fixtures; e2e `client_didcomm` 49/49; `vta-cli-common`, `vta-mcp`, `pnm-cli`, `cnm-cli` all green.

No `version =` field touched — release-plz assigns those.
