### PR TITLE
refactor!: delete the Verifiable-prefixed credential tags that were never DTG types

### DIFF
--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -530,7 +530,7 @@ consults live inputs (trust-registry queries, etc.).
 | `role_definitions` | Map roles to permissions (incl. Custom) | The matrix in §5.3 for standard roles only |
 | `cross_community_roles` | Honour external VEC role grants | **Deny-all** |
 | `cross_community_relationships` | Store external VRCs | **Deny-all** |
-| `relationships` | Store published VRCs | Store if both parties are current members |
+| `relationships` | Store published VRCs | Store if the caller is a current member (attributed form also requires both named parties to be) |
 
 ### 7.2 Activation
 
@@ -553,7 +553,7 @@ file-watching, no auto-reload.
 | `role_definitions` | `{ role, action, resource? }` |
 | `cross_community_roles` | `{ foreign_vec, target_role, vtc_state }` |
 | `cross_community_relationships` | `{ vrc, viewer_member, vtc_state }` |
-| `relationships` | `{ vrc, issuer_member, subject_member }` |
+| `relationships` | `{ vrc, authenticated_member, identifier_form, issuer, subject }` |
 
 ## 8. Trust-registry integration
 

--- a/trust-tasks/relationships/publish/1.0/spec.md
+++ b/trust-tasks/relationships/publish/1.0/spec.md
@@ -12,7 +12,7 @@ applies_to:
 
 # VTC — VRC Publish
 
-Publishes a member-issued Verifiable Recognition Credential
+Publishes a member-issued Verifiable Relationship Credential
 (VRC) — a self-asserted trust edge from the caller to another
 member. Phase 4 M4.6; spec §5.4 + §6.1; planning-review D1
 (issuer is the *member*, not the community).

--- a/vta-sdk/src/protocols/members.rs
+++ b/vta-sdk/src/protocols/members.rs
@@ -26,18 +26,29 @@ use serde_json::Value;
 /// its half of the pair — the direction is given by `issuer` /
 /// `credentialSubject.id`, not the type.
 ///
-/// The value is the canonical DTG / W3C tag `MembershipCredential` — exactly
-/// what `dtg-credentials` emits (`DTGCredentialType::Membership`) and what the
-/// VTC's own issuance stamps. The `VERIFIABLE_` prefix in the *name* is
-/// historical; the *tag* is `MembershipCredential`, not
-/// `VerifiableMembershipCredential`, so a credential built with the typed
-/// `dtg-credentials` API verifies without hand-rolling the VC JSON.
-pub const VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE: &str = "MembershipCredential";
+/// The canonical DTG tag, exactly as `dtg-credentials` emits it
+/// (`DTGCredentialType::Membership`) and as the VTC's own issuance stamps it.
+///
+/// The name previously carried a `VERIFIABLE_` prefix that the *value* never
+/// had. That gap is not cosmetic: it is how
+/// `"VerifiableEndorsementCredential"` came to be hand-rolled into the
+/// recognition path, where it matched nothing any VTC issues and silently
+/// broke cross-community recognition for every real presentation
+/// (OpenVTC/verifiable-trust-infrastructure#1062). A constant whose name
+/// disagrees with its value invites exactly that.
+pub const MEMBERSHIP_CREDENTIAL_TYPE: &str = "MembershipCredential";
+
+/// Wire `type` tag of a VEC, per DTG Credentials §VEC.
+///
+/// Sibling of [`MEMBERSHIP_CREDENTIAL_TYPE`], and here for the same reason:
+/// the recognition path had this one as a bare literal, spelled wrongly, with
+/// nothing to compare it against.
+pub const ENDORSEMENT_CREDENTIAL_TYPE: &str = "EndorsementCredential";
 
 /// VTC → member: request that the member issue and send their reciprocal VMC.
 pub const MEMBER_REQUEST_VMC_TYPE: &str = "https://trusttasks.org/spec/vtc/members/request-vmc/0.1";
 
-/// Member → VTC: a member-issued [`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`] VMC,
+/// Member → VTC: a member-issued [`MEMBERSHIP_CREDENTIAL_TYPE`] VMC,
 /// the member → community half of the membership pair.
 pub const MEMBER_VMC_TYPE: &str = "https://trusttasks.org/spec/vtc/members/vmc/0.1";
 

