### PR TITLE
fix(vtc)!: tell a rejected applicant why, on the one path built to recover it

### DIFF
--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -35,6 +35,7 @@
 //!   body is the TrustTask document; the authcrypt sender authenticates
 //!   the holder (no separate signature needed).
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
@@ -186,7 +187,39 @@ pub struct JoinRequestStatusResponseBody {
     /// for a `deferred` request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub presentation_definition: Option<JsonValue>,
+    /// Stable refusal code — present only for a `rejected` request.
+    ///
+    /// A policy auto-deny carries the `code` the `join.rego` `deny` verdict
+    /// returned; an admin reject carries [`ADMIN_REJECT_CODE`], since there is
+    /// no policy verdict to source one from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    /// Human-readable elaboration of the refusal — present only for a
+    /// `rejected` request, and only when the decider supplied one (the policy's
+    /// optional `reason`, or the operator's words on an admin reject).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// When the decision was taken.
+    ///
+    /// Deliberately **not** the response document's `issuedAt`, which is when
+    /// *this* document was produced. For an admin reject the two diverge
+    /// arbitrarily — the applicant may poll days after the decision — so the
+    /// decision's own timestamp has to travel with it.
+    ///
+    /// `None` on a request decided before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decided_at: Option<DateTime<Utc>>,
 }
+
+/// The refusal code on the **admin** reject path.
+///
+/// A policy auto-deny sources its code from the `deny` verdict `join.rego`
+/// returned. An admin reject has no verdict behind it — the decision is the
+/// operator's — so the code is this constant and the operator's words ride in
+/// `reason`. Clients switch on it to tell "the community's rules refused you"
+/// (retry once you satisfy them) from "a human refused you" (retrying changes
+/// nothing).
+pub const ADMIN_REJECT_CODE: &str = "admin-reject";
 
 // ---------------------------------------------------------------------------
 // Verdict — the shared `request`/`present` response envelope
