### PR TITLE
feat(vtc)!: distinguish half-edges from complete edges in the relationships graph

### DIFF
--- a/docs/03-vtc/personhood-and-graph.md
+++ b/docs/03-vtc/personhood-and-graph.md
@@ -137,6 +137,53 @@ VRCs naming a `Tombstone` or `Historical` departure stay visible
 Bilateral counter-signing (where B confirms A's VRC) is **v2**.
 For Phase 4, every VRC is self-issued by the originator.
 
+### The connections graph: half-edges vs complete edges
+
+`GET /v1/relationships/graph` (admin-only) returns the whole edge
+set for the admin UI's connections view. DTG Credentials defines a
+DTG edge as **two** VRCs, one in each direction, so the response
+groups by unordered pair rather than listing one entry per stored
+credential:
+
+```json
+{
+  "nodes": [{ "did": "did:key:zA" }, { "did": "did:key:zB" }],
+  "edges": [{
+    "endpoints": ["did:key:zA", "did:key:zB"],
+    "halves": [
+      { "id": "…", "issuerDid": "did:key:zA", "subjectDid": "did:key:zB", "createdAt": "…" },
+      { "id": "…", "issuerDid": "did:key:zB", "subjectDid": "did:key:zA", "createdAt": "…" }
+    ],
+    "complete": true
+  }]
+}
+```
+
+`complete` is true only when a VRC exists in **both** directions.
+A single-direction edge is a *half-edge* — one party's claim that
+the other has not answered.
+
+The distinction matters because it is what replaced a check.
+Publishing used to require the subject to be a current member; that
+check was the community asserting on the subject's behalf that the
+edge was legitimate. #1061 dropped it, on the DTG rule that
+"community membership is not a precondition for issuing, holding,
+or presenting a VRC", and on the reasoning that the subject's
+consent to an edge is *their publication of the reciprocal VRC*.
+That consent signal is only visible to an operator if the graph
+shows whether the reciprocal VRC arrived — which is what
+`complete` is.
+
+`endpoints` is DID-sorted so a pair has one identity whichever
+half was published first. `halves` can hold more than two entries:
+idempotency is keyed on the credential hash, not on direction, so a
+party can publish several VRCs the same way round. That does not
+make an edge complete — the check is for a VRC in each direction,
+not for two credentials.
+
+Design record:
+[`../05-design-notes/vrc-publish-proof-of-possession.md`](../05-design-notes/vrc-publish-proof-of-possession.md).
+
 ## Custom endorsements
 
 Phase 4 also adds operator-defined custom endorsements via an

--- a/docs/05-design-notes/vrc-publish-proof-of-possession.md
+++ b/docs/05-design-notes/vrc-publish-proof-of-possession.md
@@ -190,7 +190,7 @@ acknowledgement. The same logic applies one layer down.
 Consequence: `GET /v1/relationships/graph` should distinguish half-edges from
 complete edges, and the admin UI should show the difference. That is a better
 graph than today's, which cannot tell a mutual relationship from a unilateral
-claim.
+claim. **Implemented** — see "The graph" below.
 
 ## Compatibility
 
@@ -257,6 +257,81 @@ no-op default (`vti-common/src/auth/backend.rs:284`). The criterion worth
 enforcing is that resolving an R-DID must not disclose the relationship to a
 third party; methods either meet it or do not, and the community should say which
 it accepts.
+
+## The graph — the remaining #1054 work
+
+Two things were left open on the graph in #1054. One was built and one was
+deliberately not, and the reasoning for the second is the more useful record.
+
+### Half-edges vs complete edges — built
+
+`GET /v1/relationships/graph` returned one entry per stored VRC, so a mutual
+relationship and a unilateral claim rendered identically. It now groups by
+unordered pair (`vtc-service/src/routes/relationships.rs`, `build_graph`) and
+each edge carries `endpoints` (DID-sorted), `halves` (every VRC published
+between them, oldest first) and `complete` (a VRC exists in both directions).
+The admin UI draws a complete edge solid and double-headed, a half-edge dashed
+and single-headed, and counts them separately
+(`vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx`).
+
+This is a breaking response-shape change. It is worth taking because the
+distinction is what the dropped subject-membership check was replaced *with*:
+if consent to an edge is the counterparty's publication of the reciprocal VRC,
+an operator who cannot see whether that VRC arrived cannot see consent at all.
+
+Two rules that are easy to get wrong and are pinned by tests:
+
+- **Several VRCs in the same direction do not complete an edge.** Idempotency is
+  keyed on the credential hash, not the direction, so a member can publish three
+  A→B VRCs. `complete` checks for a VRC in each direction, not for two rows.
+- **A self-issued VRC (`issuer == subject`) is never complete.** It has no
+  counterparty who could reciprocate, and the naive both-directions test matches
+  the same row twice.
+
+### Stored vs derived — not built, and why
+
+The proposal on #1054 was item 3: "make the graph derived rather than stored…
+without persisting an M-DID adjacency list." That is not built, on two grounds.
+
+**The motivation was removed by #1061, not deferred.** The concern was a durable
+*membership-DID* adjacency list — a correlation store the community holds and
+the spec's Privacy Considerations are written to avoid. Since #1061 the stored
+DIDs are the identifiers the member chose to publish under. Under the pairwise
+form those are R-DIDs, which name nobody and correlate nothing beyond the single
+relationship they were minted for; under the attributed form the member has
+deliberately asserted a correlatable edge, which DTG Credentials permits
+directly. Neither is the thing item 3 was written against.
+
+**"Derived" has no source to derive from.** The relationships keyspace is the
+only place a published VRC exists on the VTC side — `Relationship.vrc_jsonld`
+holds the credential verbatim, and `issuer_did` / `subject_did` are projections
+of fields inside it (`vtc-service/src/relationships/mod.rs`). Deriving the graph
+from something else would mean not storing published VRCs at all, which deletes
+`POST /v1/relationships` and the two read endpoints with it. What is actually
+available is a narrower change — drop the two projected DID columns and re-read
+them out of the stored credential on each scan — and that removes no
+information, because the credential containing them is still the row.
+
+**And nothing publishes.** `POST /v1/relationships` is the only production
+writer to the keyspace, and as of this note no caller exists: not in this
+workspace, not in `vta-sdk` (which has no relationship protocol module at all),
+not in `vtc-client`, and not in `openvtc`. OpenVTC mints VRCs through
+`DTGCredential::new_vrc` and exchanges them peer-to-peer over DIDComm
+(`openvtc/src/state_handler/inbox_actions.rs`,
+`openvtc/src/state_handler/main_page/mod.rs`), then retains them locally; it
+speaks the VTC's join, ACL, credential-exchange and self-remove Trust Tasks but
+never `relationships/publish`. So the graph is empty in every deployment that
+exists, and reshaping its storage would be work against no data and no reader.
+
+None of that makes the *question* wrong — a community that gets real publish
+traffic under the attributed form does accumulate a correlatable edge set, by
+design and with the members' assertion, and one that gets pairwise traffic
+accumulates a set that is correlatable only to the operator holding the audit
+trail (see "Audit attribution" above, which is where that residual was already
+recorded). It makes it premature. The point to revisit it is when something
+publishes, and the concrete decision then is whether to keep `issuer_did` and
+`subject_did` as columns or read them from the credential — not whether to hold
+the credentials.
 
 ## What this does not solve
 

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -331,18 +331,29 @@ const RELATIONSHIPS_GRAPH_TASK =
 export interface GraphNode {
   did: string;
 }
-export interface GraphEdge {
+/** One published VRC: a directed half of an edge. */
+export interface GraphHalf {
   id: string;
   issuerDid: string;
   subjectDid: string;
   createdAt: string;
+}
+/** One edge between a pair of identifiers. A DTG edge is *two* VRCs, one in
+ * each direction; `complete` says whether both have been published. A
+ * half-edge is one party's unilateral claim, not a mutual relationship. */
+export interface GraphEdge {
+  /** The two endpoints, DID-sorted. Always length 2. */
+  endpoints: string[];
+  /** Every VRC published between them, oldest first. */
+  halves: GraphHalf[];
+  complete: boolean;
 }
 export interface RelationshipsGraph {
   nodes: GraphNode[];
   edges: GraphEdge[];
 }
 
-/** The community's member-relationship (VRC) graph — every trust edge between
+/** The community's relationship (VRC) graph — every trust edge between
  * members, for the connections-graph view. Admin-gated. */
 export const fetchRelationshipsGraph = (): Promise<RelationshipsGraph> =>
   getJson<RelationshipsGraph>("/v1/relationships/graph", {

--- a/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
+++ b/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
@@ -3,14 +3,25 @@
 //
 // Unlike the recognition graph (external, query-only), member relationships are
 // local + enumerable, so we can draw the whole thing. Layout is a deterministic
-// circle: members are nodes, each published VRC is a directed edge issuer →
-// subject. Click a node to highlight its connections and list its edges.
+// circle: endpoints are nodes, each edge joins a pair. Click a node to highlight
+// its connections and list its edges.
+//
+// A DTG edge is *two* VRCs, one in each direction. The two are drawn
+// differently on purpose: a solid double-headed line is a complete edge, where
+// both parties have published; a dashed single-headed line is a half-edge — one
+// party's claim that the other has not reciprocated. These used to render
+// identically, so the view could not tell a mutual relationship from a
+// unilateral one (#1054).
 
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Share2 } from "lucide-react";
 
-import { fetchRelationshipsGraph, type RelationshipsGraph } from "@/lib/api";
+import {
+  fetchRelationshipsGraph,
+  type GraphEdge,
+  type RelationshipsGraph,
+} from "@/lib/api";
 import { useNameBook } from "@/lib/names";
 import { NamedDid } from "@/components/NamedDid";
 
@@ -23,6 +34,13 @@ interface Placed {
   x: number;
   y: number;
 }
+
+/** A stable key for an edge — the pair identity the server sorted. */
+const edgeKey = (e: GraphEdge) => e.endpoints.join("|");
+
+/** The endpoint of `e` that isn't `did`. Equals `did` for a self-issued VRC. */
+const otherEnd = (e: GraphEdge, did: string): string =>
+  (e.endpoints[0] === did ? e.endpoints[1] : e.endpoints[0]) ?? did;
 
 export function Relationships() {
   const nameBook = useNameBook();
@@ -49,11 +67,14 @@ export function Relationships() {
   }, [placed]);
 
   const edges = query.data?.edges ?? [];
+  const completeCount = edges.filter((e) => e.complete).length;
+  const halfCount = edges.length - completeCount;
+
   const selectedEdges = selected
-    ? edges.filter((e) => e.issuerDid === selected || e.subjectDid === selected)
+    ? edges.filter((e) => e.endpoints.includes(selected))
     : [];
   const neighbours = new Set<string>(
-    selectedEdges.flatMap((e) => [e.issuerDid, e.subjectDid]),
+    selectedEdges.flatMap((e) => e.endpoints),
   );
 
   const isEmpty = query.data && placed.length === 0;
@@ -65,10 +86,12 @@ export function Relationships() {
           <Share2 size={20} strokeWidth={1.75} /> Relationships
         </h2>
         <p className="muted">
-          The community's trust graph: each node is a member, each edge a
-          published Verifiable Relationship Credential (VRC), pointing from the
-          asserting member to the member they vouched for. Click a node to
-          highlight its connections.
+          The community's trust graph. Each node is an identifier a member
+          published a Verifiable Relationship Credential (VRC) under; each edge
+          joins a pair. An edge is <strong>complete</strong> when both parties
+          have published a VRC naming the other — that reciprocal credential is
+          how a member consents to the edge. A <strong>half-edge</strong> is one
+          party's claim the other has not answered.
         </p>
       </header>
 
@@ -85,95 +108,159 @@ export function Relationships() {
       {isEmpty && (
         <section className="card">
           <p className="muted">
-            No relationships published yet — members haven't issued any VRCs.
+            No relationships published yet — members haven't published any VRCs.
           </p>
         </section>
       )}
 
       {query.data && placed.length > 0 && (
         <section className="card" style={{ display: "flex", gap: "var(--space-4)", flexWrap: "wrap" }}>
-          <svg
-            viewBox={`0 0 ${SIZE} ${SIZE}`}
-            style={{ width: "min(100%, 560px)", height: "auto" }}
-            role="img"
-            aria-label="Member relationship graph"
-          >
-            <defs>
-              <marker
-                id="rel-arrow"
-                viewBox="0 0 10 10"
-                refX="9"
-                refY="5"
-                markerWidth="6"
-                markerHeight="6"
-                orient="auto-start-reverse"
-              >
-                <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border-strong)" />
-              </marker>
-            </defs>
-
-            {/* Edges */}
-            {edges.map((e) => {
-              const a = posByDid.get(e.issuerDid);
-              const b = posByDid.get(e.subjectDid);
-              if (!a || !b) return null;
-              const active =
-                !selected || e.issuerDid === selected || e.subjectDid === selected;
-              return (
-                <line
-                  key={e.id}
-                  x1={a.x}
-                  y1={a.y}
-                  x2={b.x}
-                  y2={b.y}
-                  stroke={active ? "var(--brand)" : "var(--border)"}
-                  strokeWidth={active ? 1.5 : 1}
-                  opacity={selected && !active ? 0.25 : 0.8}
-                  markerEnd="url(#rel-arrow)"
-                />
-              );
-            })}
-
-            {/* Nodes */}
-            {placed.map((p) => {
-              const isSel = selected === p.did;
-              const dim = selected && !isSel && !neighbours.has(p.did);
-              return (
-                <g
-                  key={p.did}
-                  transform={`translate(${p.x}, ${p.y})`}
-                  style={{ cursor: "pointer" }}
-                  opacity={dim ? 0.35 : 1}
-                  onClick={() => setSelected(isSel ? null : p.did)}
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
+            <svg
+              viewBox={`0 0 ${SIZE} ${SIZE}`}
+              style={{ width: "min(100%, 560px)", height: "auto" }}
+              role="img"
+              aria-label="Member relationship graph"
+            >
+              <defs>
+                <marker
+                  id="rel-arrow"
+                  viewBox="0 0 10 10"
+                  refX="9"
+                  refY="5"
+                  markerWidth="6"
+                  markerHeight="6"
+                  orient="auto-start-reverse"
                 >
-                  <circle
-                    r={isSel ? 9 : 6}
-                    fill={isSel ? "var(--brand)" : "var(--brand-tint-strong)"}
-                    stroke="var(--border-strong)"
-                    strokeWidth={1}
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border-strong)" />
+                </marker>
+              </defs>
+
+              {/* Edges. Complete: solid, arrowheads both ends. Half: dashed,
+                  one arrowhead, pointing at the party who hasn't answered. */}
+              {edges.map((e) => {
+                const [e0, e1] = e.endpoints;
+                const half = e.halves[0];
+                // The server guarantees two endpoints and at least one half;
+                // this narrows rather than defends.
+                if (!e0 || !e1 || !half) return null;
+                // A self-issued VRC has both endpoints at one point — nothing
+                // to draw, and the node itself already carries it.
+                if (e0 === e1) return null;
+                // Draw a half-edge issuer → subject; a complete edge has no
+                // meaningful direction, so orient it on the sorted pair.
+                const from = e.complete ? e0 : half.issuerDid;
+                const to = e.complete ? e1 : half.subjectDid;
+                const a = posByDid.get(from);
+                const b = posByDid.get(to);
+                if (!a || !b) return null;
+                const active = !selected || e.endpoints.includes(selected);
+                return (
+                  <line
+                    key={edgeKey(e)}
+                    x1={a.x}
+                    y1={a.y}
+                    x2={b.x}
+                    y2={b.y}
+                    stroke={active ? "var(--brand)" : "var(--border)"}
+                    strokeWidth={e.complete ? (active ? 2 : 1.5) : active ? 1.5 : 1}
+                    strokeDasharray={e.complete ? undefined : "4 3"}
+                    opacity={selected && !active ? 0.25 : 0.8}
+                    markerStart={e.complete ? "url(#rel-arrow)" : undefined}
+                    markerEnd="url(#rel-arrow)"
                   />
-                  <text
-                    x={p.x > C ? 11 : -11}
-                    y={4}
-                    textAnchor={p.x > C ? "start" : "end"}
-                    fontSize="10"
-                    fill="var(--text-muted)"
+                );
+              })}
+
+              {/* Nodes */}
+              {placed.map((p) => {
+                const isSel = selected === p.did;
+                const dim = selected && !isSel && !neighbours.has(p.did);
+                return (
+                  <g
+                    key={p.did}
+                    transform={`translate(${p.x}, ${p.y})`}
+                    style={{ cursor: "pointer" }}
+                    opacity={dim ? 0.35 : 1}
+                    onClick={() => setSelected(isSel ? null : p.did)}
                   >
-                    {nameBook.nameOrDid(p.did)}
-                  </text>
-                </g>
-              );
-            })}
-          </svg>
+                    <circle
+                      r={isSel ? 9 : 6}
+                      fill={isSel ? "var(--brand)" : "var(--brand-tint-strong)"}
+                      stroke="var(--border-strong)"
+                      strokeWidth={1}
+                    />
+                    <text
+                      x={p.x > C ? 11 : -11}
+                      y={4}
+                      textAnchor={p.x > C ? "start" : "end"}
+                      fontSize="10"
+                      fill="var(--text-muted)"
+                    >
+                      {nameBook.nameOrDid(p.did)}
+                    </text>
+                  </g>
+                );
+              })}
+            </svg>
+
+            <svg
+              viewBox="0 0 260 40"
+              style={{ width: "min(100%, 260px)", height: "auto" }}
+              role="img"
+              aria-label="Legend"
+            >
+              {/* Its own marker: a `url(#…)` reference resolving into a
+                  different inline <svg> is not something to rely on. */}
+              <defs>
+                <marker
+                  id="rel-arrow-legend"
+                  viewBox="0 0 10 10"
+                  refX="9"
+                  refY="5"
+                  markerWidth="6"
+                  markerHeight="6"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border-strong)" />
+                </marker>
+              </defs>
+              <line
+                x1={4}
+                y1={12}
+                x2={40}
+                y2={12}
+                stroke="var(--brand)"
+                strokeWidth={2}
+                markerStart="url(#rel-arrow-legend)"
+                markerEnd="url(#rel-arrow-legend)"
+              />
+              <text x={48} y={16} fontSize="10" fill="var(--text-muted)">
+                complete — both parties published
+              </text>
+              <line
+                x1={4}
+                y1={30}
+                x2={40}
+                y2={30}
+                stroke="var(--brand)"
+                strokeWidth={1.5}
+                strokeDasharray="4 3"
+                markerEnd="url(#rel-arrow-legend)"
+              />
+              <text x={48} y={34} fontSize="10" fill="var(--text-muted)">
+                half-edge — not reciprocated
+              </text>
+            </svg>
+          </div>
 
           <div style={{ flex: "1 1 220px", minWidth: 220 }}>
-            <h3>
-              {selected ? "Connections" : "Overview"}
-            </h3>
+            <h3>{selected ? "Connections" : "Overview"}</h3>
             {!selected && (
               <p className="muted">
-                {placed.length} member{placed.length === 1 ? "" : "s"} ·{" "}
-                {edges.length} relationship{edges.length === 1 ? "" : "s"}.
+                {placed.length} identifier{placed.length === 1 ? "" : "s"} ·{" "}
+                {completeCount} complete edge{completeCount === 1 ? "" : "s"} ·{" "}
+                {halfCount} half-edge{halfCount === 1 ? "" : "s"}.
                 <br />
                 Select a node to see its edges.
               </p>
@@ -187,21 +274,36 @@ export function Relationships() {
                   <p className="muted">No relationships.</p>
                 ) : (
                   <ul style={{ paddingLeft: "1.1em", margin: 0 }}>
-                    {selectedEdges.map((e) => (
-                      <li key={e.id} style={{ marginBottom: 4 }}>
-                        {e.issuerDid === selected ? (
-                          <>
-                            → vouched for{" "}
-                            <code>{nameBook.nameOrDid(e.subjectDid)}</code>
-                          </>
-                        ) : (
-                          <>
-                            ← vouched for by{" "}
-                            <code>{nameBook.nameOrDid(e.issuerDid)}</code>
-                          </>
-                        )}
-                      </li>
-                    ))}
+                    {selectedEdges.map((e) => {
+                      const other = otherEnd(e, selected);
+                      const name = nameBook.nameOrDid(other);
+                      const issuedBySelected = e.halves.some(
+                        (h) => h.issuerDid === selected,
+                      );
+                      return (
+                        <li key={edgeKey(e)} style={{ marginBottom: 4 }}>
+                          {e.complete ? (
+                            <>
+                              ↔ mutual with <code>{name}</code>
+                            </>
+                          ) : issuedBySelected ? (
+                            <>
+                              → vouched for <code>{name}</code>{" "}
+                              <span className="muted">
+                                (not reciprocated)
+                              </span>
+                            </>
+                          ) : (
+                            <>
+                              ← vouched for by <code>{name}</code>{" "}
+                              <span className="muted">
+                                (not reciprocated)
+                              </span>
+                            </>
+                          )}
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </>

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -749,25 +749,62 @@ fn canonicalise(v: &JsonValue) -> String {
 }
 
 // ── Connections graph (admin) ──────────────────────────────────────────────
+//
+// DTG Credentials defines a DTG edge as **two** VRCs, one in each direction.
+// This endpoint used to return one entry per stored VRC, so a mutual
+// relationship and a unilateral claim were indistinguishable: two members who
+// had each vouched for the other looked the same as one member asserting an
+// edge the other has never acknowledged (#1054).
+//
+// That distinction is the whole reason the subject-membership precondition
+// could be dropped in #1061. The design there
+// (`docs/05-design-notes/vrc-publish-proof-of-possession.md`) is that the
+// subject's consent to an edge **is** their publication of the reciprocal VRC,
+// rather than the community asserting on their behalf that they exist. If the
+// graph cannot show whether that reciprocal VRC arrived, the consent signal the
+// check was replaced with is invisible to the operator reading the graph.
+//
+// So the graph groups by unordered pair and reports the halves it holds.
 
-/// One node in the connections graph — a member that is an endpoint of at least
-/// one relationship (VRC). Isolated members (no VRCs) are not surfaced.
+/// One node in the connections graph — an identifier that is an endpoint of at
+/// least one relationship (VRC). Isolated members (no VRCs) are not surfaced.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphNode {
     pub did: String,
 }
 
-/// One directed edge — a published VRC from `issuerDid` (the asserting member)
-/// to `subjectDid`. Body-free (no VRC JSON-LD): the graph shows the shape, not
-/// the credential contents.
+/// One published VRC: a directed *half* of a DTG edge, from `issuerDid` (the
+/// asserting party) to `subjectDid`. Body-free (no VRC JSON-LD) — the graph
+/// shows the shape, not the credential contents. `id` is the row id, which is
+/// what `DELETE /v1/relationships/{id}` takes.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct GraphEdge {
+pub struct GraphHalf {
     pub id: String,
     pub issuer_did: String,
     pub subject_did: String,
     pub created_at: String,
+}
+
+/// One edge between a pair of identifiers, carrying every VRC published between
+/// them.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEdge {
+    /// The two endpoints, DID-sorted. Always exactly two entries, and sorting
+    /// them gives the pair one identity whichever half was published first.
+    /// Both entries are equal only for a self-issued VRC.
+    pub endpoints: Vec<String>,
+    /// Every VRC published between the endpoints, oldest first. One for a
+    /// half-edge, two for the ordinary complete edge; more only if a party
+    /// published several VRCs in the same direction, which nothing prevents
+    /// (idempotency is per credential hash, not per direction).
+    pub halves: Vec<GraphHalf>,
+    /// A VRC exists in **both** directions — a complete DTG edge, and the only
+    /// form in which both parties have consented. False means a half-edge: one
+    /// party's unilateral claim, which the other has not reciprocated.
+    pub complete: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -777,16 +814,77 @@ pub struct RelationshipsGraph {
     pub edges: Vec<GraphEdge>,
 }
 
-/// `GET /v1/relationships/graph` — the community's member-relationship (VRC)
-/// graph: every published trust edge between members, for the admin-UI
-/// connections view. Admin-gated; a full scan of the relationships keyspace
-/// (communities are small and this is operator-only). Edge-derived nodes —
-/// members with no VRCs don't appear.
+/// Group stored VRCs into pair-edges. Pure, so the half/complete rule is
+/// testable without standing up a keyspace.
+fn build_graph(mut rels: Vec<Relationship>) -> RelationshipsGraph {
+    // Oldest first, id-tiebroken, so `halves` ordering is stable across calls
+    // rather than inheriting whatever order the keyspace scan produced.
+    rels.sort_by_key(|r| (r.created_at, r.id));
+
+    let mut nodes = std::collections::BTreeSet::new();
+    // BTreeMap, not HashMap: the response order is then a function of the data
+    // and not of hash seeding, which keeps the admin view from reshuffling on
+    // every poll.
+    let mut pairs: std::collections::BTreeMap<(String, String), Vec<GraphHalf>> =
+        std::collections::BTreeMap::new();
+
+    for r in rels {
+        nodes.insert(r.issuer_did.clone());
+        nodes.insert(r.subject_did.clone());
+        let key = if r.issuer_did <= r.subject_did {
+            (r.issuer_did.clone(), r.subject_did.clone())
+        } else {
+            (r.subject_did.clone(), r.issuer_did.clone())
+        };
+        pairs.entry(key).or_default().push(GraphHalf {
+            id: r.id.to_string(),
+            issuer_did: r.issuer_did,
+            subject_did: r.subject_did,
+            created_at: r.created_at.to_rfc3339(),
+        });
+    }
+
+    let edges = pairs
+        .into_iter()
+        .map(|((lo, hi), halves)| {
+            // A self-issued VRC (`lo == hi`) has no counterparty who could ever
+            // reciprocate, so it can never be complete — without the `lo != hi`
+            // guard the two `any` checks below would both match the same row
+            // and report a self-vouch as a mutual relationship.
+            let complete = lo != hi
+                && halves
+                    .iter()
+                    .any(|h| h.issuer_did == lo && h.subject_did == hi)
+                && halves
+                    .iter()
+                    .any(|h| h.issuer_did == hi && h.subject_did == lo);
+            GraphEdge {
+                endpoints: vec![lo, hi],
+                halves,
+                complete,
+            }
+        })
+        .collect();
+
+    RelationshipsGraph {
+        nodes: nodes.into_iter().map(|did| GraphNode { did }).collect(),
+        edges,
+    }
+}
+
+/// `GET /v1/relationships/graph` — the community's relationship (VRC) graph for
+/// the admin-UI connections view. Admin-gated; a full scan of the relationships
+/// keyspace (communities are small and this is operator-only). Edge-derived
+/// nodes — members with no VRCs don't appear.
+///
+/// Edges are pairs, not individual credentials: each carries the VRCs published
+/// between its two endpoints and a `complete` flag saying whether both
+/// directions are present. See the module comment above for why.
 #[utoipa::path(
     get, path = "/relationships/graph", tag = "relationships",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "Member-relationship graph", body = RelationshipsGraph),
+        (status = 200, description = "Relationship graph", body = RelationshipsGraph),
         (status = 403, description = "Caller is not an admin"),
     ),
 )]
@@ -795,22 +893,7 @@ pub async fn graph(
     State(state): State<AppState>,
 ) -> Result<Json<RelationshipsGraph>, AppError> {
     let rels = crate::relationships::list_all(&state.relationships_ks).await?;
-    let mut nodes = std::collections::BTreeSet::new();
-    let mut edges = Vec::with_capacity(rels.len());
-    for r in rels {
-        nodes.insert(r.issuer_did.clone());
-        nodes.insert(r.subject_did.clone());
-        edges.push(GraphEdge {
-            id: r.id.to_string(),
-            issuer_did: r.issuer_did,
-            subject_did: r.subject_did,
-            created_at: r.created_at.to_rfc3339(),
-        });
-    }
-    Ok(Json(RelationshipsGraph {
-        nodes: nodes.into_iter().map(|did| GraphNode { did }).collect(),
-        edges,
-    }))
+    Ok(Json(build_graph(rels)))
 }
 
 #[cfg(test)]
@@ -848,5 +931,111 @@ mod tests {
         let a = json!({ "b": 1, "a": 2, "c": { "y": 5, "x": 4 } });
         let b = json!({ "a": 2, "c": { "x": 4, "y": 5 }, "b": 1 });
         assert_eq!(canonicalise(&a), canonicalise(&b));
+    }
+
+    // ─── Half-edges vs complete edges ───────────────────────
+    //
+    // A DTG edge is two VRCs, one each way. These pin the rule that says which
+    // is which, because getting it wrong is silent: the graph still renders, it
+    // just tells the operator a unilateral claim is a mutual relationship.
+
+    const A: &str = "did:key:zAlice";
+    const B: &str = "did:key:zBob";
+    const C: &str = "did:key:zCarol";
+
+    /// A stored row whose body is minted by the same catalog constructor the
+    /// publish path documents (`DTGCredential::new_vrc`) rather than
+    /// hand-rolled JSON — a hand-rolled fixture agrees with the test that wrote
+    /// it and with nothing that ships.
+    fn row(issuer: &str, subject: &str, minute: u32) -> Relationship {
+        use chrono::TimeZone;
+        let valid_from = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let vrc = dtg_credentials::DTGCredential::new_vrc(
+            issuer.to_string(),
+            subject.to_string(),
+            valid_from,
+            None,
+        );
+        let vrc_jsonld = serde_json::to_value(vrc.credential()).expect("VRC serialises");
+        let vrc_sha256 = hex::encode(Sha256::digest(canonicalise(&vrc_jsonld).as_bytes()));
+        Relationship {
+            id: Uuid::new_v4(),
+            issuer_did: issuer.into(),
+            subject_did: subject.into(),
+            vrc_jsonld,
+            vrc_sha256,
+            created_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, minute, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn a_reciprocated_pair_is_one_complete_edge() {
+        let g = build_graph(vec![row(A, B, 0), row(B, A, 1)]);
+        assert_eq!(g.edges.len(), 1, "two VRCs one each way are ONE edge");
+        assert_eq!(g.edges[0].endpoints, vec![A.to_string(), B.to_string()]);
+        assert_eq!(g.edges[0].halves.len(), 2);
+        assert!(g.edges[0].complete);
+        assert_eq!(g.nodes.len(), 2);
+    }
+
+    #[test]
+    fn an_unreciprocated_vrc_is_a_half_edge() {
+        let g = build_graph(vec![row(A, B, 0)]);
+        assert_eq!(g.edges.len(), 1);
+        assert_eq!(g.edges[0].halves.len(), 1);
+        assert!(
+            !g.edges[0].complete,
+            "B has never acknowledged this edge, so it is not complete"
+        );
+        // The subject still appears — the graph shows who was named, it just no
+        // longer implies they agreed.
+        assert_eq!(g.nodes.len(), 2);
+    }
+
+    /// The trap this whole change exists to close: several VRCs between two
+    /// parties are not evidence of reciprocity if they all point one way.
+    #[test]
+    fn repeated_vrcs_in_one_direction_do_not_complete_an_edge() {
+        let g = build_graph(vec![row(A, B, 0), row(A, B, 1), row(A, B, 2)]);
+        assert_eq!(g.edges.len(), 1);
+        assert_eq!(g.edges[0].halves.len(), 3);
+        assert!(!g.edges[0].complete);
+    }
+
+    /// `endpoints` is DID-sorted, so the pair has one identity whichever half
+    /// arrived first — otherwise the same relationship would appear as two
+    /// edges depending on publish order.
+    #[test]
+    fn pair_identity_does_not_depend_on_publish_order() {
+        let forward = build_graph(vec![row(A, B, 0), row(B, A, 1)]);
+        let reverse = build_graph(vec![row(B, A, 0), row(A, B, 1)]);
+        assert_eq!(forward.edges[0].endpoints, reverse.edges[0].endpoints);
+        assert!(forward.edges[0].complete && reverse.edges[0].complete);
+    }
+
+    /// A VRC a party issued to themselves has no counterparty who could
+    /// reciprocate. Both directions are the same direction, so the naive
+    /// "a VRC each way" test would report it complete.
+    #[test]
+    fn a_self_issued_vrc_is_never_complete() {
+        let g = build_graph(vec![row(A, A, 0)]);
+        assert_eq!(g.edges.len(), 1);
+        assert_eq!(g.edges[0].endpoints, vec![A.to_string(), A.to_string()]);
+        assert!(!g.edges[0].complete);
+    }
+
+    #[test]
+    fn distinct_pairs_stay_distinct_and_ordering_is_stable() {
+        let rows = vec![row(B, C, 2), row(A, B, 0), row(B, A, 1)];
+        let g = build_graph(rows);
+        assert_eq!(g.edges.len(), 2);
+        // BTreeMap keyed on the sorted pair: (A,B) before (B,C).
+        assert_eq!(g.edges[0].endpoints, vec![A.to_string(), B.to_string()]);
+        assert_eq!(g.edges[1].endpoints, vec![B.to_string(), C.to_string()]);
+        assert!(g.edges[0].complete);
+        assert!(!g.edges[1].complete);
+        // Halves are oldest-first regardless of the order rows came back in.
+        assert_eq!(g.edges[0].halves[0].issuer_did, A);
+        assert_eq!(g.edges[0].halves[1].issuer_did, B);
     }
 }

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -35,6 +35,7 @@ use vtc_service::test_support::TestVtc;
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const PUBLISH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/publish/0.1";
 const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/list/0.1";
+const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
 const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/revoke/0.1";
 const ISSUER_DID: &str = "did:key:zVrcIssuer";
 const SUBJECT_DID: &str = "did:key:zVrcSubject";
@@ -483,6 +484,89 @@ async fn list_keeps_rows_for_tombstoned_other_party() {
         1,
         "Tombstoned subject keeps the edge visible: {v}"
     );
+}
+
+// ─── Connections graph (admin) ────────────────────────────
+//
+// A DTG edge is two VRCs, one in each direction, so the graph groups by
+// unordered pair and reports whether both halves arrived. It used to return one
+// entry per stored VRC, which made a mutual relationship and an unanswered
+// claim indistinguishable to the operator reading it (#1054).
+
+#[tokio::test]
+async fn graph_separates_complete_edges_from_half_edges() {
+    let fix = build_fixture().await;
+    // ISSUER ↔ SUBJECT — reciprocated, so a complete edge.
+    let a_to_b = seed_relationship(&fix, ISSUER_DID, SUBJECT_DID).await;
+    let b_to_a = seed_relationship(&fix, SUBJECT_DID, ISSUER_DID).await;
+    // ISSUER → STRANGER — never answered, so a half-edge.
+    let a_to_c = seed_relationship(&fix, ISSUER_DID, STRANGER_DID).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/relationships/graph")
+        .header("authorization", format!("Bearer {}", fix.admin_token))
+        .header("trust-task", GRAPH_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+
+    let nodes: Vec<&str> = v["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .map(|n| n["did"].as_str().unwrap())
+        .collect();
+    assert_eq!(nodes.len(), 3, "three endpoints appear: {v}");
+
+    let edges = v["edges"].as_array().expect("edges array");
+    assert_eq!(edges.len(), 2, "three VRCs, two pairs: {v}");
+
+    let complete: Vec<_> = edges
+        .iter()
+        .filter(|e| e["complete"].as_bool().unwrap())
+        .collect();
+    assert_eq!(complete.len(), 1, "exactly one pair reciprocated: {v}");
+    let ids: Vec<&str> = complete[0]["halves"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&a_to_b.to_string().as_str()));
+    assert!(ids.contains(&b_to_a.to_string().as_str()));
+
+    let half: Vec<_> = edges
+        .iter()
+        .filter(|e| !e["complete"].as_bool().unwrap())
+        .collect();
+    assert_eq!(half.len(), 1);
+    assert_eq!(half[0]["halves"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        half[0]["halves"][0]["id"].as_str().unwrap(),
+        a_to_c.to_string(),
+        "the unanswered claim is the half-edge: {v}"
+    );
+    // Wire shape is camelCase and the pair is DID-sorted, not publish-ordered.
+    let endpoints = half[0]["endpoints"].as_array().unwrap();
+    assert_eq!(endpoints.len(), 2);
+    assert!(endpoints[0].as_str().unwrap() <= endpoints[1].as_str().unwrap());
+}
+
+#[tokio::test]
+async fn graph_is_admin_only() {
+    let fix = build_fixture().await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/relationships/graph")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", GRAPH_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 // ─── Publish under a pairwise relationship DID ────────────


### PR DESCRIPTION
Closes the remaining graph work on #1054. One of the two open items is built,
one is deliberately not, and the reasoning for the second is the part worth
reading.

## Built: half-edges vs complete edges

DTG Credentials defines a DTG edge as **two** VRCs, one in each direction.
`GET /v1/relationships/graph` returned one entry per stored VRC, so a mutual
relationship and a unilateral claim rendered identically — two members who had
each vouched for the other looked the same as one member asserting an edge the
other has never acknowledged.

That distinction is what the dropped subject-membership check was replaced
*with*. #1061 stopped requiring the subject to be a current member, on the DTG
rule that "community membership is not a precondition for issuing, holding, or
presenting a VRC", and on the reasoning that the subject's consent to an edge is
their publication of the reciprocal VRC. An operator who cannot see whether that
reciprocal VRC arrived cannot see the consent signal at all.

The response now groups by unordered pair (`build_graph`,
`vtc-service/src/routes/relationships.rs:817`). Each edge carries:

- `endpoints` — the two DIDs, sorted, so a pair has one identity whichever half
  was published first
- `halves` — every VRC published between them, oldest first, each with the row
  id that `DELETE /v1/relationships/{id}` takes
- `complete` — a VRC exists in **both** directions

Two cases that are easy to get wrong, both pinned by tests:

- **Several VRCs in one direction do not complete an edge.** Idempotency is
  keyed on the credential hash, not on direction
  (`vtc-service/src/routes/relationships.rs:322`), so a member can publish three
  A→B VRCs. `complete` checks for a VRC in each direction, not for two rows.
- **A self-issued VRC (`issuer == subject`) is never complete.** No counterparty
  can reciprocate, and the naive both-directions test matches the same row
  twice. Nothing on the publish path rejects a self-issued VRC, so this is
  reachable.

Admin UI (`vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx`): complete
edges draw solid and double-headed, half-edges dashed and single-headed pointing
at the party who has not answered; the overview counts the two separately and a
selected node's edge list reads "mutual with" vs "not reciprocated".

**Breaking:** `edges[]` was `{id, issuerDid, subjectDid, createdAt}` per VRC and
is now `{endpoints, halves, complete}` per pair, with the old fields moved onto
`halves[]`. The only consumer is the in-repo admin UI, updated here.

## Not built: making the graph derived rather than stored

Item 3 of the proposal on #1054 was "make the graph derived rather than
stored… without persisting an M-DID adjacency list." I did not build it. Three
reasons, recorded in full in
`docs/05-design-notes/vrc-publish-proof-of-possession.md`.

**The motivation was removed by #1061, not deferred.** The concern was a durable
*membership-DID* adjacency list. Since #1061 the stored DIDs are whichever
identifier the member chose to publish under: under the pairwise form an R-DID,
which names nobody and correlates nothing beyond the one relationship it was
minted for; under the attributed form a membership DID the member has
deliberately asserted, which DTG Credentials permits directly. Neither is what
item 3 was written against.

**"Derived" has no source to derive from.** The relationships keyspace is the
only place a published VRC exists on the VTC side — `Relationship.vrc_jsonld`
holds the credential verbatim, and `issuer_did`/`subject_did` are projections of
fields inside it (`vtc-service/src/relationships/mod.rs:62-85`). Deriving the
graph from something else means not storing published VRCs at all, which deletes
`POST /v1/relationships` and both read endpoints with it. The change that *is*
available is narrower — drop the two projected DID columns and re-read them from
the stored credential on each scan — and it removes no information, because the
credential containing them is still the row.

**Nothing publishes.** I checked the claim rather than taking it: `POST
/v1/relationships` is the only production writer to the keyspace and it has no
caller. Not in this workspace (only `vtc-service/tests/relationships.rs`), not
in `vta-sdk` (no relationship protocol module at all), not in `vtc-client`, and
not in `openvtc`. OpenVTC mints VRCs through `DTGCredential::new_vrc` and
exchanges them peer-to-peer over DIDComm
(`openvtc/src/state_handler/inbox_actions.rs:745`,
`openvtc/src/state_handler/main_page/mod.rs:2096`), then retains them locally;
it speaks the VTC's join, ACL, credential-exchange and self-remove Trust Tasks
but never `relationships/publish`. So the graph is empty in every deployment
that exists.

None of that makes the question wrong — a community that gets real publish
traffic under the attributed form does accumulate a correlatable edge set, by
design and with the members' assertion, and one that gets pairwise traffic
accumulates a set correlatable only to an operator holding the audit trail,
which #1061 already recorded as an accepted residual. It makes it premature.
The point to revisit is when something publishes, and the decision then is
whether to keep the two DID columns or read them out of the credential — not
whether to hold the credentials.

## Uncertainty worth flagging

The half-edge/complete rule assumes the two directions are linkable by DID
equality: A's VRC names B's identifier as subject and B's names A's as issuer.
Under pairwise identifiers that holds only because each party publishes the R-DID
its counterparty already knows. If a future flow has a party rotate its R-DID
mid-relationship, the two halves stop pairing and a complete edge silently
becomes two half-edges. Nothing in the stack does that today and the R-DID
uniqueness check would reject the rotated DID's second counterparty anyway, but
it is the assumption the grouping rests on.

## Verification

- `cargo test -p vtc-service` — 30 test binaries, 0 failures
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt`
- `npm run lint` in `vtc-service/admin-ui` (tsc, `noUncheckedIndexedAccess` on)

New coverage: 6 unit tests on `build_graph` (minted through
`DTGCredential::new_vrc`, not hand-rolled JSON) and 2 integration tests on the
endpoint (`graph_separates_complete_edges_from_half_edges` pins the wire shape,
`graph_is_admin_only` the gate — the endpoint had no test before).

Refs #1054