### PR TITLE
refactor(sdk)!: one wire, one type — decode the agent's own bodies

### DIFF
--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -6,34 +6,40 @@
 //!
 //! # These are Trust-Task decode targets, not REST bodies
 //!
-//! The name of this file is older than what is in it. Several of the response
-//! types below are the deserialize target of a **Trust Task** — `rpc_tt` carries
-//! the same document over REST, DIDComm and TSP alike, so "the REST types" has
-//! not described this module since the transports converged.
+//! The name of this file is older than what is in it. The response types here
+//! are the deserialize target of a **Trust Task** — `rpc_tt` carries the same
+//! document over REST, DIDComm and TSP alike, so "the REST types" has not
+//! described this module since the transports converged.
 //!
-//! That mattered once. #1000 folded Trust Task payloads to lowerCamelCase per
-//! SPEC §4.10 and excluded this file as REST bodies whose casing "no published
-//! schema pins". The exclusion was drawn by path, and the path was stale: the
-//! agent moved to `basePath` while [`ContextResponse`] went on demanding
-//! `base_path`, so every `pnm contexts` command failed with `missing field
-//! base_path` — plus `keys sign`/`rename`/`invalidate`, seed rotate/list, and
-//! the MCP surface that wraps them.
+//! That mattered once, badly. #1000 folded Trust Task payloads to lowerCamelCase
+//! per SPEC §4.10 and excluded this file as REST bodies whose casing "no
+//! published schema pins". The exclusion was drawn by path, and the path was
+//! stale: the agent moved to `basePath` while `ContextResponse` went on
+//! demanding `base_path`, so every `pnm contexts` command failed with `missing
+//! field base_path` — plus `keys sign`/`rename`/`revoke`, seed rotate/list, and
+//! the MCP surface wrapping them.
 //!
-//! **The casing was the symptom. The defect is that a single wire has two
-//! structs** — this one and the `protocols::**` body the agent serializes — so a
-//! change to either can move one end alone. The 50 Trust-Task call sites that
-//! did *not* break are precisely those where client and agent decode the *same*
-//! struct. Aliases restore compatibility without changing what anything emits;
-//! collapsing each pair onto one type is the real repair, and is deliberately
-//! not attempted here because it changes public type identity for
-//! `vta-cli-common` and `vta-mcp`.
+//! # A response type here is the agent's type, under the client's name
 //!
-//! Until then: **a `#[serde(alias)]` here is load-bearing.** Adding a
-//! multi-word field to any type in this file without one reintroduces the same
-//! outage. `vta-sdk/tests/trust_task_decode.rs` fails if you do.
+//! The casing was the symptom; the defect was that one wire had **two structs**,
+//! either of which could move alone. #1033 papered it with `serde` aliases;
+//! #1035 removed it: every decode target below is now a `pub use` of the very
+//! body the agent serializes. The two ends cannot disagree, because there are no
+//! longer two ends — which is a stronger guarantee than any test could give.
+//!
+//! The re-export keeps the client-facing name, so `get_context` still returns
+//! something called `ContextResponse` rather than `CreateContextResultBody`.
+//!
+//! **When adding a Trust-Task response type, re-export the agent's body rather
+//! than declaring a struct that mirrors it.** A mirror compiles, passes review,
+//! and drifts the next time someone touches the wire.
+//! `vta-sdk/tests/trust_task_decode_census.rs` refuses a new one.
+//!
+//! Request builders are a different matter and stay local: `CreateKeyRequest`
+//! and friends exist for ergonomics (`.new(..).label(..)`) and produce the wire
+//! shape rather than describing it, so they cannot drift the same way.
 
 use crate::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
-use crate::protocols::key_management::sign::SignAlgorithm;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -260,32 +266,23 @@ pub struct UpdateContextDidRequest {
     pub did: String,
 }
 
-/// Decode target for the `contexts/{create,get,update,update-did}` Trust Tasks.
+/// Decode target for the `contexts/{create,get,update,update-did}` Trust Tasks
+/// — **the agent's own body type**, under the name the client API has always
+/// used.
 ///