@@ -293,6 +326,27 @@ impl VerdictResponse {
                     role,
                     vmc,
                     role_vec,
+                    ..Default::default()
+                },
+            },
+        }
+    }
+
+    /// `deny` verdict — the policy refused a well-formed, verified request.
+    ///
+    /// `code` is the policy's stable refusal code; `reason` its optional
+    /// elaboration. A constructor rather than a hand-assembled struct because
+    /// this shape now has two producers — the correlated ceremony reply and the
+    /// status poll's projection — and hand-assembling it in both is how they
+    /// drift.
+    pub fn deny(request_id: Uuid, code: impl Into<String>, reason: Option<String>) -> Self {
+        Self {
+            request_id,
+            verdict: Verdict {
+                effect: VerdictEffect::Deny,
+                with: VerdictWith {
+                    code: Some(code.into()),
+                    reason,
                     ..Default::default()
                 },
             },

--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -114,6 +114,52 @@ pub struct JoinRequest {
     /// layer.
     #[serde(default)]
     pub extensions: JsonValue,
+    /// Why this request was refused, for the applicant.
+    ///
+    /// Written by **both** rejection paths — the policy auto-deny at
+    /// submit and the admin reject — so the status poll has one field
+    /// to read rather than two shapes to reconcile. [`JoinDecision`]
+    /// says why that matters.
+    ///
+    /// `None` for a request that has not been rejected, and for one
+    /// rejected before this field existed (see
+    /// [`JoinRequest::decision_for_applicant`], which reconstructs what
+    /// it can from [`Self::policy_decision`]).
+    #[serde(default)]
+    pub decision: Option<JoinDecision>,
+}
+
+/// The refusal, in the form the applicant is owed it.
+///
+/// Both rejection paths reach the applicant through the same poll, but
+/// the evidence used to sit in two different places and only one of them
+/// was projected: an auto-deny left a serialized `Deny` verdict on
+/// [`JoinRequest::policy_decision`], and an admin reject wrote the
+/// operator's reason to the audit log and nowhere else. So an
+/// admin-rejected applicant could never learn why — the correlated
+/// ceremony reply is a one-shot delivery, and the poll that exists to
+/// recover a missed one returned bare `{requestId, status}`.
+///
+/// One field written by both paths is the fix, and it is deliberately
+/// *not* `policy_decision`: an operator's decision is not a policy
+/// verdict, and recording it as one would make the audit trail lie about
+/// where the refusal came from.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct JoinDecision {
+    /// Stable refusal code. From the policy's `deny` verdict on the
+    /// auto-deny path; [`vta_sdk::protocols::join_requests::ADMIN_REJECT_CODE`]
+    /// on the admin path, where there is no verdict to source one from.
+    pub code: String,
+    /// Optional elaboration — the policy's `reason`, or the operator's
+    /// words. Absent when the decider supplied none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// When the decision was taken — not when the poll answering it was
+    /// produced. For an admin reject the two diverge by however long the
+    /// applicant takes to poll.
+    pub decided_at: DateTime<Utc>,
 }
 
 impl JoinRequest {
@@ -129,6 +175,36 @@ impl JoinRequest {
             policy_decision: None,
             registry_consent: false,
             extensions: JsonValue::Null,
+            decision: None,
+        }
+    }
+
+    /// The refusal to show the applicant, or `None` if there isn't one.
+    ///
+    /// Reads [`Self::decision`] when it is set. When it is not, a request
+    /// rejected before that field existed can still be answered from the
+    /// serialized `Deny` verdict on [`Self::policy_decision`] — every
+    /// auto-deny wrote one. The only thing lost to the fallback is the
+    /// decision timestamp, which was never recorded then; `decided_at`
+    /// stays `None` rather than being back-filled with a time that would
+    /// be a guess.
+    ///
+    /// An **admin** reject predating the field has nothing to recover:
+    /// its reason only ever reached the audit log. Those rows return
+    /// `None` and the poll answers exactly as it did before.
+    pub fn decision_for_applicant(
+        &self,
+    ) -> Option<(String, Option<String>, Option<DateTime<Utc>>)> {
+        if self.status != JoinStatus::Rejected {
+            return None;
+        }
+        if let Some(d) = &self.decision {
+            return Some((d.code.clone(), d.reason.clone(), Some(d.decided_at)));
+        }
+        let verdict = self.policy_decision.clone()?;
+        match serde_json::from_value::<crate::ceremony::Verdict>(verdict).ok()? {
+            crate::ceremony::Verdict::Deny(d) => Some((d.code, d.reason, None)),
+            _ => None,
         }
     }
 }
