### PR TITLE
feat(app-state): a third store for versioned, namespaced application state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8731,9 +8731,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8480433b7122652533d7c76f5378196f3be02ed295d124174ef36c6968af54cc"
+checksum = "9e058f9779880478f5b3fa4d9e374e188a91d8b233f808b7afdb49631d007974"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,15 @@ aws-lc-rs = "1.16"
 # (camelCase wire enums + `/0.2` TYPE_URIs) alongside the retained
 # `v0_1` modules — the VTA dual-accepts both during the migration.
 # Bump in lockstep with affinidi-webvh-service when upstream publishes.
-trust-tasks-rs = { version = "0.11", default-features = false, features = ["validate"] }
+#
+# Pinned to a minimum patch (not bare `0.11`) because 0.11.2 is the first
+# release carrying the `vta/app-state/*` schemas. `schema_index::schema_for`
+# is what `every_served_uri_has_a_published_spec_or_is_tracked_debt` consults,
+# so a resolve that landed on 0.11.0 or 0.11.1 would fail that harness rather
+# than fail quietly — but it would fail as "you are serving unspecced URIs",
+# which reads as an implementation fault instead of a stale dependency. The
+# pin makes the resolver say the true thing instead.
+trust-tasks-rs = { version = "0.11.2", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/docs/05-design-notes/appstate-store.md
+++ b/docs/05-design-notes/appstate-store.md
@@ -1,7 +1,14 @@
 # Application-state store
 
-Status: **Design — not implemented.** Tracked by
+Status: **Implemented.** Specifications published upstream as
+`vta/app-state/{get,put,list,delete,get-many,put-many}/1.0`
+(trustoverip/dtgwg-trust-tasks-tf#252, #253); served by this workspace per
 [#1029](https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/1029).
+
+Two things in this note were changed by building it, and both are corrected
+in place below rather than left for a reader to trip over: the version counter
+is per **namespace**, not per record (§2), and the family is named
+`app-state`, not `appstate` (§8.5). The rest stood.
 
 A third store on the VTA, beside the secrets vault and the credential vault, for
 **application state**: versioned, namespaced, per-context JSON that an
@@ -70,7 +77,7 @@ the existence of a vault next door. A boundary that is not written down erodes.
 
 | Property | Behaviour |
 |---|---|
-| `version` | Server-assigned, monotonic per record; returned by `get`, `list`, `put` |
+| `version` | Server-assigned, monotonic per `(contextId, namespace)`; returned by `get`, `list`, `put` |
 | `expectedVersion` on `put` | Optional precondition. On mismatch, a typed conflict **carrying the current version and value** |
 | `expectedVersion: 0` | "Create only — fail if it exists" |
 | `prefix` + pagination on `list` | Scoped enumeration |
@@ -78,7 +85,22 @@ the existence of a vault next door. A boundary that is not written down erodes.
 | Tombstones on `delete` | Versioned, reaped after a retention window |
 | Stated size limit | A per-record cap, and an explicit error on exceeding it |
 
-Two of these carry more weight than their row suggests.
+Three of these carry more weight than their row suggests.
+
+**The counter is per namespace, not per record — and this note originally got
+that wrong.** Implementing it surfaced the problem: `sinceVersion` compares a
+consumer's watermark against record versions, and *per-record* counters are not
+comparable to each other, so no single number can mean "everything changed after
+this point". A per-record counter would have forced a second sequence alongside
+it, and the two would have had to be kept consistent by hand.
+
+Making the counter per `(contextId, namespace)` collapses both jobs into one
+number: a record's `version` is the counter value its most recent write took, so
+it is simultaneously the optimistic-concurrency token and the sync watermark. The
+cost is that a record's version jumps by however many values its neighbours
+consumed, which is why the published contract states that versions are opaque and
+monotonic and never an edit count. That cost is real but bounded; the alternative
+was two counters and a consistency invariant between them.
 
 **Returning the current value with a conflict** is not a convenience. A caller
 that receives a bare rejection must re-read, and between the rejection and the
@@ -207,6 +229,13 @@ design is sound without blobs and blocked on nothing; blobs are the only part
 that forces a decision about REST advertisement, and deferring them keeps that
 decision out of the critical path for OpenVTC recovery.
 
+**Decided: (3).** 1.0 has no blob member at all. Adding a `blobRef` later is a
+MINOR addition rather than a breaking change, so nothing is foreclosed, and the
+REST-advertisement question stays unanswered until a consumer actually forces
+it. The published `put` spec instead states a per-record cap and requires the
+maintainer to refuse loudly at it, which is what keeps a consumer from quietly
+treating `value` as a blob store in the meantime.
+
 ---
 
 ## 6. Retry safety
@@ -232,6 +261,19 @@ obvious from its contract, it is classified `Keyed`"*), so **`put` should be
 explicitly in the spec so a future reader does not "optimise" it to `RetrySafe`
 on the strength of the precondition alone.
 
+**As shipped**, in `vta_sdk::retry_safety`: `get` / `list` / `get-many` are
+`ReadOnly`, `delete` is `RetrySafe`, and `put` / `put-many` are `Keyed`. The
+reasoning above is recorded as a comment beside the entries, because the
+temptation to "fix" the `put` classification is exactly the kind of change that
+looks like a cleanup and is not.
+
+The `delete` classification earns its `RetrySafe` from a specific
+implementation choice rather than from the shape of the task: a repeat delete
+finds a tombstone, returns `existed: false`, and **deliberately does not take a
+new counter value**. Had it taken one, every consumer watching the namespace
+would see a change that did not happen, and delete would have had to be `Keyed`
+like the writes.
+
 ---
 
 ## 7. Sequence
@@ -251,25 +293,130 @@ Steps 1–2 are in another repository and on another team's cadence. That is wor
 knowing before this is scheduled: the implementation is a few days and the
 sequencing is not.
 
+**Steps 1–3 are done.** The schemas are published upstream (#252, with #253
+correcting the error taxonomy), and this workspace serves all six URIs with
+conformance witnesses, so nothing entered `UNSPECCED_DISPATCHED_URIS`. Step 4 —
+OpenVTC adoption — is the remaining work and belongs to that repository.
+
+The sequencing prediction held, and in one respect it was optimistic: the
+implementation is what found the per-namespace counter problem (§2) and the two
+error-taxonomy defects (#253). Specifying first was still right — the dispatcher
+gives no other option — but "specify, then implement, then correct the spec" is
+the honest shape of it, and the second correction round should be budgeted.
+
 **Do not** shortcut by adding the URIs to `UNSPECCED_DISPATCHED_URIS`. That list
 is acknowledged debt from before the registry existed, it shrinks monotonically
 by test, and the harness's own message calls growing it the wrong fix.
 
 ---
 
-## 8. Open questions
+## 8. Resolved questions
 
-1. **Blobs** — §5. Recommend deferring; needs a decision either way.
-2. **Per-namespace ACLs.** The address supports them; nothing grants them. Is a
-   namespace a trust boundary between applications on one context, or only a
-   collision-avoidance convention? Answering "trust boundary" later is a
-   migration, so it is worth answering now even if the answer is "not yet".
-3. **Tombstone retention window.** Long enough that a peer offline for a
-   plausible interval still converges; short enough that deletes are real.
-   Suggest starting at the vault's 30-day grace and revisiting with evidence.
-4. **Size cap.** Needs a number. The cap interacts with the 1 MB global request
-   body limit, which is the ceiling for anything on the REST binding.
-5. **Is `appstate` the right name?** It is the noun the issue uses. `app-state`
-   or `application-state` would match the hyphenation of neighbouring task
-   families more closely; worth settling before the URIs are published, because
-   afterwards it is a new family rather than a rename.
+Each of these was open when the note was written and is settled now. The
+reasoning is kept because the answers constrain what a later change may do.
+
+1. **Blobs — deferred.** §5. No blob member in 1.0; adding a `blobRef` is a
+   MINOR addition, so the REST-advertisement question stays unanswered until a
+   consumer forces it.
+
+2. **Per-namespace ACLs — not yet, and the address is ready for them.** A
+   namespace in 1.0 is collision avoidance, **not** a trust boundary. Both the
+   `put` and `delete` specifications say so normatively in their
+   `## Authorization` sections, and say what to do instead: mutually distrusting
+   applications go in separate **contexts**.
+
+   The important half is that the *address* already carries the namespace, so
+   granting on it later is a new grant type rather than a migration of every
+   stored record. That was the point of answering the question now — the answer
+   "not yet" was only safe because the address did not foreclose it.
+
+   `delete` is where the coarseness has teeth, and its spec says that too: a
+   compromised application sharing a context can remove another's records, with
+   only the tombstone retention window between that and permanent loss.
+
+3. **Tombstone retention — configurable, default 30 days, and swept.**
+   `config.app_state.tombstone_retention_days`, matching the vault's
+   `grace_days` precedent: a destructive retention window is an operator's
+   choice, not a constant. The configured value — not a constant — is what the
+   `list` change-feed response advertises as `tombstoneRetentionSeconds`, since
+   a consumer schedules against that number and advertising 30 days while
+   reaping at 7 would strand exactly the clients that trusted it.
+
+   `sweep_expired_tombstones` runs from the storage thread's interval loop
+   beside the ACL / consent / vault sweepers, and lives in `vta-service` rather
+   than `vta-sweepers` for the reason the backup-bundle sweeper does: it is
+   coupled to this module's key layout, and a second copy of that in a lower
+   crate is a second thing to keep in step.
+
+   Two properties are worth knowing before changing it:
+
+   - **It reaps a prefix, not a set.** Each namespace walks its tombstones in
+     version order and stops at the first still inside the window. Reaping a
+     later tombstone while leaving an earlier one would make `appt:`
+     unstateable — no single watermark would describe what survives, which is
+     the one thing `watermarkTooOld` needs to be able to say. An expired
+     tombstone sitting behind a younger one waits for the next sweep.
+   - **`0` days disables it**, and that is enforced at the call site rather than
+     as a zero cutoff, because a zero cutoff means the opposite (everything is
+     expired). Disabled means tombstones are kept forever, no watermark ever
+     expires, and the keyspace grows unbounded — a legitimate trade for a
+     deployment that would rather spend disk than force a rebuild.
+
+   `reap_tombstones_through` writes the reap watermark **before** removing
+   anything: a crash mid-reap then refuses a resumable sync, where the opposite
+   order would serve an incomplete feed as though it were whole.
+
+4. **Size cap — 65536 bytes per record**, measured over the value's compact JSON
+   encoding, with `limitBytes` and `actualBytes` both returned on refusal. The
+   number matters less than the loudness; the batch surfaces carry their own
+   aggregate budgets (`get-many` defers past 512 KiB of response, `put-many`
+   refuses past 768 KiB of request), because the per-record cap times the item
+   ceiling exceeds any sane request or response limit.
+
+5. **The name is `app-state`.** Hyphenated, matching `did-management`,
+   `credential-exchange` and `task-consent`. `appstate` — the noun the issue
+   used — would have been the only unhyphenated multiword family in the
+   registry. Settled before publication, which was the whole reason to ask.
+
+## 9. Concurrency: why a lock and not a compare-and-swap
+
+The read-modify-write sequences are serialised by a process-local lock per
+`(contextId, namespace)`, plus a durable, fsynced version reservation. A
+compare-and-swap in the store layer was considered as the more robust starting
+point and rejected, because on inspection it does not protect anything the lock
+leaves exposed.
+
+**There is no reachable multi-writer topology.** fjall — the local backend —
+takes an exclusive file lock on the database directory, so two processes cannot
+open one store at all. The vsock backend proxies to a single store from a single
+enclave; `insert_if_absent` and `swap` there are already *non-atomic* get+insert
+fallbacks that log a warning, and the wire protocol has six opcodes, none
+atomic. A genuine CAS would need a seventh opcode implemented in
+`deploy/nitro/enclave-proxy` — a separate, non-workspace crate deployed to the
+parent EC2 instance — plus version negotiation between two independently
+deployed artifacts. That is a TEE-protocol decision, and it would still leave
+the fallback non-atomic on any proxy that had not been upgraded.
+
+So a CAS added today would be atomic exactly where the lock already suffices,
+and a warn-and-fallback exactly where it would need to be real. It would read as
+multi-writer safety while providing none.
+
+**What the CAS question did surface was a real bug**, and that is fixed: the
+version counter was written without an fsync. `vti_common::store::counter` makes
+the argument for BIP-32 path counters and it transfers exactly — a counter
+surviving only in the journal buffer can be re-derived after a crash and hand
+out a value already used. Here a reused *version* means two records collide on
+one `appv:` index key, so one of them disappears from the change feed and every
+incremental consumer misses that change permanently, with nothing to signal it.
+`reserve_versions` now fsyncs the reservation and re-seals the TEE integrity
+manifest before returning, and reserves a whole block for a batch so `put_many`
+pays one fsync rather than N.
+
+The residual exposure is a second VTA process against one store, which nothing
+can currently do. If that ever becomes reachable, the fix is a compare-and-swap
+in the store layer — not a bigger lock here — and it should land with the vsock
+opcode, not before it.
+
+## 10. Still open
+
+1. **OpenVTC adoption** (§7 step 4), in that repository.

--- a/vta-backup/src/test_support.rs
+++ b/vta-backup/src/test_support.rs
@@ -77,6 +77,7 @@ pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
         auth: Default::default(),
         audit: Default::default(),
         vault: Default::default(),
+        app_state: Default::default(),
         policy: Default::default(),
         secrets: Default::default(),
         hardened: Default::default(),

--- a/vta-config/src/lib.rs
+++ b/vta-config/src/lib.rs
@@ -4,7 +4,8 @@ use vti_common::error::AppError;
 
 // Re-export shared config types
 pub use vti_common::config::{
-    AuditConfig, AuthConfig, LogConfig, LogFormat, MessagingConfig, StoreConfig, VaultConfig,
+    AppStateConfig, AuditConfig, AuthConfig, LogConfig, LogFormat, MessagingConfig, StoreConfig,
+    VaultConfig,
 };
 // The `[secrets]` config shape + its seed-store backends live in the shared
 // `vti-secrets` crate (issue #501). Re-exported here so `AppConfig.secrets`
@@ -145,6 +146,9 @@ pub struct AppConfig {
     /// password vault and the credential store.
     #[serde(default)]
     pub vault: VaultConfig,
+    /// Application-state store tuning (tombstone retention).
+    #[serde(default)]
+    pub app_state: AppStateConfig,
     /// Policy Decision Point settings (enforcement toggle).
     #[serde(default)]
     pub policy: PolicyConfig,

--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -103,6 +103,30 @@ pub const ISSUED_CREDENTIALS: &str = "issued_credentials";
 /// user data → in [`BACKED_UP`].
 pub const MEMORY: &str = "memory";
 
+/// Versioned, namespaced application state (`vta/app-state/{get,put,list,
+/// delete,get-many,put-many}/1.0`) — the third store, beside [`VAULT`] (secrets
+/// and credentials) and [`MEMORY`] (agent memory), for JSON an application owns
+/// and the VTA does not interpret.
+///
+/// Four record shapes share the keyspace, distinguished by prefix:
+///
+/// - `app:<contextId>:<namespace>:<key>` — the record itself. `list` in
+///   snapshot mode is an `app:<contextId>:<namespace>:` prefix scan.
+/// - `appv:<contextId>:<namespace>:<version:020}>` — version index, mapping a
+///   zero-padded counter value to its record key. Change-feed `list` scans this
+///   so it can return changes in version order and paginate over a stable
+///   storage key; a scan-and-sort over the records could do neither.
+/// - `appc:<contextId>:<namespace>` — the namespace's monotonic write counter.
+/// - `appt:<contextId>:<namespace>` — the oldest version still covered by a
+///   retained tombstone, which is what `sinceVersion` is checked against.
+///
+/// Deliberately **not** [`MEMORY`]: clearing an agent's memory has to stay a
+/// safe thing for a user to ask, which it cannot be if account state lives
+/// there. Durable user data — an account's recoverability depends on it — so it
+/// is in [`BACKED_UP`], and a restore that came back without it would defeat
+/// the point of the feature.
+pub const APP_STATE: &str = "app_state";
+
 /// Rego policy modules for the Policy Decision Point (`policy/{upsert,list,
 /// delete,evaluate}`). One `policy::PolicyModule` per id, keyed `policy:<id>`;
 /// the active set is every enabled row, priority-ordered. Durable operator
@@ -166,6 +190,7 @@ pub const ALL: &[&str] = &[
     CONSENT_APPROVERS,
     ISSUED_CREDENTIALS,
     MEMORY,
+    APP_STATE,
     POLICY,
     TASK_CONSENT,
     OUTBOX,
@@ -185,6 +210,11 @@ pub const BACKED_UP: &[&str] = &[
     CONSENT_APPROVERS,
     // Durable agent memory is user data and must survive a restore.
     MEMORY,
+    // Application state IS the user's account for a consumer built on it —
+    // labels, relationships, contacts, join history. A restore that came back
+    // without it would return a VTA whose applications no longer recognise
+    // their own data, which is the failure the store exists to prevent.
+    APP_STATE,
     // Operator security policy — must survive a restore, else enforcement
     // silently reverts to whatever defaults boot-install provides.
     POLICY,

--- a/vta-sdk/src/client/app_state.rs
+++ b/vta-sdk/src/client/app_state.rs
@@ -1,0 +1,306 @@
+//! Application-state Trust Task client methods
+//! (`spec/vta/app-state/{get,put,list,delete,get-many,put-many}/1.0`).
+//!
+//! Drives the slice through the generic trust-task dispatcher
+//! ([`VtaClient::dispatch_trust_task`]) — there is no dedicated REST route. All
+//! six operations are gated server-side on **context access**: the caller must
+//! be permitted to act in `context_id`.
+//!
+//! Bodies are built from the typed [`protocols::app_state`] structs rather than
+//! hand-rolled `json!` literals, so a schema change surfaces here as a compile
+//! error rather than as a payload the VTA rejects at run time.
+
+use serde_json::Value;
+
+use super::VtaClient;
+use crate::error::VtaError;
+use crate::protocols::app_state::{
+    AppStateDeleteBody, AppStateGetBody, AppStateGetManyBody, AppStateListBody, AppStatePutBody,
+    AppStatePutManyBody, AppStateWrite, PutManyMode,
+};
+use crate::trust_tasks;
+
+/// Round-trip timeout (seconds) for application-state trust tasks. Matches the
+/// memory slice; the batch operations are bounded by the VTA's own per-request
+/// ceilings rather than by wall-clock, so they need no separate budget.
+const APP_STATE_TT_TIMEOUT: u64 = 30;
+
+/// Serialize a typed body, mapping the (unreachable in practice) failure into a
+/// typed SDK error rather than panicking inside a client call.
+fn body(value: impl serde::Serialize) -> Result<Value, VtaError> {
+    serde_json::to_value(value)
+        .map_err(|e| VtaError::Validation(format!("encode app-state payload: {e}")))
+}
+
+impl VtaClient {
+    /// `vta/app-state/get/1.0` — read the record at
+    /// `(context_id, namespace, key)`.
+    ///
+    /// `include_deleted` returns a tombstone as a record with `deleted: true`
+    /// instead of reporting the address absent, which is what distinguishes
+    /// "deleted, and here is the version that deleted it" from "never existed".
+    pub async fn app_state_get(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        key: &str,
+        include_deleted: bool,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStateGetBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.to_string(),
+            key: key.to_string(),
+            include_deleted: include_deleted.then_some(true),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_GET_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/put/1.0` — write `value` at
+    /// `(context_id, namespace, key)`.
+    ///
+    /// `expected_version` is the optimistic-concurrency precondition: `Some(n)`
+    /// requires the record to be at exactly version `n`, `Some(0)` requires
+    /// that no live record exists ("create only" — what makes lease acquisition
+    /// safe), and `None` is an unconditional upsert. A failed precondition
+    /// comes back as `vta/app-state/put:versionConflict` carrying the VTA's
+    /// current version *and* value, so a caller can merge and re-issue without
+    /// a re-read — the re-read would race the next write.
+    pub async fn app_state_put(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        key: &str,
+        value: Value,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStatePutBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.to_string(),
+            key: key.to_string(),
+            value: Some(value),
+            merge_patch: None,
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_PUT_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/put/1.0` with an RFC 7386 merge patch instead of a whole
+    /// value.
+    ///
+    /// Cuts payload, and more usefully cuts *conflicts*: two instances patching
+    /// different members of one record both succeed where two whole-value
+    /// writes would have serialised behind `expected_version`. Requires a live
+    /// record — a patch against an empty address is `notFound`.
+    ///
+    /// RFC 7386's sharp edge applies: a member set to `null` in `patch` is
+    /// **removed**, and a patch cannot set a member to the JSON literal null.
+    /// Send a whole value via [`Self::app_state_put`] when you need that.
+    pub async fn app_state_patch(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        key: &str,
+        patch: Value,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStatePutBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.to_string(),
+            key: key.to_string(),
+            value: None,
+            merge_patch: Some(patch),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_PUT_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/list/1.0` — key-ordered snapshot of live records,
+    /// optionally narrowed to a namespace and a key prefix.
+    ///
+    /// For incremental sync use [`Self::app_state_changes_since`] instead; this
+    /// call deliberately cannot express a watermark, because a snapshot and a
+    /// change feed differ in ordering, in tombstone handling, and in what the
+    /// caller must persist afterwards.
+    pub async fn app_state_list(
+        &self,
+        context_id: &str,
+        namespace: Option<&str>,
+        prefix: Option<&str>,
+        include_values: bool,
+        page_size: Option<usize>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStateListBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.map(str::to_string),
+            prefix: prefix.map(str::to_string),
+            since_version: None,
+            include_values: include_values.then_some(true),
+            include_deleted: None,
+            page_size,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_LIST_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/list/1.0` in change-feed mode — every record in
+    /// `namespace` whose version exceeds `since_version`, **tombstones
+    /// included**, in ascending version order.
+    ///
+    /// Pass `0` for a first full pull in change-feed form. Persist the
+    /// response's `highWatermark` as the next `since_version` — **not** the
+    /// maximum version among the returned records, which is wrong whenever a
+    /// `prefix` filtered a later change out of the page and undefined when the
+    /// page is empty. Do not advance the stored watermark until the final page
+    /// has been drained.
+    ///
+    /// `vta/app-state/list:watermarkTooOld` means the watermark predates the
+    /// oldest retained tombstone, so resuming would silently omit deletions:
+    /// rebuild from [`Self::app_state_list`] rather than retrying.
+    pub async fn app_state_changes_since(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        since_version: u64,
+        prefix: Option<&str>,
+        include_values: bool,
+        page_size: Option<usize>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStateListBody {
+            context_id: context_id.to_string(),
+            namespace: Some(namespace.to_string()),
+            prefix: prefix.map(str::to_string),
+            since_version: Some(since_version),
+            include_values: include_values.then_some(true),
+            include_deleted: None,
+            page_size,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_LIST_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/delete/1.0` — remove the record at
+    /// `(context_id, namespace, key)`, leaving a versioned tombstone.
+    ///
+    /// Deleting an address that holds nothing **succeeds** with
+    /// `existed: false`; that is what makes the task safe to retry. Supply
+    /// `expected_version` to refuse a delete that would discard an edit made
+    /// since the caller last read.
+    pub async fn app_state_delete(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        key: &str,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStateDeleteBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.to_string(),
+            key: key.to_string(),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_DELETE_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/get-many/1.0` — read up to 256 records from one namespace
+    /// in a single round trip.
+    ///
+    /// Every requested key comes back in exactly one of `records`, `missing` or
+    /// `deferred`, so a caller never diffs its request against the response.
+    /// `deferred` names keys the VTA did not evaluate because the response
+    /// reached its size budget — re-request exactly those.
+    pub async fn app_state_get_many(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        keys: &[String],
+        include_deleted: bool,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStateGetManyBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.to_string(),
+            keys: keys.to_vec(),
+            include_deleted: include_deleted.then_some(true),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_GET_MANY_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `vta/app-state/put-many/1.0` — up to 64 writes to one namespace in a
+    /// single round trip, each carrying its own precondition.
+    ///
+    /// [`PutManyMode::Independent`] (the default) applies each write on its own
+    /// merits and returns per-record outcomes; a batch in which some writes
+    /// conflicted is still a success, because the task did what it promised.
+    /// [`PutManyMode::Atomic`] applies all or none and, when it does not apply,
+    /// returns `vta/app-state/put-many:atomicBatchRejected` whose details carry
+    /// the same per-record outcomes — including `skipped` for the writes that
+    /// were never attempted.
+    ///
+    /// Reach for `Atomic` only when the records carry a joint invariant.
+    /// Choosing it out of caution converts every independent conflict into a
+    /// total failure.
+    pub async fn app_state_put_many(
+        &self,
+        context_id: &str,
+        namespace: &str,
+        writes: Vec<AppStateWrite>,
+        mode: PutManyMode,
+    ) -> Result<Value, VtaError> {
+        let payload = body(AppStatePutManyBody {
+            context_id: context_id.to_string(),
+            namespace: namespace.to_string(),
+            mode: Some(mode),
+            writes,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_VTA_APP_STATE_PUT_MANY_1_0,
+            payload,
+            APP_STATE_TT_TIMEOUT,
+        )
+        .await
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -230,6 +230,7 @@ mod keys;
 // this crate — the workspace patches `vta-sdk` onto itself, so the `-p` node
 // and the built node differ and cargo reports the unit Fresh — which is why the
 // census lives downstream rather than in this crate's own tests.
+mod app_state;
 #[cfg(feature = "test-loopback")]
 pub mod loopback;
 mod memory;

--- a/vta-sdk/src/protocols/app_state.rs
+++ b/vta-sdk/src/protocols/app_state.rs
@@ -1,0 +1,707 @@
+//! Wire payloads for the application-state Trust Tasks
+//! (`spec/vta/app-state/{get,put,list,delete,get-many,put-many}/1.0`).
+//!
+//! A third store on the VTA, beside the secrets/credential vault
+//! ([`crate::protocols::vault`]) and agent memory
+//! ([`crate::protocols::memory`]): versioned, namespaced, per-context JSON that
+//! an application owns and the VTA does not interpret.
+//!
+//! Records are addressed by `(contextId, namespace, key)`. Access is gated on
+//! **context** — the same `require_context` ACL check the memory and
+//! context-scoped key tasks use. A namespace is collision avoidance, not a
+//! trust boundary: two applications with write access to one context can reach
+//! each other's namespaces, and isolating them means separate contexts. The
+//! address is shaped for a future per-namespace grant, which is why `namespace`
+//! is a field rather than a convention on `key`.
+//!
+//! ## The version counter
+//!
+//! [`AppStateRecord::version`] is a monotonic counter maintained **per
+//! `(contextId, namespace)`**, not per record. Every write in a namespace takes
+//! the counter's next value, and a record's `version` is the value its most
+//! recent write took.
+//!
+//! One number therefore serves two jobs that would otherwise need two: it is
+//! the optimistic-concurrency token [`AppStatePutBody::expected_version`] is
+//! compared against, and the watermark [`AppStateListBody::since_version`] is
+//! compared against. A per-record counter could do the first but not the
+//! second — two records' per-record counters are not comparable to each other,
+//! so no single number could mean "everything changed after this point".
+//!
+//! The cost is that a record's version jumps between writes, by however many
+//! values its neighbours consumed. Consumers must treat versions as opaque and
+//! monotonic, never as an edit count.
+//!
+//! ## Not a secret store
+//!
+//! Values are stored as supplied and returned as stored — no sealing, no
+//! release policy, no audit of the value itself. Secret material belongs in
+//! `vault/*`. This boundary is stated in the published specification rather
+//! than merely implied by the vault next door, because a boundary that is not
+//! written down erodes.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+/// Deserialize a present member into `Some`, including a present `null`.
+///
+/// serde's built-in `Option<T>` handling collapses a present `null` to `None`,
+/// which would make "the application stored JSON null" indistinguishable from
+/// "the VTA did not send a value". Paired with `#[serde(default)]` — which
+/// covers the absent case — this keeps the two apart.
+fn present_value<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Value::deserialize(deserializer).map(Some)
+}
+
+/// A record as the VTA holds it.
+///
+/// `value` is absent in three distinct situations and a consumer must not
+/// conflate them: the record is a tombstone (`deleted`); the caller asked for a
+/// metadata-only view (`list` without `include_values`); or the stored value
+/// genuinely is JSON `null`, in which case `value` is `Some(Value::Null)`.
+/// That is why [`deleted`](Self::deleted) is a plain `bool` rather than
+/// something a caller infers — a consumer that has to derive deletion from an
+/// absent value gets the tombstone case wrong exactly when convergence depends
+/// on it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStateRecord {
+    /// The context the record is scoped to; the isolation boundary.
+    pub context_id: String,
+    /// The application partition within the context.
+    pub namespace: String,
+    /// The application-chosen key. Opaque to the VTA.
+    pub key: String,
+    /// The namespace counter value this record's most recent write took.
+    pub version: u64,
+    /// True when this is a tombstone: the record was deleted, and this entry
+    /// exists so an incremental consumer learns of the deletion.
+    pub deleted: bool,
+    /// The stored JSON, in whatever shape the owning application chose.
+    /// Absent on a tombstone and in metadata-only views.
+    ///
+    /// `deserialize_with` is load-bearing rather than decorative: serde's
+    /// default for `Option<Value>` maps a **present** `null` onto `None`, so an
+    /// application that stores the JSON literal null would read it back
+    /// indistinguishable from a metadata view or a tombstone. Because
+    /// `deserialize_with` runs only when the member is present, and `default`
+    /// supplies `None` when it is absent, this pair preserves exactly the
+    /// three-way distinction this type's docs promise.
+    #[serde(
+        default,
+        deserialize_with = "present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub value: Option<Value>,
+    /// Size of the stored value in bytes as measured against the per-record
+    /// cap. Present in metadata views so a consumer can decide what to fetch
+    /// without fetching it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_bytes: Option<u64>,
+    /// When the record was first created at this address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// When the write that produced this `version` was applied.
+    pub updated_at: String,
+    /// When the record was deleted. Present only when `deleted`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// get
+// ---------------------------------------------------------------------------
+
+/// `spec/vta/app-state/get/1.0` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStateGetBody {
+    /// The context the record is scoped to. The caller must have ACL access.
+    pub context_id: String,
+    /// The application partition within the context.
+    pub namespace: String,
+    /// The record key.
+    pub key: String,
+    /// When true, a tombstone is returned as a record with `deleted: true`
+    /// rather than reported absent. Lets a repair path distinguish "deleted,
+    /// and here is the version that deleted it" from "never existed".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_deleted: Option<bool>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/vta/app-state/get/1.0` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStateGetResponse {
+    /// The record at the requested address.
+    pub record: AppStateRecord,
+}
+
+// ---------------------------------------------------------------------------
+// put
+// ---------------------------------------------------------------------------
+
+/// `spec/vta/app-state/put/1.0` request body.
+///
+/// Exactly one of [`value`](Self::value) or [`merge_patch`](Self::merge_patch)
+/// is supplied; the handler rejects both-or-neither rather than picking one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStatePutBody {
+    /// The context the record is scoped to. The caller must have ACL access.
+    pub context_id: String,
+    /// The application partition within the context.
+    pub namespace: String,
+    /// The record key.
+    pub key: String,
+    /// The complete new value, replacing whatever the record held. Any JSON,
+    /// including `null` — `Some(Value::Null)` stores the JSON literal null and
+    /// is not the same as `None`. See [`AppStateRecord::value`] for why the
+    /// custom deserializer is required to keep those apart.
+    #[serde(
+        default,
+        deserialize_with = "present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub value: Option<Value>,
+    /// An RFC 7386 JSON Merge Patch applied to the record's current value.
+    /// Requires a live record. Note RFC 7386's sharp edge: a member set to
+    /// `null` in the patch *removes* that member, and a patch cannot set a
+    /// member to the JSON literal null.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_patch: Option<Value>,
+    /// Optional precondition. A positive value requires the record to be at
+    /// exactly that version; `0` requires that no live record exists
+    /// ("create only" — what makes lease acquisition safe).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/vta/app-state/put/1.0` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStatePutResponse {
+    /// Echoed from the request.
+    pub context_id: String,
+    /// Echoed from the request.
+    pub namespace: String,
+    /// Echoed from the request.
+    pub key: String,
+    /// The version this write took. Supply it as `expectedVersion` on the next
+    /// write to chain conditional updates without an intervening read.
+    pub version: u64,
+    /// True when no live record existed beforehand — including when the
+    /// address held a tombstone, which is not a live record.
+    pub created: bool,
+    /// When the write was applied.
+    pub updated_at: String,
+    /// Size of the stored value as measured against the per-record cap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_bytes: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+/// `spec/vta/app-state/list/1.0` request body.
+///
+/// Two modes, selected by whether [`since_version`](Self::since_version) is
+/// supplied. Without it this is a key-ordered **snapshot** of live records.
+/// With it this is a version-ordered **change feed** that always includes
+/// tombstones — a feed that omitted deletions could not converge, so asking for
+/// one (`include_deleted: Some(false)` alongside `since_version`) is refused as
+/// a contradiction rather than honoured.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStateListBody {
+    /// The context to enumerate. The caller must have ACL access.
+    pub context_id: String,
+    /// Restrict to one namespace. Optional in snapshot mode; **required** in
+    /// change-feed mode, because the counter `since_version` compares against
+    /// is per `(contextId, namespace)` and a watermark spanning namespaces
+    /// would name no single point in time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    /// Restrict to keys beginning with this byte prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+    /// Watermark. Selects change-feed mode: only records whose version is
+    /// strictly greater are returned, tombstones included.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since_version: Option<u64>,
+    /// When true, each record carries its `value`. Defaults to false, which
+    /// returns the metadata view so a prefix scan stays cheap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_values: Option<bool>,
+    /// Snapshot mode only: include tombstones still inside the retention
+    /// window. Ignored — and refused when explicitly false — in change-feed
+    /// mode, where tombstones are always returned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_deleted: Option<bool>,
+    /// Caller's upper bound on records per page. The VTA applies its own
+    /// ceiling and may return fewer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<usize>,
+    /// Opaque continuation token from a previous response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/vta/app-state/list/1.0` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStateListResponse {
+    /// Matching records — ascending key order in snapshot mode, ascending
+    /// version order in change-feed mode so that applying them in order
+    /// reaches the state the VTA holds.
+    pub records: Vec<AppStateRecord>,
+    /// True when more matching records exist beyond this page.
+    pub truncated: bool,
+    /// Opaque continuation token, present only when `truncated`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// The namespace's current counter value, present whenever `namespace` was
+    /// supplied.
+    ///
+    /// This — **not** the maximum version among `records` — is what an
+    /// incremental consumer stores as its next `since_version`. The maximum is
+    /// wrong whenever a `prefix` filtered a later change out of the page, and
+    /// undefined when the page is empty. A paginating consumer must not adopt
+    /// it until it has drained the final page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub high_watermark: Option<u64>,
+    /// How long this VTA retains tombstones before reaping them, so a consumer
+    /// can schedule syncs to stay inside the window rather than discovering it
+    /// has fallen out of it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tombstone_retention_seconds: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+/// `spec/vta/app-state/delete/1.0` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStateDeleteBody {
+    /// The context the record is scoped to. The caller must have ACL access.
+    pub context_id: String,
+    /// The application partition within the context.
+    pub namespace: String,
+    /// The record key.
+    pub key: String,
+    /// Optional precondition. A positive value requires the live record to be
+    /// at exactly that version, so a delete cannot discard an edit the caller
+    /// never saw. `0` is meaningless on a delete and is refused.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/vta/app-state/delete/1.0` response body.
+///
+/// Deleting an address that holds nothing is a **success**, not an error —
+/// which is what makes the task converge under replay, since a second delete
+/// finds a tombstone and changes nothing further.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStateDeleteResponse {
+    /// Echoed from the request.
+    pub context_id: String,
+    /// Echoed from the request.
+    pub namespace: String,
+    /// Echoed from the request.
+    pub key: String,
+    /// True when a live record was removed by this request. False when the
+    /// address already held a tombstone, or held nothing at all.
+    pub existed: bool,
+    /// The tombstone's version — the value this delete took, or the value the
+    /// existing tombstone already held. Absent only when the address held
+    /// nothing and no tombstone was written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
+    /// When the deletion was recorded. Absent on the same terms as `version`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// get-many
+// ---------------------------------------------------------------------------
+
+/// `spec/vta/app-state/get-many/1.0` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStateGetManyBody {
+    /// The context the records are scoped to. The caller must have ACL access.
+    pub context_id: String,
+    /// The application partition. Required — a key is only unique within one.
+    pub namespace: String,
+    /// The keys to read (1–256, distinct). Duplicates are refused rather than
+    /// deduplicated, because a caller that sent one did not mean to.
+    pub keys: Vec<String>,
+    /// When true, a tombstone yields a record with `deleted: true` rather than
+    /// appearing in `missing`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_deleted: Option<bool>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/vta/app-state/get-many/1.0` response body.
+///
+/// Every requested key appears in exactly one of `records`, `missing` or
+/// `deferred`, so a caller never has to diff its request against the response
+/// to discover what happened to a key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStateGetManyResponse {
+    /// The records found, each with its value, in requested-key order.
+    pub records: Vec<AppStateRecord>,
+    /// Requested keys holding no record — and, unless `include_deleted` was
+    /// set, keys holding only a tombstone.
+    pub missing: Vec<String>,
+    /// Requested keys not evaluated because the response reached its size
+    /// budget. The caller re-requests exactly these.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deferred: Option<Vec<String>>,
+}
+
+// ---------------------------------------------------------------------------
+// put-many
+// ---------------------------------------------------------------------------
+
+/// How a [`AppStatePutManyBody`] batch treats a single failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum PutManyMode {
+    /// Each write applies on its own merits, so one conflicted record does not
+    /// block the other nine. The default, and what a flush of unrelated edits
+    /// wants — an atomic default would let one stale record silently wedge an
+    /// entire flush, and the caller could not tell a wedged flush from a slow
+    /// one.
+    #[default]
+    Independent,
+    /// All or none, for records carrying a joint invariant.
+    Atomic,
+}
+
+/// One write within a [`AppStatePutManyBody`]. Shaped like an
+/// [`AppStatePutBody`] minus the context and namespace, which the batch
+/// supplies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStateWrite {
+    /// The record key.
+    pub key: String,
+    /// The complete new value. Mutually exclusive with `merge_patch`.
+    /// A present `null` stores the JSON literal null — see
+    /// [`AppStateRecord::value`].
+    #[serde(
+        default,
+        deserialize_with = "present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub value: Option<Value>,
+    /// An RFC 7386 merge patch. Mutually exclusive with `value`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_patch: Option<Value>,
+    /// This write's own precondition, evaluated independently of every other
+    /// write in the batch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+}
+
+/// `spec/vta/app-state/put-many/1.0` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppStatePutManyBody {
+    /// The context the records are scoped to. The caller must have ACL access.
+    pub context_id: String,
+    /// The application partition. One namespace per batch — atomicity is only
+    /// meaningful within the counter the writes take their versions from.
+    pub namespace: String,
+    /// What a single failure costs. Defaults to
+    /// [`PutManyMode::Independent`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<PutManyMode>,
+    /// The writes to apply (1–64, distinct keys).
+    pub writes: Vec<AppStateWrite>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// What happened to one write in a batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WriteOutcome {
+    /// Applied; `version` carries the new value.
+    Written,
+    /// `expected_version` did not match; the `current_*` fields carry the
+    /// VTA's view so the caller can resolve without a re-read.
+    Conflict,
+    /// The value exceeded the per-record cap.
+    TooLarge,
+    /// A `merge_patch` write named an address with no live record.
+    NotFound,
+    /// Atomic mode only: not attempted because another write in the batch
+    /// failed.
+    Skipped,
+}
+
+/// The outcome of one write within a batch. Per-record rather than per-batch,
+/// because the default mode applies each write on its own merits: a caller
+/// flushing ten unrelated edits needs to know which one conflicted, not merely
+/// that something did.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WriteResult {
+    /// The key this result is for.
+    pub key: String,
+    /// What happened.
+    pub outcome: WriteOutcome,
+    /// The new version, on [`WriteOutcome::Written`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
+    /// On `Written`: true when no live record existed beforehand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<bool>,
+    /// On `Conflict`: the version the VTA actually holds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_version: Option<u64>,
+    /// On `Conflict`: the value the VTA actually holds, returned *with* the
+    /// rejection. A bare rejection has no fixed point under contention —
+    /// between the rejection and a re-read the record can change again — so
+    /// returning the winner's view removes the race rather than narrowing it.
+    #[serde(
+        default,
+        deserialize_with = "present_value",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub current_value: Option<Value>,
+    /// On `Conflict`: true when the address holds a tombstone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_deleted: Option<bool>,
+    /// On `TooLarge`: the per-record cap in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_bytes: Option<u64>,
+    /// On `TooLarge`: the size of the rejected value in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actual_bytes: Option<u64>,
+}
+
+/// `spec/vta/app-state/put-many/1.0` response body (independent mode).
+///
+/// A batch in which some writes conflicted is a **success**: the task did what
+/// it promised — applied each write on its own merits — and the per-record
+/// outcomes are the answer rather than the failure. An `atomic` batch that does
+/// not apply is a `trust-task-error` carrying
+/// `vta/app-state/put-many:atomicBatchRejected` instead, whose details carry
+/// the same per-record outcomes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppStatePutManyResponse {
+    /// The mode applied, echoed so a caller relying on the default sees what
+    /// it got.
+    pub mode: PutManyMode,
+    /// One result per requested write, in request order.
+    pub results: Vec<WriteResult>,
+    /// The namespace's counter value after the batch, so a writer that is also
+    /// a sync consumer can adopt it without a separate list call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub high_watermark: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The three-way distinction [`AppStateRecord::value`] promises must
+    /// survive a wire round trip. serde's default `Option<Value>` handling does
+    /// not give it — a present `null` comes back as `None` — so this pins the
+    /// custom deserializer that does.
+    #[test]
+    fn a_stored_json_null_is_not_an_absent_value() {
+        let with_null = json!({
+            "contextId": "ctx", "namespace": "openvtc", "key": "k",
+            "version": 1, "deleted": false, "value": null,
+            "updatedAt": "2026-08-22T00:00:00Z"
+        });
+        let rec: AppStateRecord = serde_json::from_value(with_null).expect("parse");
+        assert_eq!(
+            rec.value,
+            Some(Value::Null),
+            "a present null is a stored value, not an absent one"
+        );
+
+        let without = json!({
+            "contextId": "ctx", "namespace": "openvtc", "key": "k",
+            "version": 1, "deleted": false,
+            "updatedAt": "2026-08-22T00:00:00Z"
+        });
+        let rec: AppStateRecord = serde_json::from_value(without).expect("parse");
+        assert_eq!(rec.value, None, "an absent member stays absent");
+    }
+
+    /// A `put` whose value genuinely is JSON null must not read as "neither
+    /// value nor mergePatch supplied", which the handler refuses.
+    #[test]
+    fn put_with_a_null_value_still_counts_as_supplying_a_value() {
+        let body: AppStatePutBody = serde_json::from_value(json!({
+            "contextId": "ctx", "namespace": "openvtc", "key": "k", "value": null
+        }))
+        .expect("parse");
+        assert_eq!(body.value, Some(Value::Null));
+        assert!(body.merge_patch.is_none());
+    }
+
+    /// A tombstone carries no value, and `deleted` is what says so.
+    #[test]
+    fn a_tombstone_is_distinguished_by_deleted_not_by_an_absent_value() {
+        let tomb: AppStateRecord = serde_json::from_value(json!({
+            "contextId": "ctx", "namespace": "openvtc", "key": "k",
+            "version": 9, "deleted": true,
+            "updatedAt": "2026-08-22T00:00:00Z",
+            "deletedAt": "2026-08-22T00:00:00Z"
+        }))
+        .expect("parse");
+        assert!(tomb.deleted);
+        assert!(tomb.value.is_none());
+    }
+
+    /// `mode` defaults to `independent`, and that default is the specification's
+    /// central claim rather than a convenience — an atomic default would let one
+    /// stale record silently wedge an entire flush.
+    #[test]
+    fn put_many_mode_defaults_to_independent() {
+        assert_eq!(PutManyMode::default(), PutManyMode::Independent);
+        let body: AppStatePutManyBody = serde_json::from_value(json!({
+            "contextId": "ctx", "namespace": "openvtc",
+            "writes": [{ "key": "k", "value": 1 }]
+        }))
+        .expect("parse");
+        assert!(
+            body.mode.is_none(),
+            "an omitted mode stays absent on the wire rather than being materialised"
+        );
+        assert_eq!(body.mode.unwrap_or_default(), PutManyMode::Independent);
+    }
+
+    /// A conforming producer may send `ext` (SPEC §4.5.1), and the published
+    /// payload schemas declare the slot — so `deny_unknown_fields` must not
+    /// reject it. It must still reject a typo, which is what that clause is for.
+    #[test]
+    fn ext_is_accepted_but_a_typo_is_not() {
+        let with_ext: AppStateGetBody = serde_json::from_value(json!({
+            "contextId": "ctx", "namespace": "openvtc", "key": "k",
+            "ext": { "org.example.tracing": { "traceId": "abc" } }
+        }))
+        .expect("a conforming producer's ext must be accepted");
+        assert!(with_ext.ext.is_some());
+
+        let typo = serde_json::from_value::<AppStateGetBody>(json!({
+            "contextId": "ctx", "namespace": "openvtc", "key": "k",
+            "includeDelted": true
+        }));
+        assert!(
+            typo.is_err(),
+            "a misspelled member must still be refused rather than silently ignored"
+        );
+    }
+
+    /// Specification-defined enum values are lowerCamelCase (SPEC §4.10).
+    #[test]
+    fn wire_enums_are_lower_camel_case() {
+        assert_eq!(
+            serde_json::to_value(PutManyMode::Atomic).unwrap(),
+            json!("atomic")
+        );
+        assert_eq!(
+            serde_json::to_value(WriteOutcome::TooLarge).unwrap(),
+            json!("tooLarge")
+        );
+        assert_eq!(
+            serde_json::to_value(WriteOutcome::NotFound).unwrap(),
+            json!("notFound")
+        );
+    }
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -22,6 +22,12 @@ pub mod members;
 /// Per-context key/value store for AI-agent memory
 /// (`spec/vta/memory/{put,list,delete}/0.1`).
 pub mod memory;
+
+/// Versioned, namespaced application state
+/// (`spec/vta/app-state/{get,put,list,delete,get-many,put-many}/1.0`) — the
+/// third store, beside the vault and agent memory, for JSON an application owns
+/// and the VTA does not interpret.
+pub mod app_state;
 /// Passkey-based login flow (`vta/auth/passkey-login-{start,finish}/1.0`).
 pub mod passkey_login;
 /// Runtime Policy Decision Point management (`policy/*`) — where the

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -385,6 +385,33 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_VTA_MEMORY_PUT_0_1, RetrySafe),
     (trust_tasks::TASK_VTA_MEMORY_LIST_0_1, ReadOnly),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),
+    // ── Application state ───────────────────────────────────────────────
+    //
+    // `put` and `put-many` are `Keyed`, and the reason is worth stating
+    // because a future reader will be tempted to "optimise" them.
+    //
+    // A `put` carrying `expectedVersion` genuinely converges: the replay
+    // fails its own precondition and one record results. But the class is
+    // per URI, not per payload, and a `put` WITHOUT the precondition does
+    // not converge — the replay writes twice and takes two values of the
+    // namespace counter, so every consumer watching that namespace's change
+    // feed sees a change that never happened. Since one URI carries both
+    // shapes, the conservative reading this module already prescribes
+    // applies: where convergence is not obvious from the contract, classify
+    // `Keyed`. The `expectedVersion` path simply benefits twice.
+    //
+    // `put-many` is worse still: partial application in `independent` mode
+    // means a blind replay's conflicts differ from the first attempt's.
+    //
+    // `delete` converges — a second delete finds the tombstone, returns
+    // `existed: false`, and deliberately does NOT take a new counter value,
+    // so a watcher sees nothing.
+    (trust_tasks::TASK_VTA_APP_STATE_GET_1_0, ReadOnly),
+    (trust_tasks::TASK_VTA_APP_STATE_PUT_1_0, Keyed),
+    (trust_tasks::TASK_VTA_APP_STATE_LIST_1_0, ReadOnly),
+    (trust_tasks::TASK_VTA_APP_STATE_DELETE_1_0, RetrySafe),
+    (trust_tasks::TASK_VTA_APP_STATE_GET_MANY_1_0, ReadOnly),
+    (trust_tasks::TASK_VTA_APP_STATE_PUT_MANY_1_0, Keyed),
     // ── Policy ──────────────────────────────────────────────────────────
     (trust_tasks::TASK_POLICY_LIST_0_2, ReadOnly),
     (trust_tasks::TASK_POLICY_GET_0_1, ReadOnly),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -736,6 +736,57 @@ pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memo
 /// [`crate::protocols::memory::MemoryDeleteBody`].
 pub const TASK_VTA_MEMORY_DELETE_0_1: &str = "https://trusttasks.org/spec/vta/memory/delete/0.1";
 
+// ─── Application-state slice (spec/vta/app-state/*) ──────────────────────
+//
+// The third store, beside the vault (secrets + credentials) and agent memory:
+// versioned, namespaced, per-context JSON an application owns and the VTA does
+// not interpret. Records are addressed `(contextId, namespace, key)`; auth is
+// context access, the same `require_context` gate the memory slice uses.
+//
+// Deliberately not built on `vta/memory/*`: `MemoryItem` is `{key, value}` with
+// nothing to hang a precondition on, its `list` returns the whole context, and
+// — the argument that settles it — "forget everything" has to stay a safe thing
+// to ask an agent, which it cannot be if account state lives there.
+
+/// `spec/vta/app-state/get/1.0` — read one record by
+/// `(contextId, namespace, key)`. Auth: context access. Payload:
+/// [`crate::protocols::app_state::AppStateGetBody`].
+pub const TASK_VTA_APP_STATE_GET_1_0: &str = "https://trusttasks.org/spec/vta/app-state/get/1.0";
+
+/// `spec/vta/app-state/put/1.0` — write one record, optionally conditional on
+/// `expectedVersion` (`0` = create only). A failed precondition returns the
+/// VTA's current version *and value*, so the caller resolves without a re-read.
+/// Auth: context access. Payload:
+/// [`crate::protocols::app_state::AppStatePutBody`].
+pub const TASK_VTA_APP_STATE_PUT_1_0: &str = "https://trusttasks.org/spec/vta/app-state/put/1.0";
+
+/// `spec/vta/app-state/list/1.0` — key-ordered snapshot, or (with
+/// `sinceVersion`) a version-ordered change feed that always includes
+/// tombstones. Auth: context access. Payload:
+/// [`crate::protocols::app_state::AppStateListBody`].
+pub const TASK_VTA_APP_STATE_LIST_1_0: &str = "https://trusttasks.org/spec/vta/app-state/list/1.0";
+
+/// `spec/vta/app-state/delete/1.0` — remove one record, leaving a versioned
+/// tombstone so an incremental consumer learns of the deletion. Deleting an
+/// absent address is a success. Auth: context access. Payload:
+/// [`crate::protocols::app_state::AppStateDeleteBody`].
+pub const TASK_VTA_APP_STATE_DELETE_1_0: &str =
+    "https://trusttasks.org/spec/vta/app-state/delete/1.0";
+
+/// `spec/vta/app-state/get-many/1.0` — read up to 256 records in one round
+/// trip; every requested key comes back in exactly one of `records`, `missing`
+/// or `deferred`. Auth: context access. Payload:
+/// [`crate::protocols::app_state::AppStateGetManyBody`].
+pub const TASK_VTA_APP_STATE_GET_MANY_1_0: &str =
+    "https://trusttasks.org/spec/vta/app-state/get-many/1.0";
+
+/// `spec/vta/app-state/put-many/1.0` — up to 64 writes in one round trip, each
+/// with its own precondition, applied `independent` (default) or `atomic`.
+/// Auth: context access. Payload:
+/// [`crate::protocols::app_state::AppStatePutManyBody`].
+pub const TASK_VTA_APP_STATE_PUT_MANY_1_0: &str =
+    "https://trusttasks.org/spec/vta/app-state/put-many/1.0";
+
 // ─── DID-management slice (spec/did-management/*) ────────────────────────
 //
 // Canonical Trust Tasks for DID + domain + server + registry management
@@ -1605,6 +1656,13 @@ pub const ALL_URIS: &[&str] = &[
     TASK_VTA_MEMORY_PUT_0_1,
     TASK_VTA_MEMORY_LIST_0_1,
     TASK_VTA_MEMORY_DELETE_0_1,
+    // Application-state slice (spec/vta/app-state/*)
+    TASK_VTA_APP_STATE_GET_1_0,
+    TASK_VTA_APP_STATE_PUT_1_0,
+    TASK_VTA_APP_STATE_LIST_1_0,
+    TASK_VTA_APP_STATE_DELETE_1_0,
+    TASK_VTA_APP_STATE_GET_MANY_1_0,
+    TASK_VTA_APP_STATE_PUT_MANY_1_0,
     // Policy slice (spec/policy/*)
     TASK_POLICY_LIST_0_2,
     TASK_POLICY_GET_0_1,

--- a/vta-service/src/operations/app_state.rs
+++ b/vta-service/src/operations/app_state.rs
@@ -1,0 +1,2896 @@
+//! Application-state store (operations layer) — versioned, namespaced,
+//! per-context JSON an application owns and the VTA does not interpret.
+//!
+//! Backs the `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` Trust
+//! Tasks (`crate::trust_tasks::app_state`). The transport/auth ceremony (the
+//! context-ACL gate, audit) stays in the trust-task handler; this module owns
+//! the store operations and the invariants below.
+//!
+//! ## Layout
+//!
+//! Everything lives in the [`APP_STATE`](crate::keyspaces::APP_STATE) keyspace,
+//! four record families distinguished by prefix. Context ids are
+//! `[A-Za-z0-9._-]` plus `/` and namespaces are `[a-z0-9-]`, so neither can
+//! contain the `:` delimiter and every prefix below is unambiguous.
+//!
+//! | Key | Value |
+//! |---|---|
+//! | `app:<ctx>:<ns>:<key>` | [`StoredRecord`] — the record, live or tombstoned |
+//! | `appv:<ctx>:<ns>:<version:020>` | the record key that version belongs to |
+//! | `appc:<ctx>:<ns>` | the namespace's write counter |
+//! | `appt:<ctx>:<ns>` | highest version whose tombstones have been reaped |
+//!
+//! ## The version counter, and why it is per namespace
+//!
+//! One counter per `(contextId, namespace)`. Every write takes its next value,
+//! and a record's `version` is the value its most recent write took.
+//!
+//! This is the design's load-bearing choice. A *per-record* counter would serve
+//! `expectedVersion` perfectly well, but could not serve `sinceVersion` at all:
+//! two records' per-record counters are not comparable to each other, so no
+//! single number could mean "everything changed after this point", and
+//! incremental sync would need a second sequence anyway. One counter answers
+//! both questions. The cost is that a record's version jumps by however many
+//! values its neighbours consumed — which is why the wire contract states that
+//! versions are opaque and monotonic, never an edit count.
+//!
+//! ## The version index, and why a scan-and-sort will not do
+//!
+//! `appv:` maps counter values to record keys, exactly one entry per record
+//! (its *current* version), tombstones included. A change feed is therefore a
+//! range scan from `sinceVersion + 1`, already in version order.
+//!
+//! Deriving the same answer by scanning `app:` and sorting would be correct but
+//! unpaginatable: [`vti_common::pagination`] cursors carry a *storage key* and
+//! resume strictly after it, so the ordering has to exist in the store rather
+//! than in a sort applied afterwards. Maintaining the index costs one extra
+//! delete+insert per write, under the same lock.
+//!
+//! ## Atomicity
+//!
+//! Read-modify-write sequences (check the precondition, take a counter value,
+//! rewrite the index) are guarded by [`NamespaceLocks`], one lock per
+//! `(contextId, namespace)`. The store's own write lock serialises *individual*
+//! operations, not sequences of them, and there is no transaction primitive to
+//! reach for — so the lock lives here, in the one process that writes.
+//!
+//! That is sound for the VTA's deployment shape: a single service owns its
+//! fjall store, and the enclave build proxies to one store over vsock from one
+//! writer. It would **not** be sound for two VTA processes sharing a store,
+//! which nothing does today; making it so needs a compare-and-swap in the store
+//! layer, not a bigger lock here.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use vta_sdk::protocols::app_state::{
+    AppStateRecord, AppStateWrite, PutManyMode, WriteOutcome, WriteResult,
+};
+use vti_common::pagination::{Cursor, CursorKey, MAX_LIMIT, paginate};
+
+use crate::error::AppError;
+use crate::store::KeyspaceHandle;
+
+// ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+/// Per-record value cap, in bytes of the value's compact JSON encoding.
+///
+/// The published specification RECOMMENDS this number and requires only that a
+/// maintainer enforce a *documented* cap and refuse loudly. 64 KiB is chosen to
+/// sit far enough under the 1 MB request-body ceiling that a full 64-write
+/// batch is still expressible, while being generous for what the store is for
+/// — labels, relationships, contacts, join history.
+///
+/// The requirement that matters is the loudness, not the number: a limit that
+/// drops a write silently has already cost a real deployment a lost join.
+pub const MAX_VALUE_BYTES: u64 = 65_536;
+
+/// Maximum keys in one `get-many`. Matches the published schema's `maxItems`.
+pub const MAX_GET_MANY_KEYS: usize = 256;
+
+/// Maximum writes in one `put-many`. Matches the published schema's `maxItems`.
+pub const MAX_PUT_MANY_WRITES: usize = 64;
+
+/// Response budget for `get-many`, in bytes of returned value.
+///
+/// [`MAX_VALUE_BYTES`] × [`MAX_GET_MANY_KEYS`] is 16 MiB, far past any sane
+/// response ceiling, so a maintainer must be able to return a partial batch.
+/// Keys past this budget come back as `deferred` rather than as an error: the
+/// alternative — refusing the whole batch — makes a caller bisect for a
+/// workable size, which it cannot compute without knowing the values' sizes.
+pub const GET_MANY_RESPONSE_BUDGET_BYTES: u64 = 512 * 1024;
+
+/// Aggregate request budget for `put-many`, in bytes of submitted value.
+pub const PUT_MANY_REQUEST_BUDGET_BYTES: u64 = 768 * 1024;
+
+/// Default tombstone retention, in seconds (30 days).
+///
+/// The operative value is `config.app_state.tombstone_retention_days`; this is
+/// only the fallback for call sites with no config to hand (tests, offline
+/// tooling). Matches the vault's grace window, which the specification calls a
+/// starting point to revisit on evidence.
+pub const DEFAULT_TOMBSTONE_RETENTION_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+/// Namespace grammar, matching the published schema's `pattern`.
+fn namespace_is_valid(ns: &str) -> bool {
+    if ns.is_empty() || ns.len() > 64 {
+        return false;
+    }
+    let bytes = ns.as_bytes();
+    if !bytes[0].is_ascii_lowercase() {
+        return false;
+    }
+    let mut prev_hyphen = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'a'..=b'z' | b'0'..=b'9' => prev_hyphen = false,
+            b'-' => {
+                // No leading, trailing, or consecutive hyphens.
+                if prev_hyphen || i + 1 == bytes.len() {
+                    return false;
+                }
+                prev_hyphen = true;
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Key grammar: 1–512 bytes, no NUL. Otherwise opaque — the store never
+/// parses, normalises, or case-folds a key, and `/` is a convention between an
+/// application and itself.
+fn key_is_valid(key: &str) -> bool {
+    !key.is_empty() && key.len() <= 512 && !key.contains('\0')
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Why an `expectedVersion` precondition failed. Mirrors the published
+/// `detailsSchema` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ConflictReason {
+    /// A positive `expectedVersion` did not match the live record's version.
+    VersionMismatch,
+    /// `expectedVersion: 0` ("create only") but a live record exists.
+    RecordExists,
+    /// A positive `expectedVersion` but no live record exists.
+    RecordAbsent,
+    /// `expectedVersion: 0` on a delete — never satisfiable, never intended.
+    CreateOnlyNotApplicable,
+}
+
+/// Why a `list` request's members cannot be answered together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FilterConflict {
+    /// `sinceVersion` without `namespace`: the counter is per namespace, so a
+    /// watermark spanning namespaces names no single point in time.
+    SinceVersionRequiresNamespace,
+    /// `sinceVersion` with `includeDeleted: false`: a change feed that omits
+    /// deletions cannot converge, so this is a contradiction, not a preference.
+    ChangeFeedCannotExcludeDeleted,
+}
+
+/// Failures the application-state operations raise, mapped by the trust-task
+/// handler onto the published error taxonomy.
+#[derive(Debug)]
+pub enum AppStateError {
+    /// No record at the address (`get`), or a `mergePatch` with nothing to
+    /// apply to (`put`).
+    NotFound,
+    /// An `expectedVersion` precondition failed. Carries the VTA's current
+    /// version **and value** so the caller resolves without a re-read — a bare
+    /// rejection has no fixed point under contention.
+    VersionConflict {
+        reason: ConflictReason,
+        current_version: Option<u64>,
+        current_value: Option<Value>,
+        current_deleted: Option<bool>,
+    },
+    /// The value exceeded [`MAX_VALUE_BYTES`].
+    ValueTooLarge { limit_bytes: u64, actual_bytes: u64 },
+    /// The `list` filters cannot be answered together.
+    FilterConflict(FilterConflict),
+    /// `sinceVersion` predates the oldest retained tombstone, so a feed from it
+    /// would omit deletions. The consumer must rebuild from a snapshot.
+    WatermarkTooOld {
+        oldest_retained_version: u64,
+        high_watermark: u64,
+    },
+    /// A batch named the same key twice.
+    DuplicateKey(Vec<String>),
+    /// An atomic batch did not apply. Carries the per-record outcomes so the
+    /// caller learns which write blocked it, and which were merely skipped.
+    AtomicBatchRejected(Vec<WriteResult>),
+    /// The batch's aggregate size exceeds what one request may carry.
+    BatchTooLarge { limit_bytes: u64, actual_bytes: u64 },
+    /// A malformed request the schema did not catch (bad namespace, bad key,
+    /// both/neither of `value` and `mergePatch`, too many items).
+    Validation(String),
+    /// A store or encoding failure.
+    Internal(String),
+}
+
+impl std::fmt::Display for AppStateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no record at that address"),
+            Self::VersionConflict {
+                reason,
+                current_version,
+                ..
+            } => match (reason, current_version) {
+                (ConflictReason::VersionMismatch, Some(v)) => {
+                    write!(
+                        f,
+                        "record is at version {v}; the supplied expectedVersion did not match"
+                    )
+                }
+                (ConflictReason::RecordExists, Some(v)) => {
+                    write!(
+                        f,
+                        "expectedVersion 0 requires no live record, but one exists at version {v}"
+                    )
+                }
+                (ConflictReason::RecordAbsent, _) => {
+                    write!(f, "expectedVersion was supplied but no live record exists")
+                }
+                (ConflictReason::CreateOnlyNotApplicable, _) => write!(
+                    f,
+                    "expectedVersion 0 is not applicable to a delete: a create-only \
+                     precondition on a removal can never be satisfied"
+                ),
+                (ConflictReason::VersionMismatch | ConflictReason::RecordExists, None) => {
+                    write!(f, "the supplied expectedVersion did not match")
+                }
+            },
+            Self::ValueTooLarge {
+                limit_bytes,
+                actual_bytes,
+            } => write!(
+                f,
+                "value is {actual_bytes} bytes; this VTA's per-record cap is {limit_bytes}"
+            ),
+            Self::FilterConflict(FilterConflict::SinceVersionRequiresNamespace) => write!(
+                f,
+                "sinceVersion requires namespace: the version counter is per (contextId, \
+                 namespace), so a watermark spanning namespaces names no single point in time"
+            ),
+            Self::FilterConflict(FilterConflict::ChangeFeedCannotExcludeDeleted) => write!(
+                f,
+                "a change feed cannot exclude tombstones: without them a consumer never \
+                 learns of a deletion and its copy cannot converge"
+            ),
+            Self::WatermarkTooOld {
+                oldest_retained_version,
+                ..
+            } => write!(
+                f,
+                "tombstones before version {oldest_retained_version} have been reaped; \
+                 resume from a snapshot rather than this watermark"
+            ),
+            Self::DuplicateKey(keys) => {
+                write!(f, "duplicate keys in one batch: {}", keys.join(", "))
+            }
+            Self::AtomicBatchRejected(_) => {
+                write!(f, "atomic batch not applied; nothing was written")
+            }
+            Self::BatchTooLarge {
+                limit_bytes,
+                actual_bytes,
+            } => write!(
+                f,
+                "batch is {actual_bytes} bytes; this VTA accepts {limit_bytes} per request"
+            ),
+            Self::Validation(m) => write!(f, "{m}"),
+            Self::Internal(m) => write!(f, "internal error: {m}"),
+        }
+    }
+}
+
+impl From<AppError> for AppStateError {
+    fn from(e: AppError) -> Self {
+        match e {
+            AppError::InvalidCursor => {
+                Self::Validation("cursor is not valid for this query".into())
+            }
+            other => Self::Internal(other.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-namespace serialisation
+// ---------------------------------------------------------------------------
+
+/// One async lock per `(contextId, namespace)`, guarding the read-modify-write
+/// sequences the store cannot make atomic on its own. See the module docs for
+/// why this lives here and what it does not cover.
+#[derive(Clone, Default)]
+pub struct NamespaceLocks {
+    inner: Arc<StdMutex<HashMap<String, Arc<AsyncMutex<()>>>>>,
+}
+
+impl NamespaceLocks {
+    /// Acquire the lock for one namespace, creating it on first use.
+    pub async fn acquire(&self, context_id: &str, namespace: &str) -> OwnedMutexGuard<()> {
+        let name = format!("{context_id}\u{0}{namespace}");
+        let lock = {
+            let mut map = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Arc::clone(map.entry(name).or_default())
+        };
+        lock.lock_owned().await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+fn record_key(context_id: &str, namespace: &str, key: &str) -> String {
+    format!("app:{context_id}:{namespace}:{key}")
+}
+
+fn namespace_prefix(context_id: &str, namespace: &str) -> String {
+    format!("app:{context_id}:{namespace}:")
+}
+
+fn context_prefix(context_id: &str) -> String {
+    format!("app:{context_id}:")
+}
+
+/// Version-index key. Zero-padded to 20 digits so lexicographic order over the
+/// storage key is numeric order over the version — `u64::MAX` is 20 digits.
+fn index_key(context_id: &str, namespace: &str, version: u64) -> String {
+    format!("appv:{context_id}:{namespace}:{version:020}")
+}
+
+fn index_prefix(context_id: &str, namespace: &str) -> String {
+    format!("appv:{context_id}:{namespace}:")
+}
+
+fn counter_key(context_id: &str, namespace: &str) -> String {
+    format!("appc:{context_id}:{namespace}")
+}
+
+fn reaped_key(context_id: &str, namespace: &str) -> String {
+    format!("appt:{context_id}:{namespace}")
+}
+
+// ---------------------------------------------------------------------------
+// Stored shape
+// ---------------------------------------------------------------------------
+
+/// The stored value for one record.
+///
+/// The address is held verbatim rather than parsed back out of the storage key.
+/// Context ids may contain `/` and keys may contain `:`, so splitting a storage
+/// key is ambiguous in general — the memory store learned the same lesson.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredRecord {
+    context_id: String,
+    namespace: String,
+    key: String,
+    version: u64,
+    deleted: bool,
+    /// The stored value, **always present**.
+    ///
+    /// Deliberately not `Option<Value>`: serde deserializes a present `null`
+    /// into `None`, so an application that legitimately stores the JSON literal
+    /// null would read it back as an absent value — exactly the conflation the
+    /// wire contract forbids. `deleted` is the only thing that distinguishes a
+    /// tombstone, and a tombstone simply carries `Null` here and never emits a
+    /// value on the wire.
+    #[serde(default)]
+    value: Value,
+    value_bytes: u64,
+    created_at: String,
+    updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    deleted_at: Option<String>,
+}
+
+impl StoredRecord {
+    /// Project to the wire shape. `with_value` false yields the metadata view;
+    /// a tombstone never carries a value regardless.
+    fn to_wire(&self, with_value: bool) -> AppStateRecord {
+        AppStateRecord {
+            context_id: self.context_id.clone(),
+            namespace: self.namespace.clone(),
+            key: self.key.clone(),
+            version: self.version,
+            deleted: self.deleted,
+            value: (with_value && !self.deleted).then(|| self.value.clone()),
+            value_bytes: (!self.deleted).then_some(self.value_bytes),
+            created_at: Some(self.created_at.clone()),
+            updated_at: self.updated_at.clone(),
+            deleted_at: self.deleted_at.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+async fn read_record(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+    key: &str,
+) -> Result<Option<StoredRecord>, AppStateError> {
+    let raw = ks.get_raw(record_key(context_id, namespace, key)).await?;
+    match raw {
+        None => Ok(None),
+        Some(bytes) => serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(|e| AppStateError::Internal(format!("decode app-state record: {e}"))),
+    }
+}
+
+async fn read_counter(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+) -> Result<u64, AppStateError> {
+    read_u64(ks, counter_key(context_id, namespace)).await
+}
+
+async fn read_reaped_through(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+) -> Result<u64, AppStateError> {
+    read_u64(ks, reaped_key(context_id, namespace)).await
+}
+
+async fn read_u64(ks: &KeyspaceHandle, key: String) -> Result<u64, AppStateError> {
+    match ks.get_raw(key).await? {
+        None => Ok(0),
+        Some(bytes) => {
+            let text = std::str::from_utf8(&bytes)
+                .map_err(|e| AppStateError::Internal(format!("counter is not UTF-8: {e}")))?;
+            text.parse()
+                .map_err(|e| AppStateError::Internal(format!("counter is not a u64: {e}")))
+        }
+    }
+}
+
+async fn write_u64(ks: &KeyspaceHandle, key: String, value: u64) -> Result<(), AppStateError> {
+    ks.insert_raw(key, value.to_string().into_bytes()).await?;
+    Ok(())
+}
+
+/// Reserve `count` consecutive version numbers for a namespace, returning the
+/// first. The caller holds the namespace lock.
+///
+/// **The reservation is fsynced before it is returned**, and this is the whole
+/// point of the function rather than an aside. `vti_common::store::counter`
+/// makes the argument for BIP-32 path counters and it transfers exactly: a
+/// counter that survives only in the journal buffer can be re-derived after a
+/// crash, handing out an already-used value. Here an already-used *version*
+/// means two records land on one `appv:` index key — so one of them vanishes
+/// from the change feed, and every consumer syncing incrementally misses that
+/// change permanently, with nothing to signal it happened. A wasted version is
+/// a harmless gap; a reused one is silent data loss.
+///
+/// Re-sealing the TEE integrity manifest is the same argument against rollback
+/// rather than against a crash: a snapshot restored behind the live counter
+/// would hand out used versions on purpose. No-op outside a TEE.
+///
+/// Reserving a **block** exists so a batch pays one fsync instead of N, which
+/// mirrors `counter::allocate_u32_block` and is why `put_many` can afford to be
+/// durable. Writes that then fail leave their reserved versions unused, which
+/// is safe for the reason above.
+async fn reserve_versions(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+    count: u64,
+) -> Result<u64, AppStateError> {
+    let current = read_counter(ks, context_id, namespace).await?;
+    let first = current + 1;
+    write_u64(ks, counter_key(context_id, namespace), current + count).await?;
+    ks.persist().await?;
+    vti_common::integrity::reseal_if_active()
+        .await
+        .map_err(|e| AppStateError::Internal(format!("reseal after version reservation: {e}")))?;
+    Ok(first)
+}
+
+/// Compact-JSON byte length of a value, which is what the per-record cap is
+/// measured over.
+fn value_size(value: &Value) -> u64 {
+    serde_json::to_vec(value)
+        .map(|v| v.len() as u64)
+        .unwrap_or(0)
+}
+
+/// RFC 7386 JSON Merge Patch.
+///
+/// Implemented here rather than pulled in as a dependency: the algorithm is
+/// fifteen lines and fully specified, and the workspace's dependency policy
+/// does not spend a supply-chain edge on that.
+///
+/// The rule that surprises people is the third arm — a member whose patch value
+/// is `null` is **removed**, which is also why a patch cannot set a member to
+/// the JSON literal null.
+fn merge_patch(target: &mut Value, patch: &Value) {
+    match patch {
+        Value::Object(patch_map) => {
+            if !target.is_object() {
+                *target = Value::Object(serde_json::Map::new());
+            }
+            let target_map = target.as_object_mut().expect("just made it an object");
+            for (k, v) in patch_map {
+                if v.is_null() {
+                    target_map.remove(k);
+                } else {
+                    let entry = target_map.entry(k.clone()).or_insert(Value::Null);
+                    merge_patch(entry, v);
+                }
+            }
+        }
+        // A non-object patch replaces the target wholesale.
+        other => *target = other.clone(),
+    }
+}
+
+fn validate_address(namespace: &str, key: &str) -> Result<(), AppStateError> {
+    if !namespace_is_valid(namespace) {
+        return Err(AppStateError::Validation(format!(
+            "namespace `{namespace}` is not a valid partition name \
+             (lowercase alphanumeric with single interior hyphens, 1-64 bytes)"
+        )));
+    }
+    if !key_is_valid(key) {
+        return Err(AppStateError::Validation(
+            "key must be 1-512 bytes and must not contain NUL".into(),
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// get
+// ---------------------------------------------------------------------------
+
+/// Read one record. Returns [`AppStateError::NotFound`] when the address holds
+/// nothing, and when it holds a tombstone that `include_deleted` did not ask
+/// for.
+pub async fn get(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+    key: &str,
+    include_deleted: bool,
+) -> Result<AppStateRecord, AppStateError> {
+    validate_address(namespace, key)?;
+    match read_record(ks, context_id, namespace, key).await? {
+        Some(r) if !r.deleted || include_deleted => Ok(r.to_wire(true)),
+        _ => Err(AppStateError::NotFound),
+    }
+}
+
+/// Read many records in one pass, accounting for every requested key.
+///
+/// Returns `(records, missing, deferred)`. `deferred` names keys not evaluated
+/// because [`GET_MANY_RESPONSE_BUDGET_BYTES`] was reached; keys are evaluated
+/// in request order so that a caller re-requesting `deferred` makes forward
+/// progress rather than receiving an arbitrary subset each time.
+pub async fn get_many(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+    keys: &[String],
+    include_deleted: bool,
+) -> Result<(Vec<AppStateRecord>, Vec<String>, Vec<String>), AppStateError> {
+    if keys.is_empty() || keys.len() > MAX_GET_MANY_KEYS {
+        return Err(AppStateError::Validation(format!(
+            "keys must hold between 1 and {MAX_GET_MANY_KEYS} entries"
+        )));
+    }
+    let mut seen = HashSet::with_capacity(keys.len());
+    let mut dupes = Vec::new();
+    for k in keys {
+        if !seen.insert(k.as_str()) {
+            dupes.push(k.clone());
+        }
+    }
+    if !dupes.is_empty() {
+        dupes.sort();
+        dupes.dedup();
+        return Err(AppStateError::DuplicateKey(dupes));
+    }
+    for k in keys {
+        validate_address(namespace, k)?;
+    }
+
+    let mut records = Vec::new();
+    let mut missing = Vec::new();
+    let mut deferred = Vec::new();
+    let mut budget = GET_MANY_RESPONSE_BUDGET_BYTES;
+
+    for key in keys {
+        if !deferred.is_empty() {
+            // Once the budget is spent, everything after it defers — evaluating
+            // a later small record out of order would break the forward-progress
+            // guarantee a caller relies on when it re-requests.
+            deferred.push(key.clone());
+            continue;
+        }
+        match read_record(ks, context_id, namespace, key).await? {
+            Some(r) if !r.deleted || include_deleted => {
+                if r.value_bytes > budget && !records.is_empty() {
+                    deferred.push(key.clone());
+                    continue;
+                }
+                budget = budget.saturating_sub(r.value_bytes);
+                records.push(r.to_wire(true));
+            }
+            _ => missing.push(key.clone()),
+        }
+    }
+    Ok((records, missing, deferred))
+}
+
+// ---------------------------------------------------------------------------
+// put
+// ---------------------------------------------------------------------------
+
+/// What one applied write produced.
+#[derive(Debug, Clone)]
+pub struct PutOutcome {
+    pub version: u64,
+    pub created: bool,
+    pub updated_at: String,
+    pub value_bytes: u64,
+}
+
+/// Write one record at an already-reserved `version`.
+///
+/// Caller **must** hold the namespace lock ([`NamespaceLocks::acquire`]) and
+/// must have reserved `version` via [`reserve_versions`]. Neither is done here,
+/// so that [`put_many`] can hold the lock across a whole batch and pay a single
+/// fsync for the whole block of versions it reserves.
+///
+/// A failure after reservation leaves `version` unused. That is deliberate and
+/// safe — see [`reserve_versions`] for why a gap costs nothing and a reuse
+/// costs a change off the feed.
+#[allow(clippy::too_many_arguments)]
+async fn put_locked(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+    key: &str,
+    value: Option<&Value>,
+    patch: Option<&Value>,
+    expected_version: Option<u64>,
+    version: u64,
+    now: &str,
+) -> Result<PutOutcome, AppStateError> {
+    validate_address(namespace, key)?;
+
+    let existing = read_record(ks, context_id, namespace, key).await?;
+    let live = existing.as_ref().filter(|r| !r.deleted);
+
+    // Precondition. A tombstone is not a live record: `expectedVersion: 0`
+    // succeeds over one, and the new record takes a counter value necessarily
+    // greater than the tombstone's.
+    match expected_version {
+        None => {}
+        Some(0) => {
+            if let Some(cur) = live {
+                return Err(AppStateError::VersionConflict {
+                    reason: ConflictReason::RecordExists,
+                    current_version: Some(cur.version),
+                    current_value: Some(cur.value.clone()),
+                    current_deleted: None,
+                });
+            }
+        }
+        Some(want) => match live {
+            None => {
+                return Err(AppStateError::VersionConflict {
+                    reason: ConflictReason::RecordAbsent,
+                    current_version: existing.as_ref().map(|r| r.version),
+                    current_value: None,
+                    current_deleted: existing.as_ref().map(|r| r.deleted),
+                });
+            }
+            Some(cur) if cur.version != want => {
+                return Err(AppStateError::VersionConflict {
+                    reason: ConflictReason::VersionMismatch,
+                    current_version: Some(cur.version),
+                    current_value: Some(cur.value.clone()),
+                    current_deleted: None,
+                });
+            }
+            Some(_) => {}
+        },
+    }
+
+    // Resolve the new value.
+    let new_value = match (value, patch) {
+        (Some(v), None) => v.clone(),
+        (None, Some(p)) => {
+            let Some(cur) = live else {
+                // A patch has nothing to apply to. Refused rather than treated
+                // as a create: RFC 7386 against a null target would silently
+                // invent a record from the patch minus its nulls.
+                return Err(AppStateError::NotFound);
+            };
+            let mut base = cur.value.clone();
+            merge_patch(&mut base, p);
+            base
+        }
+        _ => {
+            return Err(AppStateError::Validation(
+                "exactly one of `value` or `mergePatch` must be supplied".into(),
+            ));
+        }
+    };
+
+    let size = value_size(&new_value);
+    if size > MAX_VALUE_BYTES {
+        return Err(AppStateError::ValueTooLarge {
+            limit_bytes: MAX_VALUE_BYTES,
+            actual_bytes: size,
+        });
+    }
+
+    let next = version;
+    let created = live.is_none();
+    let created_at = existing
+        .as_ref()
+        .map(|r| r.created_at.clone())
+        .filter(|_| !created)
+        .unwrap_or_else(|| now.to_string());
+
+    let record = StoredRecord {
+        context_id: context_id.to_string(),
+        namespace: namespace.to_string(),
+        key: key.to_string(),
+        version: next,
+        deleted: false,
+        value: new_value,
+        value_bytes: size,
+        created_at,
+        updated_at: now.to_string(),
+        deleted_at: None,
+    };
+
+    // The counter was already advanced and fsynced by `reserve_versions`
+    // before this function was called, so `next` cannot be handed out twice
+    // even across a crash here. What remains is index-then-record: a crash
+    // between them leaves an index entry pointing at a record still holding
+    // its previous version, which the change feed resolves to a real record
+    // and may therefore deliver twice. At-least-once is the failure this
+    // design accepts throughout; losing a change is the one it does not.
+    if let Some(prev) = existing.as_ref() {
+        ks.remove(index_key(context_id, namespace, prev.version))
+            .await?;
+    }
+    ks.insert_raw(
+        index_key(context_id, namespace, next),
+        key.as_bytes().to_vec(),
+    )
+    .await?;
+    ks.insert(record_key(context_id, namespace, key), &record)
+        .await?;
+
+    Ok(PutOutcome {
+        version: next,
+        created,
+        updated_at: now.to_string(),
+        value_bytes: size,
+    })
+}
+
+/// Write one record, taking the namespace lock.
+pub async fn put(
+    ks: &KeyspaceHandle,
+    locks: &NamespaceLocks,
+    context_id: &str,
+    namespace: &str,
+    key: &str,
+    value: Option<&Value>,
+    patch: Option<&Value>,
+    expected_version: Option<u64>,
+) -> Result<PutOutcome, AppStateError> {
+    // Validate before reserving. A reservation is a durable write, so a
+    // malformed namespace would otherwise leave an `appc:` counter behind for
+    // an address that can never hold a record.
+    validate_address(namespace, key)?;
+
+    let _guard = locks.acquire(context_id, namespace).await;
+    let now = Utc::now().to_rfc3339();
+    let version = reserve_versions(ks, context_id, namespace, 1).await?;
+    put_locked(
+        ks,
+        context_id,
+        namespace,
+        key,
+        value,
+        patch,
+        expected_version,
+        version,
+        &now,
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// put-many
+// ---------------------------------------------------------------------------
+
+/// Apply a batch of writes.
+///
+/// In [`PutManyMode::Independent`] every write applies on its own merits and
+/// the per-record outcomes are the answer. In [`PutManyMode::Atomic`] the batch
+/// is **dry-run first** — every precondition and size check evaluated against
+/// the store before anything is written — and applied only if all pass;
+/// otherwise nothing is written and [`AppStateError::AtomicBatchRejected`]
+/// carries the outcomes, `Skipped` for the writes never attempted.
+///
+/// The dry run is what makes "all or none" real without a store transaction:
+/// nothing else touches the namespace while the lock is held, so a check that
+/// passes in the dry run still passes in the apply.
+pub async fn put_many(
+    ks: &KeyspaceHandle,
+    locks: &NamespaceLocks,
+    context_id: &str,
+    namespace: &str,
+    writes: &[AppStateWrite],
+    mode: PutManyMode,
+) -> Result<(Vec<WriteResult>, u64), AppStateError> {
+    if writes.is_empty() || writes.len() > MAX_PUT_MANY_WRITES {
+        return Err(AppStateError::Validation(format!(
+            "writes must hold between 1 and {MAX_PUT_MANY_WRITES} entries"
+        )));
+    }
+    let mut seen = HashSet::with_capacity(writes.len());
+    let mut dupes = Vec::new();
+    for w in writes {
+        if !seen.insert(w.key.as_str()) {
+            dupes.push(w.key.clone());
+        }
+    }
+    if !dupes.is_empty() {
+        dupes.sort();
+        dupes.dedup();
+        return Err(AppStateError::DuplicateKey(dupes));
+    }
+
+    for w in writes {
+        validate_address(namespace, &w.key)?;
+    }
+
+    let submitted: u64 = writes
+        .iter()
+        .map(|w| {
+            w.value
+                .as_ref()
+                .or(w.merge_patch.as_ref())
+                .map(value_size)
+                .unwrap_or(0)
+        })
+        .sum();
+    if submitted > PUT_MANY_REQUEST_BUDGET_BYTES {
+        return Err(AppStateError::BatchTooLarge {
+            limit_bytes: PUT_MANY_REQUEST_BUDGET_BYTES,
+            actual_bytes: submitted,
+        });
+    }
+
+    let _guard = locks.acquire(context_id, namespace).await;
+    let now = Utc::now().to_rfc3339();
+
+    if mode == PutManyMode::Atomic {
+        // Dry run: find the first write that would fail, and report every
+        // other write as `Skipped` so the caller can see that a retry does not
+        // need its create-only preconditions rewritten.
+        if let Some(failed_at) = dry_run_atomic(ks, context_id, namespace, writes).await? {
+            let results = writes
+                .iter()
+                .enumerate()
+                .map(|(i, w)| {
+                    if i == failed_at.index {
+                        failed_at.result.clone()
+                    } else {
+                        WriteResult {
+                            key: w.key.clone(),
+                            outcome: WriteOutcome::Skipped,
+                            version: None,
+                            created: None,
+                            current_version: None,
+                            current_value: None,
+                            current_deleted: None,
+                            limit_bytes: None,
+                            actual_bytes: None,
+                        }
+                    }
+                })
+                .collect();
+            return Err(AppStateError::AtomicBatchRejected(results));
+        }
+    }
+
+    // One reservation, one fsync, for the whole batch — the reason
+    // `reserve_versions` takes a count. Writes that then conflict leave their
+    // reserved versions unused, which is a gap and therefore safe.
+    let first = reserve_versions(ks, context_id, namespace, writes.len() as u64).await?;
+
+    let mut results = Vec::with_capacity(writes.len());
+    for (i, w) in writes.iter().enumerate() {
+        let outcome = put_locked(
+            ks,
+            context_id,
+            namespace,
+            &w.key,
+            w.value.as_ref(),
+            w.merge_patch.as_ref(),
+            w.expected_version,
+            first + i as u64,
+            &now,
+        )
+        .await;
+        results.push(write_result(&w.key, outcome)?);
+    }
+    let high = read_counter(ks, context_id, namespace).await?;
+    Ok((results, high))
+}
+
+/// One write's dry-run failure.
+struct DryRunFailure {
+    index: usize,
+    result: WriteResult,
+}
+
+/// Evaluate every write's precondition and size against the store without
+/// writing. Returns the first failure, or `None` when the whole batch would
+/// apply.
+///
+/// Preconditions are evaluated against the *stored* state, not against the
+/// batch's own intermediate states. Two writes in one atomic batch therefore
+/// cannot chain (`expectedVersion` on the second naming the version the first
+/// would produce) — the keys are distinct so no write in a batch can observe
+/// another, which is what makes evaluating them all up-front sound.
+async fn dry_run_atomic(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: &str,
+    writes: &[AppStateWrite],
+) -> Result<Option<DryRunFailure>, AppStateError> {
+    for (index, w) in writes.iter().enumerate() {
+        validate_address(namespace, &w.key)?;
+        let existing = read_record(ks, context_id, namespace, &w.key).await?;
+        let live = existing.as_ref().filter(|r| !r.deleted);
+
+        let conflict = match w.expected_version {
+            None => None,
+            Some(0) => live.map(|cur| (ConflictReason::RecordExists, Some(cur))),
+            Some(want) => match live {
+                None => Some((ConflictReason::RecordAbsent, None)),
+                Some(cur) if cur.version != want => {
+                    Some((ConflictReason::VersionMismatch, Some(cur)))
+                }
+                Some(_) => None,
+            },
+        };
+        if let Some((_reason, cur)) = conflict {
+            return Ok(Some(DryRunFailure {
+                index,
+                result: WriteResult {
+                    key: w.key.clone(),
+                    outcome: WriteOutcome::Conflict,
+                    version: None,
+                    created: None,
+                    current_version: cur
+                        .map(|c| c.version)
+                        .or(existing.as_ref().map(|r| r.version)),
+                    current_value: cur.map(|c| c.value.clone()),
+                    current_deleted: existing.as_ref().map(|r| r.deleted).filter(|d| *d),
+                    limit_bytes: None,
+                    actual_bytes: None,
+                },
+            }));
+        }
+
+        // A patch needs a live record; a whole value does not.
+        if w.merge_patch.is_some() && live.is_none() {
+            return Ok(Some(DryRunFailure {
+                index,
+                result: WriteResult {
+                    key: w.key.clone(),
+                    outcome: WriteOutcome::NotFound,
+                    version: None,
+                    created: None,
+                    current_version: None,
+                    current_value: None,
+                    current_deleted: None,
+                    limit_bytes: None,
+                    actual_bytes: None,
+                },
+            }));
+        }
+
+        let projected = match (&w.value, &w.merge_patch) {
+            (Some(v), None) => v.clone(),
+            (None, Some(p)) => {
+                let mut base = live.map(|c| c.value.clone()).unwrap_or(Value::Null);
+                merge_patch(&mut base, p);
+                base
+            }
+            _ => {
+                return Err(AppStateError::Validation(format!(
+                    "write for key `{}`: exactly one of `value` or `mergePatch` must be supplied",
+                    w.key
+                )));
+            }
+        };
+        let size = value_size(&projected);
+        if size > MAX_VALUE_BYTES {
+            return Ok(Some(DryRunFailure {
+                index,
+                result: WriteResult {
+                    key: w.key.clone(),
+                    outcome: WriteOutcome::TooLarge,
+                    version: None,
+                    created: None,
+                    current_version: None,
+                    current_value: None,
+                    current_deleted: None,
+                    limit_bytes: Some(MAX_VALUE_BYTES),
+                    actual_bytes: Some(size),
+                },
+            }));
+        }
+    }
+    Ok(None)
+}
+
+/// Fold one write's `Result` into its per-record [`WriteResult`]. Genuine
+/// faults (validation, store) propagate — they are not per-record outcomes and
+/// reporting them as such would tell a caller to retry a malformed batch.
+fn write_result(
+    key: &str,
+    outcome: Result<PutOutcome, AppStateError>,
+) -> Result<WriteResult, AppStateError> {
+    let base = |o: WriteOutcome| WriteResult {
+        key: key.to_string(),
+        outcome: o,
+        version: None,
+        created: None,
+        current_version: None,
+        current_value: None,
+        current_deleted: None,
+        limit_bytes: None,
+        actual_bytes: None,
+    };
+    match outcome {
+        Ok(o) => Ok(WriteResult {
+            version: Some(o.version),
+            created: Some(o.created),
+            ..base(WriteOutcome::Written)
+        }),
+        Err(AppStateError::VersionConflict {
+            current_version,
+            current_value,
+            current_deleted,
+            ..
+        }) => Ok(WriteResult {
+            current_version,
+            current_value,
+            current_deleted,
+            ..base(WriteOutcome::Conflict)
+        }),
+        Err(AppStateError::ValueTooLarge {
+            limit_bytes,
+            actual_bytes,
+        }) => Ok(WriteResult {
+            limit_bytes: Some(limit_bytes),
+            actual_bytes: Some(actual_bytes),
+            ..base(WriteOutcome::TooLarge)
+        }),
+        Err(AppStateError::NotFound) => Ok(base(WriteOutcome::NotFound)),
+        Err(other) => Err(other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+/// What a delete produced.
+#[derive(Debug, Clone)]
+pub struct DeleteOutcome {
+    pub existed: bool,
+    pub version: Option<u64>,
+    pub deleted_at: Option<String>,
+}
+
+/// Delete one record, leaving a versioned tombstone.
+///
+/// Three cases, all successes:
+///
+/// - a live record → replaced by a tombstone taking the next counter value,
+///   `existed: true`;
+/// - an existing tombstone → unchanged, `existed: false`, and deliberately
+///   **no** new counter value, because taking one would present a change to
+///   every watching consumer where none occurred;
+/// - nothing at all → `existed: false` and **no** tombstone written. Nothing
+///   ever existed there for a consumer to have learned about, so there is
+///   nothing to converge.
+pub async fn delete(
+    ks: &KeyspaceHandle,
+    locks: &NamespaceLocks,
+    context_id: &str,
+    namespace: &str,
+    key: &str,
+    expected_version: Option<u64>,
+) -> Result<DeleteOutcome, AppStateError> {
+    validate_address(namespace, key)?;
+    if expected_version == Some(0) {
+        return Err(AppStateError::VersionConflict {
+            reason: ConflictReason::CreateOnlyNotApplicable,
+            current_version: None,
+            current_value: None,
+            current_deleted: None,
+        });
+    }
+
+    let _guard = locks.acquire(context_id, namespace).await;
+    let existing = read_record(ks, context_id, namespace, key).await?;
+    let live = existing.as_ref().filter(|r| !r.deleted);
+
+    if let Some(want) = expected_version {
+        match live {
+            None => {
+                return Err(AppStateError::VersionConflict {
+                    reason: ConflictReason::RecordAbsent,
+                    current_version: existing.as_ref().map(|r| r.version),
+                    current_value: None,
+                    current_deleted: existing.as_ref().map(|r| r.deleted),
+                });
+            }
+            Some(cur) if cur.version != want => {
+                return Err(AppStateError::VersionConflict {
+                    reason: ConflictReason::VersionMismatch,
+                    current_version: Some(cur.version),
+                    current_value: Some(cur.value.clone()),
+                    current_deleted: None,
+                });
+            }
+            Some(_) => {}
+        }
+    }
+
+    let Some(prev) = existing else {
+        return Ok(DeleteOutcome {
+            existed: false,
+            version: None,
+            deleted_at: None,
+        });
+    };
+    if prev.deleted {
+        return Ok(DeleteOutcome {
+            existed: false,
+            version: Some(prev.version),
+            deleted_at: prev.deleted_at,
+        });
+    }
+
+    let now = Utc::now().to_rfc3339();
+    // Reserved only once a tombstone is actually going to be written — the
+    // no-op paths above return before this, so a repeated delete consumes
+    // nothing and presents no change to a watching consumer.
+    let next = reserve_versions(ks, context_id, namespace, 1).await?;
+    let tombstone = StoredRecord {
+        context_id: context_id.to_string(),
+        namespace: namespace.to_string(),
+        key: key.to_string(),
+        version: next,
+        deleted: true,
+        value: Value::Null,
+        value_bytes: 0,
+        created_at: prev.created_at,
+        updated_at: now.clone(),
+        deleted_at: Some(now.clone()),
+    };
+
+    ks.remove(index_key(context_id, namespace, prev.version))
+        .await?;
+    ks.insert_raw(
+        index_key(context_id, namespace, next),
+        key.as_bytes().to_vec(),
+    )
+    .await?;
+    ks.insert(record_key(context_id, namespace, key), &tombstone)
+        .await?;
+
+    Ok(DeleteOutcome {
+        existed: true,
+        version: Some(next),
+        deleted_at: Some(now),
+    })
+}
+
+/// Reap tombstones at or below `through`, and record that the namespace's feed
+/// is no longer complete from before that point.
+///
+/// **Nothing schedules this yet.** It exists so the watermark check in
+/// [`list`] is live rather than dead code, and so that adding a sweeper is a
+/// pure addition rather than a change to the read path. A VTA that never calls
+/// it retains tombstones forever and never emits `watermarkTooOld`, which the
+/// published specification explicitly permits.
+///
+/// Recording `appt:` **before** removing anything is the safe order: a crash
+/// mid-reap leaves the watermark claiming more was reaped than actually was,
+/// which refuses a resumable sync (recoverable), where the opposite order would
+/// serve an incomplete feed as if it were whole (not recoverable).
+pub async fn reap_tombstones_through(
+    ks: &KeyspaceHandle,
+    locks: &NamespaceLocks,
+    context_id: &str,
+    namespace: &str,
+    through: u64,
+) -> Result<usize, AppStateError> {
+    let _guard = locks.acquire(context_id, namespace).await;
+    write_u64(ks, reaped_key(context_id, namespace), through).await?;
+
+    let mut reaped = 0;
+    for (_ik, key_bytes) in ks
+        .prefix_iter_raw(index_prefix(context_id, namespace))
+        .await?
+    {
+        let Ok(key) = std::str::from_utf8(&key_bytes) else {
+            continue;
+        };
+        let Some(rec) = read_record(ks, context_id, namespace, key).await? else {
+            continue;
+        };
+        if rec.deleted && rec.version <= through {
+            ks.remove(index_key(context_id, namespace, rec.version))
+                .await?;
+            ks.remove(record_key(context_id, namespace, key)).await?;
+            reaped += 1;
+        }
+    }
+    Ok(reaped)
+}
+
+/// Reap every tombstone whose retention window has elapsed, across every
+/// context and namespace in the keyspace.
+///
+/// Run from the storage thread's interval loop alongside the ACL / consent /
+/// vault sweepers. Lives here rather than in `vta-sweepers` for the same reason
+/// the backup-bundle sweeper stays in `vta-service`: it is coupled to this
+/// module's key layout and record shape, and a second copy of those in a lower
+/// crate is a second thing to keep in step.
+///
+/// ## Why it reaps a *prefix*, not a set
+///
+/// The obvious implementation removes each expired tombstone individually. That
+/// is wrong here. `sinceVersion` resumption is only sound while the maintainer
+/// can promise that a consumer's watermark is at or above everything it has
+/// discarded — that promise is exactly what `appt:` records and what
+/// `watermarkTooOld` enforces. Reaping version 7 while leaving version 4 makes
+/// the promise unstateable: no single watermark describes what survives.
+///
+/// So each namespace advances through its tombstones in version order and stops
+/// at the first one still inside the window. Everything below that point is
+/// reaped and the watermark moves with it. A tombstone that is expired but sits
+/// behind a younger one simply waits for the next sweep — a bounded delay, in
+/// exchange for a watermark that always means what it says.
+///
+/// Walking in version order rather than filtering on time also makes the sweep
+/// robust to a clock that has moved backwards: a stale `deletedAt` on a *later*
+/// version stops the walk instead of licensing the removal of everything under
+/// it.
+///
+/// `retention_seconds` is a pure cutoff — `now - retention_seconds` — so `0`
+/// here means "everything already written is expired", not "disabled".
+/// Disabling lives at the **call site**: the storage thread skips the sweep
+/// entirely when `tombstone_retention_days` is 0. Keeping the two apart means
+/// this function has one unambiguous meaning and the operator-facing knob has
+/// the safer one, rather than overloading a single number with both.
+///
+/// Returns the number of tombstones removed.
+pub async fn sweep_expired_tombstones(
+    ks: &KeyspaceHandle,
+    locks: &NamespaceLocks,
+    audit: &vta_audit::SharedAuditSink,
+    retention_seconds: u64,
+) -> Result<usize, AppStateError> {
+    let cutoff = Utc::now() - chrono::Duration::seconds(retention_seconds as i64);
+
+    // Collect (contextId, namespace) -> tombstones, reading the address from
+    // the record rather than parsing the storage key: a context id may contain
+    // `/` and a key may contain `:`, so splitting the key is ambiguous.
+    let mut by_namespace: HashMap<(String, String), Vec<(u64, Option<String>)>> = HashMap::new();
+    for (_sk, bytes) in ks.prefix_iter_raw("app:").await? {
+        let rec: StoredRecord = match serde_json::from_slice(&bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(error = %e, "app-state sweeper: skipping unreadable row");
+                continue;
+            }
+        };
+        if !rec.deleted {
+            continue;
+        }
+        by_namespace
+            .entry((rec.context_id.clone(), rec.namespace.clone()))
+            .or_default()
+            .push((rec.version, rec.deleted_at.clone()));
+    }
+
+    let mut total = 0usize;
+    for ((context_id, namespace), mut tombstones) in by_namespace {
+        tombstones.sort_by_key(|(v, _)| *v);
+
+        let mut through = 0u64;
+        for (version, deleted_at) in &tombstones {
+            let expired = deleted_at
+                .as_deref()
+                .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
+                .is_some_and(|t| t.with_timezone(&Utc) < cutoff);
+            if !expired {
+                break;
+            }
+            through = *version;
+        }
+        if through == 0 {
+            continue;
+        }
+
+        let reaped = reap_tombstones_through(ks, locks, &context_id, &namespace, through).await?;
+        if reaped == 0 {
+            continue;
+        }
+        total += reaped;
+        tracing::info!(
+            context_id = %context_id,
+            namespace = %namespace,
+            reaped,
+            through,
+            "app-state sweeper: reaped expired tombstones"
+        );
+        // Audited per namespace, not per record: what an operator needs to
+        // reconstruct later is that the namespace's feed is no longer complete
+        // from before `through`, which is one fact per namespace. The resource
+        // carries that boundary so an incident review can tell whether a given
+        // consumer's watermark was still valid.
+        if let Err(e) = vta_audit::record(
+            audit,
+            "app_state.tombstone.purge",
+            "system:sweeper",
+            Some(&format!("{namespace}@{through}")),
+            "success:retention-expired",
+            None,
+            Some(&context_id),
+        )
+        .await
+        {
+            tracing::warn!(
+                error = %e,
+                "app-state sweeper: purge succeeded but audit::record failed"
+            );
+        }
+    }
+    Ok(total)
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+/// One page of a list, plus what an incremental consumer needs to resume.
+#[derive(Debug)]
+pub struct ListPage {
+    pub records: Vec<AppStateRecord>,
+    pub truncated: bool,
+    pub cursor: Option<String>,
+    pub high_watermark: Option<u64>,
+    pub tombstone_retention_seconds: Option<u64>,
+}
+
+/// Enumerate records.
+///
+/// Snapshot mode (`since_version` absent) scans records by key. Change-feed
+/// mode scans the version index, so the page is already in version order and
+/// its cursor is a real storage key.
+#[allow(clippy::too_many_arguments)]
+pub async fn list(
+    ks: &KeyspaceHandle,
+    context_id: &str,
+    namespace: Option<&str>,
+    prefix: Option<&str>,
+    since_version: Option<u64>,
+    include_values: bool,
+    include_deleted: Option<bool>,
+    page_size: Option<usize>,
+    cursor: Option<&str>,
+    // Retention this VTA is configured for, reported to change-feed callers so
+    // they can schedule inside it. `None` when reaping is disabled — the feed
+    // then omits the member rather than advertising a window that will never
+    // expire anything, because a consumer reading a number would reasonably
+    // infer it must sync more often than that.
+    tombstone_retention_seconds: Option<u64>,
+) -> Result<ListPage, AppStateError> {
+    if let Some(ns) = namespace
+        && !namespace_is_valid(ns)
+    {
+        return Err(AppStateError::Validation(format!(
+            "namespace `{ns}` is not a valid partition name"
+        )));
+    }
+
+    // Mode conflicts, refused rather than reconciled.
+    if since_version.is_some() {
+        if namespace.is_none() {
+            return Err(AppStateError::FilterConflict(
+                FilterConflict::SinceVersionRequiresNamespace,
+            ));
+        }
+        if include_deleted == Some(false) {
+            return Err(AppStateError::FilterConflict(
+                FilterConflict::ChangeFeedCannotExcludeDeleted,
+            ));
+        }
+    }
+
+    let cursor_key = CursorKey::new(ks.clone()).get().await?;
+    // Bind the query shape into the cursor's MAC so a cursor cannot be replayed
+    // against a different filter set and silently skip records.
+    let binding = format!(
+        "app-state|{context_id}|{}|{}|{}",
+        namespace.unwrap_or(""),
+        prefix.unwrap_or(""),
+        since_version.map(|v| v.to_string()).unwrap_or_default()
+    );
+    let decoded = match cursor {
+        None => None,
+        Some(raw) => Some(
+            Cursor::decode_bound(raw, &cursor_key, binding.as_bytes())
+                .map_err(|_| AppStateError::from(AppError::InvalidCursor))?,
+        ),
+    };
+    let limit = page_size.unwrap_or(50).clamp(1, MAX_LIMIT);
+    let snapshot = Utc::now().timestamp().max(0) as u64;
+
+    // **Read the watermark BEFORE scanning**, and do not reorder these. No lock
+    // is held across a read, so a write can land in between, and the two orders
+    // differ in which way that failure goes:
+    //
+    // - Counter first (here): a write landing between the read and the scan may
+    //   appear in `records` while `highWatermark` still sits below it. The
+    //   consumer re-receives that change on its next pull — at-least-once,
+    //   which is safe because applying a versioned record twice reaches the
+    //   same state.
+    // - Scan first: the same write appears in neither `records` nor the
+    //   consumer's next query, because the watermark it stores already covers
+    //   it. Silent loss, and nothing downstream can detect it.
+    //
+    // Duplicate delivery is the acceptable failure here; a missed change is not.
+    let high_watermark = match namespace {
+        Some(ns) => Some(read_counter(ks, context_id, ns).await?),
+        None => None,
+    };
+
+    let pairs = match since_version {
+        // ── Change feed ────────────────────────────────────────────────
+        Some(since) => {
+            let ns = namespace.expect("checked above");
+            let reaped_through = read_reaped_through(ks, context_id, ns).await?;
+            if since < reaped_through {
+                return Err(AppStateError::WatermarkTooOld {
+                    oldest_retained_version: reaped_through + 1,
+                    high_watermark: high_watermark.unwrap_or(0),
+                });
+            }
+            // The index is ordered by zero-padded version, so a range scan from
+            // `since + 1` is the feed. Resolve each index entry to its record.
+            let mut out = Vec::new();
+            for (ik, key_bytes) in ks.prefix_iter_raw(index_prefix(context_id, ns)).await? {
+                let Some(version) = version_from_index_key(&ik) else {
+                    continue;
+                };
+                if version <= since {
+                    continue;
+                }
+                let Ok(key) = std::str::from_utf8(&key_bytes) else {
+                    continue;
+                };
+                if let Some(p) = prefix
+                    && !key.starts_with(p)
+                {
+                    continue;
+                }
+                let Some(rec) = read_record(ks, context_id, ns, key).await? else {
+                    continue;
+                };
+                out.push((ik, serde_json::to_vec(&rec).map_err(encode_err)?));
+            }
+            out
+        }
+        // ── Snapshot ───────────────────────────────────────────────────
+        None => {
+            let scan_prefix = match namespace {
+                Some(ns) => namespace_prefix(context_id, ns),
+                None => context_prefix(context_id),
+            };
+            let want_deleted = include_deleted.unwrap_or(false);
+            let mut out = Vec::new();
+            for (sk, bytes) in ks.prefix_iter_raw(scan_prefix).await? {
+                let rec: StoredRecord = serde_json::from_slice(&bytes).map_err(decode_err)?;
+                if rec.deleted && !want_deleted {
+                    continue;
+                }
+                if let Some(p) = prefix
+                    && !rec.key.starts_with(p)
+                {
+                    continue;
+                }
+                out.push((sk, bytes));
+            }
+            out
+        }
+    };
+
+    let page = paginate(pairs, decoded.as_ref(), limit, &cursor_key, snapshot, |v| {
+        let rec: StoredRecord = serde_json::from_slice(v).map_err(decode_err_app)?;
+        Ok(rec.to_wire(include_values))
+    })?;
+
+    // `paginate` signs its cursor unbound; re-sign under the query binding so a
+    // cursor cannot be carried to a different filter set.
+    let cursor = page
+        .next_cursor
+        .as_deref()
+        .map(|raw| rebind_cursor(raw, &cursor_key, binding.as_bytes(), snapshot))
+        .transpose()?;
+
+    Ok(ListPage {
+        truncated: cursor.is_some(),
+        records: page.items,
+        cursor,
+        high_watermark,
+        tombstone_retention_seconds: since_version
+            .is_some()
+            .then_some(tombstone_retention_seconds)
+            .flatten(),
+    })
+}
+
+/// Re-encode a cursor minted by [`paginate`] under the query binding.
+fn rebind_cursor(
+    raw: &str,
+    cursor_key: &[u8; 32],
+    binding: &[u8],
+    snapshot: u64,
+) -> Result<String, AppStateError> {
+    let decoded = Cursor::decode(raw, cursor_key)
+        .map_err(|e| AppStateError::Internal(format!("re-decode own cursor: {e}")))?;
+    Ok(Cursor::new(decoded.last_key, snapshot).encode_bound(cursor_key, binding))
+}
+
+/// Parse the version out of an `appv:<ctx>:<ns>:<version:020>` storage key.
+fn version_from_index_key(index_key: &[u8]) -> Option<u64> {
+    let text = std::str::from_utf8(index_key).ok()?;
+    text.rsplit_once(':')?.1.parse().ok()
+}
+
+fn encode_err(e: serde_json::Error) -> AppStateError {
+    AppStateError::Internal(format!("encode app-state record: {e}"))
+}
+
+fn decode_err(e: serde_json::Error) -> AppStateError {
+    AppStateError::Internal(format!("decode app-state record: {e}"))
+}
+
+fn decode_err_app(e: serde_json::Error) -> AppError {
+    AppError::Internal(format!("decode app-state record: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn open() -> (tempfile::TempDir, KeyspaceHandle, NamespaceLocks) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(crate::keyspaces::APP_STATE).unwrap();
+        (dir, ks, NamespaceLocks::default())
+    }
+
+    async fn put_value(
+        ks: &KeyspaceHandle,
+        locks: &NamespaceLocks,
+        ctx: &str,
+        ns: &str,
+        key: &str,
+        v: Value,
+    ) -> PutOutcome {
+        put(ks, locks, ctx, ns, key, Some(&v), None, None)
+            .await
+            .expect("put")
+    }
+
+    // ── The version counter ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn version_counter_is_shared_across_the_namespace() {
+        // The property the whole design rests on: a record's version is a value
+        // of the NAMESPACE counter, so writing a neighbour advances what the
+        // next write to this record will take.
+        let (_d, ks, locks) = open().await;
+        let a1 = put_value(&ks, &locks, "ctx", "openvtc", "a", json!(1)).await;
+        let b1 = put_value(&ks, &locks, "ctx", "openvtc", "b", json!(1)).await;
+        let a2 = put_value(&ks, &locks, "ctx", "openvtc", "a", json!(2)).await;
+        assert_eq!(a1.version, 1);
+        assert_eq!(b1.version, 2);
+        assert_eq!(
+            a2.version, 3,
+            "a's second write takes the namespace's next value, not its own"
+        );
+    }
+
+    #[tokio::test]
+    async fn namespaces_have_independent_counters() {
+        let (_d, ks, locks) = open().await;
+        let a = put_value(&ks, &locks, "ctx", "openvtc", "k", json!(1)).await;
+        let b = put_value(&ks, &locks, "ctx", "cnm", "k", json!(1)).await;
+        assert_eq!(a.version, 1);
+        assert_eq!(b.version, 1, "a second namespace starts its own counter");
+    }
+
+    // ── Preconditions ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn expected_version_zero_creates_only_once() {
+        // Lease acquisition: exactly one winner, and the loser is told who won.
+        let (_d, ks, locks) = open().await;
+        let first = put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "lease",
+            Some(&json!({"holder": "a"})),
+            None,
+            Some(0),
+        )
+        .await
+        .expect("first create-only wins");
+        assert!(first.created);
+
+        let second = put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "lease",
+            Some(&json!({"holder": "b"})),
+            None,
+            Some(0),
+        )
+        .await;
+        match second {
+            Err(AppStateError::VersionConflict {
+                reason,
+                current_version,
+                current_value,
+                ..
+            }) => {
+                assert_eq!(reason, ConflictReason::RecordExists);
+                assert_eq!(current_version, Some(first.version));
+                assert_eq!(
+                    current_value,
+                    Some(json!({"holder": "a"})),
+                    "the loser must be handed the winner's value, not just a rejection"
+                );
+            }
+            other => panic!("expected a create-only conflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn conflict_carries_the_current_version_and_value() {
+        let (_d, ks, locks) = open().await;
+        let first = put_value(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "k",
+            json!({"role": "member"}),
+        )
+        .await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!({"role": "owner"})).await;
+
+        let stale = put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "k",
+            Some(&json!({"role": "admin"})),
+            None,
+            Some(first.version),
+        )
+        .await;
+        match stale {
+            Err(AppStateError::VersionConflict {
+                reason,
+                current_value,
+                ..
+            }) => {
+                assert_eq!(reason, ConflictReason::VersionMismatch);
+                assert_eq!(
+                    current_value,
+                    Some(json!({"role": "owner"})),
+                    "returning the winner's view is what removes the re-read race"
+                );
+            }
+            other => panic!("expected a version conflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_only_succeeds_over_a_tombstone() {
+        // A tombstone is not a live record, and the replacement must take a
+        // version above the tombstone's so the change feed stays ordered.
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!(1)).await;
+        let del = delete(&ks, &locks, "ctx", "openvtc", "k", None)
+            .await
+            .unwrap();
+        let recreated = put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "k",
+            Some(&json!(2)),
+            None,
+            Some(0),
+        )
+        .await
+        .expect("create-only applies over a tombstone");
+        assert!(recreated.created);
+        assert!(recreated.version > del.version.unwrap());
+    }
+
+    // ── Merge patch ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn merge_patch_edits_one_member_and_null_removes() {
+        let (_d, ks, locks) = open().await;
+        put_value(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "k",
+            json!({"label": "Acme", "role": "member", "joinedAt": "2026-07-02"}),
+        )
+        .await;
+        put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "k",
+            None,
+            Some(&json!({"label": "Acme EMEA", "role": null})),
+            None,
+        )
+        .await
+        .expect("patch applies");
+
+        let rec = get(&ks, "ctx", "openvtc", "k", false).await.unwrap();
+        assert_eq!(
+            rec.value,
+            Some(json!({"label": "Acme EMEA", "joinedAt": "2026-07-02"})),
+            "RFC 7386: a null member is removed, untouched members survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_patch_on_absent_record_is_not_found() {
+        // Refused rather than treated as a create: RFC 7386 against a null
+        // target would silently invent a record from the patch minus its nulls.
+        let (_d, ks, locks) = open().await;
+        let err = put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "nope",
+            None,
+            Some(&json!({"a": 1})),
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppStateError::NotFound), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn merge_patch_replaces_wholesale_when_not_an_object() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!({"a": 1})).await;
+        put(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            "k",
+            None,
+            Some(&json!("scalar")),
+            None,
+        )
+        .await
+        .unwrap();
+        let rec = get(&ks, "ctx", "openvtc", "k", false).await.unwrap();
+        assert_eq!(rec.value, Some(json!("scalar")));
+    }
+
+    // ── Tombstones and convergence ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_leaves_a_tombstone_the_change_feed_reports() {
+        // The property the store exists for: a consumer syncing from a
+        // watermark must LEARN about the deletion, not merely stop seeing the
+        // record.
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        let watermark = put_value(&ks, &locks, "ctx", "openvtc", "stays", json!(1))
+            .await
+            .version;
+        delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+
+        let feed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(watermark),
+            true,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(feed.records.len(), 1);
+        assert_eq!(feed.records[0].key, "gone");
+        assert!(
+            feed.records[0].deleted,
+            "the deletion must reach the consumer as a tombstone"
+        );
+        assert!(feed.records[0].value.is_none());
+    }
+
+    #[tokio::test]
+    async fn snapshot_hides_tombstones_unless_asked() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "stays", json!(1)).await;
+        delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+
+        let plain = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(plain.records.len(), 1);
+        assert_eq!(plain.records[0].key, "stays");
+
+        let with_tombs = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            false,
+            Some(true),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(with_tombs.records.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn repeated_delete_takes_no_new_version() {
+        // A second delete must present NO change to a watching consumer.
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!(1)).await;
+        let first = delete(&ks, &locks, "ctx", "openvtc", "k", None)
+            .await
+            .unwrap();
+        assert!(first.existed);
+        let second = delete(&ks, &locks, "ctx", "openvtc", "k", None)
+            .await
+            .unwrap();
+        assert!(
+            !second.existed,
+            "a repeat delete is a success, not an error"
+        );
+        assert_eq!(
+            second.version, first.version,
+            "a repeat delete must not advance the counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_of_never_written_address_writes_no_tombstone() {
+        let (_d, ks, locks) = open().await;
+        let out = delete(&ks, &locks, "ctx", "openvtc", "never", None)
+            .await
+            .unwrap();
+        assert!(!out.existed);
+        assert!(
+            out.version.is_none(),
+            "nothing existed to converge, so no tombstone is written"
+        );
+        assert_eq!(read_counter(&ks, "ctx", "openvtc").await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_with_expected_version_zero_is_refused() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!(1)).await;
+        let err = delete(&ks, &locks, "ctx", "openvtc", "k", Some(0))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AppStateError::VersionConflict {
+                    reason: ConflictReason::CreateOnlyNotApplicable,
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    // ── The change feed ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn change_feed_is_in_version_order() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "zebra", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "alpha", json!(1)).await;
+        let feed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let keys: Vec<_> = feed.records.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec!["zebra", "alpha"],
+            "change feed orders by version, not by key"
+        );
+    }
+
+    #[tokio::test]
+    async fn high_watermark_is_the_counter_not_the_max_returned_version() {
+        // The distinction that makes prefix-filtered sync correct: a change
+        // outside the prefix still advances the counter, and a consumer that
+        // stored max(version) would replay it forever.
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "community/a", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "other/b", json!(1)).await;
+
+        let feed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            Some("community/"),
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(feed.records.len(), 1);
+        assert_eq!(feed.records[0].version, 1);
+        assert_eq!(
+            feed.high_watermark,
+            Some(2),
+            "the watermark is the namespace counter, past the filtered-out change"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_gap_in_the_version_sequence_does_not_break_the_change_feed() {
+        // Writes reserve their counter value BEFORE writing the record, so a
+        // crash in between consumes a version that no record ever occupies.
+        // That trade is only sound if a gap is harmless to a consumer — this
+        // pins that half. (The other half, that a REUSED version silently drops
+        // a change from the feed, is what the ordering exists to prevent and
+        // cannot be provoked without crash injection.)
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "before", json!(1)).await;
+
+        // Simulate the crash: burn counter values with no record behind them.
+        write_u64(&ks, counter_key("ctx", "openvtc"), 40)
+            .await
+            .unwrap();
+
+        let after = put_value(&ks, &locks, "ctx", "openvtc", "after", json!(1)).await;
+        assert_eq!(after.version, 41, "the next write resumes above the gap");
+
+        let feed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let keys: Vec<_> = feed.records.iter().map(|r| r.key.as_str()).collect();
+        assert_eq!(keys, vec!["before", "after"], "the gap is simply absent");
+        assert_eq!(feed.high_watermark, Some(41));
+
+        // And resuming from the watermark yields nothing further.
+        let resumed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(41),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(resumed.records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn change_feed_requires_a_namespace() {
+        let (_d, ks, _l) = open().await;
+        let err = list(
+            &ks,
+            "ctx",
+            None,
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AppStateError::FilterConflict(FilterConflict::SinceVersionRequiresNamespace)
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn change_feed_cannot_be_asked_to_exclude_tombstones() {
+        let (_d, ks, _l) = open().await;
+        let err = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            Some(false),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AppStateError::FilterConflict(FilterConflict::ChangeFeedCannotExcludeDeleted)
+            ),
+            "{err:?}"
+        );
+    }
+
+    /// A real sink over a scratch keyspace — the sweeper audits each reap, and
+    /// a sink that swallowed the call would leave that path untested.
+    fn test_audit_sink(ks: &KeyspaceHandle) -> vta_audit::SharedAuditSink {
+        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(ks.clone()))
+    }
+
+    #[tokio::test]
+    async fn sweeper_reaps_expired_tombstones_and_leaves_live_records() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "keep", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        let del = delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+
+        // retention 0 → everything already written is past its window.
+        let reaped = sweep_expired_tombstones(&ks, &locks, &test_audit_sink(&ks), 0)
+            .await
+            .unwrap();
+        assert_eq!(reaped, 1, "only the tombstone is reaped");
+
+        // The live record survives.
+        assert!(get(&ks, "ctx", "openvtc", "keep", false).await.is_ok());
+        // The tombstone is gone even to a caller asking for it.
+        assert!(
+            matches!(
+                get(&ks, "ctx", "openvtc", "gone", true).await,
+                Err(AppStateError::NotFound)
+            ),
+            "a reaped tombstone leaves nothing behind"
+        );
+
+        // And the watermark moved with it, so a consumer that was behind is
+        // told to rebuild rather than served a feed missing that deletion.
+        let err = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        match err {
+            AppStateError::WatermarkTooOld {
+                oldest_retained_version,
+                ..
+            } => assert_eq!(oldest_retained_version, del.version.unwrap() + 1),
+            other => panic!("expected WatermarkTooOld, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sweeper_leaves_tombstones_inside_the_retention_window() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+
+        let reaped = sweep_expired_tombstones(&ks, &locks, &test_audit_sink(&ks), 3600)
+            .await
+            .unwrap();
+        assert_eq!(reaped, 0, "a fresh tombstone is inside the window");
+
+        // Still reported to an incremental consumer, which is the point of
+        // keeping it.
+        let feed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(feed.records.iter().any(|r| r.deleted));
+    }
+
+    #[tokio::test]
+    async fn sweeper_stops_at_the_first_unexpired_tombstone() {
+        // The walk is a prefix, not a filter: reaping a later tombstone while
+        // leaving an earlier one would make `appt:` unstateable, because no
+        // single watermark would describe what survives. Here the *earlier*
+        // tombstone is expired and the later one is not, so nothing below the
+        // later one may be reaped past it.
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "old", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "new", json!(1)).await;
+        delete(&ks, &locks, "ctx", "openvtc", "old", None)
+            .await
+            .unwrap();
+        let newer = delete(&ks, &locks, "ctx", "openvtc", "new", None)
+            .await
+            .unwrap();
+
+        // Backdate only the first tombstone, leaving the second inside the
+        // window, then sweep with a window that expires the backdated one.
+        let mut rec = read_record(&ks, "ctx", "openvtc", "old")
+            .await
+            .unwrap()
+            .expect("tombstone");
+        rec.deleted_at = Some((Utc::now() - chrono::Duration::days(90)).to_rfc3339());
+        ks.insert(record_key("ctx", "openvtc", "old"), &rec)
+            .await
+            .unwrap();
+
+        let reaped =
+            sweep_expired_tombstones(&ks, &locks, &test_audit_sink(&ks), 30 * 24 * 60 * 60)
+                .await
+                .unwrap();
+        assert_eq!(reaped, 1, "only the backdated tombstone goes");
+
+        // The younger tombstone is untouched and still reachable.
+        let still = read_record(&ks, "ctx", "openvtc", "new").await.unwrap();
+        assert!(still.is_some_and(|r| r.deleted));
+        // And the watermark stops below it, so a consumer at that version can
+        // still resume.
+        assert!(
+            list(
+                &ks,
+                "ctx",
+                Some("openvtc"),
+                None,
+                Some(newer.version.unwrap() - 1),
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .is_ok(),
+            "a watermark above the reap point must still resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn change_feed_reports_the_configured_retention_and_omits_it_when_disabled() {
+        // A consumer schedules its syncs against this number, so it has to be
+        // the window the operator actually configured. When reaping is off the
+        // member is omitted rather than set to something: any number would tell
+        // the consumer it must sync more often than that, which is false.
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!(1)).await;
+
+        let configured = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            Some(604_800),
+        )
+        .await
+        .unwrap();
+        assert_eq!(configured.tombstone_retention_seconds, Some(604_800));
+
+        let disabled = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(disabled.tombstone_retention_seconds, None);
+
+        // A snapshot never reports it — the window only bears on resumption.
+        let snapshot = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            Some(604_800),
+        )
+        .await
+        .unwrap();
+        assert_eq!(snapshot.tombstone_retention_seconds, None);
+    }
+
+    #[tokio::test]
+    async fn sweeper_is_namespace_scoped() {
+        let (_d, ks, locks) = open().await;
+        for ns in ["openvtc", "cnm"] {
+            put_value(&ks, &locks, "ctx", ns, "gone", json!(1)).await;
+            delete(&ks, &locks, "ctx", ns, "gone", None).await.unwrap();
+        }
+        let reaped = sweep_expired_tombstones(&ks, &locks, &test_audit_sink(&ks), 0)
+            .await
+            .unwrap();
+        assert_eq!(reaped, 2, "each namespace is swept on its own counter");
+        for ns in ["openvtc", "cnm"] {
+            assert!(read_record(&ks, "ctx", ns, "gone").await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn reaped_tombstones_make_an_old_watermark_refuse_rather_than_lie() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        let del = delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+        put_value(&ks, &locks, "ctx", "openvtc", "later", json!(1)).await;
+
+        let reaped = reap_tombstones_through(&ks, &locks, "ctx", "openvtc", del.version.unwrap())
+            .await
+            .unwrap();
+        assert_eq!(reaped, 1);
+
+        // A watermark from before the reap point can no longer converge.
+        let err = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            Some(0),
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, AppStateError::WatermarkTooOld { .. }),
+            "{err:?}"
+        );
+
+        // One at or after it still resumes.
+        assert!(
+            list(
+                &ks,
+                "ctx",
+                Some("openvtc"),
+                None,
+                Some(del.version.unwrap()),
+                false,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    // ── Isolation and limits ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn namespaces_do_not_bleed_into_each_other() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!("openvtc")).await;
+        put_value(&ks, &locks, "ctx", "cnm", "k", json!("cnm")).await;
+        let listed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            true,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(listed.records.len(), 1);
+        assert_eq!(listed.records[0].value, Some(json!("openvtc")));
+    }
+
+    #[tokio::test]
+    async fn contexts_do_not_bleed_into_each_other() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx-a", "openvtc", "k", json!("a")).await;
+        put_value(&ks, &locks, "ctx-b", "openvtc", "k", json!("b")).await;
+        let a = list(&ks, "ctx-a", None, None, None, true, None, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(a.records.len(), 1);
+        assert_eq!(a.records[0].value, Some(json!("a")));
+    }
+
+    #[tokio::test]
+    async fn metadata_view_omits_the_value_but_keeps_its_size() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", json!({"a": "bb"})).await;
+        let listed = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(listed.records[0].value.is_none());
+        assert_eq!(listed.records[0].value_bytes, Some(10));
+    }
+
+    #[tokio::test]
+    async fn oversized_value_is_refused_loudly_with_both_numbers() {
+        let (_d, ks, locks) = open().await;
+        let big = json!("x".repeat(MAX_VALUE_BYTES as usize + 10));
+        let err = put(&ks, &locks, "ctx", "openvtc", "k", Some(&big), None, None)
+            .await
+            .unwrap_err();
+        match err {
+            AppStateError::ValueTooLarge {
+                limit_bytes,
+                actual_bytes,
+            } => {
+                assert_eq!(limit_bytes, MAX_VALUE_BYTES);
+                assert!(actual_bytes > limit_bytes);
+            }
+            other => panic!("expected ValueTooLarge, got {other:?}"),
+        }
+        // Nothing was written. The reserved version is simply unused — a gap,
+        // which `a_gap_in_the_version_sequence_does_not_break_the_change_feed`
+        // covers. Reserving before validating is what lets a batch pay one
+        // fsync instead of N, and a gap is the price.
+        assert!(
+            matches!(
+                get(&ks, "ctx", "openvtc", "k", false).await,
+                Err(AppStateError::NotFound)
+            ),
+            "a refused write must leave no record behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_null_value_is_stored_and_is_not_an_absent_value() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "k", Value::Null).await;
+        let rec = get(&ks, "ctx", "openvtc", "k", false).await.unwrap();
+        assert_eq!(rec.value, Some(Value::Null));
+        assert!(!rec.deleted);
+    }
+
+    #[tokio::test]
+    async fn invalid_namespace_is_refused() {
+        let (_d, ks, locks) = open().await;
+        for bad in ["OpenVTC", "open_vtc", "-lead", "trail-", "a--b", ""] {
+            let err = put(&ks, &locks, "ctx", bad, "k", Some(&json!(1)), None, None)
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, AppStateError::Validation(_)),
+                "namespace `{bad}` should be refused, got {err:?}"
+            );
+        }
+    }
+
+    // ── Batches ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn independent_batch_applies_the_writes_that_pass() {
+        let (_d, ks, locks) = open().await;
+        let a = put_value(&ks, &locks, "ctx", "openvtc", "a", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "b", json!(1)).await;
+
+        let writes = vec![
+            AppStateWrite {
+                key: "a".into(),
+                value: Some(json!(2)),
+                merge_patch: None,
+                expected_version: Some(a.version),
+            },
+            AppStateWrite {
+                key: "b".into(),
+                value: Some(json!(2)),
+                merge_patch: None,
+                // Stale on purpose.
+                expected_version: Some(999),
+            },
+            AppStateWrite {
+                key: "c".into(),
+                value: Some(json!(1)),
+                merge_patch: None,
+                expected_version: Some(0),
+            },
+        ];
+        let (results, high) = put_many(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            &writes,
+            PutManyMode::Independent,
+        )
+        .await
+        .expect("an independent batch with a conflict is still a success");
+
+        assert_eq!(results[0].outcome, WriteOutcome::Written);
+        assert_eq!(results[1].outcome, WriteOutcome::Conflict);
+        assert_eq!(
+            results[1].current_value,
+            Some(json!(1)),
+            "a conflicted write in a batch carries the same current-value payload as a single put"
+        );
+        assert_eq!(results[2].outcome, WriteOutcome::Written);
+        assert!(high >= results[2].version.unwrap());
+
+        // The conflicted record is untouched; the others landed.
+        assert_eq!(
+            get(&ks, "ctx", "openvtc", "b", false).await.unwrap().value,
+            Some(json!(1))
+        );
+    }
+
+    #[tokio::test]
+    async fn atomic_batch_writes_nothing_when_one_write_fails() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "index", json!({"ids": []})).await;
+        let counter_before = read_counter(&ks, "ctx", "openvtc").await.unwrap();
+
+        let writes = vec![
+            AppStateWrite {
+                key: "member".into(),
+                value: Some(json!({"label": "Cyprus"})),
+                merge_patch: None,
+                expected_version: Some(0),
+            },
+            AppStateWrite {
+                key: "index".into(),
+                value: Some(json!({"ids": ["cyprus"]})),
+                merge_patch: None,
+                expected_version: Some(999), // stale
+            },
+        ];
+        let err = put_many(&ks, &locks, "ctx", "openvtc", &writes, PutManyMode::Atomic)
+            .await
+            .unwrap_err();
+
+        match err {
+            AppStateError::AtomicBatchRejected(results) => {
+                assert_eq!(
+                    results[0].outcome,
+                    WriteOutcome::Skipped,
+                    "the write that was never attempted must say so, so a retry \
+                     does not rewrite its create-only precondition"
+                );
+                assert_eq!(results[1].outcome, WriteOutcome::Conflict);
+            }
+            other => panic!("expected AtomicBatchRejected, got {other:?}"),
+        }
+
+        assert!(
+            get(&ks, "ctx", "openvtc", "member", false).await.is_err(),
+            "an atomic batch that did not apply must have written nothing"
+        );
+        assert_eq!(
+            read_counter(&ks, "ctx", "openvtc").await.unwrap(),
+            counter_before,
+            "a rejected atomic batch must not consume counter values"
+        );
+    }
+
+    #[tokio::test]
+    async fn atomic_batch_applies_when_every_write_passes() {
+        let (_d, ks, locks) = open().await;
+        let idx = put_value(&ks, &locks, "ctx", "openvtc", "index", json!({"ids": []})).await;
+        let writes = vec![
+            AppStateWrite {
+                key: "member".into(),
+                value: Some(json!({"label": "Cyprus"})),
+                merge_patch: None,
+                expected_version: Some(0),
+            },
+            AppStateWrite {
+                key: "index".into(),
+                value: Some(json!({"ids": ["cyprus"]})),
+                merge_patch: None,
+                expected_version: Some(idx.version),
+            },
+        ];
+        let (results, _) = put_many(&ks, &locks, "ctx", "openvtc", &writes, PutManyMode::Atomic)
+            .await
+            .unwrap();
+        assert!(results.iter().all(|r| r.outcome == WriteOutcome::Written));
+    }
+
+    #[tokio::test]
+    async fn duplicate_keys_in_a_batch_are_refused() {
+        let (_d, ks, locks) = open().await;
+        let writes = vec![
+            AppStateWrite {
+                key: "k".into(),
+                value: Some(json!(1)),
+                merge_patch: None,
+                expected_version: None,
+            },
+            AppStateWrite {
+                key: "k".into(),
+                value: Some(json!(2)),
+                merge_patch: None,
+                expected_version: None,
+            },
+        ];
+        let err = put_many(
+            &ks,
+            &locks,
+            "ctx",
+            "openvtc",
+            &writes,
+            PutManyMode::Independent,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppStateError::DuplicateKey(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn get_many_accounts_for_every_requested_key() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "a", json!(1)).await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+
+        let keys = vec!["a".to_string(), "gone".to_string(), "never".to_string()];
+        let (records, missing, deferred) =
+            get_many(&ks, "ctx", "openvtc", &keys, false).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(missing, vec!["gone", "never"]);
+        assert!(deferred.is_empty());
+
+        let total = records.len() + missing.len() + deferred.len();
+        assert_eq!(
+            total,
+            keys.len(),
+            "every requested key must be accounted for"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_many_defers_past_the_budget_and_still_accounts_for_every_key() {
+        // The published spec makes the three-way accounting a MUST: every
+        // requested key lands in exactly one of records / missing / deferred.
+        // The deferral branch is the one that can silently drop a key, so it
+        // needs its own test rather than riding on the happy path.
+        let (_d, ks, locks) = open().await;
+        let big = json!("x".repeat(65_000)); // just under the per-record cap
+        let keys: Vec<String> = (0..10).map(|i| format!("k{i}")).collect();
+        for k in &keys {
+            put_value(&ks, &locks, "ctx", "openvtc", k, big.clone()).await;
+        }
+
+        let (records, missing, deferred) =
+            get_many(&ks, "ctx", "openvtc", &keys, false).await.unwrap();
+
+        assert!(
+            !deferred.is_empty(),
+            "10 x ~64KiB must exceed the {GET_MANY_RESPONSE_BUDGET_BYTES}-byte budget"
+        );
+        assert!(!records.is_empty(), "the batch must make forward progress");
+        assert_eq!(
+            records.len() + missing.len() + deferred.len(),
+            keys.len(),
+            "every requested key must be accounted for exactly once"
+        );
+
+        // Deferral is in request order, so re-requesting `deferred` progresses
+        // rather than returning an arbitrary subset again.
+        let returned: Vec<&str> = records.iter().map(|r| r.key.as_str()).collect();
+        let expected_prefix: Vec<&str> = keys
+            .iter()
+            .take(records.len())
+            .map(String::as_str)
+            .collect();
+        assert_eq!(returned, expected_prefix);
+
+        let (r2, _m2, d2) = get_many(&ks, "ctx", "openvtc", &deferred, false)
+            .await
+            .unwrap();
+        assert!(
+            !r2.is_empty(),
+            "the re-request must return the deferred keys"
+        );
+        assert!(d2.len() < deferred.len(), "and must shrink the remainder");
+    }
+
+    #[tokio::test]
+    async fn get_many_include_deleted_returns_the_tombstone() {
+        let (_d, ks, locks) = open().await;
+        put_value(&ks, &locks, "ctx", "openvtc", "gone", json!(1)).await;
+        delete(&ks, &locks, "ctx", "openvtc", "gone", None)
+            .await
+            .unwrap();
+        let keys = vec!["gone".to_string()];
+        let (records, missing, _) = get_many(&ks, "ctx", "openvtc", &keys, true).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert!(records[0].deleted);
+        assert!(missing.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_many_refuses_duplicates() {
+        let (_d, ks, _l) = open().await;
+        let keys = vec!["a".to_string(), "a".to_string()];
+        let err = get_many(&ks, "ctx", "openvtc", &keys, false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppStateError::DuplicateKey(_)), "{err:?}");
+    }
+
+    // ── Pagination ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn snapshot_paginates_and_the_cursor_resumes() {
+        let (_d, ks, locks) = open().await;
+        for i in 0..5 {
+            put_value(&ks, &locks, "ctx", "openvtc", &format!("k{i}"), json!(i)).await;
+        }
+        let first = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            false,
+            None,
+            Some(2),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.records.len(), 2);
+        assert!(first.truncated);
+
+        let second = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None,
+            None,
+            false,
+            None,
+            Some(2),
+            first.cursor.as_deref(),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.records.len(), 2);
+        assert_ne!(first.records[0].key, second.records[0].key);
+    }
+
+    #[tokio::test]
+    async fn a_cursor_cannot_be_replayed_against_a_different_filter() {
+        // Otherwise a consumer could resume a `community/` scan inside an
+        // `other/` one and silently skip everything in between.
+        let (_d, ks, locks) = open().await;
+        for i in 0..5 {
+            put_value(
+                &ks,
+                &locks,
+                "ctx",
+                "openvtc",
+                &format!("community/{i}"),
+                json!(i),
+            )
+            .await;
+        }
+        let page = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            Some("community/"),
+            None,
+            false,
+            None,
+            Some(2),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let err = list(
+            &ks,
+            "ctx",
+            Some("openvtc"),
+            None, // different filter set
+            None,
+            false,
+            None,
+            Some(2),
+            page.cursor.as_deref(),
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppStateError::Validation(_)), "{err:?}");
+    }
+}

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -1,4 +1,12 @@
 pub mod acl;
+/// Versioned, namespaced application state. Backs the
+/// `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` Trust Tasks.
+/// Records are keyed `app:<contextId>:<namespace>:<key>` in the
+/// [`APP_STATE`](crate::keyspaces::APP_STATE) keyspace, alongside an `appv:`
+/// version index and an `appc:` per-namespace write counter. Deliberately not
+/// [`memory`] — clearing an agent's memory must stay safe, which it cannot be
+/// if account state lives there.
+pub mod app_state;
 #[cfg(feature = "tee")]
 pub mod attestation;
 pub mod audit;

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -181,6 +181,19 @@ pub struct AppState {
     /// delete}/0.1`). Entries keyed `mem:<contextId>:<key>`; gated on context
     /// access. Durable user data.
     pub memory_ks: KeyspaceHandle,
+    /// Versioned, namespaced application state (`vta/app-state/*`) — the third
+    /// store, beside the vault and agent memory, for JSON an application owns
+    /// and the VTA does not interpret. Records keyed
+    /// `app:<contextId>:<namespace>:<key>`, with a `appv:` version index and an
+    /// `appc:` per-namespace write counter alongside; gated on context access.
+    /// Durable user data an account's recoverability depends on.
+    pub app_state_ks: KeyspaceHandle,
+    /// One lock per `(contextId, namespace)`, serialising the read-modify-write
+    /// sequences the application-state store needs and that the store layer
+    /// cannot make atomic on its own (it serialises individual operations, not
+    /// sequences of them). See `operations::app_state` for why this is sound
+    /// for a single-writer VTA and what it does not cover.
+    pub app_state_locks: crate::operations::app_state::NamespaceLocks,
     /// Rego policy modules for the Policy Decision Point (`policy/*`). One
     /// [`crate::policy::PolicyModule`] per id; the active set is every enabled
     /// row, priority-ordered. A migration-safe baseline is boot-installed if
@@ -383,6 +396,7 @@ pub async fn build_app_state(
     let issued_credentials_ks =
         apply_encryption(store.keyspace(crate::keyspaces::ISSUED_CREDENTIALS)?);
     let memory_ks = apply_encryption(store.keyspace(crate::keyspaces::MEMORY)?);
+    let app_state_ks = apply_encryption(store.keyspace(crate::keyspaces::APP_STATE)?);
     let policy_ks = apply_encryption(store.keyspace(crate::keyspaces::POLICY)?);
     let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
     #[cfg(feature = "webvh")]
@@ -461,6 +475,8 @@ pub async fn build_app_state(
         consent_approvers_ks,
         issued_credentials_ks,
         memory_ks,
+        app_state_ks,
+        app_state_locks: crate::operations::app_state::NamespaceLocks::default(),
         policy_ks,
         task_consent_ks,
         #[cfg(feature = "webvh")]
@@ -850,6 +866,8 @@ pub async fn run(
         let storage_idempotency_ks = idempotency_ks.clone();
         let storage_task_consent_ks = task_consent_ks.clone();
         let storage_vault_ks = vault_ks.clone();
+        let storage_app_state_ks = apply_encryption(store.keyspace(crate::keyspaces::APP_STATE)?);
+        let storage_app_state_retention_days = config.app_state.tombstone_retention_days;
         let storage_backup_bundles_ks = backup_bundles_ks.clone();
         let storage_backup_blob_dir = backup_blob_dir.clone();
         let storage_audit_config = config.audit.clone();
@@ -893,6 +911,14 @@ pub async fn run(
             )
             .await?
         };
+
+        // The tombstone sweeper takes a namespace's lock to reap it, so it must
+        // hold the *same* map the request path writes through. Cloned from the
+        // built `AppState` rather than injected through `AppStateParts`: adding
+        // a public field to that struct is a semver break (it is not
+        // `#[non_exhaustive]`, unlike `AppState`), and the storage thread is
+        // spawned after `build_app_state` anyway, so there is nothing to inject.
+        let storage_app_state_locks = app_state.app_state_locks.clone();
         // The wrapping-key cache reaper is a run()-path concern (build_app_state
         // just constructs the cache); arm it on the live state.
         #[cfg(any(feature = "rest", feature = "didcomm"))]
@@ -1158,6 +1184,9 @@ pub async fn run(
                     storage_idempotency_ks,
                     storage_task_consent_ks,
                     storage_vault_ks,
+                    storage_app_state_ks,
+                    storage_app_state_locks,
+                    storage_app_state_retention_days,
                     storage_backup_bundles_ks,
                     storage_backup_blob_dir,
                     storage_audit_config,
@@ -1275,6 +1304,9 @@ fn run_storage_thread(
     idempotency_ks: KeyspaceHandle,
     task_consent_ks: KeyspaceHandle,
     vault_ks: KeyspaceHandle,
+    app_state_ks: KeyspaceHandle,
+    app_state_locks: crate::operations::app_state::NamespaceLocks,
+    app_state_retention_days: u32,
     backup_bundles_ks_storage: KeyspaceHandle,
     backup_blob_dir_storage: std::path::PathBuf,
     audit_config: crate::config::AuditConfig,
@@ -1380,6 +1412,36 @@ fn run_storage_thread(
                             crate::vault_sweeper::sweep_expired(&vault_ks, &audit_sink).await
                         {
                             warn!("vault sweeper error: {e}");
+                        }
+                        // Reap application-state tombstones past their retention
+                        // window. This is what makes the window real rather than
+                        // advertised — and what makes `watermarkTooOld`
+                        // reachable, so a consumer resuming from a watermark
+                        // whose deletions have been discarded is told to rebuild
+                        // instead of being served a feed that silently omits
+                        // them.
+                        // `0` days disables reaping outright: tombstones are
+                        // kept forever, no watermark ever expires, and the
+                        // keyspace grows unbounded. That is a legitimate choice
+                        // for a deployment that would rather spend disk than
+                        // ever force a consumer to rebuild — so it is a skip
+                        // here rather than a zero cutoff, which would mean the
+                        // opposite and reap everything.
+                        if app_state_retention_days > 0 {
+                            match crate::operations::app_state::sweep_expired_tombstones(
+                                &app_state_ks,
+                                &app_state_locks,
+                                &audit_sink,
+                                u64::from(app_state_retention_days) * 24 * 60 * 60,
+                            )
+                            .await
+                            {
+                                Ok(n) if n > 0 => {
+                                    info!(reaped = n, "app-state tombstone sweeper")
+                                }
+                                Ok(_) => {}
+                                Err(e) => warn!("app-state tombstone sweeper error: {e}"),
+                            }
                         }
                     }
                     _ = shutdown_rx.changed() => {

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1069,6 +1069,7 @@ pub async fn apply_inputs(
         },
         audit: inputs.audit.clone(),
         vault: Default::default(),
+        app_state: Default::default(),
         policy: Default::default(),
         secrets: secrets_config,
         #[cfg(feature = "tee")]
@@ -1638,6 +1639,7 @@ fn scratch_config_for_seed_store(
         auth: AuthConfig::default(),
         audit: Default::default(),
         vault: Default::default(),
+        app_state: Default::default(),
         policy: Default::default(),
         secrets,
         #[cfg(feature = "tee")]

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -140,6 +140,7 @@ pub fn test_app_config(data_dir: PathBuf) -> AppConfig {
         auth: Default::default(),
         audit: Default::default(),
         vault: Default::default(),
+        app_state: Default::default(),
         policy: Default::default(),
         secrets: Default::default(),
         #[cfg(feature = "tee")]
@@ -1041,6 +1042,8 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
             .keyspace(crate::keyspaces::ISSUED_CREDENTIALS)
             .unwrap(),
         memory_ks: store.keyspace(crate::keyspaces::MEMORY).unwrap(),
+        app_state_ks: store.keyspace(crate::keyspaces::APP_STATE).unwrap(),
+        app_state_locks: crate::operations::app_state::NamespaceLocks::default(),
         policy_ks: policy_ks.clone(),
         task_consent_ks: store.keyspace(crate::keyspaces::TASK_CONSENT).unwrap(),
         service_state_ks,

--- a/vta-service/src/trust_tasks/app_state.rs
+++ b/vta-service/src/trust_tasks/app_state.rs
@@ -1,0 +1,891 @@
+//! Application-state trust-task slice
+//! (`spec/vta/app-state/{get,put,list,delete,get-many,put-many}/1.0`).
+//!
+//! Versioned, namespaced, per-context JSON an application owns and the VTA does
+//! not interpret — the third store, beside the vault and agent memory. Each
+//! handler is:
+//!
+//! - **Context-gated** — the caller must be permitted to act in
+//!   `payload.contextId`, enforced via [`AuthClaims::require_context`], the
+//!   same ACL gate the memory and context-scoped key tasks use. This is the
+//!   privilege boundary. A **namespace is not** one: an application with write
+//!   access to a context reaches every namespace in it, which is why both the
+//!   `put` and `delete` specifications say in their `## Authorization` sections
+//!   that mutually distrusting applications belong in separate contexts.
+//! - **Audited** — `app_state.{get,put,list,delete,get_many,put_many}` via
+//!   [`crate::audit::record`], with the context id. The value is deliberately
+//!   **not** recorded: copying application data into the audit store would give
+//!   it a second home under a different retention policy.
+//!
+//! ## Error taxonomy
+//!
+//! Failures map onto the published error codes: framework **standard** codes
+//! where the framework already has one (`permissionDenied`, `malformedRequest`,
+//! `internalError`), and **extended** `<task-slug>:<local>` codes for the
+//! task-specific failures, each carrying the `details` shape its spec declares.
+//!
+//! The one that matters most is `versionConflict`. Its details carry the VTA's
+//! **current version and current value**, not merely a rejection: a bare
+//! rejection obliges the caller to re-read, and between the rejection and the
+//! re-read the record can change again, so the pattern has no fixed point under
+//! contention. Returning the winner's view removes the race rather than
+//! narrowing it, and the specification makes that normative rather than a
+//! courtesy.
+
+use serde_json::{Value, json};
+use trust_tasks_rs::{ErrorPayload, StandardCode, TrustTask, TrustTaskCode};
+
+use vta_sdk::protocols::app_state::{
+    AppStateDeleteBody, AppStateDeleteResponse, AppStateGetBody, AppStateGetManyBody,
+    AppStateGetManyResponse, AppStateGetResponse, AppStateListBody, AppStateListResponse,
+    AppStatePutBody, AppStatePutManyBody, AppStatePutManyResponse, AppStatePutResponse,
+};
+
+use crate::audit;
+use crate::auth::AuthClaims;
+use crate::operations::app_state as ops;
+use crate::operations::app_state::AppStateError;
+use crate::server::AppState;
+
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, error_response, parse_payload, reject_with, success_response,
+};
+use trust_tasks_rs::RejectReason;
+
+/// The family namespace for codes shared by every task in the slice. A proper
+/// path prefix of each task slug, which SPEC §8.5 permits precisely so a
+/// family-wide meaning is defined once.
+const FAMILY_SLUG: &str = "vta/app-state";
+
+/// Task slug (`vta/app-state/<op>`) from the incoming document's type URI, so
+/// an extended code is namespaced to whichever task raised it. Falls back to
+/// the family slug if the shape is unexpected — the document arrived via
+/// dispatch, so a known URI is the norm.
+fn slug_from_doc(doc: &TrustTask<Value>) -> String {
+    doc.type_uri
+        .to_string()
+        .strip_prefix("https://trusttasks.org/spec/")
+        .and_then(|rest| rest.rsplit_once('/'))
+        .map(|(slug, _ver)| slug.to_string())
+        .unwrap_or_else(|| FAMILY_SLUG.to_string())
+}
+
+fn ext(slug: &str, local: &str) -> TrustTaskCode {
+    TrustTaskCode::new_extended(slug, local).expect("app-state extended code is grammar-valid")
+}
+
+/// Render an [`AppStateError`] as a spec-taxonomy trust-task error response.
+fn app_state_reject(
+    doc: &TrustTask<Value>,
+    err: AppStateError,
+) -> super::helpers::TrustTaskOutcome {
+    let slug = slug_from_doc(doc);
+    let message = err.to_string();
+
+    let (code, details): (TrustTaskCode, Option<Value>) = match err {
+        AppStateError::NotFound => (ext(&slug, "notFound"), None),
+
+        AppStateError::VersionConflict {
+            reason,
+            current_version,
+            current_value,
+            current_deleted,
+        } => {
+            let mut d = json!({ "reason": reason });
+            let obj = d.as_object_mut().expect("just built an object");
+            if let Some(v) = current_version {
+                obj.insert("currentVersion".into(), json!(v));
+            }
+            // Present-and-null is meaningful here: it is the stored value.
+            if let Some(v) = current_value {
+                obj.insert("currentValue".into(), v);
+            }
+            if let Some(v) = current_deleted {
+                obj.insert("currentDeleted".into(), json!(v));
+            }
+            (ext(&slug, "versionConflict"), Some(d))
+        }
+
+        AppStateError::ValueTooLarge {
+            limit_bytes,
+            actual_bytes,
+        } => (
+            ext(&slug, "valueTooLarge"),
+            Some(json!({ "limitBytes": limit_bytes, "actualBytes": actual_bytes })),
+        ),
+
+        AppStateError::FilterConflict(reason) => (
+            ext(&slug, "filterConflict"),
+            Some(json!({ "reason": reason })),
+        ),
+
+        AppStateError::WatermarkTooOld {
+            oldest_retained_version,
+            high_watermark,
+        } => (
+            ext(&slug, "watermarkTooOld"),
+            Some(json!({
+                "oldestRetainedVersion": oldest_retained_version,
+                "highWatermark": high_watermark,
+            })),
+        ),
+
+        AppStateError::DuplicateKey(keys) => {
+            (ext(&slug, "duplicateKey"), Some(json!({ "keys": keys })))
+        }
+
+        AppStateError::AtomicBatchRejected(results) => (
+            ext(&slug, "atomicBatchRejected"),
+            Some(json!({ "results": results })),
+        ),
+
+        AppStateError::BatchTooLarge {
+            limit_bytes,
+            actual_bytes,
+        } => (
+            ext(&slug, "batchTooLarge"),
+            Some(json!({ "limitBytes": limit_bytes, "actualBytes": actual_bytes })),
+        ),
+
+        // A caller fault the schema did not catch. `malformedRequest` rather
+        // than an extended code: the framework already names this failure, and
+        // an extended synonym would downgrade the status a client switches on.
+        AppStateError::Validation(_) => (StandardCode::MalformedRequest.into(), None),
+        AppStateError::Internal(_) => (StandardCode::InternalError.into(), None),
+    };
+
+    let mut payload = ErrorPayload::new(code).with_message(message);
+    if let Some(d) = details {
+        payload = payload.with_details(d);
+    }
+    error_response(doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload))
+}
+
+/// The context-access gate, shared by every handler.
+///
+/// Emits the framework's **standard** `permissionDenied` rather than an
+/// extended synonym: the framework already names this failure and maps it to
+/// the right status, and a task-namespaced duplicate would tell a client that
+/// switches on the standard code that something else went wrong.
+fn require_context(
+    doc: &TrustTask<Value>,
+    auth: &AuthClaims,
+    context_id: &str,
+) -> Result<(), super::helpers::TrustTaskOutcome> {
+    auth.require_context(context_id).map_err(|e| {
+        reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: e.to_string(),
+            },
+        )
+    })
+}
+
+/// Handler for `spec/vta/app-state/get/1.0`.
+pub(super) async fn handle_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: AppStateGetBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = require_context(&doc, auth, &req.context_id) {
+        return resp;
+    }
+    let record = match ops::get(
+        &state.app_state_ks,
+        &req.context_id,
+        &req.namespace,
+        &req.key,
+        req.include_deleted.unwrap_or(false),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return app_state_reject(&doc, e),
+    };
+    audit_app_state(state, "app_state.get", auth, &req.key, &req.context_id).await;
+    success_response(&doc, AppStateGetResponse { record })
+}
+
+/// Handler for `spec/vta/app-state/put/1.0`.
+pub(super) async fn handle_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: AppStatePutBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = require_context(&doc, auth, &req.context_id) {
+        return resp;
+    }
+    let outcome = match ops::put(
+        &state.app_state_ks,
+        &state.app_state_locks,
+        &req.context_id,
+        &req.namespace,
+        &req.key,
+        req.value.as_ref(),
+        req.merge_patch.as_ref(),
+        req.expected_version,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => return app_state_reject(&doc, e),
+    };
+    audit_app_state(state, "app_state.put", auth, &req.key, &req.context_id).await;
+    success_response(
+        &doc,
+        AppStatePutResponse {
+            context_id: req.context_id,
+            namespace: req.namespace,
+            key: req.key,
+            version: outcome.version,
+            created: outcome.created,
+            updated_at: outcome.updated_at,
+            value_bytes: Some(outcome.value_bytes),
+        },
+    )
+}
+
+/// Handler for `spec/vta/app-state/list/1.0`.
+pub(super) async fn handle_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: AppStateListBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = require_context(&doc, auth, &req.context_id) {
+        return resp;
+    }
+    // Report the window this VTA is actually configured for, not a constant.
+    // A consumer schedules against this number, so advertising 30 days while
+    // the operator reaps at 7 would strand exactly the clients that trusted it.
+    // `0` days means reaping is off, and the feed then says nothing rather than
+    // naming a window that never expires anything.
+    let retention_days = state.config.read().await.app_state.tombstone_retention_days;
+    let retention_seconds = (retention_days > 0).then(|| u64::from(retention_days) * 24 * 60 * 60);
+
+    let page = match ops::list(
+        &state.app_state_ks,
+        &req.context_id,
+        req.namespace.as_deref(),
+        req.prefix.as_deref(),
+        req.since_version,
+        req.include_values.unwrap_or(false),
+        req.include_deleted,
+        req.page_size,
+        req.cursor.as_deref(),
+        retention_seconds,
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => return app_state_reject(&doc, e),
+    };
+    audit_app_state(
+        state,
+        "app_state.list",
+        auth,
+        &req.context_id,
+        &req.context_id,
+    )
+    .await;
+    success_response(
+        &doc,
+        AppStateListResponse {
+            records: page.records,
+            truncated: page.truncated,
+            cursor: page.cursor,
+            high_watermark: page.high_watermark,
+            tombstone_retention_seconds: page.tombstone_retention_seconds,
+        },
+    )
+}
+
+/// Handler for `spec/vta/app-state/delete/1.0`.
+pub(super) async fn handle_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: AppStateDeleteBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = require_context(&doc, auth, &req.context_id) {
+        return resp;
+    }
+    let outcome = match ops::delete(
+        &state.app_state_ks,
+        &state.app_state_locks,
+        &req.context_id,
+        &req.namespace,
+        &req.key,
+        req.expected_version,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => return app_state_reject(&doc, e),
+    };
+    audit_app_state(state, "app_state.delete", auth, &req.key, &req.context_id).await;
+    success_response(
+        &doc,
+        AppStateDeleteResponse {
+            context_id: req.context_id,
+            namespace: req.namespace,
+            key: req.key,
+            existed: outcome.existed,
+            version: outcome.version,
+            deleted_at: outcome.deleted_at,
+        },
+    )
+}
+
+/// Handler for `spec/vta/app-state/get-many/1.0`.
+pub(super) async fn handle_get_many(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: AppStateGetManyBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = require_context(&doc, auth, &req.context_id) {
+        return resp;
+    }
+    let (records, missing, deferred) = match ops::get_many(
+        &state.app_state_ks,
+        &req.context_id,
+        &req.namespace,
+        &req.keys,
+        req.include_deleted.unwrap_or(false),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return app_state_reject(&doc, e),
+    };
+    audit_app_state(
+        state,
+        "app_state.get_many",
+        auth,
+        &req.context_id,
+        &req.context_id,
+    )
+    .await;
+    success_response(
+        &doc,
+        AppStateGetManyResponse {
+            records,
+            missing,
+            // Omitted rather than empty when nothing deferred, so a consumer
+            // reading `deferred` at all is reading a real partial batch.
+            deferred: (!deferred.is_empty()).then_some(deferred),
+        },
+    )
+}
+
+/// Handler for `spec/vta/app-state/put-many/1.0`.
+pub(super) async fn handle_put_many(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    let req: AppStatePutManyBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(resp) = require_context(&doc, auth, &req.context_id) {
+        return resp;
+    }
+    let mode = req.mode.unwrap_or_default();
+    let (results, high_watermark) = match ops::put_many(
+        &state.app_state_ks,
+        &state.app_state_locks,
+        &req.context_id,
+        &req.namespace,
+        &req.writes,
+        mode,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return app_state_reject(&doc, e),
+    };
+    audit_app_state(
+        state,
+        "app_state.put_many",
+        auth,
+        &req.context_id,
+        &req.context_id,
+    )
+    .await;
+    success_response(
+        &doc,
+        AppStatePutManyResponse {
+            mode,
+            results,
+            high_watermark: Some(high_watermark),
+        },
+    )
+}
+
+/// Record an `app_state.*` audit row (best-effort; a failed write never fails
+/// the operation). `resource` is the record key for single-record tasks and the
+/// context id for the enumerating ones — never the value, which would copy
+/// application data into a store with a different retention policy.
+async fn audit_app_state(
+    state: &AppState,
+    action: &str,
+    auth: &AuthClaims,
+    resource: &str,
+    context_id: &str,
+) {
+    if let Err(e) = audit::record(
+        &state.audit_sink,
+        action,
+        &auth.did,
+        Some(resource),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        Some(context_id),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, action = %action, "audit record failed for app-state task");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::Role;
+    use crate::test_support::build_signing_test_app_state;
+    use trust_tasks_rs::TypeUri;
+    use vta_sdk::trust_tasks::{
+        TASK_VTA_APP_STATE_DELETE_1_0, TASK_VTA_APP_STATE_GET_1_0, TASK_VTA_APP_STATE_GET_MANY_1_0,
+        TASK_VTA_APP_STATE_LIST_1_0, TASK_VTA_APP_STATE_PUT_1_0, TASK_VTA_APP_STATE_PUT_MANY_1_0,
+    };
+
+    /// An admin whose ACL grants exactly `ctx` — not a super-admin, whose empty
+    /// `allowed_contexts` would reach every context and defeat the isolation
+    /// test.
+    fn admin_of(ctx: &str) -> AuthClaims {
+        AuthClaims {
+            did: "did:key:zCtxAdmin".into(),
+            role: Role::Admin,
+            allowed_contexts: vec![ctx.to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        }
+    }
+
+    fn doc(uri: &str, payload: Value) -> TrustTask<Value> {
+        let uri: TypeUri = uri.parse().expect("app-state uri");
+        TrustTask::new(format!("urn:uuid:{}", uuid::Uuid::new_v4()), uri, payload)
+    }
+
+    fn payload_of(out: &super::super::helpers::TrustTaskOutcome) -> Value {
+        let doc: Value = serde_json::from_slice(&out.body).expect("response is JSON");
+        doc.get("payload").cloned().unwrap_or(Value::Null)
+    }
+
+    #[tokio::test]
+    async fn put_then_get_round_trips_with_a_version() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        let put = handle_put(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_1_0,
+                json!({
+                    "contextId": "acme", "namespace": "openvtc", "key": "community/a",
+                    "value": { "label": "Acme" }
+                }),
+            ),
+        )
+        .await;
+        assert!(
+            put.status.is_success(),
+            "{}",
+            String::from_utf8_lossy(&put.body)
+        );
+        let version = payload_of(&put)
+            .get("version")
+            .and_then(Value::as_u64)
+            .expect("version");
+        assert_eq!(version, 1);
+        assert_eq!(
+            payload_of(&put).get("created").and_then(Value::as_bool),
+            Some(true)
+        );
+
+        let got = handle_get(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_GET_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "community/a" }),
+            ),
+        )
+        .await;
+        assert!(got.status.is_success());
+        let rec = payload_of(&got).get("record").cloned().expect("record");
+        assert_eq!(rec.get("version").and_then(Value::as_u64), Some(1));
+        assert_eq!(rec.get("value"), Some(&json!({ "label": "Acme" })));
+    }
+
+    #[tokio::test]
+    async fn a_conflict_carries_the_current_value_on_the_wire() {
+        // The property that removes the re-read race has to survive the
+        // handler, not merely exist in the operations layer.
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        let base = json!({ "contextId": "acme", "namespace": "openvtc", "key": "k" });
+
+        let mut first = base.clone();
+        first["value"] = json!("original");
+        handle_put(&state, &auth, doc(TASK_VTA_APP_STATE_PUT_1_0, first)).await;
+
+        let mut second = base.clone();
+        second["value"] = json!("winner");
+        handle_put(&state, &auth, doc(TASK_VTA_APP_STATE_PUT_1_0, second)).await;
+
+        let mut stale = base.clone();
+        stale["value"] = json!("loser");
+        stale["expectedVersion"] = json!(1);
+        let out = handle_put(&state, &auth, doc(TASK_VTA_APP_STATE_PUT_1_0, stale)).await;
+
+        assert!(!out.status.is_success());
+        let p = payload_of(&out);
+        assert_eq!(
+            p.get("code").and_then(Value::as_str),
+            Some("vta/app-state/put:versionConflict")
+        );
+        let details = p.get("details").expect("conflict carries details");
+        assert_eq!(
+            details.get("currentVersion").and_then(Value::as_u64),
+            Some(2)
+        );
+        assert_eq!(
+            details.get("currentValue"),
+            Some(&json!("winner")),
+            "the loser must be handed the winner's value, not just a rejection"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_then_change_feed_reports_the_tombstone() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        handle_put(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "gone", "value": 1 }),
+            ),
+        )
+        .await;
+        let del = handle_delete(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_DELETE_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "gone" }),
+            ),
+        )
+        .await;
+        assert!(del.status.is_success());
+        assert_eq!(
+            payload_of(&del).get("existed").and_then(Value::as_bool),
+            Some(true)
+        );
+
+        let feed = handle_list(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_LIST_1_0,
+                json!({
+                    "contextId": "acme", "namespace": "openvtc", "sinceVersion": 1
+                }),
+            ),
+        )
+        .await;
+        assert!(feed.status.is_success());
+        let p = payload_of(&feed);
+        let records = p.get("records").and_then(Value::as_array).cloned().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].get("deleted").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert!(
+            p.get("highWatermark").and_then(Value::as_u64).is_some(),
+            "a change feed must tell the consumer what to store as its next watermark"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_change_feed_without_a_namespace_is_refused() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let out = handle_list(
+            &state,
+            &admin_of("acme"),
+            doc(
+                TASK_VTA_APP_STATE_LIST_1_0,
+                json!({ "contextId": "acme", "sinceVersion": 0 }),
+            ),
+        )
+        .await;
+        assert!(!out.status.is_success());
+        let p = payload_of(&out);
+        assert_eq!(
+            p.get("code").and_then(Value::as_str),
+            Some("vta/app-state/list:filterConflict")
+        );
+        assert_eq!(
+            p.get("details")
+                .and_then(|d| d.get("reason"))
+                .and_then(Value::as_str),
+            Some("sinceVersionRequiresNamespace")
+        );
+    }
+
+    #[tokio::test]
+    async fn an_independent_batch_reports_per_record_outcomes() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        handle_put(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "b", "value": 1 }),
+            ),
+        )
+        .await;
+
+        let out = handle_put_many(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_MANY_1_0,
+                json!({
+                    "contextId": "acme", "namespace": "openvtc",
+                    "writes": [
+                        { "key": "a", "value": 1, "expectedVersion": 0 },
+                        { "key": "b", "value": 2, "expectedVersion": 999 }
+                    ]
+                }),
+            ),
+        )
+        .await;
+        assert!(
+            out.status.is_success(),
+            "an independent batch with a conflict is still a success"
+        );
+        let results = payload_of(&out)
+            .get("results")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap();
+        assert_eq!(
+            results[0].get("outcome").and_then(Value::as_str),
+            Some("written")
+        );
+        assert_eq!(
+            results[1].get("outcome").and_then(Value::as_str),
+            Some("conflict")
+        );
+        assert_eq!(
+            payload_of(&out).get("mode").and_then(Value::as_str),
+            Some("independent"),
+            "the applied mode is echoed so a caller relying on the default sees what it got"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_rejected_atomic_batch_is_an_error_carrying_every_outcome() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        handle_put(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "index", "value": [] }),
+            ),
+        )
+        .await;
+
+        let out = handle_put_many(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_MANY_1_0,
+                json!({
+                    "contextId": "acme", "namespace": "openvtc", "mode": "atomic",
+                    "writes": [
+                        { "key": "member", "value": 1, "expectedVersion": 0 },
+                        { "key": "index", "value": ["x"], "expectedVersion": 999 }
+                    ]
+                }),
+            ),
+        )
+        .await;
+        assert!(!out.status.is_success());
+        let p = payload_of(&out);
+        assert_eq!(
+            p.get("code").and_then(Value::as_str),
+            Some("vta/app-state/put-many:atomicBatchRejected")
+        );
+        let results = p
+            .get("details")
+            .and_then(|d| d.get("results"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap();
+        assert_eq!(
+            results[0].get("outcome").and_then(Value::as_str),
+            Some("skipped"),
+            "the write never attempted must say so, so a retry does not rewrite \
+             its create-only precondition"
+        );
+
+        // And nothing landed.
+        let got = handle_get(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_GET_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "member" }),
+            ),
+        )
+        .await;
+        assert!(
+            !got.status.is_success(),
+            "an atomic batch that failed wrote nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_many_accounts_for_every_key() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+        handle_put(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_PUT_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "a", "value": 1 }),
+            ),
+        )
+        .await;
+        let out = handle_get_many(
+            &state,
+            &auth,
+            doc(
+                TASK_VTA_APP_STATE_GET_MANY_1_0,
+                json!({
+                    "contextId": "acme", "namespace": "openvtc",
+                    "keys": ["a", "missing"]
+                }),
+            ),
+        )
+        .await;
+        assert!(out.status.is_success());
+        let p = payload_of(&out);
+        assert_eq!(p.get("records").and_then(Value::as_array).unwrap().len(), 1);
+        assert_eq!(
+            p.get("missing").and_then(Value::as_array).unwrap(),
+            &vec![json!("missing")]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_caller_without_context_access_is_refused_and_writes_nothing() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let intruder = admin_of("other");
+        let out = handle_put(
+            &state,
+            &intruder,
+            doc(
+                TASK_VTA_APP_STATE_PUT_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc", "key": "k", "value": 1 }),
+            ),
+        )
+        .await;
+        assert!(!out.status.is_success());
+        assert!(
+            String::from_utf8_lossy(&out.body).contains("permissionDenied"),
+            "context refusal should carry the framework's standard permissionDenied"
+        );
+
+        let listed = handle_list(
+            &state,
+            &admin_of("acme"),
+            doc(
+                TASK_VTA_APP_STATE_LIST_1_0,
+                json!({ "contextId": "acme", "namespace": "openvtc" }),
+            ),
+        )
+        .await;
+        assert!(
+            payload_of(&listed)
+                .get("records")
+                .and_then(Value::as_array)
+                .unwrap()
+                .is_empty(),
+            "a refused put must not have written"
+        );
+    }
+
+    #[tokio::test]
+    async fn one_context_cannot_see_another_contexts_records() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        for ctx in ["ctx-a", "ctx-b"] {
+            handle_put(
+                &state,
+                &admin_of(ctx),
+                doc(
+                    TASK_VTA_APP_STATE_PUT_1_0,
+                    json!({ "contextId": ctx, "namespace": "openvtc", "key": "k", "value": ctx }),
+                ),
+            )
+            .await;
+        }
+        let a = handle_list(
+            &state,
+            &admin_of("ctx-a"),
+            doc(
+                TASK_VTA_APP_STATE_LIST_1_0,
+                json!({ "contextId": "ctx-a", "namespace": "openvtc", "includeValues": true }),
+            ),
+        )
+        .await;
+        let records = payload_of(&a)
+            .get("records")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].get("value"), Some(&json!("ctx-a")));
+    }
+}

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -109,6 +109,12 @@ use vta_sdk::protocols::acl_management::get::{GetAclBody, GetAclResultBody};
 use vta_sdk::protocols::acl_management::list::{ListAclBody, ListAclResultBody};
 use vta_sdk::protocols::acl_management::swap::{SwapKeyBody, SwapKeyResultBody};
 use vta_sdk::protocols::acl_management::update::UpdateAclBody;