-/// The agent serializes
-/// [`CreateContextResultBody`](crate::protocols::context_management::create::CreateContextResultBody),
-/// which is lowerCamelCase per SPEC §4.10. This type is a *separate* struct for
-/// the same wire, so the fold in #1000 moved one end and not the other — see the
-/// module note on [`super::types`] about why the aliases below are load-bearing
-/// rather than decoration.
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ContextResponse {
-    pub id: String,
-    pub name: String,
-    pub did: Option<String>,
-    pub description: Option<String>,
-    #[serde(alias = "basePath")]
-    pub base_path: String,
-    #[serde(alias = "createdAt")]
-    pub created_at: DateTime<Utc>,
-    #[serde(alias = "updatedAt")]
-    pub updated_at: DateTime<Utc>,
-}
+/// It was a separate struct with the same members until #1035. Being separate is
+/// what let #1000 move the agent to `basePath` while this went on demanding
+/// `base_path`, breaking every `pnm contexts` command; being the same type makes
+/// that unrepresentable rather than merely tested for.
+///
+/// The old struct also had no `parent`, so a nested context rendered without
+/// one. That is fixed here by construction — the member now exists because the
+/// agent's type has it.
+pub use crate::protocols::context_management::create::CreateContextResultBody as ContextResponse;
 
