### PR TITLE
fix(sdk): finish the seeds/list fold, and make an inert alias fail the build

### DIFF
--- a/vta-sdk/src/protocols/seed_management/list.rs
+++ b/vta-sdk/src/protocols/seed_management/list.rs
@@ -9,8 +9,29 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct ListSeedsBody {}
 
+/// One seed record as `seeds/list` reports it.
+///
+/// # The `rename_all` here is load-bearing
+///
+/// #1000 folded Trust Task payloads to lowerCamelCase per SPEC §4.10 and added
+/// the aliases below — but not `rename_all`, without which an alias equal to the
+/// field's own name is a no-op. So this stayed snake_case while
+/// [`ListSeedsResultBody`] around it moved, and `seeds/list` emitted a body that
+/// disagreed with itself:
+///
+/// ```json
+/// {"seeds":[{"id":1,"status":"active","created_at":"…"}],"activeSeedId":1}
+/// ```
+///
+/// That is not a preserved contract, it is half a fold (#1034). Finished here;
+/// the aliases now do the Postel job they were written for, so a producer still
+/// sending `created_at` keeps decoding.
+///
+/// `tests/inert_alias_census.rs` is what makes this stick — it fails on any
+/// alias that accepts only what would be accepted anyway.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct SeedInfo {
     pub id: u32,
     pub status: String,

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -642,14 +642,13 @@ async fn list_seeds_returns_active() {
         "GET",
         "/keys/seeds",
         200,
-        // `seeds[]` is deliberately snake_case while `activeSeedId` is not:
-        // that asymmetry is what the agent really emits, because #1000 folded
-        // `ListSeedsResultBody` and left the nested `SeedInfo` alone. Making
-        // this fixture uniformly camelCase would describe an agent that does
-        // not exist. See `tests/trust_task_decode.rs::seeds_list_*`.
+        // Uniformly camelCase since #1034 folded the nested `SeedInfo`. This
+        // fixture previously carried a snake_case `seeds[]` inside a camelCase
+        // `activeSeedId` — the half-folded body #1000 actually left behind. That
+        // asymmetry is gone, so describing it here would now be the fiction.
         json!({
             "seeds": [
-                {"id": 1, "status": "active", "created_at": "2026-01-01T00:00:00Z", "retired_at": null}
+                {"id": 1, "status": "active", "createdAt": "2026-01-01T00:00:00Z", "retiredAt": null}
             ],
             "activeSeedId": 1
         }),

--- a/vta-sdk/tests/inert_alias_census.rs
+++ b/vta-sdk/tests/inert_alias_census.rs
@@ -147,14 +147,12 @@ fn aliases(attrs: &[syn::Attribute]) -> Vec<String> {
         let mut cursor = tokens.as_str();
         while let Some(idx) = cursor.find("alias") {
             let rest = &cursor[idx..];
-            if let Some(open) = rest.find('"') {
-                if let Some(close) = rest[open + 1..].find('"') {
-                    found.push(rest[open + 1..open + 1 + close].to_string());
-                    cursor = &rest[open + 1 + close..];
-                    continue;
-                }
-            }
-            break;
+            let Some(open) = rest.find('"') else { break };
+            let Some(close) = rest[open + 1..].find('"') else {
+                break;
+            };
+            found.push(rest[open + 1..open + 1 + close].to_string());
+            cursor = &rest[open + 1 + close..];
         }
     }
     found

--- a/vta-sdk/tests/inert_alias_census.rs
+++ b/vta-sdk/tests/inert_alias_census.rs
@@ -1,0 +1,352 @@
+//! Census: no `#[serde(alias = "…")]` under `protocols/` may be a no-op.
+//!
+//! ## The invariant
+//!
+//! An alias exists so a member spelled the *old* way still decodes. If the alias
+//! equals the member's own serialized name, it accepts what would be accepted
+//! anyway and buys nothing — and its presence claims a fold happened that did
+//! not.
+//!
+//! That is not a tidiness complaint. It is how #1000 half-shipped.
+//!
+//! ## What it missed, and why nobody noticed
+//!
+//! #1000 folded 53 wire structs to lowerCamelCase and gave 126 members an alias
+//! for the retired spelling. Two structs got the aliases and **not** the
+//! `#[serde(rename_all = "camelCase")]` that gives them meaning, so they kept
+//! emitting snake_case with `alias = "created_at"` sitting on a member already
+//! called `created_at`:
+//!
+//! - `SeedInfo` — inside `ListSeedsResultBody`, which *was* folded. `seeds/list`
+//!   therefore emitted a body that disagreed with itself,
+//!   `{"seeds":[{"created_at":…}],"activeSeedId":1}`. Fixed in #1034.
+//! - `CapabilitiesResponse` — still open, see [`INERT_BY_DECISION`].
+//!
+//! Both were found by hand, months later, while auditing something else. Nothing
+//! failed: the code compiled, every test passed, and the attributes read as
+//! though the work was done. A reviewer looking at the diff sees `alias =
+//! "created_at"` and reasonably assumes the member is now `createdAt`.
+//!
+//! ## Why the class, not the instances
+//!
+//! Fixing the two found instances leaves the next fold free to repeat it, and
+//! the next fold is coming — the REST bodies #1000 deferred are still snake_case.
+//! An inert alias is decidable from the source, so it is decided here, once, for
+//! every wire type at the same time.
+//!
+//! Parsed with `syn`, like [`payload_null_census`](../payload_null_census.rs) and
+//! for the same reason: these attributes wrap across lines, and a line-oriented
+//! regex misreads them in the direction that lets a violation through.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use syn::{Fields, Item, ItemStruct, Meta};
+
+/// Structs whose inert aliases are a **recorded decision**, not an oversight.
+///
+/// An entry says: this type deliberately still emits snake_case, and the alias
+/// is kept for the fold that is coming. Anything else belongs in a fix.
+const INERT_BY_DECISION: &[(&str, &str)] = &[
+    (
+        "CapabilitiesResponse",
+        "Served on `GET /capabilities` as well as the Trust-Task and DIDComm \
+         surfaces. #1000 never touched its emission, so folding it is a fresh \
+         REST wire change of exactly the kind that PR deferred — not the \
+         completion of a half-done one, which is what made SeedInfo \
+         unambiguous. Tracked in #1039; the aliases stay so the eventual fold \
+         is a one-line change.",
+    ),
+    (
+        "UpdateRetentionBody",
+        "Found by this census, not by anyone reading the file. Its sibling \
+         `RetentionResultBody` — one screen down, same task — IS folded, so \
+         `audit/update-retention` takes a snake_case request and returns a \
+         camelCase response. Plainly a miss. Deferred anyway because it is a \
+         REQUEST body: folding changes what clients SEND, on the Trust-Task, \
+         DIDComm and REST surfaces at once, and an agent that predates the \
+         change rejects the new spelling. SeedInfo is safe to finish precisely \
+         because its containing body already moved; this one has not moved at \
+         all. Tracked in #1039.",
+    ),
+];
+
+/// One alias that accepts what would be accepted anyway.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Violation {
+    file: String,
+    strukt: String,
+    field: String,
+    alias: String,
+}
+
+fn protocols_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("protocols")
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("protocols/ is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// `snake_case` → `camelCase`, matching what `serde`'s `rename_all` does.
+fn to_camel(ident: &str) -> String {
+    let mut out = String::with_capacity(ident.len());
+    let mut upper_next = false;
+    for c in ident.chars() {
+        if c == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.extend(c.to_uppercase());
+            upper_next = false;
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// The container-level `rename_all` value, if any.
+fn rename_all(attrs: &[syn::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Meta::List(l) = &attr.meta else { continue };
+        let tokens = l.tokens.to_string();
+        if let Some(idx) = tokens.find("rename_all") {
+            // `rename_all = "camelCase"` — take the next quoted run.
+            let rest = &tokens[idx..];
+            if let Some(open) = rest.find('"')
+                && let Some(close) = rest[open + 1..].find('"')
+            {
+                return Some(rest[open + 1..open + 1 + close].to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Every `alias = "…"` on a field.
+fn aliases(attrs: &[syn::Attribute]) -> Vec<String> {
+    let mut found = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Meta::List(l) = &attr.meta else { continue };
+        let tokens = l.tokens.to_string();
+        let mut cursor = tokens.as_str();
+        while let Some(idx) = cursor.find("alias") {
+            let rest = &cursor[idx..];
+            if let Some(open) = rest.find('"') {
+                if let Some(close) = rest[open + 1..].find('"') {
+                    found.push(rest[open + 1..open + 1 + close].to_string());
+                    cursor = &rest[open + 1 + close..];
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+    found
+}
+
+/// The field's explicit `rename = "…"`, if any. Wins over `rename_all`.
+fn explicit_rename(attrs: &[syn::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Meta::List(l) = &attr.meta else { continue };
+        let tokens = l.tokens.to_string();
+        // Careful: `rename_all` contains `rename`. Only a bare `rename` counts.
+        for (idx, _) in tokens.match_indices("rename") {
+            if tokens[idx..].starts_with("rename_all") {
+                continue;
+            }
+            let rest = &tokens[idx..];
+            if let Some(open) = rest.find('"')
+                && let Some(close) = rest[open + 1..].find('"')
+            {
+                return Some(rest[open + 1..open + 1 + close].to_string());
+            }
+        }
+    }
+    None
+}
+
+/// What this member is actually called on the wire.
+fn effective_name(field_ident: &str, attrs: &[syn::Attribute], container: Option<&str>) -> String {
+    if let Some(explicit) = explicit_rename(attrs) {
+        return explicit;
+    }
+    match container {
+        Some("camelCase") => to_camel(field_ident),
+        // Only camelCase is used in this crate; anything else is reported as-is
+        // rather than guessed at, so a new convention surfaces here rather than
+        // being silently mis-evaluated.
+        _ => field_ident.to_string(),
+    }
+}
+
+fn inspect(strukt: &ItemStruct, file: &str, out: &mut Vec<Violation>) {
+    let container = rename_all(&strukt.attrs);
+    let Fields::Named(fields) = &strukt.fields else {
+        return;
+    };
+    for field in &fields.named {
+        let Some(ident) = &field.ident else { continue };
+        let ident = ident.to_string();
+        let effective = effective_name(&ident, &field.attrs, container.as_deref());
+        for alias in aliases(&field.attrs) {
+            if alias == effective {
+                out.push(Violation {
+                    file: file.to_string(),
+                    strukt: strukt.ident.to_string(),
+                    field: ident.clone(),
+                    alias,
+                });
+            }
+        }
+    }
+}
+
+/// No alias under `protocols/` accepts only what is already accepted.
+#[test]
+fn no_wire_type_carries_an_inert_alias() {
+    let mut files = Vec::new();
+    rust_sources(&protocols_dir(), &mut files);
+    files.sort();
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+    for path in &files {
+        let src = fs::read_to_string(path).expect("wire source is readable");
+        let ast = syn::parse_file(&src).expect("wire source parses");
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+        for item in ast.items {
+            if let Item::Struct(s) = item {
+                inspect(&s, &rel, &mut violations);
+            }
+        }
+    }
+    violations.sort();
+
+    let excused: Vec<&str> = INERT_BY_DECISION.iter().map(|(s, _)| *s).collect();
+    let unexcused: Vec<&Violation> = violations
+        .iter()
+        .filter(|v| !excused.contains(&v.strukt.as_str()))
+        .collect();
+
+    assert!(
+        unexcused.is_empty(),
+        "these `serde(alias)` attributes accept only what is already accepted:\n{}\n\n\
+         An alias equal to the member's own serialized name does nothing, and \
+         implies a fold that did not happen. Either:\n\
+         \n\
+         - add `#[serde(rename_all = \"camelCase\")]` to the container, which is \
+           what the alias was written to accompany; or\n\
+         - if this type is deliberately staying snake_case, record it in \
+           INERT_BY_DECISION with the reason.\n\
+         \n\
+         Deleting the alias is usually wrong — it is the only thing that will let \
+         an older producer keep working once the fold lands.",
+        unexcused
+            .iter()
+            .map(|v| format!(
+                "  {}: {}.{} — alias = \"{}\"",
+                v.file, v.strukt, v.field, v.alias
+            ))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Every name in [`INERT_BY_DECISION`] is still inert.
+///
+/// Without this the exception list only grows: a type could be folded and its
+/// entry left behind, quietly excusing a struct that no longer needs it — and
+/// the next genuine violation in that struct would pass unnoticed.
+#[test]
+fn the_exception_list_has_no_stale_entries() {
+    let mut files = Vec::new();
+    rust_sources(&protocols_dir(), &mut files);
+
+    let mut violations = Vec::new();
+    for path in &files {
+        let src = fs::read_to_string(path).expect("wire source is readable");
+        let ast = syn::parse_file(&src).expect("wire source parses");
+        for item in ast.items {
+            if let Item::Struct(s) = item {
+                inspect(&s, "", &mut violations);
+            }
+        }
+    }
+
+    let still_inert: Vec<String> = violations.iter().map(|v| v.strukt.clone()).collect();
+    let stale: Vec<&str> = INERT_BY_DECISION
+        .iter()
+        .map(|(s, _)| *s)
+        .filter(|s| !still_inert.contains(&s.to_string()))
+        .collect();
+
+    assert!(
+        stale.is_empty(),
+        "INERT_BY_DECISION excuses these, but they carry no inert alias any more \
+         — they were fixed, and the entry should go:\n  {}",
+        stale.join("\n  ")
+    );
+}
+
+/// The census sees the wire types at all.
+///
+/// A move of `protocols/`, or a `syn` upgrade that changes how these attributes
+/// parse, would leave both tests above passing over an empty set — green because
+/// nothing was examined. The alias count is asserted rather than the file count,
+/// because it is the thing the parser has to actually understand.
+#[test]
+fn the_census_is_not_scanning_an_empty_set() {
+    let mut files = Vec::new();
+    rust_sources(&protocols_dir(), &mut files);
+    assert!(
+        files.len() >= 30,
+        "only {} files under protocols/ — the walk is broken, do not lower this floor",
+        files.len()
+    );
+
+    let root = protocols_dir();
+    let mut total_aliases = 0usize;
+    for path in &files {
+        let src = fs::read_to_string(path).expect("wire source is readable");
+        let ast = syn::parse_file(&src).expect("wire source parses");
+        for item in ast.items {
+            let Item::Struct(s) = item else { continue };
+            let Fields::Named(fields) = &s.fields else {
+                continue;
+            };
+            for field in &fields.named {
+                total_aliases += aliases(&field.attrs).len();
+            }
+        }
+    }
+    let _ = root;
+    assert!(
+        total_aliases >= 80,
+        "only {total_aliases} serde aliases found under protocols/; #1000 added \
+         126. The attribute parser has stopped understanding them — fix it rather \
+         than lowering this floor."
+    );
+}


### PR DESCRIPTION
Closes #1034. Refs #1039.

`seeds/list` emitted a body that disagreed with itself:

```json
{"seeds":[{"id":1,"status":"active","created_at":"…"}],"activeSeedId":1}
```

#1000 folded Trust Task payloads to lowerCamelCase and gave 126 members an `alias` for the retired spelling. `SeedInfo` got the aliases and **not** the `rename_all` that gives them meaning — and an alias equal to the member's own name is a no-op — so it kept emitting snake_case while `ListSeedsResultBody` around it moved.

Adding the `rename_all` finishes that fold and activates the aliases, so a producer still sending `created_at` keeps decoding.

**Safe to finish precisely because the containing body already moved.** The same REST route (`GET /keys/seeds`) has emitted `activeSeedId` since #1000, and since #1035 the client's `SeedInfoResponse` *is* `SeedInfo`, so both ends move together.

## The class, not the instances

An inert alias is not untidiness — it is how this shipped. The code compiled, every test passed, and the attribute reads as though the work was done; a reviewer seeing `alias = "created_at"` reasonably assumes the member is now `createdAt`. Both known instances were found **by hand, months later, while auditing something else**.

`vta-sdk/tests/inert_alias_census.rs` decides it from the source instead, for every wire type under `protocols/` at once.

**Verified non-vacuous in every direction** — each guard was proven by making it fail, not assumed:

| Guard | Injected | Result |
|---|---|---|
| Catches the original bug | reverted this PR's `rename_all` | reports `SeedInfo.created_at` + `.retired_at` — **red** |
| Catches a new one | inert alias added to an already-folded struct | reports it by file, struct, field — **red** |
| Allow-list can't rot | entry for a type that no longer needs one | reports it as stale — **red** |
| Not scanning nothing | — | floors on files scanned **and** aliases parsed |

That last floor matters: a `syn` upgrade that stopped understanding these attributes would otherwise leave the census green over an empty set — which is the exact failure mode (#1033) that started this whole thread.

## It immediately found a third instance

`UpdateRetentionBody.retention_days` — which nobody knew about, and which is the clearest miss of the three. One screen down **in the same file**, `RetentionResultBody` *is* folded, and even the empty `GetRetentionBody` carries `rename_all`. So `audit/update-retention` currently takes a **snake_case request** and returns a **camelCase response**.

## What is deferred, and why the line is where it is

Both remaining instances are recorded in `INERT_BY_DECISION` with their reasons and tracked in #1039. The distinction is whether folding **completes a change already made** or **starts a new one**:

- **`SeedInfo`** — containing body already moved. Finishing it removes an inconsistency. ✅ done here.
- **`CapabilitiesResponse`** — has not moved at all, and is served on `GET /capabilities` as well as the Trust-Task and DIDComm surfaces. Folding is a fresh REST wire change of exactly the kind #1000 explicitly deferred.
- **`UpdateRetentionBody`** — a **request** body. Folding changes what clients *send*, and an agent predating the change rejects the new spelling. That is the opposite direction from `SeedInfo`, where a new agent's output is absorbed by aliases the client already holds.

**Deleting an inert alias is the wrong repair in every case**, and the census says so at the point where someone would try it: the alias is the only thing that lets an older producer keep working once the fold lands.

## Fixtures

The `client_rest.rs` seeds fixture is re-cut. It carried a comment (added in #1033) explaining that `seeds[]` was snake_case inside a camelCase `activeSeedId` *because that was what the agent really emitted*. That asymmetry is gone, so describing it would now be the fiction.

## Verification

- `cargo check --workspace --all-targets`, `cargo fmt --check`, `cargo clippy --workspace --all-targets` all clean.
- Full `cargo test --workspace`: every target green except the four `vtc-service` `admin_ui::tests`, which fail on `VTC_SKIP_ADMIN_UI_BUILD=1` leaving the embedded dir empty — the flag, not this change.
- New census 3/3, and confirmed running under CI's feature set alongside `trust_task_decode` (4/4) and `trust_task_decode_census` (3/3).
- No conformance witness exists for `seeds/list` (the URI is in `UNSPECCED_DISPATCHED_URIS`), and `api_integration.rs` asserts only `body["seeds"].is_array()`, so no server-side fixture pinned the old nested spelling.
