### PR TITLE
feat(vtc): implement the VPC as the deliberate-correlation mechanism on an edge

### DIFF
--- a/docs/03-vtc/architecture.md
+++ b/docs/03-vtc/architecture.md
@@ -97,7 +97,7 @@ sealed-transfer, and protocol types shared with the VTA.
 | `policy/` | `regorus`-backed engine, policy-id storage, default policies, evaluation helpers. |
 | `recognition/` | Foreign-credential verifier (status list + registry membership) for cross-community session minting. |
 | `registry/` | Trust-registry client + `RegistryHealth` + `MembershipSyncer` + RTBF batching. |
-| `relationships/` | VRC primary keyspace + per-DID secondary index. |
+| `relationships/` | VRC primary keyspace + per-DID secondary index. Each row optionally carries a persona (VPC) annotation — see `docs/05-design-notes/vpc-persona-annotation.md`. |
 | `routes/` | All axum handlers; one file per resource. `routes/mod.rs` wires the `TrustTaskRouter`. |
 | `routing/` | Phase 5 middleware: `host_dispatch`, `csrf`, `security_headers`. |
 | `server.rs` | `AppState` + binary entry point + three OS threads (REST / DIDComm / storage). |

--- a/docs/05-design-notes/vpc-persona-annotation.md
+++ b/docs/05-design-notes/vpc-persona-annotation.md
@@ -1,0 +1,183 @@
+# VPC: the persona annotation on a relationship edge
+
+Status: implemented (VTC half) — see `vtc-service/src/routes/relationships.rs`
+Tracking: OpenVTC/verifiable-trust-infrastructure#1067
+Upstream: trustoverip/dtgwg-cred-spec#9 (open — read §The binding, below)
+Companion: `docs/05-design-notes/vrc-publish-proof-of-possession.md`
+
+## Why
+
+The proof-of-possession change gave a member two ways to publish a
+relationship edge, and only two:
+
+- **attributed** — the VRC is issued under the membership DID. Every edge
+  names the member, and the graph correlates completely.
+- **pairwise** — the VRC is issued under a relationship DID unique to one
+  counterparty. No edge correlates with any other.
+
+There is nothing between them, and DTG Credentials says there should be. Its
+Privacy Considerations §3: "Correlation across relationships should occur only
+through the holder's deliberate assertion of a persona (via a VPC) or an M-DID
+— never as a side effect of credential structure." A member who wants three of
+their pairwise edges to be recognisable as one party currently has one option
+— republish all three under their M-DID — which correlates those three *and*
+every other edge they have, forever, to anyone who retains the credential.
+
+The VPC is the precise instrument the blunt one was standing in for. It had no
+implementation anywhere in this stack: `PersonaCredential` appeared nowhere,
+`DTGCredential::new_vpc` was never called, and — as #1067 records — the word
+"persona" drifted onto the membership DID in the absence of anything to anchor
+it.
+
+## Scope: the VTC half only
+
+The VPC is **self-issued by a person**, exactly like the VRC. Its `issuer` is a
+persona DID (P-DID) the member controls; the VTC has no key that may
+legitimately sign one, and `credentials/dtg.rs` therefore gained no
+`issue_persona`. What the VTC owns is the other half: verifying a VPC presented
+to it, deciding whether it may annotate an edge in this community's graph, and
+surfacing the correlation it asserts.
+
+Minting the VPC, choosing when to assert a persona, and reusing a P-DID across
+communities are all client concerns (`openvtc`). None of that is here.
+
+## Model
+
+A VPC is a DTG **annotation** credential: "annotation credentials do not create
+graph structure. They attach data to existing edges or parties." So there is no
+"publish a VPC" endpoint. There is `POST` / `DELETE
+/v1/relationships/{id}/persona`, and the annotation is stored as an optional
+field on the edge row rather than in a keyspace of its own — there is no
+persona record without an edge to hang it on, and deleting the edge deletes the
+annotation with it.
+
+One VRC is one *direction* of an edge, and the persona it carries belongs to
+the party who issued it. The counterparty asserts their own persona on their
+own reciprocal VRC. Neither party can put words in the other's mouth.
+
+## The binding — and the assumption in it
+
+**trustoverip/dtgwg-cred-spec#9 is open and asks exactly this question. Nothing
+below is settled upstream, and none of it is proposed as an answer.**
+
+A VPC names its persona (`issuer`) and the counterparty
+(`credentialSubject.id`). It does *not* name the relationship DID the persona
+used, so a VPC on its own does not identify an edge.
+
+Rather than add a field to the credential and present it as the resolution, the
+binding here is made at the **request** level, from three parts:
+
+1. the caller names the edge, by id, in the URL;
+2. the caller proves control of that edge's `issuerDid`, with the same
+   proof-of-possession construction publishing the edge required;
+3. the VPC's `credentialSubject.id` must equal the edge's `subjectDid`.
+
+(2) is what makes it safe. The only party who could have published this edge is
+the only party who can annotate it, so attaching a persona is exactly as
+authorized as publishing the edge was — no new trust is extended. (3) is a
+consistency check, not a binding: it rules out attaching a persona that was
+asserted to some *other* counterparty.
+
+The authorization object mirrors `VrcPublishAuthorization` field for field,
+plus the edge it names:
+
+```json
+{
+  "type": "VpcAttachAuthorization",
+  "vpc": "<sha-256 of the VPC, hex>",
+  "relationship": "<uuid of the edge>",
+  "aud": "<this VTC's C-DID>",
+  "sessionId": "<the caller's authenticated session id>",
+  "issuedAt": "2026-08-23T07:40:00Z"
+}
+```
+
+`VpcDetachAuthorization` is the same without `vpc`. The two `type` values are
+distinct on purpose: a captured attach authorization must not let its holder
+strip the persona it was made to assert.
+
+Like the publish authorization, **it is verified and discarded** — it carries
+`sessionId`, and persisting that would rebuild the membership-to-relationship
+linkage the pairwise identifier exists to remove.
+
+If #9 lands an in-credential binding — a `digest` over the VRC, as the VWC
+already has — this endpoint can require that in addition, without changing the
+stored shape or the authorization object.
+
+### Known limitation
+
+DTG Credentials says the VPC's subject is "typically the R-DID **or M-DID**
+used in the relationship". A VPC whose subject is the counterparty's M-DID, on
+an edge whose `subjectDid` is their R-DID, fails check (3) and is rejected.
+That case is real. Accepting it needs the same #9 answer, and guessing at it
+would mean accepting a VPC that names a party the VTC cannot tie to the edge —
+which is the whole problem, restated.
+
+## What the community learns
+
+The P-DID lands on `GET /v1/relationships/graph` as `personaDid`. Two pairwise
+edges carrying the same `personaDid` are the same party, said so by that party.
+That is the deliberate correlation, and making it visible is the point — an
+annotation nothing reads would leave #1067 in the state it describes.
+
+**There is deliberately no uniqueness check on the P-DID**, in direct contrast
+to the R-DID rule the publish path enforces unconditionally. A relationship DID
+that recurs across counterparties is a defect; a persona DID that recurs is the
+entire purpose of the credential.
+
+There is also no `relationships_by_did` index entry for the P-DID, so there is
+no "list every edge of persona P" query. The admin graph answers the same
+question, and a per-persona lookup is an enumeration surface that deserves its
+own design rather than falling out of an index write.
+
+## Audit
+
+`VpcAttached` / `VpcDetached` record the edge id and the P-DID, with the
+**authenticated member** as actor — the same attribution decision the VRC
+publish trail makes, for the same reason: under a pairwise identifier the edge
+issuer names nobody, so a trail keyed on it could answer "who asserted this
+persona" for no one, ever.
+
+This does put an M-DID-to-P-DID mapping in the audit store. It is the same
+accepted trade set out in `vrc-publish-proof-of-possession.md` §Audit
+attribution — the store HMACs the actor under a rotating key, keeps the
+plaintext in a field RTBF can null without breaking the tamper-evidence chain,
+and is admin-gated — and it stops there. The `info!` on both paths carries the
+persona and not the member.
+
+Detach is audited too. Withdrawing a persona is as much a privacy act as
+asserting one.
+
+## What is not here
+
+- **No policy purpose.** Attach is gated on a live member session plus proof of
+  control of the edge's issuer. There is no `persona.rego`, because a community
+  that can already decide whether an edge may be published has not obviously
+  earned a second, separate say over what its issuer calls themselves. If that
+  turns out to be wrong it is additive.
+- **No ZKP.** The Pairwise Zero-Knowledge Proof discloses P-DIDs while hiding
+  R-DIDs. It now has something to disclose, which was #1067's third point, but
+  the construction itself waits on #9 as the ZKP task force has said.
+- **No client.** `openvtc` still has to mint the VPC and rename its
+  `persona_did` field, which is what made the word ambiguous in the first
+  place.
+- **No Trust Task spec.** `vtc/relationships/persona/0.1` is bound ahead of its
+  publication in the upstream registry, and recorded as such in
+  `UNPUBLISHED_CANONICAL_OK`. Authoring a payload schema now would mean
+  encoding this request-level binding as if #9 were closed.
+
+## Test matrix
+
+| Case | Expected |
+|---|---|
+| VPC + valid authorization on a pairwise edge | 200, `personaDid` on the graph edge |
+| Same P-DID on two edges under two R-DIDs | 200 both; graph groups them, issuers stay distinct |
+| Authorization signed by a key other than the edge's issuer | 403 |
+| No authorization, pairwise edge | 403 |
+| Authorization naming a different edge | 403 |
+| A VRC posted to the persona endpoint | 400 |
+| VPC naming a counterparty other than the edge's subject | 400 |
+| Detach | 200, persona gone, edge intact |
+| Attach authorization replayed as a detach | 403 |
+| Unknown edge | 404 |
+| Stored row and audit envelopes | contain no `sessionId` and no membership DID |

--- a/docs/05-design-notes/vrc-publish-proof-of-possession.md
+++ b/docs/05-design-notes/vrc-publish-proof-of-possession.md
@@ -241,9 +241,32 @@ Note this decision is not VRC-specific. It answers "when a member acts under a
 pairwise identifier, what does the audit trail record?", and it should hold for
 every pairwise-capable operation added later.
 
