### PR TITLE
test(vtc)!: check ingressed credentials against the catalog, and test validators against it too

### DIFF
--- a/vtc-service/src/credentials/ingress.rs
+++ b/vtc-service/src/credentials/ingress.rs
@@ -1,0 +1,204 @@
+//! The one place a DTG credential arriving from outside is checked for being
+//! a DTG credential at all.
+//!
+//! DTG Credentials §Common Structure is normative for every subtype:
+//!
+//! - `@context` MUST include both the W3C VC v2 context and the DTG context
+//! - `type` MUST include `VerifiableCredential`, `DTGCredential`, and exactly
+//!   one concrete subtype
+//!
+//! The VTC asserted all of that on everything it *mints* — `credentials::dtg`
+//! builds through the `dtg-credentials` catalog behind the `catalog_wire_shape`
+//! guard — and, until this module, on almost nothing it *accepted*. Each
+//! ingress point compared string literals of its own. Every literal that
+//! drifted, drifted silently: the recognition path spent its whole life
+//! matching `"VerifiableEndorsementCredential"`, a type nothing has ever
+//! issued, rejecting every real presentation (#1062), and the VRC publish path
+//! never looked at `type` at all, so any signed JSON with an `issuer` and a
+//! `credentialSubject.id` became an edge in the community trust graph.
+//!
+//! Classification here goes through `dtg_credentials::DTGCredentialType` — the
+//! same catalog the issuing side mints from — so the two cannot drift apart
+//! without the round-trip tests below failing.
+
+use dtg_credentials::DTGCredentialType;
+use serde_json::Value as JsonValue;
+use vti_common::error::AppError;
+
+/// The two `@context` entries every DTG credential MUST carry.
+pub const DTG_CONTEXTS: [&str; 2] = [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://firstperson.network/credentials/dtg/v1",
+];
+
+/// The base `type` entries every DTG credential MUST carry, alongside exactly
+/// one concrete subtype.
+pub const DTG_BASE_TYPES: [&str; 2] = ["VerifiableCredential", "DTGCredential"];
+
+/// Check the DTG common structure and return the concrete subtype.
+///
+/// Says nothing about signatures, validity windows or revocation — those are
+/// the caller's, and are checked on their own paths. This answers only "is
+/// this a DTG credential, and which one".
+pub fn classify_dtg(doc: &JsonValue) -> Result<DTGCredentialType, AppError> {
+    let ctx: Vec<String> = doc
+        .get("@context")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or_else(|| {
+            AppError::Validation("credential `@context` missing or not an array".into())
+        })?;
+    for required in DTG_CONTEXTS {
+        if !ctx.iter().any(|c| c == required) {
+            return Err(AppError::Validation(format!(
+                "credential `@context` must include `{required}`"
+            )));
+        }
+    }
+
+    let types: Vec<String> = doc
+        .get("type")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .ok_or_else(|| AppError::Validation("credential `type` missing or not an array".into()))?;
+    for required in DTG_BASE_TYPES {
+        if !types.iter().any(|t| t == required) {
+            return Err(AppError::Validation(format!(
+                "credential `type` must include `{required}`"
+            )));
+        }
+    }
+
+    DTGCredentialType::try_from(types.as_slice()).map_err(|_| {
+        AppError::Validation("credential `type` names no DTG credential subtype".into())
+    })
+}
+
+/// Check the common structure and require one specific subtype.
+///
+/// `context` names the endpoint in the rejection, so an operator reading a 400
+/// learns which surface refused what — "this endpoint publishes relationship
+/// edges; got a MembershipCredential" rather than a bare type mismatch.
+pub fn require_dtg_type(
+    doc: &JsonValue,
+    expected: DTGCredentialType,
+    context: &str,
+) -> Result<(), AppError> {
+    let got = classify_dtg(doc)?;
+    if std::mem::discriminant(&got) == std::mem::discriminant(&expected) {
+        Ok(())
+    } else {
+        Err(AppError::Validation(format!("{context}; got a {got}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::dtg_json;
+    use chrono::Utc;
+    use dtg_credentials::DTGCredential;
+
+    fn vrc() -> JsonValue {
+        dtg_json(&DTGCredential::new_vrc(
+            "did:peer:2.zR1".into(),
+            "did:peer:2.zR2".into(),
+            Utc::now(),
+            None,
+        ))
+    }
+
+    fn vmc() -> JsonValue {
+        dtg_json(&DTGCredential::new_vmc(
+            "did:web:community.example".into(),
+            "did:key:zMember".into(),
+            Utc::now(),
+            None,
+            false,
+        ))
+    }
+
+    fn vec_cred() -> JsonValue {
+        dtg_json(&DTGCredential::new_vec(
+            "did:web:issuer.example".into(),
+            "did:key:zSubject".into(),
+            Utc::now(),
+            None,
+            serde_json::json!({ "role": "moderator" }),
+        ))
+    }
+
+    /// The guard that makes this module worth having: every subtype the
+    /// catalog can mint is classified as itself, asserted against **catalog
+    /// output** rather than literals.
+    ///
+    /// A literal here could agree with a literal in the validator while both
+    /// disagreed with what clients send — the failure mode behind #1062, where
+    /// handler and test agreed on a type nothing issues.
+    #[test]
+    fn classifies_every_subtype_the_catalog_mints() {
+        for (doc, expected, label) in [
+            (vrc(), DTGCredentialType::Relationship, "VRC"),
+            (vmc(), DTGCredentialType::Membership, "VMC"),
+            (vec_cred(), DTGCredentialType::Endorsement, "VEC"),
+        ] {
+            let got = classify_dtg(&doc)
+                .unwrap_or_else(|e| panic!("catalog-minted {label} must classify: {e:?}"));
+            assert_eq!(
+                std::mem::discriminant(&got),
+                std::mem::discriminant(&expected),
+                "{label} classified as {got}"
+            );
+        }
+    }
+
+    #[test]
+    fn requires_the_expected_subtype() {
+        require_dtg_type(
+            &vrc(),
+            DTGCredentialType::Relationship,
+            "this endpoint publishes relationship edges",
+        )
+        .expect("a VRC satisfies a VRC requirement");
+
+        let err = require_dtg_type(
+            &vmc(),
+            DTGCredentialType::Relationship,
+            "this endpoint publishes relationship edges",
+        )
+        .expect_err("a VMC must not satisfy a VRC requirement");
+        assert!(format!("{err:?}").contains("relationship edges"));
+    }
+
+    #[test]
+    fn rejects_a_credential_missing_either_half_of_the_common_structure() {
+        let mut no_ctx = vrc();
+        no_ctx["@context"] = serde_json::json!(["https://www.w3.org/ns/credentials/v2"]);
+        assert!(classify_dtg(&no_ctx).is_err(), "missing DTG context");
+
+        let mut no_base = vrc();
+        no_base["type"] = serde_json::json!(["VerifiableCredential", "RelationshipCredential"]);
+        assert!(classify_dtg(&no_base).is_err(), "missing DTGCredential");
+
+        let mut no_subtype = vrc();
+        no_subtype["type"] = serde_json::json!(["VerifiableCredential", "DTGCredential"]);
+        assert!(classify_dtg(&no_subtype).is_err(), "no concrete subtype");
+    }
+
+    /// `VerifiableRecognitionCredential` and the `Verifiable`-prefixed
+    /// membership/endorsement tags were never DTG types. Nothing here may
+    /// re-admit them.
+    #[test]
+    fn refuses_types_the_specification_does_not_define() {
+        for fiction in [
+            "VerifiableRecognitionCredential",
+            "VerifiableMembershipCredential",
+            "VerifiableEndorsementCredential",
+        ] {
+            let mut doc = vrc();
+            doc["type"] = serde_json::json!(["VerifiableCredential", "DTGCredential", fiction]);
+            assert!(
+                classify_dtg(&doc).is_err(),
+                "`{fiction}` is not a DTG credential type"
+            );
+        }
+    }
+}

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -48,6 +48,7 @@ pub mod custom_endorsement;
 pub mod delivery;
 pub mod dtg;
 pub mod exchange;
+pub mod ingress;
 pub mod invitation;
 pub mod invitation_registry;
 pub mod invitation_verify;

--- a/vtc-service/src/routes/recognise.rs
+++ b/vtc-service/src/routes/recognise.rs
@@ -320,6 +320,16 @@ fn extract_vec_vmc(
         let cred: VerifiableCredential = serde_json::from_value(entry.clone()).map_err(|e| {
             AppError::Validation(format!("embedded credential is not a valid VC: {e}"))
         })?;
+        // Common structure first: a presented credential must be a DTG
+        // credential before its subtype means anything. This path used to
+        // classify on `type` alone, so a document carrying the right subtype
+        // tag and neither `@context` entry was routed as though it were a VEC.
+        // Non-DTG credentials in a VP are legitimate and simply skipped — only
+        // the VEC + VMC pair is acted on — so a failure here is not an error.
+        if crate::credentials::ingress::classify_dtg(entry).is_err() {
+            continue;
+        }
+
         // Route the credential to its slot by type. Other credential types are
         // ignored — the recognition gate only acts on the VEC + VMC pair.
         let (slot, label) = match classify(&cred.types) {
@@ -669,6 +679,70 @@ mod classify_tests {
                 "VerifiableMembershipCredential"
             ]))
             .is_none()
+        );
+    }
+
+    /// The guard that would have caught #1062.
+    ///
+    /// Every other test in this module states the wire form as a literal, and
+    /// a literal here can agree with a literal in the handler while both
+    /// disagree with what the VTC actually issues — which is exactly what
+    /// happened. This one asserts against **catalog output**: it mints through
+    /// the same `dtg-credentials` constructors `issue_endorsement` and the VMC
+    /// path use, serialises as `credentials::dtg` does, and requires
+    /// `classify` to recognise the result.
+    ///
+    /// Change the catalog's wire form and this fails. Change `classify` away
+    /// from the catalog and this fails. No literal in this file can make it
+    /// pass.
+    #[tokio::test]
+    async fn classifies_what_the_catalog_actually_mints() {
+        use dtg_credentials::DTGCredential;
+
+        fn types_of(dtg: &DTGCredential) -> Vec<String> {
+            crate::test_support::dtg_json(dtg)["type"]
+                .as_array()
+                .expect("`type` is an array")
+                .iter()
+                .map(|t| t.as_str().expect("`type` entries are strings").to_string())
+                .collect()
+        }
+
+        let now = chrono::Utc::now();
+        let vec = DTGCredential::new_vec(
+            "did:web:issuer.example".into(),
+            "did:key:zSubject".into(),
+            now,
+            None,
+            serde_json::json!({ "role": "moderator" }),
+        );
+        assert!(
+            is_endorsement(classify(&types_of(&vec))),
+            "a catalog-minted VEC must classify as an endorsement — got {:?}",
+            types_of(&vec)
+        );
+
+        let vmc = DTGCredential::new_vmc(
+            "did:web:community.example".into(),
+            "did:key:zMember".into(),
+            now,
+            None,
+            false,
+        );
+        assert!(
+            is_membership(classify(&types_of(&vmc))),
+            "a catalog-minted VMC must classify as a membership — got {:?}",
+            types_of(&vmc)
+        );
+
+        // A relationship credential is neither, and the recognition gate must
+        // ignore it rather than routing it into a slot.
+        let vrc =
+            DTGCredential::new_vrc("did:peer:2.zR1".into(), "did:peer:2.zR2".into(), now, None);
+        let vrc_types = types_of(&vrc);
+        assert!(
+            !is_endorsement(classify(&vrc_types)) && !is_membership(classify(&vrc_types)),
+            "a VRC must not be routed to the VEC or VMC slot"
         );
     }
 

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -804,7 +804,6 @@ mod tests {
         assert_eq!(extract_subject_id(&vrc).unwrap(), "did:key:zSubject");
     }
 
-    #[test]
     /// `check_vrc_shape` must accept exactly what the catalog mints as a VRC,
     /// and reject what it mints as anything else.
     ///

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -508,59 +508,20 @@ fn extract_subject_id(vrc: &JsonValue) -> Result<String, AppError> {
         })
 }
 
