### PR TITLE
test(approvals): prove a reprovision can be gated on a human, and say what that does not buy

### DIFF
--- a/docs/02-vta/approvals.md
+++ b/docs/02-vta/approvals.md
@@ -176,6 +176,71 @@ be **stopped** (fjall takes a per-data-dir lock, so it will refuse to open
 otherwise), and it is **not available in TEE** — inside an enclave the store lives
 behind a vsock proxy that the host-side binary cannot reach.
 
+## Recipe: approve a device recovery instead of running it as an operator
+
+Recovering a lost client normally needs someone holding `pnm` to run the
+reprovision:
+
+```bash
+new install   pnm bootstrap request --out req.json
+operator      pnm context reprovision --id <ctx> --recipient req.json
+new install   pnm bootstrap open --bundle <f> --expect-digest <hex>
+```
+
+The out-of-band step is a real security boundary — anything that lets an
+unauthenticated caller re-issue an admin credential means anyone who knows your
+context id can become you. But where the holder can already prove a second
+enrolled device, the operator in the middle is friction rather than security.
+
+Provisioning is a Trust Task (`provision/integration/0.2`), so it takes an
+approval rule like anything else:
+
+```bash
+pnm approvals approvers add recovery did:key:z6MkTheUsersPhoneDeviceKey
+pnm approvals require https://trusttasks.org/spec/provision/integration/0.2 \
+    --consent --set recovery
+```
+
+Now the reprovision is refused with `auth:consent_required` and a
+challenge-salted digest, the nominated device is sent a VTA-signed
+`task-consent/request`, and re-submitting the same payload after an approval
+executes it. Three properties make this a good fit rather than merely a
+convenient one:
+
+- **Approver-set membership alone authorizes the decision.** The phone approving
+  your laptop's recovery does not need an ACL entry of its own.
+- **Consent binds to the payload digest, not to a session.** The approver
+  approves *this* reprovision — this context, this recipient key — rather than
+  elevating anything.
+- The approver only ever sees the challenge-salted digest, never the bundle.
+
+It also leaves better evidence than an audit row: `task-consent/decision/0.1` is
+signed by the approver, so an approved recovery produces a second independently
+verifiable artifact beside the sealed bundle's own producer assertion.
+
+### What this does not remove
+
+**The requester still needs a credential.** Consent is the *policy* gate, and it
+sits behind the bearer/authcrypt gate that authenticates the caller — so a
+brand-new install holding nothing cannot dispatch the task at all, approval rule
+or not. What the rule buys is recovery **without an operator**, not recovery
+from nothing: an already-enrolled device relays the request for the new one,
+which is exactly the relayer-is-not-the-holder split provisioning was built
+around. Nominate the approver set while you still have two devices; one
+established at recovery time is not a recovery mechanism.
+
+Two further caveats:
+
+- Rules are inert unless `policy.enforcement` is on (see **Enforcement** above),
+  so this is opt-in per deployment.
+- The `pnm approvals` surface is Trust-Task transport only. A REST-only VTA
+  cannot configure this today — the SDK's REST arm is unimplemented and there is
+  no `/policies` route, so a REST client gets a 404.
+
+The flow is exercised end to end by
+`a_reprovision_is_refused_pending_consent_and_executes_once_approved` in
+`vta-service/tests/delegated_consent_e2e.rs`.
+
 ## See also
 
 - `docs/05-design-notes/approvals-convergence.md` — why there is one model rather

--- a/sealed-bootstrap.md
+++ b/sealed-bootstrap.md
@@ -1,6 +1,19 @@
 # Sealed Bootstrap: Unified Secret Transfer Design
 
-Status: **Design — not yet implemented**
+Status: **Implemented.** Retained as the design record — the rationale below is
+still the reason the code is shaped as it is, but do not read the phase plan in
+§"Phased rollout" as outstanding work. Spot-checked against the tree: the
+`vta_sdk::sealed_transfer` module and the `vta bootstrap` / `pnm bootstrap`
+surfaces (phases 1–2), the unified `POST /bootstrap/request` with its single-use
+`BOOTSTRAP_CARVEOUT_CLOSED_KEY` and the retired
+`GET /attestation/admin-credential` (phase 3), `keys/wrapping.rs` built on
+`sealed_transfer` (phase 4), and no plaintext bundle encode paths left in
+`vta-sdk` (phase 5).
+
+The stale header cost at least one reader a wrong assumption in a downstream
+design doc (#1030), which is the cost of a status line nobody owns: it is
+written once, at the moment it is least likely to be true for long.
+
 Scope: workspace-wide (`openvtc`, `verifiable-trust-infrastructure`)
 
 ## Problem

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -908,3 +908,180 @@ async fn the_webvh_rest_route_is_gated_like_its_trust_task() {
         "a refused update must not have rotated the DID's update key"
     );
 }
