### PR TITLE
feat(vtc)!: let a member publish a relationship edge without naming themselves in it

### DIFF
--- a/docs/05-design-notes/vrc-publish-proof-of-possession.md
+++ b/docs/05-design-notes/vrc-publish-proof-of-possession.md
@@ -1,0 +1,267 @@
+# VRC publish: proof-of-possession in place of the issuer pin
+
+Status: implemented — see `vtc-service/src/routes/relationships.rs`
+Tracking: OpenVTC/verifiable-trust-infrastructure#1054, OpenVTC/openvtc#241
+Upstream: trustoverip/dtgwg-cred-spec#21, trustoverip/dtgwg-cred-spec#9
+
+## Why
+
+`POST /v1/relationships` pins the VRC's `issuer` to the authenticated session
+DID (`vtc-service/src/routes/relationships.rs:97-107`):
+
+```rust
+if auth.did != issuer_did { return Err(AppError::Forbidden(...)) }
+```
+
+That equality is what forces a member's membership DID (M-DID) into the durable,
+publishable credential. Removing it is the change #1054 is blocking on. But the
+pin is doing real work, and dropping it without a replacement removes a property
+we want to keep.
+
+## What the pin actually protects
+
+Two properties are conflated in one line, and they need separating before
+anything is replaced.
+
+**P1 — the VRC was made by the party it names as issuer.** Provided already by
+`verify_vc_proof` + `check_issuer_binding` (`relationships.rs:316-343`): the
+data-integrity proof is verified against a verification method bound to the
+`issuer` field. This holds whatever identifier the issuer used and is untouched
+by anything below.
+
+**P2 — the party publishing the VRC is the party that issued it.** This is what
+the pin provides, and it is the property that needs a replacement.
+
+P2 is worth keeping. Issuance and publication are distinct acts. A VRC handed
+privately to a counterparty should not become an edge in the community graph
+because the *counterparty* chose to upload it. Appearing in the graph is a
+disclosure, and it should be the issuer's disclosure to make. Without P2 any
+authenticated member could publish any VRC that ever reached them.
+
+## Design
+
+Replace the identity equality with a **publish-time proof of possession** of the
+issuer's key, bound to the request. The session proves membership; the PoP proves
+control of the issuing identifier; neither requires the two to be the same
+string, and neither requires disclosing that they belong to one member.
+
+### The authorization object
+
+The client signs, with the private key of the VRC's `issuer`:
+
+```json
+{
+  "type": "VrcPublishAuthorization",
+  "vrc": "<sha-256 of the VRC, hex>",
+  "aud": "<this VTC's C-DID>",
+  "sessionId": "<the caller's authenticated session id>",
+  "issuedAt": "2026-08-23T07:40:00Z"
+}
+```
+
+Each field earns its place:
+
+| Field | Prevents |
+|---|---|
+| `vrc` | replaying a captured PoP to authorize a *different* credential |
+| `aud` | replaying a PoP made for one community at another |
+| `sessionId` | replaying another member's PoP — this is the load-bearing binding |
+| `issuedAt` | unbounded replay within a live session (accept a narrow window) |
+
+`sessionId` is the field that does the real work. It ties "controls this R-DID"
+to "is making this request" *inside the request*, rather than by naming the
+member inside the credential. `AuthClaims.session_id`
+(`vti-common/src/auth/extractor.rs:30`) is already carried through to handlers
+for exactly this class of session-targeted operation, so nothing new is needed
+to reach it.
+
+The PoP is carried as a second field on `PublishBody`, which today is a single
+`vrc` (`relationships.rs:57-65`).
+
+### Canonicalization
+
+The authorization object is signed with an `eddsa-jcs-2022` data-integrity
+proof, so the signature is over RFC 8785 (JCS) canonical form and is reproducible
+by any conforming implementation. This is the same `DataIntegrityProof` path the
+VRC itself and the credential-exchange verifiers use, so no new machinery.
+
+The `vrc` field of the authorization binds to the hash the handler computes with
+its own `canonicalise` (`relationships.rs`), which is a recursive key sort only —
+no number normalization, no string-escaping rules. That is adequate for the
+idempotency key it was written for, and this change does not alter it, but it is
+not a canonicalization a second implementation could reproduce from a
+specification. It is a latent interop problem of the same kind
+trustoverip/dtgwg-cred-spec#6 was filed about, and it now has a second consumer.
+Worth a follow-up; deliberately out of scope here to keep the change reviewable.
+
+### Verification order
+
+1. Authenticate the session (unchanged). `auth.did` is a current member.
+2. Extract `issuer` and `credentialSubject.id` from the VRC (unchanged).
+3. **New, and it must stay here:** if no PoP was supplied and `issuer` is not the
+   session DID, reject. This gate is before the resolver is touched, because the
+   resolver is a *daemon-configuration* prerequisite — putting it first lets a
+   missing resolver return 500 for what is really a 403, masking a caller error
+   with an operator error. The original code ordered it this way deliberately
+   ("Daemon-config prerequisites surface after caller validation"); an early
+   draft of this change lost that, and the existing
+   `publish_rejects_caller_not_issuer` test caught it.
+4. Verify the VRC's data-integrity proof (unchanged) — **P1**.
+5. Compute the VRC hash. Moves ahead of policy evaluation, since the PoP binds
+   to it.
+6. Verify the PoP signature against the `issuer` DID's verification method,
+   reusing `DidVmResolver` and the same `check_issuer_binding` rule as step 4.
+   Then check `type`, `vrc`, `aud`, `sessionId`, and the `issuedAt` freshness
+   window — **P2**.
+7. Evaluate policy against the new input shape (below).
+8. Store, audit, respond (unchanged).
+
+The `type` guard on the authorization object is not decoration: without it, any
+object the member legitimately signed with the same key and which happens to
+carry the right field names could be replayed as authorization to publish.
+
+### The PoP is verified and discarded
+
+**It must not be persisted, logged, or written to the audit trail.** The PoP
+contains `sessionId`, and the session is attributable to an M-DID; storing it
+would create exactly the durable M-DID-to-R-DID linkage this change exists to
+remove. The ZKP task force made this point on trustoverip/dtgwg-cred-spec#9 —
+"adding a visible field to make the association checkable would recreate exactly
+the correlation surface you are flagging." A stored PoP is that field.
+
+The `Relationship` row (`relationships.rs:167-176`) keeps only what it keeps
+today, with R-DIDs in the two DID fields.
+
+### Policy input
+
+The current default policy asks whether both named parties are current members,
+which is unanswerable once both are R-DIDs. The question it was really asking —
+*is this publication authorized by a member of this community?* — is still
+answerable, and more precisely than before:
+
+```rego
+package vtc.relationships
+import rego.v1
+
+default allow := false
+
+allow if {
+	input.action == "publish"
+	input.authenticated_member.is_current   # the session is a live member
+	input.issuer.pop_verified               # the caller controls the issuing DID
+}
+```
+
+with input:
+
+```json
+{
+  "vrc": { },
+  "authenticated_member": { "did": "<M-DID>", "is_current": true },
+  "issuer": { "did": "<R-DID>", "pop_verified": true },
+  "subject": { "did": "<R-DID>" },
+  "action": "publish"
+}
+```
+
+`authenticated_member.did` is present for operator-authored policies that
+legitimately need it (rate limits, per-member quotas, moderation holds). The
+default policy does not read it, and the handler does not store it.
+
+### The subject side
+
+Today the handler requires the subject to be a current member
+(`relationships.rs:120-134`). With R-DIDs that check is not merely unanswerable —
+it is the wrong question, and the spec says so directly: "Community membership is
+**not** a precondition for issuing, holding, or presenting a VRC"
+(§Community-Anchored Zero-Knowledge Proof).
+
+Drop it, and let the DTG edge model supply the consent it was standing in for.
+Two VRCs, one in each direction, form a complete edge. Each half is published by
+its own issuer under its own PoP. **The subject's consent to the edge is their
+publication of the reciprocal VRC** — not the VTC's assertion that they exist.
+
+This is the pattern the join flow already uses: the member-issued reciprocal VMC
+in `trust-tasks/join-requests/accept/1.0/spec.md`, described upstream by the
+spec editors as the member's *consent artifact*, on the reasoning that a
+community can always assert someone is a member but cannot forge their
+acknowledgement. The same logic applies one layer down.
+
+Consequence: `GET /v1/relationships/graph` should distinguish half-edges from
+complete edges, and the admin UI should show the difference. That is a better
+graph than today's, which cannot tell a mutual relationship from a unilateral
+claim.
+
+## Compatibility
+
+Accept both forms for one release, keyed on what the credential contains:
+
+- `issuer == auth.did` → the M-DID form. No PoP required; behaves as today.
+  Emit a deprecation warning.
+- `issuer != auth.did` → PoP required, verified as above.
+
+Then flip the OpenVTC default (openvtc#241 has already landed the client half in
+openvtc#254), then remove the legacy branch. This mirrors the `--generate-did`
+no-op-that-warns approach openvtc#241 took, in the same direction.
+
+## Tradeoffs to decide, not assume
+
+**Audit attribution changes.** `audit_writer.write(&issuer_did, ...)`
+(`relationships.rs:193-205`) records the issuer as the actor. Once the issuer is
+an R-DID, the audit trail no longer attributes publications to a named member.
+That is the intended privacy property and a real loss for moderation. Options:
+attribute to the R-DID and accept it; attribute to the session's M-DID and accept
+a linkage inside the audit store with its own retention rules; or record neither
+and rely on the row itself. **This needs an explicit decision — it should not be
+settled by whichever variable happens to be in scope.**
+
+**Admin revocation is unaffected.** It keys on row id, not issuer identity
+(`relationships.rs`, revoke section), so moderation of a specific edge still
+works.
+
+**Accepted DID methods become policy.** If the issuer identifier is
+method-independent — and it should be; nothing in this design reads a method
+prefix, and neither does the current handler — the VTC cannot assume what members
+mint R-DIDs under. `DIDCacheClient::new(DIDCacheConfigBuilder::default().build())`
+(`vtc-service/src/server.rs:1715`) currently accepts whatever the library
+default supports, which is permissive by accident. `vta-config` already has the
+shape to copy: `allowed_did_methods` (`vta-config/src/lib.rs:497`), enforced at
+`vta-service/src/auth/backend.rs:136-145`. The VTC's `validate_did` hook is the
+no-op default (`vti-common/src/auth/backend.rs:284`). The criterion worth
+enforcing is that resolving an R-DID must not disclose the relationship to a
+third party; methods either meet it or do not, and the community should say which
+it accepts.
+
+## What this does not solve
+
+The VTC still observes the session's M-DID and the R-DID in the same request. The
+association is transient and unstored, which is a real improvement over today —
+where the linkage *is* the stored credential field — but it is not zero.
+
+Removing it needs the community-anchored ZKP construction (§Community-Anchored
+Zero-Knowledge Proof), which needs the identity linkages raised in
+trustoverip/dtgwg-cred-spec#9 to be defined first. The ZKP TF's position there is
+that it is "a real dependency, not a blocker". This design is the shape that
+takes that proof when it arrives: predicate `issuer.pop_verified` is replaced by
+a ZK proof of the same predicate, and neither the policy input shape nor the
+stored row changes.
+
+## Test matrix
+
+| Case | Expected |
+|---|---|
+| R-DID issuer, valid PoP, member session | 201, row stores R-DIDs |
+| R-DID issuer, no PoP | 403 |
+| PoP signed by a different key than `issuer` | 403 |
+| PoP replayed with a different VRC | 403 (`vrc` mismatch) |
+| PoP replayed by a different member's session | 403 (`sessionId` mismatch) |
+| PoP replayed at another VTC | 403 (`aud` mismatch) |
+| PoP outside the freshness window | 403 |
+| Same VRC published twice | 200, idempotent, same id |
+| Subject not a member | 201 — no longer an error |
+| One direction only | edge shows as half, not complete |
+| `issuer == auth.did`, no PoP | 201 + deprecation warning |
+| Stored row / audit / logs | contain no `sessionId` and no M-DID |
+
+The last row is the one that regresses silently if someone later adds a debug
+log. It deserves an explicit assertion, not a review comment.

--- a/docs/05-design-notes/vrc-publish-proof-of-possession.md
+++ b/docs/05-design-notes/vrc-publish-proof-of-possession.md
@@ -206,14 +206,40 @@ no-op-that-warns approach openvtc#241 took, in the same direction.
 
 ## Tradeoffs to decide, not assume
 
-**Audit attribution changes.** `audit_writer.write(&issuer_did, ...)`
-(`relationships.rs:193-205`) records the issuer as the actor. Once the issuer is
-an R-DID, the audit trail no longer attributes publications to a named member.
-That is the intended privacy property and a real loss for moderation. Options:
-attribute to the R-DID and accept it; attribute to the session's M-DID and accept
-a linkage inside the audit store with its own retention rules; or record neither
-and rely on the row itself. **This needs an explicit decision — it should not be
-settled by whichever variable happens to be in scope.**
+**Audit attribution — decided.** The trail attributes a publication to the
+**authenticated member**, not to the VRC's issuer. Under the pairwise form
+those differ, and the issuing relationship DID names nobody, so recording it
+would leave the trail unable to answer "which member published this edge" for
+anyone, at any access level, ever.
+
+This is a deliberate, narrow exception to the rule above that the
+membership-to-relationship linkage must not be persisted, and the reasoning for
+drawing it here and nowhere else:
+
+- What #1054 set out to remove is *public, permanent, unavoidable* correlation
+  — a membership DID welded into a credential anyone can retain and republish.
+  The audit store is none of those things: `AuditEnvelope` HMACs the actor
+  under a rotating key (`actor_did_hash`, covered by the tamper-evidence
+  chain), keeps the plaintext in a field deliberately excluded from the chain
+  digest so RTBF can null it without breaking verification
+  (`actor_did_plain`), and the surface is admin-gated.
+- Giving it up would buy little. `VrcPublishedData` carries `vrc_id`, `vrc_id`
+  resolves to the row, and the row holds the relationship DIDs — so any trail
+  that both references the edge and names the member creates the mapping
+  transitively. There is no variant that attributes without linking.
+- Moderation needs the reverse lookup. "This edge is abusive, who made it?" is
+  the question an operator actually has; a hash-only variant answers only the
+  forward one ("this member is suspect, what have they done?").
+
+**The residual, stated plainly:** an operator with audit access can map every
+pairwise edge to its member. That is the cost, it is accepted, and it is why
+the linkage stops at the audit store — the `info!` on the publish path carries
+the relationship DID and not the member, because logs have neither the
+redaction machinery nor the access controls that make this trade defensible.
+
+Note this decision is not VRC-specific. It answers "when a member acts under a
+pairwise identifier, what does the audit trail record?", and it should hold for
+every pairwise-capable operation added later.
 
 **Admin revocation is unaffected.** It keys on row id, not issuer identity
 (`relationships.rs`, revoke section), so moderation of a specific edge still
@@ -261,7 +287,8 @@ stored row changes.
 | Subject not a member | 201 — no longer an error |
 | One direction only | edge shows as half, not complete |
 | `issuer == auth.did`, no PoP | 201 + deprecation warning |
-| Stored row / audit / logs | contain no `sessionId` and no M-DID |
+| Stored row and logs | contain no `sessionId` and no membership DID |
+| Audit envelope | actor is the member, never the relationship DID |
 
 The last row is the one that regresses silently if someone later adds a debug
 log. It deserves an explicit assertion, not a review comment.

--- a/docs/05-design-notes/vti-credential-architecture.md
+++ b/docs/05-design-notes/vti-credential-architecture.md
@@ -107,7 +107,7 @@ catalog (a superset of `docs/05-design-notes/vtc-mvp.md` §6.1):
 | **MembershipCredential (VMC)** | community | member | "is a member of X" | yes — prove membership without other claims |
 | **RoleCredential (Role VEC)** | community | member | proves a role (admin/moderator/issuer/member/custom) | yes |
 | **EndorsementCredential (VEC)** | community or issuer-role member | member | community-defined claims | yes |
-| **RecognitionCredential (VRC)** | member (self-issued) | another member | peer trust edge | n/a (Phase 3) |
+| **RelationshipCredential (VRC)** | member (self-issued) | another member | peer trust edge | n/a (Phase 3) |
 | **PersonhoodCredential** | personhood oracle / community | member | Sybil resistance | yes |
 
 `vtc-service/src/credentials/{vmc,vec}.rs` become thin adapters over DTG

--- a/vtc-service/policies/default/relationships.rego
+++ b/vtc-service/policies/default/relationships.rego
@@ -1,44 +1,63 @@
 # Default `relationships` policy — store iff the caller is a
-# current member and has proven control of the issuing DID.
+# current member of this community.
 #
-# A VRC names two parties (issuer + subject). Under pairwise
-# relationship DIDs — which DTG Credentials recommends, and
-# requires to be unique per counterparty — neither party is
-# resolvable to a community member, and is not meant to be.
-# Asking "are both parties current members?" is therefore no
-# longer answerable, and per DTG Credentials §Community-Anchored
-# ZKP it is also the wrong question: "community membership is
-# not a precondition for issuing, holding, or presenting a VRC".
+# A VRC names two parties (issuer + subject). Under the pairwise
+# form neither is resolvable to a member, and is not meant to be:
+# DTG Credentials §Community-Anchored ZKP is explicit that
+# "community membership is not a precondition for issuing,
+# holding, or presenting a VRC". So the question this policy asks
+# is not "are both parties members?" but "is this publication
+# authorized by a member of this community?".
 #
-# The question that *is* answerable, and is the one this policy
-# was really asking, is whether the publication is authorized by
-# a member of this community. That splits in two:
+# The handler answers that before the policy runs — the session
+# is authenticated, and for a pairwise VRC the caller has proven
+# control of the issuing DID. What is left for the policy is the
+# membership check and whatever the community wants to add.
 #
-#   authenticated_member.is_current — the session belongs to a
-#     live, ACL-listed, non-tombstoned member.
-#   issuer.pop_verified — the caller proved control of the key
-#     behind the VRC's `issuer` (see `verify_publish_authorization`),
-#     so this is the issuer publishing its own edge rather than a
-#     third party republishing one it was handed.
+# ## Identifier form
 #
-# The subject's consent to the edge is their own publication of
-# the reciprocal VRC — the two-VRC DTG edge model — not this
-# community's assertion that they exist.
+# `identifier_form` is how the credential identifies its parties:
+#
+#   "attributed" — issued under the member's membership DID. The
+#     edge names them; the graph is correlatable by design. A
+#     public community (an open-source project, say) reasonably
+#     wants this, and DTG Credentials permits it directly: "the
+#     member may also assert the M-DID in any VRC where the
+#     member wishes to assert a VTC relationship".
+#
+#   "pairwise" — issued under a relationship DID unique to one
+#     counterparty. DTG Credentials RECOMMENDS this, and requires
+#     the uniqueness the handler enforces.
+#
+# Both are permanent, supported forms. **The member chooses per
+# relationship and this default policy accepts either.** The
+# community *declares* which it expects in the community profile
+# (`relationshipIdentifierDefault`), which clients read before
+# minting — a declaration, not a gate.
+#
+# A community that wants to *require* one form enforces it here.
+# To require attributed edges, replace the two rules below with:
+#
+#   allow if {
+#     input.action == "publish"
+#     input.authenticated_member.is_current
+#     input.identifier_form == "attributed"
+#   }
 #
 # Input shape (enriched by the handler):
 #   { vrc,
 #     authenticated_member: { did, is_current },
+#     identifier_form: "attributed" | "pairwise",
 #     issuer:  { did, pop_verified },
 #     subject: { did },
-#     issuer_member:  { did, is_current },   # deprecated
-#     subject_member: { did, is_current },   # deprecated
+#     issuer_member:  { did, is_current },   # deprecated shape
+#     subject_member: { did, is_current },   # deprecated shape
 #     action }
 #
-# `issuer_member` / `subject_member` remain in the input for
-# operator-authored policies written against the old shape. For a
-# pairwise VRC both report `is_current: false`, so an un-updated
-# operator policy denies the publish. That is deliberate — this
-# change does not silently loosen a policy someone wrote.
+# `issuer_member` / `subject_member` remain for operator policies
+# written against the old shape. For a pairwise VRC both report
+# `is_current: false`, so an un-updated operator policy denies the
+# publish rather than being silently loosened.
 
 package vtc.relationships
 
@@ -46,21 +65,21 @@ import rego.v1
 
 default allow := false
 
-# Pairwise form: membership comes from the session, control of the
-# issuing DID from the publish authorization.
+# Pairwise: membership comes from the session; control of the
+# relationship DID was proven to the handler, which also enforced
+# that the DID is unique to this counterparty.
 allow if {
 	input.action == "publish"
 	input.authenticated_member.is_current
-	input.issuer.pop_verified
+	input.identifier_form == "pairwise"
 }
 
-# Deprecated form: the VRC is issued under the member's own
-# membership DID and carries no publish authorization. Accepted
-# for one release; both named parties must be current members, as
-# before.
+# Attributed: the member issues under their own membership DID, so
+# both named parties are community members and the historical
+# both-parties-current check still applies.
 allow if {
 	input.action == "publish"
-	not input.issuer.pop_verified
+	input.identifier_form == "attributed"
 	input.issuer_member.is_current
 	input.subject_member.is_current
 }

--- a/vtc-service/policies/default/relationships.rego
+++ b/vtc-service/policies/default/relationships.rego
@@ -1,23 +1,44 @@
-# Default `relationships` policy — store iff both parties are
-# current members (spec §7.1).
+# Default `relationships` policy — store iff the caller is a
+# current member and has proven control of the issuing DID.
 #
-# A VRC names two parties (issuer + subject). The default
-# behaviour is to accept the publication only when both DIDs
-# are current members of this community — preserves the "we
-# don't publish relationship claims that span unknown parties"
-# privacy floor. Operators relax by uploading their own
-# policy.
+# A VRC names two parties (issuer + subject). Under pairwise
+# relationship DIDs — which DTG Credentials recommends, and
+# requires to be unique per counterparty — neither party is
+# resolvable to a community member, and is not meant to be.
+# Asking "are both parties current members?" is therefore no
+# longer answerable, and per DTG Credentials §Community-Anchored
+# ZKP it is also the wrong question: "community membership is
+# not a precondition for issuing, holding, or presenting a VRC".
 #
-# The handler enriches each party with an `is_current` flag
-# (true iff the DID has an active ACL row and the Member row
-# is not tombstoned). Default policy reads only that flag —
-# the handler picks the canonical shape that future operator-
-# authored policies will inherit.
+# The question that *is* answerable, and is the one this policy
+# was really asking, is whether the publication is authorized by
+# a member of this community. That splits in two:
 #
-# Input shape (spec §7.3, enriched):
-#   { vrc, issuer_member: { did, is_current },
-#          subject_member: { did, is_current },
+#   authenticated_member.is_current — the session belongs to a
+#     live, ACL-listed, non-tombstoned member.
+#   issuer.pop_verified — the caller proved control of the key
+#     behind the VRC's `issuer` (see `verify_publish_authorization`),
+#     so this is the issuer publishing its own edge rather than a
+#     third party republishing one it was handed.
+#
+# The subject's consent to the edge is their own publication of
+# the reciprocal VRC — the two-VRC DTG edge model — not this
+# community's assertion that they exist.
+#
+# Input shape (enriched by the handler):
+#   { vrc,
+#     authenticated_member: { did, is_current },
+#     issuer:  { did, pop_verified },
+#     subject: { did },
+#     issuer_member:  { did, is_current },   # deprecated
+#     subject_member: { did, is_current },   # deprecated
 #     action }
+#
+# `issuer_member` / `subject_member` remain in the input for
+# operator-authored policies written against the old shape. For a
+# pairwise VRC both report `is_current: false`, so an un-updated
+# operator policy denies the publish. That is deliberate — this
+# change does not silently loosen a policy someone wrote.
 
 package vtc.relationships
 
@@ -25,8 +46,21 @@ import rego.v1
 
 default allow := false
 
+# Pairwise form: membership comes from the session, control of the
+# issuing DID from the publish authorization.
 allow if {
 	input.action == "publish"
+	input.authenticated_member.is_current
+	input.issuer.pop_verified
+}
+
+# Deprecated form: the VRC is issued under the member's own
+# membership DID and carries no publish authorization. Accepted
+# for one release; both named parties must be current members, as
+# before.
+allow if {
+	input.action == "publish"
+	not input.issuer.pop_verified
 	input.issuer_member.is_current
 	input.subject_member.is_current
 }

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -53,6 +53,18 @@ fn cap_len(field: &str, value: Option<&str>, max: usize) -> Result<(), AppError>
     Ok(())
 }
 