-/// The two `@context` entries every DTG credential MUST carry
-/// (DTG Credentials §Common Structure — normative).
-const DTG_CONTEXTS: [&str; 2] = [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://firstperson.network/credentials/dtg/v1",
-];
-
 /// Reject anything that is not a conformant VRC before it becomes an edge in
 /// the community's trust graph.
 ///
 /// The VTC does not mint VRCs — they are self-issued — but it decides what
 /// enters the graph, and an edge is only interpretable if it says what it is.
-/// Until this existed the publish path never looked at `type` at all, so any
-/// signed JSON with an `issuer` and a `credentialSubject.id` could be stored as
-/// a relationship.
-///
-/// Classification goes through `dtg_credentials`, the same catalog
-/// `DTGCredential::new_vrc` mints from, rather than string-matching here — one
-/// definition of the wire form, shared by issuer and verifier.
+/// Delegates to [`crate::credentials::ingress`], the one place the DTG common
+/// structure is checked, so this endpoint and every other ingress point agree
+/// about what a DTG credential is.
 fn check_vrc_shape(vrc: &JsonValue) -> Result<(), AppError> {
-    let ctx: Vec<String> = vrc
-        .get("@context")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .ok_or_else(|| AppError::Validation("VRC `@context` missing or not an array".into()))?;
-    for required in DTG_CONTEXTS {
-        if !ctx.iter().any(|c| c == required) {
-            return Err(AppError::Validation(format!(
-                "VRC `@context` must include `{required}`"
-            )));
-        }
-    }
-
-    let types: Vec<String> = vrc
-        .get("type")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .ok_or_else(|| AppError::Validation("VRC `type` missing or not an array".into()))?;
-    for required in ["VerifiableCredential", "DTGCredential"] {
-        if !types.iter().any(|t| t == required) {
-            return Err(AppError::Validation(format!(
-                "VRC `type` must include `{required}`"
-            )));
-        }
-    }
-
-    match dtg_credentials::DTGCredentialType::try_from(types.as_slice()) {
-        Ok(dtg_credentials::DTGCredentialType::Relationship) => Ok(()),
-        Ok(other) => Err(AppError::Validation(format!(
-            "this endpoint publishes relationship edges; got a {other}"
-        ))),
-        Err(_) => Err(AppError::Validation(
-            "VRC `type` names no DTG credential subtype — expected `RelationshipCredential`".into(),
-        )),
-    }
+    crate::credentials::ingress::require_dtg_type(
+        vrc,
+        dtg_credentials::DTGCredentialType::Relationship,
+        "this endpoint publishes relationship edges",
+    )
 }
 
 /// `type` of the publish authorization object. Guarding on it stops a
