### PR TITLE
test(sdk): make forgetting the client/agent seam fail here, not in the field

### DIFF
--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -366,7 +366,13 @@ nitro_attest = { version = "0.2", features = ["builder"] }
 # rather than grepped: the attribute it looks for is routinely written across
 # several lines, which a regex reads wrong in exactly the direction that lets a
 # violation through.
-syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
+#
+# `visit` is for the decode census (tests/trust_task_decode_census.rs), which
+# has to find `rpc_tt` *call sites* inside method bodies — nested in `match`
+# arms, behind `?`, sometimes built across statements. A visitor finds the real
+# method call; searching the body's tokens would also match a mention in a
+# comment or a doc link.
+syn = { version = "2", features = ["full", "parsing", "extra-traits", "visit"] }
 
 [lints]
 workspace = true

--- a/vta-sdk/tests/trust_task_decode.rs
+++ b/vta-sdk/tests/trust_task_decode.rs
@@ -42,10 +42,12 @@
 use chrono::{TimeZone, Utc};
 
 use vta_sdk::client::{
-    ContextListResponse, ContextResponse, GetKeySecretResponse, InvalidateKeyResponse,
-    ListSeedsResponse, RenameKeyResponse, RotateSeedResponse, SignResponse,
+    AclEntryResponse, AclListResponse, ContextListResponse, ContextResponse, GetKeySecretResponse,
+    InvalidateKeyResponse, ListSeedsResponse, RenameKeyResponse, RotateSeedResponse, SignResponse,
 };
 use vta_sdk::keys::{KeyStatus, KeyType};
+use vta_sdk::protocols::acl_management::entry::AclEntry;
+use vta_sdk::protocols::acl_management::list::ListAclResultBody;
 use vta_sdk::protocols::context_management::create::CreateContextResultBody;
 use vta_sdk::protocols::context_management::list::ListContextsResultBody;
 use vta_sdk::protocols::key_management::rename::RenameKeyResultBody;
@@ -211,6 +213,79 @@ fn seeds_list_decodes_including_its_elements() {
     assert_eq!(got.active_seed_id, 1);
     assert_eq!(got.seeds.len(), 1, "the element must survive the decode");
     assert_eq!(got.seeds[0].created_at, ts());
+}
+
+// ── ACL ─────────────────────────────────────────────────────────────
+
+/// A representative entry, with every optional member **set**.
+///
+/// A fixture that leaves optionals unset would serialize without them (they all
+/// carry `skip_serializing_if`), and a member absent from the wire is exactly a
+/// member this seam cannot check. `allowed_keys` is `Some(vec![])` on purpose:
+/// `None` and `Some(∅)` are opposite grants on this type, and the empty vec is
+/// the one that must survive as `"allowedKeys": []`.
+fn agent_acl_entry() -> AclEntry {
+    AclEntry {
+        subject: "did:key:z6MkSubject".into(),
+        role: "admin".into(),
+        scopes: vec!["personal".into()],
+        allowed_keys: Some(vec![]),
+        label: Some("laptop".into()),
+        created_at: Some(ts()),
+        created_by: Some("did:key:z6MkAdmin".into()),
+        updated_at: Some(ts()),
+        updated_by: Some("did:key:z6MkAdmin".into()),
+        expires_at: Some(ts()),
+        step_up: None,
+        approve: None,
+    }
+}
+
+/// `pnm acl show` / `grant` / `update` / `change-role`.
+///
+/// These decode a `pub(crate)` `{ entry }` envelope, which a `tests/` file
+/// cannot name — and which cannot drift anyway, its one member being
+/// single-word. The seam that *can* drift is the entry inside it, so that is
+/// what is asserted: the agent's `AclEntry` into the client's
+/// `AclEntryResponse`, which renames `subject`→`did` and `scopes`→
+/// `allowed_contexts` and converts RFC 3339 to epoch seconds.
+///
+/// The audit for #1033 classified this pair safe by reading the attributes on
+/// both types. That reading was right — and it is the same kind of reasoning
+/// that classified `client/types.rs` as REST bodies, so it is a check now.
+#[test]
+fn acl_entry_decodes() {
+    let got: AclEntryResponse =
+        agent_to_client("pnm acl grant / show / update", &agent_acl_entry());
+    assert_eq!(got.did, "did:key:z6MkSubject", "subject renames to did");
+    assert_eq!(
+        got.allowed_contexts,
+        vec!["personal".to_string()],
+        "scopes renames to allowed_contexts"
+    );
+    assert_eq!(
+        got.allowed_keys,
+        Some(vec![]),
+        "Some(empty) is the narrowest grant and must not decode as None"
+    );
+    assert_eq!(got.label.as_deref(), Some("laptop"));
+    assert_ne!(got.created_at, 0, "RFC 3339 must convert to epoch seconds");
+    assert!(got.expires_at.is_some());
+}
+
+/// `pnm acl list`, including its elements.
+#[test]
+fn acl_list_decodes_including_its_elements() {
+    let agent = ListAclResultBody {
+        entries: vec![agent_acl_entry()],
+        truncated: false,
+        cursor: None,
+        redacted_fields: vec![],
+    };
+    let got: AclListResponse = agent_to_client("pnm acl list", &agent);
+    assert_eq!(got.entries.len(), 1, "the element must survive the decode");
+    assert_eq!(got.entries[0].did, "did:key:z6MkSubject");
+    assert_ne!(got.entries[0].created_at, 0);
 }
 
 // ── The other direction ─────────────────────────────────────────────