-**Admin revocation is unaffected.** It keys on row id, not issuer identity
-(`relationships.rs`, revoke section), so moderation of a specific edge still
-works.
+**Revocation — both halves, corrected.** This paragraph originally read only
+"admin revocation is unaffected: it keys on row id, not issuer identity, so
+moderation of a specific edge still works." That is true, and it was the wrong
+half to reassure the reader about.
+
+*Issuer* revocation keys on `auth.did == rel.issuer_did` — the same identity
+equality this design replaced on the publish path, sitting one function below
+it in the same file. Under a pairwise identifier that compares a membership DID
+against a relationship DID and is false by construction, so from #1061 until
+#1067's follow-up a member could publish an edge under a relationship DID and
+then never retract it; only an admin could. Writing "admin revocation is
+unaffected" and stopping there is what let that pass review: the sentence
+answers the question nobody needed answered and is silent on the one that
+mattered.
+
+`DELETE /v1/relationships/{id}` now takes an optional `VrcRevokeAuthorization`
+in the request body — same construction as the publish authorization, bound to
+the row id rather than to a credential digest, since the request names a row and
+carries no credential. Verified and discarded, for the same `sessionId` reason.
+The attributed form (`auth.did == rel.issuer_did`) and admin moderation are
+unchanged and need no proof.
+
+The general lesson, worth applying to anything added later: **replacing an
+identity equality is not done until every sibling operation on the same
+resource has been checked for the same equality.** Grep for the field, not for
+the function.
 
 **Accepted DID methods become policy.** If the issuer identifier is
 method-independent — and it should be; nothing in this design reads a method

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -337,6 +337,11 @@ export interface GraphHalf {
   issuerDid: string;
   subjectDid: string;
   createdAt: string;
+  /** The persona (P-DID) the edge's issuer has asserted on it, via a VPC.
+   *  Absent unless they chose to. Two edges sharing one `personaDid` are the
+   *  same party, said so by that party — the only correlation the graph is
+   *  entitled to draw between two pairwise identifiers. */
+  personaDid?: string;
 }
 /** One edge between a pair of identifiers. A DTG edge is *two* VRCs, one in
  * each direction; `complete` says whether both have been published. A

--- a/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
+++ b/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
@@ -280,6 +280,18 @@ export function Relationships() {
                       const issuedBySelected = e.halves.some(
                         (h) => h.issuerDid === selected,
                       );
+                      // Personas (VPCs) asserted on this edge. Rendered per
+                      // half, and attributed, because a persona is asserted by
+                      // one party about one relationship — a complete edge can
+                      // carry two different ones, and picking a single
+                      // `personaDid` off the edge (as this did before the
+                      // graph became pair-grouped) would silently drop the
+                      // other party's.
+                      const personas = e.halves.flatMap((h) =>
+                        h.personaDid
+                          ? [{ id: h.id, by: h.issuerDid, as: h.personaDid }]
+                          : [],
+                      );
                       return (
                         <li key={edgeKey(e)} style={{ marginBottom: 4 }}>
                           {e.complete ? (
@@ -301,6 +313,13 @@ export function Relationships() {
                               </span>
                             </>
                           )}
+                          {personas.map((p) => (
+                            <span key={p.id} className="muted">
+                              {" · "}
+                              <code>{nameBook.nameOrDid(p.by)}</code> as{" "}
+                              <code>{nameBook.nameOrDid(p.as)}</code>
+                            </span>
+                          ))}
                         </li>
                       );
                     })}

--- a/vtc-service/src/credentials/dtg.rs
+++ b/vtc-service/src/credentials/dtg.rs
@@ -475,6 +475,42 @@ mod catalog_wire_shape {
         );
     }
 
+    /// The VPC is the one DTG credential in this file the VTC **verifies but
+    /// never mints** — it is self-issued by a person under a persona DID, and
+    /// the community signer has no business asserting someone's persona. So
+    /// there is no `issue_persona`, and this test mints one only to pin the
+    /// shape `routes::relationships::check_vpc_shape` validates against.
+    ///
+    /// That makes the pin more load-bearing here than for the credentials
+    /// above, not less: for a VMC a catalog drift changes what we emit and we
+    /// find out from a consumer, but for a VPC it changes what we *accept*,
+    /// and the failure is every conformant VPC in the ecosystem being
+    /// rejected by a VTC that still compiles and still passes its own tests.
+    #[test]
+    fn persona_credential_wire_shape() {
+        let (valid_from, valid_until) = super::window(Duration::days(30));
+        let dtg = dtg_credentials::DTGCredential::new_vpc(
+            "did:key:zPersona".into(),
+            "did:key:zCounterparty".into(),
+            valid_from,
+            Some(valid_until),
+        );
+        // Not signed: the VTC has no key that may legitimately sign a VPC, so
+        // the body alone is what is pinned. Every other test here goes through
+        // `finalize` because the VTC does mint those.
+        let doc = serde_json::to_value(dtg.credential()).expect("VPC body -> value");
+        assert_shape(
+            &doc,
+            &["VerifiableCredential", "DTGCredential", "PersonaCredential"],
+            "VPC",
+        );
+        // DTG Credentials §VPC: issuer is the P-DID, subject is the
+        // counterparty. The VTC reads both — the first to verify the proof,
+        // the second to check the annotation names the edge's counterparty.
+        assert_eq!(doc["issuer"], "did:key:zPersona");
+        assert_eq!(doc["credentialSubject"]["id"], "did:key:zCounterparty");
+    }
+
     #[tokio::test]
     async fn invitation_credential_wire_shape() {
         let doc = issue_invitation(&signer(), "did:key:zM", None, None, Duration::days(30), &[])

--- a/vtc-service/src/relationships/mod.rs
+++ b/vtc-service/src/relationships/mod.rs
@@ -41,6 +41,10 @@
 //! (the route layer verifies caller-DID == VC.issuer + the
 //! VC's data-integrity proof verifies against the member's
 //! `#key-0`). The community signer is uninvolved.
+//!
+//! The same holds for the optional [`PersonaAnnotation`]: the
+//! VPC is self-issued by the member under a persona DID, and the
+//! VTC only verifies and stores it.
 
 pub mod storage;
 
@@ -83,4 +87,46 @@ pub struct Relationship {
     /// rather than creating a duplicate row.
     pub vrc_sha256: String,
     pub created_at: DateTime<Utc>,
+    /// The persona (VPC) this edge's issuer has asserted on it,
+    /// if any. Absent on every edge published before #1067 and
+    /// on every edge whose issuer has not asserted a persona —
+    /// which is why it is `#[serde(default)]`: existing rows
+    /// decode unchanged.
+    ///
+    /// A VPC is an *annotation* credential (DTG Credentials
+    /// §Annotation Credentials): it creates no graph structure,
+    /// it attaches to structure that already exists. Storing it
+    /// on the edge row rather than in a keyspace of its own is
+    /// the direct expression of that — there is no persona
+    /// record without an edge to hang it on, and deleting the
+    /// edge deletes the annotation with it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona: Option<PersonaAnnotation>,
+}
+
+/// A Verifiable Persona Credential (VPC) attached to one edge.
+///
+/// The VPC is issued by the *edge issuer* under a persona DID
+/// (P-DID) and names the edge's counterparty as its subject. It
+/// is the sanctioned mechanism for deliberate correlation: a
+/// member who wants several of their pairwise edges to be
+/// recognisable as one party asserts the same P-DID on each,
+/// without ever putting their membership DID in a credential.
+///
+/// See `docs/05-design-notes/vpc-persona-annotation.md` for how
+/// the annotation is bound to the edge, and for what upstream
+/// (trustoverip/dtgwg-cred-spec#9) has not yet settled.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct PersonaAnnotation {
+    /// The VPC's `issuer` — the P-DID. Denormalised out of
+    /// `vpc_jsonld` so the graph view can group edges by persona
+    /// without re-parsing every credential.
+    pub persona_did: String,
+    /// The VPC body verbatim, including its data-integrity
+    /// proof, so a consumer of the row can re-verify the
+    /// assertion rather than taking the VTC's word for it.
+    pub vpc_jsonld: JsonValue,
+    pub attached_at: DateTime<Utc>,
 }

--- a/vtc-service/src/relationships/storage.rs
+++ b/vtc-service/src/relationships/storage.rs
@@ -301,6 +301,7 @@ mod tests {
             }),
             vrc_sha256: format!("{:x}", id.as_u128()),
             created_at: Utc::now(),
+            persona: None,
         }
     }
 
@@ -311,6 +312,25 @@ mod tests {
         store_relationship(&primary, &index, &rel).await.unwrap();
         let got = get_relationship(&primary, rel.id).await.unwrap().unwrap();
         assert_eq!(got, rel);
+    }
+
+    #[tokio::test]
+    async fn rows_written_before_the_persona_field_still_decode() {
+        // #1067 added `persona` to an already-shipped row. Every edge in
+        // every live VTC predates it, so the field has to be optional on
+        // read, not merely optional on write — a bare `Option` without
+        // `#[serde(default)]` would fail here and take the whole
+        // relationships surface down on upgrade.
+        let raw = serde_json::json!({
+            "id": Uuid::new_v4().to_string(),
+            "issuerDid": "did:key:zA",
+            "subjectDid": "did:key:zB",
+            "vrcJsonld": { "type": ["VerifiableCredential"] },
+            "vrcSha256": "deadbeef",
+            "createdAt": "2026-01-01T00:00:00Z",
+        });
+        let rel = decode(raw.to_string().as_bytes()).expect("pre-#1067 row must decode");
+        assert!(rel.persona.is_none());
     }
 
     #[tokio::test]

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -643,6 +643,14 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(relationships::revoke),
             "https://trusttasks.org/spec/vtc/relationships/revoke/0.1",
         ))
+        // #1067 — the VPC (persona annotation) on an existing
+        // edge. POST + DELETE share one task mount, the same
+        // workaround the personhood assert/revoke pair uses; the
+        // two verbs are one operation in either direction.
+        .routes(tt(
+            routes!(relationships::attach_persona, relationships::detach_persona),
+            "https://trusttasks.org/spec/vtc/relationships/persona/0.1",
+        ))
         // Phase 4 M4.8.1 — operator-uploaded endorsement type
         // registry. Admin-gated CRUD.
         // POST + GET on `/endorsement-types` each carry their own canonical

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -2,7 +2,7 @@
 //! — Phase 4 M4.6. Spec §5.4 + §6.1; planning-review D1
 //! (issuer is the *member*, not the community).
 //!
-//! ## Three endpoints
+//! ## Four endpoints
 //!
 //! 1. `POST /v1/relationships` — publish a self-issued VRC.
 //!    The VTC verifies the credential's data-integrity proof
@@ -33,6 +33,11 @@
 //!    plus secondary-index entries; emits `VrcRevoked`. Per
 //!    D7, VRCs carry no `credentialStatus`; revocation is row
 //!    deletion, not a status-list bit flip.
+//!
+//! 4. `POST` / `DELETE /v1/relationships/{id}/persona` —
+//!    attach or withdraw a VPC (persona credential) on an
+//!    edge that already exists. See [`attach_persona`] for the
+//!    binding argument and for what upstream has not settled.
 
 use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
 use affinidi_did_resolver_cache_sdk::DIDCacheClient;
@@ -47,7 +52,7 @@ use serde_json::{Value as JsonValue, json};
 use sha2::{Digest, Sha256};
 use tracing::info;
 use uuid::Uuid;
-use vti_common::audit::{AuditEvent, VrcPublishedData, VrcRevokedData};
+use vti_common::audit::{AuditEvent, VpcAnnotationData, VrcPublishedData, VrcRevokedData};
 use vti_common::error::AppError;
 
 use crate::acl::get_acl_entry;
@@ -343,6 +348,9 @@ pub async fn publish(
         vrc_jsonld: vrc.clone(),
         vrc_sha256: vrc_sha256.clone(),
         created_at: Utc::now(),
+        // A persona is asserted separately, against an edge that already
+        // exists — see [`attach_persona`].
+        persona: None,
     };
     store_relationship(
         &state.relationships_ks,
@@ -477,6 +485,344 @@ pub async fn revoke(
     Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })))
 }
 
+// ─── Persona annotation (VPC) ────────────────────────────
+//
+// DTG Credentials §Annotation Credentials: a VPC creates no
+// graph structure, it annotates structure that already exists.
+// So there is no "publish a VPC" — there is only "attach this
+// persona to that edge", which is why both verbs sit under
+// `/v1/relationships/{id}/persona` rather than on a collection
+// of their own.
+//
+// What the VPC is *for* (§Privacy Considerations 3): correlation
+// across relationships should happen only through the holder's
+// deliberate assertion of a persona or an M-DID, "never as a
+// side effect of credential structure". Before this existed the
+// VTC offered a member exactly two settings — publish under a
+// pairwise R-DID and be correlatable with nothing, or publish
+// under the M-DID and be correlatable with everything. The VPC
+// is the third: correlate these edges, under this name, because
+// I chose to.
+
+/// `type` of the attach authorization. Distinct from the detach type so an
+/// attach authorization cannot be replayed to remove a persona, or vice versa.
+const VPC_ATTACH_AUTHORIZATION_TYPE: &str = "VpcAttachAuthorization";
+
+/// `type` of the detach authorization.
+const VPC_DETACH_AUTHORIZATION_TYPE: &str = "VpcDetachAuthorization";
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct AttachPersonaBody {
+    /// The self-issued VPC, in the DTG Credentials wire form:
+    /// `type` including `PersonaCredential`, `issuer` the P-DID
+    /// of the persona, `credentialSubject.id` the counterparty's
+    /// DID, and a data-integrity proof. Built by
+    /// `dtg_credentials::DTGCredential::new_vpc`.
+    pub vpc: JsonValue,
+    /// Proof that the caller controls the key behind the edge's
+    /// `issuerDid`, when that is not the caller's session DID.
+    /// Required for every pairwise edge, since a relationship
+    /// DID is never the session DID by construction.
+    #[serde(default)]
+    pub pop: Option<JsonValue>,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct DetachPersonaBody {
+    /// As for [`AttachPersonaBody::pop`], with
+    /// `type: "VpcDetachAuthorization"` and no `vpc` field.
+    #[serde(default)]
+    pub pop: Option<JsonValue>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct PersonaResponse {
+    pub id: Uuid,
+    /// The P-DID now on the edge, or `null` after a detach.
+    pub persona_did: Option<String>,
+}
+
+/// `POST /v1/relationships/{id}/persona` — attach a VPC to a published edge,
+/// asserting that the party behind the edge's `issuerDid` is this persona.
+///
+/// ## How the VPC is bound to the edge — and what is assumed
+///
+/// **This is the part trustoverip/dtgwg-cred-spec#9 has not settled.** A VPC
+/// names its persona (`issuer`) and the counterparty (`credentialSubject.id`).
+/// It does *not* name the relationship DID the persona used, so a VPC on its
+/// own does not identify an edge, and nothing in the current specification
+/// says how it should.
+///
+/// Rather than invent a credential-level binding and present it as settled,
+/// the binding here is made at the *request* level, out of three parts:
+///
+/// 1. the caller names the edge, by id, in the URL;
+/// 2. the caller proves control of that edge's `issuerDid` — the same
+///    proof-of-possession construction publishing the edge required
+///    (`docs/05-design-notes/vrc-publish-proof-of-possession.md`);
+/// 3. the VPC's `credentialSubject.id` must equal the edge's `subjectDid`.
+///
+/// (2) is what makes it safe: the only party who could have published this
+/// edge is the only party who can annotate it, so attaching a persona is
+/// exactly as authorized as publishing the edge was. (3) is a consistency
+/// check, not a binding — it rules out attaching a persona asserted to some
+/// *other* counterparty. Nothing is added to the VPC and no claim is made
+/// about how the specification should resolve #9; if it lands an in-credential
+/// binding (a `digest` over the VRC, as the VWC has), this endpoint can
+/// require that as well without changing the stored shape.
+///
+/// **Known limitation of (3).** DTG Credentials says the VPC's subject is
+/// "typically the R-DID or M-DID used in the relationship". A VPC whose
+/// subject is the counterparty's *M-DID*, on an edge whose `subjectDid` is
+/// their *R-DID*, is rejected here. That case is real and this endpoint
+/// cannot presently accept it — resolving it needs the same #9 answer.
+///
+/// ## The persona is the edge issuer's
+///
+/// One VRC is one direction of an edge, and the persona it carries belongs to
+/// the party who issued it. The counterparty asserts their own persona on
+/// their own reciprocal VRC. This keeps each half-edge self-contained and
+/// means neither party can put words in the other's mouth.
+#[utoipa::path(
+    post, path = "/relationships/{id}/persona", tag = "relationships",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Relationship (VRC) id")),
+    request_body = AttachPersonaBody,
+    responses(
+        (status = 200, description = "Persona (VPC) attached", body = PersonaResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller does not control the edge's issuer"),
+        (status = 404, description = "Relationship not found"),
+    ),
+)]
+pub async fn attach_persona(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<AttachPersonaBody>,
+) -> Result<(StatusCode, Json<PersonaResponse>), AppError> {
+    let mut rel = get_relationship(&state.relationships_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("VRC {id} not found")))?;
+
+    // Shape first: a malformed VPC is a 400 whoever sent it, and rejecting it
+    // here costs nothing and reveals nothing about the edge.
+    check_vpc_shape(&body.vpc)?;
+    let persona_did = extract_did_field(&body.vpc, "issuer")?;
+    let vpc_subject = extract_subject_id(&body.vpc)?;
+
+    // Then authorization, before anything that could read the edge back to
+    // the caller. Edge ids are unguessable UUIDs, but a member who has seen
+    // one should still learn nothing from this endpoint about an edge they do
+    // not control — which is why neither this error nor the consistency check
+    // below quotes the row's DIDs. Same ordering rule as publish: caller
+    // errors before daemon-config prerequisites, and disclosure last.
+    if body.pop.is_none() && rel.issuer_did != auth.did {
+        return Err(AppError::Forbidden(format!(
+            "edge {id} was not issued by the session DID and no authorization \
+             (`pop`) was supplied — annotating an edge published under a \
+             relationship DID requires proof the caller controls it"
+        )));
+    }
+
+    let resolver = state.did_resolver.as_ref().cloned().ok_or_else(|| {
+        AppError::Internal("DID resolver not configured — VPC attach requires it".into())
+    })?;
+
+    // The VPC was made by the persona it names. This is the analogue of the
+    // VRC's own proof check, and it holds whatever kind of identifier the
+    // P-DID is.
+    verify_di_proof(&body.vpc, &persona_did, &resolver)
+        .await
+        .map_err(|e| AppError::Validation(format!("VpcProofInvalid: {e}")))?;
+
+    if let Some(pop) = &body.pop {
+        let aud = crate::routes::recognise::vtc_did(&state).await?;
+        let vpc_sha256 = hex::encode(Sha256::digest(canonicalise(&body.vpc).as_bytes()));
+        check_authorization_envelope(pop, VPC_ATTACH_AUTHORIZATION_TYPE, &aud, &auth.session_id)
+            .and_then(|()| {
+                let bound = authorization_field(pop, "vpc")?;
+                if bound != vpc_sha256 {
+                    return Err("authorization is bound to a different VPC".into());
+                }
+                let edge = authorization_field(pop, "relationship")?;
+                if edge != id.to_string() {
+                    return Err("authorization is bound to a different edge".into());
+                }
+                Ok(())
+            })
+            .map_err(|e| AppError::Forbidden(format!("VpcAttachAuthorizationInvalid: {e}")))?;
+        verify_di_proof(pop, &rel.issuer_did, &resolver)
+            .await
+            .map_err(|e| AppError::Forbidden(format!("VpcAttachAuthorizationInvalid: {e}")))?;
+    }
+
+    if vpc_subject != rel.subject_did {
+        return Err(AppError::Validation(format!(
+            "VPC names {vpc_subject} as the counterparty but edge {id} points at \
+             a different DID — a persona is asserted to the party the edge names"
+        )));
+    }
+
+    // No uniqueness check on the P-DID, deliberately, and in direct contrast
+    // to the R-DID rule the publish path enforces. A relationship DID that
+    // recurs across counterparties is a defect; a persona DID that recurs is
+    // the entire point of the credential.
+    rel.persona = Some(crate::relationships::PersonaAnnotation {
+        persona_did: persona_did.clone(),
+        vpc_jsonld: body.vpc.clone(),
+        attached_at: Utc::now(),
+    });
+    store_relationship(
+        &state.relationships_ks,
+        &state.relationships_by_did_ks,
+        &rel,
+    )
+    .await?;
+
+    audit_persona_change(&state, &auth.did, &rel, id, &persona_did, true).await?;
+    info!(vrc_id = %id, persona = %persona_did, "VPC attached");
+
+    Ok((
+        StatusCode::OK,
+        Json(PersonaResponse {
+            id,
+            persona_did: Some(persona_did),
+        }),
+    ))
+}
+
+/// `DELETE /v1/relationships/{id}/persona` — withdraw the persona from an
+/// edge, leaving the edge itself in place.
+///
+/// This exists because the assertion it reverses is a disclosure. A member who
+/// can correlate their edges under a persona but can never stop is worse off
+/// than one who never could, so the withdrawal has to be as available as the
+/// assertion — and gated the same way, or anyone could strip another member's
+/// persona.
+///
+/// Idempotent: detaching from an edge that carries no persona is a 200 with a
+/// null `personaDid`, matching `delete_relationship`'s convention. No audit
+/// entry is written in that case — nothing changed.
+///
+/// The authorization object is carried in the request body. `DELETE` with a
+/// body is unusual, but the alternative is putting a signed object in a query
+/// string, and the proof of control has to travel with the request somehow.
+#[utoipa::path(
+    delete, path = "/relationships/{id}/persona", tag = "relationships",
+    security(("bearer_jwt" = [])),
+    params(("id" = String, Path, description = "Relationship (VRC) id")),
+    request_body = DetachPersonaBody,
+    responses(
+        (status = 200, description = "Persona (VPC) detached", body = PersonaResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller does not control the edge's issuer"),
+        (status = 404, description = "Relationship not found"),
+    ),
+)]
+pub async fn detach_persona(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<DetachPersonaBody>,
+) -> Result<(StatusCode, Json<PersonaResponse>), AppError> {
+    let mut rel = get_relationship(&state.relationships_ks, id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("VRC {id} not found")))?;
+
+    if body.pop.is_none() && rel.issuer_did != auth.did {
+        return Err(AppError::Forbidden(format!(
+            "edge {id} was not issued by the session DID and no authorization \
+             (`pop`) was supplied"
+        )));
+    }
+
+    if let Some(pop) = &body.pop {
+        let resolver = state.did_resolver.as_ref().cloned().ok_or_else(|| {
+            AppError::Internal("DID resolver not configured — VPC detach requires it".into())
+        })?;
+        let aud = crate::routes::recognise::vtc_did(&state).await?;
+        check_authorization_envelope(pop, VPC_DETACH_AUTHORIZATION_TYPE, &aud, &auth.session_id)
+            .and_then(|()| {
+                let edge = authorization_field(pop, "relationship")?;
+                if edge != id.to_string() {
+                    return Err("authorization is bound to a different edge".into());
+                }
+                Ok(())
+            })
+            .map_err(|e| AppError::Forbidden(format!("VpcDetachAuthorizationInvalid: {e}")))?;
+        verify_di_proof(pop, &rel.issuer_did, &resolver)
+            .await
+            .map_err(|e| AppError::Forbidden(format!("VpcDetachAuthorizationInvalid: {e}")))?;
+    }
+
+    let Some(previous) = rel.persona.take() else {
+        return Ok((
+            StatusCode::OK,
+            Json(PersonaResponse {
+                id,
+                persona_did: None,
+            }),
+        ));
+    };
+    store_relationship(
+        &state.relationships_ks,
+        &state.relationships_by_did_ks,
+        &rel,
+    )
+    .await?;
+
+    audit_persona_change(&state, &auth.did, &rel, id, &previous.persona_did, false).await?;
+    info!(vrc_id = %id, persona = %previous.persona_did, "VPC detached");
+
+    Ok((
+        StatusCode::OK,
+        Json(PersonaResponse {
+            id,
+            persona_did: None,
+        }),
+    ))
+}
+
+/// Write the `VpcAttached` / `VpcDetached` audit entry.
+///
+/// The actor is the **authenticated member**, not the edge's issuer, for the
+/// same reason the VRC publish trail records it that way: under a pairwise
+/// identifier the issuer names nobody, so a trail keyed on it could never
+/// answer "who asserted this persona". Recording the P-DID beside the member
+/// does create an M-DID-to-P-DID mapping inside the audit store — accepted, on
+/// the same reasoning set out in
+/// `docs/05-design-notes/vrc-publish-proof-of-possession.md` §Audit
+/// attribution, and confined to the same store. The `info!` above deliberately
+/// carries the persona and not the member.
+async fn audit_persona_change(
+    state: &AppState,
+    actor_did: &str,
+    rel: &Relationship,
+    id: Uuid,
+    persona_did: &str,
+    attached: bool,
+) -> Result<(), AppError> {
+    let Some(writer) = state.audit_writer.as_ref() else {
+        return Ok(());
+    };
+    let data = VpcAnnotationData {
+        vrc_id: id.to_string(),
+        persona_did: persona_did.to_string(),
+    };
+    let event = if attached {
+        AuditEvent::VpcAttached(data)
+    } else {
+        AuditEvent::VpcDetached(data)
+    };
+    writer
+        .write(actor_did, Some(&rel.subject_did), event)
+        .await?;
+    Ok(())
+}
+
 // ─── Helpers ─────────────────────────────────────────────
 
 /// Extract a DID from a JSON-LD VC field that may be either a
@@ -524,6 +870,25 @@ fn check_vrc_shape(vrc: &JsonValue) -> Result<(), AppError> {
     )
 }
 
+/// Reject anything that is not a conformant VPC before it annotates an edge.
+///
+/// Same contract as [`check_vrc_shape`], one subtype over: DTG Credentials
+/// §VPC says `type` MUST include `PersonaCredential`, and classification goes
+/// through the catalog rather than a string comparison here.
+///
+/// This delegates to `credentials::ingress` rather than carrying its own copy
+/// of the common-structure check. The VPC arrived on a branch cut before that
+/// module existed and brought a local `check_dtg_shape` with it; keeping both
+/// would have put two definitions of "is this a DTG credential" in the tree,
+/// which is the condition #1064 was filed about.
+fn check_vpc_shape(vpc: &JsonValue) -> Result<(), AppError> {
+    crate::credentials::ingress::require_dtg_type(
+        vpc,
+        dtg_credentials::DTGCredentialType::Persona,
+        "this endpoint attaches a persona annotation",
+    )
+}
+
 /// `type` of the publish authorization object. Guarding on it stops a
 /// signature the member made over some *other* object being replayed here as
 /// authorization to publish.
@@ -566,36 +931,64 @@ async fn verify_publish_authorization(
     expected_session_id: &str,
     resolver: &DIDCacheClient,
 ) -> Result<(), String> {
-    let field = |name: &str| -> Result<String, String> {
-        pop.get(name)
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .ok_or_else(|| format!("authorization missing `{name}`"))
-    };
+    check_authorization_envelope(
+        pop,
+        PUBLISH_AUTHORIZATION_TYPE,
+        expected_aud,
+        expected_session_id,
+    )?;
 
-    let ty = field("type")?;
-    if ty != PUBLISH_AUTHORIZATION_TYPE {
-        return Err(format!(
-            "authorization `type` must be `{PUBLISH_AUTHORIZATION_TYPE}`, got `{ty}`"
-        ));
-    }
-
-    let bound_vrc = field("vrc")?;
+    let bound_vrc = authorization_field(pop, "vrc")?;
     if bound_vrc != expected_vrc_sha256 {
         return Err("authorization is bound to a different VRC".into());
     }
 
-    let aud = field("aud")?;
+    // Signed by the key the VRC's `issuer` names. `check_issuer_binding`
+    // inside `verify_di_proof` is what makes this proof-of-possession rather
+    // than proof-of-anything-signed.
+    verify_di_proof(pop, issuer_did, resolver).await
+}
+
+/// Read a required string field off an authorization object.
+fn authorization_field(pop: &JsonValue, name: &str) -> Result<String, String> {
+    pop.get(name)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| format!("authorization missing `{name}`"))
+}
+
+/// The checks every request-bound authorization object in this module shares:
+/// what it authorizes (`type`), where (`aud`), by whom (`sessionId`), and how
+/// recently (`issuedAt`).
+///
+/// Factored out because the persona endpoints need exactly these and would
+/// otherwise copy them — and a copy is how one of the four quietly goes
+/// missing. The per-object bindings (which VRC, which edge) stay at the call
+/// sites, since those are what distinguish the objects.
+fn check_authorization_envelope(
+    pop: &JsonValue,
+    expected_type: &str,
+    expected_aud: &str,
+    expected_session_id: &str,
+) -> Result<(), String> {
+    let ty = authorization_field(pop, "type")?;
+    if ty != expected_type {
+        return Err(format!(
+            "authorization `type` must be `{expected_type}`, got `{ty}`"
+        ));
+    }
+
+    let aud = authorization_field(pop, "aud")?;
     if aud != expected_aud {
         return Err("authorization `aud` is not this community".into());
     }
 
-    let session_id = field("sessionId")?;
+    let session_id = authorization_field(pop, "sessionId")?;
     if session_id != expected_session_id {
         return Err("authorization is bound to a different session".into());
     }
 
-    let issued_at = chrono::DateTime::parse_from_rfc3339(&field("issuedAt")?)
+    let issued_at = chrono::DateTime::parse_from_rfc3339(&authorization_field(pop, "issuedAt")?)
         .map_err(|e| format!("authorization `issuedAt` is not an RFC 3339 timestamp: {e}"))?
         .with_timezone(&Utc);
     let age = Utc::now().signed_duration_since(issued_at).num_seconds();
@@ -605,11 +998,7 @@ async fn verify_publish_authorization(
              {PUBLISH_AUTHORIZATION_MAX_AGE_SECS}s freshness window (age {age}s)"
         ));
     }
-
-    // Signed by the key the VRC's `issuer` names. `check_issuer_binding`
-    // inside `verify_di_proof` is what makes this proof-of-possession rather
-    // than proof-of-anything-signed.
-    verify_di_proof(pop, issuer_did, resolver).await
+    Ok(())
 }
 
 /// Verify a data-integrity proof on a JSON document: bind the proof's
@@ -746,6 +1135,15 @@ pub struct GraphHalf {
     pub issuer_did: String,
     pub subject_did: String,
     pub created_at: String,
+    /// The persona (P-DID) the issuer has asserted on this edge, if any.
+    ///
+    /// This is the one place the deliberate correlation a VPC exists to
+    /// enable becomes visible: two pairwise edges carrying the same
+    /// `personaDid` are the same party, said so by that party. Without it the
+    /// annotation would be stored and never read, which is the state #1067
+    /// describes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persona_did: Option<String>,
 }
 
 /// One edge between a pair of identifiers, carrying every VRC published between
@@ -797,11 +1195,14 @@ fn build_graph(mut rels: Vec<Relationship>) -> RelationshipsGraph {
         } else {
             (r.subject_did.clone(), r.issuer_did.clone())
         };
+        // Taken before the DIDs are moved into the half below.
+        let persona_did = r.persona.map(|p| p.persona_did);
         pairs.entry(key).or_default().push(GraphHalf {
             id: r.id.to_string(),
             issuer_did: r.issuer_did,
             subject_did: r.subject_did,
             created_at: r.created_at.to_rfc3339(),
+            persona_did,
         });
     }
 

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -29,7 +29,10 @@
 //!    file because the URL is rooted under `/v1/members/`.
 //!
 //! 3. `DELETE /v1/relationships/{id}` — issuer-only retraction
-//!    (admin can also revoke for moderation). Deletes the row
+//!    (admin can also revoke for moderation). Authorized the
+//!    same three ways publication is: session DID equals the
+//!    row's issuer, admin, or a `VrcRevokeAuthorization`
+//!    proving control of a pairwise issuer. Deletes the row
 //!    plus secondary-index entries; emits `VrcRevoked`. Per
 //!    D7, VRCs carry no `credentialStatus`; revocation is row
 //!    deletion, not a status-list bit flip.
@@ -435,10 +438,58 @@ pub struct RevokeResponse {
     pub id: String,
 }
 
+/// `type` of the revoke authorization. Distinct from the publish type so the
+/// authorization a member signs every time they lodge an edge cannot be
+/// replayed to delete it.
+const REVOKE_AUTHORIZATION_TYPE: &str = "VrcRevokeAuthorization";
+
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
+pub struct RevokeBody {
+    /// Proof that the caller controls the key behind the row's `issuerDid`,
+    /// when that is not the caller's session DID — i.e. for every edge
+    /// published under a pairwise relationship DID.
+    ///
+    /// Bound to the row `id` rather than to a credential, because `DELETE
+    /// /v1/relationships/{id}` names the row and carries no credential to
+    /// bind to.
+    #[serde(default)]
+    pub pop: Option<JsonValue>,
+}
+
+/// `DELETE /v1/relationships/{id}` — retract an edge.
+///
+/// ## Why there is a body here at all
+///
+/// `revoke` kept the identity equality that `publish` replaced in #1054/#1061:
+/// `auth.did == rel.issuer_did`. For an edge published under a pairwise
+/// relationship DID that compares a membership DID against an R-DID and is
+/// false by construction, so a member could lodge an edge and then never take
+/// it back — only an admin could. The property the equality was standing in
+/// for is *control of the issuing key*, and once the identifier stopped being
+/// the member's own, only a proof can establish it.
+///
+/// Three routes to authorization, and the first two are exactly as before:
+///
+/// - **attributed** — `auth.did == rel.issuer_did`. Still correct, still
+///   sufficient, no proof needed. The session already demonstrates control of
+///   that key.
+/// - **admin** — moderation, keyed on the row id and not on issuer identity.
+///   Unchanged.
+/// - **pairwise** — a `VrcRevokeAuthorization` signed by the row's
+///   `issuerDid`, bound to this row, this community, this session and this
+///   moment. New.
+///
+/// Like the publish authorization, **it is verified and discarded** — never
+/// stored, logged or audited. It carries `sessionId`, which is attributable to
+/// a membership DID, and this handler writes to the audit store, so it is the
+/// one place on the pairwise path where that linkage could plausibly become
+/// durable. See `docs/05-design-notes/vrc-publish-proof-of-possession.md`.
 #[utoipa::path(
     delete, path = "/relationships/{id}", tag = "relationships",
     security(("bearer_jwt" = [])),
     params(("id" = String, Path, description = "Relationship (VRC) id")),
+    request_body(content = RevokeBody, description = "Optional. Required only \
+        for an edge issued under a pairwise relationship DID."),
     responses(
         (status = 200, description = "Relationship (VRC) revoked", body = RevokeResponse),
         (status = 401, description = "Missing or invalid bearer token"),
@@ -450,23 +501,68 @@ pub async fn revoke(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
+    // Optional: every client sending this request today sends no body at all,
+    // and must keep working. `Option<Json<_>>` yields `None` when there is no
+    // JSON content-type, and still rejects a malformed body when there is.
+    body: Option<Json<RevokeBody>>,
 ) -> Result<(StatusCode, Json<RevokeResponse>), AppError> {
     let rel = get_relationship(&state.relationships_ks, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("VRC {id} not found")))?;
 
-    // Auth: issuer of the row OR admin.
+    let pop = body.and_then(|Json(b)| b.pop);
     let is_issuer = auth.did == rel.issuer_did;
     let is_admin = auth.role == vti_common::acl::Role::Admin;
-    if !is_issuer && !is_admin {
+
+    // Cheapest gate first, before the resolver is touched: with none of the
+    // three routes available this is a caller error, and reaching the
+    // daemon-config prerequisite below would report it as a 500. Same ordering
+    // rule the publish path documents.
+    if !is_issuer && !is_admin && pop.is_none() {
         return Err(AppError::Forbidden(
-            "only the issuer or an admin can revoke a VRC".into(),
+            "only the issuer or an admin can revoke a VRC — an edge issued \
+             under a relationship DID needs a revoke authorization (`pop`) \
+             proving control of it"
+                .into(),
         ));
+    }
+
+    // A supplied authorization must verify, whoever supplied it. Accepting a
+    // request that carried an authorization we then ignored would make the
+    // failure of a *bad* one indistinguishable from success.
+    let mut proved_control = false;
+    if let Some(pop) = &pop {
+        let resolver = state.did_resolver.as_ref().cloned().ok_or_else(|| {
+            AppError::Internal(
+                "DID resolver not configured — VRC revoke authorization requires it".into(),
+            )
+        })?;
+        let aud = crate::routes::recognise::vtc_did(&state).await?;
+        check_authorization_envelope(pop, REVOKE_AUTHORIZATION_TYPE, &aud, &auth.session_id)
+            .and_then(|()| {
+                let edge = authorization_field(pop, "relationship")?;
+                if edge != id.to_string() {
+                    return Err("authorization is bound to a different edge".into());
+                }
+                Ok(())
+            })
+            .map_err(|e| AppError::Forbidden(format!("VrcRevokeAuthorizationInvalid: {e}")))?;
+        verify_di_proof(pop, &rel.issuer_did, &resolver)
+            .await
+            .map_err(|e| AppError::Forbidden(format!("VrcRevokeAuthorizationInvalid: {e}")))?;
+        proved_control = true;
     }
 
     delete_relationship(&state.relationships_ks, &state.relationships_by_did_ks, id).await?;
 
-    let revoked_by = if is_issuer { "issuer" } else { "admin" };
+    // Proving control of the issuing key *is* being the issuer. Recording it
+    // as an admin action would misattribute a member's own retraction in the
+    // one trail an operator uses to answer who did what.
+    let revoked_by = if is_issuer || proved_control {
+        "issuer"
+    } else {
+        "admin"
+    };
     if let Some(writer) = state.audit_writer.as_ref() {
         writer
             .write(
@@ -1363,6 +1459,10 @@ mod tests {
             vrc_jsonld,
             vrc_sha256,
             created_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, minute, 0).unwrap(),
+            // These fixtures exercise the half/complete grouping, which is
+            // independent of whether a persona was asserted. The persona
+            // rendering has its own tests.
+            persona: None,
         }
     }
 

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -282,6 +282,7 @@ async fn seed_relationship(fix: &Fixture, issuer: &str, subject: &str) -> Uuid {
         vrc_jsonld: fake_vrc(issuer, subject),
         vrc_sha256: format!("seed-{id}"),
         created_at: chrono::Utc::now(),
+        persona: None,
     };
     store_relationship(&fix.relationships_ks, &fix.relationships_by_did_ks, &rel)
         .await
@@ -1211,5 +1212,419 @@ mod pairwise {
             post(&fix, &v, Some(pop)).await.status(),
             StatusCode::FORBIDDEN
         );
+    }
+
+    // ─── Persona annotation (VPC) — #1067 ─────────────────
+    //
+    // These live inside `pairwise` because that is where they
+    // matter. On an attributed edge the member is already
+    // correlatable and a persona changes nothing; on pairwise
+    // edges the VPC is the only thing that lets a member be
+    // recognised across relationships without surrendering
+    // their membership DID.
+
+    mod persona {
+        use super::*;
+
+        const PERSONA: u8 = 0x45;
+        const RDID2: u8 = 0x46;
+        const PEER2_RDID: u8 = 0x47;
+        const GRAPH_ADMIN: u8 = 0x7A;
+
+        const PERSONA_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/persona/0.1";
+        const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
+
+        /// A signed VPC: issued under `persona_seed`'s P-DID, naming
+        /// `counterparty_seed` as the subject. DTG Credentials §VPC.
+        async fn vpc(persona_seed: u8, counterparty_seed: u8) -> Value {
+            sign(
+                persona_seed,
+                json!({
+                    "@context": [
+                        "https://www.w3.org/ns/credentials/v2",
+                        "https://firstperson.network/credentials/dtg/v1"
+                    ],
+                    "type": ["VerifiableCredential", "DTGCredential", "PersonaCredential"],
+                    "issuer": did_for(persona_seed),
+                    "validFrom": "2020-01-01T00:00:00Z",
+                    "credentialSubject": { "id": did_for(counterparty_seed) },
+                }),
+            )
+            .await
+        }
+
+        fn attach_authorization(vpc_hash: &str, edge: Uuid, session_id: &str) -> Value {
+            json!({
+                "type": "VpcAttachAuthorization",
+                "vpc": vpc_hash,
+                "relationship": edge.to_string(),
+                "aud": TEST_VTC_DID,
+                "sessionId": session_id,
+                "issuedAt": chrono::Utc::now().to_rfc3339(),
+            })
+        }
+
+        fn detach_authorization(edge: Uuid, session_id: &str) -> Value {
+            json!({
+                "type": "VpcDetachAuthorization",
+                "relationship": edge.to_string(),
+                "aud": TEST_VTC_DID,
+                "sessionId": session_id,
+                "issuedAt": chrono::Utc::now().to_rfc3339(),
+            })
+        }
+
+        /// Publish a pairwise edge `issuer_seed -> subject_seed`, return its id.
+        async fn publish_edge(fix: &Pw, issuer_seed: u8, subject_seed: u8) -> Uuid {
+            let v = vrc(issuer_seed, subject_seed).await;
+            let pop = sign(
+                issuer_seed,
+                authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+            )
+            .await;
+            let (status, body) = body_value(post(fix, &v, Some(pop)).await).await;
+            assert_eq!(status, StatusCode::CREATED, "seed publish failed: {body}");
+            Uuid::parse_str(body["id"].as_str().unwrap()).unwrap()
+        }
+
+        async fn attach(
+            fix: &Pw,
+            edge: Uuid,
+            vpc: &Value,
+            pop: Option<Value>,
+        ) -> (StatusCode, Value) {
+            let mut body = json!({ "vpc": vpc });
+            if let Some(p) = pop {
+                body["pop"] = p;
+            }
+            persona_request(fix, "POST", edge, body).await
+        }
+
+        async fn detach(fix: &Pw, edge: Uuid, pop: Option<Value>) -> (StatusCode, Value) {
+            let mut body = json!({});
+            if let Some(p) = pop {
+                body["pop"] = p;
+            }
+            persona_request(fix, "DELETE", edge, body).await
+        }
+
+        async fn persona_request(
+            fix: &Pw,
+            method: &str,
+            edge: Uuid,
+            body: Value,
+        ) -> (StatusCode, Value) {
+            let req = Request::builder()
+                .method(method)
+                .uri(format!("/v1/relationships/{edge}/persona"))
+                .header("authorization", format!("Bearer {}", fix.token))
+                .header("trust-task", PERSONA_TASK)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap();
+            body_value(fix.router.clone().oneshot(req).await.unwrap()).await
+        }
+
+        /// The attach happy path in one call, for tests whose subject is what
+        /// happens *after* a successful attach. The authorization is signed by
+        /// `RDID`, so this is only for edges that `RDID` issued.
+        async fn attach_ok(fix: &Pw, edge: Uuid, persona_seed: u8, counterparty_seed: u8) {
+            let v = vpc(persona_seed, counterparty_seed).await;
+            let pop = sign(
+                RDID,
+                attach_authorization(&sha256_hex(&v), edge, &fix.session_id),
+            )
+            .await;
+            let (status, body) = attach(fix, edge, &v, Some(pop)).await;
+            assert_eq!(status, StatusCode::OK, "body: {body}");
+        }
+
+        /// The admin connections graph is where the correlation a persona
+        /// enables actually becomes visible, so the assertions that matter
+        /// read it rather than the storage layer. Seeds its own admin because
+        /// the `pairwise` fixture only has the one member session.
+        async fn graph_edges(fix: &Pw) -> Vec<Value> {
+            let now = now_epoch();
+            let admin = did_for(GRAPH_ADMIN);
+            store_acl_entry(
+                &fix._vtc.state.acl_ks,
+                &VtcAclEntry {
+                    did: admin.clone(),
+                    role: VtcRole::Admin,
+                    label: None,
+                    allowed_contexts: vec![],
+                    created_at: now,
+                    created_by: "did:key:vtc-install".into(),
+                    updated_at: None,
+                    updated_by: None,
+                    expires_at: None,
+                },
+            )
+            .await
+            .unwrap();
+            store_member(&fix._vtc.state.members_ks, &Member::fresh(&admin))
+                .await
+                .unwrap();
+            let session_id = format!("sess-{}", Uuid::new_v4());
+            store_session(
+                &fix._vtc.state.sessions_ks,
+                &Session {
+                    session_id: session_id.clone(),
+                    did: admin.clone(),
+                    challenge: "test".into(),
+                    state: SessionState::Authenticated,
+                    created_at: now,
+                    last_seen: now,
+                    refresh_token: None,
+                    refresh_expires_at: None,
+                    tee_attested: false,
+                    amr: Vec::new(),
+                    acr: String::new(),
+                    acr_expires_at: None,
+                    token_id: None,
+                    session_pubkey_b58btc: None,
+                },
+            )
+            .await
+            .unwrap();
+            let claims =
+                fix._vtc
+                    .jwt_keys
+                    .new_claims(admin, session_id, "admin".into(), vec![], 3600, true);
+            let token = fix._vtc.jwt_keys.encode(&claims).unwrap();
+
+            let req = Request::builder()
+                .method("GET")
+                .uri("/v1/relationships/graph")
+                .header("authorization", format!("Bearer {token}"))
+                .header("trust-task", GRAPH_TASK)
+                .body(Body::empty())
+                .unwrap();
+            let (status, body) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+            assert_eq!(status, StatusCode::OK, "graph: {body}");
+            body["edges"].as_array().cloned().unwrap_or_default()
+        }
+
+        /// The property #1067 exists to restore: a member can be recognised
+        /// across relationships under a name they chose, while every edge
+        /// still names only pairwise identifiers.
+        #[tokio::test]
+        async fn attaches_a_persona_to_a_pairwise_edge() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            attach_ok(&fix, edge, PERSONA, PEER_RDID).await;
+
+            let edges = graph_edges(&fix).await;
+            assert_eq!(edges.len(), 1);
+            assert_eq!(edges[0]["personaDid"], did_for(PERSONA));
+            assert_eq!(edges[0]["issuerDid"], did_for(RDID));
+
+            // The annotation must not smuggle the member back in.
+            let rows = vtc_service::relationships::list_all(&fix.relationships_ks)
+                .await
+                .unwrap();
+            let stored = serde_json::to_string(&rows[0]).unwrap();
+            assert!(
+                !stored.contains(&did_for(MEMBER)),
+                "membership DID leaked into the annotated row"
+            );
+            assert!(
+                !stored.contains(&fix.session_id),
+                "session id leaked into the annotated row"
+            );
+        }
+
+        /// The whole point: two edges under two different relationship DIDs,
+        /// correlatable because — and only because — the member said so.
+        #[tokio::test]
+        async fn the_same_persona_may_be_asserted_on_several_edges() {
+            let fix = fixture().await;
+            let e1 = publish_edge(&fix, RDID, PEER_RDID).await;
+            let e2 = publish_edge(&fix, RDID2, PEER2_RDID).await;
+            attach_ok(&fix, e1, PERSONA, PEER_RDID).await;
+
+            // Second edge: same persona, different relationship DID, so the
+            // authorization is signed by RDID2.
+            let v = vpc(PERSONA, PEER2_RDID).await;
+            let pop = sign(
+                RDID2,
+                attach_authorization(&sha256_hex(&v), e2, &fix.session_id),
+            )
+            .await;
+            let (status, body) = attach(&fix, e2, &v, Some(pop)).await;
+            assert_eq!(status, StatusCode::OK, "body: {body}");
+
+            let edges = graph_edges(&fix).await;
+            assert_eq!(edges.len(), 2);
+            for e in &edges {
+                assert_eq!(e["personaDid"], did_for(PERSONA));
+            }
+            // A P-DID recurring is the feature. An R-DID recurring is not:
+            // the two edges must still carry distinct issuers.
+            let issuers: std::collections::BTreeSet<_> = edges
+                .iter()
+                .map(|e| e["issuerDid"].as_str().unwrap().to_string())
+                .collect();
+            assert_eq!(issuers.len(), 2);
+        }
+
+        /// Anyone who was ever handed a VPC could otherwise staple it to
+        /// someone else's edge. Control of the edge's issuing key is the gate.
+        #[tokio::test]
+        async fn rejects_an_authorization_signed_by_another_key() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let v = vpc(PERSONA, PEER_RDID).await;
+            let pop = sign(
+                OTHER,
+                attach_authorization(&sha256_hex(&v), edge, &fix.session_id),
+            )
+            .await;
+            let (status, body) = attach(&fix, edge, &v, Some(pop)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+        }
+
+        /// A pairwise edge's issuer is never the session DID, so omitting the
+        /// authorization is never valid there.
+        #[tokio::test]
+        async fn rejects_an_attach_with_no_authorization_on_a_pairwise_edge() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let v = vpc(PERSONA, PEER_RDID).await;
+            let (status, body) = attach(&fix, edge, &v, None).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+        }
+
+        /// An authorization for one edge must not annotate another. Without
+        /// the `relationship` binding a member could move a persona onto any
+        /// edge they control.
+        #[tokio::test]
+        async fn rejects_an_authorization_bound_to_a_different_edge() {
+            let fix = fixture().await;
+            let e1 = publish_edge(&fix, RDID, PEER_RDID).await;
+            let e2 = publish_edge(&fix, RDID2, PEER2_RDID).await;
+            let v = vpc(PERSONA, PEER2_RDID).await;
+            let pop = sign(
+                RDID2,
+                attach_authorization(&sha256_hex(&v), e1, &fix.session_id),
+            )
+            .await;
+            let (status, body) = attach(&fix, e2, &v, Some(pop)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+        }
+
+        /// This endpoint annotates; it does not publish. A VRC posted here is
+        /// a caller error, not a second way to create an edge.
+        #[tokio::test]
+        async fn rejects_a_credential_that_is_not_a_vpc() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let not_a_vpc = vrc(PERSONA, PEER_RDID).await;
+            let pop = sign(
+                RDID,
+                attach_authorization(&sha256_hex(&not_a_vpc), edge, &fix.session_id),
+            )
+            .await;
+            let (status, body) = attach(&fix, edge, &not_a_vpc, Some(pop)).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        }
+
+        /// A persona is asserted *to* a counterparty. A VPC naming somebody
+        /// else has nothing to say about this edge.
+        #[tokio::test]
+        async fn rejects_a_vpc_asserted_to_a_different_counterparty() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let v = vpc(PERSONA, OTHER).await;
+            let pop = sign(
+                RDID,
+                attach_authorization(&sha256_hex(&v), edge, &fix.session_id),
+            )
+            .await;
+            let (status, body) = attach(&fix, edge, &v, Some(pop)).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        }
+
+        /// Withdrawing a persona has to work, or the feature is a one-way
+        /// disclosure. The edge itself survives.
+        #[tokio::test]
+        async fn detach_removes_the_persona_and_leaves_the_edge() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            attach_ok(&fix, edge, PERSONA, PEER_RDID).await;
+
+            let pop = sign(RDID, detach_authorization(edge, &fix.session_id)).await;
+            let (status, body) = detach(&fix, edge, Some(pop)).await;
+            assert_eq!(status, StatusCode::OK, "body: {body}");
+            assert!(body["personaDid"].is_null());
+
+            let edges = graph_edges(&fix).await;
+            assert_eq!(edges.len(), 1, "the edge must outlive its annotation");
+            assert!(edges[0].get("personaDid").is_none());
+        }
+
+        /// The two authorization types are distinct so that one cannot stand
+        /// in for the other — otherwise a captured attach authorization would
+        /// let its holder strip the persona it was made to assert.
+        #[tokio::test]
+        async fn rejects_an_attach_authorization_replayed_as_a_detach() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let v = vpc(PERSONA, PEER_RDID).await;
+            attach_ok(&fix, edge, PERSONA, PEER_RDID).await;
+
+            let pop = sign(
+                RDID,
+                attach_authorization(&sha256_hex(&v), edge, &fix.session_id),
+            )
+            .await;
+            let (status, body) = detach(&fix, edge, Some(pop)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+        }
+
+        /// Both verbs leave a trail, and neither leaves the session id in it.
+        #[tokio::test]
+        async fn attach_and_detach_are_audited_without_the_session_id() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            attach_ok(&fix, edge, PERSONA, PEER_RDID).await;
+            let pop = sign(RDID, detach_authorization(edge, &fix.session_id)).await;
+            assert_eq!(detach(&fix, edge, Some(pop)).await.0, StatusCode::OK);
+
+            let (mut saw_attach, mut saw_detach) = (false, false);
+            for (_k, raw) in fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap() {
+                assert!(
+                    !String::from_utf8_lossy(&raw).contains(&fix.session_id),
+                    "session id reached the audit store"
+                );
+                let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+                match env.event {
+                    AuditEvent::VpcAttached(d) => {
+                        assert_eq!(d.persona_did, did_for(PERSONA));
+                        saw_attach = true;
+                    }
+                    AuditEvent::VpcDetached(d) => {
+                        assert_eq!(d.persona_did, did_for(PERSONA));
+                        saw_detach = true;
+                    }
+                    _ => {}
+                }
+            }
+            assert!(saw_attach && saw_detach);
+        }
+
+        #[tokio::test]
+        async fn unknown_edge_is_404() {
+            let fix = fixture().await;
+            let v = vpc(PERSONA, PEER_RDID).await;
+            let missing = Uuid::new_v4();
+            let pop = sign(
+                RDID,
+                attach_authorization(&sha256_hex(&v), missing, &fix.session_id),
+            )
+            .await;
+            let (status, _) = attach(&fix, missing, &v, Some(pop)).await;
+            assert_eq!(status, StatusCode::NOT_FOUND);
+        }
     }
 }

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -1416,10 +1416,15 @@ mod pairwise {
             let edge = publish_edge(&fix, RDID, PEER_RDID).await;
             attach_ok(&fix, edge, PERSONA, PEER_RDID).await;
 
+            // The graph groups by pair (#1073), so the per-VRC fields — and
+            // the persona, which is asserted per VRC — live on the half, not
+            // on the edge. Only one direction is published here, so there is
+            // exactly one half.
             let edges = graph_edges(&fix).await;
             assert_eq!(edges.len(), 1);
-            assert_eq!(edges[0]["personaDid"], did_for(PERSONA));
-            assert_eq!(edges[0]["issuerDid"], did_for(RDID));
+            assert_eq!(edges[0]["halves"].as_array().unwrap().len(), 1);
+            assert_eq!(edges[0]["halves"][0]["personaDid"], did_for(PERSONA));
+            assert_eq!(edges[0]["halves"][0]["issuerDid"], did_for(RDID));
 
             // The annotation must not smuggle the member back in.
             let rows = vtc_service::relationships::list_all(&fix.relationships_ks)
@@ -1459,13 +1464,13 @@ mod pairwise {
             let edges = graph_edges(&fix).await;
             assert_eq!(edges.len(), 2);
             for e in &edges {
-                assert_eq!(e["personaDid"], did_for(PERSONA));
+                assert_eq!(e["halves"][0]["personaDid"], did_for(PERSONA));
             }
             // A P-DID recurring is the feature. An R-DID recurring is not:
             // the two edges must still carry distinct issuers.
             let issuers: std::collections::BTreeSet<_> = edges
                 .iter()
-                .map(|e| e["issuerDid"].as_str().unwrap().to_string())
+                .map(|e| e["halves"][0]["issuerDid"].as_str().unwrap().to_string())
                 .collect();
             assert_eq!(issuers.len(), 2);
         }

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -749,6 +749,21 @@ mod pairwise {
         hex::encode(Sha256::digest(sorted(v.clone()).to_string().as_bytes()))
     }
 
+    /// Publish a pairwise edge `issuer_seed -> subject_seed`, return its id.
+    /// Shared by the `persona` and `revocation` suites below, both of which
+    /// need an already-published pairwise edge to act on.
+    async fn publish_edge(fix: &Pw, issuer_seed: u8, subject_seed: u8) -> Uuid {
+        let v = vrc(issuer_seed, subject_seed).await;
+        let pop = sign(
+            issuer_seed,
+            authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+        )
+        .await;
+        let (status, body) = body_value(post(fix, &v, Some(pop)).await).await;
+        assert_eq!(status, StatusCode::CREATED, "seed publish failed: {body}");
+        Uuid::parse_str(body["id"].as_str().unwrap()).unwrap()
+    }
+
     /// A well-formed publish authorization, before signing.
     fn authorization(vrc_hash: &str, aud: &str, session_id: &str) -> Value {
         json!({
@@ -1274,19 +1289,6 @@ mod pairwise {
             })
         }
 
-        /// Publish a pairwise edge `issuer_seed -> subject_seed`, return its id.
-        async fn publish_edge(fix: &Pw, issuer_seed: u8, subject_seed: u8) -> Uuid {
-            let v = vrc(issuer_seed, subject_seed).await;
-            let pop = sign(
-                issuer_seed,
-                authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
-            )
-            .await;
-            let (status, body) = body_value(post(fix, &v, Some(pop)).await).await;
-            assert_eq!(status, StatusCode::CREATED, "seed publish failed: {body}");
-            Uuid::parse_str(body["id"].as_str().unwrap()).unwrap()
-        }
-
         async fn attach(
             fix: &Pw,
             edge: Uuid,
@@ -1625,6 +1627,287 @@ mod pairwise {
             .await;
             let (status, _) = attach(&fix, missing, &v, Some(pop)).await;
             assert_eq!(status, StatusCode::NOT_FOUND);
+        }
+    }
+
+    // ─── Retracting a pairwise edge ───────────────────────
+    //
+    // `revoke` kept the identity equality the publish path
+    // replaced — `auth.did == rel.issuer_did` — one function
+    // below where it was fixed. For a pairwise edge that
+    // compares a membership DID against a relationship DID and
+    // is false by construction, so from #1061 until this suite
+    // a member could publish an edge under a relationship DID
+    // and then never take it back; only an admin could.
+    //
+    // `revoke_issuer_can_retract_own` (top of this file) seeds
+    // the *attributed* form, where the equality still holds,
+    // which is exactly why the regression shipped green.
+
+    mod revocation {
+        use super::*;
+
+        /// A second relationship DID + counterparty, so a caller can hold two
+        /// edges at once and try to retract one with the other's proof.
+        const RDID_B: u8 = 0x48;
+        const PEER_B_RDID: u8 = 0x49;
+        /// A second community member, for the cross-session replay test.
+        const OTHER_MEMBER: u8 = 0x4A;
+
+        /// A well-formed revoke authorization, before signing. Bound to the
+        /// row id, because that is what `DELETE /v1/relationships/{id}`
+        /// names — there is no credential in the request to bind to.
+        fn revoke_authorization(edge: Uuid, session_id: &str) -> Value {
+            json!({
+                "type": "VrcRevokeAuthorization",
+                "relationship": edge.to_string(),
+                "aud": TEST_VTC_DID,
+                "sessionId": session_id,
+                "issuedAt": chrono::Utc::now().to_rfc3339(),
+            })
+        }
+
+        async fn delete_edge(fix: &Pw, edge: Uuid, pop: Option<Value>) -> (StatusCode, Value) {
+            let mut req = Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/relationships/{edge}"))
+                .header("authorization", format!("Bearer {}", fix.token))
+                .header("trust-task", REVOKE_TASK);
+            // No `pop` means no body and no content-type at all — the shape
+            // every client sending this request today uses, and the shape the
+            // optional extractor has to keep accepting.
+            let body = match pop {
+                Some(p) => {
+                    req = req.header("content-type", "application/json");
+                    Body::from(json!({ "pop": p }).to_string())
+                }
+                None => Body::empty(),
+            };
+            let resp = fix
+                .router
+                .clone()
+                .oneshot(req.body(body).unwrap())
+                .await
+                .unwrap();
+            body_value(resp).await
+        }
+
+        async fn edge_count(fix: &Pw) -> usize {
+            vtc_service::relationships::list_all(&fix.relationships_ks)
+                .await
+                .unwrap()
+                .len()
+        }
+
+        /// Seed a second current member with their own live session, and
+        /// return their bearer token. Used to replay one member's
+        /// authorization inside another member's session.
+        async fn other_member_token(fix: &Pw) -> String {
+            let now = now_epoch();
+            let did = did_for(OTHER_MEMBER);
+            store_acl_entry(
+                &fix._vtc.state.acl_ks,
+                &VtcAclEntry {
+                    did: did.clone(),
+                    role: VtcRole::Member,
+                    label: None,
+                    allowed_contexts: vec![],
+                    created_at: now,
+                    created_by: "did:key:vtc-install".into(),
+                    updated_at: None,
+                    updated_by: None,
+                    expires_at: None,
+                },
+            )
+            .await
+            .unwrap();
+            store_member(&fix._vtc.state.members_ks, &Member::fresh(&did))
+                .await
+                .unwrap();
+            let session_id = format!("sess-{}", Uuid::new_v4());
+            store_session(
+                &fix._vtc.state.sessions_ks,
+                &Session {
+                    session_id: session_id.clone(),
+                    did: did.clone(),
+                    challenge: "test".into(),
+                    state: SessionState::Authenticated,
+                    created_at: now,
+                    last_seen: now,
+                    refresh_token: None,
+                    refresh_expires_at: None,
+                    tee_attested: false,
+                    amr: Vec::new(),
+                    acr: String::new(),
+                    acr_expires_at: None,
+                    token_id: None,
+                    session_pubkey_b58btc: None,
+                },
+            )
+            .await
+            .unwrap();
+            let claims =
+                fix._vtc
+                    .jwt_keys
+                    .new_claims(did, session_id, "reader".into(), vec![], 3600, true);
+            fix._vtc.jwt_keys.encode(&claims).unwrap()
+        }
+
+        /// The regression. Fails against the pre-fix handler with 403: the
+        /// session DID is the member's, the row's issuer is a relationship
+        /// DID, and nothing in `revoke` could bridge them.
+        #[tokio::test]
+        async fn issuer_can_retract_a_pairwise_edge_with_an_authorization() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            assert_eq!(edge_count(&fix).await, 1);
+
+            let pop = sign(RDID, revoke_authorization(edge, &fix.session_id)).await;
+            let (status, body) = delete_edge(&fix, edge, Some(pop)).await;
+            assert_eq!(status, StatusCode::OK, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 0, "the row must actually be gone");
+        }
+
+        /// Without proof of control the answer is still 403 — that part was
+        /// never wrong. What was wrong was that there was no way to supply
+        /// the proof.
+        #[tokio::test]
+        async fn a_pairwise_edge_still_needs_an_authorization() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let (status, body) = delete_edge(&fix, edge, None).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 1);
+        }
+
+        /// Holding a session is not holding the issuing key. Without this,
+        /// any member could delete any pairwise edge in the community.
+        #[tokio::test]
+        async fn rejects_an_authorization_signed_by_another_key() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let pop = sign(OTHER, revoke_authorization(edge, &fix.session_id)).await;
+            let (status, body) = delete_edge(&fix, edge, Some(pop)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 1);
+        }
+
+        /// An authorization naming one edge must not delete another, even
+        /// when both were issued under keys the caller controls.
+        #[tokio::test]
+        async fn rejects_an_authorization_bound_to_a_different_edge() {
+            let fix = fixture().await;
+            let e1 = publish_edge(&fix, RDID, PEER_RDID).await;
+            let e2 = publish_edge(&fix, RDID_B, PEER_B_RDID).await;
+            let pop = sign(RDID_B, revoke_authorization(e1, &fix.session_id)).await;
+            let (status, body) = delete_edge(&fix, e2, Some(pop)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 2);
+        }
+
+        /// The `type` guard on its own.
+        ///
+        /// Added because mutation testing showed it was untested: with the
+        /// type comparison removed, every test here still passed. The replay
+        /// test below was being caught by the *edge* binding — a publish
+        /// authorization has no `relationship` field — so it never exercised
+        /// `type` at all. This object is a valid revoke authorization in every
+        /// respect except the one under test, so nothing else can catch it.
+        #[tokio::test]
+        async fn rejects_an_authorization_of_the_wrong_type() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let mut a = revoke_authorization(edge, &fix.session_id);
+            a["type"] = json!("SomeOtherSignedThing");
+            let pop = sign(RDID, a).await;
+            let (status, body) = delete_edge(&fix, edge, Some(pop)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 1);
+        }
+
+        /// The `type` guard as a member would actually meet it. A member signs
+        /// a publish authorization every time they lodge an edge; replaying
+        /// one here must not delete it. (Belt and braces with the test above:
+        /// this one is currently caught by the missing `relationship` field,
+        /// which is a second reason it fails and a fine one.)
+        #[tokio::test]
+        async fn rejects_a_publish_authorization_replayed_as_a_revoke() {
+            let fix = fixture().await;
+            let v = vrc(RDID, PEER_RDID).await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let stolen = sign(
+                RDID,
+                authorization(&sha256_hex(&v), TEST_VTC_DID, &fix.session_id),
+            )
+            .await;
+            let (status, body) = delete_edge(&fix, edge, Some(stolen)).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 1);
+        }
+
+        /// The `sessionId` binding — the load-bearing one, per the publish
+        /// design note.
+        ///
+        /// Added because mutation testing showed it was untested here: with
+        /// the session comparison neutered, every other test still passed,
+        /// because every other test happens to present the authorization in
+        /// the session it was minted for. The threat is a *different* member
+        /// replaying a captured authorization: the signature on it is still
+        /// the issuer's and verifies, so `sessionId` is the only thing that
+        /// stops them deleting an edge they do not control.
+        #[tokio::test]
+        async fn rejects_an_authorization_replayed_in_another_members_session() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            // Minted for — and correctly signed for — the *first* member's
+            // session, then presented by someone else.
+            let pop = sign(RDID, revoke_authorization(edge, &fix.session_id)).await;
+
+            let token = other_member_token(&fix).await;
+            let req = Request::builder()
+                .method("DELETE")
+                .uri(format!("/v1/relationships/{edge}"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("trust-task", REVOKE_TASK)
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "pop": pop }).to_string()))
+                .unwrap();
+            let (status, body) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+            assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+            assert_eq!(edge_count(&fix).await, 1);
+        }
+
+        /// The authorization carries `sessionId`, which is attributable to a
+        /// membership DID. Persisting it would rebuild the durable linkage
+        /// publishing under a relationship DID exists to remove — and the
+        /// revoke path writes to the audit store, so it is the one place it
+        /// could plausibly leak.
+        #[tokio::test]
+        async fn authorization_is_never_persisted_to_the_audit_trail() {
+            let fix = fixture().await;
+            let edge = publish_edge(&fix, RDID, PEER_RDID).await;
+            let pop = sign(RDID, revoke_authorization(edge, &fix.session_id)).await;
+            assert_eq!(delete_edge(&fix, edge, Some(pop)).await.0, StatusCode::OK);
+
+            let mut saw_revoke = false;
+            for (_k, raw) in fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap() {
+                assert!(
+                    !String::from_utf8_lossy(&raw).contains(&fix.session_id),
+                    "session id reached the audit store"
+                );
+                assert!(
+                    !String::from_utf8_lossy(&raw).contains("VrcRevokeAuthorization"),
+                    "the authorization object reached the audit store"
+                );
+                let env: AuditEnvelope = serde_json::from_slice(&raw).unwrap();
+                if let AuditEvent::VrcRevoked(d) = env.event {
+                    // Proving control of the issuing key *is* being the
+                    // issuer; the trail should not call it an admin action.
+                    assert_eq!(d.revoked_by, "issuer");
+                    saw_revoke = true;
+                }
+            }
+            assert!(saw_revoke, "expected a VrcRevoked audit entry");
         }
     }
 }

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -410,6 +410,26 @@ fn no_new_bindings_on_the_retired_authority() {
 /// (#821) is what produced this list. **None of it was previously checked by
 /// anything.**
 const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
+    // `vtc/relationships/persona/0.1` — the VPC annotation endpoints (#1067).
+    // Bound ahead of its spec, which is the mechanism this list exists for,
+    // not an exception to it: `vta/webvh/servers/reconcile/0.1` went up and
+    // back down the same way once the registry served it.
+    //
+    // It is bound ahead deliberately rather than by oversight. The credential
+    // it carries is specified — DTG Credentials §VPC — but how a VPC binds to
+    // a specific edge is open upstream (trustoverip/dtgwg-cred-spec#9), and a
+    // Trust Task payload schema authored before that settles would have to
+    // encode this implementation's request-level binding as if it were the
+    // answer. The endpoint can move first; the schema should not.
+    //
+    // This is the first entry the `spec/vtc/` family has ever had. It goes
+    // back to zero when the task is authored upstream.
+    (
+        "https://trusttasks.org/spec/vtc/relationships/persona/",
+        1,
+        "VPC persona annotation (#1067) — bound ahead of its spec while \
+         dtgwg-cred-spec#9 (how a VPC binds to an edge) is open upstream",
+    ),
     // Not a dispatchable task: the framework's error envelope is a *response*
     // type, deliberately absent from the task index, so `schema_for` will never
     // resolve it. This entry is permanent — the others are debt.

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -250,6 +250,25 @@ pub enum AuditEvent {
     /// row deletion in the local `relationships:` keyspace.
     VrcRevoked(VrcRevokedData),
 
+    /// A member attached a Verifiable Persona Credential (VPC)
+    /// to one of their published relationship edges — DTG
+    /// Credentials §Annotation Credentials. The actor is the
+    /// authenticated member; `persona_did` is the VPC's issuer,
+    /// the P-DID the member chose to be correlated under.
+    ///
+    /// Recording the P-DID alongside the member is the same
+    /// deliberate, narrow exception the VRC publish trail makes
+    /// for the actor: the audit store is access-controlled,
+    /// redactable and tamper-evident, and without it no operator
+    /// could answer "who asserted this persona" for moderation.
+    /// See `docs/05-design-notes/vpc-persona-annotation.md`.
+    VpcAttached(VpcAnnotationData),
+
+    /// A member removed the VPC annotation from one of their
+    /// edges. Withdrawing a persona is as much a privacy act as
+    /// asserting one, so it leaves the same trail.
+    VpcDetached(VpcAnnotationData),
+
     /// A member's personhood flag was asserted true via
     /// `POST /v1/members/{did}/personhood/assert`. Phase 4
     /// M4.3. The actor is the asserter (admin or issuer); the
@@ -437,6 +456,8 @@ impl AuditEvent {
             Self::CrossCommunitySessionMinted(..) => "CrossCommunitySessionMinted",
             Self::VrcPublished(..) => "VrcPublished",
             Self::VrcRevoked(..) => "VrcRevoked",
+            Self::VpcAttached(..) => "VpcAttached",
+            Self::VpcDetached(..) => "VpcDetached",
             Self::PersonhoodAsserted(..) => "PersonhoodAsserted",
             Self::PersonhoodRevoked(..) => "PersonhoodRevoked",
             Self::CustomEndorsementIssued(..) => "CustomEndorsementIssued",
@@ -1061,6 +1082,25 @@ pub struct VrcRevokedData {
     /// or `"admin"` (an admin revoked on behalf of the
     /// community).
     pub revoked_by: String,
+}
+
+/// Payload for [`AuditEvent::VpcAttached`] and
+/// [`AuditEvent::VpcDetached`]. One shape for both because the
+/// facts are the same in each direction — which edge, which
+/// persona — and the verb is already the variant.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VpcAnnotationData {
+    /// Server-allocated id (UUID) of the relationship row the
+    /// VPC annotates. Annotation credentials do not create graph
+    /// structure, so a VPC is always recorded against an edge
+    /// that already exists.
+    pub vrc_id: String,
+    /// The VPC's `issuer` — the persona DID (P-DID) the member
+    /// asserted. Unlike a relationship DID, a P-DID is *meant*
+    /// to recur across edges: that is what makes the correlation
+    /// deliberate rather than accidental.
+    pub persona_did: String,
 }
 
 /// Payload for [`AuditEvent::PersonhoodAsserted`]. Phase 4
@@ -1856,6 +1896,32 @@ mod tests {
     }
 
     #[test]
+    fn vpc_attach_and_detach_share_one_payload_shape() {
+        for (e, expected) in [
+            (
+                AuditEvent::VpcAttached(VpcAnnotationData {
+                    vrc_id: "id".into(),
+                    persona_did: "did:key:zPersona".into(),
+                }),
+                "VpcAttached",
+            ),
+            (
+                AuditEvent::VpcDetached(VpcAnnotationData {
+                    vrc_id: "id".into(),
+                    persona_did: "did:key:zPersona".into(),
+                }),
+                "VpcDetached",
+            ),
+        ] {
+            let v = wire_value(&e);
+            assert_eq!(v["type"], expected);
+            assert_eq!(v["data"]["vrcId"], "id");
+            assert_eq!(v["data"]["personaDid"], "did:key:zPersona");
+            round_trip(&e);
+        }
+    }
+
+    #[test]
     fn personhood_asserted_round_trip() {
         let e = AuditEvent::PersonhoodAsserted(PersonhoodAssertedData {
             vmc_id: "vmc-7".into(),
@@ -2150,6 +2216,20 @@ mod tests {
                     revoked_by: "admin".into(),
                 }),
                 "VrcRevoked",
+            ),
+            (
+                AuditEvent::VpcAttached(VpcAnnotationData {
+                    vrc_id: "id".into(),
+                    persona_did: "did:key:zPersona".into(),
+                }),
+                "VpcAttached",
+            ),
+            (
+                AuditEvent::VpcDetached(VpcAnnotationData {
+                    vrc_id: "id".into(),
+                    persona_did: "did:key:zPersona".into(),
+                }),
+                "VpcDetached",
             ),
             (
                 AuditEvent::PersonhoodAsserted(PersonhoodAssertedData {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -50,9 +50,9 @@ pub use event::{
     MembershipRenewedData, PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData,
     PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
     RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
-    SchemaChangeData, SessionRevokedData, SignedOutData, StatusListFlippedData, VrcPublishedData,
-    VrcRevokedData, WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
-    WebsiteGenerationRolledBackData,
+    SchemaChangeData, SessionRevokedData, SignedOutData, StatusListFlippedData, VpcAnnotationData,
+    VrcPublishedData, VrcRevokedData, WebsiteBundleDeployedData, WebsiteFileDeletedData,
+    WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
Closes #1067.

Two commits. The first implements the VPC. The second fixes a regression found while doing so, on the function directly below the one the VPC work touches — it lands here rather than separately because it needs the same `check_authorization_envelope` helper, and a competing generalisation on main would conflict with this one.

---

# 1. `feat(vtc)`: the VPC as the deliberate-correlation mechanism

`PersonaCredential` appeared nowhere in this repo and `DTGCredential::new_vpc` was never called, so the P-DID had no implementation and the word "persona" drifted onto the membership DID for want of anything to anchor it.

## What the absence cost

After the publish proof-of-possession change (#1054) a member had exactly two settings: publish under a pairwise relationship DID and correlate with nothing, or publish under the membership DID and correlate with everything, permanently, for anyone who retains the credential. DTG Credentials §Privacy Considerations 3 says correlation "should occur only through the holder's deliberate assertion of a persona (via a VPC) or an M-DID". The precise instrument was missing, so members had only the blunt one.

## What this implements — and what it deliberately does not

**The VTC half only.** A VPC is self-issued by a person, exactly like a VRC: its `issuer` is a persona DID the member controls, and the VTC has no key that may legitimately sign one. So `credentials/dtg.rs` gained no `issue_persona`. What the VTC owns is verifying a presented VPC, deciding whether it may annotate an edge in this community's graph, and surfacing the correlation it asserts.

Minting the VPC, choosing when to assert a persona, and renaming `openvtc`'s `persona_did` — the field whose name is what made the word ambiguous — are all client-side and **not in this PR**.

New surface, both on `vtc-service/src/routes/relationships.rs`:

- `POST /v1/relationships/{id}/persona` — attach a VPC to a published edge.
- `DELETE /v1/relationships/{id}/persona` — withdraw it, leaving the edge.

A VPC is an *annotation* credential — it creates no graph structure, it attaches to structure that already exists — so there is no "publish a VPC" collection endpoint, and the annotation is stored on the edge row (`vtc-service/src/relationships/mod.rs`, optional + `#[serde(default)]`, so pre-existing rows decode unchanged) rather than in a keyspace of its own. The P-DID surfaces on `GET /v1/relationships/graph` as `personaDid` and in the admin UI's connections view; an annotation nothing reads would leave #1067 in the state it describes.

## The binding assumption — please read this part

**trustoverip/dtgwg-cred-spec#9 asks how a VPC binds to a specific relationship, and is open. Nothing here answers it, and nothing here should be read as a proposal that it be answered this way.**

A VPC names its persona (`issuer`) and the counterparty (`credentialSubject.id`), and *not* the relationship DID the persona used — so it does not identify an edge on its own. Rather than add a field to the credential and present that as the resolution, the binding is made at the **request** level:

1. the caller names the edge by id in the URL;
2. the caller proves control of that edge's `issuerDid`, with the same proof-of-possession construction publishing the edge required (`VpcAttachAuthorization` / `VpcDetachAuthorization`, envelope shared with `VrcPublishAuthorization`);
3. the VPC's `credentialSubject.id` must equal the edge's `subjectDid`.

(2) is what makes it safe: the only party who could have published this edge is the only party who can annotate it, so attaching a persona is exactly as authorized as publishing the edge was — no new trust is extended. (3) is a consistency check, not a binding. If #9 lands an in-credential binding (a `digest` over the VRC, as the VWC already has), this endpoint can require it *as well*, without changing the stored shape.

**Stated limitation.** The spec says a VPC's subject is "typically the R-DID **or M-DID** used in the relationship". A VPC naming the counterparty's M-DID, on an edge whose `subjectDid` is their R-DID, fails check (3) and is rejected. That case is real. Accepting it needs the same #9 answer; guessing would mean accepting a VPC that names a party the VTC cannot tie to the edge, which is the problem restated.

## Judgement calls, with reasoning

- **No uniqueness check on the P-DID**, in direct contrast to the R-DID rule the publish path enforces unconditionally a few lines away. A relationship DID that recurs across counterparties is a defect; a persona DID that recurs is the entire purpose of the credential. The contrast is deliberate and commented at the site.
- **Detach is in scope**, though it grows the change. A privacy mechanism that cannot be reversed is worse than none — a member who can correlate their edges but never stop is worse off than one who never could. It is gated identically, or anyone could strip another member's persona, and the two authorization `type` values are distinct so neither can be replayed as the other.
- **No `persona.rego`.** Attach is gated on a live member session plus proof of control of the edge's issuer. A community that already decides whether an edge may be published has not obviously earned a second, separate say over what its issuer calls themselves. Additive if that turns out to be wrong.
- **No P-DID secondary index.** "List every edge of persona P" is answerable from the admin graph. Falling into an enumeration surface as a side effect of an index write is not how that should get designed.
- **`new_vpc` is used in a wire-shape pin, not a mint path** (`vtc-service/src/credentials/dtg.rs`). The pin matters *more* here than for credentials the VTC mints: catalog drift on a minted credential changes what we emit and a consumer tells us, but drift on the VPC changes what we *accept*, and the failure is every conformant VPC in the ecosystem being rejected by a VTC that still compiles and still passes its own tests.
- **Audit** (`VpcAttached` / `VpcDetached`) records the P-DID with the authenticated member as actor. Same attribution decision, and the same explicitly-accepted residual, as VRC publish — set out in `docs/05-design-notes/vrc-publish-proof-of-possession.md` §Audit attribution. The `info!` on both paths carries the persona and not the member.
- **The 403s do not quote the row's DIDs.** Edge ids are unguessable UUIDs, but a member who has seen one should learn nothing from this endpoint about an edge they do not control.

## Trust Task registry

`vtc/relationships/persona/0.1` is bound ahead of its publication upstream, recorded in `UNPUBLISHED_CANONICAL_OK` (`vtc-service/tests/trust_task_manifest.rs`). This is the **first entry the `spec/vtc/` family has ever had**, so it deserves a reviewer's attention rather than a nod. The reasoning: the mechanism exists for exactly this (`vta/webvh/servers/reconcile/0.1` went up and back down the same way once the registry served it), and a payload schema authored now would have to encode this implementation's request-level binding as if #9 were closed. The endpoint can move first; the schema should not. It goes back to zero when the task is authored upstream.

Design note: `docs/05-design-notes/vpc-persona-annotation.md`.

---

# 2. `fix(vtc)`: let the issuer of a pairwise edge retract it

Found while implementing the above, verified independently by the coordinator.

`revoke` kept the identity equality `publish` replaced in #1054/#1061 — `auth.did == rel.issuer_did` — sitting one function below where it was fixed, in the same file. For an edge published under a pairwise relationship DID that compares a membership DID against an R-DID and is **false by construction**, so since #1061 a member could lodge an edge and then never take it back. Only an admin could.

`revoke_issuer_can_retract_own` (`vtc-service/tests/relationships.rs`) seeds `ISSUER_DID` as the session DID — the *attributed* form, where the equality still holds. That is why this shipped green, and it is why the new suite is written entirely against the pairwise form.

`DELETE /v1/relationships/{id}` now takes an optional body carrying a `VrcRevokeAuthorization`: the shared `check_authorization_envelope` (`type`, `aud`, `sessionId`, `issuedAt`) plus the row `id`, then the same data-integrity check against the row's `issuerDid`. Bound to the row rather than to a credential digest, because the request names a row and carries no credential.

Three routes to authorization; the first two are unchanged:

- **attributed** — `auth.did == rel.issuer_did`. Still correct, still sufficient, no proof needed.
- **admin** — moderation, keys on row id. Untouched.
- **pairwise** — the new proof.

Every client sending this request today sends no body at all and keeps working: `Option<Json<_>>` yields `None` without a JSON content-type, and still rejects a malformed body when one is present. The authorization is verified and **discarded** — it carries `sessionId`, and this handler writes to the audit store, so it is the one place on the pairwise path where that linkage could plausibly become durable. Proving control of the issuing key is recorded as `revoked_by: "issuer"`, not "admin".

## Mutation testing — it found two tests that passed for the wrong reason

The suite was written first and **confirmed failing** against the unfixed handler (403 `only the issuer or an admin can revoke a VRC`). Four mutations were then applied to the new check:

| Mutation | Result |
|---|---|
| `type` guard neutered | **survived** → new test |
| edge (`relationship`) binding removed | killed by `rejects_an_authorization_bound_to_a_different_edge` |
| signature check (`verify_di_proof`) removed | killed by `rejects_an_authorization_signed_by_another_key` |
| `sessionId` binding neutered | **survived** → new test |

- **Type guard.** `rejects_a_publish_authorization_replayed_as_a_revoke` was being caught by the *edge* binding — a publish authorization has no `relationship` field — so `type` was never exercised at all. Added `rejects_an_authorization_of_the_wrong_type`, valid in every respect except the one field under test. Mutant now killed.
- **Session binding.** Every test presented its authorization in the session it was minted for, so nothing exercised the binding the publish design note calls load-bearing. Added `rejects_an_authorization_replayed_in_another_members_session`: a second member replays a captured object whose signature is still the issuer's and still verifies, so `sessionId` is the only thing between them and an edge they do not control. Mutant now killed.

Neither gap was visible by reading the diff.

## Design-note correction

`docs/05-design-notes/vrc-publish-proof-of-possession.md` said "admin revocation is unaffected — it keys on row id, not issuer identity". True, and the wrong half to reassure the reader about; the sentence answers the question nobody needed answered and is silent on the one that mattered. It now states what happens to both halves and records the general lesson: **replacing an identity equality is not done until every sibling operation on the same resource has been checked for the same equality. Grep for the field, not for the function.**

---

## Testing

`cargo test -p vtc-service` fully green across all test binaries; `cargo clippy --workspace --all-targets` clean; `cargo fmt --check` clean; admin-UI build passes.

`tests/relationships.rs` goes 34 → 48 tests: eleven for the persona surface under `pairwise::persona` (happy path, one persona across two edges under two different R-DIDs, wrong signing key, missing authorization, wrong edge, a VRC posted to the persona endpoint, wrong counterparty, detach, attach-replayed-as-detach, absence of the session id and membership DID from the row and audit trail, 404), seven for revocation under `pairwise::revocation` as above, plus a storage test that rows written before the `persona` field still decode and the catalog wire-shape pin.

No `version =` edits, no changelog file.
