### PR TITLE
refactor(discovery)!: retire vta/discovery/capabilities — every member had a better home

### DIFF
--- a/docs/05-design-notes/canonical-task-reduction.md
+++ b/docs/05-design-notes/canonical-task-reduction.md
@@ -157,7 +157,7 @@ should be authored **top-level**, not under `vta/`, so other agents can use them
 | `vta/seeds/*` | 3 | Master-seed lifecycle. Meaningless to an agent that is not the key authority. |
 | `vta/attestation/*` | 2 | Nitro/SEV attestation posture. |
 | `vta/audit/{get,update}-retention` | 2 | Extends the canonical `audit/*` family; author as `audit/retention/{show,update}` if generic, else `vta/`. |
-| `vta/discovery/capabilities` | 1 | Overlaps `trust-task-discovery/*` — **needs a diff**. |
+| `vta/discovery/capabilities` | 0 | **Retired (#1043).** Diffed against `trust-task-discovery/0.1`, which is now served; every remaining member duplicated a better source. |
 | `vta/management/reload-services` | 1 | Overlaps `config/reload` — **needs a diff**. |
 
 ### F. Not a task — 1

--- a/docs/05-design-notes/registry-drift-triage.md
+++ b/docs/05-design-notes/registry-drift-triage.md
@@ -134,7 +134,7 @@ Recommendation vocabulary: **spec** (author upstream, URI stays),
 
 | URI | Recommendation |
 |---|---|
-| `vta/discovery/capabilities/1.0` | **Diffed (#1039).** The published `trust-task-discovery/0.1` answers *"which Trust Tasks do you serve"* and is now served, from the dispatch table. What remains here genuinely exceeds it — webvh hosts, DID-creation modes, compiled features — so the recommendation resolves to *"keep, spec the delta"* rather than a straight fold. Still open: whether `features`/`services` should exist at all, given the DID document is already authoritative for what a party speaks. |
+| `vta/discovery/capabilities/1.0` | **RESOLVED — retired (#1039, #1043).** The original recommendation (fold) was right. `trust-task-discovery/0.1` now answers *"which tasks do you serve"*, from the dispatch table. Every other member had a better home: `features`/`services` at the DID document (authoritative for what a party speaks, and these could contradict it); `version` at `GET /health/details`, same auth, same `env!`; `webvhServers` at `webvh/servers/list/1.0`, a strict superset at the same auth; `didCreationModes` nowhere — it had no consumer and its vocabulary existed nowhere else in the codebase. |
 | `vta/management/reload-services/1.0` | Diff against published `config/reload/0.1`. The VTA already folded `vta/config/*` onto `config/{show,patch}` (#840 phase A); reload is the same shape of thing. Expected outcome: **fold onto `config/reload/0.1`, delete**. |
 
 ### `vta/backup/*` — 5 × fold-to-new-canonical (§D)

--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -309,7 +309,6 @@ with no HTTPS transport).
 | URI | Today's surface |
 |---|---|
 | `spec/trust-task-discovery/0.1` | Trust Task only — **the canonical "which tasks do you serve"**, answered from the dispatch table |
-| `spec/vta/discovery/capabilities/1.0` | Trust Task only — VTA deployment inventory (webvh hosts, DID-creation modes, compiled features) |
 
 `GET /capabilities` was removed in #1039. Nothing consumed it, and a REST route
 running parallel to a Trust Task is the shape #1020 removed everywhere else —
@@ -490,7 +489,8 @@ DIDComm protocols:
   backup-management/1.0/{export,import}             → vta/backup/{export,import}/1.0
   did-management/1.0/*                              → vta/webvh/*/1.0 (server + did sub-ops)
   did-template-management/1.0/*                     → vta/did-templates/*/1.0 + vta/contexts/did-templates/*/1.0
-  discovery/1.0/capabilities                        → vta/discovery/capabilities/1.0
+  (discovery/1.0/capabilities                       → RETIRED in #1043 with the
+                                                      task; use trust-task-discovery/0.1)
   join-requests/1.0/*                               → vta/join-requests/*/1.0
   protocol-management/services-management/1.0/*     → vta/services/*/1.0
   provision-integration/1.0/*                       → vta/bootstrap/provision-integration/1.0 (single op now)

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -194,17 +194,14 @@ fn acl_entry_envelope(did: &str) -> Value {
 // ── Discovery / VTA management ──────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn capabilities_via_didcomm() {
+async fn supported_trust_tasks_via_didcomm() {
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0) {
+        if is_tt(msg_type, body, trust_tasks::TASK_TRUST_TASK_DISCOVERY_0_1) {
             tt_ok(
-                trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
+                trust_tasks::TASK_TRUST_TASK_DISCOVERY_0_1,
                 json!({
-                    "version": "0.5.0",
-                    "features": {"webvh": true, "didcomm": true, "tee": false, "rest": true},
-                    "services": {"rest": true, "didcomm": true},
-                    "webvh_servers": [],
-                    "did_creation_modes": ["webvh"]
+                    "frameworkVersion": "0.2",
+                    "supportedTypes": ["https://trusttasks.org/spec/acl/grant/0.1"]
                 }),
             )
         } else {
@@ -213,13 +210,12 @@ async fn capabilities_via_didcomm() {
     })
     .await;
 
-    let caps = client.capabilities().await.unwrap();
-    assert_eq!(caps.version, "0.5.0");
-    // `features.didcomm` was asserted here until #1039. It reported a compile
-    // time `cfg!` flag — what the binary could serve, not what it does — and the
-    // DID document is authoritative for what a party speaks. The transport this
-    // very call arrived on is the better evidence anyway.
-    assert!(caps.webvh_servers.is_empty());
+    // Replaces `capabilities_via_didcomm` (#1043). The property that mattered
+    // there — a discovery answer survives the DIDComm round trip — is unchanged;
+    // the question being asked is the one with a canonical answer.
+    let tasks = client.supported_trust_tasks(&["acl/*"]).await.unwrap();
+    assert_eq!(tasks.framework_version.as_deref(), Some("0.2"));
+    assert_eq!(tasks.supported_types.len(), 1);
 
     shutdown_all(client, responder, mediator).await;
 }
@@ -1265,15 +1261,15 @@ async fn with_didcomm_sequential_cycles_for_same_did_do_not_duel() {
     let (mediator, responder) = TestVtaResponder::spawn_with_mediator(
         vec![client_did.clone()],
         |msg_type: &str, body: &Value| {
-            if is_tt(msg_type, body, trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0) {
+            // Any round-tripping task will do — this test is about session
+            // lifecycle, not about what was asked. Discovery is used because it
+            // needs no state on the responder.
+            if is_tt(msg_type, body, trust_tasks::TASK_TRUST_TASK_DISCOVERY_0_1) {
                 tt_ok(
-                    trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
+                    trust_tasks::TASK_TRUST_TASK_DISCOVERY_0_1,
                     json!({
-                        "version": "0.5.0",
-                        "features": {"webvh": true, "didcomm": true, "tee": false, "rest": true},
-                        "services": {"rest": true, "didcomm": true},
-                        "webvh_servers": [],
-                        "did_creation_modes": ["webvh"]
+                        "frameworkVersion": "0.2",
+                        "supportedTypes": ["https://trusttasks.org/spec/acl/grant/0.1"]
                     }),
                 )
             } else {
@@ -1291,11 +1287,11 @@ async fn with_didcomm_sequential_cycles_for_same_did_do_not_duel() {
             responder.did(),
             mediator.did(),
             None,
-            |client| async move { client.capabilities().await },
+            |client| async move { client.supported_trust_tasks(&["acl/*"]).await },
         )
         .await
         .unwrap_or_else(|e| panic!("cycle {cycle} round-trip failed — leaked-session duel? {e:?}"));
-        assert_eq!(caps.version, "0.5.0", "cycle {cycle}");
+        assert_eq!(caps.supported_types.len(), 1, "cycle {cycle}");
     }
 
     responder.shutdown().await;

--- a/vta-mcp/src/server.rs
+++ b/vta-mcp/src/server.rs
@@ -42,6 +42,19 @@ fn ok_json(value: impl serde::Serialize) -> Result<CallToolResult, McpError> {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct SupportedTasksParams {
+    /// Slug-glob patterns, ORed. `*` matches every task; `acl/*` matches a
+    /// family; anything else is an exact slug. Omit for everything.
+    ///
+    /// Patterns match the slug — the part after
+    /// `https://trusttasks.org/spec/` — so `acl/*`, not the full URI. An
+    /// unmatched pattern returns an empty list rather than an error, so a
+    /// wrong prefix looks like "serves nothing".
+    #[serde(default)]
+    pub patterns: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ListKeysParams {
     /// Pagination offset (default 0).
     #[serde(default)]
@@ -160,12 +173,29 @@ impl VtaMcp {
         self.agent.client()
     }
 
+    /// Replaces the old `vta_capabilities` tool, which #1043 retired along with
+    /// the task behind it.
+    ///
+    /// The rename is not cosmetic: the old tool promised "enabled features,
+    /// advertised services, WebVH servers, and DID-creation modes" — four
+    /// answers, three of which were better held elsewhere and one of which
+    /// (`didCreationModes`) described a vocabulary nothing else used. What an
+    /// agent actually needs before calling something is whether the VTA serves
+    /// it, and that is a question with a canonical answer.
     #[tool(
-        description = "Discover the connected VTA's capabilities: enabled features, advertised services, WebVH servers, and supported DID-creation modes."
+        description = "Discover which Trust Tasks the connected VTA serves. Optionally narrow with                        slug-glob patterns such as 'acl/*' or 'vta/webvh/*'; omit for everything.                        Ask this before assuming an operation exists — calling one the VTA does not                        serve fails as a transport timeout rather than a clear error."
     )]
-    async fn vta_capabilities(&self) -> Result<CallToolResult, McpError> {
-        let caps = self.client().capabilities().await.map_err(to_mcp)?;
-        ok_json(caps)
+    async fn vta_supported_tasks(
+        &self,
+        Parameters(p): Parameters<SupportedTasksParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let patterns: Vec<&str> = p.patterns.iter().map(String::as_str).collect();
+        let tasks = self
+            .client()
+            .supported_trust_tasks(&patterns)
+            .await
+            .map_err(to_mcp)?;
+        ok_json(tasks)
     }
 
     #[tool(description = "List the signing keys available on the VTA.")]
@@ -366,7 +396,7 @@ impl ServerHandler for VtaMcp {
             .with_server_info(server_info)
             .with_instructions(
                 "Bridges a Verifiable Trust Agent (VTA) to MCP. Convenience tools: \
-                 vta_capabilities, list_keys, sign (signing oracle), vault_list, vault_get, \
+                 vta_supported_tasks, list_keys, sign (signing oracle), vault_list, vault_get, \
                  vault_release (DIDComm only), device_heartbeat, resolve_did, issue_vp. \
                  For the FULL management surface (contexts, keys, acl, did-management, webvh, \
                  did-templates, device, vault, seeds, audit, backup, …) use vta_list_operations \
@@ -387,7 +417,7 @@ mod tests {
     fn tool_router_exposes_the_expected_tools() {
         let router = VtaMcp::tool_router();
         let expected = [
-            "vta_capabilities",
+            "vta_supported_tasks",
             "list_keys",
             "sign",
             "vault_list",

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1963,21 +1963,11 @@ impl VtaClient {
 
     // ── Discovery ──────────────────────────────────────────────────
 
-    /// Discover VTA capabilities: enabled features, services, WebVH servers,
-    /// and supported DID creation modes.
-    ///
-    /// Requires authentication — any role (including Reader) can access.
-    #[cfg(feature = "client")]
-    pub async fn capabilities(
-        &self,
-    ) -> Result<crate::protocols::discovery::CapabilitiesResponse, VtaError> {
-        self.rpc_tt(
-            crate::trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
-            serde_json::json!({}),
-            30,
-        )
-        .await
-    }
+    // `capabilities()` was removed in #1043 along with the task behind it. Its
+    // members each had a better home: `version` at `GET /health/details`,
+    // `webvhServers` at `list_webvh_servers()` (a strict superset, same auth),
+    // and `features`/`services` at the DID document, which is authoritative for
+    // what a party speaks. `didCreationModes` had no consumer at all.
 
     /// Ask which Trust Task types this agent serves — `trust-task-discovery/0.1`.
     ///

--- a/vta-sdk/src/protocols/discovery.rs
+++ b/vta-sdk/src/protocols/discovery.rs
@@ -1,19 +1,34 @@
+//! Capability discovery.
+//!
+//! One question, one answer: **which Trust Tasks does this agent serve?** —
+//! `trust-task-discovery/0.1`, the published canonical family, answered from the
+//! agent's own dispatch table.
+//!
+//! # What used to be here
+//!
+//! `vta/discovery/capabilities/1.0` and the `discovery/1.0/*` DIDComm protocol
+//! beside it, both retired in #1043. Between them they carried five members, and
+//! by the end not one of them was the best answer to its own question:
+//!
+//! - `features` / `services` — the DID document is authoritative for which
+//!   protocols a party speaks, and these answered from `cfg!` flags and local
+//!   config respectively, either of which could contradict it (#1039).
+//! - `version` — `GET /health/details` already reports it, at the same auth
+//!   level and from the same `env!`.
+//! - `webvhServers` — `webvh/servers/list/1.0` returns a strict superset
+//!   (`{id, did, label, createdAt, updatedAt}` against `{id, label}`) at the
+//!   same auth level, and is what every production caller already used.
+//! - `didCreationModes` — no consumer anywhere, and a vocabulary
+//!   (`vta-built` / `template` / `final` / `user-specified-keys`) that existed
+//!   nowhere else in the codebase. It predated `WebvhPathMode`, which is the
+//!   axis DID creation actually turns on now.
+//!
+//! The lesson worth keeping is the shape rather than the members: a task called
+//! "capabilities" attracts fields, because every deployment fact looks like a
+//! capability from far enough away. Discovery answers one question; anything
+//! else belongs to the subsystem that owns it.
+
 use serde::{Deserialize, Serialize};
-
-/// Empty request body for the capabilities discovery operation.
-/// Exists so the trust-task envelope's `payload` field has a typed
-/// shape; the operation takes no input parameters.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase")]
-pub struct CapabilitiesBody {}
-
-pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/discovery/1.0";
-
-pub const DISCOVER_CAPABILITIES: &str =
-    "https://firstperson.network/protocols/discovery/1.0/discover-capabilities";
-pub const DISCOVER_CAPABILITIES_RESULT: &str =
-    "https://firstperson.network/protocols/discovery/1.0/discover-capabilities-result";
 
 /// Response to `trust-task-discovery/0.1` — the Trust Task types an agent
 /// serves.
@@ -35,58 +50,4 @@ pub struct SupportedTasksResponse {
     /// answer from an older peer rather than a malformed one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub framework_version: Option<String>,
-}
-
-/// Response describing the VTA's capabilities and enabled features.
-///
-/// # `rename_all` here is load-bearing
-///
-/// #1000 added the aliases below without it, which made them no-ops: an alias
-/// equal to the member's own serialized name accepts what is already accepted.
-/// So this kept emitting snake_case while its siblings moved, and read — to
-/// anyone glancing at the attributes — as though it had been folded.
-///
-/// It stayed that way through #1034 because this body was also served on the
-/// REST route `GET /capabilities`, and re-casing a public discovery endpoint is
-/// a change to readers nobody can enumerate. That route is gone (#1039), so the
-/// only consumers left are Trust-Task and DIDComm callers who decode this very
-/// struct — and the fold is free.
-/// # Reduced to the delta (#1039)
-///
-/// This carried `features` and `services` — booleans for webvh / didcomm / tee
-/// / rest. Both are gone, because **the DID document is authoritative for which
-/// protocols a party speaks** (see the workspace CLAUDE.md), and a second
-/// answer to the same question is a second answer that can be wrong.
-///
-/// It was not hypothetically wrong, either. `services` was read from local
-/// config while a peer resolves the DID document, and runtime service
-/// management can change what is advertised without the config moving —
-/// so the two could disagree about the very thing a caller was asking.
-/// `features` reported compile-time `cfg!` flags, which say what the binary
-/// *could* serve rather than what it *does*; the honest version of that
-/// question is now `trust-task-discovery/0.1`, answered from the dispatch
-/// table.
-///
-/// What remains is genuinely VTA-specific inventory that neither the DID
-/// document nor task discovery covers.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase")]
-pub struct CapabilitiesResponse {
-    /// Crate version of the VTA service.
-    pub version: String,
-    /// Configured WebVH servers available for DID creation.
-    #[serde(alias = "webvh_servers")]
-    pub webvh_servers: Vec<WebvhServerInfo>,
-    /// Supported DID creation modes.
-    #[serde(alias = "did_creation_modes")]
-    pub did_creation_modes: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct WebvhServerInfo {
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
 }

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -210,7 +210,6 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_AUDIT_UPDATE_RETENTION_1_0, RetrySafe),
     // ── Discovery ───────────────────────────────────────────────────────
     (trust_tasks::TASK_TRUST_TASK_DISCOVERY_0_1, ReadOnly),
-    (trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0, ReadOnly),
     // ── Password vault ──────────────────────────────────────────────────
     (trust_tasks::TASK_VAULT_LIST_0_1, ReadOnly),
     (trust_tasks::TASK_VAULT_LIST_0_2, ReadOnly),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -495,20 +495,6 @@ pub const TASK_AUDIT_GET_RETENTION_1_0: &str =
 pub const TASK_AUDIT_UPDATE_RETENTION_1_0: &str =
     "https://trusttasks.org/spec/vta/audit/update-retention/1.0";
 
-/// `spec/vta/discovery/capabilities/1.0` — describe VTA features,
-/// services, and configured webvh hosts. Payload: empty
-/// (`ListSeedsBody`-style — no input required). Auth: any
-/// authenticated user.
-///
-/// **Deployment inventory only.** "Which Trust Tasks does this agent serve" is
-/// [`TASK_TRUST_TASK_DISCOVERY_0_1`] — the published, canonical answer. This
-/// task is the VTA-specific remainder (webvh hosts, DID-creation modes) that
-/// the canonical family does not cover; see
-/// `docs/05-design-notes/registry-drift-triage.md`, which records the intent to
-/// reduce this to that delta.
-pub const TASK_DISCOVERY_CAPABILITIES_1_0: &str =
-    "https://trusttasks.org/spec/vta/discovery/capabilities/1.0";
-
 /// `spec/trust-task-discovery/0.1` — **the canonical capability negotiation.**
 ///
 /// A client asks which Trust Task types this agent serves, optionally narrowed
@@ -1510,7 +1496,6 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
     TASK_TRUST_TASK_DISCOVERY_0_1,
-    TASK_DISCOVERY_CAPABILITIES_1_0,
     // Vault slice (0.1 + 0.2 dual-accept; delete is 0.1-only upstream)
     TASK_VAULT_LIST_0_1,
     TASK_VAULT_LIST_0_2,

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -226,34 +226,36 @@ async fn health_500_maps_to_server_error() {
 
 // ── Discovery + VTA management ──────────────────────────────────────
 
+/// `trust-task-discovery/0.1` replaces the retired `capabilities` task (#1043).
+///
+/// Asserts the decode, not the transport: the response is a bare list plus an
+/// optional framework version, and `frameworkVersion` is OPTIONAL in 0.1, so a
+/// responder that omits it must still decode rather than erroring.
 #[tokio::test]
-async fn capabilities_returns_features() {
+async fn supported_trust_tasks_decodes_without_a_framework_version() {
     let server = MockServer::start().await;
     let _g = mount_json(
         &server,
-        "GET",
-        "/capabilities",
+        "POST",
+        "/api/trust-tasks",
         200,
-        // Deliberately snake_case: the agent emits camelCase since #1039, and
-        // the aliases must keep accepting the retired spelling from an older
-        // one. `features` / `services` are gone — the DID document answers
-        // "what do you speak" — and are left in the fixture as members a
-        // current agent no longer sends, which must be ignored rather than
-        // rejected.
+        // `mount_json` wraps this in the response envelope itself — the body
+        // supplied here is the payload, not the whole document.
         json!({
-            "version": "0.5.0",
-            "features": {"webvh": true, "didcomm": false, "tee": false, "rest": true},
-            "services": {"rest": true, "didcomm": false},
-            "webvh_servers": [{"id": "s1"}],
-            "did_creation_modes": ["webvh"]
+            "supportedTypes": [
+                "https://trusttasks.org/spec/acl/grant/0.1",
+                "https://trusttasks.org/spec/acl/revoke/0.1"
+            ]
         }),
     )
     .await;
     let c = client(&server).await;
-    let caps = c.capabilities().await.unwrap();
-    assert_eq!(caps.version, "0.5.0");
-    assert_eq!(caps.webvh_servers.len(), 1);
-    assert_eq!(caps.webvh_servers[0].id, "s1");
+    let tasks = c.supported_trust_tasks(&["acl/*"]).await.unwrap();
+    assert_eq!(tasks.supported_types.len(), 2);
+    assert!(
+        tasks.framework_version.is_none(),
+        "an omitted frameworkVersion is legitimate in 0.1, not an error"
+    );
 }
 
 #[tokio::test]

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -104,12 +104,6 @@ const SUPERSEDED: &[(&str, &str, &str, &str)] = &[
     ),
     (
         "GET",
-        "/capabilities",
-        "GET /capabilities",
-        trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0,
-    ),
-    (
-        "GET",
         "/config",
         "GET /config",
         trust_tasks::TASK_CONFIG_SHOW_0_1,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1337,46 +1337,6 @@ pub async fn handle_problem_report(_ctx: HandlerContext, message: Message) -> Ha
 // Discovery
 // ---------------------------------------------------------------------------
 
-pub async fn handle_discover_capabilities(
-    _ctx: HandlerContext,
-    _message: Message,
-    Extension(state): Extension<Arc<VtaState>>,
-) -> HandlerResult {
-    // `features` / `services` removed in #1039 — the DID document is
-    // authoritative for which protocols a party speaks, and this answered from
-    // local config, which runtime service management can leave behind.
-    #[cfg(feature = "webvh")]
-    let webvh_servers = {
-        let servers = app_try!(crate::webvh_store::list_servers(&state.webvh_ks).await);
-        servers
-            .into_iter()
-            .map(|s| vta_sdk::protocols::discovery::WebvhServerInfo {
-                id: s.id,
-                label: s.label,
-            })
-            .collect()
-    };
-    #[cfg(not(feature = "webvh"))]
-    let webvh_servers: Vec<vta_sdk::protocols::discovery::WebvhServerInfo> = vec![];
-
-    let mut did_creation_modes = vec!["vta-built".to_string()];
-    if cfg!(feature = "webvh") {
-        did_creation_modes.push("template".to_string());
-        did_creation_modes.push("final".to_string());
-        did_creation_modes.push("user-specified-keys".to_string());
-    }
-
-    let result = vta_sdk::protocols::discovery::CapabilitiesResponse {
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        webvh_servers,
-        did_creation_modes,
-    };
-    response(
-        vta_sdk::protocols::discovery::DISCOVER_CAPABILITIES_RESULT,
-        &result,
-    )
-}
-
 // ---------------------------------------------------------------------------
 // Provision-integration (DIDComm transport for the VP→sealed-bundle flow)
 // ---------------------------------------------------------------------------

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -565,12 +565,10 @@ pub async fn dispatch(
         }
     }
 
-    // ── Discovery (no auth) ──────────────────────────────────────────
-    if t == protocols::discovery::DISCOVER_CAPABILITIES {
-        return finish(
-            handlers::handle_discover_capabilities(ctx, msg, Extension(vta_state)).await,
-        );
-    }
+    // The `discovery/1.0/*` DIDComm protocol was routed here — unauthenticated
+    // — until #1043 retired it with the task behind it. Capability discovery is
+    // `trust-task-discovery/0.1` on the Trust-Task spine, which is authenticated
+    // like everything else there.
 
     // ── Fallback ─────────────────────────────────────────────────────
     finish(handlers::handle_unknown(ctx, msg).await)

--- a/vta-service/src/trust_tasks/discovery.rs
+++ b/vta-service/src/trust_tasks/discovery.rs
@@ -1,82 +1,24 @@
-//! Discovery slice trust-task handlers. Any authenticated caller.
+//! Discovery slice. One URI, one question: **which Trust Tasks does this agent
+//! serve?**
 //!
-//! Two URIs, answering two different questions:
+//! `spec/trust-task-discovery/0.1` — the published canonical family from the
+//! dtgwg-trust-tasks-tf registry, carried by `trust-tasks-rs`. Any
+//! authenticated caller. This is what a client should ask before assuming a
+//! task exists.
 //!
-//! - **`spec/trust-task-discovery/0.1`** — *which Trust Tasks does this agent
-//!   serve?* The published, canonical family from the dtgwg-trust-tasks-tf
-//!   registry, already carried by `trust-tasks-rs`. This is what a client
-//!   should ask before assuming a task exists.
-//! - **`spec/vta/discovery/capabilities/1.0`** — the VTA-specific *deployment
-//!   inventory*: webvh hosts and DID-creation modes. Reduced to exactly that
-//!   delta in #1039; its `features` / `services` booleans are gone, because the
-//!   DID document is authoritative for which protocols a party speaks and a
-//!   second answer to that question is one that can disagree.
-//!
-//! The capabilities body used to be served on `GET /capabilities` as well.
-//! That route is gone (#1039): nothing consumed it — `VtaClient::capabilities`
-//! goes over `rpc_tt` like every other task — and a REST route parallel to a
-//! Trust Task is the shape #1020 spent a PR removing everywhere else.
+//! `vta/discovery/capabilities/1.0` and `GET /capabilities` used to live here
+//! too. Both are retired (#1039, #1043) — see
+//! `vta_sdk::protocols::discovery` for what each of their members turned out to
+//! duplicate, and why a task named "capabilities" accumulated them.
 
 use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
-use vta_sdk::protocols::discovery::{CapabilitiesBody, CapabilitiesResponse, WebvhServerInfo};
 
 use crate::auth::AuthClaims;
 use crate::server::AppState;
 
-// `app_error_to_reject` is only reachable when the `webvh` feature is
-// on (the only branch that produces an `AppError`). Gate the import
-// alongside to avoid an "unused import" lint in non-webvh combos.
-#[cfg(feature = "webvh")]
-use super::helpers::app_error_to_reject;
 use super::helpers::{parse_payload, success_response};
-
-/// Handler for `spec/vta/discovery/capabilities/1.0`.
-pub(super) async fn handle_capabilities(
-    state: &AppState,
-    _auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    let _req: CapabilitiesBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-
-    // `features` and `services` used to be assembled here and are gone (#1039).
-    // The DID document is authoritative for which protocols a party speaks, and
-    // `services` answered from local config — which runtime service management
-    // can leave behind, so the two could disagree about exactly the thing a
-    // caller was asking. `features` reported `cfg!` flags: what the binary could
-    // serve, not what it does. That question is `trust-task-discovery/0.1` now.
-    #[cfg(feature = "webvh")]
-    let webvh_servers = match crate::webvh_store::list_servers(&state.webvh_ks).await {
-        Ok(servers) => servers
-            .into_iter()
-            .map(|s| WebvhServerInfo {
-                id: s.id,
-                label: s.label,
-            })
-            .collect(),
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
-    #[cfg(not(feature = "webvh"))]
-    let webvh_servers: Vec<WebvhServerInfo> = vec![];
-
-    let mut did_creation_modes = vec!["vta-built".to_string()];
-    if cfg!(feature = "webvh") {
-        did_creation_modes.push("template".to_string());
-        did_creation_modes.push("final".to_string());
-        did_creation_modes.push("user-specified-keys".to_string());
-    }
-
-    let body = CapabilitiesResponse {
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        webvh_servers,
-        did_creation_modes,
-    };
-    success_response(&doc, body)
-}
 
 /// Handler for `spec/trust-task-discovery/0.1` — canonical capability
 /// negotiation.

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -238,8 +238,9 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     // ─ vta/audit retention pair — candidate `audit/retention/{show,update}`.
     "https://trusttasks.org/spec/vta/audit/get-retention/1.0",
     "https://trusttasks.org/spec/vta/audit/update-retention/1.0",
-    // ─ Discovery / management singletons — diff against canonical first.
-    "https://trusttasks.org/spec/vta/discovery/capabilities/1.0",
+    // ─ Management singleton — diff against canonical first.
+    // (`vta/discovery/capabilities/1.0` was here until #1043 retired the task;
+    // its debt is discharged by deletion rather than by a spec.)
     "https://trusttasks.org/spec/vta/management/reload-services/1.0",
     // ─ vta/backup/* — author top-level `backup/*` (reduction plan §D).
     "https://trusttasks.org/spec/vta/backup/initiate-export/1.0",
@@ -933,8 +934,6 @@ dispatch_table! {
         [ Mutating None false ],
     // ─── Discovery ───────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_TRUST_TASK_DISCOVERY_0_1 => discovery::handle_trust_task_discovery
-        [ None None false ],
-    vta_sdk::trust_tasks::TASK_DISCOVERY_CAPABILITIES_1_0 => discovery::handle_capabilities
         [ None None false ],
     // ─── Credential-exchange: deferred-presentation approval ─────
     //

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -317,53 +317,25 @@ fn delete_auth(uri: &str, token: &str) -> Request<Body> {
 
 // ── Capabilities ──────────────────────────────────────────────────
 
+/// The Trust-Task surface is authenticated.
+///
+/// This was `capabilities_requires_auth`, pointed at the retired task (#1043).
+/// The property is the spine's, not that task's, so it is asserted through the
+/// discovery task that replaced it rather than deleted with its subject.
 #[tokio::test]
-async fn capabilities_requires_auth() {
-    // `GET /capabilities` was removed in #1039; the task it wrapped remains and
-    // is still authenticated. Asserted through the Trust-Task surface, which is
-    // where every caller reaches it now.
+async fn trust_tasks_require_auth() {
     let (app, _ctx) = TestApp::new().await;
     let (status, _) = app
         .request(post_unauth(
             "/api/trust-tasks",
             json!({
                 "id": "urn:uuid:2a1b3c4d-5e6f-4071-8293-a4b5c6d7e8f0",
-                "type": "https://trusttasks.org/spec/vta/discovery/capabilities/1.0",
+                "type": "https://trusttasks.org/spec/trust-task-discovery/0.1",
                 "payload": {},
             }),
         ))
         .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn capabilities_returns_features() {
-    let (app, ctx) = TestApp::new().await;
-    let token = ctx
-        .auth_token("did:key:z6MkReader", "reader", vec!["any".into()])
-        .await;
-    let (status, body) = app
-        .request(post_auth(
-            "/api/trust-tasks",
-            &token,
-            json!({
-                "id": "urn:uuid:3b2c4d5e-6f70-4182-93a4-b5c6d7e8f901",
-                "type": "https://trusttasks.org/spec/vta/discovery/capabilities/1.0",
-                "payload": {},
-            }),
-        ))
-        .await;
-    assert_eq!(status, StatusCode::OK, "body: {body}");
-    let payload = &body["payload"];
-    assert!(payload["version"].as_str().is_some());
-    // `didCreationModes`, not `did_creation_modes` — this body was folded to
-    // lowerCamelCase in #1039 once removing the REST route made it free.
-    assert!(payload["didCreationModes"].is_array());
-    // `features` / `services` were asserted here until #1039. The DID document
-    // is authoritative for what a party speaks, so this body no longer offers a
-    // second answer that could disagree with it.
-    assert!(payload.get("features").is_none(), "body: {body}");
-    assert!(payload.get("services").is_none(), "body: {body}");
 }
 
 /// `trust-task-discovery/0.1` answers from the dispatch table.

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -437,7 +437,7 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        14,
+        13,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
@@ -462,7 +462,15 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
          The same move retired those 22 from UNSPECCED_DISPATCHED_URIS into \
          real conformance witnesses, so they went from bound-but-unchecked to \
          validated against a published schema on every request. What is left \
-         is mostly the seeds, backup and attestation families",
+         is mostly the seeds, backup and attestation families. \
+         \
+         14 → 13 is a different mechanism from every fall above it. \
+         `vta/discovery/capabilities/1.0` was not folded onto a canonical \
+         family and was not specified upstream — it was RETIRED (#1043), \
+         audited member by member and found to hold nothing a better source \
+         did not already answer. A URI leaves this list either by gaining a \
+         spec or by ceasing to exist, and the two are worth telling apart: \
+         the first grows the registry, the second does not",
     ),
 ];
 


### PR DESCRIPTION
Closes #1043.

Follow-up to #1039, which reduced `spec/vta/discovery/capabilities/1.0` to `version` + `webvhServers` + `didCreationModes` and left the question open: **does what remains still earn a task?**

Audited each member against the rest of the surface. The answer is no — every one of them has a better home or describes nothing.

## `version` — duplicated at `GET /health/details`

`HealthDetailsResponse` already carries it, from the same `env!("CARGO_PKG_VERSION")`, at the same auth level (`health_details` takes `AuthClaims`).

The weakest of the three findings: both read the same constant, so unlike `services` they cannot disagree. Duplicated, not wrong.

## `webvhServers` — a *lossy* duplicate of `webvh/servers/list/1.0`

| | shape |
|---|---|
| capabilities | `WebvhServerInfo { id, label }` |
| `webvh/servers/list/1.0` | `WebvhServerRecord { id, did, label, createdAt, updatedAt }` |

Same underlying `webvh_store::list_servers` call. The dedicated task returns a strict superset.

The obvious objection is authorization — a cheap summary for callers who cannot see the full list — and **it does not hold**. `operations::did_webvh::list_webvh_servers` is commented *"Any authenticated user can list servers"*, exactly the gate capabilities used.

No production code read it from capabilities. `vtc-service/src/setup/wizard.rs` already calls `list_webvh_servers()`.

## `didCreationModes` — dead, and misleading

- **No consumer** in this repo or in OpenVTC.
- Derived entirely from `cfg!(feature = "webvh")` — the same species as the `features` booleans #1039 removed, reporting what the binary *could* do rather than what it does.
- Its vocabulary — `vta-built` / `template` / `final` / `user-specified-keys` — **appears nowhere else in the codebase**. It dates to #22 (April) and predates `WebvhPathMode`, which is the axis DID creation actually turns on now.
- The fixtures "covering" it assert `["webvh"]` — a *fourth* vocabulary, matching neither the code nor anything else. Its test coverage was fiction, the same defect class as #1033.

## Conclusion: retire the task

Every member migrates or dies:

| member | goes to |
|---|---|
| `version` | `GET /health/details` |
| `webvhServers` | `webvh/servers/list/1.0` (strict superset, same auth) |
| `didCreationModes` | nothing — it describes nothing |

This closes the `registry-drift-triage.md` row as **fold/delete**, which was its original recommendation before #1039 recorded "keep the delta".

The `discovery/1.0/*` DIDComm protocol beside it goes too — it was routed **unauthenticated**, which is worth noting on the way out.

Only consumer to migrate: `vta-mcp`'s `vta_capabilities` tool.

## On retiring rather than deprecating

`deprecation.rs` sets this repo's practice for removing a REST route — mark it, count usage, delete on an *observed zero* rather than a guessed date. **There is no equivalent for Trust Task URIs**, so that instrument is not available here.

The justification is therefore the audit above rather than a metric: zero consumers across both repos, plus a member whose vocabulary corresponds to nothing. That is a weaker instrument than the REST routes get, and worth stating rather than glossing.

If that is too weak a basis, the alternative is to build task-level deprecation signalling first — which is a larger piece of work and probably worth doing on its own merits.


---

## What the change does

Removes the task, the `discovery/1.0/*` DIDComm protocol beside it, and the types behind them: `CapabilitiesResponse`, `CapabilitiesBody`, `FeaturesInfo`, `ServicesInfo`, `WebvhServerInfo`, and `VtaClient::capabilities`.

`vta-mcp`'s `vta_capabilities` becomes **`vta_supported_tasks`**. Not a rename — the old tool promised four answers, three better held elsewhere and one describing nothing. The new description says what an agent actually needs to know before calling an operation, including that calling an unserved task fails as a *transport timeout* rather than a clear error, which is the reason to ask first.

Also discharges the `UNSPECCED_DISPATCHED_URIS` entry **by deletion rather than by a spec** — the cheaper way to shrink that list when the answer is "this should not exist".

## A dangling row #1042 left behind

`deprecation.rs` still carried a `GET /capabilities` row after #1042 deleted the route — matching a path that can never be hit again. **Nothing catches that**: no test ties the superseded-route table to the live router. Removed by hand here.

Worth a follow-up on its own: that table is meant to gate route removal on observed-zero usage, and a row for a route that no longer exists silently reads as "zero" forever.

## Tests

Rewritten rather than deleted, because the properties survive their subject:

- `capabilities_requires_auth` → **`trust_tasks_require_auth`**. The property was the dispatch spine's, not that task's.
- `capabilities_via_didcomm` → **`supported_trust_tasks_via_didcomm`**. Same property — a discovery answer survives the DIDComm round trip — asked of the task with a canonical answer.
- `with_didcomm_sequential_cycles_for_same_did_do_not_duel` repointed. It is about session lifecycle, not about what was asked; discovery suits because it needs no responder state.
- New: `supported_trust_tasks_decodes_without_a_framework_version`, because `frameworkVersion` is **OPTIONAL in 0.1** — an older responder omitting it must decode, not error.

## Verification

- `cargo check --workspace --all-targets`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` all clean.
- Full `cargo test --workspace` green except the four `vtc-service` `admin_ui::tests`, which fail on `VTC_SKIP_ADMIN_UI_BUILD=1` leaving the embedded dir empty — the flag, not this change.
- Net **−172 lines**.

Rebased onto `main` after #1042 merged, so this is no longer stacked.

## Breaking change

Flagged as `BREAKING CHANGE:` in the commit body. Migration: `trust-task-discovery/0.1` (`VtaClient::supported_trust_tasks`) for what an agent serves, `GET /health/details` for its version, `webvh/servers/list/1.0` for its webvh hosts. No `version =` touched.