--- a/vta-sdk/tests/trust_task_decode_census.rs
+++ b/vta-sdk/tests/trust_task_decode_census.rs
@@ -1,0 +1,397 @@
+//! Census: every Trust-Task call site whose decode type is **private to the
+//! client** must be covered by `trust_task_decode.rs`.
+//!
+//! ## The invariant
+//!
+//! `rpc_tt` sends a Trust Task and deserializes the agent's reply. When the type
+//! it deserializes into is the *same* type the agent serializes, the two ends
+//! cannot disagree: any change moves both at once. When it is a **separate**
+//! struct describing the same wire, either end can move alone — and then the
+//! command fails in the field, not in CI.
+//!
+//! So: a client-private decode type is allowed, but only if the seam test
+//! actually drives the agent's body into it.
+//!
+//! ## Why a census rather than more cases
+//!
+//! #1033 was this defect. #1000 folded the agent's payloads to lowerCamelCase
+//! and excluded `client/types.rs` as "REST bodies"; the exclusion was drawn by
+//! file path and the path was stale, so the agent moved to `basePath` while
+//! `ContextResponse` went on demanding `base_path`. Every `pnm contexts`
+//! command, four `pnm keys` commands, seed rotate/list and the MCP surface
+//! failed against any current agent.
+//!
+//! The audit that followed found the split is total: of 61 call sites, the 50
+//! that decode a shared `protocols::**` type were all fine, and all 11 with a
+//! private type in `client/types.rs` were broken. The correlation is the point.
+//!
+//! `trust_task_decode.rs` fixed the eleven. It cannot stop the twelfth, because
+//! it is a list someone has to remember to extend — and the whole failure mode
+//! here is a change that looks unrelated to a list. This file makes forgetting a
+//! compile-time-adjacent failure instead of a production one.
+//!
+//! The real repair is to collapse each pair onto one type (#1035), after which
+//! [`COVERED_BY_SEAM_TEST`] empties and this census keeps it empty.
+//!
+//! ## Scope and method
+//!
+//! Every `rpc_tt` call under `vta-sdk/src/client/`. `rpc_tt_void` is excluded —
+//! it decodes nothing, so it has no seam to drift.
+//!
+//! Parsed with `syn`, not grepped, for the same reason as
+//! [`payload_null_census`](../payload_null_census.rs): return types wrap across
+//! lines, and a line-oriented regex misreads that in the direction that lets a
+//! violation through.
+
+#![cfg(feature = "client")]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use syn::{ImplItem, Item, ReturnType, Type};
+
+/// Decode types that are private to the client, each covered by a case in
+/// `trust_task_decode.rs`.
+///
+/// An entry here is a statement that this type is a **second struct for a wire
+/// the agent already has a type for** — a known hazard held safe by a test, not
+/// a design. Adding one is allowed; adding one without the matching seam case is
+/// what this census refuses.
+///
+/// Every name here should disappear as #1035 collapses the pairs.
+const COVERED_BY_SEAM_TEST: &[&str] = &[
+    "ContextResponse",
+    "ContextListResponse",
+    "SignResponse",
+    "RenameKeyResponse",
+    "InvalidateKeyResponse",
+    "GetKeySecretResponse",
+    "RotateSeedResponse",
+    "ListSeedsResponse",
+    // Not part of the #1033 outage — classified safe by reading the attributes
+    // on both types. That reading was right, but it is the same kind of
+    // reasoning that classified `client/types.rs` as REST bodies, so it is now a
+    // check rather than a conclusion.
+    "AclListResponse",
+];
+
+/// Client-private types that are nonetheless safe, each with the reason.
+///
+/// "Defined in `client/`" is the census's proxy for "the agent does not
+/// serialize this type", and these are the places the proxy over-reports. Each
+/// entry is a claim that drift is *impossible*, not merely unobserved — the
+/// weaker claim is what [`COVERED_BY_SEAM_TEST`] is for.
+const CLIENT_PRIVATE_BUT_SAFE: &[(&str, &str)] = &[
+    (
+        "ConfigResponse",
+        "`#[serde(flatten)]` over the agent's own GetConfigResultBody; declares \
+         no fields of its own, so there is nothing to spell differently",
+    ),
+    (
+        "GetDidLogResponse",
+        "only single-word members (`did`, `log`) — no casing difference is \
+         expressible",
+    ),
+    (
+        "ListKeysResponse",
+        "`keys` + `total` are single-word; the nested KeyRecord is shared with \
+         the agent and camelCase on both sides",
+    ),
+    (
+        "AclEntryEnvelope",
+        "`pub(crate)` `{ entry }` wrapper — its one member is single-word, so \
+         the envelope itself cannot drift. What it wraps is covered by \
+         trust_task_decode.rs::acl_entry_decodes",
+    ),
+];
+
+fn src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn client_dir() -> PathBuf {
+    src_dir().join("client")
+}
+
+/// Names of types **defined under `src/client/`**.
+///
+/// This is the census's operative question. A decode type defined here is the
+/// client's own struct for a wire the agent describes with a different one, so
+/// the two can move independently. A decode type defined anywhere else in the
+/// crate is a type the agent serializes directly — `protocols::**` bodies,
+/// `webvh::WebvhDidRecord`, and so on — and cannot drift against itself.
+///
+/// Derived rather than listed, so a type that *moves* into or out of `client/`
+/// is reclassified automatically. Hand-listing the shared side was the first
+/// attempt and would have meant ~40 names to maintain, which is its own way of
+/// going stale.
+fn client_private_types() -> BTreeSet<String> {
+    let mut files = Vec::new();
+    rust_sources(&client_dir(), &mut files);
+
+    let mut names = BTreeSet::new();
+    for path in files {
+        let src = fs::read_to_string(&path).expect("client source is readable");
+        let ast = syn::parse_file(&src).expect("client source parses");
+        for item in ast.items {
+            match item {
+                Item::Struct(s) => {
+                    names.insert(s.ident.to_string());
+                }
+                Item::Enum(e) => {
+                    names.insert(e.ident.to_string());
+                }
+                _ => {}
+            }
+        }
+    }
+    names
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("client/ is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// The `T` of a `Result<T, VtaError>` return, rendered as its final path
+/// segment.
+///
+/// The last segment is what matters: `context_management::create::Foo` and a
+/// bare `Foo` are the same type to this census, and comparing full paths would
+/// make the allow-lists depend on how each call site happened to import.
+fn ok_type_name(sig: &syn::Signature) -> Option<String> {
+    let ReturnType::Type(_, ty) = &sig.output else {
+        return None;
+    };
+    let Type::Path(tp) = &**ty else { return None };
+    let last = tp.path.segments.last()?;
+    if last.ident != "Result" {
+        return None;
+    }
+    let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
+        return None;
+    };
+    let syn::GenericArgument::Type(ok) = args.args.first()? else {
+        return None;
+    };
+    match ok {
+        // `rpc_tt_void` — nothing decoded, nothing to drift.
+        Type::Tuple(t) if t.elems.is_empty() => None,
+        Type::Path(p) => Some(p.path.segments.last()?.ident.to_string()),
+        _ => None,
+    }
+}
+
+/// Finds a real `self.rpc_tt(..)` call anywhere inside a method body.
+///
+/// A visitor rather than a search over the body's tokens: the call sits inside
+/// `match` arms and behind `?`, and a token search would also match the name
+/// where it appears in a comment or a doc link — of which this client has
+/// several, since `rpc_tt` is the thing its docs keep explaining.
+///
+/// `rpc_tt_void` decodes nothing, so it has no seam and is deliberately not
+/// matched.
+#[derive(Default)]
+struct FindRpcTt {
+    found: bool,
+}
+
+impl<'ast> syn::visit::Visit<'ast> for FindRpcTt {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if node.method == "rpc_tt" {
+            self.found = true;
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn expr_calls_rpc_tt(expr: &syn::Expr) -> bool {
+    let mut v = FindRpcTt::default();
+    syn::visit::Visit::visit_expr(&mut v, expr);
+    v.found
+}
+
+fn calls_rpc_tt(item: &ImplItem) -> bool {
+    let ImplItem::Fn(f) = item else { return false };
+    let mut v = FindRpcTt::default();
+    syn::visit::Visit::visit_block(&mut v, &f.block);
+    v.found
+}
+
+/// The types a method *deserializes into*, taken from annotated `let` bindings
+/// whose initializer contains the `rpc_tt` call.
+///
+/// This is the distinction the first draft of this census got wrong. Several
+/// methods decode the **agent's** body into a local and then map it field by
+/// field into a friendlier client-side shape:
+///
+/// ```ignore
+/// let wrapped: protocols::key_management::create::CreateKeyResponseBody =
+///     self.rpc_tt(..).await?;
+/// Ok(CreateKeyResponse { key_id: wrapped.key.key_id, .. })
+/// ```
+///
+/// Reading the *return* type there reports `CreateKeyResponse` and asks for a
+/// seam case that would prove nothing: the decode is against the shared type,
+/// and the mapping is checked by the compiler — change the agent's struct and
+/// this stops building. The hazard is only where the client's own type is what
+/// `serde` is handed.
+struct DecodeTypes {
+    found: Vec<String>,
+}
+
+impl<'ast> syn::visit::Visit<'ast> for DecodeTypes {
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some(init) = &node.init
+            && expr_calls_rpc_tt(&init.expr)
+            && let syn::Pat::Type(pt) = &node.pat
+            && let Type::Path(p) = &*pt.ty
+            && let Some(last) = p.path.segments.last()
+        {
+            self.found.push(last.ident.to_string());
+        }
+        syn::visit::visit_local(self, node);
+    }
+}
+
+/// Collect `(method, decode type)` for every `rpc_tt` call site in the client.
+fn decode_targets() -> Vec<(String, String)> {
+    let mut files = Vec::new();
+    rust_sources(&client_dir(), &mut files);
+    files.sort();
+
+    let mut found = Vec::new();
+    for path in files {
+        let src = fs::read_to_string(&path).expect("client source is readable");
+        let ast = syn::parse_file(&src).expect("client source parses");
+        for item in ast.items {
+            let Item::Impl(imp) = item else { continue };
+            for sub in &imp.items {
+                if !calls_rpc_tt(sub) {
+                    continue;
+                }
+                let ImplItem::Fn(f) = sub else { continue };
+                let method = f.sig.ident.to_string();
+
+                // An annotated `let` is the authoritative answer: it is literally
+                // the type handed to serde. Only when there is none does the
+                // reply flow straight out of the method, making the return type
+                // the decode type.
+                let mut annotated = DecodeTypes { found: Vec::new() };
+                syn::visit::Visit::visit_block(&mut annotated, &f.block);
+
+                if annotated.found.is_empty() {
+                    if let Some(ty) = ok_type_name(&f.sig) {
+                        found.push((method, ty));
+                    }
+                } else {
+                    for ty in annotated.found {
+                        found.push((method.clone(), ty));
+                    }
+                }
+            }
+        }
+    }
+    found
+}
+
+/// Every client-private decode type is exercised by the seam test.
+///
+/// The failure text names the specific repair, because the instinct on seeing
+/// this red is to add the type to the allow-list — which is exactly the move
+/// that reopens #1033.
+#[test]
+fn every_client_private_decode_type_has_a_seam_case() {
+    let private = client_private_types();
+    let accounted: BTreeSet<&str> = COVERED_BY_SEAM_TEST
+        .iter()
+        .copied()
+        .chain(CLIENT_PRIVATE_BUT_SAFE.iter().map(|(ty, _)| *ty))
+        .collect();
+
+    let mut unclassified: Vec<String> = decode_targets()
+        .into_iter()
+        // Only types the client defines itself can drift against the agent.
+        .filter(|(_, ty)| private.contains(ty.as_str()))
+        .filter(|(_, ty)| !accounted.contains(ty.as_str()))
+        .map(|(m, ty)| format!("  {m} -> {ty}"))
+        .collect();
+    unclassified.sort();
+    unclassified.dedup();
+
+    assert!(
+        unclassified.is_empty(),
+        "these Trust-Task call sites decode a type the client defines itself, with \
+         nothing checking it against what the agent sends:\n{}\n\n\
+         A client-private decode type is a SECOND struct for a wire the agent already \
+         types, so the two ends can move apart. Do one of:\n\
+         \n\
+         - Decode the agent's own type instead (best — see #1035). Nothing to list.\n\
+         - Add a case to tests/trust_task_decode.rs that serializes the AGENT's body \
+           into this type, then name it in COVERED_BY_SEAM_TEST.\n\
+         - If drift is genuinely impossible — only single-word members, or a flatten \
+           wrapper over the agent's body — add it to CLIENT_PRIVATE_BUT_SAFE with that \
+           reason.\n\
+         \n\
+         Reach for the last one only if it is actually true. \"These are just the REST \
+         bodies, nothing pins their casing\" was said about client/types.rs in #1000, \
+         and it broke every `pnm contexts` command in the field.",
+        unclassified.join("\n")
+    );
+}
+
+/// Each name in [`COVERED_BY_SEAM_TEST`] really appears in the seam test.
+///
+/// Without this the allow-list is only a promise: a type could be listed as
+/// covered while its case was deleted, renamed, or never written, and the census
+/// above would still pass. Cheap to check, and it is the half that makes the
+/// other half mean anything.
+#[test]
+fn the_seam_test_covers_what_the_allow_list_claims() {
+    let seam = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("trust_task_decode.rs"),
+    )
+    .expect("trust_task_decode.rs is readable");
+
+    let missing: Vec<&str> = COVERED_BY_SEAM_TEST
+        .iter()
+        .copied()
+        .filter(|ty| !seam.contains(ty))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "COVERED_BY_SEAM_TEST claims these are covered, but they do not appear in \
+         tests/trust_task_decode.rs:\n  {}\n\n\
+         Either write the case, or — if the pair was collapsed onto one type \
+         (#1035) — drop the name from the list and move it to SHARED_WITH_AGENT.",
+        missing.join("\n  ")
+    );
+}
+
+/// The census sees a realistic number of call sites.
+///
+/// A refactor that renamed `rpc_tt`, moved the client, or changed the return
+/// shape would leave both tests above passing over an empty set — green because
+/// nothing was examined. #1033's own root cause was a check that had quietly
+/// stopped covering its subject, so this file states its floor out loud.
+#[test]
+fn the_census_is_not_scanning_an_empty_set() {
+    let found = decode_targets();
+    assert!(
+        found.len() >= 40,
+        "only {} rpc_tt call sites found; the audit for #1033 counted 55. \
+         Something moved and this census is now looking at almost nothing — \
+         fix the walk, do not lower this floor.",
+        found.len()
+    );
+}


