### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6242,7 +6242,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9188,7 +9188,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "tokio",
@@ -9200,7 +9200,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.14"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9229,7 +9229,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9287,7 +9287,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9320,7 +9320,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "vti-common",
 ]
@@ -9371,7 +9371,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "hex",
  "multibase",
@@ -9391,7 +9391,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9455,7 +9455,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",
@@ -9558,7 +9558,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9578,7 +9578,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9594,7 +9594,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm",
@@ -9628,7 +9628,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9662,7 +9662,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9683,7 +9683,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.3.11"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9782,7 +9782,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
@@ -9856,7 +9856,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -9885,7 +9885,7 @@ dependencies = [
 
 [[package]]
 name = "vti-webauthn"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.12.1...cnm-cli-v0.12.2) — 2026-08-26
+
+
 ## [0.12.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.12.0...cnm-cli-v0.12.1) — 2026-08-22
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.11", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }
@@ -26,7 +26,7 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 # SLIP-0010 key derivation (`vti_common::slip10`) — the harness re-derives the
 # same keys the VTA does, from the same seed and paths.
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }
 
 [lints]
 workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.13.1...pnm-cli-v0.13.2) — 2026-08-26
+
+
 ## [0.13.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.13.0...pnm-cli-v0.13.1) — 2026-08-22
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.10...vta-audit-v0.2.0) — 2026-08-26
+
+
+### Added
+
+- **audit**: Make the audit destination a deployment choice, not a protocol one ([#1049](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1049))
+
+`AuditLogEntry` is `{id, timestamp, action, actor, resource, outcome, channel,
+  contextId, detail}` — no signature, no hash chain. The log corroborates what
+  happened; it cannot prove it, and a compromised VTA can rewrite its own history.
+  The canonical `AuditEnvelope` already names the members that would change that
+  (`prevHash`, `entryHash`, `schemaVersion`) and records why this maintainer omits
+  them: its log is flat and unchained.
+
+  This does not add tamper-evidence, deliberately. It adds the seam, so an
+  operator who needs a stronger guarantee implements one — an append-only file, a
+  transparency log, a blockchain anchor, a hash chain filling in those three
+  members — without the VTA committing to any scheme. Closes #1031.
+
+  ## The shape
+
+
+
 ## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.9...vta-audit-v0.1.10) — 2026-08-22
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.1.10"
+version = "0.2.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,8 +20,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13" }
-vta-sdk = { path = "../vta-sdk", version = "0.28" }
+vti-common = { path = "../vti-common", version = "0.14" }
+vta-sdk = { path = "../vta-sdk", version = "0.29" }
 async-trait = "0.1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,132 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.14...vta-backup-v0.2.0) — 2026-08-26
+
+
+### Added
+
+- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))
+
+Applications built on a VTA have had nowhere to keep versioned metadata.
+  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
+  beside the secrets vault and the credential vault, for JSON an application
+  owns and the VTA does not interpret.
+
+  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
+  application so several tools can share a context without colliding, and is the
+  seam a per-namespace grant would later use — which is why it is part of the
+  address rather than a prefix convention on the key. In 1.0 a namespace is
+  collision avoidance and NOT a trust boundary: an application with write access
+  to a context reaches every namespace in it, and the `put` and `delete` specs
+  say so normatively. Isolation means separate contexts.
+
+  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
+  nothing to hang a precondition on, and its `list` returns the whole context —
+  but the argument that settles it is that "forget everything" has to stay a safe
+  thing to ask an agent, which it cannot be if account state lives there.
+
+  Three properties are why this is a store rather than a field on an existing one.
+
+  **One counter per `(contextId, namespace)`, not per record.** A record's
+  `version` is the counter value its most recent write took, so one number is
+  simultaneously the optimistic-concurrency token `expectedVersion` compares
+  against and the watermark `sinceVersion` compares against. A per-record counter
+  serves the first but cannot serve the second — two records' counters are not
+  comparable, so no single number means "everything after this point" — and would
+  have forced a second sequence kept consistent by hand. The cost is that a
+  record's version jumps by whatever its neighbours consumed, which the wire
+  contract states: versions are opaque and monotonic, never an edit count.
+
+  **A failed precondition returns the current version AND value.** A bare
+  rejection obliges a re-read, and the re-read races the next write; the pattern
+  has no fixed point under contention. Returning the winner's view removes the
+  race rather than narrowing it, and the spec makes it normative.
+
+  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
+  one, a consumer pulling from a watermark learns of every create and update and
+  never of a deletion, so deleted records resurrect on its next rebuild.
+  Retention is `app_state.tombstone_retention_days` (default 30, matching the
+  vault's `grace_days`) — a destructive window is an operator's choice, not a
+  constant — and `list` advertises the configured value, since a consumer
+  schedules against that number. The sweeper runs from the storage thread beside
+  the ACL/consent/vault sweepers.
+
+  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
+  version order and stops at the first still inside the window. Reaping a later
+  tombstone while leaving an earlier one would make the reap watermark
+  unstateable — no single number would describe what survives, which is precisely
+  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
+  that is enforced at the call site rather than as a zero cutoff, which would mean
+  the opposite.
+
+  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
+  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
+  surviving only in the journal buffer can be re-derived after a crash and reissue
+  a used value. Here a reused version means two records collide on one `appv:`
+  index key, so one disappears from the change feed and every incremental consumer
+  misses that change permanently, silently. A batch reserves a block and pays one
+  fsync rather than N; writes that then fail leave gaps, which are safe and
+  tested.
+
+  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
+  finds a tombstone and deliberately takes no new version, so a watcher sees
+  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
+  does not converge, and the class is per URI, not per payload.
+
+  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.
+
+  Concurrency is a process-local lock per namespace, not a store-layer
+  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
+  share a store, and the vsock protocol has no atomic opcode — its
+  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
+  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
+  would need to be real. Recorded in the design note with what would change that.
+
+  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
+  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
+  an older resolve fails as a stale dependency rather than as unspecced URIs.
+  Conformance witnesses cover all six URIs, so nothing enters
+  `UNSPECCED_DISPATCHED_URIS`.
+
+
+
+### Fixed
+
+- **vtc**: Follow the spec on every auth response, and close the conformance gate ([#1112](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1112))
+
+* test(vtc)!: make response conformance fail the build
+
+  Until now the layer reported and a green suite was not evidence of
+  conformance — #1107's own memory note said to grep the run rather than trust
+  the exit code, which is a signal nobody has to obey.
+
+  A violation outside the allowlist now returns 500 with the schema error, so the
+  test that provoked it fails on its own status assertion and prints the reason.
+  Chosen over panicking in middleware, which surfaces at the call site as a
+  transport error and says nothing about which task or why.
+
+  The allowlist is eight `auth/*` tasks with ALLOWED_COUNT asserted beside them —
+  the same discipline as KNOWN_DRIFT_COUNT, because the cheapest way to make a
+  failing check pass is to add a line to a list nobody watches. An allowlisted
+  violation is still reported, pinned by a test: a list that suppressed the
+  evidence would mean rediscovering each entry before it could be closed.
+
+  Two existing guards caught mistakes of mine on the first run. The allowlist
+  named login/{start,finish}/0.1 where the service binds 0.2 — built from the
+  violation output rather than the route mounts — and the manifest guard flagged a
+  fake `trusttasks.org/spec/` URI in a new unit test, correctly, since binding
+  such a URI asserts the registry serves it.
+
+  Also retargets relationships/{list,graph} to the 0.2s from
+  trustoverip/dtgwg-trust-tasks-tf#266, and fixes a seeder that wrote
+  `seed-{uuid}` into `vrcDigestMultibase` — unique per row, and so a suite
+  structurally blind to digest format.
+
+  The VTC family is now clean; every remaining violation is `auth/*`.
+
+
+
 ## [0.1.14](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.13...vta-backup-v0.1.14) — 2026-08-22
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.1.14"
+version = "0.2.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,10 +27,10 @@ webvh = ["vta-keyspaces/webvh"]
 tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13" }
-vta-sdk = { path = "../vta-sdk", version = "0.28" }
+vti-common = { path = "../vti-common", version = "0.14" }
+vta-sdk = { path = "../vta-sdk", version = "0.29" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vta-keys = { path = "../vta-keys", version = "0.2" }
+vta-keys = { path = "../vta-keys", version = "0.3" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }
 tokio = { workspace = true }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.11.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.4...vta-cli-common-v0.11.5) — 2026-08-26
+
+
 ## [0.11.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.3...vta-cli-common-v0.11.4) — 2026-08-22
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,13 +18,13 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,96 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.13](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.12...vta-config-v0.3.13) — 2026-08-26
+
+
+### Added
+
+- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))
+
+Applications built on a VTA have had nowhere to keep versioned metadata.
+  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
+  beside the secrets vault and the credential vault, for JSON an application
+  owns and the VTA does not interpret.
+
+  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
+  application so several tools can share a context without colliding, and is the
+  seam a per-namespace grant would later use — which is why it is part of the
+  address rather than a prefix convention on the key. In 1.0 a namespace is
+  collision avoidance and NOT a trust boundary: an application with write access
+  to a context reaches every namespace in it, and the `put` and `delete` specs
+  say so normatively. Isolation means separate contexts.
+
+  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
+  nothing to hang a precondition on, and its `list` returns the whole context —
+  but the argument that settles it is that "forget everything" has to stay a safe
+  thing to ask an agent, which it cannot be if account state lives there.
+
+  Three properties are why this is a store rather than a field on an existing one.
+
+  **One counter per `(contextId, namespace)`, not per record.** A record's
+  `version` is the counter value its most recent write took, so one number is
+  simultaneously the optimistic-concurrency token `expectedVersion` compares
+  against and the watermark `sinceVersion` compares against. A per-record counter
+  serves the first but cannot serve the second — two records' counters are not
+  comparable, so no single number means "everything after this point" — and would
+  have forced a second sequence kept consistent by hand. The cost is that a
+  record's version jumps by whatever its neighbours consumed, which the wire
+  contract states: versions are opaque and monotonic, never an edit count.
+
+  **A failed precondition returns the current version AND value.** A bare
+  rejection obliges a re-read, and the re-read races the next write; the pattern
+  has no fixed point under contention. Returning the winner's view removes the
+  race rather than narrowing it, and the spec makes it normative.
+
+  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
+  one, a consumer pulling from a watermark learns of every create and update and
+  never of a deletion, so deleted records resurrect on its next rebuild.
+  Retention is `app_state.tombstone_retention_days` (default 30, matching the
+  vault's `grace_days`) — a destructive window is an operator's choice, not a
+  constant — and `list` advertises the configured value, since a consumer
+  schedules against that number. The sweeper runs from the storage thread beside
+  the ACL/consent/vault sweepers.
+
+  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
+  version order and stops at the first still inside the window. Reaping a later
+  tombstone while leaving an earlier one would make the reap watermark
+  unstateable — no single number would describe what survives, which is precisely
+  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
+  that is enforced at the call site rather than as a zero cutoff, which would mean
+  the opposite.
+
+  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
+  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
+  surviving only in the journal buffer can be re-derived after a crash and reissue
+  a used value. Here a reused version means two records collide on one `appv:`
+  index key, so one disappears from the change feed and every incremental consumer
+  misses that change permanently, silently. A batch reserves a block and pays one
+  fsync rather than N; writes that then fail leave gaps, which are safe and
+  tested.
+
+  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
+  finds a tombstone and deliberately takes no new version, so a watcher sees
+  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
+  does not converge, and the class is per URI, not per payload.
+
+  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.
+
+  Concurrency is a process-local lock per namespace, not a store-layer
+  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
+  share a store, and the vsock protocol has no atomic opcode — its
+  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
+  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
+  would need to be real. Recorded in the design note with what would change that.
+
+  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
+  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
+  an older resolve fails as a stale dependency rather than as unspecced URIs.
+  Conformance witnesses cover all six URIs, so nothing enters
+  `UNSPECCED_DISPATCHED_URIS`.
+
+
+
 ## [0.3.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.11...vta-config-v0.3.12) — 2026-08-22
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.3.12"
+version = "0.3.13"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,11 +26,11 @@ default = []
 tee = []
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }
 vti-secrets = { path = "../vti-secrets", version = "0.2" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.28", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.29", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,8 +34,8 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.20", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.21", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.14", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build
 # links no overlay code.

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.9...vta-keys-v0.3.0) — 2026-08-26
+
+
+### Chore
+
+- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))
+
+`cargo outdated` reported 13 direct dependencies behind and `cargo update`
+  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
+  reports "All dependencies are up to date".
+
+  Two of these were not cosmetic.
+
+  **p256 was duplicated in the build.** Our crates declared `0.13` while
+  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
+  already pulled `0.14`, so the graph carried two copies of a curve
+  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
+  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
+  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
+  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.
+
+  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
+  depends on it solely as a feature enabler: iOS has no native trust store, so
+  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
+  fails with "no native root CA certificates found". Features unify per major
+  version, so the declaration only works while it matches the version
+  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
+  Updating everything *except* this one would have stranded the enabler and
+  broken iOS `wss://` silently.
+
+  The rest:
+
+  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
+    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
+    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
+    which is also a more direct statement of what it wanted.
+  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
+    `trust-tasks-rs`.
+  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
+    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
+    on is unchanged.
+  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
+    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
+    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
+    flags, drops out of the graph entirely.
+
+  Two deliberate choices where the shortest path was worse:
+
+  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
+  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
+  encoding" and "valid encoding, point not on the curve" into one error, and
+  those say different things to whoever reads the log — a broken client versus
+  a point somebody chose.
+
+  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
+  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
+  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
+  than resting on a panic inside a deprecated helper.
+
+  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
+  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
+  path. `cargo deny check advisories` passes.
+
+
+
 ## [0.2.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.8...vta-keys-v0.2.9) — 2026-08-22
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.2.9"
+version = "0.3.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -36,9 +36,9 @@ tee = ["vti-secrets/tee"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3" }
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }
 vti-secrets = { path = "../vti-secrets", version = "0.2" }
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,96 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.0...vta-keyspaces-v0.2.1) — 2026-08-26
+
+
+### Added
+
+- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))
+
+Applications built on a VTA have had nowhere to keep versioned metadata.
+  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
+  beside the secrets vault and the credential vault, for JSON an application
+  owns and the VTA does not interpret.
+
+  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
+  application so several tools can share a context without colliding, and is the
+  seam a per-namespace grant would later use — which is why it is part of the
+  address rather than a prefix convention on the key. In 1.0 a namespace is
+  collision avoidance and NOT a trust boundary: an application with write access
+  to a context reaches every namespace in it, and the `put` and `delete` specs
+  say so normatively. Isolation means separate contexts.
+
+  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
+  nothing to hang a precondition on, and its `list` returns the whole context —
+  but the argument that settles it is that "forget everything" has to stay a safe
+  thing to ask an agent, which it cannot be if account state lives there.
+
+  Three properties are why this is a store rather than a field on an existing one.
+
+  **One counter per `(contextId, namespace)`, not per record.** A record's
+  `version` is the counter value its most recent write took, so one number is
+  simultaneously the optimistic-concurrency token `expectedVersion` compares
+  against and the watermark `sinceVersion` compares against. A per-record counter
+  serves the first but cannot serve the second — two records' counters are not
+  comparable, so no single number means "everything after this point" — and would
+  have forced a second sequence kept consistent by hand. The cost is that a
+  record's version jumps by whatever its neighbours consumed, which the wire
+  contract states: versions are opaque and monotonic, never an edit count.
+
+  **A failed precondition returns the current version AND value.** A bare
+  rejection obliges a re-read, and the re-read races the next write; the pattern
+  has no fixed point under contention. Returning the winner's view removes the
+  race rather than narrowing it, and the spec makes it normative.
+
+  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
+  one, a consumer pulling from a watermark learns of every create and update and
+  never of a deletion, so deleted records resurrect on its next rebuild.
+  Retention is `app_state.tombstone_retention_days` (default 30, matching the
+  vault's `grace_days`) — a destructive window is an operator's choice, not a
+  constant — and `list` advertises the configured value, since a consumer
+  schedules against that number. The sweeper runs from the storage thread beside
+  the ACL/consent/vault sweepers.
+
+  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
+  version order and stops at the first still inside the window. Reaping a later
+  tombstone while leaving an earlier one would make the reap watermark
+  unstateable — no single number would describe what survives, which is precisely
+  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
+  that is enforced at the call site rather than as a zero cutoff, which would mean
+  the opposite.
+
+  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
+  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
+  surviving only in the journal buffer can be re-derived after a crash and reissue
+  a used value. Here a reused version means two records collide on one `appv:`
+  index key, so one disappears from the change feed and every incremental consumer
+  misses that change permanently, silently. A batch reserves a block and pays one
+  fsync rather than N; writes that then fail leave gaps, which are safe and
+  tested.
+
+  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
+  finds a tombstone and deliberately takes no new version, so a watcher sees
+  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
+  does not converge, and the class is per URI, not per payload.
+
+  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.
+
+  Concurrency is a process-local lock per namespace, not a store-layer
+  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
+  share a store, and the vsock protocol has no atomic opcode — its
+  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
+  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
+  would need to be real. Recorded in the design note with what would change that.
+
+  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
+  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
+  an older resolve fails as a stale dependency rather than as unspecced URIs.
+  Conformance witnesses cover all six URIs, so nothing enters
+  `UNSPECCED_DISPATCHED_URIS`.
+
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.1.5...vta-keyspaces-v0.2.0) — 2026-08-20
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,4 +26,4 @@ webvh = []
 
 [dependencies]
 # For `KeyspaceHandle` in the shared `Keyspaces` handle bundle.
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.11...vta-policy-v0.2.12) — 2026-08-26
+
+
 ## [0.2.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.10...vta-policy-v0.2.11) — 2026-08-22
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,12 +20,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }
 vta-config = { path = "../vta-config", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.28", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.29", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,536 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.29.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.28.0...vta-sdk-v0.29.0) — 2026-08-26