+/// Identifier form a community declares when it has not chosen one. DTG
+/// Credentials recommends relationship DIDs, so silence declares the more
+/// conservative expectation rather than the more convenient one.
+pub const RELATIONSHIP_IDENTIFIER_DEFAULT: &str = "pairwise";
+
+/// The two identifier forms a community may declare.
+pub const RELATIONSHIP_IDENTIFIER_FORMS: [&str; 2] = ["attributed", "pairwise"];
+
+fn default_relationship_identifier() -> String {
+    RELATIONSHIP_IDENTIFIER_DEFAULT.to_string()
+}
+
 /// The singleton record. Field names are wire contract — operators
 /// + the admin UX read this shape directly.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -69,6 +81,28 @@ pub struct CommunityProfile {
     pub contact_email: Option<String>,
     /// BCP 47 language tag. Defaults to `"en"`.
     pub language: String,
+    /// Which identifier form this community expects members to issue
+    /// relationship credentials under — `"attributed"` (the member's
+    /// membership DID, so edges name them) or `"pairwise"` (a relationship
+    /// DID unique to each counterparty).
+    ///
+    /// A **declaration, not an enforcement**: the member still chooses per
+    /// relationship, and both forms are accepted. It exists so a client can
+    /// read what the community expects *before* minting — a public
+    /// open-source community reasonably declares `attributed`, one organised
+    /// around privacy declares `pairwise`.
+    ///
+    /// A community that wants to *require* a form does so in
+    /// `relationships.rego`, which receives `identifier_form` on every
+    /// publish. Defaults to `"pairwise"`, matching DTG Credentials'
+    /// recommendation, so a community that has not considered the question
+    /// declares the more conservative expectation.
+    ///
+    /// `serde(default)` is load-bearing: a config export taken before this
+    /// field existed must still import. Without it every saved export becomes
+    /// unreadable — which the admin-config round-trip tests caught.
+    #[serde(default = "default_relationship_identifier")]
+    pub relationship_identifier_default: String,
     pub created_at: DateTime<Utc>,
     /// Opaque per-community JSON. Capped at [`MAX_EXTENSIONS_BYTES`]
     /// when serialised. Defaults to `null` when no extension data