### PR DESCRIPTION
Follow-up to #1033. Refs #1035.

#1033 fixed eleven Trust-Task call sites whose client decode type had drifted from the agent's body. It cannot stop the twelfth: `trust_task_decode.rs` is a list, and the failure mode is a change that looks unrelated to a list. #1000 was a casing fold — nobody folding casing thinks to go and check a client's decode types.

This derives the obligation instead of listing it.

## What it does

Walks every `rpc_tt` call under `src/client/`, resolves what each one deserializes into, and requires any type the **client defines itself** to be either exercised by the seam test or declared incapable of drifting, with the reason. A new call site with a new private decode type now fails in CI.

The classification is **structural, not enumerated**. "Is this type defined under `src/client/`?" is the operative question: a decode type from anywhere else in the crate is one the agent serializes directly and cannot drift against itself. My first draft hand-listed the ~40 shared types, which is its own way of going stale — deriving it means a type that *moves* into or out of `client/` is reclassified without anyone remembering to.

## Two corrections the census forced

Both are places where reading the code had been enough to be *right* and not enough to stay right:

**It was reading the wrong type.** `create_key` and `import_key` decode the agent's `CreateKeyResponseBody` into a local, then map it field-by-field into a friendlier shape:

```rust
let wrapped: protocols::key_management::create::CreateKeyResponseBody = self.rpc_tt(..).await?;
Ok(CreateKeyResponse { key_id: wrapped.key.key_id, .. })
```