@@ -841,6 +802,43 @@ mod tests {
             "credentialSubject": { "id": "did:key:zSubject", "role": "member" }
         });
         assert_eq!(extract_subject_id(&vrc).unwrap(), "did:key:zSubject");
+    }
+
+    #[test]
+    /// `check_vrc_shape` must accept exactly what the catalog mints as a VRC,
+    /// and reject what it mints as anything else.
+    ///
+    /// Asserted against **catalog output** rather than a literal. A literal
+    /// here could agree with the literal in `check_vrc_shape` while both
+    /// disagreed with what clients actually send — the failure mode that let
+    /// `VerifiableRecognitionCredential` live in this file's fixtures while no
+    /// client ever emitted it, and that broke recognition in #1062 next door.
+    #[test]
+    fn accepts_what_the_catalog_mints_as_a_vrc_and_nothing_else() {
+        use dtg_credentials::DTGCredential;
+
+        use crate::test_support::dtg_json as body;
+
+        let now = Utc::now();
+        let vrc =
+            DTGCredential::new_vrc("did:peer:2.zR1".into(), "did:peer:2.zR2".into(), now, None);
+        check_vrc_shape(&body(&vrc)).expect("a catalog-minted VRC must be publishable");
+
+        // Same catalog, different subtype — this endpoint publishes
+        // relationship edges, and a membership edge has different issuance
+        // rules.
+        let vmc = DTGCredential::new_vmc(
+            "did:web:community.example".into(),
+            "did:key:zMember".into(),
+            now,
+            None,
+            false,
+        );
+        let err = check_vrc_shape(&body(&vmc)).expect_err("a VMC must not publish as a VRC");
+        assert!(
+            format!("{err:?}").contains("relationship edges"),
+            "unexpected rejection: {err:?}"
+        );
     }
 
     #[test]

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -1615,3 +1615,20 @@ mod didcomm_harness {
         secret
     }
 }