+
+// ─── Reprovision under consent (#1030) ───────────────────────────────────────
+
+/// Build the wire form of a signed `BootstrapRequest` for `template` — the
+/// `request` member of a `provision-integration` payload.
+///
+/// Passed as the **wire value** the holder signed rather than a typed struct,
+/// because the handler verifies the bytes as received. Re-serialising a typed
+/// view here would re-impose this crate's casing on the very document the proof
+/// covers, which is the defect `verify_value` exists to prevent.
+async fn signed_bootstrap_request_value(template: &str, context_hint: &str) -> Value {
+    use std::collections::BTreeMap;
+
+    use chrono::Duration;
+    use vta_sdk::provision_integration::{
+        BootstrapAsk, BootstrapRequest, DidTemplateRef, TemplateBootstrapAsk,
+    };
+
+    // The same `[7u8; 32]` setup seed the other provisioning helpers use, so the
+    // holder DID this derives is one a test VTA already trusts.
+    let seed = [7u8; 32];
+    let signing = SigningKey::from_bytes(&seed);
+    let client_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(&signing.verifying_key().to_bytes());
+
+    let ask = BootstrapAsk::TemplateBootstrap(TemplateBootstrapAsk {
+        context_hint: Some(context_hint.into()),
+        template: DidTemplateRef {
+            name: template.into(),
+            vars: BTreeMap::new(),
+        },
+        admin_template: None,
+        note: None,
+    });
+
+    BootstrapRequest::sign(
+        &seed,
+        &client_did,
+        [0u8; 16],
+        Duration::minutes(10),
+        None,
+        ask,
+    )
+    .await
+    .expect("sign bootstrap request")
+    .to_signed_wire_value()
+    .expect("wire value")
+}
+
+/// **#1030: reprovisioning can be gated on a human rather than an operator.**
+///
+/// Recovery today needs someone holding `pnm` to run `context reprovision`. The
+/// claim in #1030 is that this is already just DTTE — register the provisioning
+/// task URI as consent-requiring and the existing ceremony does the rest. That
+/// claim is plausible and had never been executed, which is the condition every
+/// bug this file exists for was found in.
+///
+/// `provision-integration/0.2` is dispatched and classified `[Mutating Secret
+/// false]`, so the PDP gate sees it and it is not ceremony-exempt. But "the gate
+/// sees it" and "the ceremony completes for it" are different claims, and only
+/// the second is worth anything to an operator.
+///
+/// What this does **not** show, and what the issue's framing understates:
+/// consent is the *policy* gate, and it sits behind the bearer/authcrypt gate
+/// that authenticates the relayer. A brand-new install holding no credential
+/// cannot dispatch this task at all. The flow that works is the one the
+/// relayer≠holder split was built for — an already-enrolled device relays for
+/// the new one — so the requester here keeps a real token throughout. "Recovery
+/// without an operator" is true; "recovery from nothing" is not.
+#[tokio::test]
+async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
+    let (router, ctx) = build_test_app_with(TestAppOptions {
+        provisionable_vta: true,
+        ..Default::default()
+    })
+    .await;
+    let requester = "did:key:z6MkTestRequester";
+    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let ops = approver(23);
+
+    vta_service::contexts::create_context(&ctx.contexts_ks, "default", "Default")
+        .await
+        .expect("seed the default context");
+
+    {
+        let mut cfg = ctx.config.write().await;
+        cfg.policy.enforcement = true;
+        cfg.policy
+            .approver_sets
+            .insert("operators".into(), vec![ops.did.clone()]);
+    }
+    install_policy(&ctx, REQUIRE_CONSENT).await;
+
+    let request = signed_bootstrap_request_value("vta-admin", "default").await;
+    // `context`, not `contextId` — the published `provision/integration/0.2`
+    // schema is `additionalProperties: false` and names it `context`. Written
+    // from the schema rather than from the neighbouring tasks, most of which do
+    // spell it `contextId`; the first draft of this test used that and the
+    // spine refused it as malformed.
+    let payload = json!({ "request": request, "context": "default" });
+
+    // ── 1. Refused, pending a human.
+    let doc = envelope(
+        vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+        requester,
+        &ctx.vta_did,
+        payload.clone(),
+    );
+    let (status, rejected) = post(&router, &token, &doc).await;
+    assert!(
+        !status.is_success(),
+        "a reprovision needing consent must be refused, not executed: {rejected}"
+    );
+    // Non-vacuity: a reprovision that failed for an unrelated reason — a bad
+    // template, a missing context — would satisfy the assertion above while
+    // proving nothing about consent, and the rest of this test would then be
+    // exercising a flow that never started.
+    assert_eq!(
+        rejected["payload"]["details"]["reason"], "auth:consent_required",
+        "the refusal must name the consent requirement: {rejected}"
+    );
+
+    // ── 2. The approver is shown a digest bound to *this* bundle.
+    let details = &rejected["payload"]["details"];
+    let payload_digest = details["payloadDigest"].as_str().expect("a digest");
+    let challenge = details["challenge"].as_str().expect("a challenge");
+    let requests = details["consentRequests"]
+        .as_array()
+        .expect("signed consent requests");
+    assert_eq!(requests.len(), 1, "one request per eligible approver");
+    assert!(
+        requests[0]["proof"].is_object(),
+        "the request must be VTA-signed, or anyone can author what the human reads"
+    );
+    assert_eq!(requests[0]["recipient"], json!(ops.did));
+
+    // ── 3. The human approves. Approver-set membership alone authorizes the
+    //       decision (#907) — `ops` holds no ACL entry, which is exactly the
+    //       property that lets a recovery approver be a device rather than an
+    //       administrator.
+    let decision = sign_as(
+        &ops,
+        envelope(
+            TASK_CONSENT_DECISION,
+            &ops.did,
+            &ctx.vta_did,
+            json!({
+                "challenge": challenge,
+                "payloadDigest": payload_digest,
+                "decision": "approve"
+            }),
+        ),
+    );
+    let (status, granted) = post(&router, &token, &decision).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "decision must be accepted: {granted}"
+    );
+    assert_eq!(granted["payload"]["status"], "granted", "{granted}");
+
+    // ── 4. The same payload in a fresh envelope: the grant binds the payload
+    //       digest, not the envelope id, and the replay guard would refuse a
+    //       reused id outright.
+    let resubmit = envelope(
+        vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+        requester,
+        &ctx.vta_did,
+        payload,
+    );
+    let (status, executed) = post(&router, &token, &resubmit).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the approved reprovision must execute: {executed}"
+    );
+}