+use vta_sdk::protocols::app_state::{
+    AppStateDeleteBody, AppStateDeleteResponse, AppStateGetBody, AppStateGetManyBody,
+    AppStateGetManyResponse, AppStateGetResponse, AppStateListBody, AppStateListResponse,
+    AppStatePutBody, AppStatePutManyBody, AppStatePutManyResponse, AppStatePutResponse,
+    AppStateRecord, AppStateWrite, PutManyMode, WriteOutcome, WriteResult,
+};
 use vta_sdk::protocols::audit_management::list::{
     AuditEnvelope, ListAuditLogsBody, ListAuditLogsResultBody,
 };
@@ -277,6 +283,41 @@ fn dt() -> chrono::DateTime<chrono::Utc> {
     chrono::DateTime::parse_from_rfc3339(TS)
         .expect("valid ts")
         .with_timezone(&chrono::Utc)
+}
+
+/// A live application-state record, with a version deliberately not 1: versions
+/// are values of the *namespace* counter, so a fixture using 1 would quietly
+/// model the per-record counter the design rejects.
+fn app_state_record() -> AppStateRecord {
+    AppStateRecord {
+        context_id: "ctx-a".into(),
+        namespace: "openvtc".into(),
+        key: "community/acme".into(),
+        version: 52,
+        deleted: false,
+        value: Some(serde_json::json!({ "label": "Acme", "role": "admin" })),
+        value_bytes: Some(95),
+        created_at: Some(TS.into()),
+        updated_at: TS.into(),
+        deleted_at: None,
+    }
+}
+
+/// A tombstone: `deleted` true, no value, and a `deletedAt`. Carried in the
+/// list witness because a change feed that cannot express one cannot converge.
+fn app_state_tombstone() -> AppStateRecord {
+    AppStateRecord {
+        context_id: "ctx-a".into(),
+        namespace: "openvtc".into(),
+        key: "community/defunct".into(),
+        version: 44,
+        deleted: true,
+        value: None,
+        value_bytes: None,
+        created_at: Some(TS.into()),
+        updated_at: TS.into(),
+        deleted_at: Some(TS.into()),
+    }
 }
 
 /// The Rego the declarative approvals fixture synthesizes to. Derived, not