--- a/vtc-service/policies/default/relationships.rego
+++ b/vtc-service/policies/default/relationships.rego
@@ -48,16 +48,13 @@
 #   { vrc,
 #     authenticated_member: { did, is_current },
 #     identifier_form: "attributed" | "pairwise",
-#     issuer:  { did, pop_verified },
-#     subject: { did },
-#     issuer_member:  { did, is_current },   # deprecated shape
-#     subject_member: { did, is_current },   # deprecated shape
+#     issuer:  { did, is_current },
+#     subject: { did, is_current },
 #     action }
 #
-# `issuer_member` / `subject_member` remain for operator policies
-# written against the old shape. For a pairwise VRC both report
-# `is_current: false`, so an un-updated operator policy denies the
-# publish rather than being silently loosened.
+# `is_current` on the credential'"'"'s own parties is meaningful only
+# for the attributed form; under pairwise identifiers neither
+# party resolves to a member, and is not meant to.
 
 package vtc.relationships
 
@@ -80,6 +77,6 @@ allow if {
 allow if {
 	input.action == "publish"
 	input.identifier_form == "attributed"
-	input.issuer_member.is_current
-	input.subject_member.is_current
+	input.issuer.is_current
+	input.subject.is_current
 }

--- a/vtc-service/src/members/inbound_vmc.rs
+++ b/vtc-service/src/members/inbound_vmc.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 use vti_common::audit::{AuditEvent, MembershipReciprocatedData};
 use vti_common::error::AppError;
 
-use vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE;
+use vta_sdk::protocols::members::MEMBERSHIP_CREDENTIAL_TYPE;
 
 use crate::credentials::vm_resolver::{DidVmResolver, check_issuer_binding};
 use crate::join::{JoinStatus, get_join_request};
@@ -47,7 +47,7 @@ pub struct MemberVmcOutcome {
 /// Verify a member-issued VMC and store it on the member's row.
 ///
 /// Checks: the member exists and is active; `vc.issuer == member_did`; `type`
-/// includes [`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`];
+/// includes [`MEMBERSHIP_CREDENTIAL_TYPE`];
 /// `credentialSubject.id == <this VTC's DID>`; the issuer DI proof's
 /// `verificationMethod` is under the member and verifies against the resolved
 /// key. Idempotent: re-sending the same `id` is a no-op.
@@ -190,11 +190,11 @@ async fn verify_member_vmc(
         .is_some_and(|a| {
             a.iter()
                 .filter_map(JsonValue::as_str)
-                .any(|t| t == VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
+                .any(|t| t == MEMBERSHIP_CREDENTIAL_TYPE)
         });
     if !has_type {
         return Err(AppError::Validation(format!(
-            "member vmc `type` must include `{VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE}`"
+            "member vmc `type` must include `{MEMBERSHIP_CREDENTIAL_TYPE}`"
         )));
     }
 

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -1065,8 +1065,8 @@ mod tests {
                 "vrc": {},
                 "identifier_form": "attributed",
                 "authenticated_member": { "did": "did:key:zIssuer", "is_current": true },
-                "issuer_member": { "did": "did:key:zIssuer", "is_current": true },
-                "subject_member": { "did": "did:key:zSubject", "is_current": true },
+                "issuer": { "did": "did:key:zIssuer", "is_current": true },
+                "subject": { "did": "did:key:zSubject", "is_current": true },
                 "action": "publish"
             }),
         )
@@ -1080,8 +1080,8 @@ mod tests {
                 "vrc": {},
                 "identifier_form": "attributed",
                 "authenticated_member": { "did": "did:key:zIssuer", "is_current": true },
-                "issuer_member": { "did": "did:key:zIssuer", "is_current": true },
-                "subject_member": { "did": "did:key:zSubject", "is_current": false },
+                "issuer": { "did": "did:key:zIssuer", "is_current": true },
+                "subject": { "did": "did:key:zSubject", "is_current": false },
                 "action": "publish"
             }),
         )