+
+/// Serialise a catalog-built DTG credential to the JSON body the VTC's
+/// validators see, exactly as `credentials::dtg` does before signing.
+///
+/// The sanctioned way for a test to obtain a DTG credential. Hand-rolling the
+/// JSON instead states the *implementation's* belief about the wire form
+/// rather than the catalog's definition of it — so a fixture and a validator
+/// can agree with each other while both disagree with what any client sends.
+/// That is not hypothetical: it is how the recognition path came to match
+/// `"VerifiableEndorsementCredential"`, a type nothing has ever issued, and
+/// reject every real presentation (#1062), with a green suite throughout.
+///
+/// Hand-rolled JSON remains correct for malformed-input cases — the catalog
+/// cannot produce a credential that is missing its own `@context`.
+pub fn dtg_json(dtg: &dtg_credentials::DTGCredential) -> serde_json::Value {
+    serde_json::to_value(dtg.credential()).expect("catalog credential serialises")
+}


### PR DESCRIPTION
Closes #1064 (F2) and #1066 (F4) **together**, because either alone reopens the
trap: a shared ingress validator whose tests hand-roll their input validates
the implementation against itself, which is the exact condition that let the
recognition path match `"VerifiableEndorsementCredential"` for its entire life
while nothing has ever issued that type.