@@ -1407,6 +1448,180 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 }),
                 to_v(MemoryDeleteResponse {
                     key: "greeting".into(),
+                })
+            ),
+        ),
+        // ─── vta/app-state ───────────────────────────────────────
+        //
+        // The fixtures deliberately exercise the members the design turns on
+        // rather than a minimal payload: a version on every record, a conflict
+        // carrying `currentValue`, a tombstone with `deleted: true` and no
+        // value, and a change-feed response with its `highWatermark`. A witness
+        // built from the smallest legal document would validate while testing
+        // none of it.
+        (
+            uris::TASK_VTA_APP_STATE_GET_1_0,
+            checked!(
+                specs::vta::app_state::get::v1_0::Payload,
+                specs::vta::app_state::get::v1_0::Response,
+                to_v(AppStateGetBody {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    key: "community/acme".into(),
+                    include_deleted: None,
+                    ext: None,
+                }),
+                to_v(AppStateGetResponse {
+                    record: app_state_record(),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VTA_APP_STATE_PUT_1_0,
+            checked!(
+                specs::vta::app_state::put::v1_0::Payload,
+                specs::vta::app_state::put::v1_0::Response,
+                to_v(AppStatePutBody {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    key: "community/acme".into(),
+                    value: Some(serde_json::json!({ "label": "Acme" })),
+                    merge_patch: None,
+                    expected_version: Some(47),
+                    ext: None,
+                }),
+                to_v(AppStatePutResponse {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    key: "community/acme".into(),
+                    version: 52,
+                    created: false,
+                    updated_at: TS.into(),
+                    value_bytes: Some(95),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VTA_APP_STATE_LIST_1_0,
+            checked!(
+                specs::vta::app_state::list::v1_0::Payload,
+                specs::vta::app_state::list::v1_0::Response,
+                to_v(AppStateListBody {
+                    context_id: "ctx-a".into(),
+                    namespace: Some("openvtc".into()),
+                    prefix: Some("community/".into()),
+                    since_version: Some(40),
+                    include_values: Some(true),
+                    include_deleted: None,
+                    page_size: Some(50),
+                    cursor: None,
+                    ext: None,
+                }),
+                to_v(AppStateListResponse {
+                    records: vec![app_state_record(), app_state_tombstone()],
+                    truncated: false,
+                    cursor: None,
+                    high_watermark: Some(52),
+                    tombstone_retention_seconds: Some(2_592_000),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VTA_APP_STATE_DELETE_1_0,
+            checked!(
+                specs::vta::app_state::delete::v1_0::Payload,
+                specs::vta::app_state::delete::v1_0::Response,
+                to_v(AppStateDeleteBody {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    key: "community/defunct".into(),
+                    expected_version: Some(44),
+                    ext: None,
+                }),
+                to_v(AppStateDeleteResponse {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    key: "community/defunct".into(),
+                    existed: true,
+                    version: Some(54),
+                    deleted_at: Some(TS.into()),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VTA_APP_STATE_GET_MANY_1_0,
+            checked!(
+                specs::vta::app_state::get_many::v1_0::Payload,
+                specs::vta::app_state::get_many::v1_0::Response,
+                to_v(AppStateGetManyBody {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    keys: vec!["community/acme".into(), "profile/labels".into()],
+                    include_deleted: None,
+                    ext: None,
+                }),
+                to_v(AppStateGetManyResponse {
+                    records: vec![app_state_record()],
+                    missing: vec!["profile/labels".into()],
+                    deferred: None,
+                })
+            ),
+        ),
+        (
+            uris::TASK_VTA_APP_STATE_PUT_MANY_1_0,
+            checked!(
+                specs::vta::app_state::put_many::v1_0::Payload,
+                specs::vta::app_state::put_many::v1_0::Response,
+                to_v(AppStatePutManyBody {
+                    context_id: "ctx-a".into(),
+                    namespace: "openvtc".into(),
+                    mode: Some(PutManyMode::Independent),
+                    writes: vec![
+                        AppStateWrite {
+                            key: "community/acme".into(),
+                            value: None,
+                            merge_patch: Some(serde_json::json!({ "role": "owner" })),
+                            expected_version: Some(52),
+                        },
+                        AppStateWrite {
+                            key: "profile/labels".into(),
+                            value: Some(serde_json::json!({ "colours": { "acme": "blue" } })),
+                            merge_patch: None,
+                            expected_version: Some(0),
+                        },
+                    ],
+                    ext: None,
+                }),
+                to_v(AppStatePutManyResponse {
+                    mode: PutManyMode::Independent,
+                    results: vec![
+                        WriteResult {
+                            key: "community/acme".into(),
+                            outcome: WriteOutcome::Written,
+                            version: Some(59),
+                            created: Some(false),
+                            current_version: None,
+                            current_value: None,
+                            current_deleted: None,
+                            limit_bytes: None,
+                            actual_bytes: None,
+                        },
+                        // A conflict carrying the winner's view — the member
+                        // that removes the re-read race, and the one most
+                        // likely to be dropped by a well-meaning refactor.
+                        WriteResult {
+                            key: "profile/labels".into(),
+                            outcome: WriteOutcome::Conflict,
+                            version: None,
+                            created: None,
+                            current_version: Some(57),
+                            current_value: Some(serde_json::json!({ "colours": {} })),
+                            current_deleted: None,
+                            limit_bytes: None,
+                            actual_bytes: None,
+                        },
+                    ],
+                    high_watermark: Some(60),
                 })
             ),
         ),

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -45,6 +45,7 @@ use crate::error::AppError;
 use crate::server::AppState;
 
 mod acl;
+mod app_state;
 mod audit;
 mod auth;
 mod backup;
@@ -1060,6 +1061,26 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_VTA_MEMORY_LIST_0_1 => memory::handle_list
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_VTA_MEMORY_DELETE_0_1 => memory::handle_delete
+        [ Mutating None false ],
+    // ─── Application-state slice (spec/vta/app-state/*) ──────────
+    // Versioned, namespaced per-context JSON the VTA stores but never
+    // interprets. Gated on context access (require_context), NOT operator
+    // step-up — same boundary as the memory slice. `discloses: Metadata` on
+    // the reads because the values are application data rather than secrets;
+    // secret material belongs in the vault, and the published specs say so
+    // normatively. `delete` is Destructive: the value goes immediately and,
+    // once the tombstone is reaped, nothing records the record ever existed.
+    vta_sdk::trust_tasks::TASK_VTA_APP_STATE_GET_1_0 => app_state::handle_get
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_VTA_APP_STATE_PUT_1_0 => app_state::handle_put
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_VTA_APP_STATE_LIST_1_0 => app_state::handle_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_VTA_APP_STATE_DELETE_1_0 => app_state::handle_delete
+        [ Destructive None false ],
+    vta_sdk::trust_tasks::TASK_VTA_APP_STATE_GET_MANY_1_0 => app_state::handle_get_many
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_VTA_APP_STATE_PUT_MANY_1_0 => app_state::handle_put_many
         [ Mutating None false ],
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_SHOW_0_1 => config::handle_get

--- a/vti-common/src/config.rs
+++ b/vti-common/src/config.rs
@@ -182,6 +182,44 @@ fn default_vault_grace_days() -> u32 {
     30
 }
 
+/// Application-state store tuning (`vta/app-state/*`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppStateConfig {
+    /// Days a deleted record's **tombstone** is retained before the sweeper
+    /// reaps it. Default 30, matching the vault's grace window.
+    ///
+    /// This is a correctness parameter, not just housekeeping. A tombstone is
+    /// how a consumer syncing from a watermark learns a record was deleted;
+    /// once it is reaped, any watermark from before that point can no longer
+    /// converge, and the VTA answers such a resume with
+    /// `vta/app-state/list:watermarkTooOld` so the consumer rebuilds instead of
+    /// being served a feed that silently omits deletions.
+    ///
+    /// So the window is really "how long may a consumer be offline and still
+    /// resume incrementally". Too short and a client that was away for a
+    /// weekend pays for a full rebuild; too long and deletions are not real.
+    /// Raising it is always safe; lowering it strands consumers whose
+    /// watermarks predate the new cutoff.
+    ///
+    /// `0` disables reaping entirely — tombstones are kept forever, no watermark
+    /// ever expires, and the keyspace grows without bound. Legitimate for a
+    /// deployment that would rather spend disk than ever force a rebuild.
+    #[serde(default = "default_tombstone_retention_days")]
+    pub tombstone_retention_days: u32,
+}
+
+fn default_tombstone_retention_days() -> u32 {
+    30
+}
+
+impl Default for AppStateConfig {
+    fn default() -> Self {
+        Self {
+            tombstone_retention_days: default_tombstone_retention_days(),
+        }
+    }
+}
+
 impl Default for VaultConfig {
     fn default() -> Self {
         Self {
@@ -360,6 +398,29 @@ mod mdoc_trust_anchor_config_tests {
         assert!(
             cfg.mdoc_iaca_trust_anchors.is_empty(),
             "absent means no mdoc issuer is trusted, not a permissive default"
+        );
+    }
+
+    /// An existing deployment's config has no `[app_state]` section at all, and
+    /// must keep loading with the documented default rather than failing or
+    /// silently disabling retention.
+    #[test]
+    fn app_state_config_defaults_when_absent() {
+        let cfg: AppStateConfig = toml::from_str("").expect("an absent section loads");
+        assert_eq!(cfg.tombstone_retention_days, 30);
+        assert_eq!(AppStateConfig::default().tombstone_retention_days, 30);
+    }
+
+    /// `0` is a meaningful value, not a missing one: it disables reaping. The
+    /// distinction matters because the sweeper treats a zero *cutoff* as "expire
+    /// everything", so this must survive as 0 rather than falling back to 30.
+    #[test]
+    fn app_state_retention_zero_survives_as_zero() {
+        let cfg: AppStateConfig =
+            toml::from_str("tombstone_retention_days = 0").expect("explicit zero loads");
+        assert_eq!(
+            cfg.tombstone_retention_days, 0,
+            "an explicit 0 must not be rewritten to the default"
         );
     }
 


### PR DESCRIPTION
Closes #1029. Implements `vta/app-state/{get,put,list,delete,get-many,put-many}/1.0` — a third store beside the secrets vault and the credential vault, for versioned, namespaced, per-context JSON an application owns and the VTA does not interpret.

The specs were published upstream first, as §7 of `docs/05-design-notes/appstate-store.md` requires: **trustoverip/dtgwg-trust-tasks-tf#252** (merged) and **#253** (merged, correcting the error taxonomy). This depends on the released `trust-tasks-rs` 0.11.2 — there is **no `[patch.crates-io]`** in this diff.

## Why a third store

Records are addressed `(contextId, namespace, key)`. The namespace scopes one application so several tools share a context without colliding, and is the seam a per-namespace grant would later use — which is why it is part of the address rather than a prefix convention on the key.

In 1.0 a namespace is **collision avoidance, not a trust boundary**. An application with write access to a context reaches every namespace in it; the `put` and `delete` specs say so normatively in their `## Authorization` sections, and say what to do instead — separate contexts. `delete` is where that coarseness has teeth, and its spec says that too.

Not built on `vta/memory/*`: `MemoryItem` has nothing to hang a precondition on and its `list` returns the whole context — but the settling argument is that *"forget everything"* must stay a safe thing to ask an agent, which it cannot be if account state lives there.

## Three properties, and what building it changed

**One counter per `(contextId, namespace)`, not per record.** This is the one place the design note was wrong, and it is corrected in the note. `sinceVersion` compares a watermark against record versions, and per-record counters are not comparable to each other, so no single number means "everything after this point" — a per-record counter would have forced a second sequence kept consistent by hand. One counter serves as both the CAS token and the watermark. The cost is that a record's version jumps by whatever its neighbours consumed, which the wire contract states.

**A failed precondition returns the current version *and value*.** A bare rejection obliges a re-read and the re-read races the next write; the pattern has no fixed point under contention. Normative, not a courtesy.

**Tombstones, and they are actually reaped.** Retention is `app_state.tombstone_retention_days` (default 30, following the vault's `grace_days` — a destructive window is an operator's choice). `list` advertises the *configured* value, since consumers schedule against it; advertising 30 while reaping at 7 would strand exactly the clients that trusted the number.

The sweeper reaps a **prefix, not a set**: each namespace walks tombstones in version order and stops at the first still inside the window. Reaping a later tombstone while leaving an earlier one makes the reap watermark unstateable — no single number would describe what survives, which is precisely what `watermarkTooOld` has to be able to say. `0` days disables reaping, enforced at the **call site** rather than as a zero cutoff, which would mean the opposite.

## Defects found while building, all fixed

- **`Option<Value>` silently ate stored JSON nulls.** serde deserializes a present `null` to `None`, so a legitimately-stored null read back as "absent" — the exact three-way conflation the spec warns against. Fixed with `deserialize_with` on every value-bearing member; regression-tested.
- **The version counter was never fsynced.** `vti_common::store::counter` makes this argument for BIP-32 counters and it transfers exactly: a counter surviving only in the journal buffer can be re-derived after a crash and reissue a used value. Here a reused version means two records collide on one `appv:` index key, so one disappears from the change feed and every incremental consumer misses that change permanently, silently. `reserve_versions` now fsyncs and re-seals the TEE integrity manifest, reserving a **block** so a batch pays one fsync rather than 64.
- **`deny_unknown_fields` rejected the `ext` slot the schemas declare**, which would have broken interop with a conforming producer. Explicit `ext` fields added; typo-rejection kept.
- **A crash-safety bug in the write ordering**, with a comment asserting the opposite of what the code did. Superseded by the reservation above, which makes reuse impossible rather than merely unlikely.

Reserving before validating means a rejected write burns a version, leaving a gap. Gaps are safe and there is a test pinning that the change feed tolerates them; the test that had encoded the old behaviour was changed rather than preserved.

## Concurrency: a lock, not a compare-and-swap

Considered and rejected, recorded in the note's §9. fjall takes an exclusive lock on the database directory, so two processes cannot open one store. The vsock protocol has six opcodes, none atomic — its `insert_if_absent`/`swap` are already non-atomic get+insert fallbacks that log a warning. A real CAS needs a seventh opcode in `deploy/nitro/enclave-proxy`, a separate non-workspace crate on the parent EC2 instance, plus version negotiation between two independently-deployed artifacts.

Added today it would be atomic exactly where the lock already suffices and warn-and-fallback exactly where it would need to be real — reading as multi-writer safety while providing none. If that topology becomes reachable, the fix is a store-layer CAS landing *with* the vsock opcode.

## Retry safety

Reads `ReadOnly`; `delete` `RetrySafe` (a second delete finds a tombstone and deliberately takes **no** new version, so a watcher sees nothing); `put`/`put-many` `Keyed` — a `put` without `expectedVersion` does not converge, and the class is per URI, not per payload. The reasoning sits beside the entries, because "optimising" `put` to `RetrySafe` on the strength of the precondition looks like a cleanup and is not.

## Scope notes

- Blobs deliberately out of scope in 1.0; a `blobRef` is additive later.
- Conformance witnesses cover all six URIs — nothing enters `UNSPECCED_DISPATCHED_URIS`.
- `trust-tasks-rs` pinned to a minimum patch so an older resolve fails as a stale dependency rather than as "you are serving unspecced URIs".
- The sweeper lives in `vta-service`, not `vta-sweepers`, for the reason the backup-bundle sweeper does: it is coupled to this module's key layout.

## Verification

- `cargo test --workspace` — 149 suites, 0 failed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- 49 app-state tests + 2 config tests (an existing TOML with no `[app_state]` section still loads; an explicit `0` is not rewritten to the default)