@@ -1104,11 +1104,9 @@ mod tests {
                 "vrc": {},
                 "identifier_form": if pairwise { "pairwise" } else { "attributed" },
                 "authenticated_member": { "did": "did:key:zMember", "is_current": member_current },
-                "issuer":  { "did": "did:peer:2.zR1", "pop_verified": pairwise },
-                "subject": { "did": "did:peer:2.zR2" },
-                // Pairwise DIDs are not members; the deprecated fields say so.
-                "issuer_member":  { "did": "did:peer:2.zR1", "is_current": false },
-                "subject_member": { "did": "did:peer:2.zR2", "is_current": false },
+                // Pairwise DIDs are not members, and are not meant to be.
+                "issuer":  { "did": "did:peer:2.zR1", "is_current": false },
+                "subject": { "did": "did:peer:2.zR2", "is_current": false },
                 "action": "publish"
             })
         };

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
 use uuid::Uuid;
+use vta_sdk::protocols::members::ENDORSEMENT_CREDENTIAL_TYPE;
 use vti_common::audit::{
     AuditEvent, CredentialIssuedData, CustomEndorsementIssuedData, CustomEndorsementRevokedData,
     StatusListFlippedData,
@@ -223,7 +224,7 @@ pub async fn issue(
             Some(&body.subject_did),
             AuditEvent::VecIssued(CredentialIssuedData {
                 credential_id: vec_id.clone(),
-                credential_type: "VerifiableEndorsementCredential".into(),
+                credential_type: ENDORSEMENT_CREDENTIAL_TYPE.into(),
                 valid_from: rfc3339(now),
                 valid_until: rfc3339(valid_until),
                 status_list_index: Some(slot),

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -70,7 +70,7 @@ use crate::recognition::{
 };
 use crate::server::AppState;
 use affinidi_vc::VerifiableCredential;
-use vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE;
+use vta_sdk::protocols::members::{ENDORSEMENT_CREDENTIAL_TYPE, MEMBERSHIP_CREDENTIAL_TYPE};
 
 /// Request body for `POST /v1/auth/recognise`. The caller supplies a
 /// holder-signed W3C Verifiable Presentation that embeds the foreign VEC and
@@ -281,27 +281,6 @@ pub(crate) async fn vtc_did(state: &AppState) -> Result<String, AppError> {
         .ok_or_else(|| AppError::Validation("VTC DID not configured".into()))
 }
 
-/// Wire type of a VEC, per DTG Credentials §VEC. Note the absence of a
-/// `Verifiable` prefix: as with `VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE`, the
-/// prefix belongs to the *concept* ("verifiable endorsement credential") and
-/// never to the wire tag.
-const ENDORSEMENT_CREDENTIAL_TYPE: &str = "EndorsementCredential";
-
-/// Type tags emitted by VTCs predating the DTG catalog adoption (`cb06fb31`),
-/// which hand-rolled credential bodies with a `Verifiable` prefix that was
-/// never a DTG type. Recognition is cross-community, so a peer may still be
-/// running one of those; accepted here and nowhere else.
-const LEGACY_TYPE_TAGS: [(&str, DTGCredentialType); 2] = [
-    (
-        "VerifiableEndorsementCredential",
-        DTGCredentialType::Endorsement,
-    ),
-    (
-        "VerifiableMembershipCredential",
-        DTGCredentialType::Membership,
-    ),
-];
-
 /// Classify an embedded credential by its `type` array.
 ///
 /// Classification goes through `dtg_credentials` — the same catalog the VTC
@@ -311,21 +290,14 @@ const LEGACY_TYPE_TAGS: [(&str, DTGCredentialType); 2] = [
 /// `"VerifiableEndorsementCredential"` while `issue_endorsement` minted
 /// `"EndorsementCredential"`, so no genuinely-issued VEC was ever routed to its
 /// slot, and cross-community recognition rejected every real presentation.
+///
+/// The catalog is the only accepted authority. Nothing here re-admits the
+/// `Verifiable`-prefixed tags that hand-rolled pre-catalog bodies carried:
+/// they were never DTG credential types, and a reference implementation that
+/// accepts a type the specification does not define reintroduces the drift
+/// this function exists to prevent.
 fn classify(types: &[String]) -> Option<DTGCredentialType> {
-    if let Ok(kind) = DTGCredentialType::try_from(types) {
-        return Some(kind);
-    }
-    for (tag, kind) in LEGACY_TYPE_TAGS {
-        if types.iter().any(|t| t == tag) {
-            tracing::warn!(
-                legacy_type = tag,
-                "peer presented a pre-catalog credential type; accepted, but the \
-                 issuing VTC should be upgraded"
-            );
-            return Some(kind);
-        }
-    }
-    None
+    DTGCredentialType::try_from(types).ok()
 }
 
 /// Pull the foreign VEC + VMC out of a VP's `verifiableCredential`, classifying
@@ -352,9 +324,7 @@ fn extract_vec_vmc(
         // ignored — the recognition gate only acts on the VEC + VMC pair.
         let (slot, label) = match classify(&cred.types) {
             Some(DTGCredentialType::Endorsement) => (&mut vec_cred, ENDORSEMENT_CREDENTIAL_TYPE),
-            Some(DTGCredentialType::Membership) => {
-                (&mut vmc_cred, VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE)
-            }
+            Some(DTGCredentialType::Membership) => (&mut vmc_cred, MEMBERSHIP_CREDENTIAL_TYPE),
             _ => continue,
         };
         if slot.replace(cred).is_some() {
@@ -368,9 +338,7 @@ fn extract_vec_vmc(
         AppError::Validation(format!("presentation has no {ENDORSEMENT_CREDENTIAL_TYPE}"))
     })?;
     let vmc = vmc_cred.ok_or_else(|| {
-        AppError::Validation(format!(
-            "presentation has no {VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE}"
-        ))
+        AppError::Validation(format!("presentation has no {MEMBERSHIP_CREDENTIAL_TYPE}"))
     })?;
     Ok((vec, vmc))
 }
@@ -683,19 +651,25 @@ mod classify_tests {
         ]))));
     }
 