## One place decides what a DTG credential is

`credentials::ingress` checks §Common Structure — both required `@context`
entries, `VerifiableCredential` + `DTGCredential`, exactly one concrete subtype
— and classifies through `dtg_credentials::DTGCredentialType`, the same catalog
the issuing side mints from.

- `check_vrc_shape` becomes a call to it.
- **The recognition path gains the check it never had.** It classified on
  `type` alone, so a document carrying the right subtype tag and neither
  `@context` entry was routed as though it were a VEC.

## The tests assert against catalog output, not literals

This is the half that matters. A literal in a test can agree with a literal in
a validator while both disagree with what any client sends — that is not a
hypothetical, it is #1062.

So the guards mint through `new_vrc` / `new_vmc` / `new_vec` and require the
validator to accept the result. **Change the catalog's wire form and they fail;
change a validator away from the catalog and they fail; no literal in the file
can make them pass.**

`test_support::dtg_json` is the sanctioned way for a test to obtain a DTG
credential. Hand-rolled JSON stays correct for malformed-input cases — the
catalog cannot produce a credential missing its own `@context`.

## Each guard was mutation-tested, not assumed

A guard that cannot fail is worth nothing, so I broke each invariant and
confirmed the guard caught it:

| Mutation | Result |
|---|---|
| `check_vrc_shape` accepted subtype `Relationship` → `Membership` | round-trip test fails |
| legacy tag re-added to `classify` | refusal test fails |
| DTG context dropped from the recognition fixture | end-to-end holder test fails — with the same 400 #1062 produced |

## Also pinned by name

`VerifiableRecognitionCredential` and the `Verifiable`-prefixed membership and
endorsement tags are refused explicitly. All three were invented in this repo,
none is a DTG type, and each has already cost a bug.

## Breaking

A credential presented to `/v1/auth/recognise` that does not carry the DTG
common structure is now skipped rather than routed to its slot. Credentials
minted through `dtg-credentials` — every credential this stack issues — are
unaffected.

Full suite green: 53 suites, 0 failures, clippy clean.

## Scope note

35 hand-rolled credential fixtures remain across 16 files. I did not migrate
them: most are malformed-input cases or non-DTG credentials (status lists,
schema validation) where hand-rolling is correct, and a 35-file mechanical diff
would bury the part of this that matters. The guards above pin the invariant
those fixtures could violate, which is the durable fix — a fixture that drifts
from the catalog now fails a test that mints from it.
