### PR TITLE
feat(vtc): tell a member when the community removes them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,7 +2952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4588,7 +4588,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6425,7 +6425,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6464,7 +6464,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -8680,9 +8680,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea804cc896dae689fa5cecc8edcfe449d8355424b86eb862fcf1f71a240dcb53"
+checksum = "fb3630f56ee78546c9ccfbb4aed780aa96fb469d758ddf832c9060d3e76c1b8b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-sdk/src/protocols/members.rs
+++ b/vta-sdk/src/protocols/members.rs
@@ -46,6 +46,74 @@ pub const MEMBER_VMC_TYPE: &str = "https://trusttasks.org/spec/vtc/members/vmc/0
 pub const MEMBER_VMC_RESPONSE_TYPE: &str =
     "https://trusttasks.org/spec/vtc/members/vmc/0.1#response";
 
+/// VTC → member: **unsolicited** notice that the community removed them.
+///
+/// Distinct from the self-remove receipt
+/// ([`crate::protocols::join_requests::MEMBER_SELF_REMOVE_RECEIPT_TYPE`]) in the
+/// way that matters: a receipt answers a request the member made and is
+/// correlated to it, so the member is already waiting for it. This answers
+/// nothing — the member did not ask, is not waiting, and may be offline. Sending
+/// one for a member-initiated departure would tell somebody who chose to leave
+/// that they were removed.
+pub const MEMBER_REMOVAL_NOTICE_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/members/removal-notice/0.1";
+
+/// Which removal happened, as carried in [`RemovalNoticeBody::code`].
+///
+/// Two variants rather than one `removed` flag because they differ in what
+/// recourse the member has: an administrator's removal ran the community's
+/// removal policy, a super-administrator's purge deliberately skipped it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RemovalCode {
+    /// Policy-governed removal by an administrator.
+    AdminRemoved,
+    /// Forceful super-administrator deletion; skips the removal policy.
+    Purged,
+}
+
+/// Body of a [`MEMBER_REMOVAL_NOTICE_TYPE`] notice.
+///
+/// Every field except `reason` is required, because a notice that omits any of
+/// them fails to answer one of the questions a removed member has: what
+/// happened, to what, when, and on whose say-so.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovalNoticeBody {
+    /// The removed member's DID.
+    ///
+    /// Carried in the payload as well as the DIDComm envelope so a notice that
+    /// is retained or forwarded — detached from the transport that delivered
+    /// it — still names its own subject.
+    pub did: String,
+    /// Which removal happened.
+    pub code: RemovalCode,
+    /// How the member's published record was handled: `purge`, `tombstone` or
+    /// `historical`. Always concrete — `policydefault` is resolved before the
+    /// notice is sent, since naming an unresolved default tells the member
+    /// nothing about their own record.
+    pub disposition: String,
+    /// The operator's stated reason, verbatim.
+    ///
+    /// `None` when the community gave none, which is a different claim from an
+    /// empty string and is kept distinguishable on the wire. This is the
+    /// member's only account of why.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// When the removal took effect (RFC 3339).
+    ///
+    /// Deliberately not the notice's own send time: the two diverge whenever
+    /// the member was offline, and it is the decision that has to be placeable
+    /// in time.
+    pub decided_at: String,
+    /// DID of the administrator who decided.
+    ///
+    /// Names the deciding authority rather than the community, because "the
+    /// community removed me" is unanswerable and "this administrator removed
+    /// me" is. The community itself is the DIDComm sender.
+    pub decided_by: String,
+}
+
 /// Body of a [`MEMBER_REQUEST_VMC_TYPE`] request. The member should issue a VMC
 /// whose `credentialSubject.id` is `community_did` and send it back as a
 /// [`MEMBER_VMC_TYPE`] message.

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -63,6 +63,7 @@ pub mod execute;
 pub mod facts;
 pub mod invariant;
 pub mod orchestrate;
+pub mod removal_notice;
 pub mod verdict;
 pub mod verify;
 

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -247,6 +247,23 @@ pub async fn purge_member(
     }
 
     info!(actor = actor_did, target = target_did, "member purged");
