### PR TITLE
feat(service): retire routes and Trust Tasks on evidence, not on a hand audit

### DIFF
--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -1,15 +1,35 @@
-//! Deprecation signalling for legacy REST routes that a canonical
-//! `/api/trust-tasks` Trust-Task now supersedes.
+//! How this service retires things, in two halves.
 //!
-//! These routes keep working — the deprecation is advisory. We add response
-//! headers so clients can detect the deprecation and migrate, and increment a
-//! hit counter (`deprecated_route_requests_total`, labelled by route) so that
-//! removal can be gated on **observed usage dropping to zero** rather than a
-//! guessed calendar date. (No `Sunset` date is emitted for that reason.)
+//! **Legacy REST routes** that a canonical `/api/trust-tasks` Trust-Task now
+//! supersedes. These routes keep working — the deprecation is advisory. We add
+//! response headers so clients can detect the deprecation and migrate, and
+//! increment a hit counter (`deprecated_route_requests_total`, labelled by
+//! route) so that removal can be gated on **observed usage dropping to zero**
+//! rather than a guessed calendar date. (No `Sunset` date is emitted for that
+//! reason.) The canonical replacement for every route marked here is the same
+//! operation dispatched as a Trust-Task via `POST /api/trust-tasks` (reachable
+//! over REST, DIDComm, and TSP through the shared `dispatch_trust_task_core`
+//! spine).
 //!
-//! The canonical replacement for every route marked here is the same operation
-//! dispatched as a Trust-Task via `POST /api/trust-tasks` (reachable over REST,
-//! DIDComm, and TSP through the shared `dispatch_trust_task_core` spine).
+//! **Superseded Trust Task URIs**, further down. Same rule, same evidence:
+//! `deprecated_trust_task_requests_total` labelled by URI, a successor named
+//! in the response so a client can act rather than guess, and removal on an
+//! observed zero. Added in #1045, because until then a task could be retired
+//! only by deleting it and the only evidence available was a source audit —
+//! grep the repos we can see and reason about the rest.
+//!
+//! Both tables are pinned to the thing they describe by a test, because a row
+//! that outlives its route or its handler reads zero forever and **that is the
+//! same reading as "safe to delete"**. See
+//! `every_superseded_row_names_a_live_route` (`tests/api_integration.rs`) and
+//! `superseded_tasks_are_dispatched` (`crate::trust_tasks`).
+//!
+//! One consequence worth naming: a URI can now leave
+//! `UNSPECCED_DISPATCHED_URIS` (or `vtc-service`'s `UNPUBLISHED_CANONICAL_OK`)
+//! by *ceasing to exist* rather than by gaining a spec. Both censuses shrink
+//! monotonically by test, so that departure looks identical to progress in the
+//! count alone. A row here, and its removal, is the explicit record of which
+//! one happened.
 
 use axum::extract::{MatchedPath, Request};
 use axum::http::{HeaderMap, HeaderValue};
@@ -565,4 +585,318 @@ pub async fn mark_superseded(req: Request, next: Next) -> Response {
         }
     }
     resp
