### PR TITLE
fix(service)!: make AppStateParts non-exhaustive so adding a field stops being a break

### DIFF
--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -304,7 +304,30 @@ impl AuthState for AppState {
 /// literal) keeps `build_app_state` the single `AppState` constructor — one
 /// `WebvhAuthLocks::new()`, one config `RwLock`, one `init_auth` — so the REST
 /// and DIDComm transports can't diverge (P1.1).
+/// **`#[non_exhaustive]` for the same reason [`AppState`] carries it** (#1024),
+/// and the gap that motivated adding it here was found the same way: a field
+/// addition landing as a source-breaking change nobody had labelled.
+///
+/// Every field is public with no private field and no constructor guard, so
+/// before this attribute any crate could write an `AppStateParts { .. }`
+/// literal — including the functional-update form — which made *adding a
+/// field* break them under `constructible_struct_adds_field`. That is not
+/// hypothetical: #1049 added `audit_sink` and #1051 nearly added
+/// `app_state_locks` before the break was noticed and routed around.
+///
+/// Construction inside this crate is unaffected. Outside it, `Default` plus
+/// field assignment replaces the literal:
+///
+/// ```ignore
+/// let mut parts = AppStateParts::default();
+/// parts.audit_sink = Some(sink);
+/// ```
+///
+/// which is what this crate's own integration tests now do — they are separate
+/// crates, so they were the first thing the attribute broke, and they are a
+/// fair proxy for what a consumer has to change.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct AppStateParts {
     /// Telemetry sink shared with the mediator registry. `None` → fresh ring buffer.
     pub telemetry: Option<vti_common::telemetry::SharedTelemetrySink>,

--- a/vta-service/tests/audit_sink.rs
+++ b/vta-service/tests/audit_sink.rs
@@ -56,18 +56,15 @@ async fn state_with_sink(
     let seed_store: Arc<dyn vta_service::keys::seed_store::SeedStore> =
         Arc::new(TestSeedStore(vec![0xABu8; 32]));
     let (restart_tx, _rx) = tokio::sync::watch::channel(false);
-    let state = build_app_state(
-        config,
-        &store,
-        seed_store,
-        None,
-        None,
-        restart_tx,
-        AppStateParts {
-            audit_sink: sink,
-            ..AppStateParts::default()
-        },
-    )
+    let state = build_app_state(config, &store, seed_store, None, None, restart_tx, {
+        // `AppStateParts` is `#[non_exhaustive]`, so a struct literal is
+        // not available from another crate — and an integration test is
+        // one. Default-then-assign is the supported shape, and the same
+        // change any external consumer makes.
+        let mut parts = AppStateParts::default();
+        parts.audit_sink = sink;
+        parts
+    })
     .await
     .expect("build app state");
     (state, dir)


### PR DESCRIPTION
`AppState` got `#[non_exhaustive]` in #1024 for a defect `AppStateParts` has too — and the two are constructed side by side, a few lines apart.

## The break is recent and repeated

`AppStateParts` is all public fields, no private field, no constructor guard. Any crate could write an `AppStateParts { .. }` literal, including the functional-update form, which made **adding a field** a source break under `constructible_struct_adds_field`.

Not hypothetical:

- **#1049** added `audit_sink` — and it is in the current `semver checks` failure list on every PR against `main`.
- **#1051** nearly added `app_state_locks`, then routed around it by taking the value off the built `AppState` instead. That was the right call for a feature PR, but it treated the symptom.

This is the third time the same struct has come up in a fortnight, which is the argument for closing the class rather than dodging it again.

## What changes for a consumer

Construction inside this crate is unaffected. Outside it, `Default` plus field assignment replaces the literal:

```rust
let mut parts = AppStateParts::default();
parts.audit_sink = Some(sink);
```

One line per call site, and the last change this struct will require — which is the point.

`tests/audit_sink.rs` now does exactly that, and it is worth saying why that file had to change: **an integration test is a separate crate**, so it was the first thing the attribute broke. That makes it a fair proxy for what a downstream consumer faces, and a standing check that the supported shape keeps working.

## Marked breaking, deliberately

Unlike the p256 field-type change in #1055, `cargo-semver-checks` **does** report this class — `constructible_struct_adds_field` is exactly how #1049's addition surfaced. The `!` is still what makes release-plz move the compatibility field rather than ship it as a patch.

`vta-service` was already taking a major bump at the next release (#1049 and #1055 both landed breaks), so this rides along rather than forcing one of its own.

## Verification

- `cargo test -p vta-service` — 27 suites, 0 failed
- `cargo clippy -p vta-service --all-targets` — clean
- `cargo fmt --all --check` — clean

Rebased on `main` after #1056.