@@ -89,6 +123,7 @@ impl CommunityProfile {
             public_url: None,
             contact_email: None,
             language: "en".into(),
+            relationship_identifier_default: RELATIONSHIP_IDENTIFIER_DEFAULT.into(),
             created_at: Utc::now(),
             extensions: Value::Null,
         }
@@ -113,6 +148,9 @@ pub struct CommunityProfileUpdate {
     pub public_url: Option<Option<String>>,
     pub contact_email: Option<Option<String>>,
     pub language: Option<String>,
+    /// See [`CommunityProfile::relationship_identifier_default`]. Must be one
+    /// of [`RELATIONSHIP_IDENTIFIER_FORMS`].
+    pub relationship_identifier_default: Option<String>,
     pub extensions: Option<Value>,
 }
 
@@ -163,7 +201,25 @@ impl CommunityProfileUpdate {
             }
         }
 
+        // Validated before mutating, with the other pre-checks: an
+        // unrecognised value would be published to clients as the community's
+        // expectation, and they cannot act on a form they do not understand.
+        if let Some(form) = self.relationship_identifier_default.as_deref()
+            && !RELATIONSHIP_IDENTIFIER_FORMS.contains(&form)
+        {
+            return Err(AppError::Validation(format!(
+                "relationshipIdentifierDefault must be one of {:?} (got {form:?})",
+                RELATIONSHIP_IDENTIFIER_FORMS
+            )));
+        }
+
         let mut changed = Vec::new();
+        if let Some(form) = self.relationship_identifier_default
+            && profile.relationship_identifier_default != form
+        {
+            profile.relationship_identifier_default = form;
+            changed.push("relationshipIdentifierDefault".into());
+        }
         if let Some(name) = self.name
             && profile.name != name
         {

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -1087,4 +1087,45 @@ mod tests {
             "relationships default must deny when one party isn't a member"
         );
     }
+
+    /// The pairwise form: neither credential party is a member, and the
+    /// publish is authorized by the session plus proof of control of the
+    /// issuing DID. This is the shape #1054 exists to allow.
+    #[test]
+    fn relationships_default_allows_pairwise_publish_with_pop() {
+        let c = compile_default(PolicyPurpose::Relationships);
+
+        let input = |member_current: bool, pop_verified: bool| {
+            json!({
+                "vrc": {},
+                "authenticated_member": { "did": "did:key:zMember", "is_current": member_current },
+                "issuer":  { "did": "did:peer:2.zR1", "pop_verified": pop_verified },
+                "subject": { "did": "did:peer:2.zR2" },
+                // Pairwise DIDs are not members; the deprecated fields say so.
+                "issuer_member":  { "did": "did:peer:2.zR1", "is_current": false },
+                "subject_member": { "did": "did:peer:2.zR2", "is_current": false },
+                "action": "publish"
+            })
+        };
+
+        let allowed = evaluate(&c, "data.vtc.relationships.allow", input(true, true)).unwrap();
+        assert!(
+            pluck_bool(&allowed),
+            "a current member proving control of the issuing DID must be allowed to publish"
+        );
+
+        let no_pop = evaluate(&c, "data.vtc.relationships.allow", input(true, false)).unwrap();
+        assert!(
+            !pluck_bool(&no_pop),
+            "without proof of control the pairwise rule must not fire, and the \
+             deprecated rule must not rescue it — neither party is a member"
+        );
+
+        let not_a_member =
+            evaluate(&c, "data.vtc.relationships.allow", input(false, true)).unwrap();
+        assert!(
+            !pluck_bool(&not_a_member),
+            "proof of control is not membership; a non-member session must be denied"
+        );
+    }
 }

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -1055,7 +1055,7 @@ mod tests {
     }
 
     #[test]