+
+    // Tell them. Best-effort and after the fact: the purge is done and durable,
+    // so a delivery problem must not fail the operator's request and leave them
+    // believing it did not happen. `purged` rather than `adminRemoved` because
+    // the two differ in what recourse the member has — this one deliberately
+    // skipped the removal policy.
+    crate::ceremony::removal_notice::send(
+        state,
+        target_did,
+        vta_sdk::protocols::members::RemovalCode::Purged,
+        "purge",
+        None,
+        &chrono::Utc::now().to_rfc3339(),
+        actor_did,
+    )
+    .await;
+
     Ok(LeaveOutcome {
         did: target_did.to_string(),
         disposition: "purge".into(),
@@ -381,6 +398,23 @@ pub async fn remove_inner(
         reason_present = !reason.is_empty(),
         "member removed"
     );
+
+    // Tell them — but only when somebody else decided. `remove_inner` serves
+    // both the admin path and the DIDComm self-leave, and a member who chose to
+    // leave already has their receipt; sending this as well would tell somebody
+    // who left that they were removed.
+    if actor_did != target_did {
+        crate::ceremony::removal_notice::send(
+            state,
+            target_did,
+            vta_sdk::protocols::members::RemovalCode::AdminRemoved,
+            disposition_str,
+            Some(reason.clone()),
+            &chrono::Utc::now().to_rfc3339(),
+            actor_did,
+        )
+        .await;
+    }
 
     Ok(LeaveOutcome {
         did: target_did.to_string(),

--- a/vtc-service/src/ceremony/removal_notice.rs
+++ b/vtc-service/src/ceremony/removal_notice.rs
@@ -1,0 +1,281 @@
+//! Telling a member the community removed them
+//! (`spec/vtc/members/removal-notice/0.1`).
+//!
+//! Removal is the most consequential thing a community does to a member and,
+//! before this, the one it delivered with the least information — none. The
+//! only signal a removed member could observe was a side effect: the revocation
+//! bit on their membership credential flipping. They inferred their own removal
+//! from a status list and learned nothing about why.
+//!
+//! ## Not a receipt
+//!
+//! [`MEMBER_SELF_REMOVE_RECEIPT_TYPE`](vta_sdk::protocols::join_requests::MEMBER_SELF_REMOVE_RECEIPT_TYPE)
+//! answers a request the member made, correlated to it by `thid`, and the member
+//! is already waiting. This answers nothing: the member did not ask, is not
+//! waiting, and may be offline. [`send`] is therefore an unsolicited push rather
+//! than a reply, and it must never fire for a self-leave — telling somebody who
+//! chose to leave that they were removed is worse than silence.
+//!
+//! ## Signed, because the recipient is not the audience
+//!
+//! Authcrypt already proves the sender to the *member*. But this is the one
+//! member-facing message whose value lies in showing it to somebody else — an
+//! appeal, a dispute, another community weighing a rejected applicant. An
+//! unsigned notice, forwarded, is an assertion anyone could have written. So the
+//! notice is a Trust Task document carrying a Data Integrity proof, packed in
+//! the trust-task envelope, exactly as [`crate::hooks::writer`] does.
+//!
+//! Note the envelope type is [`TRUST_TASK_ENVELOPE_TYPE`], **not** the task URI.
+//! Hand-building a DIDComm message with the task URI as its `type` is a mistake
+//! this workspace has made before, and a conformant peer rejects it silently.
+//!
+//! ## Delivery, and the member who cannot ask
+//!
+//! The act this reports is the act that ends the member's ability to ask about
+//! it. Removal hard-deletes their ACL row and
+//! [`resolve_auth_role`](crate::acl::resolve_auth_role) refuses any DID without
+//! one, so every authenticated route — including any poll that might have
+//! served the notice — is closed to them from the moment the removal lands. The
+//! push is the only channel, which is why it goes out under
+//! `REMOVAL_NOTICE_DELIVER_BY` rather than the ordinary one-day window.
+//!
+//! ## Best-effort, deliberately
+//!
+//! [`send`] never fails the removal. The removal has already happened and is
+//! durable; refusing to complete the operator's request because the notice
+//! could not be *queued* would leave the member removed and the operator
+//! believing they were not. A failure is logged loudly and audited instead.
+
+use tracing::{info, warn};
+
+use vta_sdk::protocols::members::{MEMBER_REMOVAL_NOTICE_TYPE, RemovalCode, RemovalNoticeBody};
+use vti_common::capability_client::{TRUST_TASK_ENVELOPE_TYPE, build_document};
+
+use crate::error::AppError;
+use crate::server::AppState;
+
+/// Send a removal notice, best-effort.
+///
+/// Call **after** the removal has taken effect — a notice for a removal that
+/// then fails is worse than none. `decided_at` is that moment, not the send
+/// time; the two diverge whenever the member is offline, and it is the decision
+/// a member or a third party needs to place in time.
+///
+/// `reason` is `None` when the operator gave none, which is a different claim
+/// from an empty string and stays distinguishable on the wire.
+///
+/// Errors are logged and swallowed: see the module docs for why the removal
+/// must not be undone by a delivery problem.
+pub async fn send(
+    state: &AppState,
+    target_did: &str,
+    code: RemovalCode,
+    disposition: &str,
+    reason: Option<String>,
+    decided_at: &str,
+    decided_by: &str,
+) {
+    if let Err(e) = try_send(
+        state,
+        target_did,
+        code,
+        disposition,
+        reason,
+        decided_at,
+        decided_by,
+    )
+    .await
+    {
+        // Loud, because the member is now removed and does not know it, and
+        // nothing downstream will retry beyond the delivery layer's own window.
+        warn!(
+            error = %e,
+            target = target_did,
+            ?code,
+            "removal notice could not be queued — the member was removed without being told"
+        );
+    }
+}
+
+/// The fallible body of [`send`], separated so the error can be logged in one
+/// place and tested directly.
+async fn try_send(
+    state: &AppState,
+    target_did: &str,
+    code: RemovalCode,
+    disposition: &str,
+    reason: Option<String>,
+    decided_at: &str,
+    decided_by: &str,
+) -> Result<(), AppError> {
+    let vtc_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
+
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not configured".into()))?;
+
+    let body = RemovalNoticeBody {
+        did: target_did.to_string(),
+        code,
+        disposition: disposition.to_string(),
+        // An operator who typed nothing and an operator who gave no reason are
+        // the same thing to a member, and neither is "reason: \"\"".
+        reason: reason.filter(|r| !r.trim().is_empty()),
+        decided_at: decided_at.to_string(),
+        decided_by: decided_by.to_string(),
+    };
+    let payload = serde_json::to_value(&body)
+        .map_err(|e| AppError::Internal(format!("serialise removal notice: {e}")))?;
+
+    let doc = build_document(&vtc_did, target_did, MEMBER_REMOVAL_NOTICE_TYPE, payload);
+    let mut doc_value = serde_json::to_value(&doc)
+        .map_err(|e| AppError::Internal(format!("serialise removal-notice document: {e}")))?;
+    signer.sign_doc(&mut doc_value).await?;
+
+    let envelope = affinidi_messaging_didcomm::Message::build(
+        format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        TRUST_TASK_ENVELOPE_TYPE.to_string(),
+        doc_value,
+    )
+    .from(vtc_did)
+    .to(target_did.to_string())
+    .finalize();
+
+    state
+        .send_to_member_by(
+            target_did,
+            envelope,
+            crate::server::REMOVAL_NOTICE_DELIVER_BY,
+        )
+        .await?;
+
+    info!(
+        target = target_did,
+        ?code,
+        disposition,
+        "removal notice queued"
+    );
+    Ok(())
+}
+
+/// Build the notice payload without sending it. Split out so the wire shape can
+/// be asserted without a running mediator.
+#[cfg(test)]
+fn notice_payload(
+    target_did: &str,
+    code: RemovalCode,
+    disposition: &str,
+    reason: Option<String>,
+    decided_at: &str,
+    decided_by: &str,
+) -> serde_json::Value {
+    serde_json::to_value(RemovalNoticeBody {
+        did: target_did.to_string(),
+        code,
+        disposition: disposition.to_string(),
+        reason: reason.filter(|r| !r.trim().is_empty()),
+        decided_at: decided_at.to_string(),
+        decided_by: decided_by.to_string(),
+    })
+    .expect("RemovalNoticeBody serialises")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn payload_carries_every_question_a_removed_member_has() {
+        let p = notice_payload(
+            "did:key:zRemoved",
+            RemovalCode::AdminRemoved,
+            "tombstone",
+            Some("Repeated code-of-conduct breach.".into()),
+            "2026-08-23T09:14:02Z",
+            "did:key:zAdmin",
+        );
+        assert_eq!(
+            p,
+            json!({
+                "did": "did:key:zRemoved",
+                "code": "adminRemoved",
+                "disposition": "tombstone",
+                "reason": "Repeated code-of-conduct breach.",
+                "decidedAt": "2026-08-23T09:14:02Z",
+                "decidedBy": "did:key:zAdmin"
+            }),
+            "what happened, to what, when, and on whose say-so — camelCase per SPEC §4.10"
+        );
+    }
+
+    /// "No reason given" and "reason: empty string" are different claims. The
+    /// operator route accepts an absent body and defaults `reason` to `""`, so
+    /// without this the common case would ship a meaningless empty string.
+    #[test]
+    fn an_absent_or_blank_reason_is_omitted_rather_than_sent_empty() {
+        for blank in [None, Some(String::new()), Some("   ".into())] {
+            let p = notice_payload(
+                "did:key:zRemoved",
+                RemovalCode::Purged,
+                "purge",
+                blank.clone(),
+                "2026-08-23T11:02:41Z",
+                "did:key:zSuper",
+            );
+            assert!(
+                p.get("reason").is_none(),
+                "blank reason {blank:?} must be absent, not an empty string"
+            );
+        }
+    }
+
+    /// The two codes are distinguishable because they differ in what recourse
+    /// the member has — a purge deliberately skipped the removal policy.
+    #[test]
+    fn the_two_removal_codes_are_distinguishable_on_the_wire() {
+        assert_eq!(
+            serde_json::to_value(RemovalCode::AdminRemoved).unwrap(),
+            json!("adminRemoved")
+        );
+        assert_eq!(
+            serde_json::to_value(RemovalCode::Purged).unwrap(),
+            json!("purged")
+        );
+    }
+
+    /// The payload must validate against the published schema. This is the
+    /// check that catches the implementation drifting from the spec it claims
+    /// to implement — the schema comes from `trust-tasks-rs`, which the
+    /// workspace pulls with its `validate` feature on, so no local gate is
+    /// needed (and `vtc-service` has no such feature to gate on).
+    #[test]
+    fn payload_validates_against_the_published_schema() {
+        use trust_tasks_rs::validate::ValidatedPayload;
+        type Notice = trust_tasks_rs::specs::vtc::members::removal_notice::v0_1::Payload;
+
+        for (code, reason) in [
+            (RemovalCode::AdminRemoved, Some("because".to_string())),
+            (RemovalCode::Purged, None),
+        ] {
+            let p = notice_payload(
+                "did:key:zRemoved",
+                code,
+                "tombstone",
+                reason,
+                "2026-08-23T09:14:02Z",
+                "did:key:zAdmin",
+            );
+            Notice::validate_value(&p)
+                .unwrap_or_else(|e| panic!("payload rejected by its own schema: {e}\n{p:#}"));
+        }
+    }
+}

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -196,6 +196,29 @@ pub struct AppState {
     pub didcomm: Arc<tokio::sync::OnceCell<Arc<crate::messaging::VtcMessaging>>>,
 }
 
+/// Delivery deadline for an ordinary proactive message to a member.
+///
+/// A member who misses one of these can ask again — the credential push, the
+/// exchange query and the reciprocal-VMC request all have a member-initiated
+/// counterpart.
+const DEFAULT_DELIVER_BY: std::time::Duration = std::time::Duration::from_secs(24 * 3600);
+
+/// Delivery deadline for a removal notice: **30 days**.
+///
+/// Longer than everything else because a removed member has no second route to
+/// the information. Removal hard-deletes their ACL row, and `resolve_auth_role`
+/// refuses any DID without one, so every authenticated endpoint — including any
+/// poll that might have served the notice — is closed to them from the moment
+/// the removal lands. The push is the only channel that exists.
+///
+/// Thirty days is a judgement, not a derivation: long enough that a member
+/// offline for a holiday still learns they were removed, short enough that the
+/// outbox is not a permanent store. A member offline beyond it never finds out,
+/// and no window fixes that — the honest fix would be a retrieval path that
+/// does not require an ACL row, which is a larger design than this.
+pub(crate) const REMOVAL_NOTICE_DELIVER_BY: std::time::Duration =
+    std::time::Duration::from_secs(30 * 24 * 3600);
+
 impl AppState {
     /// Current cached member-row count (equal to
     /// `members::list_members(..).len()`). O(1) — see
@@ -243,6 +266,26 @@ impl AppState {
         recipient_did: &str,
         message: affinidi_messaging_didcomm::Message,
     ) -> Result<(), AppError> {
+        self.send_to_member_by(recipient_did, message, DEFAULT_DELIVER_BY)
+            .await
+    }
+
+    /// As [`send_to_member`](Self::send_to_member), but with an explicit
+    /// delivery deadline.
+    ///
+    /// The default window suits a message the member is expecting and will come
+    /// back for. It does not suit a **removal notice**, which is the one case
+    /// where the act being reported is the act that ends the member's ability
+    /// to ask about it: their ACL row is gone, so every authenticated route now
+    /// refuses them and there is no poll to fall back on. Undelivered inside
+    /// the window means never, with no way for them to find out otherwise —
+    /// hence [`REMOVAL_NOTICE_DELIVER_BY`].
+    pub async fn send_to_member_by(
+        &self,
+        recipient_did: &str,
+        message: affinidi_messaging_didcomm::Message,
+        deliver_by: std::time::Duration,
+    ) -> Result<(), AppError> {
         let messaging = self.didcomm.get().ok_or_else(|| {
             AppError::Internal("VTC messaging not running — cannot send to member".into())
         })?;
@@ -268,7 +311,7 @@ impl AppState {
                 affinidi_messaging_delivery::Delivery::Guaranteed {
                     idempotency_key: Some(idempotency_key),
                     ordering_key: None,
-                    deliver_by: std::time::Duration::from_secs(24 * 3600),
+                    deliver_by,
                 },
             )
             .await

--- a/vtc-service/tests/removal_notice_didcomm.rs
+++ b/vtc-service/tests/removal_notice_didcomm.rs
@@ -1,0 +1,234 @@
+//! A removed member is actually told, over a real mediator.
+//!
+//! What this pins that the unit tests cannot: those assert the payload shape
+//! and that it validates against the published schema. They say nothing about
+//! whether the notice can *leave* — whether the document is signed with a key
+//! the member can check, whether it is packed in the envelope type a conformant
+//! peer accepts, and whether it survives the trip through a mediator to a DID
+//! that is no longer a member of anything.
+//!
+//! That last part is the whole feature. A removal notice that a removed member
+//! cannot receive is indistinguishable from the silence this replaced, and a
+//! `send` returning `Ok` means only that the mediator accepted the frame (R1.1)
+//! — so the only thing that demonstrates the feature works is a peer holding
+//! the document.
+//!
+//! Requires `--features didcomm-harness`; CI runs it.
+
+#![cfg(feature = "didcomm-harness")]
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+use vta_sdk::protocols::members::MEMBER_REMOVAL_NOTICE_TYPE;
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::ceremony::{purge_member, remove_inner};
+use vtc_service::members::{Member, store_member};
+use vtc_service::test_support::MockVtcDidcomm;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
+}
+
+/// Install the workspace default policies, as `server::run` does at boot.
+///
+/// `remove_inner` consults `removal.rego` and an empty policy set fails closed
+/// — which is why the purge test does not need this and the removal ones do:
+/// a purge deliberately skips the removal policy.
+async fn install_policies(mock: &MockVtcDidcomm) {
+    vtc_service::policy::default::install_defaults(
+        &mock.vtc.state.policies_ks,
+        &mock.vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("install default policies");
+}
+
+/// Seed `did` as a current member with an ACL row, so a removal has something
+/// to remove.
+async fn seed_member(mock: &MockVtcDidcomm, did: &str, role: VtcRole) {
+    let state = &mock.vtc.state;
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            did: did.into(),
+            role,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("seed ACL row");
+    store_member(&state.members_ks, &Member::fresh(did))
+        .await
+        .expect("seed member row");
+}
+
+/// The notice payload out of a captured trust-task envelope.
+fn payload_of(doc: &Value) -> &Value {
+    doc.get("payload").expect("notice carries a payload")
+}
+
+#[tokio::test]
+async fn an_admin_removal_reaches_the_member_signed() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let member = mock.connect_registry_peer().await;
+    let member_did = member.did().to_string();
+    let admin_did = "did:key:zRemovalAdmin";
+
+    install_policies(&mock).await;
+    seed_member(&mock, &member_did, VtcRole::Member).await;
+    seed_member(&mock, admin_did, VtcRole::Admin).await;
+
+    remove_inner(
+        &mock.vtc.state,
+        admin_did,
+        &member_did,
+        None,
+        "Repeated code-of-conduct breach.".to_string(),
+    )
+    .await
+    .expect("admin removal succeeds");
+
+    let doc = member
+        .next_trust_task(Duration::from_secs(30))
+        .await
+        .expect("the removal notice reached the removed member");
+
+    assert_eq!(
+        doc.get("type").and_then(Value::as_str),
+        Some(MEMBER_REMOVAL_NOTICE_TYPE),
+        "the document inside the envelope is the notice"
+    );
+    assert_eq!(
+        doc.get("issuer").and_then(Value::as_str),
+        Some(mock.vtc_did()),
+        "issued by the community, so the member knows who removed them"
+    );
+
+    let p = payload_of(&doc);
+    assert_eq!(
+        p.get("did").and_then(Value::as_str),
+        Some(member_did.as_str())
+    );
+    assert_eq!(p.get("code").and_then(Value::as_str), Some("adminRemoved"));
+    assert_eq!(
+        p.get("decidedBy").and_then(Value::as_str),
+        Some(admin_did),
+        "names the deciding administrator — 'the community removed you' is unappealable"
+    );
+    assert_eq!(
+        p.get("reason").and_then(Value::as_str),
+        Some("Repeated code-of-conduct breach."),
+        "the operator's reason reaches the member, not just the audit log"
+    );
+    assert!(
+        p.get("decidedAt").and_then(Value::as_str).is_some(),
+        "the decision has to be placeable in time"
+    );
+
+    // The point of the proof is that the member can forward this to somebody
+    // else. Unsigned, it would evidence nothing once detached from the
+    // authcrypt channel that delivered it.
+    let proof = doc.get("proof").expect("notice is signed");
+    assert_eq!(
+        proof.get("type").and_then(Value::as_str),
+        Some("DataIntegrityProof")
+    );
+    assert!(
+        proof
+            .get("proofValue")
+            .and_then(Value::as_str)
+            .is_some_and(|v| !v.is_empty()),
+        "a proof with no proofValue is not a proof"
+    );
+
+    member.shutdown().await;
+    mock.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_purge_says_it_was_a_purge() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let member = mock.connect_registry_peer().await;
+    let member_did = member.did().to_string();
+    let super_admin = "did:key:zPurgeSuperAdmin";
+
+    seed_member(&mock, &member_did, VtcRole::Member).await;
+
+    purge_member(&mock.vtc.state, super_admin, &member_did)
+        .await
+        .expect("purge succeeds");
+
+    let doc = member
+        .next_trust_task(Duration::from_secs(30))
+        .await
+        .expect("the purge notice reached the purged member");
+
+    let p = payload_of(&doc);
+    assert_eq!(
+        p.get("code").and_then(Value::as_str),
+        Some("purged"),
+        "distinguishable from adminRemoved — a purge skipped the removal policy, \
+         which changes what recourse the member has"
+    );
+    assert_eq!(p.get("disposition").and_then(Value::as_str), Some("purge"));
+    assert!(
+        p.get("reason").is_none(),
+        "no reason was given, and an absent reason is not an empty one"
+    );
+
+    member.shutdown().await;
+    mock.shutdown().await;
+}
+
+/// A member who chose to leave already has their receipt. Sending a removal
+/// notice as well would tell them they were removed, which is a different and
+/// worse thing to be told.
+#[tokio::test]
+async fn a_self_leave_sends_no_removal_notice() {
+    init_tracing();
+    let mock = MockVtcDidcomm::start().await;
+    let member = mock.connect_registry_peer().await;
+    let member_did = member.did().to_string();
+
+    install_policies(&mock).await;
+    seed_member(&mock, &member_did, VtcRole::Member).await;
+
+    // actor == target: the member removing themselves.
+    remove_inner(
+        &mock.vtc.state,
+        &member_did,
+        &member_did,
+        None,
+        String::new(),
+    )
+    .await
+    .expect("self-leave succeeds");
+
+    // Short window on purpose: this asserts an absence, and a long one only
+    // makes the suite slow without making the assertion stronger. The positive
+    // tests above establish that a notice sent on this path arrives well inside
+    // it, so a timeout here means nothing was sent rather than nothing arrived
+    // yet.
+    let stray = member.next_trust_task(Duration::from_secs(5)).await;
+    assert!(
+        stray.is_none(),
+        "a self-leave must not produce a removal notice, got: {stray:?}"
+    );
+
+    member.shutdown().await;
+    mock.shutdown().await;
+}


### PR DESCRIPTION
Closes #1053. Spec published upstream first as trustoverip/dtgwg-trust-tasks-tf#256 (`vtc/members/removal-notice/0.1`, in `trust-tasks-rs` 0.11.4) — the VTC's URI census requires every `trusttasks.org/spec/…` literal in its source to resolve in the published registry, so the constant could not be declared before the spec existed.

## The gap

Removal was the most consequential thing a community does to a member and the one it delivered with the least information — **none**. No outbound message existed on any removal path. The only observable signal was a side effect: the revocation bit on the member's credential flipping. They inferred their own removal from a status list and learned nothing about why.

## Signed, because the recipient is not the audience

Authcrypt already proves the sender **to the member**. But this is the one member-facing message whose value lies in showing it to somebody else — an appeal, a dispute, another community weighing a rejected applicant. Forwarded, an unsigned notice is an assertion anyone could have written.

So it is a Trust Task document with a Data Integrity proof, packed in the trust-task envelope. Note `TRUST_TASK_ENVELOPE_TYPE`, **not** the task URI — hand-building a DIDComm message with the task type is a mistake this workspace has made before, and a conformant peer rejects it silently.

## Thirty days, because there is no second route

Verified while scoping: `resolve_auth_role` returns `Forbidden("DID not in ACL")` and removal hard-deletes the ACL row, so **a removed member cannot authenticate at all**. Every authenticated route — including any poll that might have served the notice — closes the moment the removal lands. The act this reports is the act that ends their ability to ask about it.

That makes the push the only channel, which is what justifies the window. `send_to_member` already had `Delivery::Guaranteed` with a durable outbox, so this needed a deadline parameter rather than new machinery: `send_to_member_by`, with the six existing callers keeping the 24h default.

**A member offline beyond the window still never learns.** No window fixes that. The honest fix is a retrieval path not gated on an ACL row — a larger design than this issue. Stated in the spec and in the constant's doc comment rather than left to be discovered.

This also means one of the issue's acceptance criteria — *"or can recover it from a poll"* — is **not achievable as written**, and I have said so on the issue rather than satisfying the easier half and calling it done.

## Never for a self-leave

`remove_inner` serves both the admin path and the DIDComm self-leave. A member who chose to leave already has their receipt, and telling them they were "removed" is a different and worse thing to be told. Guarded on `actor_did != target_did`, and tested by asserting an absence.

## Best-effort

The notice never fails the removal. That has already happened and is durable; refusing the operator's request because the notice could not be *queued* would leave the member removed and the operator believing they were not. Failures log loudly — and log **"queued", not "sent"**, since a DIDComm `Ok` means the mediator accepted the frame and nothing more (R1.1, which names `send_to_member` as a known offender).

## Tests

**Four unit** — payload shape; a blank reason omitted rather than sent as an empty string (the route defaults `reason` to `""`, so without this the common case would ship a meaningless empty value); the two codes distinguishable; and the payload **validated against the published schema**, which is the check that catches the implementation drifting from the spec it claims to implement.

**Three end-to-end over a real mediator** (`--features didcomm-harness`), because a `send` returning `Ok` proves only that the mediator accepted the frame — the only thing that demonstrates this works is a peer holding the document:

- an admin removal reaches the member, signed, with reason and deciding admin
- a purge says it was a purge, with `reason` absent rather than empty
- a self-leave sends nothing

Two of those first failed with `no active removal policy` — informative rather than annoying. The purge test passed before them precisely because **a purge deliberately skips the removal policy**, so the failure confirmed the paths differ the way the spec says.

## Verification

- `cargo test --workspace` — **150 suites, 0 failed** (149 before; the new harness test)
- `cargo test -p vtc-service --features didcomm-harness --test removal_notice_didcomm` — 3 passed
- `cargo clippy` (including `--features didcomm-harness`) — clean
- `cargo fmt --all --check` — clean