+}
+
+// ─── The superseded-task table ─────────────────────────────────────────────
+//
+// The Trust-Task half of everything above. A REST route gets `Deprecation:
+// true`, a `Link: rel="successor-version"`, and a per-route hit counter, so it
+// can be removed on evidence. A Trust Task URI had none of that: it could be
+// retired only by deleting it, and the only available evidence was a source
+// audit — grep this repo and the ones we can see, and reason about the rest.
+// That was defensible for `vta/discovery/capabilities/1.0` (#1044: zero
+// consumers anywhere, plus a member whose vocabulary corresponded to nothing)
+// and it does not generalise. The next retirement may be one somebody is
+// calling, and we would find out from a support ticket.
+//
+// ## Invention, not adoption — the framework has no signal to adopt
+//
+// Checked first, per #1045. The *registry* has the concept: a spec's front
+// matter can say `status: retired` with `supersededBy`, which is how twelve
+// `messaging/*` tasks were retired upstream. `trust-tasks-rs` (0.11) exposes
+// none of it — `schema_index` maps URI → payload schema and nothing else,
+// `Payload` carries `IS_BEARER` / `IS_PROOF_REQUIRED` and no lifecycle
+// constant, and `trust-task-discovery/0.1`'s expanded `supportedTypes` entry is
+// `additionalProperties: false` over `{type, requiredExt}`. So a consumer
+// cannot read a task's retirement status at runtime and a producer has nowhere
+// framework-defined to announce one. This stays local machinery until that
+// changes; the vocabulary deliberately matches the registry's (`supersededBy`)
+// so adopting a published signal later is a rename, not a redesign.
+
+/// One Trust Task the VTA still dispatches and intends to stop dispatching.
+///
+/// Rows are added when a task is superseded and removed when the task itself
+/// is — retirement is gated on `deprecated_trust_task_requests_total` reaching
+/// zero for the URI, exactly as route removal is gated on
+/// `deprecated_route_requests_total`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SupersededTask {
+    /// The Type URI clients still send. MUST be one the dispatch spine
+    /// actually routes — pinned by `superseded_tasks_are_dispatched` in
+    /// `crate::trust_tasks`. A row for a URI nothing dispatches reads zero
+    /// forever, which is the "safe to delete" signal produced about something
+    /// already deleted.
+    pub uri: &'static str,
+    /// The Type URI to send instead. Named on the wire so a client can act
+    /// rather than guess.
+    pub successor: &'static str,
+    /// Why, in one line, rendered to the caller alongside the successor.
+    pub reason: &'static str,
+}
+
+/// The table.
+///
+/// Seeded from what this workspace had already declared deprecated in prose:
+/// the eleven dispatched URIs carrying `#[deprecated]` in
+/// `vta_sdk::trust_tasks`, each naming its 0.2 successor. Those attributes
+/// told a Rust caller to migrate and told a wire caller nothing at all, and no
+/// instrument anywhere said whether anyone was still sending them.
+///
+/// `auth/passkey/login/{start,finish}/0.1` are deprecated too and are
+/// deliberately **absent**: they are `REST_ROUTED_URIS`, served by dedicated
+/// unauthenticated routes the dispatcher never sees, so a row here would count
+/// nothing and read a permanent zero.
+///
+/// Naming the gap rather than hiding it: those two are covered by *neither*
+/// instrument. The route table above excludes `/auth/*` on purpose (genuinely
+/// REST, and the pre-login bootstrap that has to work before a Trust Task can
+/// be authenticated at all), and a per-route counter could not separate 0.1
+/// from 0.2 anyway — one path serves both and the only difference is the
+/// casing of a `purpose` value inside the body. Distinguishing them needs a
+/// counter inside those two handlers, which is its own change.
+#[allow(deprecated)] // names the deprecated 0.1 URIs on purpose — that is the point
+const SUPERSEDED_TASKS: &[SupersededTask] = &[
+    // ── auth ────────────────────────────────────────────────────────────
+    SupersededTask {
+        uri: trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
+        successor: trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
+        reason: "0.2 spells the evidence enum `didSigned` in camelCase; the payload is \
+                 signed, so the two versions have separate typed handlers rather than \
+                 an edge transform",
+    },
+    // ── device ──────────────────────────────────────────────────────────
+    SupersededTask {
+        uri: trust_tasks::TASK_DEVICE_REGISTER_0_1,
+        successor: trust_tasks::TASK_DEVICE_REGISTER_0_2,
+        reason: "0.2 spells the enum values in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_DEVICE_HEARTBEAT_0_1,
+        successor: trust_tasks::TASK_DEVICE_HEARTBEAT_0_2,
+        reason: "0.2 spells the enum values in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_DEVICE_LIST_0_1,
+        successor: trust_tasks::TASK_DEVICE_LIST_0_2,
+        reason: "0.2 spells the enum values in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_DEVICE_SET_WAKE_0_1,
+        successor: trust_tasks::TASK_DEVICE_SET_WAKE_0_2,
+        reason: "no enum values changed; the bump is canonical-version alignment, so \
+                 the whole device slice sits on one version",
+    },
+    // ── vault ───────────────────────────────────────────────────────────
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_LIST_0_1,
+        successor: trust_tasks::TASK_VAULT_LIST_0_2,
+        reason: "0.2 spells secretKind and the related enums in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_GET_0_1,
+        successor: trust_tasks::TASK_VAULT_GET_0_2,
+        reason: "0.2 spells the response enums in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_UPSERT_0_1,
+        successor: trust_tasks::TASK_VAULT_UPSERT_0_2,
+        reason: "0.2 spells the secretKind / sealed-envelope / target enums in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_RELEASE_0_1,
+        successor: trust_tasks::TASK_VAULT_RELEASE_0_2,
+        reason: "0.2 spells the secretKind / sealed-envelope / step-up-proof enums in \
+                 camelCase, inside the sealed cleartext as well as around it",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_PROXY_LOGIN_0_1,
+        successor: trust_tasks::TASK_VAULT_PROXY_LOGIN_0_2,
+        reason: "0.2 spells the site-target / step-up-proof enums in camelCase, inside \
+                 the sealed cleartext as well as around it",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_SIGN_TRUST_TASK_0_1,
+        successor: trust_tasks::TASK_VAULT_SIGN_TRUST_TASK_0_2,
+        reason: "0.2 spells the step-up-proof enums in camelCase",
+    },
+];
+
+/// The table, for the dispatch spine and for tests that assert on its contents.
+pub fn superseded_tasks_table() -> &'static [SupersededTask] {
+    SUPERSEDED_TASKS
+}
+
+/// The row for `type_uri`, or `None` when the task is not superseded.
+pub fn superseded_task(type_uri: &str) -> Option<&'static SupersededTask> {
+    SUPERSEDED_TASKS.iter().find(|t| t.uri == type_uri)
+}
+
+/// Top-level document member carrying the deprecation notice.
+///
+/// A reverse-DNS name, matching SPEC §4.5.1's `ext` namespace convention and
+/// the `org.openvtc.*` names this workspace already uses (`vault-session`,
+/// `authorization-context`, `purpose`).
+///
+/// **Document level, not `payload.ext`.** The framework's envelope keeps
+/// unrecognized top-level members in `TrustTask::extra`, and SPEC §7.1/§7.2
+/// tells consumers to preserve rather than reject them, so a member here
+/// cannot break a client that has never heard of it. `payload` can make no
+/// such promise: every published payload schema is `additionalProperties:
+/// false`, the generated `Response` types are `deny_unknown_fields`, and the
+/// conformance sweep validates response payloads against those schemas — so a
+/// member there would have to go in per-spec, and only for specs whose schema
+/// happens to define `ext`. This is the Trust-Task analogue of putting the
+/// REST signal in a header: beside the answer rather than inside it.
+pub const DEPRECATION_MEMBER: &str = "org.openvtc.deprecation";
+
+/// Record a dispatch of a superseded task.
+///
+/// Unlike [`mark_superseded`], this counts the request whatever the outcome.
+/// The route middleware filters non-success responses because an unauthorised
+/// request there says nothing about a client depending on the route — those
+/// routes are reachable without credentials. The dispatch spine is behind
+/// authentication on all three transports (bearer on REST, authcrypt sender on
+/// DIDComm, VID on TSP), so there is no unauthenticated-prober class to filter
+/// out: an authenticated party emitting this URI *is* the usage being
+/// measured, whether or not its payload turned out to be well-formed.
+pub fn note_superseded_task(task: &SupersededTask) {
+    counter!("deprecated_trust_task_requests_total", "task" => task.uri).increment(1);
+}
+
+/// Stamp the deprecation notice onto a serialized response document.
+///
+/// Refuses to touch a document carrying a `proof`: adding a member after
+/// signing voids the signature, and a silently-invalid proof is worse than an
+/// absent notice. Also a no-op on a body that is not a JSON object, or that
+/// already carries the member.
+pub fn annotate_superseded(body: &mut Vec<u8>, task: &SupersededTask) {
+    let Ok(mut doc) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return;
+    };
+    let Some(obj) = doc.as_object_mut() else {
+        return;
+    };
+    if obj.contains_key("proof") || obj.contains_key(DEPRECATION_MEMBER) {
+        return;
+    }
+    obj.insert(
+        DEPRECATION_MEMBER.to_string(),
+        serde_json::json!({
+            "supersededBy": task.successor,
+            "reason": task.reason,
+        }),
+    );
+    if let Ok(bytes) = serde_json::to_vec(&doc) {
+        *body = bytes;
+    }
+}
+
+#[cfg(test)]
+mod superseded_task_tests {
+    use super::*;
+
+    #[test]
+    fn a_notice_rides_the_document_top_level_not_the_payload() {
+        let task = &SUPERSEDED_TASKS[0];
+        let mut body = serde_json::to_vec(&serde_json::json!({
+            "id": "urn:uuid:1",
+            "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "payload": { "devices": [] },
+        }))
+        .unwrap();
+
+        annotate_superseded(&mut body, task);
+
+        let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(doc[DEPRECATION_MEMBER]["supersededBy"], task.successor);
+        assert_eq!(doc[DEPRECATION_MEMBER]["reason"], task.reason);
+        // The payload is what a published schema validates and what a generated
+        // `Response` type deserialises with `deny_unknown_fields`. It must come
+        // back unchanged.
+        assert_eq!(doc["payload"], serde_json::json!({ "devices": [] }));
+    }
+
+    #[test]
+    fn a_signed_document_is_left_alone() {
+        // Stamping a member into a signed document voids the proof over it. A
+        // notice is worth less than a verifiable signature, so the notice loses.
+        let task = &SUPERSEDED_TASKS[0];
+        let original = serde_json::json!({
+            "id": "urn:uuid:1",
+            "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "payload": {},
+            "proof": { "type": "DataIntegrityProof" },
+        });
+        let mut body = serde_json::to_vec(&original).unwrap();
+
+        annotate_superseded(&mut body, task);
+
+        let doc: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            doc, original,
+            "a proofed document must be returned untouched"
+        );
+    }
+
+    #[test]
+    fn annotating_twice_does_not_nest_or_duplicate() {
+        // The spine annotates exactly once today — the idempotency store
+        // records the un-annotated outcome and the replay is annotated on its
+        // way out like any other. This pins the helper against a future caller
+        // that does not preserve that ordering: a second stamp must be a no-op,
+        // not a nested or duplicated notice.
+        let task = &SUPERSEDED_TASKS[0];
+        let mut body = serde_json::to_vec(&serde_json::json!({
+            "id": "urn:uuid:1",
+            "type": "x",
+            "payload": {},
+        }))
+        .unwrap();
+
+        annotate_superseded(&mut body, task);
+        let once = body.clone();
+        annotate_superseded(&mut body, task);
+
+        assert_eq!(body, once);
+    }
+
+    #[test]
+    fn a_body_that_is_not_a_document_is_left_alone() {
+        // `error_response` falls back to an empty body when serialisation
+        // fails. Annotation must not turn that into a panic or a fake document.
+        let task = &SUPERSEDED_TASKS[0];
+        let mut empty: Vec<u8> = Vec::new();
+        annotate_superseded(&mut empty, task);
+        assert!(empty.is_empty());
+
+        let mut array = b"[1,2,3]".to_vec();
+        annotate_superseded(&mut array, task);
+        assert_eq!(array, b"[1,2,3]");
+    }
+
+    #[test]
+    fn every_row_names_a_different_successor() {
+        // A row whose successor is itself would advertise "migrate to where you
+        // already are" and could never be retired.
+        for t in SUPERSEDED_TASKS {
+            assert_ne!(
+                t.uri, t.successor,
+                "{} is listed as its own successor",
+                t.uri
+            );
+            assert!(!t.reason.is_empty(), "{} has no reason", t.uri);
+        }
+    }
+
+    #[test]
+    fn no_uri_is_listed_twice() {
+        // `superseded_task` returns the first match, so a duplicate would make
+        // one of the two rows unreachable — and unreachable is exactly what a
+        // zero reading means.
+        let mut seen: Vec<&str> = SUPERSEDED_TASKS.iter().map(|t| t.uri).collect();
+        seen.sort_unstable();
+        let before = seen.len();
+        seen.dedup();
+        assert_eq!(before, seen.len(), "a URI is listed more than once");
+    }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -478,6 +478,10 @@ pub(crate) async fn dispatch_trust_task_core(
 /// the transport scope wraps every path out of it, including the early
 /// rejections — a handler that reads the transport must never see a scope that
 /// was skipped because the envelope failed validation first.
+///
+/// This layer parses the envelope and attaches the superseded-task signal; the
+/// checks and dispatch are in [`dispatch_trust_task_validated`], for the same
+/// wrap-every-exit reason.
 async fn dispatch_trust_task_inner(
     state: &AppState,
     auth: &AuthClaims,
@@ -486,9 +490,57 @@ async fn dispatch_trust_task_inner(
     // 1. Parse the envelope.
     let doc: TrustTask<Value> = match serde_json::from_slice(body) {
         Ok(d) => d,
+        // No `type` to attribute the request to, so nothing to count and no
+        // successor to name. The one exit that legitimately carries no
+        // deprecation signal.
         Err(e) => return body_parse_error_response(&e.to_string()),
     };
 
+    // Superseded-task signalling wraps everything below, for the same reason
+    // `mark_superseded` is a layer rather than a call inside each of the 56
+    // REST handlers: [`dispatch_trust_task_validated`] has a dozen early
+    // returns — expiry, wrong recipient, replay, schema validation, the policy
+    // gate — and a signal applied at only some of them is worse than none.
+    // Removal is gated on this counter reading zero; a URI that goes quiet
+    // because its callers are all being rejected before the hook would read as
+    // "nobody sends this any more" and be deleted out from under them.
+    //
+    // Read from the URI as it *arrived*, before the 0.2 down-convert rewrites
+    // `doc.type_uri`: what is being measured is what the client sent, and
+    // reading it after the rewrite would count every 0.2 caller as a 0.1 one
+    // and hold the metric off zero permanently.
+    let superseded = crate::deprecation::superseded_task(&doc.type_uri.to_string());
+
+    // `Box::pin` rather than a bare `.await`: the callee's state machine
+    // inlines every handler's future through `dispatch_typed`, so awaiting it
+    // by value would nest that whole thing inside this frame as well. It does
+    // not fit — a debug build of `--workspace` (where feature unification turns
+    // on `tee` and the rest) overflowed the test-thread stack in
+    // `tests/mock_vta.rs` the moment this split was introduced. Boxing puts the
+    // large half on the heap and leaves a pointer here.
+    let mut outcome = Box::pin(dispatch_trust_task_validated(state, auth, doc)).await;
+
+    if let Some(task) = superseded {
+        // Whatever the outcome. A superseded task that was *rejected* is still
+        // a client sending a URI we want to stop serving, and a client about to
+        // retry is the one most in need of knowing what to retry onto.
+        crate::deprecation::note_superseded_task(task);
+        crate::deprecation::annotate_superseded(&mut outcome.body, task);
+    }
+
+    outcome
+}
+
+/// Everything after the envelope parses: framework checks, replay, schema
+/// validation, idempotency, the policy gate, and typed dispatch.
+///
+/// Split from [`dispatch_trust_task_inner`] so the deprecation signal there
+/// wraps every exit path out of this function, not just the last one.
+async fn dispatch_trust_task_validated(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
     // 2. Framework §7.2 items 4 + 5 — expiry + recipient
     //    enforcement. Closes L5 from the May 2026 security
     //    review: the hand-rolled dispatcher previously skipped
@@ -1316,6 +1368,97 @@ mod tests {
         }
     }
 
+    /// Every `SUPERSEDED_TASKS` row must name a URI this spine dispatches.
+    ///
+    /// The table exists so a task can be retired on an observed zero, and the
+    /// counter only moves when the spine sees the URI. A row for something the
+    /// spine never routes — a REST-routed URI, a typo, a task already deleted —
+    /// reads zero forever, which is precisely the "safe to delete" signal,
+    /// produced about something that is already gone. That is the route-table
+    /// defect from #1042 in the other half of the mechanism, and it is why the
+    /// row and the handler have to be pinned to each other rather than each
+    /// maintained by hand.
+    ///
+    /// Fixing a failure: if the task was retired, drop its row (the whole
+    /// point of the row has been served). If the URI is a typo, correct it. If
+    /// the operation is served by a dedicated REST route rather than the
+    /// dispatcher, it belongs in `deprecation::SUPERSEDED` — the route table —
+    /// not here.
+    #[test]
+    fn superseded_tasks_are_dispatched() {
+        let dispatched = dispatched_uris();
+
+        for task in crate::deprecation::superseded_tasks_table() {
+            let served = dispatched.contains(&task.uri)
+                // Feature-gated arms drop out of `dispatched_uris()` when their
+                // cfg is off; the allowlist is where the parity harness tracks
+                // them, so it is the right second source here too.
+                || KNOWN_FEATURE_GATED_URIS.contains(&task.uri);
+            assert!(
+                served,
+                "`{}` is marked superseded but nothing dispatches it, so its counter \
+                 reads zero forever and would report the task as safe to retire when \
+                 it has already been retired. Drop the row if the task is gone; fix \
+                 the URI if it is a typo; move it to `deprecation::SUPERSEDED` if the \
+                 operation is served by a REST route rather than this dispatcher.",
+                task.uri
+            );
+        }
+    }
+
+    /// A successor must be something the client can actually send instead.
+    ///
+    /// A row pointing at a URI this VTA does not serve tells a client to
+    /// migrate onto a 404 — worse than saying nothing, because the client acts
+    /// on it. `REST_ROUTED` counts: the operation is reachable, just not
+    /// through this dispatcher.
+    #[test]
+    fn superseded_task_successors_are_served() {
+        let dispatched = dispatched_uris();
+
+        for task in crate::deprecation::superseded_tasks_table() {
+            let served = dispatched.contains(&task.successor)
+                || KNOWN_FEATURE_GATED_URIS.contains(&task.successor)
+                || REST_ROUTED.contains(&task.successor)
+                || wire_v0_2::WIRE_V0_2_URIS.contains(&task.successor);
+            assert!(
+                served,
+                "`{}` is advertised as the successor to `{}`, but this VTA does not \
+                 serve it — the notice would send a migrating client onto an \
+                 unsupported type",
+                task.successor, task.uri
+            );
+        }
+    }
+
+    /// The two 0.1→0.2 tables must agree.
+    ///
+    /// `wire_v0_2::WIRE_SPECS_V0_2` is where a spec is declared dual-accepted;
+    /// `deprecation::SUPERSEDED_TASKS` is where the 0.1 form is declared on its
+    /// way out. They are separate because only the second carries a reason and
+    /// only the first carries the enum paths — but a 0.2 form added without the
+    /// matching deprecation row is a task nothing is measuring, which is the
+    /// state #1045 exists to end. Adding one entry now requires the other.
+    #[test]
+    fn every_dual_accepted_spec_marks_its_0_1_form_superseded() {
+        for spec in wire_v0_2::WIRE_SPECS_V0_2 {
+            let row = crate::deprecation::superseded_task(spec.uri_0_1).unwrap_or_else(|| {
+                panic!(
+                    "`{}` is dual-accepted at `{}` but its 0.1 form is not in \
+                     `deprecation::SUPERSEDED_TASKS`, so nothing counts the callers \
+                     still on it and it can never be retired on evidence",
+                    spec.uri_0_1, spec.uri_0_2
+                )
+            });
+            assert_eq!(
+                row.successor, spec.uri_0_2,
+                "`{}` is down-converted from `{}` but its deprecation row points \
+                 somewhere else",
+                spec.uri_0_1, spec.uri_0_2
+            );
+        }
+    }
+
     /// Reverse parity harness (#854) — the opposite direction of
     /// [`dispatcher_handles_every_vta_sdk_uri`]. Every URI this service
     /// *serves* — dispatched, REST-routed, feature-gated, or accepted via the
@@ -1631,6 +1774,133 @@ mod payload_validation_tests {
                 .await
                 .is_some(),
             "an operator who would rather fail closed can"
+        );
+    }
+}
+
+#[cfg(test)]
+mod superseded_task_dispatch_tests {
+    //! The Trust-Task deprecation signal, end to end through the spine.
+    //!
+    //! `deprecation.rs` covers the table and the annotation in isolation. What
+    //! those cannot show is that the spine *reaches* them — and a signal that
+    //! is silently not attached reads exactly like "nobody sends this any
+    //! more", which is the reading the whole mechanism exists to trust. That is
+    //! why the REST half has `superseded_route_advertises_its_trust_task_successor`
+    //! against a live router rather than a unit test of `superseded()`.
+
+    use serde_json::{Value, json};
+
+    use crate::deprecation::DEPRECATION_MEMBER;
+    use crate::test_support::{build_signing_test_app_state, super_admin_claims};
+    use crate::trust_tasks::transport::TransportConfidentiality;
+
+    /// Dispatch `type_uri` with `payload` and return the response document.
+    async fn dispatch(type_uri: &str, payload: Value) -> Value {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let vta_did = state
+            .config
+            .read()
+            .await
+            .vta_did
+            .clone()
+            .expect("the signing test state configures a vta_did");
+        let body = serde_json::to_vec(&json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": type_uri,
+            "issuer": "did:key:zTestAdmin",
+            "recipient": vta_did,
+            "issuedAt": "2026-08-22T00:00:00Z",
+            "payload": payload,
+        }))
+        .unwrap();
+
+        let outcome = super::dispatch_trust_task_core(
+            &state,
+            &super_admin_claims(),
+            &body,
+            TransportConfidentiality::HopByHop,
+        )
+        .await;
+        serde_json::from_slice(&outcome.body).expect("a response document")
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)] // sends a deprecated URI on purpose — that is the subject
+    async fn a_superseded_task_names_its_successor_in_the_response() {
+        let uri = vta_sdk::trust_tasks::TASK_DEVICE_LIST_0_1;
+        let doc = dispatch(uri, json!({})).await;
+
+        // Non-vacuity: a rejection document would also carry the notice (that
+        // is deliberate — see the spine), but then this test would be
+        // asserting nothing about the case that matters, which is a task that
+        // still works and is on its way out.
+        assert_eq!(
+            doc["type"],
+            format!("{uri}#response"),
+            "expected a success response to annotate, got: {doc}"
+        );
+
+        let notice = &doc[DEPRECATION_MEMBER];
+        assert_eq!(
+            notice["supersededBy"],
+            vta_sdk::trust_tasks::TASK_DEVICE_LIST_0_2,
+            "the response must name what to send instead, so a client can act \
+             rather than guess; got document: {doc}"
+        );
+        assert!(
+            notice["reason"].as_str().is_some_and(|r| !r.is_empty()),
+            "the notice must say why, got: {notice}"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)] // sends a deprecated URI on purpose — that is the subject
+    async fn a_rejected_superseded_task_still_names_its_successor() {
+        // A client whose request was refused is the client most in need of the
+        // successor: it is about to retry, and it can retry onto the right URI.
+        // `device/register/0.1` requires members an empty payload does not
+        // carry, so this is a schema rejection, not a handler failure.
+        let uri = vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_1;
+        let doc = dispatch(uri, json!({})).await;
+
+        assert_eq!(
+            doc["payload"]["code"], "malformedRequest",
+            "expected a rejection to annotate, got: {doc}"
+        );
+        assert_eq!(
+            doc[DEPRECATION_MEMBER]["supersededBy"],
+            vta_sdk::trust_tasks::TASK_DEVICE_REGISTER_0_2,
+            "a rejection must carry the successor too: {doc}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_current_task_carries_no_notice() {
+        // The counterpart the route table learned to need: a signal attached to
+        // everything is a signal about nothing. `auth/whoami/0.1` is current.
+        let doc = dispatch(vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1, json!({})).await;
+        assert!(
+            doc.get(DEPRECATION_MEMBER).is_none(),
+            "a task that is not superseded must not be advertised as one: {doc}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_payload_is_untouched_by_the_notice() {
+        // The notice rides the document top level precisely so the payload
+        // stays exactly what the spec says it is — every published payload
+        // schema is `additionalProperties: false` and the generated `Response`
+        // types are `deny_unknown_fields`. Assert it on a real dispatch, not
+        // just on the annotation helper.
+        #[allow(deprecated)]
+        let uri = vta_sdk::trust_tasks::TASK_DEVICE_LIST_0_1;
+        let doc = dispatch(uri, json!({})).await;
+
+        let payload = doc.get("payload").expect("a response carries a payload");
+        assert!(
+            payload.get(DEPRECATION_MEMBER).is_none() && payload.get("ext").is_none(),
+            "the notice must not reach the payload: {payload}"
         );
     }
 }

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -4264,6 +4264,106 @@ async fn a_services_route_advertises_its_task_successor() {
     }
 }
 