Reading the method's *return* type reports `CreateKeyResponse` and demands a seam case that would prove nothing — the decode is against the shared type and the mapping is compiler-checked. It now reads the annotated `let` where there is one, falling back to the return type otherwise.

**The ACL pair was classified by reading, not checking.** #1033's audit called `AclEntryResponse` safe because it carries `rename_all` plus per-field renames. That was true — and it is the same species of reasoning that called `client/types.rs` "REST bodies". It has real cases now: the agent's `AclEntry` into the client's `AclEntryResponse`, asserting that the `subject`→`did` and `scopes`→`allowed_contexts` renames and the RFC-3339→epoch conversion actually happen.

The ACL fixture sets **every** optional member, because they all carry `skip_serializing_if` and a member absent from the wire is a member this seam cannot check. `allowed_keys` is `Some(vec![])` specifically: `None` and `Some(∅)` are opposite grants on that type, and the empty vec is the one that must survive as `"allowedKeys": []`.

## Method

Parsed with `syn` and a visitor, not grepped. `rpc_tt` appears in comments and doc links throughout this client — it is the thing its docs keep explaining — so a token search reports methods that merely mention it. Adds the `visit` feature to the existing `syn` dev-dependency; no new crate.

## Verified non-vacuous, in both directions

A census that cannot fail is worse than none, so each guard was proven against an injected violation:

| Guard | Injected | Result |
|---|---|---|
| Uncovered decode type | a method with a fresh `ProbeResponse` | `probe_temp -> ProbeResponse` — **red** |
| Lying allow-list | `NeverWrittenResponse` in `COVERED_BY_SEAM_TEST` | named as claimed-but-absent — **red** |
| Empty scan | — | floor of 40 call sites asserted |

The third matters most. Without it, a refactor renaming `rpc_tt` or moving the client would leave both other tests passing over an empty set — green because nothing was examined. That is #1033's own root cause in miniature: a check that had quietly stopped covering its subject.

The failure text names the specific repair and says which escape hatch *not* to reach for, because the instinct on seeing this red is to add the type to the safe list — the exact move that reopens #1033.

## This is scaffolding

The defect should stop existing. #1035 collapses each pair onto the agent's type; as it lands, `COVERED_BY_SEAM_TEST` empties, the derived cases become tautological and are removed, and this file keeps the invariant from coming back.

## Verification

- `cargo check --workspace --all-targets`, `cargo fmt --check`, `cargo clippy --workspace --all-targets` all clean.
- Seam test 13/13 (up from 11 — ACL added), census 3/3.
- Both confirmed running under CI's feature set (`cargo test --workspace`), not only under an explicit `--features client`.

Tests only — no production code changes, no `version =` touched.