### PR DESCRIPTION
#1030 argues that self-service recovery is already just DTTE: register the
provisioning task URI as consent-requiring and the existing ceremony does the
rest. The argument is sound and had never been run, which is the condition every
bug `delegated_consent_e2e.rs` exists for was found in. So this runs it.
Closes #1030.

## What the test establishes

`provision/integration/0.2` is dispatched and classified `[Mutating Secret
false]`, so the PDP gate sees it and it is not ceremony-exempt. That makes
consent-gating *plausible*; it does not make it work. The new case drives the
whole ceremony over the real router: the reprovision is refused with
`auth:consent_required` and a challenge-salted digest, a VTA-signed
`task-consent/request` is minted for the nominated approver, the approver signs
a decision, and the same payload in a fresh envelope then executes.

The approver deliberately holds **no ACL entry** — approver-set membership alone
authorizes the decision (#907), which is the property that lets a recovery
approver be a device rather than an administrator. Without that, the phone
approving your laptop's recovery would need admin rights over the context, and
the whole arrangement would be worse than the operator it replaces.

## The framing correction

The issue reads as though this delivers recovery for a new install. It does not,
and the gap is worth stating where operators will read it rather than leaving it
to be discovered during one.

Consent is the *policy* gate. It sits behind the bearer/authcrypt gate that
authenticates the caller, so a brand-new install holding no credential cannot
dispatch the task at all — approval rule or not. What the rule buys is recovery
**without an operator**, not recovery **from nothing**: an already-enrolled
device relays the request for the new one, which is exactly the
relayer-is-not-the-holder split provisioning was built around. The docs now say
so, and add the practical consequence — nominate the approver set while you
still have two devices, because a set established at recovery time is not a
recovery mechanism.

## The wire shape, found rather than assumed

The first draft sent `contextId`, the spelling most neighbouring tasks use. The
published `provision/integration/0.2` schema is `additionalProperties: false`
and names it `context`, so the spine refused the document as malformed.

That is the whole reason the refusal assertion checks
`details.reason == "auth:consent_required"` rather than just "the call failed".
A malformed-request rejection satisfies "it was refused" perfectly well, and the
remaining four steps would then have been exercising a ceremony that never
started — a green test proving nothing, which is the failure mode this file's
header is about.

## Also

`sealed-bootstrap.md` said `Status: **Design — not yet implemented**`. It is
implemented, and the stale line cost a reader a wrong assumption in a downstream
design doc, which is what #1030 reported. Corrected against the tree rather than
from memory: `sealed_transfer` plus the `vta`/`pnm bootstrap` surfaces, the
unified `POST /bootstrap/request` with its single-use carve-out and the retired
`GET /attestation/admin-credential`, `keys/wrapping.rs` built on
`sealed_transfer`, and no plaintext bundle encode paths left in `vta-sdk`. The
phase plan is retained as the design record with a note not to read it as
outstanding work.

No production code changes.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