@@ -194,5 +270,94 @@ mod tests {
     fn join_transport_str_round_trip() {
         assert_eq!(JoinTransport::Rest.as_str(), "rest");
         assert_eq!(JoinTransport::DIDComm.as_str(), "didcomm");
+    }
+
+    // -- decision_for_applicant (#1052) ------------------------------------
+
+    fn rejected(decision: Option<JoinDecision>, policy: Option<JsonValue>) -> JoinRequest {
+        let mut r = JoinRequest::new("did:key:zApplicant", serde_json::json!({}));
+        r.status = JoinStatus::Rejected;
+        r.decision = decision;
+        r.policy_decision = policy;
+        r
+    }
+
+    #[test]
+    fn a_stored_decision_is_returned_verbatim() {
+        let at = Utc::now();
+        let r = rejected(
+            Some(JoinDecision {
+                code: "membership-required".into(),
+                reason: Some("members of the parent community only".into()),
+                decided_at: at,
+            }),
+            None,
+        );
+        assert_eq!(
+            r.decision_for_applicant(),
+            Some((
+                "membership-required".to_string(),
+                Some("members of the parent community only".to_string()),
+                Some(at),
+            ))
+        );
+    }
+
+    /// Rows rejected before `decision` existed are not lost: an auto-deny
+    /// always wrote the serialized `Deny` verdict, so the code and reason are
+    /// still recoverable. Only the timestamp is not — it was never recorded,
+    /// and reporting `None` is honest where back-filling `Utc::now()` would
+    /// tell the applicant they were rejected the instant they polled.
+    #[test]
+    fn a_legacy_auto_deny_row_falls_back_to_the_policy_verdict() {
+        let r = rejected(
+            None,
+            Some(serde_json::json!({
+                "effect": "deny",
+                "with": { "code": "closed", "reason": "not accepting applications" }
+            })),
+        );
+        assert_eq!(
+            r.decision_for_applicant(),
+            Some((
+                "closed".to_string(),
+                Some("not accepting applications".to_string()),
+                None,
+            )),
+            "the code and reason survive; the never-recorded timestamp does not"
+        );
+    }
+
+    /// A legacy **admin** reject has nothing to fall back to — its reason only
+    /// ever reached the audit log, which the applicant cannot read. The poll
+    /// answers exactly as it did before rather than inventing a code.
+    #[test]
+    fn a_legacy_admin_reject_row_yields_nothing() {
+        assert_eq!(rejected(None, None).decision_for_applicant(), None);
+    }
+
+    /// A `request_more` verdict on `policy_decision` is not a refusal, and a
+    /// `Deferred` row is not a rejected one. Neither may leak into the
+    /// refusal fields.
+    #[test]
+    fn only_a_rejected_request_has_a_refusal() {
+        let mut deferred = rejected(
+            None,
+            Some(serde_json::json!({
+                "effect": "request_more",
+                "with": { "needs": ["agreed:code-of-conduct"] }
+            })),
+        );
+        // Still Rejected, but the stored verdict is not a deny.
+        assert_eq!(deferred.decision_for_applicant(), None);
+
+        // And a Deferred row never reports a refusal, whatever it carries.
+        deferred.status = JoinStatus::Deferred;
+        deferred.decision = Some(JoinDecision {
+            code: "should-not-surface".into(),
+            reason: None,
+            decided_at: Utc::now(),
+        });
+        assert_eq!(deferred.decision_for_applicant(), None);
     }
 }

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -33,7 +33,9 @@ use crate::credentials::invitation_verify::{
 };
 use crate::credentials::vec::VEC_TYPE;
 use crate::credentials::vmc::VMC_TYPE;
-use crate::join::{JoinRequest, JoinStatus, JoinTransport, list_join_requests, store_join_request};
+use crate::join::{
+    JoinDecision, JoinRequest, JoinStatus, JoinTransport, list_join_requests, store_join_request,
+};
 use crate::policy::{PolicyPurpose, extract::extract_vp_claims, load_active_compiled};
 use crate::server::AppState;
 
@@ -389,9 +391,18 @@ pub async fn realize_join_verdict(
             request.status = JoinStatus::Deferred;
             request.policy_decision = Some(serde_json::to_value(&verdict)?);
         }
-        Verdict::Deny(_) => {
+        Verdict::Deny(d) => {
             request.status = JoinStatus::Rejected;
             request.policy_decision = Some(serde_json::to_value(&verdict)?);
+            // The same refusal, in the shape the applicant's poll reads.
+            // `policy_decision` keeps the whole verdict for the audit
+            // trail; this carries the part the applicant is owed, plus
+            // the decision time the verdict has no room for.
+            request.decision = Some(JoinDecision {
+                code: d.code.clone(),
+                reason: d.reason.clone(),
+                decided_at: chrono::Utc::now(),
+            });
         }
     }
     store_join_request(&state.join_requests_ks, &request).await?;

--- a/vtc-service/src/routes/join_requests/decide.rs
+++ b/vtc-service/src/routes/join_requests/decide.rs
@@ -17,11 +17,13 @@
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::{info, warn};
 use uuid::Uuid;
 
+use vta_sdk::protocols::join_requests::ADMIN_REJECT_CODE;
 use vti_common::audit::{AuditEvent, JoinRequestData, JoinRequestRejectedData};
 use vti_common::error::AppError;
 
