### PR TITLE
chore(deps)!: bring every dependency to latest, collapsing two duplicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,21 +93,21 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00fbf84b8b1e8b813fdbb4572e8f688ab47147d8ea21738d256d39afb0ab7810"
+checksum = "3c5420ba310200f4caaa72efb95898a1202636ee40c3baeb6555be88a7dde423"
 dependencies = [
  "aes 0.8.4",
  "affinidi-encoding",
  "base58",
- "base64 0.22.1",
+ "base64 0.23.1",
  "cbc 0.1.2",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac 0.12.1",
  "k256",
  "multibase",
- "p256 0.14.0",
+ "p256",
  "p384",
  "p521",
  "rand 0.10.2",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6baa61c2753f158f246e9b5b5c15d2ec989c8694e7ab550bee817db8d776ade8"
+checksum = "9fd06555e5116cca844aa1d2f2e42cc75bd3bbf85069b49e3f466c8ba245e317"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -159,7 +159,7 @@ dependencies = [
  "affinidi-encoding",
  "affinidi-messaging-didcomm",
  "affinidi-secrets-resolver",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "reqwest",
  "serde",
@@ -172,13 +172,13 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27925d715c71293b31bb3a7aefcd78bc6652a50ff69bfbf208fa440b246f9260"
+checksum = "2210e6f982142b24ba5bab49bbddcaff57cd6fac60e826c9291dbfbb9026db39"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
- "base64 0.22.1",
+ "base64 0.23.1",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.22"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cba98f055e65c584ac895a6e90dc2c7d7a3173c2eb4d1b94cf0731ec2365032"
+checksum = "c730f7f9e73817ff7d04eec292d9f63b2848424848d2e48f5befc30ff000fcc7"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -199,7 +199,7 @@ dependencies = [
  "affinidi-task-utils",
  "agent-names",
  "ahash",
- "base64 0.22.1",
+ "base64 0.23.1",
  "did-scid",
  "didwebvh-rs",
  "highway",
@@ -210,7 +210,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.20",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -271,7 +271,7 @@ dependencies = [
  "hex",
  "hkdf 0.12.4",
  "hmac 0.12.1",
- "p256 0.14.0",
+ "p256",
  "rand 0.9.5",
  "serde",
  "serde_bytes",
@@ -284,16 +284,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-meeting-place"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6565622f50c85268391a202f5783e9917fa7bb0f39270c5f141c1ed4e573b7bc"
+checksum = "891fc1a20c99c50e5b2296d9bfa2b540d32587690073ae588d3345e02d7a6063"
 dependencies = [
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-tdk-common",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "reqwest",
  "serde",
@@ -343,7 +343,7 @@ dependencies = [
  "base64ct",
  "ed25519-dalek",
  "k256",
- "p256 0.14.0",
+ "p256",
  "rand 0.10.2",
  "rand_core 0.6.4",
  "serde",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.20"
+version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d65f2641d3df7aef6687abd2bd0788d7f9e725755baed7460449303b42dee"
+checksum = "ec3721aba4b156eab55260ec148b6e8058d78a0efed2122a2954868b7fcaa5c0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -378,7 +378,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-server",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "clap",
  "dashmap",
@@ -406,11 +406,11 @@ dependencies = [
  "subtle",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "trust-tasks-rs",
@@ -420,16 +420,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.34"
+version = "0.15.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc68b34013290e9053caf792bd017495b95525906d75ffee02d06acac55bf36"
+checksum = "2972b94ba1f4236c8739ad5660ec1ffe92e0b6a55c64b4ed13ad0c029cf4f283"
 dependencies = [
  "aes-gcm",
  "ahash",
  "argon2",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.1",
  "futures-util",
  "hex",
  "hkdf 0.12.4",
@@ -448,7 +448,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
  "url",
  "uuid",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.9"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd4c9f5aaf47ef876e858a80e1a4c396a04f19a2301f2b0eb4ec4af45ea7180"
+checksum = "5996f7bd090aacad06be16e86a4a9774f45adab1e90c6cab2d15ef6b98bea5ea"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -488,19 +488,18 @@ dependencies = [
  "affinidi-tsp",
  "ahash",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "futures-util",
  "rand 0.10.2",
  "regex",
  "reqwest",
  "rustls 0.23.43",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha256",
  "thiserror 2.0.20",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
  "trust-tasks-rs",
  "uuid",
@@ -508,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.52"
+version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5727932e3b6db173056fd0faa74b21c3000db7b7e718aedf237611107e0f699f"
+checksum = "0a8fa256525937b8c95cedf5c508558da313663245326e034c49b23720553882"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -535,13 +534,13 @@ dependencies = [
 
 [[package]]
 name = "affinidi-oid4vc-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b1692196f12d54fd5ca6a0a1f56e011c647f26158b0a3835b21fb4b00e793d"
+checksum = "cc3c8a85c6353e7952bdbc1c5509591bbd54d9e9d62c57e2198079f95955923a"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "ed25519-dalek",
- "p256 0.14.0",
+ "p256",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -608,11 +607,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-sd-jwt"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e849a20a49af4762e7520adb38dbb98800642ccc98c3ce1a64669bc56a311ac8"
+checksum = "a4120ce8a4aa5f270dd6db899295655ab96c891554ad4f7a9f9b1898e42076a0"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "rand 0.9.5",
  "serde",
  "serde_json",
@@ -632,15 +631,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25be139fd212ca8fa338332ef5c0e6b4027d96d7eb6102cb37cd228c5a128ac6"
+checksum = "e7a913e027583fb282b22370a35562221240ee4923d1d1b0900b84512bf2961c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
  "ahash",
  "base58",
- "base64 0.22.1",
+ "base64 0.23.1",
  "getrandom 0.3.4",
  "multibase",
  "rand 0.10.2",
@@ -657,11 +656,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-status-list"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39bd34539e86ec366e77064ec583323b8701e1e0e44efce403975fb585e1f6b"
+checksum = "3c23e9d4a6487df835d5ae02d9aa2f78a928e58444d4801c1595fa12e932d752"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "rand 0.9.5",
  "serde",
@@ -712,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0bb62312c455dce9dc7e4899bacecea4b0abb2bb2b11f4b2269d85dcfbd630"
+checksum = "864083bc98bc29e8ed049b8c477532f9f435a6befe75edb9cac2d9cf257842ec"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
@@ -723,13 +722,12 @@ dependencies = [
  "affinidi-secrets-resolver",
  "ahash",
  "apple-native-keyring-store",
- "base64 0.22.1",
+ "base64 0.23.1",
  "dbus-secret-service-keyring-store",
  "keyring-core",
  "moka",
  "reqwest",
  "rustls 0.23.43",
- "rustls-pemfile",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -1155,9 +1153,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+checksum = "a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1176,7 +1174,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.5.0",
- "sha1",
+ "sha1 0.10.7",
  "time",
  "tokio",
  "tracing",
@@ -1273,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.121.0"
+version = "1.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de999e21177c7513e70b4adfdc6656f438651b2de2c6690e058073da3a3082c"
+checksum = "da6141acba66f1db7da2b3c7b2c0ee5178f86240cee676ed5c37cf74b9a2b37b"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1300,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.115.0"
+version = "1.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b034f8b7ceadb873d0bc607c30bb4b0be68e09a84c837174e7c2c6878ff882"
+checksum = "484ecdbea2a1cfc0e6eea69ce0a665f93913671b303ba40b2361b1d826544e7e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1326,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.112.0"
+version = "1.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230ecd791109507f2bec2f907ed605a5c9fbd37033736943f06c9a09ad3914d"
+checksum = "99fc1d4c623a7b49ad4379fa9872711d0c02b76d5d196c8fd02ea80292ccd094"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1352,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.106.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0efcee834347b6705eca3eea2defd88242f43774f55d7326604222e3c86260"
+checksum = "769b0abd0f89cfe11da5099986dd493e4f94347ce9a4562cb86ddecfe926b6c0"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1378,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.108.0"
+version = "1.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59312a04cf19c962cfee32b64ecfee758f8786407ff6da5b30fff46ae96f201"
+checksum = "f4075b8a2c8cda4076a3dcc43b9d6dabd93e0c2502abeaaf7e14aaead9bb312b"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1404,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.111.0"
+version = "1.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e7eb63457a9e547f9986fe3b273f77c43679da4d04f46359fa881c5e19b6e"
+checksum = "3f582002918346a3e685be1b391c7bea155073088cea6bd4e4b7663df9e43b6c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1493,7 +1491,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.17",
+ "h2 0.4.18",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -1691,10 +1689,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1894,6 +1892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +1982,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -2224,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2521,12 +2534,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -2618,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -2827,12 +2834,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.0",
- "darling_macro 0.24.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -2864,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -2899,11 +2906,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.0",
+ "darling_core 0.24.1",
  "quote",
  "syn 3.0.3",
 ]
@@ -3044,23 +3051,12 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "const-oid 0.10.2",
- "pem-rfc7468 1.0.0",
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -3243,7 +3239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -3255,7 +3250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
  "zeroize",
@@ -3334,30 +3329,16 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.8.1",
+ "der",
  "digest 0.11.3",
  "elliptic-curve 0.14.1",
- "rfc6979 0.6.0",
+ "rfc6979",
  "signature 3.0.0",
- "spki 0.8.0",
+ "spki",
  "zeroize",
 ]
 
@@ -3387,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -3403,10 +3384,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3425,10 +3403,10 @@ dependencies = [
  "group 0.14.0",
  "hkdf 0.13.0",
  "hybrid-array",
- "pem-rfc7468 1.0.0",
- "pkcs8 0.11.0",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.10.1",
- "sec1 0.8.1",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -4216,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4302,7 +4280,7 @@ dependencies = [
  "http 1.5.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -4536,7 +4514,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.17",
+ "h2 0.4.18",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -4712,9 +4690,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4829,7 +4807,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.24.0",
+ "darling 0.24.1",
  "indoc",
  "proc-macro2",
  "quote",
@@ -5071,9 +5049,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
  "cpubits",
- "ecdsa 0.17.0",
+ "ecdsa",
  "elliptic-curve 0.14.1",
- "primeorder 0.14.0",
+ "primeorder",
  "sha2 0.11.0",
  "signature 3.0.0",
  "wnaf",
@@ -5104,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -5173,7 +5151,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
 ]
 
@@ -5285,9 +5263,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loom"
@@ -5582,7 +5560,7 @@ dependencies = [
  "aws-nitro-enclaves-nsm-api 0.4.0",
  "coset 0.3.8",
  "hex",
- "rcgen",
+ "rcgen 0.13.2",
  "ring",
  "serde_bytes",
  "serde_cbor",
@@ -5932,26 +5910,14 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder 0.13.6",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p256"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
- "ecdsa 0.17.0",
+ "ecdsa",
  "elliptic-curve 0.14.1",
  "primefield",
- "primeorder 0.14.0",
+ "primeorder",
  "sha2 0.11.0",
 ]
 
@@ -5961,11 +5927,11 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
- "ecdsa 0.17.0",
+ "ecdsa",
  "elliptic-curve 0.14.1",
  "fiat-crypto",
  "primefield",
- "primeorder 0.14.0",
+ "primeorder",
  "sha2 0.11.0",
 ]
 
@@ -5976,10 +5942,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct 1.0.0",
- "ecdsa 0.17.0",
+ "ecdsa",
  "elliptic-curve 0.14.1",
  "primefield",
- "primeorder 0.14.0",
+ "primeorder",
  "sha2 0.11.0",
 ]
 
@@ -6091,15 +6057,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -6263,22 +6220,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.1",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -6416,15 +6363,6 @@ dependencies = [
  "rand_core 0.10.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -6781,8 +6719,21 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.16.0",
- "yasna",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.18.1",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -6964,7 +6915,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.17",
+ "h2 0.4.18",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -6988,23 +6939,13 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
 ]
 
 [[package]]
@@ -7033,14 +6974,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
- "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "futures",
+ "indexmap 2.14.0",
  "pastey 0.2.3",
  "pin-project-lite",
  "rmcp-macros",
@@ -7051,19 +6992,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7159,7 +7101,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.14",
+ "rustls-webpki 0.103.15",
  "subtle",
  "zeroize",
 ]
@@ -7174,15 +7116,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -7209,7 +7142,7 @@ dependencies = [
  "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.14",
+ "rustls-webpki 0.103.15",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7234,9 +7167,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7362,27 +7295,13 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct 1.0.0",
  "ctutils",
- "der 0.8.1",
+ "der",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -7673,6 +7592,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7803,7 +7733,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7933,22 +7862,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
-name = "spki"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.1",
+ "der",
 ]
 
 [[package]]
@@ -8386,12 +8305,24 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
  "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite",
+ "tungstenite 0.30.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -8481,7 +8412,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.17",
+ "h2 0.4.18",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -8545,6 +8476,24 @@ dependencies = [
  "tower-service",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8731,9 +8680,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e058f9779880478f5b3fa4d9e374e188a91d8b233f808b7afdb49631d007974"
+checksum = "ea804cc896dae689fa5cecc8edcfe449d8355424b86eb862fcf1f71a240dcb53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8763,9 +8712,25 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.5.0",
+ "httparse",
+ "log",
+ "rand 0.10.2",
  "rustls 0.23.43",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.20",
 ]
 
@@ -9139,9 +9104,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -9334,7 +9299,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "multibase",
- "p256 0.13.2",
+ "p256",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -9394,7 +9359,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
  "trust-tasks-rs",
@@ -9468,7 +9433,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tempfile",
  "thiserror 2.0.20",
  "time",
@@ -9535,7 +9500,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "multibase",
- "p256 0.13.2",
+ "p256",
  "rand 0.10.2",
  "regorus",
  "reqwest",
@@ -9551,7 +9516,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower_governor",
  "tracing",
  "tracing-subscriber",
@@ -9677,7 +9642,7 @@ dependencies = [
  "coset 0.3.8",
  "ed25519-dalek",
  "multibase",
- "rcgen",
+ "rcgen 0.14.9",
  "reqwest",
  "serde",
  "serde_json",
@@ -9787,7 +9752,7 @@ dependencies = [
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower_governor",
  "tracing",
  "tracing-subscriber",
@@ -9921,7 +9886,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "multibase",
- "p256 0.13.2",
+ "p256",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -10542,7 +10507,6 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry 0.7.1",
- "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -10613,6 +10577,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 
@@ -10724,9 +10698,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -59,7 +59,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 x25519-dalek = { workspace = true }
-p256 = "0.13"
+p256 = "0.14"
 
 [dev-dependencies]
 tempfile = "3"

--- a/vta-keys/src/derivation.rs
+++ b/vta-keys/src/derivation.rs
@@ -140,9 +140,16 @@ impl Bip32Extension for ExtendedSigningKey {
         let hmac_output = mac.finalize().into_bytes();
 
         // First 32 bytes → P-256 scalar. from_bytes() reduces mod n automatically.
-        let secret_key =
-            p256::SecretKey::from_bytes(p256::FieldBytes::from_slice(&hmac_output[..32]))
-                .map_err(|e| key_derivation_error(format!("P-256 key creation failed: {e}")))?;
+        //
+        // `TryFrom` rather than the deprecated `FieldBytes::from_slice`: the
+        // slice is a fixed 32-byte window of a SHA-512 HMAC so the conversion
+        // cannot fail, but the fallible form is the supported one in
+        // elliptic-curve 0.14 and it keeps the length check explicit rather
+        // than resting on a panic inside the old helper.
+        let field_bytes = p256::FieldBytes::try_from(&hmac_output[..32])
+            .map_err(|e| key_derivation_error(format!("P-256 scalar is not 32 bytes: {e}")))?;
+        let secret_key = p256::SecretKey::from_bytes(&field_bytes)
+            .map_err(|e| key_derivation_error(format!("P-256 key creation failed: {e}")))?;
 
         Ok(P256Secret { secret_key })
     }
@@ -201,7 +208,7 @@ pub async fn load_or_generate_seed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use p256::elliptic_curve::sec1::ToEncodedPoint;
+    use p256::elliptic_curve::sec1::ToSec1Point;
 
     fn get_bip32() -> ExtendedSigningKey {
         ExtendedSigningKey::from_seed(&[
@@ -534,7 +541,7 @@ mod tests {
 
         // Public key must be derivable
         let pk = p256_1.secret_key.public_key();
-        let encoded = pk.to_encoded_point(true);
+        let encoded = pk.to_sec1_point(true);
         assert_eq!(
             encoded.len(),
             33,

--- a/vta-keys/src/internal.rs
+++ b/vta-keys/src/internal.rs
@@ -33,7 +33,7 @@
 //! a non-TEE VTA tamper-proof.
 
 use aes_gcm::aead::{OsRng, rand_core::RngCore};
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use serde::{Deserialize, Serialize};
 use vta_sdk::keys::KeyType;
 use vti_common::error::AppError;
@@ -96,11 +96,7 @@ pub async fn generate(
             let secret = p256::SecretKey::from_slice(&raw)
                 .map_err(|e| AppError::Internal(format!("internal P-256 keygen: {e}")))?;
             raw.zeroize();
-            let public = secret
-                .public_key()
-                .to_encoded_point(true)
-                .as_bytes()
-                .to_vec();
+            let public = secret.public_key().to_sec1_point(true).as_bytes().to_vec();
             (secret.to_bytes().to_vec(), public)
         }
         // X25519 is a key-agreement key, not a signing key. Internal keys exist

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
 vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
-rmcp = { version = "1.7", features = ["server", "transport-io", "macros", "schemars"] }
+rmcp = { version = "3", features = ["server", "transport-io", "macros", "schemars"] }
 schemars = "1"
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/vta-mcp/src/server.rs
+++ b/vta-mcp/src/server.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -38,7 +38,7 @@ fn to_mcp(e: VtaError) -> McpError {
 fn ok_json(value: impl serde::Serialize) -> Result<CallToolResult, McpError> {
     let text = serde_json::to_string_pretty(&value)
         .map_err(|e| McpError::internal_error(format!("serialising result: {e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -85,7 +85,7 @@ vta-sdk = { path = "../vta-sdk", version = "0.28", features = [
 # adds the bundled Mozilla webpki roots — so `wss://` works on iOS. We don't use
 # the crate directly (`use tokio_tungstenite as _` in lib.rs); it's a feature
 # enabler matched to the version affinidi-messaging-sdk already pulls.
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 # Test-only Ed25519 signing for the did-signed verify round-trip (stands in for

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -372,7 +372,7 @@ nitro_attest = { version = "0.2", features = ["builder"] }
 # arms, behind `?`, sometimes built across statements. A visitor finds the real
 # method call; searching the body's tokens would also match a mention in a
 # comment or a doc link.
-syn = { version = "2", features = ["full", "parsing", "extra-traits", "visit"] }
+syn = { version = "3", features = ["full", "parsing", "extra-traits", "visit"] }
 
 [lints]
 workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -307,7 +307,7 @@ serde_json_canonicalizer = "0.3"
 subtle = { workspace = true }
 x25519-dalek = { workspace = true }
 multibase = { workspace = true }
-p256 = "0.13"
+p256 = "0.14"
 # WebAuthn — used by `operations::passkey_vms` to drive the
 # registration ceremony for passkey-as-verificationMethod enrolment.
 webauthn-rs = { workspace = true }

--- a/vta-service/src/keys_cli.rs
+++ b/vta-service/src/keys_cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::sec1::ToSec1Point;
 
 use crate::cli_store::CliStore;
 use crate::config::AppConfig;
@@ -144,7 +144,7 @@ pub async fn run_keys_secrets(
                     .derive_p256(&record.derivation_path)
                     .map_err(|e| format!("failed to derive key {key_id}: {e}"))?;
                 let verifying_key = p256_secret.secret_key.public_key();
-                let encoded = verifying_key.to_encoded_point(true);
+                let encoded = verifying_key.to_sec1_point(true);
                 (
                     multibase::encode(multibase::Base::Base58Btc, encoded.as_bytes()),
                     multibase::encode(

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -5,7 +5,7 @@ use affinidi_secrets_resolver::secrets::Secret;
 use base64::Engine;
 use chrono::Utc;
 use multibase::Base;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use tracing::info;
 use zeroize::Zeroize;
 
@@ -232,7 +232,7 @@ pub async fn create_key(
         KeyType::P256 => {
             let p256_secret = bip32.derive_p256(&derivation_path)?;
             let verifying_key = p256_secret.secret_key.public_key();
-            let encoded = verifying_key.to_encoded_point(true);
+            let encoded = verifying_key.to_sec1_point(true);
             multibase::encode(Base::Base58Btc, encoded.as_bytes())
         }
     };
@@ -362,7 +362,7 @@ pub async fn import_key(
             let secret_key = p256::SecretKey::from_slice(&private_bytes)
                 .map_err(|e| AppError::Validation(format!("invalid P-256 private key: {e}")))?;
             let public = secret_key.public_key();
-            let encoded = public.to_encoded_point(true);
+            let encoded = public.to_sec1_point(true);
             let pub_multibase = multibase::encode(Base::Base58Btc, encoded.as_bytes());
             (pub_multibase, "p256")
         }
@@ -794,7 +794,7 @@ pub async fn get_key_secret(
                 KeyType::P256 => {
                     let p256_secret = bip32.derive_p256(&record.derivation_path)?;
                     let public_key = p256_secret.secret_key.public_key();
-                    let encoded = public_key.to_encoded_point(true);
+                    let encoded = public_key.to_sec1_point(true);
                     let pub_mb = encode_public_multibase(&KeyType::P256, encoded.as_bytes());
                     let priv_mb = encode_private_multibase(
                         &KeyType::P256,
@@ -915,7 +915,7 @@ pub async fn get_key_secret_internal(
                 KeyType::P256 => {
                     let p256_secret = bip32.derive_p256(&record.derivation_path)?;
                     let public_key = p256_secret.secret_key.public_key();
-                    let encoded = public_key.to_encoded_point(true);
+                    let encoded = public_key.to_sec1_point(true);
                     let pub_mb = encode_public_multibase(&KeyType::P256, encoded.as_bytes());
                     let priv_mb = encode_private_multibase(
                         &KeyType::P256,

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -62,6 +62,6 @@ reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Generates the IACA -> Document Signer chains the mdoc trust tests need.
-rcgen = { version = "0.13", features = ["x509-parser"] }
+rcgen = { version = "0.14", features = ["x509-parser"] }
 tokio = { workspace = true }
 tempfile = "3"

--- a/vta-vault/src/mdoc_trust.rs
+++ b/vta-vault/src/mdoc_trust.rs
@@ -319,7 +319,7 @@ mod tests {
     use affinidi_mdoc::mso::ValidityInfo;
     use coset::CoseSign1;
     use rcgen::{
-        BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, KeyUsagePurpose,
         PKCS_ECDSA_P256_SHA256,
     };
 
@@ -338,7 +338,7 @@ mod tests {
         params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
         let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let cert = params.clone().self_signed(&key).unwrap();
+        let cert = params.self_signed(&key).unwrap();
         Iaca {
             pem: cert.pem(),
             params,
@@ -355,8 +355,8 @@ mod tests {
         params.is_ca = IsCa::NoCa;
         params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
         let ds_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let issuer = root.params.clone().self_signed(&root.key).unwrap();
-        let cert = params.signed_by(&ds_key, &issuer, &root.key).unwrap();
+        let issuer = Issuer::from_params(&root.params, &root.key);
+        let cert = params.signed_by(&ds_key, &issuer).unwrap();
         (cert.der().to_vec(), ds_key)
     }
 

--- a/vti-webauthn/Cargo.toml
+++ b/vti-webauthn/Cargo.toml
@@ -34,7 +34,7 @@ url = { workspace = true }
 
 # Crate-local deps.
 aws-lc-rs = { workspace = true }                # ECDSA verification — workspace crypto policy.
-p256 = "0.13"                                   # SEC1 point decompression ONLY (not signing or
+p256 = "0.14"                                   # SEC1 point decompression ONLY (not signing or
                                                 # verifying). aws-lc-rs requires uncompressed
                                                 # points; Multikey carries compressed. Already
                                                 # in the workspace dep tree transitively.

--- a/vti-webauthn/src/verify.rs
+++ b/vti-webauthn/src/verify.rs
@@ -115,17 +115,25 @@ fn verify_p256(resolved: &ResolvedVm, message: &[u8], signature: &[u8]) -> Resul
 /// Uses the `p256` crate for the curve-point math only — no
 /// cryptographic operations (signing, verifying) go through it.
 fn decompress_p256_point(compressed: &[u8]) -> Result<[u8; 65], VerifyError> {
-    use p256::EncodedPoint;
+    // elliptic-curve 0.14 renamed this family: `EncodedPoint` -> `Sec1Point`,
+    // `From/ToEncodedPoint` -> `From/ToSec1Point`. The old names survive as
+    // deprecated stubs; these are the current ones.
     use p256::PublicKey;
-    use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+    use p256::Sec1Point;
+    use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 
-    let ep = EncodedPoint::from_bytes(compressed)
+    // Kept as parse-then-validate rather than the one-shot
+    // `PublicKey::from_sec1_bytes`: that collapses both failures into a single
+    // error, and the two say different things to whoever reads the log — a
+    // malformed encoding is a broken client, a valid encoding off the curve is
+    // a point someone chose.
+    let ep = Sec1Point::from_bytes(compressed)
         .map_err(|_| VerifyError::MalformedAssertion("invalid SEC1 compressed P-256 point"))?;
-    let pk: Option<PublicKey> = Option::from(PublicKey::from_encoded_point(&ep));
+    let pk: Option<PublicKey> = Option::from(PublicKey::from_sec1_point(&ep));
     let pk = pk.ok_or(VerifyError::MalformedAssertion(
         "compressed P-256 point is not on the curve",
     ))?;
-    let uncompressed = pk.to_encoded_point(false);
+    let uncompressed = pk.to_sec1_point(false);
     let bytes = uncompressed.as_bytes();
     if bytes.len() != 65 {
         return Err(VerifyError::MalformedAssertion(


### PR DESCRIPTION
`cargo outdated` reported 13 direct dependencies behind and `cargo update` had 36 compatible updates waiting. Both are clear now — `cargo outdated` reports **"All dependencies are up to date"**.

Most of this is routine. Two items were not.

## p256 was duplicated in the build

Our crates declared `0.13` while `affinidi-crypto` — reached via `affinidi-data-integrity` and the TDK — already pulled `0.14`. The graph carried **two copies of a curve implementation**. The lock now holds a single `p256 0.14.0`.

The bump brings `elliptic-curve` 0.14 and `ecdsa` 0.17, which rename the SEC1 family: `EncodedPoint` → `Sec1Point`, `From/ToEncodedPoint` → `From/ToSec1Point`. Renamed across `vta-keys`, `vta-service`, `vti-webauthn`.

## tokio-tungstenite was load-bearing, not incidental

`vta-mobile-core` depends on it *solely as a feature enabler*: iOS has no native trust store, so `rustls-tls-webpki-roots` must be on graph-wide or the mediator WebSocket fails with `no native root CA certificates found`. Features unify per major version, so the declaration only works while it matches the version `affinidi-messaging-sdk` pulls — and the SDK moved to **0.30** in this refresh.

Updating everything *except* this one would have stranded the enabler and broken iOS `wss://` **silently**. The existing comment on that dependency is what flagged it.

## The rest

| Dep | Jump | Cost |
|---|---|---|
| `rcgen` | 0.13 → 0.14 (dev) | `signed_by` takes an `Issuer`; `self_signed` borrows. Test helper now uses `Issuer::from_params`, which states its intent more directly. |
| `syn` | 2 → 3 (dev) | No source change — syn 3 was already in the graph via `trust-tasks-rs`. |
| `rmcp` | 1.7 → 3.1.4 | Two majors, one rename: `Content` → `ContentBlock`. The `#[tool_router]`/`#[tool_handler]` surface the crate is built on is unchanged. |
| lockfile | 36 updates | Includes `trust-tasks-rs` 0.11.3 (the corrected `vta/app-state` error taxonomy from dtgwg-trust-tasks-tf#253) and the AWS SDK set. **`rustls-pemfile` drops out of the graph entirely** — one of the unmaintained crates `cargo audit` flags. |

## Two places the shortest path was worse

**`vti-webauthn` keeps parse-then-validate** rather than collapsing to the one-shot `PublicKey::from_sec1_bytes`. That call merges "malformed SEC1 encoding" and "valid encoding, point not on the curve" into a single error, and those say different things to whoever reads the log — a broken client versus a point somebody chose.

**BIP-32 P-256 derivation** replaces the now-deprecated `FieldBytes::from_slice` with `TryFrom` and a real error arm. The input is a fixed 32-byte window of a SHA-512 HMAC so it cannot fail, but the length check is explicit instead of resting on a panic inside a deprecated helper. Worth noting because CI runs clippy with `-D warnings`, so the deprecation would have failed the build.

## Unchanged

The four `cargo audit` advisories ignored in `deny.toml` — all transitive through the AWS SDK's hyper 0.14 / rustls 0.21 path. `cargo deny check advisories` passes.

Separately worth someone's attention (not touched here): `cargo deny` reports the `RUSTSEC-2026-0258` ignore as **stale** — "no crate matched advisory criteria". If the AWS SDK has moved off that path, the entry can be dropped, which is the condition `deny.toml` itself names.

## Verification

- `cargo test --workspace` — **149 suites, 0 failed** (same count as the pre-refresh baseline)
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo outdated --workspace --root-deps-only` — all up to date