+/// Every `SUPERSEDED` row must correspond to a route the service still serves.
+///
+/// The table's purpose is that removal can be gated on **observed usage
+/// dropping to zero**. A row whose route no longer exists matches a path that
+/// can never be hit again, so it reads zero forever — which is exactly the
+/// signal the table exists to produce, emitted about something already
+/// deleted. #1042 left such a row behind when it removed `GET /capabilities`;
+/// it was found by accident in #1044 and removed by hand, because nothing tied
+/// the table to the live router.
+///
+/// The assertion is on `MatchedPath`, not on a status code, because
+/// `MatchedPath` is what `mark_superseded` matches on. A row that spells a live
+/// route's parameter differently — `/acl/{id}` where the router registered
+/// `/acl/{did}` — matches nothing, attaches no header and counts nothing, while
+/// the route goes on answering. A status-only probe reads green over that.
+///
+/// The reverse direction is deliberately **not** asserted: a live route absent
+/// from the table is legitimate, and `deprecation.rs` documents which routes
+/// are excluded and why.
+///
+/// Feature-gated: the table lists `/webvh/*` and `/services/*` unconditionally
+/// while their routes are behind `webvh` / `didcomm`, so the guard only holds
+/// in a build that serves all of them. Both are on by default and are what CI
+/// builds; in a narrower build the metric those rows govern is not emitted
+/// either.
+#[cfg(all(feature = "webvh", feature = "didcomm"))]
+#[tokio::test]
+async fn every_superseded_row_names_a_live_route() {
+    use axum::extract::MatchedPath;
+    use axum::http::HeaderValue;
+
+    /// Echo the router's `MatchedPath` into a response header so the probe can
+    /// read it. Added with `Router::layer`, the same way `mark_superseded` is,
+    /// so it observes the extension at the same point that middleware does.
+    async fn echo_matched_path(
+        req: axum::extract::Request,
+        next: axum::middleware::Next,
+    ) -> axum::response::Response {
+        let matched = req
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|m| m.as_str().to_owned());
+        let mut resp = next.run(req).await;
+        if let Some(m) = matched
+            && let Ok(v) = HeaderValue::from_str(&m)
+        {
+            resp.headers_mut().insert("x-probe-matched-path", v);
+        }
+        resp
+    }
+
+    let (app, _ctx) = TestApp::new().await;
+    let probe = app
+        .router
+        .clone()
+        .layer(axum::middleware::from_fn(echo_matched_path));
+
+    for (method, path, label, successor) in vta_service::deprecation::superseded_table() {
+        // Substitute a literal for each `{param}` segment. The value is
+        // irrelevant — every probe is unauthenticated and is refused by the
+        // route's auth extractor, which runs *after* path matching, so the
+        // handler never sees it.
+        let uri: String = path
+            .split('/')
+            .map(|seg| if seg.starts_with('{') { "probe" } else { seg })
+            .collect::<Vec<_>>()
+            .join("/");
+
+        let req = Request::builder()
+            .method(*method)
+            .uri(&uri)
+            .body(Body::empty())
+            .unwrap();
+        let resp = probe.clone().oneshot(req).await.expect("request failed");
+
+        let matched = resp
+            .headers()
+            .get("x-probe-matched-path")
+            .map(|v| v.to_str().unwrap().to_owned());
+
+        assert_eq!(
+            matched.as_deref(),
+            Some(*path),
+            "the superseded row `{method} {path}` (successor `{successor}`) does not \
+             match a live route — it matched {matched:?}. If the route was removed, \
+             drop the row: it now reads zero usage forever and would report the route \
+             as safe to delete when it is already gone. If the row is a typo, correct \
+             it — do not delete it to silence this, because the row is what carries \
+             the successor URI."
+        );
+        assert_ne!(
+            resp.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "the superseded row `{method} {path}` (label `{label}`) names a path the \
+             service serves but not that method, so `mark_superseded` never fires for \
+             it. Correct the method, or drop the row if the operation is gone."
+        );
+    }
+}
+
 #[test]
 fn the_two_drain_routes_split_on_method_not_path() {
     // `/services/didcomm/drain` is one path serving two operations: GET lists


### PR DESCRIPTION
Two gaps in how this workspace retires things, both surfaced while retiring
`vta/discovery/capabilities/1.0` (#1043, #1044). Closes #1045.

## The superseded-route table had no guard

`deprecation.rs` maps legacy REST routes to the Trust Task that supersedes them
so that removal can be gated on observed usage dropping to zero. #1042 deleted
`GET /capabilities` and left its row behind — a row matching a path that can
never be hit again reads zero forever, which is exactly the signal the table
exists to produce, emitted about something already deleted. It was noticed by
accident and removed by hand in #1044, because nothing tied the table to the
live router.

`every_superseded_row_names_a_live_route` now walks the assembled router and
asserts every row matches a live route. It asserts on `MatchedPath` rather than
on a status code, because `MatchedPath` is what `mark_superseded` matches on: a
row spelling a parameter differently — `/acl/{id}` where the router registered
`/acl/{did}` — attaches no header and counts nothing while the route goes on
answering, and a status-only probe reads green over that. The failure text says
which way to fix it. The reverse direction is deliberately not asserted; a live
route absent from the table is legitimate, and `deprecation.rs` already records
which routes are excluded and why.

## Trust Task URIs had no deprecation path at all

A task could be retired only by deleting it, and the only evidence available was
a source audit — grep the repos we can see and reason about the rest. That was
defensible for one task with zero consumers anywhere and does not generalise;
the next retirement may be one somebody is calling.

`SUPERSEDED_TASKS` gives them the route mechanism:
`deprecated_trust_task_requests_total` labelled by URI, the successor named in
the response so a client can act rather than guess, and removal on an observed
zero. Seeded with the eleven dispatched URIs already carrying `#[deprecated]` in
`vta_sdk::trust_tasks` — attributes that told a Rust caller to migrate, told a
wire caller nothing, and left no instrument saying whether anyone was still
sending them.

Checked against the framework first. The *registry* has the concept
(`status: retired` + `supersededBy`, how twelve `messaging/*` tasks were retired
upstream), but `trust-tasks-rs` 0.11 exposes none of it: `schema_index` is
URI → payload schema and nothing else, `Payload` carries no lifecycle constant,
and `trust-task-discovery/0.1`'s expanded `supportedTypes` entry is closed over
`{type, requiredExt}`. So this is invention rather than adoption; the vocabulary
matches the registry's so that adopting a published signal later is a rename.

The notice rides the response document's **top level**, not `payload.ext`. The
framework envelope keeps unrecognized top-level members in `TrustTask::extra`
and SPEC §7.1/§7.2 tells consumers to preserve rather than reject them, so a
member there cannot break a client that has never heard of it. `payload` can
make no such promise: every published payload schema is
`additionalProperties: false`, the generated `Response` types are
`deny_unknown_fields`, and the conformance sweep validates against both. This is
the Trust-Task analogue of putting the REST signal in a header — beside the
answer rather than inside it. A document carrying a `proof` is left untouched.

## Both tables are now pinned to what they describe

`superseded_tasks_are_dispatched` refuses a row nothing routes (that reads zero
forever, same defect as the dangling route row), `superseded_task_successors_are
_served` refuses a successor this VTA does not serve (a notice that sends a
migrating client onto an unsupported type), and
`every_dual_accepted_spec_marks_its_0_1_form_superseded` pins
`wire_v0_2::WIRE_SPECS_V0_2` against `SUPERSEDED_TASKS`, so a new dual-accept
cannot land without an instrument on the form it replaces.

Not covered, and said so in the source rather than papered over:
`auth/passkey/login/{start,finish}/0.1` are deprecated but reach neither
instrument. They are REST-routed on paths the route table excludes on purpose,
and one path serves both versions with the delta inside the body, so separating
them needs a counter in those two handlers.

Two things the tests found rather than confirmed. The signal is attached in
`dispatch_trust_task_inner` wrapping every exit out of the checks, not after
them — the spine has a dozen early returns, and a URI going quiet because its
callers are all being rejected before the hook would read as "nobody sends this
any more"; the first version had exactly that hole and the rejection test caught
it. And that split is `Box::pin`ed: the callee's state machine inlines every
handler's future through `dispatch_typed`, and awaiting it by value overflowed
the test-thread stack in `tests/mock_vta.rs` under `cargo test --workspace`,
where feature unification builds more of vta-service than `-p vta-service` does.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