@@ -29,7 +31,7 @@ use crate::acl::VtcRole;
 use crate::auth::AdminAuth;
 use crate::ceremony::execute;
 use crate::ceremony::{EffectOutcome, EffectPlan};
-use crate::join::{JoinRequest, JoinStatus, get_join_request, store_join_request};
+use crate::join::{JoinDecision, JoinRequest, JoinStatus, get_join_request, store_join_request};
 use crate::server::AppState;
 
 const REJECT_REASON_MAX: usize = 1024;
@@ -235,6 +237,18 @@ async fn reject_pending(
         .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
 
     req.status = JoinStatus::Rejected;
+    // Record the refusal on the row, not only in the audit log. The audit
+    // trail is admin-facing; the applicant reads their own request, and
+    // until this was written the operator's reason reached them through no
+    // path at all - reject_pending emits no message and the poll returned
+    // bare {requestId, status}. ADMIN_REJECT_CODE rather than a policy
+    // code because no policy decided this: a human did, and a client that
+    // can tell the two apart knows whether re-applying could ever help.
+    req.decision = Some(JoinDecision {
+        code: ADMIN_REJECT_CODE.to_string(),
+        reason: (!reason.is_empty()).then(|| reason.clone()),
+        decided_at: Utc::now(),
+    });
     store_join_request(&state.join_requests_ks, &req).await?;
 
     audit_writer

--- a/vtc-service/src/routes/join_requests/status.rs
+++ b/vtc-service/src/routes/join_requests/status.rs
@@ -128,10 +128,27 @@ pub async fn status_by_applicant(
 
 /// Shared projection of a stored request into the applicant-facing response.
 /// Only non-sensitive lifecycle fields (never the stored VP).
+///
+/// Two statuses carry more than the bare lifecycle word, for the same reason:
+/// a `Deferred` applicant cannot act without knowing what is still missing,
+/// and a `Rejected` one cannot act — or stop — without knowing why. Both are
+/// projected here rather than only in the correlated ceremony reply, because
+/// that reply is a **one-shot** delivery: an applicant whose socket was down,
+/// whose reply was lost, or who was rejected by an admin long after the fact
+/// never sees it. The poll is the recovery path, so it has to carry the
+/// evidence the reply would have.
 fn project_status(
     id: Uuid,
     req: crate::join::JoinRequest,
 ) -> Result<JoinRequestStatusResponseBody, AppError> {
+    // Why the request was refused — `None` unless it was. Reconciles the two
+    // rejection paths (policy auto-deny, admin reject) into one shape; see
+    // `JoinRequest::decision_for_applicant`.
+    let (code, reason, decided_at) = match req.decision_for_applicant() {
+        Some((code, reason, at)) => (Some(code), reason, at),
+        None => (None, None, None),
+    };
+
     // Project the outstanding requirements only for a Deferred request
     // (a `request_more` verdict the daemon persisted on `policy_decision`).
     let (needs, presentation_definition) = if req.status == JoinStatus::Deferred {
@@ -151,6 +168,9 @@ fn project_status(
         status: req.status.to_string(),
         needs,
         presentation_definition,
+        code,
+        reason,
+        decided_at,
     })
 }
 

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -269,17 +269,7 @@ fn outcome_to_verdict(outcome: &JoinSubmitOutcome) -> Result<VerdictResponse, Ap
                 },
             },
         },
