### PR TITLE
fix(vtc): route a presented VEC by the type the catalog actually mints

### DIFF
--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 use axum::Json;
 use axum::extract::State;
 use chrono::Utc;
+use dtg_credentials::DTGCredentialType;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::{info, warn};
@@ -280,6 +281,53 @@ async fn vtc_did(state: &AppState) -> Result<String, AppError> {
         .ok_or_else(|| AppError::Validation("VTC DID not configured".into()))
 }
 
+/// Wire type of a VEC, per DTG Credentials §VEC. Note the absence of a
+/// `Verifiable` prefix: as with `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`, the
+/// prefix belongs to the *concept* ("verifiable endorsement credential") and
+/// never to the wire tag.
+const ENDORSEMENT_CREDENTIAL_TYPE: &str = "EndorsementCredential";
+
+/// Type tags emitted by VTCs predating the DTG catalog adoption (`cb06fb31`),
+/// which hand-rolled credential bodies with a `Verifiable` prefix that was
+/// never a DTG type. Recognition is cross-community, so a peer may still be
+/// running one of those; accepted here and nowhere else.
+const LEGACY_TYPE_TAGS: [(&str, DTGCredentialType); 2] = [
+    (
+        "VerifiableEndorsementCredential",
+        DTGCredentialType::Endorsement,
+    ),
+    (
+        "VerifiableMembershipCredential",
+        DTGCredentialType::Membership,
+    ),
+];
+
+/// Classify an embedded credential by its `type` array.
+///
+/// Classification goes through `dtg_credentials` — the same catalog the VTC
+/// mints through — rather than comparing string literals here. A literal on
+/// this side can drift from what the catalog emits without anything failing,
+/// which is exactly what happened: this path matched
+/// `"VerifiableEndorsementCredential"` while `issue_endorsement` minted
+/// `"EndorsementCredential"`, so no genuinely-issued VEC was ever routed to its
+/// slot, and cross-community recognition rejected every real presentation.
+fn classify(types: &[String]) -> Option<DTGCredentialType> {
+    if let Ok(kind) = DTGCredentialType::try_from(types) {
+        return Some(kind);
+    }
+    for (tag, kind) in LEGACY_TYPE_TAGS {
+        if types.iter().any(|t| t == tag) {
+            tracing::warn!(
+                legacy_type = tag,
+                "peer presented a pre-catalog credential type; accepted, but the \
+                 issuing VTC should be upgraded"
+            );
+            return Some(kind);
+        }
+    }
+    None
+}
+
 /// Pull the foreign VEC + VMC out of a VP's `verifiableCredential`, classifying
 /// by `type`. Both must be present exactly once. Accepts either a single object
 /// or an array (the W3C VP shape).
@@ -302,20 +350,12 @@ fn extract_vec_vmc(
         })?;
         // Route the credential to its slot by type. Other credential types are
         // ignored — the recognition gate only acts on the VEC + VMC pair.