-#[derive(Debug, Deserialize)]
-pub struct ContextListResponse {
-    pub contexts: Vec<ContextResponse>,
-}
+/// Decode target for `contexts/list` — the agent's own body type. See
+/// [`ContextResponse`].
+pub use crate::protocols::context_management::list::ListContextsResultBody as ContextListResponse;
 
 #[derive(Debug, Deserialize)]
 pub struct CreateKeyResponse {
@@ -307,48 +304,28 @@ fn default_derived_origin() -> KeyOrigin {
     KeyOrigin::Derived
 }
 
-#[derive(Debug, Deserialize)]
-pub struct InvalidateKeyResponse {
-    #[serde(alias = "keyId")]
-    pub key_id: String,
-    pub status: KeyStatus,
-    #[serde(alias = "updatedAt")]
-    pub updated_at: DateTime<Utc>,
-}
+/// Decode target for `keys/revoke` — the agent's own body type. See
+/// [`ContextResponse`] for why these are re-exports rather than structs.
+pub use crate::protocols::key_management::revoke::RevokeKeyResultBody as InvalidateKeyResponse;
 
 #[derive(Debug, Serialize)]
 pub struct RenameKeyRequest {
     pub key_id: String,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct RenameKeyResponse {
-    #[serde(alias = "keyId")]
-    pub key_id: String,
-    #[serde(alias = "updatedAt")]
-    pub updated_at: DateTime<Utc>,
-}
+/// Decode target for `keys/rename` — the agent's own body type.
+pub use crate::protocols::key_management::rename::RenameKeyResultBody as RenameKeyResponse;
 
-#[derive(Debug, Deserialize)]
-pub struct GetKeySecretResponse {
-    #[serde(alias = "keyId")]
-    pub key_id: String,
-    #[serde(alias = "keyType")]
-    pub key_type: KeyType,
-    #[serde(alias = "publicKeyMultibase")]
-    pub public_key_multibase: String,
-    #[serde(alias = "privateKeyMultibase")]
-    pub private_key_multibase: String,
-}
+/// Decode target for `seeds/export-mnemonic` — the agent's own body type.
+///
+/// Carries a real improvement beyond deduplication: the struct this replaces
+/// derived `Debug`, so `{:?}` on a response printed the **raw private key**.
+/// The agent's type hand-writes `Debug` to redact it, precisely so a caller
+/// cannot tracing-log it by accident.
+pub use crate::protocols::key_management::secret::GetKeySecretResultBody as GetKeySecretResponse;
 
-/// Response from the `keys/sign` Trust Task.
-#[derive(Debug, Deserialize)]
-pub struct SignResponse {
-    #[serde(alias = "keyId")]
-    pub key_id: String,
-    pub signature: String,
-    pub algorithm: SignAlgorithm,
-}
+/// Decode target for `keys/sign` — the agent's own body type.
+pub use crate::protocols::key_management::sign::SignResultBody as SignResponse;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ListKeysResponse {
@@ -363,31 +340,16 @@ pub struct ErrorResponse {
 
 // ── Seed types ──────────────────────────────────────────────────────
 
-/// Nested element of [`ListSeedsResponse`].
+/// Nested element of [`ListSeedsResponse`] — the agent's own body type.
 ///
-/// The agent's counterpart
-/// ([`SeedInfo`](crate::protocols::seed_management::list::SeedInfo)) is the one
-/// payload struct #1000 left *without* `rename_all`, so it still emits
-/// snake_case and its own `alias = "created_at"` attributes are inert. These
-/// aliases are therefore pre-emptive: they cost nothing today and mean this type
-/// keeps decoding when `SeedInfo` is folded, instead of breaking a release later
-/// for a reason nobody will connect to that change.
-#[derive(Debug, Deserialize)]
-pub struct SeedInfoResponse {
-    pub id: u32,
-    pub status: String,
-    #[serde(alias = "createdAt")]
-    pub created_at: DateTime<Utc>,
-    #[serde(alias = "retiredAt")]
-    pub retired_at: Option<DateTime<Utc>>,
-}
+/// Note that `SeedInfo` is the one payload struct #1000 left without
+/// `rename_all`, so it still emits snake_case and its own `alias` attributes are
+/// inert (#1034). Sharing the type means that when #1034 folds it, both ends
+/// move together and there is nothing here to forget.
+pub use crate::protocols::seed_management::list::SeedInfo as SeedInfoResponse;
 
-#[derive(Debug, Deserialize)]
-pub struct ListSeedsResponse {
-    pub seeds: Vec<SeedInfoResponse>,
-    #[serde(alias = "activeSeedId")]
-    pub active_seed_id: u32,
-}
+/// Decode target for `seeds/list` — the agent's own body type.
+pub use crate::protocols::seed_management::list::ListSeedsResultBody as ListSeedsResponse;
 
 #[derive(Debug, Serialize)]
 pub struct RotateSeedRequest {
@@ -395,13 +357,8 @@ pub struct RotateSeedRequest {
     pub mnemonic: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct RotateSeedResponse {
-    #[serde(alias = "previousSeedId")]
-    pub previous_seed_id: u32,
-    #[serde(alias = "newSeedId")]
-    pub new_seed_id: u32,
-}
+/// Decode target for `seeds/rotate` — the agent's own body type.
+pub use crate::protocols::seed_management::rotate::RotateSeedResultBody as RotateSeedResponse;
 
 // ── ACL types ───────────────────────────────────────────────────────
 

--- a/vta-sdk/tests/trust_task_decode.rs
+++ b/vta-sdk/tests/trust_task_decode.rs
@@ -1,5 +1,6 @@
-//! The seam nothing tested: does what the **agent serializes** decode into what
-//! the **client deserializes**?
+//! The seam between what the **agent serializes** and what the **client
+//! deserializes**, for the call sites where those are still two different
+//! types.
 //!
 //! # Why this file exists
 //!
@@ -14,11 +15,18 @@
 //!   emitting.
 //! - Nothing compared those two fixtures, so they disagreed for days.
 //!
-//! Both fixtures were hand-written, and only one was maintained. This file takes
-//! the fixtures out of the loop: it constructs the **agent's own body type**,
-//! serializes it exactly as the agent would, and requires the **client's own
-//! decode type** to accept the bytes. No JSON literal appears anywhere below, so
-//! there is no third spelling to drift.
+//! # Most of what this file used to hold is gone, and that is the point
+//!
+//! It opened with nine cases covering the types #1033 repaired with `serde`
+//! aliases. #1035 then collapsed each of those onto the agent's own body type,
+//! so the client and the agent no longer have separate structs to disagree
+//! about. Serializing one of them and decoding it back would now assert that
+//! `serde` round-trips a type through itself — true of every type everywhere,
+//! and no longer a fact about this codebase. They were deleted rather than kept
+//! as reassurance.
+//!
+//! What is left is the genuine article: response types that really are a
+//! *different shape* from the agent's, by design.
 //!
 //! # What a failure here means
 //!
@@ -26,14 +34,8 @@
 //! any current agent — not a stylistic complaint. Fix the types; do not adjust
 //! the test to agree with them.
 //!
-//! # Scope, stated honestly
-//!
-//! This covers the 11 Trust-Task call sites whose client decode type differs
-//! from the agent's serialize type (all in `client/types.rs`). The other 50
-//! decode the *same* struct both ends and cannot drift this way — that is a
-//! property of the type graph, and `same_type_sites_cannot_drift` below records
-//! why they are excluded rather than leaving the omission to look like an
-//! oversight.
+//! `trust_task_decode_census.rs` is what keeps this file honest: it refuses any
+//! new client-private decode type that does not appear here.
 
 // The decode targets under test live behind `client`; without it there is no
 // client half of the seam to check.
@@ -41,21 +43,9 @@
 
 use chrono::{TimeZone, Utc};
 
-use vta_sdk::client::{
-    AclEntryResponse, AclListResponse, ContextListResponse, ContextResponse, GetKeySecretResponse,
-    InvalidateKeyResponse, ListSeedsResponse, RenameKeyResponse, RotateSeedResponse, SignResponse,
-};
-use vta_sdk::keys::{KeyStatus, KeyType};
+use vta_sdk::client::{AclEntryResponse, AclListResponse, ContextResponse, RenameKeyResponse};
 use vta_sdk::protocols::acl_management::entry::AclEntry;
 use vta_sdk::protocols::acl_management::list::ListAclResultBody;
-use vta_sdk::protocols::context_management::create::CreateContextResultBody;
-use vta_sdk::protocols::context_management::list::ListContextsResultBody;
-use vta_sdk::protocols::key_management::rename::RenameKeyResultBody;
-use vta_sdk::protocols::key_management::revoke::RevokeKeyResultBody;
-use vta_sdk::protocols::key_management::secret::GetKeySecretResultBody;
-use vta_sdk::protocols::key_management::sign::{SignAlgorithm, SignResultBody};
-use vta_sdk::protocols::seed_management::list::{ListSeedsResultBody, SeedInfo};
-use vta_sdk::protocols::seed_management::rotate::RotateSeedResultBody;
 
 /// Serialize what the agent returns, then decode it as the client does.
 ///
@@ -76,8 +66,9 @@ where
              \n  agent emitted: {wire}\n  client decode: {e}\n\
              \n\
              The client's decode type disagrees with the body the agent \
-             serializes. Add the missing `#[serde(alias = \"...\")]` in \
-             vta-sdk/src/client/types.rs — do not change this test.",
+             serializes. Fix the type in vta-sdk/src/client/types.rs — best by \
+             re-exporting the agent's body (#1035) rather than mirroring it. Do \
+             not change this test.",
             surface = surface,
         ),
     }
@@ -87,135 +78,16 @@ fn ts() -> chrono::DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 8, 19, 9, 0, 0).unwrap()
 }
 
-fn agent_context() -> CreateContextResultBody {
-    CreateContextResultBody {
-        id: "personal".into(),
-        name: "Personal".into(),
-        did: None,
-        description: None,
-        parent: None,
-        base_path: "m/26'/2'/0'".into(),
-        created_at: ts(),
-        updated_at: ts(),
-    }
-}
-
-// ── Contexts ────────────────────────────────────────────────────────
-
-/// `pnm contexts create` — the one a user actually hit.
-#[test]
-fn contexts_create_decodes() {
-    let got: ContextResponse = agent_to_client("pnm contexts create", &agent_context());
-    assert_eq!(got.base_path, "m/26'/2'/0'");
-    assert_eq!(got.created_at, ts());
-    assert_eq!(got.updated_at, ts());
-}
-
-/// `contexts/get` and `contexts/update{,-did}` return the same body type, so one
-/// case covers the decode for all three call sites.
-#[test]
-fn contexts_get_and_update_decode() {
-    let got: ContextResponse = agent_to_client("pnm contexts show / update", &agent_context());
-    assert_eq!(got.id, "personal");
-}
-
-/// `pnm contexts list` — the nested case. The outer struct has only a
-/// single-word member, so the break lives one level down; decoding the outer
-/// alone would pass while the element still failed.
-#[test]
-fn contexts_list_decodes_including_its_elements() {
-    let agent = ListContextsResultBody {
-        contexts: vec![agent_context()],
-    };
-    let got: ContextListResponse = agent_to_client("pnm contexts list", &agent);
-    assert_eq!(got.contexts.len(), 1, "the element must survive the decode");
-    assert_eq!(got.contexts[0].base_path, "m/26'/2'/0'");
-}
-
-// ── Keys ────────────────────────────────────────────────────────────
-
-#[test]
-fn keys_sign_decodes() {
-    let agent = SignResultBody {
-        key_id: "key-1".into(),
-        signature: "z3sig".into(),
-        algorithm: SignAlgorithm::EdDSA,
-    };
-    let got: SignResponse = agent_to_client("pnm keys sign", &agent);
-    assert_eq!(got.key_id, "key-1");
-}
-
-#[test]
-fn keys_rename_decodes() {
-    let agent = RenameKeyResultBody {
-        key_id: "key-1".into(),
-        updated_at: ts(),
-    };
-    let got: RenameKeyResponse = agent_to_client("pnm keys rename", &agent);
-    assert_eq!(got.key_id, "key-1");
-    assert_eq!(got.updated_at, ts());
-}
-
-#[test]
-fn keys_revoke_decodes() {
-    let agent = RevokeKeyResultBody {
-        key_id: "key-1".into(),
-        status: KeyStatus::Revoked,
-        updated_at: ts(),
-    };
-    let got: InvalidateKeyResponse = agent_to_client("pnm keys revoke", &agent);
-    assert_eq!(got.key_id, "key-1");
-    assert_eq!(got.updated_at, ts());
-}
-
-#[test]
-fn keys_get_secret_decodes() {
-    let agent = GetKeySecretResultBody {
-        key_id: "key-1".into(),
-        key_type: KeyType::Ed25519,
-        public_key_multibase: "z6Mkpub".into(),
-        private_key_multibase: "z3priv".into(),
-    };
-    let got: GetKeySecretResponse = agent_to_client("pnm keys export-secret", &agent);
-    assert_eq!(got.key_id, "key-1");
-    assert_eq!(got.public_key_multibase, "z6Mkpub");
-    assert_eq!(got.private_key_multibase, "z3priv");
-}
-
-// ── Seeds ───────────────────────────────────────────────────────────
-
-#[test]
-fn seeds_rotate_decodes() {
-    let agent = RotateSeedResultBody {
-        previous_seed_id: 1,
-        new_seed_id: 2,
-    };
-    let got: RotateSeedResponse = agent_to_client("pnm seeds rotate", &agent);
-    assert_eq!(got.previous_seed_id, 1);
-    assert_eq!(got.new_seed_id, 2);
-}
-
-/// `seeds/list` is the asymmetric one: the outer body carries `rename_all`, the
-/// nested `SeedInfo` does not. Asserting the nested timestamp as well as the
-/// outer id is what keeps this honest if `SeedInfo` is folded later.
-#[test]
-fn seeds_list_decodes_including_its_elements() {
-    let agent = ListSeedsResultBody {
-        seeds: vec![SeedInfo {
-            id: 1,
-            status: "active".into(),
-            created_at: ts(),
-            retired_at: None,
-        }],
-        active_seed_id: 1,
-    };
-    let got: ListSeedsResponse = agent_to_client("pnm seeds list", &agent);
-    assert_eq!(got.active_seed_id, 1);
-    assert_eq!(got.seeds.len(), 1, "the element must survive the decode");
-    assert_eq!(got.seeds[0].created_at, ts());
-}
-
 // ── ACL ─────────────────────────────────────────────────────────────
+//
+// The one family where two types is the right answer. `AclEntryResponse` is not
+// a mirror of `AclEntry` — it renames `subject` to `did` and `scopes` to
+// `allowed_contexts`, and converts RFC 3339 to the epoch seconds the rest of the
+// CLI speaks. That conversion is the reason it exists, and the reason it cannot
+// simply be re-exported the way the others were.
+//
+// Which also makes it the one that most needs checking: an adapter with real
+// logic can be wrong in ways a mirror cannot.
 
 /// A representative entry, with every optional member **set**.
 ///
@@ -246,13 +118,11 @@ fn agent_acl_entry() -> AclEntry {
 /// These decode a `pub(crate)` `{ entry }` envelope, which a `tests/` file
 /// cannot name — and which cannot drift anyway, its one member being
 /// single-word. The seam that *can* drift is the entry inside it, so that is
-/// what is asserted: the agent's `AclEntry` into the client's
-/// `AclEntryResponse`, which renames `subject`→`did` and `scopes`→
-/// `allowed_contexts` and converts RFC 3339 to epoch seconds.
+/// what is asserted.
 ///
-/// The audit for #1033 classified this pair safe by reading the attributes on
-/// both types. That reading was right — and it is the same kind of reasoning
-/// that classified `client/types.rs` as REST bodies, so it is a check now.
+/// #1033's audit classified this pair safe by reading the attributes on both
+/// types. That reading was right — and it is the same kind of reasoning that
+/// classified `client/types.rs` as REST bodies, so it is a check now.
 #[test]
 fn acl_entry_decodes() {
     let got: AclEntryResponse =
@@ -292,15 +162,20 @@ fn acl_list_decodes_including_its_elements() {
 
 /// An agent from **before** #1000 still decodes.
 ///
-/// The aliases are Postel's rule: camelCase is what a current agent sends, and
-/// snake_case is what one running an older release sends. The fixtures in
-/// `client_rest.rs` used to be the only thing covering the snake_case half, and
-/// re-cutting them to camelCase would have retired that coverage silently — the
-/// failure mode #1019 called out when it annotated the last such case.
+/// camelCase is what a current agent sends; snake_case is what one running an
+/// older release sends, and the `alias` attributes on the agent's bodies are
+/// what accept it. The fixtures in `client_rest.rs` used to be the only thing
+/// covering that half, and re-cutting them to camelCase in #1033 would have
+/// retired the coverage silently — the failure mode #1019 called out when it
+/// annotated the last such case.
 ///
-/// So it is asserted here explicitly, where the name says why it exists. This is
-/// the one place a JSON literal is correct in this file: no current type
-/// *serializes* the retired spelling, so there is nothing to derive it from.
+/// So it is asserted here, where the name says why it exists. This is the one
+/// place a JSON literal is correct in this file: no current type *serializes*
+/// the retired spelling, so there is nothing to derive it from.
+///
+/// Still meaningful after #1035 — arguably more so. These now exercise the
+/// aliases on the **agent's** types, which is where every consumer's backward
+/// compatibility comes from, not just this client's.
 #[test]
 fn a_legacy_agent_snake_case_response_still_decodes() {
     let legacy = serde_json::json!({
@@ -325,24 +200,24 @@ fn a_legacy_agent_snake_case_response_still_decodes() {
 
 // ── The exclusion, recorded ─────────────────────────────────────────
 
-/// Why the other 50 Trust-Task call sites are absent.
+/// Why almost every Trust-Task call site is absent from this file.
 ///
-/// They decode the **same struct** the agent serializes (`protocols::**`), so a
-/// casing change moves both ends at once and this class of drift is structurally
-/// impossible — not merely untested. Re-serializing a shared type through itself
-/// would assert that `serde` round-trips, which is not a property of this
-/// codebase.
+/// They decode the **same struct** the agent serializes, so a casing change
+/// moves both ends at once and this class of drift is structurally impossible —
+/// not merely untested. After #1035 that is true of nearly all of them, the ACL
+/// adapter above being the deliberate exception.
 ///
 /// This exists so a reader counting call sites finds the reason here rather than
 /// assuming the coverage was simply incomplete. If a future change gives one of
-/// those sites its own decode type, it belongs in this file.
+/// those sites its own decode type, the census will demand it appear here.
 #[test]
 fn same_type_sites_cannot_drift() {
-    // A representative of the safe shape: the client's `create_key` decodes
-    // `CreateKeyResponseBody`, which is the very type the agent's handler
-    // returns. One type, one spelling, nothing to disagree about.
-    fn assert_same<T>(_: std::marker::PhantomData<T>) {}
-    assert_same::<vta_sdk::protocols::key_management::create::CreateKeyResponseBody>(
-        std::marker::PhantomData,
-    );
+    // `ContextResponse` IS the agent's body type now, not a copy of it. Naming
+    // both spellings in one signature only compiles if they are the same type,
+    // which is the property #1035 established.
+    fn assert_same_type(
+        _: vta_sdk::protocols::context_management::create::CreateContextResultBody,
+    ) {
+    }
+    let _: fn(ContextResponse) = assert_same_type;
 }

--- a/vta-sdk/tests/trust_task_decode_census.rs
+++ b/vta-sdk/tests/trust_task_decode_census.rs
@@ -61,20 +61,21 @@ use syn::{ImplItem, Item, ReturnType, Type};
 ///
 /// Every name here should disappear as #1035 collapses the pairs.
 const COVERED_BY_SEAM_TEST: &[&str] = &[
-    "ContextResponse",
-    "ContextListResponse",
-    "SignResponse",
-    "RenameKeyResponse",
-    "InvalidateKeyResponse",
-    "GetKeySecretResponse",
-    "RotateSeedResponse",
-    "ListSeedsResponse",
-    // Not part of the #1033 outage — classified safe by reading the attributes
-    // on both types. That reading was right, but it is the same kind of
-    // reasoning that classified `client/types.rs` as REST bodies, so it is now a
-    // check rather than a conclusion.
+    // The ACL pair is the one place two types is the right answer:
+    // `AclEntryResponse` renames `subject`→`did` and `scopes`→`allowed_contexts`
+    // and converts RFC 3339 to epoch seconds, so it cannot simply re-export the
+    // agent's `AclEntry`. An adapter carrying real logic can be wrong in ways a
+    // mirror cannot, which is why it is checked rather than reasoned about.
     "AclListResponse",
 ];
+
+// The eight names that used to sit above — ContextResponse, ContextListResponse,
+// SignResponse, RenameKeyResponse, InvalidateKeyResponse, GetKeySecretResponse,
+// RotateSeedResponse, ListSeedsResponse — are gone because the types are gone.
+// #1035 replaced each with a `pub use` of the agent's own body, so they are no
+// longer defined under `src/client/` and this census no longer classifies them
+// as private. That is the intended end state: the list shrinks as the duplicates
+// are removed, rather than growing as they are papered over.
 
 /// Client-private types that are nonetheless safe, each with the reason.
 ///

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -770,25 +770,14 @@ pub async fn run_keys_bundle(
     .await
 }
 
-/// Convert a server-side `CreateContextResultBody` (the operations-layer
-/// return type) to the client-side `ContextResponse` shape that the
-/// shared `vta_cli_common::commands::contexts::render_*` helpers
-/// consume. Field-by-field copy — the two types are identical on the
-/// wire; this adapter exists only because they're declared in
-/// different modules for layering reasons.
-fn to_context_response(
-    record: &vta_sdk::protocols::context_management::create::CreateContextResultBody,
-) -> vta_sdk::client::ContextResponse {
-    vta_sdk::client::ContextResponse {
-        id: record.id.clone(),
-        name: record.name.clone(),
-        did: record.did.clone(),
-        description: record.description.clone(),
-        base_path: record.base_path.clone(),
-        created_at: record.created_at,
-        updated_at: record.updated_at,
-    }
-}
+// The `to_context_response` adapter that used to sit here is gone (#1035).
+//
+// It copied a `CreateContextResultBody` field-by-field into the client's
+// separate `ContextResponse`, and its comment said the two were "identical on
+// the wire". They were not: the client struct had no `parent`, so this silently
+// dropped it and `vta contexts create --parent x` rendered the new context with
+// no parent shown. Both are now one type, so the render helpers take the record
+// directly and the member cannot go missing.
 
 /// `vta contexts create` — offline equivalent of `POST /contexts`
 /// (and `pnm contexts create`).
@@ -865,7 +854,7 @@ pub async fn run_context_create(
     cs.persist().await?;
 
     println!("Context created:");
-    render_context_record(&to_context_response(&record));
+    render_context_record(&record);
     Ok(())
 }
 
@@ -885,7 +874,7 @@ pub async fn run_context_list(
     let resp = crate::operations::contexts::list_contexts(&contexts_ks, &auth, "vta-contexts-list")
         .await?;
 
-    let contexts: Vec<_> = resp.contexts.iter().map(to_context_response).collect();
+    let contexts = resp.contexts;
     render_context_list(&contexts);
     Ok(())
 }
@@ -908,7 +897,7 @@ pub async fn run_context_get(
         crate::operations::contexts::get_context_op(&contexts_ks, &auth, &id, "vta-contexts-get")
             .await?;
 
-    render_context_record(&to_context_response(&record));
+    render_context_record(&record);
     Ok(())
 }
 
@@ -947,7 +936,7 @@ pub async fn run_context_update(
 
     cs.persist().await?;
     println!("Context updated:");
-    render_context_record(&to_context_response(&record));
+    render_context_record(&record);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1035.

#1033 fixed eleven Trust-Task call sites where the client's decode type had drifted from the agent's body — breaking every `pnm contexts` command, four `pnm keys` commands, seed rotate/list, and the MCP surface. It fixed them with `serde` aliases, which restores compatibility without removing the hazard: the wire still had **two structs**, and either could move alone again.

The audit behind #1033 found the correlation was total. Of 61 call sites, the 50 decoding a shared `protocols::**` type were all fine; all 11 with a private type in `client/types.rs` were broken. That is not a coincidence to test around — it is the defect.

## What changed

Each of the eight duplicates is now a `pub use` of the body the agent serializes:

| client name (unchanged) | now refers to |
|---|---|
| `ContextResponse` | `context_management::create::CreateContextResultBody` |
| `ContextListResponse` | `context_management::list::ListContextsResultBody` |
| `SignResponse` | `key_management::sign::SignResultBody` |
| `RenameKeyResponse` | `key_management::rename::RenameKeyResultBody` |
| `InvalidateKeyResponse` | `key_management::revoke::RevokeKeyResultBody` |
| `GetKeySecretResponse` | `key_management::secret::GetKeySecretResultBody` |
| `RotateSeedResponse` | `seed_management::rotate::RotateSeedResultBody` |
| `ListSeedsResponse` / `SeedInfoResponse` | `seed_management::list::{ListSeedsResultBody, SeedInfo}` |

The client-facing names are kept, so `get_context` still returns something called `ContextResponse` rather than `CreateContextResultBody`. Two ends cannot disagree when there is one end — a stronger guarantee than any test could give.

## Two bugs a field-by-field mirror was hiding

**`vta contexts create --parent x` rendered no parent.** `bootstrap_cli.rs` carried an adapter whose own comment claimed the two types were "identical on the wire". They were not — the client struct had no `parent`, so the adapter dropped it on every offline context render. The compiler found it the moment the re-export landed:

```
error[E0063]: missing field `parent` in initializer of `ContextResponse`
   --> vta-service/src/bootstrap_cli.rs:782:5
```

Deleting the adapter fixes it.

**`{:?}` on a key-secret response printed the raw private key.** The client's `GetKeySecretResponse` derived `Debug`. The agent's `GetKeySecretResultBody` hand-writes `Debug` to redact `private_key_multibase`, specifically so a caller cannot tracing-log it by accident. Sharing the type inherits the redaction.

## What deliberately stays two types

**The ACL pair.** `AclEntryResponse` renames `subject`→`did` and `scopes`→`allowed_contexts` and converts RFC 3339 to the epoch seconds the CLI speaks. It is an adapter with real logic, not a mirror, so it cannot be re-exported. It keeps its seam cases — and that matters more now, because an adapter that *computes* can be wrong in ways a copy cannot.

**Request builders.** `CreateKeyRequest` and friends exist for ergonomics (`.new(..).label(..)`) and *produce* the wire shape rather than describing it, so they cannot drift this way.

## The tests shrink, on purpose

Nine cases in `trust_task_decode.rs` are deleted. They serialized the agent's body and decoded it into the client's type; with one type on both sides, that now asserts `serde` round-trips a type through itself — true of every type everywhere, and no longer a fact about this codebase.

Keeping them as reassurance would be keeping exactly the kind of vacuous assertion that let `acl/update` ship broken through three PRs (#856). What remains is still real: the ACL adapter, and the legacy snake_case direction — the latter arguably stronger than before, since it now exercises the intake aliases on the **agent's** types, where every consumer's backward compatibility comes from rather than just this client's.

`COVERED_BY_SEAM_TEST` drops from nine names to one. That is the shape the census was built for: the list shrinks as duplicates are removed, rather than growing as they are papered over.

**The census was re-verified after the collapse**, not assumed — re-injecting a fresh client-private decode type still fails it by name (`probe_temp -> ProbeResponse`). Its empty-scan floor still holds.

## Verification

- `cargo check --workspace --all-targets`, `cargo fmt --check`, `cargo clippy --workspace --all-targets` all clean.
- Full `cargo test --workspace`: every target green except the four `vtc-service` `admin_ui::tests`, which fail on the `VTC_SKIP_ADMIN_UI_BUILD=1` flag leaving the embedded dir empty — the flag, not this change.
- Net −178 lines.

## Breaking change

`vta_sdk::client`'s Trust-Task response types are now re-exports rather than distinct structs. Code that **names** them keeps compiling; code that **constructs** one with a struct literal does not, because the field sets differ (`ContextResponse` gains `parent`).

That break is the point — the one such site in this workspace was silently dropping a member. Flagged as `BREAKING CHANGE:` in the commit body; no `version =` touched.

## Follow-on

#1034 (dead `serde` aliases on `SeedInfo` / `CapabilitiesResponse`) gets easier from here: `SeedInfoResponse` is now the same type as `SeedInfo`, so folding it moves both ends at once with nothing on this side to forget.