+
+
+### Added
+
+- **sdk**: Extract the agent-side connect ladder into vta_sdk::agent_connect ([#1081](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1081))
+
+* feat(sdk): extract the agent-side connect ladder into vta_sdk::agent_connect
+
+  Every tool that runs beside a user and talks to their VTA on their behalf
+  needs the same four ways in — did:webvh bundle, scoped did:key, bearer
+  token, existing pnm session — in the same order, with the same fail-fast
+  rules. That ladder existed only inside vta-mcp's main.rs, so the next
+  bridge had to copy 110 lines or invent a fifth way in.
+
+  `AgentConnect` is that ladder as SDK surface. `mode()` resolves the rung
+  with no I/O, so a bridge can log it (and refuse a rung it does not
+  support) before connecting; `connect()` returns the authenticated
+  VtaClient. Session mode keeps TransportChoice::Auto, so it inherits the
+  workspace preference order (TSP > DIDComm > REST) from what both DID
+  documents advertise.
+
+  Two rules are enforced rather than documented, both carried over from the
+  vta-mcp original: the two DIDComm identity modes are mutually exclusive,
+  and a half-configured rung errors naming the missing fields instead of
+  falling through to session mode — a bridge silently authenticating as the
+  operator rather than as its scoped agent identity is the failure that
+  matters here. ConnectMode::is_dedicated_agent() makes the same
+  distinction available to callers deciding whether to enroll as a device.
+
+  vta-mcp is refactored onto it, which is what proves the extraction: its
+  build_client is now a pure args -> AgentConnect mapping plus a connect,
+  and its tests assert which rung a set of flags selects.
+
+- **vtc**: Tell a member when the community removes them ([#1060](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1060))
+
+Removal was the most consequential thing a community does to a member and the
+  one it delivered with the least information — none. There was no outbound
+  message on any removal path. The only signal a removed member could observe was
+  a side effect: the revocation bit on their membership credential flipping. They
+  inferred their own removal from a status list and learned nothing about why.
+
+  `vtc/members/removal-notice/0.1` (published upstream as
+  trustoverip/dtgwg-trust-tasks-tf#256) now goes out from both admin paths,
+  carrying the deciding administrator, the moment the decision took effect, the
+  resolved disposition, and the operator's reason.
+
+  **Signed, because the recipient is not the audience.** Authcrypt already proves
+  the sender to the member. But this is the one member-facing message whose value
+  lies in showing it to somebody else — an appeal, a dispute, another community
+  weighing a rejected applicant. Forwarded, an unsigned notice is an assertion
+  anyone could have written. So it is a Trust Task document with a Data Integrity
+  proof, packed in the trust-task envelope — note `TRUST_TASK_ENVELOPE_TYPE`, not
+  the task URI, which is a mistake this workspace has made before and which a
+  conformant peer rejects silently.
+
+  **Thirty days, because there is no second route.** `resolve_auth_role` refuses
+  any DID without an ACL row and removal hard-deletes it, so a removed member
+  cannot authenticate at all: every authenticated route, including any poll that
+  might have served the notice, closes at the moment the removal lands. The act
+  this reports is the act that ends their ability to ask about it. `send_to_member`
+  already had a durable outbox, so this needed a deadline parameter rather than
+  new machinery — `send_to_member_by`, with the six existing callers keeping the
+  24h default.
+
+  A member offline beyond the window still never learns. No window fixes that; the
+  honest fix is a retrieval path not gated on an ACL row, which is a larger design
+  than this. Stated in the spec and in the constant's doc comment rather than left
+  for someone to discover.
+
+  **Never for a self-leave.** `remove_inner` serves both the admin path and the
+  DIDComm self-leave. A member who chose to leave already has their receipt, and
+  telling them they were "removed" is a different and worse thing to be told.
+
+  **Best-effort.** The notice never fails the removal. That has already happened
+  and is durable; refusing the operator's request because the notice could not be
+  *queued* would leave the member removed and the operator believing they were
+  not. Failures log loudly — and log "queued", not "sent", because a DIDComm `Ok`
+  means the mediator accepted the frame and nothing more (R1.1).
+
+  Seven tests. Four unit: payload shape, a blank reason omitted rather than sent
+  as an empty string, the two codes distinguishable, and the payload validated
+  against the *published* schema — the check that catches the implementation
+  drifting from the spec it claims to implement.
+
+  Three end-to-end over a real mediator, because only a peer holding the document
+  demonstrates the feature: an admin removal arrives signed with its reason and
+  deciding admin, a purge says it was a purge, and a self-leave sends nothing. Two
+  of them first failed on `no active removal policy`, which was the paths
+  differing exactly as specified — a purge deliberately skips the removal policy,
+  which is why that one passed before the fixture seeded any.
+
+- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))
+
+Applications built on a VTA have had nowhere to keep versioned metadata.
+  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
+  beside the secrets vault and the credential vault, for JSON an application
+  owns and the VTA does not interpret.
+
+  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
+  application so several tools can share a context without colliding, and is the
+  seam a per-namespace grant would later use — which is why it is part of the
+  address rather than a prefix convention on the key. In 1.0 a namespace is
+  collision avoidance and NOT a trust boundary: an application with write access
+  to a context reaches every namespace in it, and the `put` and `delete` specs
+  say so normatively. Isolation means separate contexts.
+
+  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
+  nothing to hang a precondition on, and its `list` returns the whole context —
+  but the argument that settles it is that "forget everything" has to stay a safe
+  thing to ask an agent, which it cannot be if account state lives there.
+
+  Three properties are why this is a store rather than a field on an existing one.
+
+  **One counter per `(contextId, namespace)`, not per record.** A record's
+  `version` is the counter value its most recent write took, so one number is
+  simultaneously the optimistic-concurrency token `expectedVersion` compares
+  against and the watermark `sinceVersion` compares against. A per-record counter
+  serves the first but cannot serve the second — two records' counters are not
+  comparable, so no single number means "everything after this point" — and would
+  have forced a second sequence kept consistent by hand. The cost is that a
+  record's version jumps by whatever its neighbours consumed, which the wire
+  contract states: versions are opaque and monotonic, never an edit count.
+
+  **A failed precondition returns the current version AND value.** A bare
+  rejection obliges a re-read, and the re-read races the next write; the pattern
+  has no fixed point under contention. Returning the winner's view removes the
+  race rather than narrowing it, and the spec makes it normative.
+
+  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
+  one, a consumer pulling from a watermark learns of every create and update and
+  never of a deletion, so deleted records resurrect on its next rebuild.
+  Retention is `app_state.tombstone_retention_days` (default 30, matching the
+  vault's `grace_days`) — a destructive window is an operator's choice, not a
+  constant — and `list` advertises the configured value, since a consumer
+  schedules against that number. The sweeper runs from the storage thread beside
+  the ACL/consent/vault sweepers.
+
+  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
+  version order and stops at the first still inside the window. Reaping a later
+  tombstone while leaving an earlier one would make the reap watermark
+  unstateable — no single number would describe what survives, which is precisely
+  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
+  that is enforced at the call site rather than as a zero cutoff, which would mean
+  the opposite.
+
+  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
+  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
+  surviving only in the journal buffer can be re-derived after a crash and reissue
+  a used value. Here a reused version means two records collide on one `appv:`
+  index key, so one disappears from the change feed and every incremental consumer
+  misses that change permanently, silently. A batch reserves a block and pays one
+  fsync rather than N; writes that then fail leave gaps, which are safe and
+  tested.
+
+  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
+  finds a tombstone and deliberately takes no new version, so a watcher sees
+  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
+  does not converge, and the class is per URI, not per payload.
+
+  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.
+
+  Concurrency is a process-local lock per namespace, not a store-layer
+  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
+  share a store, and the vsock protocol has no atomic opcode — its
+  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
+  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
+  would need to be real. Recorded in the design note with what would change that.
+
+  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
+  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
+  an older resolve fails as a stale dependency rather than as unspecced URIs.
+  Conformance witnesses cover all six URIs, so nothing enters
+  `UNSPECCED_DISPATCHED_URIS`.
+
+
+
+### Changed
+
+- Delete the Verifiable-prefixed credential tags that were never DTG types ([#1071](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1071))
+
+`VerifiableMembershipCredential` and `VerifiableEndorsementCredential` are not
+  DTG credential types and never were. The specification defines seven concrete
+  subtypes; neither is among them, and nothing in this stack has ever issued
+  either. They survived as a name, a pair of literals and a compatibility shim,
+  and between them they broke cross-community recognition for every real
+  presentation ([#1062](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1062)).
+
+  Four places, one cause.
+
+  **The SDK constant.** `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` held the value
+  `"MembershipCredential"`, with a doc comment explaining that the prefix in the
+  name was historical and the tag did not have it. A constant whose name
+  disagrees with its value is an invitation, and it was taken: someone reading
+  the name hand-rolled `"VerifiableEndorsementCredential"` into the recognition
+  path, where it matched nothing. Renamed to `MEMBERSHIP_CREDENTIAL_TYPE`, and
+  `ENDORSEMENT_CREDENTIAL_TYPE` added beside it so the VEC tag has a home rather
+  than being a literal at the point of use.
+
+  **The compatibility shim.** #1063 added `LEGACY_TYPE_TAGS`, accepting both
+  prefixed tags from peers predating the catalog adoption. Nothing is published,
+  so no such peer exists — and a reference implementation that accepts a type the
+  specification does not define reintroduces exactly the drift the function it
+  sits in was written to prevent. Removed; the test that pinned the behaviour now
+  pins its refusal.
+
+  **The audit trail.** Emitted envelopes recorded `credential_type:
+  "VerifiableMembershipCredential"` / `"VerifiableEndorsementCredential"` — tags
+  no credential ever carried, in the one record meant to be authoritative after
+  the fact. They now record what was issued.
+
+  **The policy input.** `issuer_member` / `subject_member` were carried alongside
+  `issuer` / `subject` for operator policies written against the pre-#1061 shape.
+  There are no deployed operator policies to preserve, and two spellings of one
+  concept is how the concept drifts. The duplicates are gone and the surviving
+  fields carry `is_current`.
+
+
+
+### Fixed
+
+- **vta**: Three of the four responses the conformance layer found ([#1114](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1114))
+
+Closes three of the four violations #1113 reported. The fourth is the vault
+  pair, blocked on trust-tasks-rs 0.11.16 (dtgwg-trust-tasks-tf#268).
+
+  `vta/webvh/dids/get/1.0` carried its record under `#[serde(flatten)]` since
+  #849, to make the folded task a strict superset of the two shapes it replaced.
+  That superset was readable by no conforming client: the response is
+  `additionalProperties: false`, so a flattened record fails on all eleven
+  members and the `ext` slot is unreachable. Its sibling settles which side
+  moves — `dids/list` carries the same component nested under `dids` and has
+  always conformed, so flattening made `get` the outlier in its own family.
+
+  Both SDK client methods decoded the flat shape straight into
+  `WebvhDidRecord`, so the workspace compiled clean while the wire broke. They
+  now project the envelope. `webvh_get_did_round_trips_after_the_get_log_fold`
+  predicted exactly this in its doc comment and caught it.
+
+  `provision/integration/0.2` sent `null` for `adminTemplateName` and
+  `webvhServerId`, the only two of five `Option<String>` members without
+  `skip_serializing_if`.
+
+- **vtc**: A null the schema forbids, and three fixtures that lied ([#1099](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1099))
+
+Four entries close, and three of the four closed because the **ledger was
+  wrong**, not because anything about the service changed. Drift **15 → 12**,
+  with `join-requests/submit` narrowed from both sides to response-only.
+
+  Found by making the conformance probe print the *actual* parse error for
+  every drift entry rather than re-reading the notes — the same technique that
+  surfaced the #1098 defect. The notes are prose and can be wrong in either
+  direction; the schemas cannot.
+
+  ## One real bug: a `null` where the schema says `object`
+
+  `JoinRequest.policyDecision` is `Option<JsonValue>` with `#[serde(default)]`
+  and no `skip_serializing_if`, so it went out as `"policyDecision": null` on
+  every row that had no policy decision — which is every row in Phase 1.
+
+  The component types it **`object`**, not `["object", "null"]` as it types the
+  neighbouring `vpClaims` and `decision`. It is not required, so *absent* is
+  how you say "no policy decision"; `null` is a type error. Now omitted.
+
+  `JoinRequestSubmitBody.extensions` in `vta-sdk` had the identical shape — a
+  bare `#[serde(default)]` `JsonValue` serialising `Value::Null` against a
+  schema that types it `object`, so a minimal client's submit was
+  non-conformant. The existing note had diagnosed this exactly and called it "a
+  one-line fix in vta-sdk"; this is that line.
+
+  Both are the null-into-`Option` class that shipped `keys/create/0.1` broken.
+
+  ## Three fixtures that lied
+
+  **`totalEstimate` was invented.** The `paginated()` helper hand-wrote
+  `"totalEstimate": 12`. Nothing in the workspace ever sets `total_estimate` to
+  `Some` — it is `skip_serializing_if = "Option::is_none"` and every producer
+  passes `None`, so it has never reached the wire. The fixture made
+  `endorsement-types/list` look non-conformant against a schema that simply
+  does not define the member.
+
+  **`endorsement-types/list`'s note blamed `createdByDid`**, which has been
+  defined upstream since 0.11.8. The real error was the invented
+  `totalEstimate`. Entry now `checked!`.
+
+  **`community/profile/*`'s notes over-claimed.** `show` listed
+  `relationshipIdentifierDefault` among its unspecced members — defined as of
+  0.11.8. `update` claimed `fieldsChanged` was a divergence; the response
+  schema defines it. That one is worth naming precisely, because it is a trap
+  in how the probe reads: **a serde parse stops at the first unknown member and
+  never reaches the rest**, so everything a note lists after the first is
+  inference, not evidence. Both notes now say only what the schema actually
+  refuses.
+
+  ## What the remaining twelve are
+
+  With the notes corrected, the residue is short and honest:
+
+  - `communityDid` / `createdAt` on `CommunityProfile` — 2 entries, one change
+  - `credential` / `expiresAt` not on the stored endorsement row — 2 entries,
+    a storage decision (see #1098)
+  - `factsTemplate`, `etag`, `deployedAt`/`sizeBytes`, the diagnostics
+    transport half — 4 entries, service ahead of spec
+  - `auth/recognise`, `install/claim/start`, `install/claim/finish`,
+    `join-requests/submit` — 4 entries, genuine design questions
+
+  ## Gates
+
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+  - `cargo test --workspace --no-fail-fast` — the whole workspace, since this
+    touches `vta-sdk`
+  - `cargo fmt --all --check`
+
+- **sdk**: Look for pnm sessions where pnm actually writes them ([#1087](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1087))
+- **mcp**: Look the pnm session up under the key pnm actually writes ([#1083](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1083))
+
+`vta-mcp --vta <slug>` — the invocation its own README documents — could
+  never find a session. `pnm` stores every login under the keyring key
+  `vta:<slug>` (`vta_keyring_key`, pnm-cli/src/config.rs), `cnm` uses
+  `community:<slug>` for the same reason, and neither session backend adds
+  a prefix on the way in or out. vta-mcp passed the bare slug, so the
+  lookup missed and the operator was told they were not authenticated.
+
+  That failure mode is worth naming: from the operator's side it is
+  indistinguishable from an expired login. They run `pnm auth status`, are
+  told they are fine, and are none the wiser.
+
+  The rule now has one definition, `agent_connect::pnm_session_key`, next
+  to the connect ladder both agent-side bridges share — a second consumer
+  (the agent-memory service) hit exactly this. It is idempotent, so an
+  operator who worked the bug out and passes `vta:mine` keeps working.
+
+- **vtc**: Tell a rejected applicant why, on the one path built to recover it ([#1058](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1058))
+
+`project_status` projected `needs` / `presentationDefinition` for a
+  `Deferred` request and bare `{requestId, status}` for a `Rejected` one.
+  The evidence existed on both rejection paths and neither reached the
+  applicant through the poll.
+
+  The correlated `VerdictResponse` was the only place a `{code, reason}`
+  ever reached an applicant, which makes it a one-shot delivery: a socket
+  that was down, a reply that was lost, or a rejection an admin took hours
+  later, and the reason was unrecoverable. The poll is the natural recovery
+  path and it was the one path that deliberately stripped it. An
+  admin-rejected applicant could never learn why at all — `reject_pending`
+  emits no message to them, and the operator's reason reached only the
+  audit log, which no applicant can read.
+
+  Both paths now write one `JoinRequest::decision` field — code, optional
+  reason, and the decision's own timestamp — and the poll projects it. One
+  field rather than two, because the whole failure was two producers of the
+  same fact drifting apart. It is deliberately *not* `policy_decision`: an
+  operator's decision is not a policy verdict, and recording it as one
+  would make the audit trail lie about where the refusal came from. The
+  admin path carries `ADMIN_REJECT_CODE` ("admin-reject"), which is what
+  lets a client tell "the rules refused you, satisfy them and re-apply"
+  from "a human refused you, re-applying changes nothing".
+
+  `decidedAt` is separate from the response document's `issuedAt` because
+  `issuedAt` is when *this document* was produced. For an admin reject the
+  two diverge by however long the applicant takes to poll. The test proves
+  the distinction the only way it can be proved: poll twice, and `issuedAt`
+  moves while `decidedAt` names the same moment.
+
+  Rows rejected before this existed are not abandoned. An auto-deny always
+  wrote the serialized `Deny` verdict, so `decision_for_applicant` falls
+  back to it — recovering the code and reason, and reporting `decided_at:
+  None` rather than back-filling a timestamp that would tell the applicant
+  they were rejected the instant they polled. A legacy *admin* reject has
+  nothing to recover and answers exactly as it did before.
+
+  Also adds `VerdictResponse::deny`, which the issue asked for alongside:
+  the deny shape had `allow` and `refer` constructors but was hand-assembled
+  at its one call site, and this change gave it a second producer.
+
+
+
+### Chore
+
+- **vtc**: Recognise and submit 0.2 — drift reaches zero ([#1105](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1105))
+
+Retargets `auth/recognise` and `join-requests/submit` to the `0.2` versions
+  published by trustoverip/dtgwg-trust-tasks-tf#264.
+
+  **Drift 2 → 0.** Every Trust Task this service binds now speaks the schema it
+  publishes, on both sides. It was 33 when the sweep landed yesterday.
+
+  ## Why these two moved the spec rather than the service
+
+  Both were recorded as "the service's shape is arguably stronger". Reading them
+  properly, one was not arguable at all.
+
+  **`auth/recognise/0.1` took `{vec, vmc}` — a replayable impersonation token.**
+  Both credentials are bearer artifacts, so anyone who obtained the pair from a
+  relayed join, an audit log, a backup or a compromised device held everything
+  the payload required, and the recognising community could not distinguish the
+  subject from someone holding a copy. No proof of key possession, no freshness,
+  no audience binding: one captured pair worked at every community that
+  recognised the issuer, indefinitely. This service has required a holder-signed
+  presentation — nonce, `domain`, holder-is-subject — since P0.2. `0.2` publishes
+  that.
+
+  **`join-requests/submit/0.1` returned `status: const "pending"`** where a
+  submission has four outcomes. `0.2` returns a verdict.
+
+  ## One real find in the retarget
+
+  `VerdictEffect` serialised **`request_more`**, but I had specced `requestMore`
+  in #264, and SPEC §4.10 rule 4 is explicit that specification-defined decision
+  values are lowerCamelCase. So the wire was wrong.
+
+  The fix is not to change either vocabulary wholesale, because there are two of
+  them and both are correct in their own language:
+
+  - **Rego authors verdicts.** Operator-written policy returns
+    `{"effect": "request_more", …}`, and snake_case is that language's idiom —
+    `vtc-service/policies/default/join.rego` and every deployed policy alongside
+    it. Re-casing there would break operator policies to satisfy a wire rule
+    that does not govern them.
+  - **The wire publishes `requestMore`**, per §4.10 and the new
+    `vtc/_shared/0.1/ceremony#VerdictEffect`.
+
+  `VerdictEffect` is the boundary: it now serialises camelCase and keeps
+  `#[serde(alias = "request_more")]` so anything producing the policy spelling
+  still deserialises. That is the same storage-versus-wire split `EndorsementRow`
+  ([#1096](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1096)) and `GenerationRow` ([#1095](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1095)) draw, applied to a policy vocabulary
+  instead of a keyspace.
+
+  The test that caught it now demonstrates the boundary instead of hiding it —
+  its inline Rego authors `request_more`, and it asserts the wire says
+  `requestMore`, with a comment saying why both are right.
+
+  ## The table at zero
+
+  `KNOWN_DRIFT_COUNT` stays asserted at `0`. It can no longer shrink, so the only
+  thing it can do is catch a regression — which is what an asserted count is for.
+  A new task that diverges must add a `drift!` entry and raise it deliberately.
+
+  The `drift!` macro, `Side`, and `Conformance::KnownDrift` are now unconstructed
+  and kept with `#[allow(dead_code)]` rather than deleted. They are the
+  vocabulary for *recording* a divergence, and a table with no way to say "this
+  diverges, on this side, for this reason" invites the next author to leave a
+  real divergence unrecorded rather than write the machinery back. Deleting them
+  would make the zero look permanent instead of current.
+
+  ## The header, rewritten
+
+  It described a 33-entry backlog. It now records how the 33 actually closed,
+  because the distribution is not what the sweep predicted:
+
+  | | |
+  |---|---|
+  | **10** | by correcting this service's wire shapes |
+  | **19** | on dependency bumps alone — the specs had moved and the notes had not |
+  | **4** | by correcting the **specification**, once the published shape turned out to be the weaker one |
+
+  That last group is the one worth remembering. A conformance table makes
+  divergence visible and says nothing about which side is wrong, and *"the schema
+  requires X and the service omits X"* reads as an accusation against the
+  implementation. Twice it was the schema. Once — `install/claim` — the
+  requirement had been built, found impossible in a browser, and removed two
+  months **before** the specification demanding it was written, and this table
+  recorded that as the service being behind on a security control.
+
+  ## Gates
+
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+  - `cargo test --workspace --no-fail-fast`
+  - `cargo fmt --all --check`
+
+- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))
+
+`cargo outdated` reported 13 direct dependencies behind and `cargo update`
+  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
+  reports "All dependencies are up to date".
+
+  Two of these were not cosmetic.
+
+  **p256 was duplicated in the build.** Our crates declared `0.13` while
+  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
+  already pulled `0.14`, so the graph carried two copies of a curve
+  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
+  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
+  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
+  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.
+
+  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
+  depends on it solely as a feature enabler: iOS has no native trust store, so
+  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
+  fails with "no native root CA certificates found". Features unify per major
+  version, so the declaration only works while it matches the version
+  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
+  Updating everything *except* this one would have stranded the enabler and
+  broken iOS `wss://` silently.
+
+  The rest:
+
+  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
+    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
+    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
+    which is also a more direct statement of what it wanted.
+  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
+    `trust-tasks-rs`.
+  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
+    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
+    on is unchanged.
+  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
+    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
+    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
+    flags, drops out of the graph entirely.
+
+  Two deliberate choices where the shortest path was worse:
+
+  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
+  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
+  encoding" and "valid encoding, point not on the curve" into one error, and
+  those say different things to whoever reads the log — a broken client versus
+  a point somebody chose.
+
+  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
+  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
+  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
+  than resting on a panic inside a deprecated helper.
+
+  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
+  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
+  path. `cargo deny check advisories` passes.
+
+
+
 ## [0.28.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.27.0...vta-sdk-v0.28.0) — 2026-08-22
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.28.0"
+version = "0.29.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,374 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.21.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.20.0...vta-service-v0.21.0) — 2026-08-26
+
+
+### Added
+
+- **vta**: Framework 0.5.0 freshness bounds at the dispatch spine ([#1117](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1117))
+
+Framework 0.5.0 Consumer Requirements item 13. A consumer MUST reject a
+  document whose `issuedAt` is ahead of its own clock beyond its skew tolerance,
+  and one whose `expiresAt` is at or before its `issuedAt`.
+
+  Both are `malformedRequest`, never `expired`, and that distinction is the
+  substance of the rule: `expired` names a document that was once acceptable and
+  no longer is, so it tells the producer to wait when what it must do is reissue.
+  Neither of these was acceptable at any instant.
+
+  The rule makes the duplicate-execution record of item 11 implementable. That
+  record is bounded only if every accepted document can be placed in a window,
+  and both shapes escape every window while still looking acceptable: a future
+  `issuedAt` sits in a window that has not opened and re-enters it as the clock
+  advances, and an `expiresAt` at or before issuance describes an interval that
+  never contained an instant.
+
+  This is a stand-in and says so. `trust-tasks-rs` 0.12.0
+  (dtgwg-trust-tasks-tf#274) ships `FreshnessPolicy` and
+  `TrustTask::validate_freshness`, which implement these two rules identically —
+  same 60s skew — and add the `max_age` window and the `ReplayGuard` item 11
+  needs. The 0.12 bump is blocked on an external crate: `affinidi-messaging-sdk`
+  0.19.12 pins `trust-tasks-rs ^0.11` and `vta_sdk::acl_setup` hands it a
+  generated `MediatorAcl`, so two nodes in one graph fail to compile with
+  `expected MediatorAcl, found a different MediatorAcl`. The four sibling
+  trust-tasks crates have published 0.12-compatible releases; the messaging SDK
+  has not.
+
+  The module doc names the blocker and the replacement call, and the tests are
+  written against behaviour rather than this implementation, so they survive the
+  swap unchanged and are the check that it was faithful.
+
+- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))
+
+Applications built on a VTA have had nowhere to keep versioned metadata.
+  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
+  beside the secrets vault and the credential vault, for JSON an application
+  owns and the VTA does not interpret.
+
+  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
+  application so several tools can share a context without colliding, and is the
+  seam a per-namespace grant would later use — which is why it is part of the
+  address rather than a prefix convention on the key. In 1.0 a namespace is
+  collision avoidance and NOT a trust boundary: an application with write access
+  to a context reaches every namespace in it, and the `put` and `delete` specs
+  say so normatively. Isolation means separate contexts.
+
+  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
+  nothing to hang a precondition on, and its `list` returns the whole context —
+  but the argument that settles it is that "forget everything" has to stay a safe
+  thing to ask an agent, which it cannot be if account state lives there.
+
+  Three properties are why this is a store rather than a field on an existing one.
+
+  **One counter per `(contextId, namespace)`, not per record.** A record's
+  `version` is the counter value its most recent write took, so one number is
+  simultaneously the optimistic-concurrency token `expectedVersion` compares
+  against and the watermark `sinceVersion` compares against. A per-record counter
+  serves the first but cannot serve the second — two records' counters are not
+  comparable, so no single number means "everything after this point" — and would
+  have forced a second sequence kept consistent by hand. The cost is that a
+  record's version jumps by whatever its neighbours consumed, which the wire
+  contract states: versions are opaque and monotonic, never an edit count.
+
+  **A failed precondition returns the current version AND value.** A bare
+  rejection obliges a re-read, and the re-read races the next write; the pattern
+  has no fixed point under contention. Returning the winner's view removes the
+  race rather than narrowing it, and the spec makes it normative.
+
+  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
+  one, a consumer pulling from a watermark learns of every create and update and
+  never of a deletion, so deleted records resurrect on its next rebuild.
+  Retention is `app_state.tombstone_retention_days` (default 30, matching the
+  vault's `grace_days`) — a destructive window is an operator's choice, not a
+  constant — and `list` advertises the configured value, since a consumer
+  schedules against that number. The sweeper runs from the storage thread beside
+  the ACL/consent/vault sweepers.
+
+  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
+  version order and stops at the first still inside the window. Reaping a later
+  tombstone while leaving an earlier one would make the reap watermark
+  unstateable — no single number would describe what survives, which is precisely
+  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
+  that is enforced at the call site rather than as a zero cutoff, which would mean
+  the opposite.
+
+  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
+  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
+  surviving only in the journal buffer can be re-derived after a crash and reissue
+  a used value. Here a reused version means two records collide on one `appv:`
+  index key, so one disappears from the change feed and every incremental consumer
+  misses that change permanently, silently. A batch reserves a block and pays one
+  fsync rather than N; writes that then fail leave gaps, which are safe and
+  tested.
+
+  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
+  finds a tombstone and deliberately takes no new version, so a watcher sees
+  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
+  does not converge, and the class is per URI, not per payload.
+
+  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.
+
+  Concurrency is a process-local lock per namespace, not a store-layer
+  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
+  share a store, and the vsock protocol has no atomic opcode — its
+  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
+  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
+  would need to be real. Recorded in the design note with what would change that.
+
+  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
+  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
+  an older resolve fails as a stale dependency rather than as unspecced URIs.
+  Conformance witnesses cover all six URIs, so nothing enters
+  `UNSPECCED_DISPATCHED_URIS`.
+
+- **audit**: Make the audit destination a deployment choice, not a protocol one ([#1049](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1049))
+
+`AuditLogEntry` is `{id, timestamp, action, actor, resource, outcome, channel,
+  contextId, detail}` — no signature, no hash chain. The log corroborates what
+  happened; it cannot prove it, and a compromised VTA can rewrite its own history.
+  The canonical `AuditEnvelope` already names the members that would change that
+  (`prevHash`, `entryHash`, `schemaVersion`) and records why this maintainer omits
+  them: its log is flat and unchained.
+
+  This does not add tamper-evidence, deliberately. It adds the seam, so an
+  operator who needs a stronger guarantee implements one — an append-only file, a
+  transparency log, a blockchain anchor, a hash chain filling in those three
+  members — without the VTA committing to any scheme. Closes #1031.
+
+  ## The shape
+
+- **service**: Retire routes and Trust Tasks on evidence, not on a hand audit ([#1047](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1047))
+
+Two gaps in how this workspace retires things, both surfaced while retiring
+  `vta/discovery/capabilities/1.0` (#1043, #1044). Closes #1045.
+
+  ## The superseded-route table had no guard
+
+  `deprecation.rs` maps legacy REST routes to the Trust Task that supersedes them
+  so that removal can be gated on observed usage dropping to zero. #1042 deleted
+  `GET /capabilities` and left its row behind — a row matching a path that can
+  never be hit again reads zero forever, which is exactly the signal the table
+  exists to produce, emitted about something already deleted. It was noticed by
+  accident and removed by hand in #1044, because nothing tied the table to the
+  live router.
+
+  `every_superseded_row_names_a_live_route` now walks the assembled router and
+  asserts every row matches a live route. It asserts on `MatchedPath` rather than
+  on a status code, because `MatchedPath` is what `mark_superseded` matches on: a
+  row spelling a parameter differently — `/acl/{id}` where the router registered
+  `/acl/{did}` — attaches no header and counts nothing while the route goes on
+  answering, and a status-only probe reads green over that. The failure text says
+  which way to fix it. The reverse direction is deliberately not asserted; a live
+  route absent from the table is legitimate, and `deprecation.rs` already records
+  which routes are excluded and why.
+
+  ## Trust Task URIs had no deprecation path at all
+
+  A task could be retired only by deleting it, and the only evidence available was
+  a source audit — grep the repos we can see and reason about the rest. That was
+  defensible for one task with zero consumers anywhere and does not generalise;
+  the next retirement may be one somebody is calling.
+
+  `SUPERSEDED_TASKS` gives them the route mechanism:
+  `deprecated_trust_task_requests_total` labelled by URI, the successor named in
+  the response so a client can act rather than guess, and removal on an observed
+  zero. Seeded with the eleven dispatched URIs already carrying `#[deprecated]` in
+  `vta_sdk::trust_tasks` — attributes that told a Rust caller to migrate, told a
+  wire caller nothing, and left no instrument saying whether anyone was still
+  sending them.
+
+  Checked against the framework first. The *registry* has the concept
+  (`status: retired` + `supersededBy`, how twelve `messaging/*` tasks were retired
+  upstream), but `trust-tasks-rs` 0.11 exposes none of it: `schema_index` is
+  URI → payload schema and nothing else, `Payload` carries no lifecycle constant,
+  and `trust-task-discovery/0.1`'s expanded `supportedTypes` entry is closed over
+  `{type, requiredExt}`. So this is invention rather than adoption; the vocabulary
+  matches the registry's so that adopting a published signal later is a rename.
+
+  The notice rides the response document's **top level**, not `payload.ext`. The
+  framework envelope keeps unrecognized top-level members in `TrustTask::extra`
+  and SPEC §7.1/§7.2 tells consumers to preserve rather than reject them, so a
+  member there cannot break a client that has never heard of it. `payload` can
+  make no such promise: every published payload schema is
+  `additionalProperties: false`, the generated `Response` types are
+  `deny_unknown_fields`, and the conformance sweep validates against both. This is
+  the Trust-Task analogue of putting the REST signal in a header — beside the
+  answer rather than inside it. A document carrying a `proof` is left untouched.
+
+  ## Both tables are now pinned to what they describe
+
+  `superseded_tasks_are_dispatched` refuses a row nothing routes (that reads zero
+  forever, same defect as the dangling route row), `superseded_task_successors_are
+  _served` refuses a successor this VTA does not serve (a notice that sends a
+  migrating client onto an unsupported type), and
+  `every_dual_accepted_spec_marks_its_0_1_form_superseded` pins
+  `wire_v0_2::WIRE_SPECS_V0_2` against `SUPERSEDED_TASKS`, so a new dual-accept
+  cannot land without an instrument on the form it replaces.
+
+  Not covered, and said so in the source rather than papered over:
+  `auth/passkey/login/{start,finish}/0.1` are deprecated but reach neither
+  instrument. They are REST-routed on paths the route table excludes on purpose,
+  and one path serves both versions with the delta inside the body, so separating
+  them needs a counter in those two handlers.
+
+  Two things the tests found rather than confirmed. The signal is attached in
+  `dispatch_trust_task_inner` wrapping every exit out of the checks, not after
+  them — the spine has a dozen early returns, and a URI going quiet because its
+  callers are all being rejected before the hook would read as "nobody sends this
+  any more"; the first version had exactly that hole and the rejection test caught
+  it. And that split is `Box::pin`ed: the callee's state machine inlines every
+  handler's future through `dispatch_typed`, and awaiting it by value overflowed
+  the test-thread stack in `tests/mock_vta.rs` under `cargo test --workspace`,
+  where feature unification builds more of vta-service than `-p vta-service` does.
+
+
+
+### Fixed
+
+- **vta**: Three of the four responses the conformance layer found ([#1114](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1114))
+
+Closes three of the four violations #1113 reported. The fourth is the vault
+  pair, blocked on trust-tasks-rs 0.11.16 (dtgwg-trust-tasks-tf#268).
+
+  `vta/webvh/dids/get/1.0` carried its record under `#[serde(flatten)]` since
+  #849, to make the folded task a strict superset of the two shapes it replaced.
+  That superset was readable by no conforming client: the response is
+  `additionalProperties: false`, so a flattened record fails on all eleven
+  members and the `ext` slot is unreachable. Its sibling settles which side
+  moves — `dids/list` carries the same component nested under `dids` and has
+  always conformed, so flattening made `get` the outlier in its own family.
+
+  Both SDK client methods decoded the flat shape straight into
+  `WebvhDidRecord`, so the workspace compiled clean while the wire broke. They
+  now project the envelope. `webvh_get_did_round_trips_after_the_get_log_fold`
+  predicted exactly this in its doc comment and caught it.
+
+  `provision/integration/0.2` sent `null` for `adminTemplateName` and
+  `webvhServerId`, the only two of five `Option<String>` members without
+  `skip_serializing_if`.
+
+- **vtc**: Follow the spec on every auth response, and close the conformance gate ([#1112](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1112))
+
+* test(vtc)!: make response conformance fail the build
+
+  Until now the layer reported and a green suite was not evidence of
+  conformance — #1107's own memory note said to grep the run rather than trust
+  the exit code, which is a signal nobody has to obey.
+
+  A violation outside the allowlist now returns 500 with the schema error, so the
+  test that provoked it fails on its own status assertion and prints the reason.
+  Chosen over panicking in middleware, which surfaces at the call site as a
+  transport error and says nothing about which task or why.
+
+  The allowlist is eight `auth/*` tasks with ALLOWED_COUNT asserted beside them —
+  the same discipline as KNOWN_DRIFT_COUNT, because the cheapest way to make a
+  failing check pass is to add a line to a list nobody watches. An allowlisted
+  violation is still reported, pinned by a test: a list that suppressed the
+  evidence would mean rediscovering each entry before it could be closed.
+
+  Two existing guards caught mistakes of mine on the first run. The allowlist
+  named login/{start,finish}/0.1 where the service binds 0.2 — built from the
+  violation output rather than the route mounts — and the manifest guard flagged a
+  fake `trusttasks.org/spec/` URI in a new unit test, correctly, since binding
+  such a URI asserts the registry serves it.
+
+  Also retargets relationships/{list,graph} to the 0.2s from
+  trustoverip/dtgwg-trust-tasks-tf#266, and fixes a seeder that wrote
+  `seed-{uuid}` into `vrcDigestMultibase` — unique per row, and so a suite
+  structurally blind to digest format.
+
+  The VTC family is now clean; every remaining violation is `auth/*`.
+
+- **service**: Make AppStateParts non-exhaustive so adding a field stops being a break ([#1057](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1057))
+
+`AppState` was marked `#[non_exhaustive]` in #1024 for a defect this struct
+  has too, and the two are constructed side by side. `AppStateParts` is all
+  public fields with no private field and no constructor guard, so any crate
+  could write an `AppStateParts { .. }` literal — including the
+  functional-update form — which made *adding a field* a source break under
+  `constructible_struct_adds_field`.
+
+  Not hypothetical, and recent: #1049 added `audit_sink`, and #1051 nearly added
+  `app_state_locks` before the break was spotted and routed around by taking the
+  value off the built `AppState` instead. That workaround was the right call for
+  a feature PR, but it treated the symptom.
+
+  Construction inside this crate is unaffected. Outside it, `Default` plus field
+  assignment replaces the literal:
+
+      let mut parts = AppStateParts::default();
+      parts.audit_sink = Some(sink);
+
+  `tests/audit_sink.rs` now does exactly that. It is worth noting *why* that file
+  had to change: an integration test is a separate crate, so it was the first
+  thing the attribute broke — which makes it a fair proxy for what a consumer
+  has to do, and a standing check that the supported shape keeps working.
+
+
+
+### Chore
+
+- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))
+
+`cargo outdated` reported 13 direct dependencies behind and `cargo update`
+  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
+  reports "All dependencies are up to date".
+
+  Two of these were not cosmetic.
+
+  **p256 was duplicated in the build.** Our crates declared `0.13` while
+  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
+  already pulled `0.14`, so the graph carried two copies of a curve
+  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
+  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
+  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
+  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.
+
+  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
+  depends on it solely as a feature enabler: iOS has no native trust store, so
+  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
+  fails with "no native root CA certificates found". Features unify per major
+  version, so the declaration only works while it matches the version
+  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
+  Updating everything *except* this one would have stranded the enabler and
+  broken iOS `wss://` silently.
+
+  The rest:
+
+  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
+    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
+    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
+    which is also a more direct statement of what it wanted.
+  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
+    `trust-tasks-rs`.
+  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
+    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
+    on is unchanged.
+  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
+    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
+    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
+    flags, drops out of the graph entirely.
+
+  Two deliberate choices where the shortest path was worse:
+
+  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
+  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
+  encoding" and "valid encoding, point not on the curve" into one error, and
+  those say different things to whoever reads the log — a broken client versus
+  a point somebody chose.
+
+  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
+  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
+  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
+  than resting on a panic inside a deprecated helper.
+
+  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
+  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
+  path. `cargo deny check advisories` passes.
+
+
+
 ## [0.20.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.19.0...vta-service-v0.20.0) — 2026-08-22
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -139,7 +139,7 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.14", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
@@ -147,7 +147,7 @@ vti-secrets = { path = "../vti-secrets", version = "0.2" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Structured audit logging (the `audit!` macro + audit-keyspace helpers),
 # extracted and re-exported as `crate::audit`.
-vta-audit = { path = "../vta-audit", version = "0.1" }
+vta-audit = { path = "../vta-audit", version = "0.2" }
 # VTA configuration types (AppConfig + sub-configs), extracted and re-exported
 # as `crate::config`. The `tee` feature enables `vta-config/tee`.
 vta-config = { path = "../vta-config", version = "0.3" }
@@ -156,19 +156,19 @@ vta-config = { path = "../vta-config", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }
 # Key management (seed store, BIP-32 derivation, wrapping), extracted and
 # re-exported as `crate::keys`. Backend features chain to `vta-keys/*`.
-vta-keys = { path = "../vta-keys", version = "0.2" }
+vta-keys = { path = "../vta-keys", version = "0.3" }
 # Holder credential vault (storage/query/receive/present/status), extracted to
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
-vta-vault = { path = "../vta-vault", version = "0.3" }
+vta-vault = { path = "../vta-vault", version = "0.4" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.
-vta-sweepers = { path = "../vta-sweepers", version = "0.2" }
+vta-sweepers = { path = "../vta-sweepers", version = "0.3" }
 # Backup/restore subsystem (export/import ops + backup-bundle store/sweeper),
 # extracted and re-exported as crate::operations::backup +
 # crate::{backup_bundle_store,backup_bundle_sweeper}. Feature edges: this
 # crate's `webvh` / `tee` features enable `vta-backup/webvh` / `vta-backup/tee`.
-vta-backup = { path = "../vta-backup", version = "0.1" }
+vta-backup = { path = "../vta-backup", version = "0.2" }
 # TEE bootstrap subsystem (attestation, KMS, anchor MAC, DID autogen),
 # extracted and re-exported as crate::tee behind this crate's `tee` feature.
 vta-tee = { path = "../vta-tee", version = "0.1", optional = true }
@@ -179,13 +179,13 @@ vta-policy = { path = "../vta-policy", version = "0.2" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.1", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
 # ceremony in `operations::passkey_vms`); this crate handles the
 # *assertion* (login) path against DID-document VMs.
-vti-webauthn = { path = "../vti-webauthn", version = "0.1" }
+vti-webauthn = { path = "../vti-webauthn", version = "0.2" }
 # Trust-Tasks framework — wire-envelope for the trust-task migration.
 # `trust-tasks-rs` provides TrustTask<P>, Proof, dispatcher types.
 # `trust-tasks-https` provides the HttpsHandler adapter + status-code
@@ -375,7 +375,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.12](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.11...vta-support-v0.2.12) — 2026-08-26
+
+
 ## [0.2.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.10...vta-support-v0.2.11) — 2026-08-22
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -29,8 +29,8 @@ vta-config = { path = "../vta-config", version = "0.3" }
 # verifies each crate in isolation, where nothing enables it, so the method
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
-vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.14", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.2.0...vta-sweepers-v0.3.0) — 2026-08-26
+
+
+### Added
+
+- **audit**: Make the audit destination a deployment choice, not a protocol one ([#1049](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1049))
+
+`AuditLogEntry` is `{id, timestamp, action, actor, resource, outcome, channel,
+  contextId, detail}` — no signature, no hash chain. The log corroborates what
+  happened; it cannot prove it, and a compromised VTA can rewrite its own history.
+  The canonical `AuditEnvelope` already names the members that would change that
+  (`prevHash`, `entryHash`, `schemaVersion`) and records why this maintainer omits
+  them: its log is flat and unchained.
+
+  This does not add tamper-evidence, deliberately. It adds the seam, so an
+  operator who needs a stronger guarantee implements one — an append-only file, a
+  transparency log, a blockchain anchor, a hash chain filling in those three
+  members — without the VTA committing to any scheme. Closes #1031.
+
+  ## The shape
+
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.1.4...vta-sweepers-v0.2.0) — 2026-08-20
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,10 +20,10 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13" }
-vta-audit = { path = "../vta-audit", version = "0.1" }
+vti-common = { path = "../vti-common", version = "0.14" }
+vta-audit = { path = "../vta-audit", version = "0.2" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vta-vault = { path = "../vta-vault", version = "0.3" }
+vta-vault = { path = "../vta-vault", version = "0.4" }
 tracing = { workspace = true }
 chrono = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.10](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.9...vta-tee-v0.1.10) — 2026-08-26
+
+
 ## [0.1.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.8...vta-tee-v0.1.9) — 2026-08-20
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,10 +27,10 @@ repository.workspace = true
 tenant-overlay = ["dep:tokio-vsock"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13", features = ["encryption", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.14", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.3", features = ["tee"] }
-vta-keys = { path = "../vta-keys", version = "0.2" }
+vta-keys = { path = "../vta-keys", version = "0.3" }
 vta-support = { path = "../vta-support", version = "0.2" }
 aes-gcm = { workspace = true }
 utoipa = { workspace = true }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.4...vta-vault-v0.4.0) — 2026-08-26
+
+
+### Chore
+
+- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))
+
+`cargo outdated` reported 13 direct dependencies behind and `cargo update`
+  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
+  reports "All dependencies are up to date".
+
+  Two of these were not cosmetic.
+
+  **p256 was duplicated in the build.** Our crates declared `0.13` while
+  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
+  already pulled `0.14`, so the graph carried two copies of a curve
+  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
+  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
+  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
+  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.
+
+  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
+  depends on it solely as a feature enabler: iOS has no native trust store, so
+  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
+  fails with "no native root CA certificates found". Features unify per major
+  version, so the declaration only works while it matches the version
+  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
+  Updating everything *except* this one would have stranded the enabler and
+  broken iOS `wss://` silently.
+
+  The rest:
+
+  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
+    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
+    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
+    which is also a more direct statement of what it wanted.
+  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
+    `trust-tasks-rs`.
+  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
+    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
+    on is unchanged.
+  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
+    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
+    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
+    flags, drops out of the graph entirely.
+
+  Two deliberate choices where the shortest path was worse:
+
+  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
+  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
+  encoding" and "valid encoding, point not on the curve" into one error, and
+  those say different things to whoever reads the log — a broken client versus
+  a point somebody chose.
+
+  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
+  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
+  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
+  than resting on a panic inside a deprecated helper.
+
+  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
+  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
+  path. `cargo deny check advisories` passes.
+
+
+
 ## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.3...vta-vault-v0.3.4) — 2026-08-22
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.3.4"
+version = "0.4.0"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -33,8 +33,8 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.13", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["didcomm", "sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.14", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.14](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.13...vta-webvh-v0.1.14) — 2026-08-26
+
+
 ## [0.1.13](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.12...vta-webvh-v0.1.13) — 2026-08-22
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.1.13"
+version = "0.1.14"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,8 +21,8 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.13" }
-vta-sdk = { path = "../vta-sdk", version = "0.28" }
+vti-common = { path = "../vti-common", version = "0.14" }
+vta-sdk = { path = "../vta-sdk", version = "0.29" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.11...vtc-client-v0.4.0) — 2026-08-26
+
+
+### Fixed
+
+- **common**: Send the pagination wrapper in camelCase, as the schemas always said ([#1078](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1078))
+
+`Paginated<T>` carried no `rename_all`, so every list task sent `next_cursor`
+  and `total_estimate` against published schemas that say `nextCursor` and
+  `totalEstimate`. A direct R3.1 violation, and the same casing-drift class as
+  #656/#658 — where an empty `allowed_contexts` silently minted a super-admin.
+
+  Nothing caught it because nothing compared the two. The service sent one
+  spelling, `vtc-client` mirrored the service rather than the schema, and the
+  admin SPA typed its fields from the service too. All three agreed with each
+  other and none agreed with the contract. The conformance witness added in
+  #1076 is what finally put them side by side.
+
+  Four consumers move together: the wrapper in `vti-common`, `vtc-client`'s
+  `Page<T>`, and the `joinRequests` and `members` admin plugins. `audit.tsx`
+  reads a `cursor` member of a different shape and is untouched.
+
+  ## The count goes 33 → 32, not 33 → 28
+
+  The witness refused 28 and accepted 32, which is the useful part of this
+  change and the reason the module doc is rewritten rather than decremented.
+
+  Five entries cited the wrapper. Only `relationships/list` becomes fully
+  conforming, because it was the only one whose drift was the wrapper alone —
+  its spec types `items` as free objects. The other four still diverge at row
+  level (`createdByDid`, `vpClaims`, `MemberResponse` members) and keep their
+  entries, now describing only what is left rather than restating a casing bug
+  that is fixed.
+
+  Closing a shared root cause moves four entries without closing them. A drift
+  count that fell by five would have implied more progress than happened, and
+  `known_drift_entries_still_diverge_where_they_say_they_do` is what stopped it
+  saying so.
+
+
+
 ## [0.3.11](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.3.10...vtc-client-v0.3.11) — 2026-08-22
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.3.11"
+version = "0.4.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -117,7 +117,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13", features = [
+vti-common = { path = "../vti-common", version = "0.14", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
@@ -134,7 +134,7 @@ vti-common = { path = "../vti-common", version = "0.13", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.2" }
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,364 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.13.2...vti-common-v0.14.0) — 2026-08-26
+
+
+### Added
+
+- **vtc**: Implement the VPC as the deliberate-correlation mechanism on an edge ([#1074](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1074))
+
+* feat(vtc): implement the VPC as the deliberate-correlation mechanism on an edge
+
+  `PersonaCredential` appeared nowhere in this repo and
+  `DTGCredential::new_vpc` was never called, so the P-DID had no
+  implementation and the word "persona" drifted onto the membership DID for
+  want of anything to anchor it ([#1067](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1067)).
+
+  What the absence cost, concretely. After the publish proof-of-possession
+  change ([#1054](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1054)) a member had exactly two settings: publish under a pairwise
+  relationship DID and correlate with nothing, or publish under the
+  membership DID and correlate with everything, permanently, for anyone who
+  retains the credential. DTG Credentials §Privacy Considerations 3 says
+  correlation "should occur only through the holder's deliberate assertion of
+  a persona (via a VPC) or an M-DID". The precise instrument was missing, so
+  members had only the blunt one.
+
+  This adds the VTC half of it: `POST` / `DELETE
+  /v1/relationships/{id}/persona` (`vtc-service/src/routes/relationships.rs`).
+  A VPC is an *annotation* credential — it creates no graph structure, it
+  attaches to structure that already exists — so there is no "publish a VPC",
+  only "attach this persona to that edge", and the annotation is stored on the
+  edge row (`vtc-service/src/relationships/mod.rs`) rather than in a keyspace
+  of its own. The P-DID surfaces on `GET /v1/relationships/graph` as
+  `personaDid`, which is where the correlation becomes visible; an annotation
+  nothing reads would leave #1067 in the state it describes.
+
+  trustoverip/dtgwg-cred-spec#9 asks how a VPC binds to a specific
+  relationship and is open. Nothing here answers it. A VPC names its persona
+  (`issuer`) and the counterparty (`credentialSubject.id`) and not the
+  relationship DID the persona used, so it does not identify an edge on its
+  own.
+
+  Rather than add a field to the credential and present that as the
+  resolution, the binding is made at the request level:
+
+  1. the caller names the edge by id in the URL;
+  2. the caller proves control of that edge's `issuerDid`, with the same
+     proof-of-possession construction publishing the edge required;
+  3. the VPC's `credentialSubject.id` must equal the edge's `subjectDid`.
+
+  (2) is what makes it safe — the only party who could have published this
+  edge is the only party who can annotate it, so no new trust is extended.
+  (3) is a consistency check, not a binding. If #9 lands an in-credential
+  binding (a `digest` over the VRC, as the VWC already has), the endpoint can
+  require it as well without changing the stored shape.
+
+  Stated limitation: the spec says a VPC's subject is "typically the R-DID or
+  M-DID used in the relationship". A VPC naming the counterparty's M-DID, on
+  an edge whose `subjectDid` is their R-DID, fails check (3) and is rejected.
+  That case is real and needs the same #9 answer; guessing would mean
+  accepting a VPC naming a party the VTC cannot tie to the edge, which is the
+  problem restated.
+
+  - **No uniqueness check on the P-DID**, in direct contrast to the R-DID rule
+    the publish path enforces unconditionally. A relationship DID that recurs
+    across counterparties is a defect; a persona DID that recurs is the entire
+    purpose of the credential.
+  - **Detach is in scope.** A privacy mechanism that cannot be reversed is
+    worse than none, so withdrawing a persona is as available as asserting one
+    — and gated identically, or anyone could strip another member's persona.
+    The two authorization `type` values are distinct so neither can stand in
+    for the other.
+  - **No `persona.rego`.** Attach is gated on a live member session plus proof
+    of control of the edge's issuer. A community that already decides whether
+    an edge may be published has not obviously earned a second say over what
+    its issuer calls themselves. Additive if that is wrong.
+  - **No P-DID secondary index.** "List every edge of persona P" is answerable
+    from the admin graph; an enumeration surface deserves its own design
+    rather than falling out of an index write.
+  - **`new_vpc` is used in a wire-shape test, not a mint path**
+    (`vtc-service/src/credentials/dtg.rs`). The VTC has no key that may
+    legitimately sign a VPC — it is self-issued by a person — so there is no
+    `issue_persona`. Pinning the catalog's VPC shape matters more here than
+    for the credentials the VTC does mint: drift changes what we *accept*, and
+    the failure mode is every conformant VPC in the ecosystem being rejected
+    by a VTC that still compiles and still passes its own tests.
+  - **Audit** (`VpcAttached` / `VpcDetached`, `vti-common/src/audit/event.rs`)
+    records the P-DID with the authenticated member as actor — the same
+    attribution decision, and the same accepted residual, as VRC publish. The
+    `info!` on both paths carries the persona and not the member.
+
+  `vtc/relationships/persona/0.1` is bound ahead of its publication in the
+  upstream Trust Task registry and recorded in `UNPUBLISHED_CANONICAL_OK`
+  (`vtc-service/tests/trust_task_manifest.rs`) — the first entry the
+  `spec/vtc/` family has had. Deliberate: a payload schema authored now would
+  encode this request-level binding as if #9 were closed.
+
+  Design note: `docs/05-design-notes/vpc-persona-annotation.md`.
+
+- **vtc**: Let a member publish a relationship edge without naming themselves in it ([#1061](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1061))
+
+* feat(vtc)!: let a member publish a relationship edge without naming themselves in it
+
+  Publishing a VRC required the credential's `issuer` to equal the caller's
+  session DID. That one line is why a member's membership DID ends up inside
+  the durable, publishable credential — and the community graph built from
+  those credentials is a correlatable member-to-member edge set. DTG
+  Credentials asks for the opposite: R-DIDs are RECOMMENDED, unique per
+  counterparty "even within the same community", and M-DID edges are a
+  bootstrapping allowance to migrate away from.
+
+  The pin was conflating two properties. The first — the VRC was made by the
+  party it names as issuer — is provided by the data-integrity proof and is
+  untouched here. The second — the party publishing it is the party that
+  issued it — is what the pin actually provided, and it is worth keeping:
+  issuance and publication are different disclosures, and appearing in the
+  community graph should be the issuer's disclosure to make, not that of
+  whoever happens to hold a copy.
+
+  So the pin is replaced rather than removed. The session proves community
+  membership; a publish authorization signed by the issuing key proves control
+  of it. Neither requires them to be the same string.
+
+  The authorization binds to `{type, vrc-hash, aud, sessionId, issuedAt}`, each
+  field covering a distinct replay: signatures made over other objects, other
+  credentials, other communities, other members' sessions, and unbounded reuse
+  within a live session. It is verified and dropped — never stored, logged or
+  audited, because it carries `sessionId` and persisting that would rebuild the
+  exact membership-to-relationship linkage pairwise identifiers exist to
+  remove. Two tests assert that directly, on the stored row and on the audit
+  store, since it is the kind of property a later debug log undoes silently.
+
+  The subject-must-be-a-member check is dropped on the pairwise path. It is not
+  merely unanswerable once the subject is an R-DID; DTG Credentials is explicit
+  that "community membership is not a precondition for issuing, holding, or
+  presenting a VRC". The subject's consent to the edge is their publication of
+  the reciprocal VRC — the two-VRC edge model — not this community's assertion
+  that they exist.
+
+- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))
+
+Applications built on a VTA have had nowhere to keep versioned metadata.
+  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
+  beside the secrets vault and the credential vault, for JSON an application
+  owns and the VTA does not interpret.
+
+  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
+  application so several tools can share a context without colliding, and is the
+  seam a per-namespace grant would later use — which is why it is part of the
+  address rather than a prefix convention on the key. In 1.0 a namespace is
+  collision avoidance and NOT a trust boundary: an application with write access
+  to a context reaches every namespace in it, and the `put` and `delete` specs
+  say so normatively. Isolation means separate contexts.
+
+  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
+  nothing to hang a precondition on, and its `list` returns the whole context —
+  but the argument that settles it is that "forget everything" has to stay a safe
+  thing to ask an agent, which it cannot be if account state lives there.
+
+  Three properties are why this is a store rather than a field on an existing one.
+
+  **One counter per `(contextId, namespace)`, not per record.** A record's
+  `version` is the counter value its most recent write took, so one number is
+  simultaneously the optimistic-concurrency token `expectedVersion` compares
+  against and the watermark `sinceVersion` compares against. A per-record counter
+  serves the first but cannot serve the second — two records' counters are not
+  comparable, so no single number means "everything after this point" — and would
+  have forced a second sequence kept consistent by hand. The cost is that a
+  record's version jumps by whatever its neighbours consumed, which the wire
+  contract states: versions are opaque and monotonic, never an edit count.
+
+  **A failed precondition returns the current version AND value.** A bare
+  rejection obliges a re-read, and the re-read races the next write; the pattern
+  has no fixed point under contention. Returning the winner's view removes the
+  race rather than narrowing it, and the spec makes it normative.
+
+  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
+  one, a consumer pulling from a watermark learns of every create and update and
+  never of a deletion, so deleted records resurrect on its next rebuild.
+  Retention is `app_state.tombstone_retention_days` (default 30, matching the
+  vault's `grace_days`) — a destructive window is an operator's choice, not a
+  constant — and `list` advertises the configured value, since a consumer
+  schedules against that number. The sweeper runs from the storage thread beside
+  the ACL/consent/vault sweepers.
+
+  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
+  version order and stops at the first still inside the window. Reaping a later
+  tombstone while leaving an earlier one would make the reap watermark
+  unstateable — no single number would describe what survives, which is precisely
+  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
+  that is enforced at the call site rather than as a zero cutoff, which would mean
+  the opposite.
+
+  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
+  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
+  surviving only in the journal buffer can be re-derived after a crash and reissue
+  a used value. Here a reused version means two records collide on one `appv:`
+  index key, so one disappears from the change feed and every incremental consumer
+  misses that change permanently, silently. A batch reserves a block and pays one
+  fsync rather than N; writes that then fail leave gaps, which are safe and
+  tested.
+
+  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
+  finds a tombstone and deliberately takes no new version, so a watcher sees
+  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
+  does not converge, and the class is per URI, not per payload.
+
+  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.
+
+  Concurrency is a process-local lock per namespace, not a store-layer
+  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
+  share a store, and the vsock protocol has no atomic opcode — its
+  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
+  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
+  would need to be real. Recorded in the design note with what would change that.
+
+  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
+  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
+  an older resolve fails as a stale dependency rather than as unspecced URIs.
+  Conformance witnesses cover all six URIs, so nothing enters
+  `UNSPECCED_DISPATCHED_URIS`.
+
+
+
+### Changed
+
+- Delete the Verifiable-prefixed credential tags that were never DTG types ([#1071](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1071))
+
+`VerifiableMembershipCredential` and `VerifiableEndorsementCredential` are not
+  DTG credential types and never were. The specification defines seven concrete
+  subtypes; neither is among them, and nothing in this stack has ever issued
+  either. They survived as a name, a pair of literals and a compatibility shim,
+  and between them they broke cross-community recognition for every real
+  presentation ([#1062](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1062)).
+
+  Four places, one cause.
+
+  **The SDK constant.** `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` held the value
+  `"MembershipCredential"`, with a doc comment explaining that the prefix in the
+  name was historical and the tag did not have it. A constant whose name
+  disagrees with its value is an invitation, and it was taken: someone reading
+  the name hand-rolled `"VerifiableEndorsementCredential"` into the recognition
+  path, where it matched nothing. Renamed to `MEMBERSHIP_CREDENTIAL_TYPE`, and
+  `ENDORSEMENT_CREDENTIAL_TYPE` added beside it so the VEC tag has a home rather
+  than being a literal at the point of use.
+
+  **The compatibility shim.** #1063 added `LEGACY_TYPE_TAGS`, accepting both
+  prefixed tags from peers predating the catalog adoption. Nothing is published,
+  so no such peer exists — and a reference implementation that accepts a type the
+  specification does not define reintroduces exactly the drift the function it
+  sits in was written to prevent. Removed; the test that pinned the behaviour now
+  pins its refusal.
+
+  **The audit trail.** Emitted envelopes recorded `credential_type:
+  "VerifiableMembershipCredential"` / `"VerifiableEndorsementCredential"` — tags
+  no credential ever carried, in the one record meant to be authoritative after
+  the fact. They now record what was issued.
+
+  **The policy input.** `issuer_member` / `subject_member` were carried alongside
+  `issuer` / `subject` for operator policies written against the pre-#1061 shape.
+  There are no deployed operator policies to preserve, and two spellings of one
+  concept is how the concept drifts. The duplicates are gone and the surviving
+  fields carry `is_current`.
+
+
+
+### Fixed
+
+- **vtc**: Follow the spec on every auth response, and close the conformance gate ([#1112](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1112))
+
+* test(vtc)!: make response conformance fail the build
+
+  Until now the layer reported and a green suite was not evidence of
+  conformance — #1107's own memory note said to grep the run rather than trust
+  the exit code, which is a signal nobody has to obey.
+
+  A violation outside the allowlist now returns 500 with the schema error, so the
+  test that provoked it fails on its own status assertion and prints the reason.
+  Chosen over panicking in middleware, which surfaces at the call site as a
+  transport error and says nothing about which task or why.
+
+  The allowlist is eight `auth/*` tasks with ALLOWED_COUNT asserted beside them —
+  the same discipline as KNOWN_DRIFT_COUNT, because the cheapest way to make a
+  failing check pass is to add a line to a list nobody watches. An allowlisted
+  violation is still reported, pinned by a test: a list that suppressed the
+  evidence would mean rediscovering each entry before it could be closed.
+
+  Two existing guards caught mistakes of mine on the first run. The allowlist
+  named login/{start,finish}/0.1 where the service binds 0.2 — built from the
+  violation output rather than the route mounts — and the manifest guard flagged a
+  fake `trusttasks.org/spec/` URI in a new unit test, correctly, since binding
+  such a URI asserts the registry serves it.
+
+  Also retargets relationships/{list,graph} to the 0.2s from
+  trustoverip/dtgwg-trust-tasks-tf#266, and fixes a seeder that wrote
+  `seed-{uuid}` into `vrcDigestMultibase` — unique per row, and so a suite
+  structurally blind to digest format.
+
+  The VTC family is now clean; every remaining violation is `auth/*`.
+
+- **vtc**: Speak the endorsement model the spec defines ([#1096](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1096))
+
+The endorsement family — `issue`, `list`, `show` — spoke a different model
+  from the one the spec defines. Three renames, one per row, and a request
+  member that had been deliberately renamed away from the spec's name.
+
+  | canonical `Endorsement` | this service sent |
+  |---|---|
+  | `endorsementId` | `id` |
+  | `typeUri` | `endorsementType` |
+  | `issued` | `createdAt` |
+  | `subjectDid`, `statusListIndex`, `claim`, `revokedAt` | already matched |
+
+  ## Mapping at the boundary, not renaming storage
+
+  The stored `Endorsement` derives `Deserialize` and serialises `camelCase`,
+  so `id` / `endorsementType` / `createdAt` are the on-disk keys of every row
+  already written. Renaming those fields would rewrite the persisted fjall
+  format and need a migration — for a naming problem that only exists on the
+  wire.
+
+  So `EndorsementRow` is a wire type mapping from the stored row, the same
+  split `GenerationRow` uses ([#1095](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1095)). Storage keeps the names it has; the API
+  publishes the names the spec gives.
+
+- **common**: Send the pagination wrapper in camelCase, as the schemas always said ([#1078](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1078))
+
+`Paginated<T>` carried no `rename_all`, so every list task sent `next_cursor`
+  and `total_estimate` against published schemas that say `nextCursor` and
+  `totalEstimate`. A direct R3.1 violation, and the same casing-drift class as
+  #656/#658 — where an empty `allowed_contexts` silently minted a super-admin.
+
+  Nothing caught it because nothing compared the two. The service sent one
+  spelling, `vtc-client` mirrored the service rather than the schema, and the
+  admin SPA typed its fields from the service too. All three agreed with each
+  other and none agreed with the contract. The conformance witness added in
+  #1076 is what finally put them side by side.
+
+  Four consumers move together: the wrapper in `vti-common`, `vtc-client`'s
+  `Page<T>`, and the `joinRequests` and `members` admin plugins. `audit.tsx`
+  reads a `cursor` member of a different shape and is untouched.
+
+  ## The count goes 33 → 32, not 33 → 28
+
+  The witness refused 28 and accepted 32, which is the useful part of this
+  change and the reason the module doc is rewritten rather than decremented.
+
+  Five entries cited the wrapper. Only `relationships/list` becomes fully
+  conforming, because it was the only one whose drift was the wrapper alone —
+  its spec types `items` as free objects. The other four still diverge at row
+  level (`createdByDid`, `vpClaims`, `MemberResponse` members) and keep their
+  entries, now describing only what is left rather than restating a casing bug
+  that is fixed.
+
+  Closing a shared root cause moves four entries without closing them. A drift
+  count that fell by five would have implied more progress than happened, and
+  `known_drift_entries_still_diverge_where_they_say_they_do` is what stopped it
+  saying so.
+
+
+
 ## [0.13.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.13.1...vti-common-v0.13.2) — 2026-08-22
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.28", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.29", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.2.1...vti-secrets-v0.2.2) — 2026-08-26
+
+
 ## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.2.0...vti-secrets-v0.2.1) — 2026-08-22
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,14 +47,14 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.13" }
+vti-common = { path = "../vti-common", version = "0.14" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.28", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.29", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }

--- a/vti-webauthn/CHANGELOG.md
+++ b/vti-webauthn/CHANGELOG.md
@@ -2,6 +2,71 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-webauthn-v0.1.1...vti-webauthn-v0.2.0) — 2026-08-26
+
+
+### Chore
+
+- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))
+
+`cargo outdated` reported 13 direct dependencies behind and `cargo update`
+  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
+  reports "All dependencies are up to date".
+
+  Two of these were not cosmetic.
+
+  **p256 was duplicated in the build.** Our crates declared `0.13` while
+  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
+  already pulled `0.14`, so the graph carried two copies of a curve
+  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
+  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
+  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
+  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.
+
+  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
+  depends on it solely as a feature enabler: iOS has no native trust store, so
+  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
+  fails with "no native root CA certificates found". Features unify per major
+  version, so the declaration only works while it matches the version
+  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
+  Updating everything *except* this one would have stranded the enabler and
+  broken iOS `wss://` silently.
+
+  The rest:
+
+  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
+    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
+    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
+    which is also a more direct statement of what it wanted.
+  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
+    `trust-tasks-rs`.
+  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
+    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
+    on is unchanged.
+  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
+    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
+    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
+    flags, drops out of the graph entirely.
+
+  Two deliberate choices where the shortest path was worse:
+
+  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
+  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
+  encoding" and "valid encoding, point not on the curve" into one error, and
+  those say different things to whoever reads the log — a broken client versus
+  a point somebody chose.
+
+  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
+  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
+  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
+  than resting on a panic inside a deprecated helper.
+
+  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
+  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
+  path. `cargo deny check advisories` passes.
+
+
+
 ## [0.1.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-webauthn-v0.1.0...vti-webauthn-v0.1.1) — 2026-08-13
 
 

--- a/vti-webauthn/Cargo.toml
+++ b/vti-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vti-webauthn"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.28.0 -> 0.29.0 (✓ API compatible changes)
* `vti-common`: 0.13.2 -> 0.14.0 (✓ API compatible changes)
* `cnm-cli`: 0.12.1 -> 0.12.2
* `pnm-cli`: 0.13.1 -> 0.13.2
* `vta-audit`: 0.1.10 -> 0.2.0
* `vta-config`: 0.3.12 -> 0.3.13
* `vta-keyspaces`: 0.2.0 -> 0.2.1
* `vta-keys`: 0.2.9 -> 0.3.0
* `vta-backup`: 0.1.14 -> 0.2.0
* `vta-vault`: 0.3.4 -> 0.4.0
* `vta-sweepers`: 0.2.0 -> 0.3.0
* `vti-webauthn`: 0.1.1 -> 0.2.0
* `vta-service`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `vtc-client`: 0.3.11 -> 0.4.0 (✓ API compatible changes)
* `vta-cli-common`: 0.11.4 -> 0.11.5
* `vti-secrets`: 0.2.1 -> 0.2.2
* `vta-support`: 0.2.11 -> 0.2.12
* `vta-policy`: 0.2.11 -> 0.2.12
* `vta-tee`: 0.1.9 -> 0.1.10
* `vta-webvh`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.29.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.28.0...vta-sdk-v0.29.0) — 2026-08-26

### Added

- **sdk**: Extract the agent-side connect ladder into vta_sdk::agent_connect ([#1081](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1081))

* feat(sdk): extract the agent-side connect ladder into vta_sdk::agent_connect

  Every tool that runs beside a user and talks to their VTA on their behalf
  needs the same four ways in — did:webvh bundle, scoped did:key, bearer
  token, existing pnm session — in the same order, with the same fail-fast
  rules. That ladder existed only inside vta-mcp's main.rs, so the next
  bridge had to copy 110 lines or invent a fifth way in.

  `AgentConnect` is that ladder as SDK surface. `mode()` resolves the rung
  with no I/O, so a bridge can log it (and refuse a rung it does not
  support) before connecting; `connect()` returns the authenticated
  VtaClient. Session mode keeps TransportChoice::Auto, so it inherits the
  workspace preference order (TSP > DIDComm > REST) from what both DID
  documents advertise.

  Two rules are enforced rather than documented, both carried over from the
  vta-mcp original: the two DIDComm identity modes are mutually exclusive,
  and a half-configured rung errors naming the missing fields instead of
  falling through to session mode — a bridge silently authenticating as the
  operator rather than as its scoped agent identity is the failure that
  matters here. ConnectMode::is_dedicated_agent() makes the same
  distinction available to callers deciding whether to enroll as a device.

  vta-mcp is refactored onto it, which is what proves the extraction: its
  build_client is now a pure args -> AgentConnect mapping plus a connect,
  and its tests assert which rung a set of flags selects.

- **vtc**: Tell a member when the community removes them ([#1060](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1060))

Removal was the most consequential thing a community does to a member and the
  one it delivered with the least information — none. There was no outbound
  message on any removal path. The only signal a removed member could observe was
  a side effect: the revocation bit on their membership credential flipping. They
  inferred their own removal from a status list and learned nothing about why.

  `vtc/members/removal-notice/0.1` (published upstream as
  trustoverip/dtgwg-trust-tasks-tf#256) now goes out from both admin paths,
  carrying the deciding administrator, the moment the decision took effect, the
  resolved disposition, and the operator's reason.

  **Signed, because the recipient is not the audience.** Authcrypt already proves
  the sender to the member. But this is the one member-facing message whose value
  lies in showing it to somebody else — an appeal, a dispute, another community
  weighing a rejected applicant. Forwarded, an unsigned notice is an assertion
  anyone could have written. So it is a Trust Task document with a Data Integrity
  proof, packed in the trust-task envelope — note `TRUST_TASK_ENVELOPE_TYPE`, not
  the task URI, which is a mistake this workspace has made before and which a
  conformant peer rejects silently.

  **Thirty days, because there is no second route.** `resolve_auth_role` refuses
  any DID without an ACL row and removal hard-deletes it, so a removed member
  cannot authenticate at all: every authenticated route, including any poll that
  might have served the notice, closes at the moment the removal lands. The act
  this reports is the act that ends their ability to ask about it. `send_to_member`
  already had a durable outbox, so this needed a deadline parameter rather than
  new machinery — `send_to_member_by`, with the six existing callers keeping the
  24h default.

  A member offline beyond the window still never learns. No window fixes that; the
  honest fix is a retrieval path not gated on an ACL row, which is a larger design
  than this. Stated in the spec and in the constant's doc comment rather than left
  for someone to discover.

  **Never for a self-leave.** `remove_inner` serves both the admin path and the
  DIDComm self-leave. A member who chose to leave already has their receipt, and
  telling them they were "removed" is a different and worse thing to be told.

  **Best-effort.** The notice never fails the removal. That has already happened
  and is durable; refusing the operator's request because the notice could not be
  *queued* would leave the member removed and the operator believing they were
  not. Failures log loudly — and log "queued", not "sent", because a DIDComm `Ok`
  means the mediator accepted the frame and nothing more (R1.1).

  Seven tests. Four unit: payload shape, a blank reason omitted rather than sent
  as an empty string, the two codes distinguishable, and the payload validated
  against the *published* schema — the check that catches the implementation
  drifting from the spec it claims to implement.

  Three end-to-end over a real mediator, because only a peer holding the document
  demonstrates the feature: an admin removal arrives signed with its reason and
  deciding admin, a purge says it was a purge, and a self-leave sends nothing. Two
  of them first failed on `no active removal policy`, which was the paths
  differing exactly as specified — a purge deliberately skips the removal policy,
  which is why that one passed before the fixture seeded any.

- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))

Applications built on a VTA have had nowhere to keep versioned metadata.
  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
  beside the secrets vault and the credential vault, for JSON an application
  owns and the VTA does not interpret.

  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
  application so several tools can share a context without colliding, and is the
  seam a per-namespace grant would later use — which is why it is part of the
  address rather than a prefix convention on the key. In 1.0 a namespace is
  collision avoidance and NOT a trust boundary: an application with write access
  to a context reaches every namespace in it, and the `put` and `delete` specs
  say so normatively. Isolation means separate contexts.

  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
  nothing to hang a precondition on, and its `list` returns the whole context —
  but the argument that settles it is that "forget everything" has to stay a safe
  thing to ask an agent, which it cannot be if account state lives there.

  Three properties are why this is a store rather than a field on an existing one.

  **One counter per `(contextId, namespace)`, not per record.** A record's
  `version` is the counter value its most recent write took, so one number is
  simultaneously the optimistic-concurrency token `expectedVersion` compares
  against and the watermark `sinceVersion` compares against. A per-record counter
  serves the first but cannot serve the second — two records' counters are not
  comparable, so no single number means "everything after this point" — and would
  have forced a second sequence kept consistent by hand. The cost is that a
  record's version jumps by whatever its neighbours consumed, which the wire
  contract states: versions are opaque and monotonic, never an edit count.

  **A failed precondition returns the current version AND value.** A bare
  rejection obliges a re-read, and the re-read races the next write; the pattern
  has no fixed point under contention. Returning the winner's view removes the
  race rather than narrowing it, and the spec makes it normative.

  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
  one, a consumer pulling from a watermark learns of every create and update and
  never of a deletion, so deleted records resurrect on its next rebuild.
  Retention is `app_state.tombstone_retention_days` (default 30, matching the
  vault's `grace_days`) — a destructive window is an operator's choice, not a
  constant — and `list` advertises the configured value, since a consumer
  schedules against that number. The sweeper runs from the storage thread beside
  the ACL/consent/vault sweepers.

  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
  version order and stops at the first still inside the window. Reaping a later
  tombstone while leaving an earlier one would make the reap watermark
  unstateable — no single number would describe what survives, which is precisely
  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
  that is enforced at the call site rather than as a zero cutoff, which would mean
  the opposite.

  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
  surviving only in the journal buffer can be re-derived after a crash and reissue
  a used value. Here a reused version means two records collide on one `appv:`
  index key, so one disappears from the change feed and every incremental consumer
  misses that change permanently, silently. A batch reserves a block and pays one
  fsync rather than N; writes that then fail leave gaps, which are safe and
  tested.

  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
  finds a tombstone and deliberately takes no new version, so a watcher sees
  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
  does not converge, and the class is per URI, not per payload.

  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.

  Concurrency is a process-local lock per namespace, not a store-layer
  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
  share a store, and the vsock protocol has no atomic opcode — its
  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
  would need to be real. Recorded in the design note with what would change that.

  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
  an older resolve fails as a stale dependency rather than as unspecced URIs.
  Conformance witnesses cover all six URIs, so nothing enters
  `UNSPECCED_DISPATCHED_URIS`.



### Changed

- Delete the Verifiable-prefixed credential tags that were never DTG types ([#1071](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1071))

`VerifiableMembershipCredential` and `VerifiableEndorsementCredential` are not
  DTG credential types and never were. The specification defines seven concrete
  subtypes; neither is among them, and nothing in this stack has ever issued
  either. They survived as a name, a pair of literals and a compatibility shim,
  and between them they broke cross-community recognition for every real
  presentation ([#1062](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1062)).

  Four places, one cause.

  **The SDK constant.** `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` held the value
  `"MembershipCredential"`, with a doc comment explaining that the prefix in the
  name was historical and the tag did not have it. A constant whose name
  disagrees with its value is an invitation, and it was taken: someone reading
  the name hand-rolled `"VerifiableEndorsementCredential"` into the recognition
  path, where it matched nothing. Renamed to `MEMBERSHIP_CREDENTIAL_TYPE`, and
  `ENDORSEMENT_CREDENTIAL_TYPE` added beside it so the VEC tag has a home rather
  than being a literal at the point of use.

  **The compatibility shim.** #1063 added `LEGACY_TYPE_TAGS`, accepting both
  prefixed tags from peers predating the catalog adoption. Nothing is published,
  so no such peer exists — and a reference implementation that accepts a type the
  specification does not define reintroduces exactly the drift the function it
  sits in was written to prevent. Removed; the test that pinned the behaviour now
  pins its refusal.

  **The audit trail.** Emitted envelopes recorded `credential_type:
  "VerifiableMembershipCredential"` / `"VerifiableEndorsementCredential"` — tags
  no credential ever carried, in the one record meant to be authoritative after
  the fact. They now record what was issued.

  **The policy input.** `issuer_member` / `subject_member` were carried alongside
  `issuer` / `subject` for operator policies written against the pre-#1061 shape.
  There are no deployed operator policies to preserve, and two spellings of one
  concept is how the concept drifts. The duplicates are gone and the surviving
  fields carry `is_current`.



### Fixed

- **vta**: Three of the four responses the conformance layer found ([#1114](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1114))

Closes three of the four violations #1113 reported. The fourth is the vault
  pair, blocked on trust-tasks-rs 0.11.16 (dtgwg-trust-tasks-tf#268).

  `vta/webvh/dids/get/1.0` carried its record under `#[serde(flatten)]` since
  #849, to make the folded task a strict superset of the two shapes it replaced.
  That superset was readable by no conforming client: the response is
  `additionalProperties: false`, so a flattened record fails on all eleven
  members and the `ext` slot is unreachable. Its sibling settles which side
  moves — `dids/list` carries the same component nested under `dids` and has
  always conformed, so flattening made `get` the outlier in its own family.

  Both SDK client methods decoded the flat shape straight into
  `WebvhDidRecord`, so the workspace compiled clean while the wire broke. They
  now project the envelope. `webvh_get_did_round_trips_after_the_get_log_fold`
  predicted exactly this in its doc comment and caught it.

  `provision/integration/0.2` sent `null` for `adminTemplateName` and
  `webvhServerId`, the only two of five `Option<String>` members without
  `skip_serializing_if`.

- **vtc**: A null the schema forbids, and three fixtures that lied ([#1099](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1099))

Four entries close, and three of the four closed because the **ledger was
  wrong**, not because anything about the service changed. Drift **15 → 12**,
  with `join-requests/submit` narrowed from both sides to response-only.

  Found by making the conformance probe print the *actual* parse error for
  every drift entry rather than re-reading the notes — the same technique that
  surfaced the #1098 defect. The notes are prose and can be wrong in either
  direction; the schemas cannot.
</blockquote>

## `vti-common`

<blockquote>

## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.13.2...vti-common-v0.14.0) — 2026-08-26

### Added

- **vtc**: Implement the VPC as the deliberate-correlation mechanism on an edge ([#1074](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1074))

* feat(vtc): implement the VPC as the deliberate-correlation mechanism on an edge

  `PersonaCredential` appeared nowhere in this repo and
  `DTGCredential::new_vpc` was never called, so the P-DID had no
  implementation and the word "persona" drifted onto the membership DID for
  want of anything to anchor it ([#1067](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1067)).

  What the absence cost, concretely. After the publish proof-of-possession
  change ([#1054](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1054)) a member had exactly two settings: publish under a pairwise
  relationship DID and correlate with nothing, or publish under the
  membership DID and correlate with everything, permanently, for anyone who
  retains the credential. DTG Credentials §Privacy Considerations 3 says
  correlation "should occur only through the holder's deliberate assertion of
  a persona (via a VPC) or an M-DID". The precise instrument was missing, so
  members had only the blunt one.

  This adds the VTC half of it: `POST` / `DELETE
  /v1/relationships/{id}/persona` (`vtc-service/src/routes/relationships.rs`).
  A VPC is an *annotation* credential — it creates no graph structure, it
  attaches to structure that already exists — so there is no "publish a VPC",
  only "attach this persona to that edge", and the annotation is stored on the
  edge row (`vtc-service/src/relationships/mod.rs`) rather than in a keyspace
  of its own. The P-DID surfaces on `GET /v1/relationships/graph` as
  `personaDid`, which is where the correlation becomes visible; an annotation
  nothing reads would leave #1067 in the state it describes.

  trustoverip/dtgwg-cred-spec#9 asks how a VPC binds to a specific
  relationship and is open. Nothing here answers it. A VPC names its persona
  (`issuer`) and the counterparty (`credentialSubject.id`) and not the
  relationship DID the persona used, so it does not identify an edge on its
  own.

  Rather than add a field to the credential and present that as the
  resolution, the binding is made at the request level:

  1. the caller names the edge by id in the URL;
  2. the caller proves control of that edge's `issuerDid`, with the same
     proof-of-possession construction publishing the edge required;
  3. the VPC's `credentialSubject.id` must equal the edge's `subjectDid`.

  (2) is what makes it safe — the only party who could have published this
  edge is the only party who can annotate it, so no new trust is extended.
  (3) is a consistency check, not a binding. If #9 lands an in-credential
  binding (a `digest` over the VRC, as the VWC already has), the endpoint can
  require it as well without changing the stored shape.

  Stated limitation: the spec says a VPC's subject is "typically the R-DID or
  M-DID used in the relationship". A VPC naming the counterparty's M-DID, on
  an edge whose `subjectDid` is their R-DID, fails check (3) and is rejected.
  That case is real and needs the same #9 answer; guessing would mean
  accepting a VPC naming a party the VTC cannot tie to the edge, which is the
  problem restated.

  - **No uniqueness check on the P-DID**, in direct contrast to the R-DID rule
    the publish path enforces unconditionally. A relationship DID that recurs
    across counterparties is a defect; a persona DID that recurs is the entire
    purpose of the credential.
  - **Detach is in scope.** A privacy mechanism that cannot be reversed is
    worse than none, so withdrawing a persona is as available as asserting one
    — and gated identically, or anyone could strip another member's persona.
    The two authorization `type` values are distinct so neither can stand in
    for the other.
  - **No `persona.rego`.** Attach is gated on a live member session plus proof
    of control of the edge's issuer. A community that already decides whether
    an edge may be published has not obviously earned a second say over what
    its issuer calls themselves. Additive if that is wrong.
  - **No P-DID secondary index.** "List every edge of persona P" is answerable
    from the admin graph; an enumeration surface deserves its own design
    rather than falling out of an index write.
  - **`new_vpc` is used in a wire-shape test, not a mint path**
    (`vtc-service/src/credentials/dtg.rs`). The VTC has no key that may
    legitimately sign a VPC — it is self-issued by a person — so there is no
    `issue_persona`. Pinning the catalog's VPC shape matters more here than
    for the credentials the VTC does mint: drift changes what we *accept*, and
    the failure mode is every conformant VPC in the ecosystem being rejected
    by a VTC that still compiles and still passes its own tests.
  - **Audit** (`VpcAttached` / `VpcDetached`, `vti-common/src/audit/event.rs`)
    records the P-DID with the authenticated member as actor — the same
    attribution decision, and the same accepted residual, as VRC publish. The
    `info!` on both paths carries the persona and not the member.

  `vtc/relationships/persona/0.1` is bound ahead of its publication in the
  upstream Trust Task registry and recorded in `UNPUBLISHED_CANONICAL_OK`
  (`vtc-service/tests/trust_task_manifest.rs`) — the first entry the
  `spec/vtc/` family has had. Deliberate: a payload schema authored now would
  encode this request-level binding as if #9 were closed.

  Design note: `docs/05-design-notes/vpc-persona-annotation.md`.

- **vtc**: Let a member publish a relationship edge without naming themselves in it ([#1061](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1061))

* feat(vtc)!: let a member publish a relationship edge without naming themselves in it

  Publishing a VRC required the credential's `issuer` to equal the caller's
  session DID. That one line is why a member's membership DID ends up inside
  the durable, publishable credential — and the community graph built from
  those credentials is a correlatable member-to-member edge set. DTG
  Credentials asks for the opposite: R-DIDs are RECOMMENDED, unique per
  counterparty "even within the same community", and M-DID edges are a
  bootstrapping allowance to migrate away from.

  The pin was conflating two properties. The first — the VRC was made by the
  party it names as issuer — is provided by the data-integrity proof and is
  untouched here. The second — the party publishing it is the party that
  issued it — is what the pin actually provided, and it is worth keeping:
  issuance and publication are different disclosures, and appearing in the
  community graph should be the issuer's disclosure to make, not that of
  whoever happens to hold a copy.

  So the pin is replaced rather than removed. The session proves community
  membership; a publish authorization signed by the issuing key proves control
  of it. Neither requires them to be the same string.

  The authorization binds to `{type, vrc-hash, aud, sessionId, issuedAt}`, each
  field covering a distinct replay: signatures made over other objects, other
  credentials, other communities, other members' sessions, and unbounded reuse
  within a live session. It is verified and dropped — never stored, logged or
  audited, because it carries `sessionId` and persisting that would rebuild the
  exact membership-to-relationship linkage pairwise identifiers exist to
  remove. Two tests assert that directly, on the stored row and on the audit
  store, since it is the kind of property a later debug log undoes silently.

  The subject-must-be-a-member check is dropped on the pairwise path. It is not
  merely unanswerable once the subject is an R-DID; DTG Credentials is explicit
  that "community membership is not a precondition for issuing, holding, or
  presenting a VRC". The subject's consent to the edge is their publication of
  the reciprocal VRC — the two-VRC edge model — not this community's assertion
  that they exist.

- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))

Applications built on a VTA have had nowhere to keep versioned metadata.
  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
  beside the secrets vault and the credential vault, for JSON an application
  owns and the VTA does not interpret.

  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
  application so several tools can share a context without colliding, and is the
  seam a per-namespace grant would later use — which is why it is part of the
  address rather than a prefix convention on the key. In 1.0 a namespace is
  collision avoidance and NOT a trust boundary: an application with write access
  to a context reaches every namespace in it, and the `put` and `delete` specs
  say so normatively. Isolation means separate contexts.

  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
  nothing to hang a precondition on, and its `list` returns the whole context —
  but the argument that settles it is that "forget everything" has to stay a safe
  thing to ask an agent, which it cannot be if account state lives there.

  Three properties are why this is a store rather than a field on an existing one.

  **One counter per `(contextId, namespace)`, not per record.** A record's
  `version` is the counter value its most recent write took, so one number is
  simultaneously the optimistic-concurrency token `expectedVersion` compares
  against and the watermark `sinceVersion` compares against. A per-record counter
  serves the first but cannot serve the second — two records' counters are not
  comparable, so no single number means "everything after this point" — and would
  have forced a second sequence kept consistent by hand. The cost is that a
  record's version jumps by whatever its neighbours consumed, which the wire
  contract states: versions are opaque and monotonic, never an edit count.

  **A failed precondition returns the current version AND value.** A bare
  rejection obliges a re-read, and the re-read races the next write; the pattern
  has no fixed point under contention. Returning the winner's view removes the
  race rather than narrowing it, and the spec makes it normative.

  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
  one, a consumer pulling from a watermark learns of every create and update and
  never of a deletion, so deleted records resurrect on its next rebuild.
  Retention is `app_state.tombstone_retention_days` (default 30, matching the
  vault's `grace_days`) — a destructive window is an operator's choice, not a
  constant — and `list` advertises the configured value, since a consumer
  schedules against that number. The sweeper runs from the storage thread beside
  the ACL/consent/vault sweepers.

  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
  version order and stops at the first still inside the window. Reaping a later
  tombstone while leaving an earlier one would make the reap watermark
  unstateable — no single number would describe what survives, which is precisely
  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
  that is enforced at the call site rather than as a zero cutoff, which would mean
  the opposite.

  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
  surviving only in the journal buffer can be re-derived after a crash and reissue
  a used value. Here a reused version means two records collide on one `appv:`
  index key, so one disappears from the change feed and every incremental consumer
  misses that change permanently, silently. A batch reserves a block and pays one
  fsync rather than N; writes that then fail leave gaps, which are safe and
  tested.

  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
  finds a tombstone and deliberately takes no new version, so a watcher sees
  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
  does not converge, and the class is per URI, not per payload.

  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.

  Concurrency is a process-local lock per namespace, not a store-layer
  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
  share a store, and the vsock protocol has no atomic opcode — its
  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
  would need to be real. Recorded in the design note with what would change that.

  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
  an older resolve fails as a stale dependency rather than as unspecced URIs.
  Conformance witnesses cover all six URIs, so nothing enters
  `UNSPECCED_DISPATCHED_URIS`.



### Changed

- Delete the Verifiable-prefixed credential tags that were never DTG types ([#1071](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1071))

`VerifiableMembershipCredential` and `VerifiableEndorsementCredential` are not
  DTG credential types and never were. The specification defines seven concrete
  subtypes; neither is among them, and nothing in this stack has ever issued
  either. They survived as a name, a pair of literals and a compatibility shim,
  and between them they broke cross-community recognition for every real
  presentation ([#1062](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1062)).

  Four places, one cause.

  **The SDK constant.** `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` held the value
  `"MembershipCredential"`, with a doc comment explaining that the prefix in the
  name was historical and the tag did not have it. A constant whose name
  disagrees with its value is an invitation, and it was taken: someone reading
  the name hand-rolled `"VerifiableEndorsementCredential"` into the recognition
  path, where it matched nothing. Renamed to `MEMBERSHIP_CREDENTIAL_TYPE`, and
  `ENDORSEMENT_CREDENTIAL_TYPE` added beside it so the VEC tag has a home rather
  than being a literal at the point of use.

  **The compatibility shim.** #1063 added `LEGACY_TYPE_TAGS`, accepting both
  prefixed tags from peers predating the catalog adoption. Nothing is published,
  so no such peer exists — and a reference implementation that accepts a type the
  specification does not define reintroduces exactly the drift the function it
  sits in was written to prevent. Removed; the test that pinned the behaviour now
  pins its refusal.

  **The audit trail.** Emitted envelopes recorded `credential_type:
  "VerifiableMembershipCredential"` / `"VerifiableEndorsementCredential"` — tags
  no credential ever carried, in the one record meant to be authoritative after
  the fact. They now record what was issued.

  **The policy input.** `issuer_member` / `subject_member` were carried alongside
  `issuer` / `subject` for operator policies written against the pre-#1061 shape.
  There are no deployed operator policies to preserve, and two spellings of one
  concept is how the concept drifts. The duplicates are gone and the surviving
  fields carry `is_current`.



### Fixed

- **vtc**: Follow the spec on every auth response, and close the conformance gate ([#1112](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1112))

* test(vtc)!: make response conformance fail the build

  Until now the layer reported and a green suite was not evidence of
  conformance — #1107's own memory note said to grep the run rather than trust
  the exit code, which is a signal nobody has to obey.

  A violation outside the allowlist now returns 500 with the schema error, so the
  test that provoked it fails on its own status assertion and prints the reason.
  Chosen over panicking in middleware, which surfaces at the call site as a
  transport error and says nothing about which task or why.

  The allowlist is eight `auth/*` tasks with ALLOWED_COUNT asserted beside them —
  the same discipline as KNOWN_DRIFT_COUNT, because the cheapest way to make a
  failing check pass is to add a line to a list nobody watches. An allowlisted
  violation is still reported, pinned by a test: a list that suppressed the
  evidence would mean rediscovering each entry before it could be closed.

  Two existing guards caught mistakes of mine on the first run. The allowlist
  named login/{start,finish}/0.1 where the service binds 0.2 — built from the
  violation output rather than the route mounts — and the manifest guard flagged a
  fake `trusttasks.org/spec/` URI in a new unit test, correctly, since binding
  such a URI asserts the registry serves it.

  Also retargets relationships/{list,graph} to the 0.2s from
  trustoverip/dtgwg-trust-tasks-tf#266, and fixes a seeder that wrote
  `seed-{uuid}` into `vrcDigestMultibase` — unique per row, and so a suite
  structurally blind to digest format.

  The VTC family is now clean; every remaining violation is `auth/*`.

- **vtc**: Speak the endorsement model the spec defines ([#1096](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1096))

The endorsement family — `issue`, `list`, `show` — spoke a different model
  from the one the spec defines. Three renames, one per row, and a request
  member that had been deliberately renamed away from the spec's name.

  | canonical `Endorsement` | this service sent |
  |---|---|
  | `endorsementId` | `id` |
  | `typeUri` | `endorsementType` |
  | `issued` | `createdAt` |
  | `subjectDid`, `statusListIndex`, `claim`, `revokedAt` | already matched |
</blockquote>



## `vta-audit`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.1.10...vta-audit-v0.2.0) — 2026-08-26

### Added

- **audit**: Make the audit destination a deployment choice, not a protocol one ([#1049](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1049))

`AuditLogEntry` is `{id, timestamp, action, actor, resource, outcome, channel,
  contextId, detail}` — no signature, no hash chain. The log corroborates what
  happened; it cannot prove it, and a compromised VTA can rewrite its own history.
  The canonical `AuditEnvelope` already names the members that would change that
  (`prevHash`, `entryHash`, `schemaVersion`) and records why this maintainer omits
  them: its log is flat and unchained.

  This does not add tamper-evidence, deliberately. It adds the seam, so an
  operator who needs a stronger guarantee implements one — an append-only file, a
  transparency log, a blockchain anchor, a hash chain filling in those three
  members — without the VTA committing to any scheme. Closes #1031.
</blockquote>

## `vta-config`

<blockquote>

## [0.3.13](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.12...vta-config-v0.3.13) — 2026-08-26

### Added

- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))

Applications built on a VTA have had nowhere to keep versioned metadata.
  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
  beside the secrets vault and the credential vault, for JSON an application
  owns and the VTA does not interpret.

  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
  application so several tools can share a context without colliding, and is the
  seam a per-namespace grant would later use — which is why it is part of the
  address rather than a prefix convention on the key. In 1.0 a namespace is
  collision avoidance and NOT a trust boundary: an application with write access
  to a context reaches every namespace in it, and the `put` and `delete` specs
  say so normatively. Isolation means separate contexts.

  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
  nothing to hang a precondition on, and its `list` returns the whole context —
  but the argument that settles it is that "forget everything" has to stay a safe
  thing to ask an agent, which it cannot be if account state lives there.

  Three properties are why this is a store rather than a field on an existing one.

  **One counter per `(contextId, namespace)`, not per record.** A record's
  `version` is the counter value its most recent write took, so one number is
  simultaneously the optimistic-concurrency token `expectedVersion` compares
  against and the watermark `sinceVersion` compares against. A per-record counter
  serves the first but cannot serve the second — two records' counters are not
  comparable, so no single number means "everything after this point" — and would
  have forced a second sequence kept consistent by hand. The cost is that a
  record's version jumps by whatever its neighbours consumed, which the wire
  contract states: versions are opaque and monotonic, never an edit count.

  **A failed precondition returns the current version AND value.** A bare
  rejection obliges a re-read, and the re-read races the next write; the pattern
  has no fixed point under contention. Returning the winner's view removes the
  race rather than narrowing it, and the spec makes it normative.

  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
  one, a consumer pulling from a watermark learns of every create and update and
  never of a deletion, so deleted records resurrect on its next rebuild.
  Retention is `app_state.tombstone_retention_days` (default 30, matching the
  vault's `grace_days`) — a destructive window is an operator's choice, not a
  constant — and `list` advertises the configured value, since a consumer
  schedules against that number. The sweeper runs from the storage thread beside
  the ACL/consent/vault sweepers.

  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
  version order and stops at the first still inside the window. Reaping a later
  tombstone while leaving an earlier one would make the reap watermark
  unstateable — no single number would describe what survives, which is precisely
  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
  that is enforced at the call site rather than as a zero cutoff, which would mean
  the opposite.

  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
  surviving only in the journal buffer can be re-derived after a crash and reissue
  a used value. Here a reused version means two records collide on one `appv:`
  index key, so one disappears from the change feed and every incremental consumer
  misses that change permanently, silently. A batch reserves a block and pays one
  fsync rather than N; writes that then fail leave gaps, which are safe and
  tested.

  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
  finds a tombstone and deliberately takes no new version, so a watcher sees
  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
  does not converge, and the class is per URI, not per payload.

  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.

  Concurrency is a process-local lock per namespace, not a store-layer
  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
  share a store, and the vsock protocol has no atomic opcode — its
  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
  would need to be real. Recorded in the design note with what would change that.

  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
  an older resolve fails as a stale dependency rather than as unspecced URIs.
  Conformance witnesses cover all six URIs, so nothing enters
  `UNSPECCED_DISPATCHED_URIS`.
</blockquote>

## `vta-keyspaces`

<blockquote>

## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.0...vta-keyspaces-v0.2.1) — 2026-08-26

### Added

- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))

Applications built on a VTA have had nowhere to keep versioned metadata.
  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
  beside the secrets vault and the credential vault, for JSON an application
  owns and the VTA does not interpret.

  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
  application so several tools can share a context without colliding, and is the
  seam a per-namespace grant would later use — which is why it is part of the
  address rather than a prefix convention on the key. In 1.0 a namespace is
  collision avoidance and NOT a trust boundary: an application with write access
  to a context reaches every namespace in it, and the `put` and `delete` specs
  say so normatively. Isolation means separate contexts.

  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
  nothing to hang a precondition on, and its `list` returns the whole context —
  but the argument that settles it is that "forget everything" has to stay a safe
  thing to ask an agent, which it cannot be if account state lives there.

  Three properties are why this is a store rather than a field on an existing one.

  **One counter per `(contextId, namespace)`, not per record.** A record's
  `version` is the counter value its most recent write took, so one number is
  simultaneously the optimistic-concurrency token `expectedVersion` compares
  against and the watermark `sinceVersion` compares against. A per-record counter
  serves the first but cannot serve the second — two records' counters are not
  comparable, so no single number means "everything after this point" — and would
  have forced a second sequence kept consistent by hand. The cost is that a
  record's version jumps by whatever its neighbours consumed, which the wire
  contract states: versions are opaque and monotonic, never an edit count.

  **A failed precondition returns the current version AND value.** A bare
  rejection obliges a re-read, and the re-read races the next write; the pattern
  has no fixed point under contention. Returning the winner's view removes the
  race rather than narrowing it, and the spec makes it normative.

  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
  one, a consumer pulling from a watermark learns of every create and update and
  never of a deletion, so deleted records resurrect on its next rebuild.
  Retention is `app_state.tombstone_retention_days` (default 30, matching the
  vault's `grace_days`) — a destructive window is an operator's choice, not a
  constant — and `list` advertises the configured value, since a consumer
  schedules against that number. The sweeper runs from the storage thread beside
  the ACL/consent/vault sweepers.

  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
  version order and stops at the first still inside the window. Reaping a later
  tombstone while leaving an earlier one would make the reap watermark
  unstateable — no single number would describe what survives, which is precisely
  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
  that is enforced at the call site rather than as a zero cutoff, which would mean
  the opposite.

  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
  surviving only in the journal buffer can be re-derived after a crash and reissue
  a used value. Here a reused version means two records collide on one `appv:`
  index key, so one disappears from the change feed and every incremental consumer
  misses that change permanently, silently. A batch reserves a block and pays one
  fsync rather than N; writes that then fail leave gaps, which are safe and
  tested.

  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
  finds a tombstone and deliberately takes no new version, so a watcher sees
  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
  does not converge, and the class is per URI, not per payload.

  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.

  Concurrency is a process-local lock per namespace, not a store-layer
  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
  share a store, and the vsock protocol has no atomic opcode — its
  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
  would need to be real. Recorded in the design note with what would change that.

  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
  an older resolve fails as a stale dependency rather than as unspecced URIs.
  Conformance witnesses cover all six URIs, so nothing enters
  `UNSPECCED_DISPATCHED_URIS`.
</blockquote>

## `vta-keys`

<blockquote>

## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.2.9...vta-keys-v0.3.0) — 2026-08-26

### Chore

- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))

`cargo outdated` reported 13 direct dependencies behind and `cargo update`
  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
  reports "All dependencies are up to date".

  Two of these were not cosmetic.

  **p256 was duplicated in the build.** Our crates declared `0.13` while
  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
  already pulled `0.14`, so the graph carried two copies of a curve
  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.

  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
  depends on it solely as a feature enabler: iOS has no native trust store, so
  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
  fails with "no native root CA certificates found". Features unify per major
  version, so the declaration only works while it matches the version
  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
  Updating everything *except* this one would have stranded the enabler and
  broken iOS `wss://` silently.

  The rest:

  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
    which is also a more direct statement of what it wanted.
  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
    `trust-tasks-rs`.
  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
    on is unchanged.
  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
    flags, drops out of the graph entirely.

  Two deliberate choices where the shortest path was worse:

  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
  encoding" and "valid encoding, point not on the curve" into one error, and
  those say different things to whoever reads the log — a broken client versus
  a point somebody chose.

  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
  than resting on a panic inside a deprecated helper.

  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
  path. `cargo deny check advisories` passes.
</blockquote>

## `vta-backup`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.1.14...vta-backup-v0.2.0) — 2026-08-26

### Added

- **app-state**: A third store for versioned, namespaced application state ([#1051](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1051))

Applications built on a VTA have had nowhere to keep versioned metadata.
  Adds `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a store
  beside the secrets vault and the credential vault, for JSON an application
  owns and the VTA does not interpret.

  Records are addressed `(contextId, namespace, key)`. The namespace scopes one
  application so several tools can share a context without colliding, and is the
  seam a per-namespace grant would later use — which is why it is part of the
  address rather than a prefix convention on the key. In 1.0 a namespace is
  collision avoidance and NOT a trust boundary: an application with write access
  to a context reaches every namespace in it, and the `put` and `delete` specs
  say so normatively. Isolation means separate contexts.

  Deliberately not built on `vta/memory/*`. `MemoryItem` is `{key, value}` with
  nothing to hang a precondition on, and its `list` returns the whole context —
  but the argument that settles it is that "forget everything" has to stay a safe
  thing to ask an agent, which it cannot be if account state lives there.

  Three properties are why this is a store rather than a field on an existing one.

  **One counter per `(contextId, namespace)`, not per record.** A record's
  `version` is the counter value its most recent write took, so one number is
  simultaneously the optimistic-concurrency token `expectedVersion` compares
  against and the watermark `sinceVersion` compares against. A per-record counter
  serves the first but cannot serve the second — two records' counters are not
  comparable, so no single number means "everything after this point" — and would
  have forced a second sequence kept consistent by hand. The cost is that a
  record's version jumps by whatever its neighbours consumed, which the wire
  contract states: versions are opaque and monotonic, never an edit count.

  **A failed precondition returns the current version AND value.** A bare
  rejection obliges a re-read, and the re-read races the next write; the pattern
  has no fixed point under contention. Returning the winner's view removes the
  race rather than narrowing it, and the spec makes it normative.

  **Delete leaves a versioned tombstone, and the tombstones are reaped.** Without
  one, a consumer pulling from a watermark learns of every create and update and
  never of a deletion, so deleted records resurrect on its next rebuild.
  Retention is `app_state.tombstone_retention_days` (default 30, matching the
  vault's `grace_days`) — a destructive window is an operator's choice, not a
  constant — and `list` advertises the configured value, since a consumer
  schedules against that number. The sweeper runs from the storage thread beside
  the ACL/consent/vault sweepers.

  The sweeper reaps a *prefix*, not a set: each namespace walks its tombstones in
  version order and stops at the first still inside the window. Reaping a later
  tombstone while leaving an earlier one would make the reap watermark
  unstateable — no single number would describe what survives, which is precisely
  what `watermarkTooOld` has to be able to say. `0` days disables reaping, and
  that is enforced at the call site rather than as a zero cutoff, which would mean
  the opposite.

  Version reservation is fsynced and re-seals the TEE integrity manifest, for the
  reason `vti_common::store::counter` gives for BIP-32 counters: a counter
  surviving only in the journal buffer can be re-derived after a crash and reissue
  a used value. Here a reused version means two records collide on one `appv:`
  index key, so one disappears from the change feed and every incremental consumer
  misses that change permanently, silently. A batch reserves a block and pays one
  fsync rather than N; writes that then fail leave gaps, which are safe and
  tested.

  Retry safety: reads are `ReadOnly`, `delete` is `RetrySafe` (a second delete
  finds a tombstone and deliberately takes no new version, so a watcher sees
  nothing), and `put`/`put-many` are `Keyed` — a `put` without `expectedVersion`
  does not converge, and the class is per URI, not per payload.

  Blobs are deliberately out of scope in 1.0; adding a `blobRef` is additive.

  Concurrency is a process-local lock per namespace, not a store-layer
  compare-and-swap. fjall takes an exclusive database lock so two processes cannot
  share a store, and the vsock protocol has no atomic opcode — its
  `insert_if_absent`/`swap` are already non-atomic fallbacks. A CAS today would be
  atomic exactly where the lock suffices and a warn-and-fallback exactly where it
  would need to be real. Recorded in the design note with what would change that.

  Schemas published upstream as trustoverip/dtgwg-trust-tasks-tf#252 and #253;
  this depends on the released trust-tasks-rs 0.11.2, pinned to a minimum patch so
  an older resolve fails as a stale dependency rather than as unspecced URIs.
  Conformance witnesses cover all six URIs, so nothing enters
  `UNSPECCED_DISPATCHED_URIS`.



### Fixed

- **vtc**: Follow the spec on every auth response, and close the conformance gate ([#1112](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1112))

* test(vtc)!: make response conformance fail the build

  Until now the layer reported and a green suite was not evidence of
  conformance — #1107's own memory note said to grep the run rather than trust
  the exit code, which is a signal nobody has to obey.

  A violation outside the allowlist now returns 500 with the schema error, so the
  test that provoked it fails on its own status assertion and prints the reason.
  Chosen over panicking in middleware, which surfaces at the call site as a
  transport error and says nothing about which task or why.

  The allowlist is eight `auth/*` tasks with ALLOWED_COUNT asserted beside them —
  the same discipline as KNOWN_DRIFT_COUNT, because the cheapest way to make a
  failing check pass is to add a line to a list nobody watches. An allowlisted
  violation is still reported, pinned by a test: a list that suppressed the
  evidence would mean rediscovering each entry before it could be closed.

  Two existing guards caught mistakes of mine on the first run. The allowlist
  named login/{start,finish}/0.1 where the service binds 0.2 — built from the
  violation output rather than the route mounts — and the manifest guard flagged a
  fake `trusttasks.org/spec/` URI in a new unit test, correctly, since binding
  such a URI asserts the registry serves it.

  Also retargets relationships/{list,graph} to the 0.2s from
  trustoverip/dtgwg-trust-tasks-tf#266, and fixes a seeder that wrote
  `seed-{uuid}` into `vrcDigestMultibase` — unique per row, and so a suite
  structurally blind to digest format.

  The VTC family is now clean; every remaining violation is `auth/*`.
</blockquote>

## `vta-vault`

<blockquote>

## [0.4.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.3.4...vta-vault-v0.4.0) — 2026-08-26

### Chore

- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))

`cargo outdated` reported 13 direct dependencies behind and `cargo update`
  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
  reports "All dependencies are up to date".

  Two of these were not cosmetic.

  **p256 was duplicated in the build.** Our crates declared `0.13` while
  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
  already pulled `0.14`, so the graph carried two copies of a curve
  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.

  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
  depends on it solely as a feature enabler: iOS has no native trust store, so
  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
  fails with "no native root CA certificates found". Features unify per major
  version, so the declaration only works while it matches the version
  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
  Updating everything *except* this one would have stranded the enabler and
  broken iOS `wss://` silently.

  The rest:

  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
    which is also a more direct statement of what it wanted.
  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
    `trust-tasks-rs`.
  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
    on is unchanged.
  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
    flags, drops out of the graph entirely.

  Two deliberate choices where the shortest path was worse:

  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
  encoding" and "valid encoding, point not on the curve" into one error, and
  those say different things to whoever reads the log — a broken client versus
  a point somebody chose.

  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
  than resting on a panic inside a deprecated helper.

  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
  path. `cargo deny check advisories` passes.
</blockquote>

## `vta-sweepers`

<blockquote>

## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.2.0...vta-sweepers-v0.3.0) — 2026-08-26

### Added

- **audit**: Make the audit destination a deployment choice, not a protocol one ([#1049](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1049))

`AuditLogEntry` is `{id, timestamp, action, actor, resource, outcome, channel,
  contextId, detail}` — no signature, no hash chain. The log corroborates what
  happened; it cannot prove it, and a compromised VTA can rewrite its own history.
  The canonical `AuditEnvelope` already names the members that would change that
  (`prevHash`, `entryHash`, `schemaVersion`) and records why this maintainer omits
  them: its log is flat and unchained.

  This does not add tamper-evidence, deliberately. It adds the seam, so an
  operator who needs a stronger guarantee implements one — an append-only file, a
  transparency log, a blockchain anchor, a hash chain filling in those three
  members — without the VTA committing to any scheme. Closes #1031.
</blockquote>

## `vti-webauthn`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-webauthn-v0.1.1...vti-webauthn-v0.2.0) — 2026-08-26

### Chore

- **deps**: Bring every dependency to latest, collapsing two duplicates ([#1055](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1055))

`cargo outdated` reported 13 direct dependencies behind and `cargo update`
  had 36 compatible updates waiting. Both are now clear: `cargo outdated`
  reports "All dependencies are up to date".

  Two of these were not cosmetic.

  **p256 was duplicated in the build.** Our crates declared `0.13` while
  `affinidi-crypto` — reached through `affinidi-data-integrity` and the TDK —
  already pulled `0.14`, so the graph carried two copies of a curve
  implementation. The lock now holds a single `p256 0.14.0`. The bump brings
  `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family:
  `EncodedPoint` -> `Sec1Point`, `From/ToEncodedPoint` -> `From/ToSec1Point`.
  Renamed across `vta-keys`, `vta-service` and `vti-webauthn`.

  **tokio-tungstenite was load-bearing, not incidental.** `vta-mobile-core`
  depends on it solely as a feature enabler: iOS has no native trust store, so
  `rustls-tls-webpki-roots` has to be on graph-wide or the mediator WebSocket
  fails with "no native root CA certificates found". Features unify per major
  version, so the declaration only works while it matches the version
  `affinidi-messaging-sdk` pulls — and the SDK moved to 0.30 in this refresh.
  Updating everything *except* this one would have stranded the enabler and
  broken iOS `wss://` silently.

  The rest:

  - `rcgen` 0.13 -> 0.14 (dev). `signed_by` takes an `Issuer` rather than a
    `(certificate, key)` pair, and `self_signed` borrows instead of consuming.
    The mdoc IACA test helper builds its issuer with `Issuer::from_params`,
    which is also a more direct statement of what it wanted.
  - `syn` 2 -> 3 (dev). No source change; syn 3 was already in the graph via
    `trust-tasks-rs`.
  - `rmcp` 1.7 -> 3.1.4. Two majors, one rename: `Content` -> `ContentBlock`.
    The `#[tool_router]` / `#[tool_handler]` macro surface the crate is built
    on is unchanged.
  - 36 lockfile updates, including `trust-tasks-rs` 0.11.3 (the corrected
    `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS
    SDK set. `rustls-pemfile`, one of the unmaintained crates `cargo audit`
    flags, drops out of the graph entirely.

  Two deliberate choices where the shortest path was worse:

  `vti-webauthn` keeps parse-then-validate rather than collapsing to the
  one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1
  encoding" and "valid encoding, point not on the curve" into one error, and
  those say different things to whoever reads the log — a broken client versus
  a point somebody chose.

  BIP-32 P-256 derivation replaces the now-deprecated `FieldBytes::from_slice`
  with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a
  SHA-512 HMAC so it cannot fail, but the length check is now explicit rather
  than resting on a panic inside a deprecated helper.

  Unchanged and still suppressed: the four `cargo audit` advisories ignored in
  `deny.toml`, all transitive through the AWS SDK's hyper 0.14 / rustls 0.21
  path. `cargo deny check advisories` passes.
</blockquote>

## `vta-service`

<blockquote>

## [0.21.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.20.0...vta-service-v0.21.0) — 2026-08-26

### Added

- **vta**: Framework 0.5.0 freshness bounds at the dispatch spine ([#1117](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1117))

Framework 0.5.0 Consumer Requirements item 13. A consumer MUST reject a
  document whose `issuedAt` is ahead of its own clock beyond its skew tolerance,
  and one whose `expiresAt` is at or before its `issuedAt`.

  Both are `malformedRequest`, never `expired`, and that distinction is the
  substance of the rule: `expired` names a document that was once acceptable and
  no longer is, so it tells the producer to wait when what it must do is reissue.
  Neither of these was acceptable at any instant.

  The rule makes the duplicate-execution record of item 11 implementable. That
  record is bounded only if every accepted document can be placed in a window,
  and both shapes escape every window while still looking acceptable: a future
  `issuedAt` sits in a window that has not opened and re-enters it as the clock
  advances, and an `expiresAt` at or before issuance describes an interval that
  never contained 