-        let (slot, label) = if cred
-            .types
-            .iter()
-            .any(|t| t == "VerifiableEndorsementCredential")
-        {
-            (&mut vec_cred, "VerifiableEndorsementCredential")
-        } else if cred
-            .types
-            .iter()
-            .any(|t| t == VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
-        {
-            (&mut vmc_cred, VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
-        } else {
-            continue;
+        let (slot, label) = match classify(&cred.types) {
+            Some(DTGCredentialType::Endorsement) => (&mut vec_cred, ENDORSEMENT_CREDENTIAL_TYPE),
+            Some(DTGCredentialType::Membership) => {
+                (&mut vmc_cred, VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
+            }
+            _ => continue,
         };
         if slot.replace(cred).is_some() {
             return Err(AppError::Validation(format!(
@@ -325,7 +365,7 @@ fn extract_vec_vmc(
     }
 
     let vec = vec_cred.ok_or_else(|| {
-        AppError::Validation("presentation has no VerifiableEndorsementCredential".into())
+        AppError::Validation(format!("presentation has no {ENDORSEMENT_CREDENTIAL_TYPE}"))
     })?;
     let vmc = vmc_cred.ok_or_else(|| {
         AppError::Validation(format!(
@@ -605,6 +645,63 @@ async fn emit_denied_audit(
         .await
     {
         warn!(error = %e, "failed to emit CrossCommunitySessionMinted (denied) envelope");
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+
+    fn types(ts: &[&str]) -> Vec<String> {
+        ts.iter().map(|t| t.to_string()).collect()
+    }
+
+    // `DTGCredentialType` derives no `PartialEq`, so these assert by pattern.
+    fn is_endorsement(t: Option<DTGCredentialType>) -> bool {
+        matches!(t, Some(DTGCredentialType::Endorsement))
+    }
+    fn is_membership(t: Option<DTGCredentialType>) -> bool {
+        matches!(t, Some(DTGCredentialType::Membership))
+    }
+
+    /// The wire form `issue_endorsement` actually mints. This is the case that
+    /// was broken: the routing predicate matched a string the catalog has
+    /// never emitted, so no genuinely-issued VEC was ever routed to its slot,
+    /// and every cross-community recognition failed with "presentation has no
+    /// VerifiableEndorsementCredential".
+    #[test]
+    fn classifies_the_wire_form_the_catalog_mints() {
+        assert!(is_endorsement(classify(&types(&[
+            "VerifiableCredential",
+            "DTGCredential",
+            "EndorsementCredential"
+        ]))));
+        assert!(is_membership(classify(&types(&[
+            "VerifiableCredential",
+            "DTGCredential",
+            "MembershipCredential"
+        ]))));
+    }
+
+    /// Recognition is cross-community, so a peer may still be running a VTC
+    /// from before the catalog adoption. Those tags are accepted here and
+    /// nowhere else.
+    #[test]
+    fn still_accepts_pre_catalog_type_tags() {
+        assert!(is_endorsement(classify(&types(&[
+            "VerifiableCredential",
+            "VerifiableEndorsementCredential"
+        ]))));
+        assert!(is_membership(classify(&types(&[
+            "VerifiableCredential",
+            "VerifiableMembershipCredential"
+        ]))));
+    }
+
+    #[test]
+    fn ignores_credentials_the_recognition_gate_does_not_act_on() {
+        assert!(classify(&types(&["VerifiableCredential"])).is_none());
+        assert!(classify(&types(&["EmailCredential"])).is_none());
     }
 }
 

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -327,9 +327,16 @@ mod holder_binding {
             DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite,
         };
         let issuer_did = did_for(issuer_seed);
+        // The DTG wire form, as `dtg_credentials` mints it. Hand-rolling a
+        // different shape here is what let the VEC routing bug live: the test
+        // built the type the handler matched, and neither matched what
+        // `issue_endorsement` actually issues.
         let mut vc = json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
-            "type": ["VerifiableCredential", vc_type],
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
+            "type": ["VerifiableCredential", "DTGCredential", vc_type],
             "issuer": issuer_did,
             "validFrom": "2020-01-01T00:00:00Z",
             "validUntil": "2999-01-01T00:00:00Z",
@@ -362,7 +369,7 @@ mod holder_binding {
         };
         let subject_did = did_for(subject_seed);
         let holder_did = did_for(holder_seed);
-        let vec = sign_vc(issuer_seed, "VerifiableEndorsementCredential", &subject_did).await;
+        let vec = sign_vc(issuer_seed, "EndorsementCredential", &subject_did).await;
         // The VMC's wire tag is `MembershipCredential` — NOT
         // `VerifiableMembershipCredential`. The `VERIFIABLE_` prefix lives in the
         // constant's *name* only (it's historical); the tag is what


### PR DESCRIPTION
Closes #1062. Confirmed empirically before fixing — the analysis in that issue
was inference from source, and a green suite deserved more than that.

## The proof

Changing only the *test fixture* to carry the wire type the VTC actually
mints, with the handler untouched:

```
400 Bad Request: "presentation has no VerifiableEndorsementCredential"
```

Cross-community recognition rejects every genuinely-issued VEC, and reports it
by naming a credential type that does not exist in DTG Credentials.

## Cause

`extract_vec_vmc` matched the literal `"VerifiableEndorsementCredential"`.
Nothing mints that. `issue_endorsement` builds through
`DTGCredential::new_vec`, and the catalog wire-shape guard pins the result as
`["VerifiableCredential", "DTGCredential", "EndorsementCredential"]` — no
`Verifiable` prefix, because the prefix belongs to the concept and never to the
wire tag.

The VMC branch directly beside it was always right, because it read the shared
`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` constant, whose *value* is
`"MembershipCredential"`. A comment in `tests/recognise.rs` already warned
about this exact trap and said to use the constant rather than a literal. The
VEC branch used a literal.

## Fix

Classification goes through `dtg_credentials::DTGCredentialType`, so routing
and minting share one definition of the wire form and cannot drift again.

Pre-catalog peers still work: recognition is cross-community, and a VTC
predating `cb06fb31` (the DTG catalog adoption) hand-rolled the prefixed tags.
Those route with a warning, accepted here and nowhere else — `git log -S`
confirms the prefixed string did exist in `credentials/` before that commit, so
this is a real compatibility case rather than a hypothetical one.

## Why the suite never caught it

The test hand-rolled its VEC with the same fictional type the handler matched.
Test and bug agreed, and neither agreed with what the VTC issues.

`sign_vc` now emits the DTG wire form. That is what makes this a regression
test rather than a restatement: revert the handler and
`matching_holder_clears_the_binding_gate` fails. Three unit tests pin the
classification directly — catalog form, pre-catalog form, and types the gate
must ignore.

Full suite green: 53 suites, 0 failures, clippy clean.

## Two notes for follow-up

- `DTGCredentialType` derives no `PartialEq`, so the new tests assert by
  pattern. Worth adding upstream in `dtg-credentials`; trivial, and it makes
  every consumer's tests read better.
- This is finding **F1** of a wider conformance audit of the stack against DTG
  Credentials. The systemic cause — conformance enforced on issuance but not on
  ingress, with tests that hand-roll credentials instead of minting them — is
  **F4**, and it is the reason this survived. #1061 closes the same class for
  the VRC publish path.