-        Some(PolicyVerdict::Deny(d)) => VerdictResponse {
-            request_id,
-            verdict: jr::Verdict {
-                effect: jr::VerdictEffect::Deny,
-                with: jr::VerdictWith {
-                    code: Some(d.code),
-                    reason: d.reason,
-                    ..Default::default()
-                },
-            },
-        },
+        Some(PolicyVerdict::Deny(d)) => VerdictResponse::deny(request_id, d.code, d.reason),
         Some(PolicyVerdict::Refer(r)) => {
             VerdictResponse::refer(request_id, r.queue, r.reason.unwrap_or_default())
         }

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1754,6 +1754,208 @@ decision := {"effect": "request_more", "with": {
 }
 
 // ---------------------------------------------------------------------------
+// #1052 — a rejected applicant can recover *why* from the poll.
+//
+// The correlated ceremony reply is the only place a `{code, reason}` ever
+// reached an applicant, which makes it a one-shot delivery: a dropped socket,
+// a lost reply, or a rejection an admin took hours later, and the reason was
+// gone for good. The poll is the recovery path, and it was the one path that
+// stripped the evidence — projecting `needs`/`presentationDefinition` for
+// `deferred` and bare `{requestId, status}` for `rejected`.
+//
+// Both rejection paths are covered, because they source the refusal
+// differently: the policy auto-deny has a verdict to quote, the admin reject
+// has only the operator's words.
+// ---------------------------------------------------------------------------
+
+/// Auto-deny: the poll returns the policy's own `code` and `reason`.
+#[tokio::test]
+async fn status_rejected_by_policy_returns_the_deny_code_and_reason() {
+    let fix = build_fixture().await;
+    activate_join_policy(
+        &fix,
+        r#"
+package vtc.join
+import future.keywords.if
+default decision := {"effect": "deny", "with": {
+    "code": "membership-required",
+    "reason": "this community admits members of did:web:parent.example only"
+}}
+"#,
+    )
+    .await;
+
+    let (_d, doc) = submit_doc(&json!({})).await;
+    let (_, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(verdict_effect(&body), "deny", "expected a deny: {body}");
+    let id = Uuid::parse_str(body["payload"]["requestId"].as_str().unwrap()).unwrap();
+
+    let (status, body) = post_status(&fix, id).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let payload = tt_payload(&body);
+    assert_eq!(payload["status"], "rejected");
+    assert_eq!(
+        payload["code"], "membership-required",
+        "the policy's refusal code must survive the poll: {payload}"
+    );
+    assert_eq!(
+        payload["reason"], "this community admits members of did:web:parent.example only",
+        "the policy's reason must survive the poll: {payload}"
+    );
+    assert!(
+        payload["decidedAt"].is_string(),
+        "a rejection must say when it was decided: {payload}"
+    );
+}
+
+/// Admin reject: the poll returns the operator's reason under the stable
+/// `admin-reject` code.
+///
+/// This is the path that was unrecoverable end to end — `reject_pending`
+/// sends the applicant nothing, and the reason reached only the audit log,
+/// which no applicant can read. A code distinct from any policy code is what
+/// lets a client tell "the rules refused you, satisfy them and re-apply" from
+/// "a human refused you, re-applying changes nothing".
+#[tokio::test]
+async fn status_rejected_by_admin_returns_the_operator_reason() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+
+    let (status, _body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/decide"),
+        DECIDE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({
+            "decision": "rejected",
+            "reason": "duplicate application — see request 4b1f",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = post_status(&fix, id).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let payload = tt_payload(&body);
+    assert_eq!(payload["status"], "rejected");
+    assert_eq!(
+        payload["code"], "admin-reject",
+        "an operator decision carries the admin code, not a policy one: {payload}"
+    );
+    assert_eq!(
+        payload["reason"], "duplicate application — see request 4b1f",
+        "the operator's reason must reach the applicant: {payload}"
+    );
+    assert!(
+        payload["decidedAt"].is_string(),
+        "a rejection must say when it was decided: {payload}"
+    );
+}
+
+/// An admin who supplies no reason yields a code and no `reason` field —
+/// never an empty string, which a client would render as a blank explanation.
+#[tokio::test]
+async fn status_rejected_by_admin_without_a_reason_omits_the_field() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+
+    let (status, _body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/decide"),
+        DECIDE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "decision": "rejected" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (_, body) = post_status(&fix, id).await;
+    let payload = tt_payload(&body);
+    assert_eq!(payload["code"], "admin-reject");
+    assert!(
+        payload.get("reason").is_none(),
+        "no reason given means the field is absent, not empty: {payload}"
+    );
+}
+
+/// `decidedAt` is the decision's time, not the document's.
+///
+/// The two are indistinguishable on an auto-deny polled immediately, which is
+/// exactly why asserting "they differ" would prove nothing. What separates
+/// them is that one is fixed and the other is not: poll twice and `issuedAt`
+/// moves — a fresh `#response` document each time — while `decidedAt` names
+/// the same moment it always will. An admin reject makes the gap arbitrary;
+/// the applicant may poll days later.
+#[tokio::test]
+async fn status_decided_at_is_the_decision_time_not_the_document_time() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+
+    let (status, _body) = send(
+        &fix.router,
+        "POST",
+        &format!("/v1/join-requests/{id}/decide"),
+        DECIDE_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "decision": "rejected", "reason": "not this time" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (_, first) = post_status(&fix, id).await;
+    // A measurable gap, so `issuedAt` cannot coincidentally match.
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    let (_, second) = post_status(&fix, id).await;
+
+    let decided_first = tt_payload(&first)["decidedAt"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let decided_second = tt_payload(&second)["decidedAt"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        decided_first, decided_second,
+        "the decision happened once; every poll must report the same time"
+    );
+
+    let issued_first = first["issuedAt"].as_str().unwrap().to_string();
+    let issued_second = second["issuedAt"].as_str().unwrap().to_string();
+    assert_ne!(
+        issued_first, issued_second,
+        "each poll is a fresh document, so issuedAt must move — if it does \
+         not, this test cannot tell the two timestamps apart"
+    );
+    assert_ne!(
+        decided_second, issued_second,
+        "decidedAt must not be an alias for the document's issuedAt"
+    );
+}
+
+/// A non-rejected request carries no refusal fields at all — a `pending`
+/// applicant must not be shown a code or reason.
+#[tokio::test]
+async fn status_pending_carries_no_refusal_fields() {
+    let fix = build_fixture().await;
+    let id = submit_pending(&fix).await;
+
+    let (_, body) = post_status(&fix, id).await;
+    let payload = tt_payload(&body);
+    assert_eq!(payload["status"], "pending");
+    assert!(
+        payload.get("code").is_none() && payload.get("reason").is_none(),
+        "a pending request has not been refused: {payload}"
+    );
+    assert!(
+        payload.get("decidedAt").is_none(),
+        "a pending request has no decision to time: {payload}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // P0.5 — the unauthenticated join-request POSTs (submit / status)
 // must sit on the governed branch (5 rps + burst 10 per source IP), like the
 // recognise route — they run attacker-driven crypto + Rego eval and were


### PR DESCRIPTION
`project_status` projected `needs` / `presentationDefinition` for a `Deferred`
request and bare `{requestId, status}` for a `Rejected` one. The evidence
existed on both rejection paths and neither reached the applicant through the
poll.

The correlated `VerdictResponse` was the only place a `{code, reason}` ever
reached an applicant, which makes it a one-shot delivery: a socket that was
down, a reply that was lost, or a rejection an admin took hours later, and the
reason was unrecoverable. The poll is the natural recovery path and it was the
one path that deliberately stripped it. An admin-rejected applicant could never
learn why at all — `reject_pending` emits no message to them, and the
operator's reason reached only the audit log, which no applicant can read.

Both paths now write one `JoinRequest::decision` field — code, optional reason,
and the decision's own timestamp — and the poll projects it. One field rather
than two, because the whole failure was two producers of the same fact drifting
apart. It is deliberately *not* `policy_decision`: an operator's decision is not
a policy verdict, and recording it as one would make the audit trail lie about
where the refusal came from. The admin path carries `ADMIN_REJECT_CODE`
(`"admin-reject"`), which is what lets a client tell "the rules refused you,
satisfy them and re-apply" from "a human refused you, re-applying changes
nothing".

`decidedAt` is separate from the response document's `issuedAt` because
`issuedAt` is when *this document* was produced. For an admin reject the two
diverge by however long the applicant takes to poll. The test proves the
distinction the only way it can be proved: poll twice, and `issuedAt` moves
while `decidedAt` names the same moment.

Rows rejected before this existed are not abandoned. An auto-deny always wrote
the serialized `Deny` verdict, so `decision_for_applicant` falls back to it —
recovering the code and reason, and reporting `decided_at: None` rather than
back-filling a timestamp that would tell the applicant they were rejected the
instant they polled. A legacy *admin* reject has nothing to recover and answers
exactly as it did before.

Also adds `VerdictResponse::deny`, which the issue asked for alongside: the deny
shape had `allow` and `refer` constructors but was hand-assembled at its one
call site, and this change gave it a second producer.

BREAKING CHANGE: `JoinRequestStatusResponseBody` gains three public fields, so
an exhaustive struct literal outside `vta-sdk` no longer compiles
(`constructible_struct_adds_field`, confirmed by `cargo-semver-checks`). The
wire form is additive — every field is `skip_serializing_if`-able and defaulted
— so deserializing clients are unaffected. `#[non_exhaustive]` is not the fix
here: `vtc-service` produces this body from another crate and would lose the
ability to construct it at all.

Closes #1052

---

## Acceptance

| Criterion (#1052) | Where |
|---|---|
| Poll of an auto-denied request returns the policy code and reason | `status_rejected_by_policy_returns_the_deny_code_and_reason` |
| Poll of an admin-rejected request returns the operator's reason | `status_rejected_by_admin_returns_the_operator_reason` |
| A decision timestamp distinct from the document's `issuedAt` | `status_decided_at_is_the_decision_time_not_the_document_time` |
| Round-trip test per path | both of the above, plus 4 unit tests on `decision_for_applicant` |

## Testing

- `join_requests` integration suite: **50/50** (5 new)
- `join` unit tests: **27/27** (4 new, covering the legacy-row fallback)
- `trust_task_manifest` URI census: **7/7**
- `cargo check --workspace --all-targets`, `cargo clippy` on both touched
  crates, `cargo fmt` — clean
- Full `cargo test -p vtc-service` ran to completion through doc-tests with
  every target green. `cargo test` stops at the first failing target, so
  reaching doc-tests establishes all targets passed.

## Note on the published schema (deviation, R3.*)

The registry's `vtc/join-requests/status/0.1` **response** schema is
`additionalProperties: false` and does not carry these three fields, so this
adds fields the published schema does not describe.

Flagging it rather than hiding it, but it is not a new departure for this
family: `vtc-service` already does not conform to these response schemas.
`submit/0.1` publishes `{requestId, status: "pending"}` and the service returns
`VerdictResponse {requestId, verdict: {...}}` — no `status` field at all, plus
an unspecced `verdict`. The ceremony `verdict` envelope
(`docs/05-design-notes/vtc-ceremony-protocol.md` §3) superseded those response
schemas and was never taken upstream. Nothing in the repo validates VTC response
shapes — `trust_task_manifest.rs` checks bound *task URIs* only — so no test
catches this either way.

The task-URI side **is** enforced and is untouched here: no new URI is bound, and
`every_bound_canonical_task_exists_in_the_registry` passes.

If the preference is to take the response shape upstream first, say so and I
will author the schema change instead.

## Pre-merge checklist (`vti-stack-development-guide.md` §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — none added
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [~] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
      camelCase yes (`decidedAt`). Response body, so deny_unknown_fields n/a.
      Schema NOT registered — see the deviation section above.
      Consumers: additive on the wire, so nothing breaks; the OpenVTC client
      (OpenVTC/openvtc#240) still needs a change to surface the new fields.
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations from this guide flagged explicitly with rule numbers — R3.*, above
```

**R2.1 detail.** Auto-deny writes `status` and `decision` in the same
`store_join_request`, so they cannot diverge. Admin reject writes the row, then
the audit envelope — unchanged ordering, but strictly better than before: the
reason used to live *only* in the audit write, so a crash between the two lost
it entirely. It now lands on the row first.