-    fn relationships_default_requires_both_parties_current() {
+    fn relationships_default_attributed_requires_both_parties_current() {
         let c = compile_default(PolicyPurpose::Relationships);
 
         let both = evaluate(
@@ -1063,6 +1063,8 @@ mod tests {
             "data.vtc.relationships.allow",
             json!({
                 "vrc": {},
+                "identifier_form": "attributed",
+                "authenticated_member": { "did": "did:key:zIssuer", "is_current": true },
                 "issuer_member": { "did": "did:key:zIssuer", "is_current": true },
                 "subject_member": { "did": "did:key:zSubject", "is_current": true },
                 "action": "publish"
@@ -1076,6 +1078,8 @@ mod tests {
             "data.vtc.relationships.allow",
             json!({
                 "vrc": {},
+                "identifier_form": "attributed",
+                "authenticated_member": { "did": "did:key:zIssuer", "is_current": true },
                 "issuer_member": { "did": "did:key:zIssuer", "is_current": true },
                 "subject_member": { "did": "did:key:zSubject", "is_current": false },
                 "action": "publish"
@@ -1095,11 +1099,12 @@ mod tests {
     fn relationships_default_allows_pairwise_publish_with_pop() {
         let c = compile_default(PolicyPurpose::Relationships);
 
-        let input = |member_current: bool, pop_verified: bool| {
+        let input = |member_current: bool, pairwise: bool| {
             json!({
                 "vrc": {},
+                "identifier_form": if pairwise { "pairwise" } else { "attributed" },
                 "authenticated_member": { "did": "did:key:zMember", "is_current": member_current },
-                "issuer":  { "did": "did:peer:2.zR1", "pop_verified": pop_verified },
+                "issuer":  { "did": "did:peer:2.zR1", "pop_verified": pairwise },
                 "subject": { "did": "did:peer:2.zR2" },
                 // Pairwise DIDs are not members; the deprecated fields say so.
                 "issuer_member":  { "did": "did:peer:2.zR1", "is_current": false },
@@ -1117,8 +1122,8 @@ mod tests {
         let no_pop = evaluate(&c, "data.vtc.relationships.allow", input(true, false)).unwrap();
         assert!(
             !pluck_bool(&no_pop),
-            "without proof of control the pairwise rule must not fire, and the \
-             deprecated rule must not rescue it — neither party is a member"
+            "an attributed claim whose named parties are not members must be denied — \
+             the pairwise rule must not fire, and the attributed rule must not rescue it"
         );
 
         let not_a_member =

--- a/vtc-service/src/relationships/mod.rs
+++ b/vtc-service/src/relationships/mod.rs
@@ -1,4 +1,4 @@
-//! VRC (Verifiable Recognition Credential) trust-graph
+//! VRC (Verifiable Relationship Credential) trust-graph
 //! storage — Phase 4 M4.5. Spec §5.4 + §6.1.
 //!
 //! ## What this module owns

--- a/vtc-service/src/relationships/mod.rs
+++ b/vtc-service/src/relationships/mod.rs
@@ -51,7 +51,7 @@ use uuid::Uuid;
 
 pub use storage::{
     RELATIONSHIPS_BY_DID_PREFIX, RELATIONSHIPS_PREFIX, delete_relationship, find_by_hash,
-    get_relationship, list_all, list_for_did, store_relationship,
+    get_relationship, issuer_counterparties_besides, list_all, list_for_did, store_relationship,
 };
 
 /// A stored, verified VRC. Field order matches the spec §5.4

--- a/vtc-service/src/relationships/storage.rs
+++ b/vtc-service/src/relationships/storage.rs
@@ -248,7 +248,7 @@ mod tests {
             issuer_did: issuer.into(),
             subject_did: subject.into(),
             vrc_jsonld: serde_json::json!({
-                "type": ["VerifiableCredential", "VerifiableRecognitionCredential"],
+                "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
                 "issuer": issuer,
                 "credentialSubject": { "id": subject, "endorsement": { "type": "endorses" } }
             }),

--- a/vtc-service/src/relationships/storage.rs
+++ b/vtc-service/src/relationships/storage.rs
@@ -214,6 +214,53 @@ pub async fn list_for_did(
     paginate(hydrated, cursor, limit, &audit_key.key, snapshot_id, decode)
 }
 
+/// Counterparties this DID already has an edge to, as issuer, excluding
+/// `except_subject`.
+///
+/// Used to enforce the DTG Credentials requirement that an R-DID is unique per
+/// counterparty ("a new, unique R-DID for every single entity they connect
+/// with, even within the same community"). The community is the only party
+/// that can see a violation: each counterparty sees only its own edge.
+///
+/// Carries the same `did:webvh` prefix caveat as [`list_for_did`] — the index
+/// prefix `relationships_by_did:<did>:` also matches a longer DID that has
+/// `<did>` as a colon-delimited prefix, so rows are post-filtered on the
+/// decoded issuer.
+pub async fn issuer_counterparties_besides(
+    primary: &KeyspaceHandle,
+    index: &KeyspaceHandle,
+    issuer_did: &str,
+    except_subject: &str,
+) -> Result<Vec<String>, AppError> {
+    let mut index_prefix = RELATIONSHIPS_BY_DID_PREFIX.to_vec();
+    index_prefix.extend_from_slice(issuer_did.as_bytes());
+    index_prefix.push(b':');
+
+    let mut others = Vec::new();
+    for (idx_key, _) in index.prefix_iter_raw(index_prefix).await? {
+        let Ok(key_str) = std::str::from_utf8(&idx_key) else {
+            continue;
+        };
+        let Some(id_str) = key_str.rsplit(':').next() else {
+            continue;
+        };
+        let Ok(id) = Uuid::parse_str(id_str) else {
+            continue;
+        };
+        let Some(raw) = primary.get_raw(primary_key(id)).await? else {
+            continue;
+        };
+        if let Ok(rel) = decode(&raw)
+            && rel.issuer_did == issuer_did
+            && rel.subject_did != except_subject
+            && !others.contains(&rel.subject_did)
+        {
+            others.push(rel.subject_did);
+        }
+    }
+    Ok(others)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -872,6 +872,7 @@ async fn apply_profile_import(
         public_url: Some(incoming.public_url),
         contact_email: Some(incoming.contact_email),
         language: Some(incoming.language),
+        relationship_identifier_default: Some(incoming.relationship_identifier_default),
         extensions: Some(incoming.extensions),
     };
     let mut updated = current.clone();

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -270,7 +270,7 @@ pub async fn recognise(
 
 /// This VTC's own DID — the audience a recognise challenge is bound to and the
 /// `domain` the holder's VP must name.
-async fn vtc_did(state: &AppState) -> Result<String, AppError> {
+pub(crate) async fn vtc_did(state: &AppState) -> Result<String, AppError> {
     state
         .config
         .read()

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -5,14 +5,23 @@
 //! ## Three endpoints
 //!
 //! 1. `POST /v1/relationships` — publish a self-issued VRC.
-//!    Caller's session DID must equal the VC's `issuer`
-//!    field. The VTC verifies the data-integrity proof
-//!    against the member's resolved `#key-0`, runs
+//!    The VTC verifies the credential's data-integrity proof
+//!    against the key its `issuer` field names, then authorizes
+//!    the *publication* separately: either a publish
+//!    authorization proving the caller controls the issuing key
+//!    (see [`verify_publish_authorization`]), or — deprecated —
+//!    an `issuer` equal to the session DID. It then runs
 //!    `relationships.rego` against an enriched input
-//!    (`{ vrc, issuer_member: { did, is_current },
-//!        subject_member: { did, is_current }, action }`),
-//!    persists the row + secondary-index entries on allow,
-//!    emits `VrcPublished`.
+//!    (`{ vrc, authenticated_member: { did, is_current },
+//!        issuer: { did, pop_verified }, subject: { did },
+//!        action }`), persists the row + secondary-index
+//!    entries on allow, and emits `VrcPublished`.
+//!
+//!    Splitting issuance from publication is what lets a member
+//!    publish an edge under a pairwise relationship DID rather
+//!    than their membership DID — the privacy property DTG
+//!    Credentials asks for, and the subject of #1054. See
+//!    `docs/05-design-notes/vrc-publish-proof-of-possession.md`.
 //!
 //! 2. `GET /v1/members/{did}/relationships` — see
 //!    `src/routes/members/relationships.rs`. Owns its own
@@ -58,10 +67,18 @@ use crate::server::AppState;
 pub struct PublishBody {
     /// The self-issued VRC. Must be a JSON-LD VC body with
     /// `type` array including `VerifiableRecognitionCredential`,
-    /// an `issuer` field matching the caller's session DID,
-    /// `credentialSubject.id` naming the subject, and a
-    /// data-integrity proof.
+    /// an `issuer` field, `credentialSubject.id` naming the
+    /// subject, and a data-integrity proof.
     pub vrc: JsonValue,
+    /// Proof that the caller controls the key behind the VRC's
+    /// `issuer`, when that is not the caller's session DID —
+    /// i.e. whenever the credential is issued under a pairwise
+    /// relationship DID rather than the member's membership DID.
+    ///
+    /// See [`verify_publish_authorization`]. Required unless
+    /// `issuer` equals the session DID (the deprecated form).
+    #[serde(default)]
+    pub pop: Option<JsonValue>,
 }
 
 #[derive(Debug, Serialize)]
@@ -97,44 +114,129 @@ pub async fn publish(
     let issuer_did = extract_did_field(vrc, "issuer")?;
     let subject_did = extract_subject_id(vrc)?;
 
-    // 2. Caller == issuer check (D1: self-issued only).
-    if auth.did != issuer_did {
+    // 2. Cheapest authorization gate first: a VRC issued under a
+    //    DID that is not the session's must carry a publish
+    //    authorization. Rejecting here keeps a caller error a
+    //    caller error — the daemon-config prerequisites below
+    //    would otherwise mask it with a 500.
+    if body.pop.is_none() && issuer_did != auth.did {
         return Err(AppError::Forbidden(format!(
-            "session DID ({}) does not match VRC issuer ({issuer_did}) — \
-             VRCs are self-issued; the VTC never mints them on a member's behalf",
-            auth.did
+            "VRC issuer ({issuer_did}) is not the session DID and no publish \
+             authorization (`pop`) was supplied — a VRC issued under a \
+             relationship DID must carry proof the caller controls it"
         )));
     }
 
-    // 3. Verify the VC's data-integrity proof against the
-    //    issuer's resolved #key-0. Daemon-config prerequisites
-    //    surface after caller validation.
+    // 3. Verify the VC's data-integrity proof against the key
+    //    the `issuer` field names. This establishes that the
+    //    credential was made by the party it names as issuer —
+    //    true whatever kind of identifier that is, and untouched
+    //    by the authorization change below.
     let resolver = state.did_resolver.as_ref().cloned().ok_or_else(|| {
         AppError::Internal("DID resolver not configured — VRC publish requires it".into())
     })?;
-    verify_vc_proof(vrc, &issuer_did, &resolver)
+    verify_di_proof(vrc, &issuer_did, &resolver)
         .await
         .map_err(|e| AppError::Validation(format!("VrcProofInvalid: {e}")))?;
 
-    // 4. Enrich both parties with `is_current` for the policy
-    //    input. A member is `current` iff they have a live ACL
-    //    row + a non-tombstoned Member row.
+    // 4. Hash the VRC. This moves ahead of policy evaluation
+    //    because the publish authorization binds to it.
+    let canon = canonicalise(vrc);
+    let digest = Sha256::digest(canon.as_bytes());
+    let vrc_sha256 = hex::encode(digest);
+
+    // 5. Authorize the *publication*, which is a separate act
+    //    from the issuance verified at step 2. Issuing a VRC and
+    //    publishing it to the community graph are different
+    //    disclosures, and the second one is the issuer's to make:
+    //    without this, any member who was ever handed a VRC could
+    //    publish someone else's edge.
+    //
+    //    Previously this was `auth.did == issuer_did`, which
+    //    forced the member's membership DID into the durable,
+    //    publishable credential. The session proves membership;
+    //    the authorization object proves control of the issuing
+    //    key; neither requires them to be the same string (#1054).
+    let pop_verified = match (&body.pop, issuer_did == auth.did) {
+        (Some(pop), _) => {
+            let aud = crate::routes::recognise::vtc_did(&state).await?;
+            verify_publish_authorization(
+                pop,
+                &issuer_did,
+                &vrc_sha256,
+                &aud,
+                &auth.session_id,
+                &resolver,
+            )
+            .await
+            .map_err(|e| AppError::Forbidden(format!("VrcPublishAuthorizationInvalid: {e}")))?;
+            true
+        }
+        // Deprecated: issuer == session DID, no authorization
+        // object. Accepted for one release so existing clients
+        // keep working while they move to pairwise identifiers.
+        (None, true) => {
+            info!(
+                issuer = %issuer_did,
+                "VRC published under the session DID with no publish authorization — \
+                 deprecated; issue under a relationship DID and send `pop` instead"
+            );
+            false
+        }
+        // Rejected at step 2; restated rather than `unreachable!` so a
+        // future edit that moves the gate cannot turn a caller error into
+        // a panicking request handler.
+        (None, false) => {
+            return Err(AppError::Forbidden(
+                "VRC issuer is not the session DID and no publish authorization \
+                 (`pop`) was supplied"
+                    .into(),
+            ));
+        }
+    };
+
+    // 6. Enrich for the policy input.
+    //
+    //    `authenticated_member` is the caller — the party whose
+    //    membership actually gates this publish. `issuer` and
+    //    `subject` are the credential's own parties, which under
+    //    pairwise identifiers are not resolvable to members and
+    //    are not meant to be.
+    //
+    //    `issuer_member` / `subject_member` are retained for
+    //    operator-authored policies written against the old
+    //    shape. For a pairwise VRC both report `is_current:
+    //    false`, so an un-updated operator policy *denies* the
+    //    publish. That is deliberate: a policy someone wrote is
+    //    not silently loosened by this change.
+    let member_current = is_current_member(&state, &auth.did).await?;
     let issuer_current = is_current_member(&state, &issuer_did).await?;
     let subject_current = is_current_member(&state, &subject_did).await?;
-    if !subject_current {
-        // Subject must at least exist (resolvable); the default
-        // policy refuses if either party isn't current, but
-        // we surface the more specific "subject unknown" 422
-        // before falling through to the generic policy 403.
-        if get_acl_entry(&state.acl_ks, &subject_did).await?.is_none() {
-            return Err(AppError::Validation(format!(
-                "subject DID {subject_did} is not a current community member"
-            )));
-        }
+
+    // The subject membership check only asks an answerable
+    // question on the deprecated form, where the subject is named
+    // by a membership DID. Under pairwise identifiers it is not
+    // just unanswerable but the wrong question: DTG Credentials
+    // §Community-Anchored ZKP is explicit that "community
+    // membership is not a precondition for issuing, holding, or
+    // presenting a VRC". The subject's consent to the edge is
+    // their publication of the reciprocal VRC, not our assertion
+    // that they exist.
+    if !pop_verified
+        && !subject_current
+        && get_acl_entry(&state.acl_ks, &subject_did).await?.is_none()
+    {
+        return Err(AppError::Validation(format!(
+            "subject DID {subject_did} is not a current community member"
+        )));
     }
 
     let policy_input = json!({
         "vrc": vrc,
+        "authenticated_member": { "did": auth.did, "is_current": member_current },
+        "issuer": { "did": issuer_did, "pop_verified": pop_verified },
+        "subject": { "did": subject_did },
+        // Deprecated shape — see above.
         "issuer_member": { "did": issuer_did, "is_current": issuer_current },
         "subject_member": { "did": subject_did, "is_current": subject_current },
         "action": "publish",
@@ -146,12 +248,7 @@ pub async fn publish(
         ));
     }
 
-    // 5. Compute hash for idempotent re-publish.
-    let canon = canonicalise(vrc);
-    let digest = Sha256::digest(canon.as_bytes());
-    let vrc_sha256 = hex::encode(digest);
-
-    // 6. Idempotency: same hash → same id.
+    // 7. Idempotency: same hash → same id.
     if let Some(existing) = find_by_hash(&state.relationships_ks, &vrc_sha256).await? {
         return Ok((
             StatusCode::OK,
@@ -164,7 +261,7 @@ pub async fn publish(
         ));
     }
 
-    // 7. Store the row + secondary-index entries.
+    // 8. Store the row + secondary-index entries.
     let id = Uuid::new_v4();
     let rel = Relationship {
         id,
@@ -181,7 +278,7 @@ pub async fn publish(
     )
     .await?;
 
-    // 8. Audit.
+    // 9. Audit.
     let edge_type = vrc
         .pointer("/credentialSubject/endorsement/type")
         .and_then(|v| v.as_str())
@@ -309,18 +406,111 @@ fn extract_subject_id(vrc: &JsonValue) -> Result<String, AppError> {
         })
 }
 
-/// Verify a VRC's data-integrity proof: bind the proof's `verificationMethod`
-/// to the issuer, then let the DI library resolve the key (via the shared
-/// [`DidVmResolver`]) and check the signature — the same path the
-/// credential-exchange + recognition verifiers take.
-async fn verify_vc_proof(
-    vrc: &JsonValue,
+/// `type` of the publish authorization object. Guarding on it stops a
+/// signature the member made over some *other* object being replayed here as
+/// authorization to publish.
+const PUBLISH_AUTHORIZATION_TYPE: &str = "VrcPublishAuthorization";
+
+/// How stale a publish authorization may be. Bounds replay inside a live
+/// session; the same tolerance is allowed for clock skew in either direction.
+const PUBLISH_AUTHORIZATION_MAX_AGE_SECS: i64 = 300;
+
+/// Verify a publish authorization: proof that the caller controls the key
+/// behind the VRC's `issuer`, bound to this request.
+///
+/// The session proves the caller is a community member. This proves the caller
+/// is the issuer of the credential being published. Keeping the two separate is
+/// what lets a member publish an edge under a pairwise relationship DID without
+/// putting their membership DID into the credential (#1054) — the VTC learns
+/// that *a* member published this edge, not which member is behind the
+/// relationship DID.
+///
+/// Every field is load-bearing:
+///
+/// | field       | prevents                                              |
+/// |-------------|-------------------------------------------------------|
+/// | `type`      | replaying a signature made over some other object     |
+/// | `vrc`       | authorizing a different credential                    |
+/// | `aud`       | replaying an authorization at another community       |
+/// | `sessionId` | replaying another member's authorization              |
+/// | `issuedAt`  | unbounded replay within one live session              |
+///
+/// **The object is verified and dropped.** It carries `sessionId`, which is
+/// attributable to a membership DID; persisting or logging it would rebuild
+/// exactly the durable membership-to-relationship linkage that publishing under
+/// a pairwise identifier exists to remove. See
+/// `docs/05-design-notes/vrc-publish-proof-of-possession.md`.
+async fn verify_publish_authorization(
+    pop: &JsonValue,
     issuer_did: &str,
+    expected_vrc_sha256: &str,
+    expected_aud: &str,
+    expected_session_id: &str,
     resolver: &DIDCacheClient,
 ) -> Result<(), String> {
+    let field = |name: &str| -> Result<String, String> {
+        pop.get(name)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| format!("authorization missing `{name}`"))
+    };
+
+    let ty = field("type")?;
+    if ty != PUBLISH_AUTHORIZATION_TYPE {
+        return Err(format!(
+            "authorization `type` must be `{PUBLISH_AUTHORIZATION_TYPE}`, got `{ty}`"
+        ));
+    }
+
+    let bound_vrc = field("vrc")?;
+    if bound_vrc != expected_vrc_sha256 {
+        return Err("authorization is bound to a different VRC".into());
+    }
+
+    let aud = field("aud")?;
+    if aud != expected_aud {
+        return Err("authorization `aud` is not this community".into());
+    }
+
+    let session_id = field("sessionId")?;
+    if session_id != expected_session_id {
+        return Err("authorization is bound to a different session".into());
+    }
+
+    let issued_at = chrono::DateTime::parse_from_rfc3339(&field("issuedAt")?)
+        .map_err(|e| format!("authorization `issuedAt` is not an RFC 3339 timestamp: {e}"))?
+        .with_timezone(&Utc);
+    let age = Utc::now().signed_duration_since(issued_at).num_seconds();
+    if age.abs() > PUBLISH_AUTHORIZATION_MAX_AGE_SECS {
+        return Err(format!(
+            "authorization `issuedAt` is outside the \
+             {PUBLISH_AUTHORIZATION_MAX_AGE_SECS}s freshness window (age {age}s)"
+        ));
+    }
+
+    // Signed by the key the VRC's `issuer` names. `check_issuer_binding`
+    // inside `verify_di_proof` is what makes this proof-of-possession rather
+    // than proof-of-anything-signed.
+    verify_di_proof(pop, issuer_did, resolver).await
+}
+
+/// Verify a data-integrity proof on a JSON document: bind the proof's
+/// `verificationMethod` to the named controller, then let the DI library
+/// resolve the key (via the shared [`DidVmResolver`]) and check the signature —
+/// the same path the credential-exchange + recognition verifiers take.
+///
+/// Used for both the VRC itself (controller = the credential's `issuer`) and
+/// the publish authorization object (controller = the same issuer, proving the
+/// caller holds the key rather than merely holding the credential).
+async fn verify_di_proof(
+    doc: &JsonValue,
+    controller_did: &str,
+    resolver: &DIDCacheClient,
+) -> Result<(), String> {
+    let vrc = doc;
     let proof_value = vrc
         .get("proof")
-        .ok_or_else(|| "VRC missing proof".to_string())?;
+        .ok_or_else(|| "document missing proof".to_string())?;
     let proof: DataIntegrityProof =
         serde_json::from_value(proof_value.clone()).map_err(|e| format!("parse proof: {e}"))?;
 
@@ -328,7 +518,7 @@ async fn verify_vc_proof(
         .get("verificationMethod")
         .and_then(|v| v.as_str())
         .ok_or_else(|| "proof missing verificationMethod".to_string())?;
-    check_issuer_binding(verification_method, issuer_did).map_err(|e| e.to_string())?;
+    check_issuer_binding(verification_method, controller_did).map_err(|e| e.to_string())?;
 
     let mut vrc_without_proof = vrc.clone();
     if let Some(obj) = vrc_without_proof.as_object_mut() {

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -1,4 +1,4 @@
-//! VRC (Verifiable Recognition Credential) graph endpoints
+//! VRC (Verifiable Relationship Credential) graph endpoints
 //! — Phase 4 M4.6. Spec §5.4 + §6.1; planning-review D1
 //! (issuer is the *member*, not the community).
 //!
@@ -65,10 +65,13 @@ use crate::server::AppState;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct PublishBody {
-    /// The self-issued VRC. Must be a JSON-LD VC body with
-    /// `type` array including `VerifiableRecognitionCredential`,
-    /// an `issuer` field, `credentialSubject.id` naming the
-    /// subject, and a data-integrity proof.
+    /// The self-issued VRC, in the DTG Credentials wire form:
+    /// `@context` carrying the W3C v2 and DTG contexts, `type`
+    /// `["VerifiableCredential", "DTGCredential",
+    /// "RelationshipCredential"]`, an `issuer`,
+    /// `credentialSubject.id` naming the subject, and a
+    /// data-integrity proof. Built by
+    /// `dtg_credentials::DTGCredential::new_vrc`.
     pub vrc: JsonValue,
     /// Proof that the caller controls the key behind the VRC's
     /// `issuer`, when that is not the caller's session DID —
@@ -114,7 +117,12 @@ pub async fn publish(
     let issuer_did = extract_did_field(vrc, "issuer")?;
     let subject_did = extract_subject_id(vrc)?;
 
-    // 2. Cheapest authorization gate first: a VRC issued under a
+    // 2. Shape: is this even a relationship credential? Checked
+    //    before anything expensive, and before authorization,
+    //    because a malformed body is a 400 whoever sent it.
+    check_vrc_shape(vrc)?;
+
+    // 3. Cheapest authorization gate first: a VRC issued under a
     //    DID that is not the session's must carry a publish
     //    authorization. Rejecting here keeps a caller error a
     //    caller error — the daemon-config prerequisites below
@@ -127,7 +135,7 @@ pub async fn publish(
         )));
     }
 
-    // 3. Verify the VC's data-integrity proof against the key
+    // 4. Verify the VC's data-integrity proof against the key
     //    the `issuer` field names. This establishes that the
     //    credential was made by the party it names as issuer —
     //    true whatever kind of identifier that is, and untouched
@@ -139,13 +147,13 @@ pub async fn publish(
         .await
         .map_err(|e| AppError::Validation(format!("VrcProofInvalid: {e}")))?;
 
-    // 4. Hash the VRC. This moves ahead of policy evaluation
+    // 5. Hash the VRC. This moves ahead of policy evaluation
     //    because the publish authorization binds to it.
     let canon = canonicalise(vrc);
     let digest = Sha256::digest(canon.as_bytes());
     let vrc_sha256 = hex::encode(digest);
 
-    // 5. Authorize the *publication*, which is a separate act
+    // 6. Authorize the *publication*, which is a separate act
     //    from the issuance verified at step 2. Issuing a VRC and
     //    publishing it to the community graph are different
     //    disclosures, and the second one is the issuer's to make:
@@ -195,7 +203,7 @@ pub async fn publish(
         }
     };
 
-    // 6. Enrich for the policy input.
+    // 7. Enrich for the policy input.
     //
     //    `authenticated_member` is the caller — the party whose
     //    membership actually gates this publish. `issuer` and
@@ -248,7 +256,7 @@ pub async fn publish(
         ));
     }
 
-    // 7. Idempotency: same hash → same id.
+    // 8. Idempotency: same hash → same id.
     if let Some(existing) = find_by_hash(&state.relationships_ks, &vrc_sha256).await? {
         return Ok((
             StatusCode::OK,
@@ -261,7 +269,7 @@ pub async fn publish(
         ));
     }
 
-    // 8. Store the row + secondary-index entries.
+    // 9. Store the row + secondary-index entries.
     let id = Uuid::new_v4();
     let rel = Relationship {
         id,
@@ -278,7 +286,7 @@ pub async fn publish(
     )
     .await?;
 
-    // 9. Audit.
+    // 10. Audit.
     let edge_type = vrc
         .pointer("/credentialSubject/endorsement/type")
         .and_then(|v| v.as_str())
@@ -404,6 +412,61 @@ fn extract_subject_id(vrc: &JsonValue) -> Result<String, AppError> {
         .ok_or_else(|| {
             AppError::Validation("VRC.credentialSubject.id missing or not a string".into())
         })
+}
+
+/// The two `@context` entries every DTG credential MUST carry
+/// (DTG Credentials §Common Structure — normative).
+const DTG_CONTEXTS: [&str; 2] = [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://firstperson.network/credentials/dtg/v1",
+];
+
+/// Reject anything that is not a conformant VRC before it becomes an edge in
+/// the community's trust graph.
+///
+/// The VTC does not mint VRCs — they are self-issued — but it decides what
+/// enters the graph, and an edge is only interpretable if it says what it is.
+/// Until this existed the publish path never looked at `type` at all, so any
+/// signed JSON with an `issuer` and a `credentialSubject.id` could be stored as
+/// a relationship.
+///
+/// Classification goes through `dtg_credentials`, the same catalog
+/// `DTGCredential::new_vrc` mints from, rather than string-matching here — one
+/// definition of the wire form, shared by issuer and verifier.
+fn check_vrc_shape(vrc: &JsonValue) -> Result<(), AppError> {
+    let ctx: Vec<String> = vrc
+        .get("@context")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or_else(|| AppError::Validation("VRC `@context` missing or not an array".into()))?;
+    for required in DTG_CONTEXTS {
+        if !ctx.iter().any(|c| c == required) {
+            return Err(AppError::Validation(format!(
+                "VRC `@context` must include `{required}`"
+            )));
+        }
+    }
+
+    let types: Vec<String> = vrc
+        .get("type")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or_else(|| AppError::Validation("VRC `type` missing or not an array".into()))?;
+    for required in ["VerifiableCredential", "DTGCredential"] {
+        if !types.iter().any(|t| t == required) {
+            return Err(AppError::Validation(format!(
+                "VRC `type` must include `{required}`"
+            )));
+        }
+    }
+
+    match dtg_credentials::DTGCredentialType::try_from(types.as_slice()) {
+        Ok(dtg_credentials::DTGCredentialType::Relationship) => Ok(()),
+        Ok(other) => Err(AppError::Validation(format!(
+            "this endpoint publishes relationship edges; got a {other}"
+        ))),
+        Err(_) => Err(AppError::Validation(
+            "VRC `type` names no DTG credential subtype — expected `RelationshipCredential`".into(),
+        )),
+    }
 }
 
 /// `type` of the publish authorization object. Guarding on it stops a

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -361,6 +361,35 @@ pub async fn publish(
     .await?;
 
     // 10. Audit.
+    //
+    //    The actor is the **authenticated member**, not the VRC's
+    //    issuer. Under the pairwise form those differ, and the
+    //    issuing relationship DID names nobody — recording it as
+    //    the actor would leave the trail unable to answer "which
+    //    member published this edge" for anyone, at any access
+    //    level, ever.
+    //
+    //    This is a deliberate, narrow exception to the rule that
+    //    the membership-to-relationship linkage must not be
+    //    persisted, and it is confined to the one store built to
+    //    hold privileged records: the audit envelope HMACs the
+    //    actor under a rotating key, keeps the plaintext in a
+    //    field that RTBF can null without breaking the
+    //    tamper-evidence chain, and is admin-gated. What #1054
+    //    set out to remove was *public, permanent, unavoidable*
+    //    correlation — a membership DID welded into a credential
+    //    anyone can retain and republish. Accountability inside
+    //    an access-controlled, redactable, tamper-evident log is
+    //    a different thing, and giving it up would buy nothing:
+    //    `vrc_id` resolves to the row, and the row holds the
+    //    relationship DIDs, so any trail that references the edge
+    //    and names the member creates the mapping regardless.
+    //
+    //    The residual is real and worth stating: an operator with
+    //    audit access can map every pairwise edge to its member.
+    //    The `info!` below deliberately does *not* carry the
+    //    member — logs have neither the redaction machinery nor
+    //    the access controls that make this trade defensible.
     let edge_type = vrc
         .pointer("/credentialSubject/endorsement/type")
         .and_then(|v| v.as_str())
@@ -369,7 +398,7 @@ pub async fn publish(
     if let Some(writer) = state.audit_writer.as_ref() {
         writer
             .write(
-                &issuer_did,
+                &auth.did,
                 Some(&subject_did),
                 AuditEvent::VrcPublished(VrcPublishedData {
                     vrc_id: id.to_string(),

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -13,7 +13,7 @@
 //!    an `issuer` equal to the session DID. It then runs
 //!    `relationships.rego` against an enriched input
 //!    (`{ vrc, authenticated_member: { did, is_current },
-//!        issuer: { did, pop_verified }, subject: { did },
+//!        identifier_form, issuer: { did }, subject: { did },
 //!        action }`), persists the row + secondary-index
 //!    entries on allow, and emits `VrcPublished`.
 //!
@@ -57,11 +57,36 @@ use crate::policy::{
     get_policy,
 };
 use crate::relationships::{
-    Relationship, delete_relationship, find_by_hash, get_relationship, store_relationship,
+    Relationship, delete_relationship, find_by_hash, get_relationship,
+    issuer_counterparties_besides, store_relationship,
 };
 use crate::server::AppState;
 
 // ─── Publish ─────────────────────────────────────────────
+
+/// Which kind of identifier a VRC is issued under. A member picks per
+/// relationship; the community declares which it expects (see the community
+/// profile's `relationshipIdentifierDefault`). Both are permanent, supported
+/// forms — neither is a migration state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentifierForm {
+    /// Issued under the member's membership DID. The edge names them and the
+    /// graph is correlatable by design — what a public community wants.
+    Attributed,
+    /// Issued under a relationship DID scoped to one counterparty, with a
+    /// publish authorization proving control of it.
+    Pairwise,
+}
+
+impl IdentifierForm {
+    /// Wire value, and the string operator policies match on.
+    fn as_str(self) -> &'static str {
+        match self {
+            IdentifierForm::Attributed => "attributed",
+            IdentifierForm::Pairwise => "pairwise",
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct PublishBody {
@@ -165,7 +190,25 @@ pub async fn publish(
     //    publishable credential. The session proves membership;
     //    the authorization object proves control of the issuing
     //    key; neither requires them to be the same string (#1054).
-    let pop_verified = match (&body.pop, issuer_did == auth.did) {
+    //    A member chooses this per relationship. Both forms are
+    //    first-class and permanent — neither is a migration
+    //    state:
+    //
+    //    **attributed** — the VRC is issued under the member's
+    //    own membership DID. The edge names them, and the graph
+    //    is correlatable by design. This is what a public
+    //    community wants; DTG Credentials permits it directly
+    //    ("the member may also assert the M-DID in any VRC where
+    //    the member wishes to assert a VTC relationship").
+    //
+    //    **pairwise** — the VRC is issued under a relationship
+    //    DID scoped to this counterparty, and the authorization
+    //    object proves the caller controls it.
+    //
+    //    The community declares which it expects; the member
+    //    decides each time. Only the *claim* is enforced here —
+    //    see the uniqueness check below.
+    let identifier_form = match (&body.pop, issuer_did == auth.did) {
         (Some(pop), _) => {
             let aud = crate::routes::recognise::vtc_did(&state).await?;
             verify_publish_authorization(
@@ -178,19 +221,9 @@ pub async fn publish(
             )
             .await
             .map_err(|e| AppError::Forbidden(format!("VrcPublishAuthorizationInvalid: {e}")))?;
-            true
+            IdentifierForm::Pairwise
         }
-        // Deprecated: issuer == session DID, no authorization
-        // object. Accepted for one release so existing clients
-        // keep working while they move to pairwise identifiers.
-        (None, true) => {
-            info!(
-                issuer = %issuer_did,
-                "VRC published under the session DID with no publish authorization — \
-                 deprecated; issue under a relationship DID and send `pop` instead"
-            );
-            false
-        }
+        (None, true) => IdentifierForm::Attributed,
         // Rejected at step 2; restated rather than `unreachable!` so a
         // future edit that moves the gate cannot turn a caller error into
         // a panicking request handler.
@@ -202,6 +235,42 @@ pub async fn publish(
             ));
         }
     };
+
+    //    An identifier presented as pairwise must actually be
+    //    pairwise. DTG Credentials: "each entity MUST generate a
+    //    new, unique R-DID for every single entity they connect
+    //    with, even within the same community."
+    //
+    //    This is type integrity, not a privacy policy, which is
+    //    why it is unconditional rather than something a
+    //    community can switch off. A verifier reading a pairwise
+    //    edge is entitled to conclude the identifier says nothing
+    //    beyond that one relationship; a reused R-DID breaks that
+    //    inference for every reader of the graph, not just for
+    //    the member who reused it. A member who wants to be
+    //    recognised across their relationships has a supported
+    //    way to do it — the attributed form above.
+    //
+    //    The community is the only party that can see the
+    //    violation: each counterparty sees only its own edge.
+    if identifier_form == IdentifierForm::Pairwise {
+        let others = issuer_counterparties_besides(
+            &state.relationships_ks,
+            &state.relationships_by_did_ks,
+            &issuer_did,
+            &subject_did,
+        )
+        .await?;
+        if !others.is_empty() {
+            return Err(AppError::Validation(format!(
+                "relationship DID {issuer_did} already has an edge to {} other \
+                 counterpart(y|ies) — a relationship DID must be unique to one \
+                 counterparty. Mint a new one for this relationship, or issue \
+                 under your membership DID to publish an attributed edge",
+                others.len()
+            )));
+        }
+    }
 
     // 7. Enrich for the policy input.
     //
@@ -230,7 +299,7 @@ pub async fn publish(
     // presenting a VRC". The subject's consent to the edge is
     // their publication of the reciprocal VRC, not our assertion
     // that they exist.
-    if !pop_verified
+    if identifier_form == IdentifierForm::Attributed
         && !subject_current
         && get_acl_entry(&state.acl_ks, &subject_did).await?.is_none()
     {
@@ -242,7 +311,12 @@ pub async fn publish(
     let policy_input = json!({
         "vrc": vrc,
         "authenticated_member": { "did": auth.did, "is_current": member_current },
-        "issuer": { "did": issuer_did, "pop_verified": pop_verified },
+        "identifier_form": identifier_form.as_str(),
+        "issuer": {
+            "did": issuer_did,
+            // Retained: `pairwise` implies the authorization was verified.
+            "pop_verified": identifier_form == IdentifierForm::Pairwise,
+        },
         "subject": { "did": subject_did },
         // Deprecated shape — see above.
         "issuer_member": { "did": issuer_did, "is_current": issuer_current },

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -759,6 +759,49 @@ mod pairwise {
         assert!(saw_publish, "expected a VrcPublished audit entry");
     }
 
+    /// Option B on #1061: the audit trail attributes a publication to the
+    /// **member**, not to the relationship DID that issued the credential.
+    ///
+    /// Recording the issuing R-DID as the actor would leave the trail unable
+    /// to answer "which member published this edge" for anyone, at any access
+    /// level. The linkage is confined to the audit store — HMAC'd actor,
+    /// RTBF-nullable plaintext, admin-gated — and deliberately kept out of the
+    /// credential, the stored row, and the logs.
+    #[tokio::test]
+    async fn audit_attributes_the_publication_to_the_member_not_the_relationship_did() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::CREATED
+        );
+
+        let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+        let mut saw = false;
+        for (_k, raw) in pairs {
+            let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+            if matches!(env.event, AuditEvent::VrcPublished(_)) {
+                saw = true;
+                assert_eq!(
+                    env.actor_did_plain.as_deref(),
+                    Some(did_for(MEMBER).as_str()),
+                    "the actor must be the authenticated member"
+                );
+                assert_ne!(
+                    env.actor_did_plain.as_deref(),
+                    Some(did_for(RDID).as_str()),
+                    "the relationship DID names nobody and must not be the actor"
+                );
+            }
+        }
+        assert!(saw, "expected a VrcPublished audit entry");
+    }
+
     /// Membership is not a precondition for a VRC — DTG Credentials
     /// §Community-Anchored ZKP. The subject's consent is their own reciprocal
     /// VRC, not our roster.

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -481,3 +481,411 @@ async fn list_keeps_rows_for_tombstoned_other_party() {
         "Tombstoned subject keeps the edge visible: {v}"
     );
 }
+
+// ─── Publish under a pairwise relationship DID ────────────
+//
+// The credential's `issuer` is a relationship DID that belongs
+// to no member. Membership comes from the session; control of
+// the issuing key comes from a publish authorization bound to
+// this request. See
+// `docs/05-design-notes/vrc-publish-proof-of-possession.md`.
+
+mod pairwise {
+    use super::*;
+    use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
+    use ed25519_dalek::SigningKey;
+    use vtc_service::test_support::{TEST_VTC_DID, TestVtc};
+
+    /// Seeds: `MEMBER` joins the community; `RDID` is the pairwise
+    /// identifier they issue the VRC under; `OTHER` is an unrelated key
+    /// used to forge authorizations.
+    const MEMBER: u8 = 0x41;
+    const RDID: u8 = 0x42;
+    const PEER_RDID: u8 = 0x43;
+    const OTHER: u8 = 0x44;
+
+    fn did_for(seed: u8) -> String {
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(
+            &SigningKey::from_bytes(&[seed; 32])
+                .verifying_key()
+                .to_bytes(),
+        )
+    }
+
+    fn secret_for(seed: u8) -> affinidi_secrets_resolver::secrets::Secret {
+        let did = did_for(seed);
+        let vm = format!("{did}#{}", did.strip_prefix("did:key:").unwrap());
+        affinidi_secrets_resolver::secrets::Secret::generate_ed25519(Some(&vm), Some(&[seed; 32]))
+    }
+
+    /// Attach an `eddsa-jcs-2022` data-integrity proof signed by `seed`.
+    async fn sign(seed: u8, mut doc: Value) -> Value {
+        let proof = DataIntegrityProof::sign(
+            &doc,
+            &secret_for(seed),
+            SignOptions::new()
+                .with_proof_purpose("assertionMethod")
+                .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+        )
+        .await
+        .unwrap();
+        doc["proof"] = serde_json::to_value(&proof).unwrap();
+        doc
+    }
+
+    async fn vrc(issuer_seed: u8, subject_seed: u8) -> Value {
+        sign(
+            issuer_seed,
+            json!({
+                "@context": ["https://www.w3.org/ns/credentials/v2"],
+                "type": ["VerifiableCredential", "VerifiableRecognitionCredential"],
+                "issuer": did_for(issuer_seed),
+                "validFrom": "2020-01-01T00:00:00Z",
+                "credentialSubject": {
+                    "id": did_for(subject_seed),
+                    "endorsement": { "type": "endorses" }
+                },
+            }),
+        )
+        .await
+    }
+
+    struct Pw {
+        router: axum::Router,
+        token: String,
+        session_id: String,
+        relationships_ks: vti_common::store::KeyspaceHandle,
+        audit_ks: vti_common::store::KeyspaceHandle,
+        _vtc: TestVtc,
+    }
+
+    /// A live `did:key` resolver (purely computational — no network) plus one
+    /// current member whose session we publish under.
+    async fn fixture() -> Pw {
+        let vtc = TestVtc::builder()
+            .with_audit(true)
+            .with_signers(true)
+            .with_did_resolver(true)
+            .build()
+            .await;
+
+        vtc_service::policy::default::install_defaults(
+            &vtc.state.policies_ks,
+            &vtc.state.active_policies_ks,
+        )
+        .await
+        .unwrap();
+
+        let now = now_epoch();
+        let member = did_for(MEMBER);
+        store_acl_entry(
+            &vtc.state.acl_ks,
+            &VtcAclEntry {
+                did: member.clone(),
+                role: VtcRole::Member,
+                label: None,
+                allowed_contexts: vec![],
+                created_at: now,
+                created_by: "did:key:vtc-install".into(),
+                updated_at: None,
+                updated_by: None,
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+        store_member(&vtc.state.members_ks, &Member::fresh(&member))
+            .await
+            .unwrap();
+
+        let session_id = format!("sess-{}", Uuid::new_v4());
+        store_session(
+            &vtc.state.sessions_ks,
+            &Session {
+                session_id: session_id.clone(),
+                did: member.clone(),
+                challenge: "test".into(),
+                state: SessionState::Authenticated,
+                created_at: now,
+                last_seen: now,
+                refresh_token: None,
+                refresh_expires_at: None,
+                tee_attested: false,
+                amr: Vec::new(),
+                acr: String::new(),
+                acr_expires_at: None,
+                token_id: None,
+                session_pubkey_b58btc: None,
+            },
+        )
+        .await
+        .unwrap();
+        let claims = vtc.jwt_keys.new_claims(
+            member,
+            session_id.clone(),
+            "reader".into(),
+            vec![],
+            3600,
+            true,
+        );
+        let token = vtc.jwt_keys.encode(&claims).unwrap();
+
+        Pw {
+            router: vtc.router.clone(),
+            token,
+            session_id,
+            relationships_ks: vtc.state.relationships_ks.clone(),
+            audit_ks: vtc.state.audit_ks.clone(),
+            _vtc: vtc,
+        }
+    }
+
+    fn sha256_hex(v: &Value) -> String {
+        use sha2::{Digest, Sha256};
+        // Mirrors the handler's `canonicalise`: recursive key sort.
+        fn sorted(v: Value) -> Value {
+            match v {
+                Value::Object(m) => serde_json::to_value(
+                    m.into_iter()
+                        .map(|(k, val)| (k, sorted(val)))
+                        .collect::<std::collections::BTreeMap<_, _>>(),
+                )
+                .unwrap(),
+                Value::Array(a) => Value::Array(a.into_iter().map(sorted).collect()),
+                other => other,
+            }
+        }
+        hex::encode(Sha256::digest(sorted(v.clone()).to_string().as_bytes()))
+    }
+
+    /// A well-formed publish authorization, before signing.
+    fn authorization(vrc_hash: &str, aud: &str, session_id: &str) -> Value {
+        json!({
+            "type": "VrcPublishAuthorization",
+            "vrc": vrc_hash,
+            "aud": aud,
+            "sessionId": session_id,
+            "issuedAt": chrono::Utc::now().to_rfc3339(),
+        })
+    }
+
+    async fn post(fix: &Pw, vrc: &Value, pop: Option<Value>) -> axum::response::Response {
+        let mut body = json!({ "vrc": vrc });
+        if let Some(p) = pop {
+            body["pop"] = p;
+        }
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/relationships")
+            .header("authorization", format!("Bearer {}", fix.token))
+            .header("trust-task", PUBLISH_TASK)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        fix.router.clone().oneshot(req).await.unwrap()
+    }
+
+    /// The happy path #1054 exists to enable: the published row names only
+    /// pairwise identifiers, and the member's own DID appears nowhere in it.
+    #[tokio::test]
+    async fn publishes_under_a_relationship_did() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+
+        let (status, body) = body_value(post(&fix, &v, Some(pop)).await).await;
+        assert_eq!(status, StatusCode::CREATED, "body: {body}");
+        assert_eq!(body["issuerDid"], did_for(RDID));
+        assert_eq!(body["subjectDid"], did_for(PEER_RDID));
+
+        // The stored row must carry no trace of the publishing member.
+        let rows = vtc_service::relationships::list_all(&fix.relationships_ks)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        let stored = serde_json::to_string(&rows[0].vrc_jsonld).unwrap();
+        assert_eq!(rows[0].issuer_did, did_for(RDID));
+        assert!(
+            !stored.contains(&did_for(MEMBER)),
+            "membership DID leaked into the stored VRC"
+        );
+        assert!(
+            !stored.contains(&fix.session_id),
+            "session id leaked into the stored VRC — this is the linkage the \
+             pairwise identifier exists to remove"
+        );
+    }
+
+    /// The authorization is verified and dropped. If it ever reaches the audit
+    /// store, the membership-DID-to-relationship-DID linkage becomes durable
+    /// and the privacy property is lost — silently.
+    #[tokio::test]
+    async fn authorization_is_never_persisted_to_the_audit_trail() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::CREATED
+        );
+
+        let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();
+        let mut saw_publish = false;
+        for (_k, raw) in pairs {
+            let blob = String::from_utf8_lossy(&raw);
+            assert!(
+                !blob.contains(&fix.session_id),
+                "session id reached the audit store"
+            );
+            let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+            if matches!(env.event, AuditEvent::VrcPublished(_)) {
+                saw_publish = true;
+            }
+        }
+        assert!(saw_publish, "expected a VrcPublished audit entry");
+    }
+
+    /// Membership is not a precondition for a VRC — DTG Credentials
+    /// §Community-Anchored ZKP. The subject's consent is their own reciprocal
+    /// VRC, not our roster.
+    #[tokio::test]
+    async fn subject_need_not_be_a_member() {
+        let fix = fixture().await;
+        let v = vrc(RDID, OTHER).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        let (status, body) = body_value(post(&fix, &v, Some(pop)).await).await;
+        assert_eq!(status, StatusCode::CREATED, "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn same_vrc_twice_is_idempotent() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let mk = || async {
+            sign(
+                RDID,
+                authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+            )
+            .await
+        };
+        let (s1, b1) = body_value(post(&fix, &v, Some(mk().await)).await).await;
+        let (s2, b2) = body_value(post(&fix, &v, Some(mk().await)).await).await;
+        assert_eq!(s1, StatusCode::CREATED);
+        assert_eq!(s2, StatusCode::OK);
+        assert_eq!(b1["id"], b2["id"]);
+    }
+
+    // ─── Every field of the authorization is load-bearing ───
+
+    #[tokio::test]
+    async fn rejects_missing_authorization() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        assert_eq!(post(&fix, &v, None).await.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Holding the credential is not controlling the key behind it. This is
+    /// the property the old `auth.did == issuer` pin provided.
+    #[tokio::test]
+    async fn rejects_authorization_signed_by_another_key() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let mut pop = authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id);
+        // Signed by OTHER, but claiming to authorize RDID's credential.
+        pop = sign(OTHER, pop).await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_authorization_bound_to_a_different_vrc() {
+        let fix = fixture().await;
+        let target = vrc(RDID, PEER_RDID).await;
+        let decoy = vrc(RDID, OTHER).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&decoy), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &target, Some(pop)).await.status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_authorization_from_another_session() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, "sess-someone-else"),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_authorization_for_another_community() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(
+                &sha256_hex(&v),
+                "did:webvh:other-vtc.example:xyz",
+                &fix.session_id,
+            ),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_stale_authorization() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let mut a = authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id);
+        a["issuedAt"] = json!((chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339());
+        let pop = sign(RDID, a).await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    /// A signature the member legitimately made over some *other* object must
+    /// not be replayable here as authorization to publish.
+    #[tokio::test]
+    async fn rejects_authorization_of_the_wrong_type() {
+        let fix = fixture().await;
+        let v = vrc(RDID, PEER_RDID).await;
+        let mut a = authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id);
+        a["type"] = json!("SomeOtherSignedThing");
+        let pop = sign(RDID, a).await;
+        assert_eq!(
+            post(&fix, &v, Some(pop)).await.status(),
+            StatusCode::FORBIDDEN
+        );
+    }
+}

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -186,8 +186,11 @@ async fn build_fixture() -> Fixture {
 
 fn fake_vrc(issuer: &str, subject: &str) -> Value {
     json!({
-        "@context": ["https://www.w3.org/ns/credentials/v2"],
-        "type": ["VerifiableCredential", "VerifiableRecognitionCredential"],
+        "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://firstperson.network/credentials/dtg/v1"
+        ],
+        "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
         "issuer": issuer,
         "credentialSubject": {
             "id": subject,
@@ -537,8 +540,11 @@ mod pairwise {
         sign(
             issuer_seed,
             json!({
-                "@context": ["https://www.w3.org/ns/credentials/v2"],
-                "type": ["VerifiableCredential", "VerifiableRecognitionCredential"],
+                "@context": [
+                    "https://www.w3.org/ns/credentials/v2",
+                    "https://firstperson.network/credentials/dtg/v1"
+                ],
+                "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
                 "issuer": did_for(issuer_seed),
                 "validFrom": "2020-01-01T00:00:00Z",
                 "credentialSubject": {
@@ -872,6 +878,79 @@ mod pairwise {
             post(&fix, &v, Some(pop)).await.status(),
             StatusCode::FORBIDDEN
         );
+    }
+
+    // ─── Only a conformant VRC becomes a graph edge ───
+
+    /// Build an otherwise-valid, correctly-signed credential whose shape has
+    /// been altered, and assert it cannot enter the trust graph.
+    async fn assert_shape_rejected(mutate: impl Fn(&mut Value)) {
+        let fix = fixture().await;
+        let mut body = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
+            "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
+            "issuer": did_for(RDID),
+            "validFrom": "2020-01-01T00:00:00Z",
+            "credentialSubject": { "id": did_for(PEER_RDID) },
+        });
+        mutate(&mut body);
+        let v = sign(RDID, body).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        let (status, b) = body_value(post(&fix, &v, Some(pop)).await).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {b}");
+    }
+
+    #[tokio::test]
+    async fn rejects_vrc_missing_the_dtg_context() {
+        assert_shape_rejected(|v| {
+            v["@context"] = json!(["https://www.w3.org/ns/credentials/v2"]);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn rejects_vrc_missing_the_dtg_base_type() {
+        assert_shape_rejected(|v| {
+            v["type"] = json!(["VerifiableCredential", "RelationshipCredential"]);
+        })
+        .await;
+    }
+
+    /// The relationships endpoint publishes relationship edges. A membership
+    /// credential is a different edge with different issuance rules.
+    #[tokio::test]
+    async fn rejects_a_credential_of_another_dtg_subtype() {
+        assert_shape_rejected(|v| {
+            v["type"] = json!([
+                "VerifiableCredential",
+                "DTGCredential",
+                "MembershipCredential"
+            ]);
+        })
+        .await;
+    }
+
+    /// Regression guard. `VerifiableRecognitionCredential` was never a DTG
+    /// credential type — there is no such thing as a recognition credential,
+    /// only a relationship credential. It survived in this repo's fixtures and
+    /// docs precisely because the publish path never inspected `type`.
+    #[tokio::test]
+    async fn rejects_the_invented_recognition_credential_type() {
+        assert_shape_rejected(|v| {
+            v["type"] = json!([
+                "VerifiableCredential",
+                "DTGCredential",
+                "VerifiableRecognitionCredential"
+            ]);
+        })
+        .await;
     }
 
     /// A signature the member legitimately made over some *other* object must

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -880,6 +880,124 @@ mod pairwise {
         );
     }
 
+    // ─── A relationship DID must be unique per counterparty ───
+
+    /// DTG Credentials: "each entity MUST generate a new, unique R-DID for
+    /// every single entity they connect with, even within the same community."
+    ///
+    /// This is type integrity rather than a privacy policy. A verifier reading
+    /// a pairwise edge is entitled to conclude the identifier says nothing
+    /// beyond that one relationship; a reused R-DID breaks that inference for
+    /// every reader of the graph.
+    #[tokio::test]
+    async fn rejects_a_relationship_did_reused_with_a_second_counterparty() {
+        let fix = fixture().await;
+
+        let first = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&first), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &first, Some(pop)).await.status(),
+            StatusCode::CREATED
+        );
+
+        // Same relationship DID, different counterparty.
+        let second = vrc(RDID, OTHER).await;
+        let pop2 = sign(
+            RDID,
+            authorization(&sha256_hex(&second), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        let (status, body) = body_value(post(&fix, &second, Some(pop2)).await).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    }
+
+    /// Uniqueness is per counterparty, not per credential — re-issuing to the
+    /// *same* counterparty (a renewal, a corrected claim) is not reuse.
+    #[tokio::test]
+    async fn allows_reissuing_to_the_same_counterparty() {
+        let fix = fixture().await;
+
+        let first = vrc(RDID, PEER_RDID).await;
+        let pop = sign(
+            RDID,
+            authorization(&sha256_hex(&first), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        assert_eq!(
+            post(&fix, &first, Some(pop)).await.status(),
+            StatusCode::CREATED
+        );
+
+        // Same parties, different credential body — a distinct VRC, so the
+        // idempotency hash differs and this is a genuine second publish.
+        let mut body = json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
+            "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
+            "issuer": did_for(RDID),
+            "validFrom": "2021-06-01T00:00:00Z",
+            "credentialSubject": { "id": did_for(PEER_RDID) },
+        });
+        body["validUntil"] = json!("2999-01-01T00:00:00Z");
+        let second = sign(RDID, body).await;
+        let pop2 = sign(
+            RDID,
+            authorization(&sha256_hex(&second), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        let (status, b) = body_value(post(&fix, &second, Some(pop2)).await).await;
+        assert_eq!(status, StatusCode::CREATED, "body: {b}");
+    }
+
+    /// The public-community case. In an open-source community everyone is
+    /// known, and a member may reasonably want one identifier across every
+    /// relationship. DTG Credentials supports that — as the *attributed*
+    /// form, under the membership DID — and the uniqueness rule does not
+    /// apply to it, because an M-DID is not claiming to be pairwise.
+    ///
+    /// The member is not forced to choose between being recognised and being
+    /// conformant; they choose the form that means what they intend.
+    #[tokio::test]
+    async fn attributed_edges_may_share_one_identifier_across_counterparties() {
+        let fix = fixture().await;
+        let member = did_for(MEMBER);
+
+        for peer in [PEER_RDID, OTHER] {
+            // Issued under the member's own DID, so no authorization object —
+            // the session already proves control of it.
+            let v = sign(
+                MEMBER,
+                json!({
+                    "@context": [
+                        "https://www.w3.org/ns/credentials/v2",
+                        "https://firstperson.network/credentials/dtg/v1"
+                    ],
+                    "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
+                    "issuer": member,
+                    "validFrom": "2020-01-01T00:00:00Z",
+                    "credentialSubject": { "id": did_for(peer) },
+                }),
+            )
+            .await;
+            let (status, b) = body_value(post(&fix, &v, None).await).await;
+            // The default policy's attributed rule needs both parties to be
+            // members; only the issuer is, so this is the policy's call, not
+            // the uniqueness rule's. What matters is that it is never the
+            // "relationship DID already has an edge" rejection.
+            assert!(
+                status != StatusCode::BAD_REQUEST
+                    || !b.to_string().contains("must be unique to one counterparty"),
+                "attributed edges must not be subject to R-DID uniqueness: {b}"
+            );
+        }
+    }
+
     // ─── Only a conformant VRC becomes a graph edge ───
 
     /// Build an otherwise-valid, correctly-signed credential whose shape has

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -238,7 +238,7 @@ pub enum AuditEvent {
     CrossCommunitySessionMinted(CrossCommunitySessionMintedData),
 
     // ─── Phase 4 lifecycle ─────────────────────────────────
-    /// A member published a self-issued Verifiable Recognition
+    /// A member published a self-issued Verifiable Relationship
     /// Credential (VRC) — a trust edge `issuer-member → subject-
     /// member` per spec §5.4 + §6.1. Phase 4 M4.6. The actor is
     /// the issuer; the target is the subject DID.


### PR DESCRIPTION
Closes the protocol half of #1054. Design note:
`docs/05-design-notes/vrc-publish-proof-of-possession.md`.

## The problem

`POST /v1/relationships` required the VRC's `issuer` to equal the caller's
session DID:

```rust
if auth.did != issuer_did { return Err(AppError::Forbidden(...)) }
```

That is why a member's membership DID ends up inside the durable, publishable
credential, and why `GET /v1/relationships/graph` is a correlatable
member-to-member edge set. DTG Credentials asks for the opposite — R-DIDs
RECOMMENDED, a new unique R-DID per counterparty "even within the same
community", and M-DID edges as a bootstrapping allowance to migrate away from.

## The change

The pin conflated two properties:

- **The VRC was made by the party it names as issuer.** Provided by the
  data-integrity proof. Untouched here.
- **The publisher is the issuer.** What the pin actually provided, and worth
  keeping — issuance and publication are different disclosures, and appearing
  in the community graph should be the issuer's to make rather than that of
  whoever holds a copy of the credential.

So the pin is *replaced*, not removed. The session proves membership; a publish
authorization signed by the issuing key proves control of it. Neither requires
them to be the same string.

```json
{
  "type": "VrcPublishAuthorization",
  "vrc": "<sha-256 of the VRC>",
  "aud": "<this VTC's DID>",
  "sessionId": "<caller's session>",
  "issuedAt": "2026-08-23T07:40:00Z"
}
```

Signed with `eddsa-jcs-2022`, verified through the existing `DidVmResolver` +
`check_issuer_binding` path. Every field covers a distinct replay — signatures
made over other objects, other credentials, other communities, other members'
sessions, unbounded reuse within a live session — and there is a test per field.

**The authorization is verified and dropped.** It carries `sessionId`, which is
attributable to a membership DID; persisting it would rebuild exactly the
linkage pairwise identifiers exist to remove. This is the point the ZKP task
force made on trustoverip/dtgwg-cred-spec#9 — "adding a visible field to make
the association checkable would recreate exactly the correlation surface you are
flagging." Two tests assert it directly against the stored row and the audit
store, because it is the kind of property a later debug log undoes in silence.

## Subject membership check dropped on the pairwise path

Not merely unanswerable once the subject is an R-DID — DTG Credentials
§Community-Anchored ZKP is explicit that "community membership is **not** a
precondition for issuing, holding, or presenting a VRC". The subject's consent
to the edge is their publication of the reciprocal VRC (the two-VRC edge model),
not this community's assertion that they exist. This is the same reasoning the
spec editors gave on trustoverip/dtgwg-cred-spec#8 for the member-issued
reciprocal VMC being the member's consent artifact — a pattern this codebase
already implements at join.

## Breaking: policy input shape

`relationships.rego` input gains `authenticated_member`, `issuer.pop_verified`
and `subject`. `issuer_member` / `subject_member` are still supplied; for a
pairwise VRC both report `is_current: false`, so **an operator policy written
against the old shape denies the publish** rather than being silently loosened.
That is deliberate — this change should not quietly relax a policy someone
wrote. The shipped default allows both forms.

The deprecated form (`issuer` equal to the session DID, no authorization) is
accepted for one release and logs a deprecation line, so existing clients keep
working while they move. OpenVTC/openvtc#254 already defaults the client to
pairwise R-DIDs.

## Tests

11 new integration tests in `vtc-service/tests/relationships.rs::pairwise`,
against a live `did:key` resolver:

- publishes under a relationship DID; asserts the stored row contains neither
  the member's DID nor the session id
- the authorization never reaches the audit trail
- subject need not be a member
- idempotent re-publish
- rejects: missing authorization, one signed by another key, one bound to a
  different VRC, one from another session, one for another community, a stale
  one, and one of the wrong `type`

Plus a policy unit test for the pairwise rule. `769` lib tests unchanged.

One existing test earned its keep: an early draft moved the resolver ahead of
caller validation, so a missing resolver returned 500 for what was really a 403.
`publish_rejects_caller_not_issuer` caught it, and the ordering comment in the
handler now says why the gate stays where it is.

## Not in scope, flagged

- **Audit attribution.** `audit_writer.write(&issuer_did, ...)` now records the
  R-DID, so publications are no longer attributable to a named member. That is
  the intended privacy property and a real loss for moderation. This PR takes
  the privacy-preserving option; the design note lists the alternatives. **Worth
  an explicit decision in review rather than acceptance by default.**
- **`GET /relationships/graph`** still stores and returns an adjacency list —
  now of R-DIDs, so no longer member-correlatable, but the design note argues it
  should become derived rather than stored, and should distinguish half-edges
  from complete edges.
- **`canonicalise`** is a recursive key sort, not RFC 8785. Unchanged here, but
  it now has a second consumer via the `vrc` hash binding. Same class of problem
  as trustoverip/dtgwg-cred-spec#6.
- **Accepted DID methods** should be community policy rather than whatever
  `DIDCacheConfigBuilder::default()` supports. `vta-config` already has the shape
  to copy (`allowed_did_methods`); the VTC's `validate_did` hook is still the
  no-op default.
- **The only prose spec for this endpoint** —
  `trust-tasks/relationships/publish/1.0/spec.md` — is marked `status: retired`
  and superseded by a `0.1` document that does not exist in this repo. I have
  not edited a retired spec; the design note is the current reference. Worth
  resolving separately.

## Still open upstream

The residual transient linkage — the VTC observes the session DID and the R-DID
in the same request, unstored — needs the community-anchored ZKP to remove.
That needs the identity linkages of trustoverip/dtgwg-cred-spec#9 defined first;
the ZKP TF's position there is "a real dependency, not a blocker". This design
is the shape that takes that proof when it lands: `issuer.pop_verified` is
replaced by a ZK proof of the same predicate, and neither the policy input nor
the stored row changes.

trustoverip/dtgwg-cred-spec#21 tracks the glossary/body contradiction that made
this ambiguous in the first place.