-    /// Recognition is cross-community, so a peer may still be running a VTC
-    /// from before the catalog adoption. Those tags are accepted here and
-    /// nowhere else.
+    /// The `Verifiable`-prefixed tags were never DTG credential types. They
+    /// exist only as a mistake this repo made and has since corrected, and
+    /// accepting them would reintroduce the drift `classify` prevents.
     #[test]
-    fn still_accepts_pre_catalog_type_tags() {
-        assert!(is_endorsement(classify(&types(&[
-            "VerifiableCredential",
-            "VerifiableEndorsementCredential"
-        ]))));
-        assert!(is_membership(classify(&types(&[
-            "VerifiableCredential",
-            "VerifiableMembershipCredential"
-        ]))));
+    fn refuses_the_verifiable_prefixed_tags_that_were_never_dtg_types() {
+        assert!(
+            classify(&types(&[
+                "VerifiableCredential",
+                "VerifiableEndorsementCredential"
+            ]))
+            .is_none()
+        );
+        assert!(
+            classify(&types(&[
+                "VerifiableCredential",
+                "VerifiableMembershipCredential"
+            ]))
+            .is_none()
+        );
     }
 
     #[test]

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -13,7 +13,8 @@
 //!    an `issuer` equal to the session DID. It then runs
 //!    `relationships.rego` against an enriched input
 //!    (`{ vrc, authenticated_member: { did, is_current },
-//!        identifier_form, issuer: { did }, subject: { did },
+//!        identifier_form, issuer: { did, is_current },
+//!        subject: { did, is_current },
 //!        action }`), persists the row + secondary-index
 //!    entries on allow, and emits `VrcPublished`.
 //!
@@ -280,12 +281,6 @@ pub async fn publish(
     //    pairwise identifiers are not resolvable to members and
     //    are not meant to be.
     //
-    //    `issuer_member` / `subject_member` are retained for
-    //    operator-authored policies written against the old
-    //    shape. For a pairwise VRC both report `is_current:
-    //    false`, so an un-updated operator policy *denies* the
-    //    publish. That is deliberate: a policy someone wrote is
-    //    not silently loosened by this change.
     let member_current = is_current_member(&state, &auth.did).await?;
     let issuer_current = is_current_member(&state, &issuer_did).await?;
     let subject_current = is_current_member(&state, &subject_did).await?;
@@ -312,15 +307,11 @@ pub async fn publish(
         "vrc": vrc,
         "authenticated_member": { "did": auth.did, "is_current": member_current },
         "identifier_form": identifier_form.as_str(),
-        "issuer": {
-            "did": issuer_did,
-            // Retained: `pairwise` implies the authorization was verified.
-            "pop_verified": identifier_form == IdentifierForm::Pairwise,
-        },
-        "subject": { "did": subject_did },
-        // Deprecated shape — see above.
-        "issuer_member": { "did": issuer_did, "is_current": issuer_current },
-        "subject_member": { "did": subject_did, "is_current": subject_current },
+        // `is_current` on the credential'"'"'s own parties is meaningful only for
+        // the attributed form; under pairwise identifiers neither party is
+        // resolvable to a member, and is not meant to be.
+        "issuer": { "did": issuer_did, "is_current": issuer_current },
+        "subject": { "did": subject_did, "is_current": subject_current },
         "action": "publish",
     });
     let allow = evaluate_relationships_policy(&state, &policy_input).await?;

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -410,7 +410,7 @@ async fn issue_happy_path_issuer_mints_credential() {
             AuditEvent::CustomEndorsementIssued(d) if d.endorsement_type == uri => {
                 saw_issued = true;
             }
-            AuditEvent::VecIssued(d) if d.credential_type == "VerifiableEndorsementCredential" => {
+            AuditEvent::VecIssued(d) if d.credential_type == "EndorsementCredential" => {
                 saw_vec = true;
             }
             _ => {}

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -291,7 +291,7 @@ mod holder_binding {
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
-    use vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE;
+    use vta_sdk::protocols::members::MEMBERSHIP_CREDENTIAL_TYPE;
     use vtc_service::test_support::TestVtc;
 
     const VTC_DID: &str = "did:key:z6MkTestVTC";
@@ -378,12 +378,7 @@ mod holder_binding {
         // every VP that got as far as the credential lookup 400 with
         // "presentation has no MembershipCredential" — so the three holder-binding
         // assertions below could never be reached. Use the constant, not a literal.
-        let vmc = sign_vc(
-            issuer_seed,
-            VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE,
-            &subject_did,
-        )
-        .await;
+        let vmc = sign_vc(issuer_seed, MEMBERSHIP_CREDENTIAL_TYPE, &subject_did).await;
         let mut vp = json!({
             "@context": ["https://www.w3.org/ns/credentials/v2"],
             "type": ["VerifiablePresentation"],

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -898,8 +898,13 @@ pub struct MembershipReciprocatedData {
 pub struct CredentialIssuedData {
     /// VC `id` URI (typically `urn:uuid:<server-allocated>`).
     pub credential_id: String,
-    /// Wire-form credential type (`"VerifiableMembershipCredential"`
-    /// for VMC, `"VerifiableEndorsementCredential"` for VEC).
+    /// Wire-form credential type — the DTG tag exactly as issued
+    /// (`"MembershipCredential"`, `"EndorsementCredential"`).
+    ///
+    /// This recorded `"MembershipCredential"` /
+    /// `"EndorsementCredential"` until the naming cleanup: tags no
+    /// credential ever carried, in the one record meant to be authoritative
+    /// after the fact.
     pub credential_type: String,
     /// RFC3339 `validFrom` from the issued VC.
     pub valid_from: String,
@@ -1590,17 +1595,14 @@ mod tests {
     fn vmc_issued_round_trip() {
         let e = AuditEvent::VmcIssued(CredentialIssuedData {
             credential_id: "urn:uuid:11111111-1111-1111-1111-111111111111".into(),
-            credential_type: "VerifiableMembershipCredential".into(),
+            credential_type: "MembershipCredential".into(),
             valid_from: "2026-05-12T00:00:00Z".into(),
             valid_until: "2026-06-11T00:00:00Z".into(),
             status_list_index: Some(42),
         });
         let v = wire_value(&e);
         assert_eq!(v["type"], "VmcIssued");
-        assert_eq!(
-            v["data"]["credentialType"],
-            "VerifiableMembershipCredential"
-        );
+        assert_eq!(v["data"]["credentialType"], "MembershipCredential");
         assert_eq!(v["data"]["statusListIndex"], 42);
         round_trip(&e);
     }
@@ -1609,7 +1611,7 @@ mod tests {
     fn vec_issued_round_trip_omits_status_list_index_when_none() {
         let e = AuditEvent::VecIssued(CredentialIssuedData {
             credential_id: "urn:uuid:22222222-2222-2222-2222-222222222222".into(),
-            credential_type: "VerifiableEndorsementCredential".into(),
+            credential_type: "EndorsementCredential".into(),
             valid_from: "2026-05-12T00:00:00Z".into(),
             valid_until: "2026-06-11T00:00:00Z".into(),
             status_list_index: None,
@@ -2044,7 +2046,7 @@ mod tests {
             (
                 AuditEvent::VmcIssued(CredentialIssuedData {
                     credential_id: "id".into(),
-                    credential_type: "VerifiableMembershipCredential".into(),
+                    credential_type: "MembershipCredential".into(),
                     valid_from: "vf".into(),
                     valid_until: "vu".into(),
                     status_list_index: None,
@@ -2054,7 +2056,7 @@ mod tests {
             (
                 AuditEvent::VecIssued(CredentialIssuedData {
                     credential_id: "id".into(),
-                    credential_type: "VerifiableEndorsementCredential".into(),
+                    credential_type: "EndorsementCredential".into(),
                     valid_from: "vf".into(),
                     valid_until: "vu".into(),
                     status_list_index: None,


### PR DESCRIPTION
`VerifiableMembershipCredential` and `VerifiableEndorsementCredential` are not
DTG credential types and never were. The specification defines seven concrete
subtypes; neither is among them, and nothing in this stack has ever issued
either.

They survived as a name, a pair of literals, and a compatibility shim — and
between them they broke cross-community recognition for every real presentation
(#1062). This removes all four instances.

## The SDK constant, which is the root

`VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` held the value `"MembershipCredential"`,
with a doc comment explaining that the prefix in the *name* was historical and
the tag did not have it.

A constant whose name disagrees with its value is an invitation, and it was
taken: someone reading the name hand-rolled `"VerifiableEndorsementCredential"`
into the recognition path, where it matched nothing any VTC issues. The comment
warning about the trap sat six lines from the code that fell into it.

Renamed to `MEMBERSHIP_CREDENTIAL_TYPE`, with `ENDORSEMENT_CREDENTIAL_TYPE`
added beside it so the VEC tag has a home rather than being a literal at the
point of use.

## The compatibility shim

#1063 added `LEGACY_TYPE_TAGS`, accepting both prefixed tags from peers
predating the catalog adoption. That was justified by `git log -S` showing the
strings had existed in `credentials/` — but nothing is published, so no such
peer exists, and a reference implementation that accepts a type the
specification does not define reintroduces exactly the drift the function it
sits in was written to prevent.

Removed. The test that pinned the acceptance now pins the refusal.

## The audit trail

Envelopes recorded `credential_type: "VerifiableMembershipCredential"` /
`"VerifiableEndorsementCredential"` — tags no credential ever carried, in the
one record meant to be authoritative after the fact. Now records what was
issued. Closes #1070 (audit finding F10).

## The policy input

`issuer_member` / `subject_member` were carried alongside `issuer` / `subject`
for operator policies written against the pre-#1061 shape. There are no
deployed operator policies to preserve, and two spellings of one concept is how
the concept drifts. Duplicates gone; the surviving fields carry `is_current`.

## Docs

The MVP spec's `relationships` rows described the old input shape and the old
default-policy rule. The retired `publish/1.0` trust-task doc called a VRC a
"Verifiable Recognition Credential" — wrong in every version, so corrected in
place rather than left standing behind a retired-doc excuse.

## Deliberately untouched

`subject_member` in `removal.rego` and the ceremony documents is an **unrelated
input shape that happens to share a name**. Renaming it would have been a real
bug, and it is the kind of thing a global search-and-replace gets wrong.

## Breaking

- `vta_sdk::protocols::members::VERIFIABLE_MEMBERSHIP_CREDENTIAL_TYPE` →
  `MEMBERSHIP_CREDENTIAL_TYPE` (value unchanged). `vta-sdk` is published, so
  this is a published-crate break; release-plz handles the dependent ripple.
- `relationships.rego` input drops `issuer_member` / `subject_member`. The
  shipped default is updated; an operator policy reading the old names now
  denies rather than silently passing — fail-closed, which is the right
  direction for a policy that no longer sees the field it tests.
- Recognition no longer accepts the `Verifiable`-prefixed tags.

Full workspace green: 150 suites, 0 failures, clippy clean.
