### PR TITLE
fix(vtc): reject a credential whose validity window has passed at ingress

### DIFF
--- a/vtc-service/src/credentials/ingress.rs
+++ b/vtc-service/src/credentials/ingress.rs
@@ -20,7 +20,31 @@
 //! Classification here goes through `dtg_credentials::DTGCredentialType` — the
 //! same catalog the issuing side mints from — so the two cannot drift apart
 //! without the round-trip tests below failing.
+//!
+//! ## Validity windows
+//!
+//! [`check_validity_window`] is the one implementation of the temporal check,
+//! for the same reason: it was enforced on the VIC path and the recognition
+//! path and on nothing else, so an expired VRC became a permanent graph edge
+//! (#1069). It is a free function rather than part of [`classify_dtg`] because
+//! `classify_dtg` is also used as a *filter*: `routes/recognise.rs:329` walks a
+//! presentation's `verifiableCredential` array and skips entries that are not
+//! DTG credentials, since a VP may legitimately carry others. Folding the
+//! window check into it would turn an expired VEC into a silently skipped
+//! entry, and the caller would report "presentation has no
+//! EndorsementCredential" instead of `recognition::verify`'s "VEC validUntil …
+//! is in the past".
+//!
+//! For the same reason the VIC and recognition paths are **left alone**. Both
+//! already implement `validFrom <= now < validUntil` with the same boundary
+//! this module uses, and each carries semantics the shared check does not:
+//! recognition also *clamps* the minted session TTL to the earliest
+//! `validUntil` across the pair (`routes/recognise.rs:408-417`), and both
+//! require `validUntil` to be present at all. Routing them through here would
+//! either duplicate their checks or weaken them. Three implementations was the
+//! problem; replacing two working ones with one weaker one is not the fix.
 
+use chrono::{DateTime, Utc};
 use dtg_credentials::DTGCredentialType;
 use serde_json::Value as JsonValue;
 use vti_common::error::AppError;
@@ -37,9 +61,12 @@ pub const DTG_BASE_TYPES: [&str; 2] = ["VerifiableCredential", "DTGCredential"];
 
 /// Check the DTG common structure and return the concrete subtype.
 ///
-/// Says nothing about signatures, validity windows or revocation — those are
-/// the caller's, and are checked on their own paths. This answers only "is
-/// this a DTG credential, and which one".
+/// Says nothing about signatures, validity windows or revocation. This answers
+/// only "is this a DTG credential, and which one" — deliberately, so it stays
+/// usable as a filter over a presentation that may carry non-DTG credentials
+/// (`routes/recognise.rs:329`). For the window check see
+/// [`check_validity_window`]; a caller that wants both wants
+/// [`require_dtg_type`].
 pub fn classify_dtg(doc: &JsonValue) -> Result<DTGCredentialType, AppError> {
     let ctx: Vec<String> = doc
         .get("@context")
@@ -72,29 +99,154 @@ pub fn classify_dtg(doc: &JsonValue) -> Result<DTGCredentialType, AppError> {
     })
 }
 
-/// Check the common structure and require one specific subtype.
+/// Check the common structure, require one specific subtype, and require the
+/// credential to be inside its validity window at `now`.
 ///
 /// `context` names the endpoint in the rejection, so an operator reading a 400
 /// learns which surface refused what — "this endpoint publishes relationship
 /// edges; got a MembershipCredential" rather than a bare type mismatch.
+///
+/// `now` is passed in rather than read here so a caller's several checks all
+/// evaluate at one instant, and so tests can pick the instant. Same shape as
+/// `credentials::invitation_verify::verify`.
 pub fn require_dtg_type(
     doc: &JsonValue,
     expected: DTGCredentialType,
+    now: DateTime<Utc>,
     context: &str,
 ) -> Result<(), AppError> {
     let got = classify_dtg(doc)?;
-    if std::mem::discriminant(&got) == std::mem::discriminant(&expected) {
-        Ok(())
-    } else {
-        Err(AppError::Validation(format!("{context}; got a {got}")))
+    if std::mem::discriminant(&got) != std::mem::discriminant(&expected) {
+        return Err(AppError::Validation(format!("{context}; got a {got}")));
     }
+    // Type before window: a VMC sent to a VRC endpoint is the wrong credential
+    // whatever its dates say, and that is the more useful thing to be told.
+    check_validity_window(doc, now, &got.to_string())
+}
+
+/// Reject a credential outside its `validFrom` / `validUntil` window.
+///
+/// DTG Credentials §Security Considerations 2 asks a verifier to reject
+/// credentials outside their window and to check revocation via the governing
+/// trust registry. That section is marked *informative*, so this is a
+/// conformance expectation rather than a normative MUST — but a VRC is the
+/// longest-lived credential in the graph and `routes/relationships.rs` read
+/// neither field before this, so an expired one became a permanent edge
+/// (#1069).
+///
+/// On the revocation half: VRCs deliberately carry no `credentialStatus`.
+/// Planning-review D7 makes VRC revocation a row deletion, not a status-list
+/// bit flip — see the module doc of `routes/relationships.rs`. A reader
+/// comparing this file against the specification should read that as a
+/// deliberate divergence, not a second gap. Where a credential *does* carry a
+/// status block, the path that consumes it checks it
+/// (`recognition::verify::check_status_list`).
+///
+/// **Window semantics: `validFrom <= now < validUntil`.** Half-open, matching
+/// `credentials::invitation_verify` (`invitation_verify.rs:361-373`) and
+/// `recognition::verify` (`verify.rs:198-228`). A credential whose `validUntil`
+/// is exactly `now` is expired.
+///
+/// **Absent bounds are not enforced.** Both properties are optional in W3C VC
+/// 2.0, and this checks only the bounds a credential actually states. VIC and
+/// recognition each additionally *require* `validUntil` — a bearer invitation
+/// and a foreign session both need a fixed expiry to be safe at all — but that
+/// is their own rule, not a property of being a DTG credential, and imposing it
+/// here would reject open-ended VRCs that nothing has ever said are invalid.
+/// Whether an edge may be open-ended is a community policy question, and
+/// `relationships.rego` is where it belongs.
+///
+/// **No clock-skew tolerance.** The windows on these credentials are days to
+/// years, so a grace period of any plausible size changes nothing operationally
+/// while making "expired" a fuzzy predicate that disagreed with the two paths
+/// this is meant to align with — both compare exactly. Contrast
+/// `PUBLISH_AUTHORIZATION_MAX_AGE_SECS` in `routes/relationships.rs`, which
+/// does allow skew: that bounds a five-minute freshness window, where skew is a
+/// real fraction of the budget.
+///
+/// `label` is the credential's own name (`"RelationshipCredential"`), not the
+/// endpoint's — the fact being reported is about the credential.
+pub fn check_validity_window(
+    doc: &JsonValue,
+    now: DateTime<Utc>,
+    label: &str,
+) -> Result<(), AppError> {
+    if let Some((key, valid_from)) = read_time(doc, VALID_FROM_NAMES, label)?
+        && valid_from > now
+    {
+        return Err(AppError::Validation(format!(
+            "{label} `{key}` {valid_from} is in the future"
+        )));
+    }
+    if let Some((_, valid_until)) = read_time(doc, VALID_UNTIL_NAMES, label)?
+        && valid_until <= now
+    {
+        return Err(AppError::Validation(format!(
+            "{label} expired at {valid_until}"
+        )));
+    }
+    Ok(())
+}
+
+/// `(v2.0 name, v1.1 name)` for the start of the window.
+const VALID_FROM_NAMES: (&str, &str) = ("validFrom", "issuanceDate");
+/// `(v2.0 name, v1.1 name)` for the end of the window.
+const VALID_UNTIL_NAMES: (&str, &str) = ("validUntil", "expirationDate");
+
+/// Read one window bound, accepting either the VC 2.0 or the VC 1.1 spelling.
+///
+/// Both spellings are read because the catalog's own deserializer accepts
+/// both: `DTGCommon` declares `#[serde(alias = "issuanceDate")]` /
+/// `#[serde(alias = "expirationDate")]`. Nothing in this stack *emits* the 1.1
+/// names — the catalog always serializes the 2.0 ones — but a credential
+/// arriving from a foreign issuer may use them and would still parse, so
+/// reading only `validUntil` would leave a 1.1-named credential unchecked
+/// while every other layer accepted it. (`policy/extract.rs:104` likewise
+/// surfaces `issuanceDate` to operator policies, so 1.1-named credentials do
+/// reach this stack.)
+///
+/// Carrying *both* spellings is rejected rather than resolved: they are two
+/// names for one property, a document stating both is ambiguous, and serde
+/// treats an alias as the same field, so the catalog parser rejects such a
+/// document as a duplicate field. Picking one here would let a document
+/// through ingress that the catalog cannot parse.
+///
+/// Returns the key that was actually present alongside the value, so the
+/// rejection names the field the sender wrote.
+fn read_time(
+    doc: &JsonValue,
+    names: (&'static str, &'static str),
+    label: &str,
+) -> Result<Option<(&'static str, DateTime<Utc>)>, AppError> {
+    // `Some(Null)` is treated as absent, matching serde's `Option` + `default`
+    // handling — an explicit `"validUntil": null` states no bound.
+    let present = |name: &str| doc.get(name).filter(|v| !v.is_null());
+    let (v2, v11) = names;
+    let (key, raw) = match (present(v2), present(v11)) {
+        (Some(_), Some(_)) => {
+            return Err(AppError::Validation(format!(
+                "{label} carries both `{v2}` and `{v11}`; they are two names for \
+                 one property and stating both is ambiguous"
+            )));
+        }
+        (Some(v), None) => (v2, v),
+        (None, Some(v)) => (v11, v),
+        (None, None) => return Ok(None),
+    };
+    let s = raw
+        .as_str()
+        .ok_or_else(|| AppError::Validation(format!("{label} `{key}` is not a string")))?;
+    let t = DateTime::parse_from_rfc3339(s).map_err(|e| {
+        AppError::Validation(format!("{label} `{key}` is not an RFC 3339 timestamp: {e}"))
+    })?;
+    Ok(Some((key, t.with_timezone(&Utc))))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::dtg_json;
-    use chrono::Utc;
+    use chrono::{Duration, Utc};
     use dtg_credentials::DTGCredential;
 
     fn vrc() -> JsonValue {
@@ -103,6 +255,16 @@ mod tests {
             "did:peer:2.zR2".into(),
             Utc::now(),
             None,
+        ))
+    }
+
+    /// A catalog-minted VRC with an explicit window.
+    fn vrc_valid(from: DateTime<Utc>, until: Option<DateTime<Utc>>) -> JsonValue {
+        dtg_json(&DTGCredential::new_vrc(
+            "did:peer:2.zR1".into(),
+            "did:peer:2.zR2".into(),
+            from,
+            until,
         ))
     }
 
@@ -152,9 +314,11 @@ mod tests {
 
     #[test]
     fn requires_the_expected_subtype() {
+        let now = Utc::now();
         require_dtg_type(
             &vrc(),
             DTGCredentialType::Relationship,
+            now,
             "this endpoint publishes relationship edges",
         )
         .expect("a VRC satisfies a VRC requirement");
@@ -162,10 +326,141 @@ mod tests {
         let err = require_dtg_type(
             &vmc(),
             DTGCredentialType::Relationship,
+            now,
             "this endpoint publishes relationship edges",
         )
         .expect_err("a VMC must not satisfy a VRC requirement");
         assert!(format!("{err:?}").contains("relationship edges"));
+    }
+
+    /// The gap #1069 is about: before this, an expired credential reached the
+    /// graph because nothing on the VRC path read `validUntil`.
+    #[test]
+    fn rejects_a_credential_whose_window_has_passed() {
+        let now = Utc::now();
+        let expired = vrc_valid(now - Duration::days(30), Some(now - Duration::days(1)));
+
+        let err = check_validity_window(&expired, now, "RelationshipCredential")
+            .expect_err("an expired credential must be rejected");
+        assert!(
+            format!("{err:?}").contains("expired at"),
+            "rejection should say when it expired: {err:?}"
+        );
+
+        // And through the full ingress gate, which is what the routes call.
+        assert!(
+            require_dtg_type(
+                &expired,
+                DTGCredentialType::Relationship,
+                now,
+                "this endpoint publishes relationship edges",
+            )
+            .is_err(),
+            "the shape check must not admit an expired credential"
+        );
+    }
+
+    #[test]
+    fn rejects_a_credential_not_yet_valid() {
+        let now = Utc::now();
+        let future = vrc_valid(now + Duration::days(1), Some(now + Duration::days(30)));
+        let err = check_validity_window(&future, now, "RelationshipCredential")
+            .expect_err("a credential whose validFrom is in the future must be rejected");
+        assert!(format!("{err:?}").contains("in the future"), "{err:?}");
+    }
+
+    /// Half-open, matching `invitation_verify` and `recognition::verify`:
+    /// `validFrom == now` is inside the window, `validUntil == now` is not.
+    #[test]
+    fn window_boundaries_are_valid_from_inclusive_and_valid_until_exclusive() {
+        let now = Utc::now();
+
+        let starts_now = vrc_valid(now, Some(now + Duration::days(1)));
+        check_validity_window(&starts_now, now, "RelationshipCredential")
+            .expect("validFrom == now is inside the window");
+
+        let ends_now = vrc_valid(now - Duration::days(1), Some(now));
+        assert!(
+            check_validity_window(&ends_now, now, "RelationshipCredential").is_err(),
+            "validUntil == now is outside the window"
+        );
+    }
+
+    /// Absent bounds state no bound. A VRC minted with `valid_until: None` —
+    /// which the catalog allows, and which most of this repo's fixtures use —
+    /// must still publish. Whether an open-ended edge is acceptable is a
+    /// community policy question, not a temporal one.
+    #[test]
+    fn a_credential_with_no_valid_until_is_not_expired() {
+        let now = Utc::now();
+        let open_ended = vrc_valid(now - Duration::days(365), None);
+        assert!(
+            open_ended.get("validUntil").is_none(),
+            "the catalog omits validUntil when it is None; this test is about that shape"
+        );
+        check_validity_window(&open_ended, now, "RelationshipCredential")
+            .expect("an open-ended credential has no upper bound to be outside of");
+    }
+
+    /// VC 1.1 named these `issuanceDate` / `expirationDate`. The catalog still
+    /// accepts them as deserialization aliases, so ingress must too — reading
+    /// only the 2.0 names would leave a 1.1-named credential unchecked while
+    /// every other layer accepted it.
+    #[test]
+    fn enforces_the_window_under_the_vc_1_1_property_names() {
+        let now = Utc::now();
+        let mut expired = vrc_valid(now - Duration::days(30), Some(now - Duration::days(1)));
+        let from = expired["validFrom"].take();
+        let until = expired["validUntil"].take();
+        let obj = expired
+            .as_object_mut()
+            .expect("credential is a JSON object");
+        obj.remove("validFrom");
+        obj.remove("validUntil");
+        obj.insert("issuanceDate".into(), from);
+        obj.insert("expirationDate".into(), until);
+
+        let err = check_validity_window(&expired, now, "RelationshipCredential")
+            .expect_err("a 1.1-named expired credential must be rejected too");
+        assert!(format!("{err:?}").contains("expired at"), "{err:?}");
+
+        // It is genuinely the alias doing the work: the catalog parses it.
+        serde_json::from_value::<DTGCredential>(expired)
+            .expect("the catalog accepts issuanceDate/expirationDate as aliases");
+    }
+
+    /// Two names for one property, both stated, is ambiguous — and the catalog
+    /// parser rejects it outright (serde treats an alias as the same field, so
+    /// stating both is a duplicate field). Ingress must not admit a document
+    /// the catalog cannot parse.
+    #[test]
+    fn rejects_a_credential_stating_both_spellings_of_one_bound() {
+        let now = Utc::now();
+        let mut doc = vrc_valid(now - Duration::days(1), Some(now + Duration::days(1)));
+        doc["expirationDate"] = doc["validUntil"].clone();
+
+        assert!(
+            check_validity_window(&doc, now, "RelationshipCredential").is_err(),
+            "validUntil + expirationDate together are ambiguous"
+        );
+        assert!(
+            serde_json::from_value::<DTGCredential>(doc).is_err(),
+            "the catalog parser rejects the same document; ingress must agree"
+        );
+    }
+
+    /// A bound that is not an RFC 3339 timestamp is a rejection, not a silently
+    /// skipped check. This is the failure mode that makes a guard useless:
+    /// treating an unparseable date as "no bound stated".
+    #[test]
+    fn rejects_an_unparseable_bound() {
+        let now = Utc::now();
+        let mut doc = vrc_valid(now - Duration::days(1), Some(now + Duration::days(1)));
+        doc["validUntil"] = serde_json::json!("whenever");
+        assert!(check_validity_window(&doc, now, "RelationshipCredential").is_err());
+
+        doc["validUntil"] = serde_json::json!(1_700_000_000);
+        assert!(check_validity_window(&doc, now, "RelationshipCredential").is_err());
     }
 
     #[test]

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -143,10 +143,15 @@ pub async fn publish(
     let issuer_did = extract_did_field(vrc, "issuer")?;
     let subject_did = extract_subject_id(vrc)?;
 
-    // 2. Shape: is this even a relationship credential? Checked
-    //    before anything expensive, and before authorization,
-    //    because a malformed body is a 400 whoever sent it.
-    check_vrc_shape(vrc)?;
+    // 2. Shape + validity window: is this even a relationship
+    //    credential, and is it in date? Checked before anything
+    //    expensive, and before authorization, because a
+    //    malformed or expired body is a 400 whoever sent it.
+    //
+    //    `now` is read once and passed in rather than read
+    //    inside the check, so a test can choose the instant.
+    let now = Utc::now();
+    check_vrc_shape(vrc, now)?;
 
     // 3. Cheapest authorization gate first: a VRC issued under a
     //    DID that is not the session's must carry a publish
@@ -508,18 +513,26 @@ fn extract_subject_id(vrc: &JsonValue) -> Result<String, AppError> {
         })
 }
 
-/// Reject anything that is not a conformant VRC before it becomes an edge in
-/// the community's trust graph.
+/// Reject anything that is not a conformant, currently-valid VRC before it
+/// becomes an edge in the community's trust graph.
 ///
 /// The VTC does not mint VRCs — they are self-issued — but it decides what
 /// enters the graph, and an edge is only interpretable if it says what it is.
 /// Delegates to [`crate::credentials::ingress`], the one place the DTG common
-/// structure is checked, so this endpoint and every other ingress point agree
-/// about what a DTG credential is.
-fn check_vrc_shape(vrc: &JsonValue) -> Result<(), AppError> {
+/// structure and the validity window are checked, so this endpoint and every
+/// other ingress point agree about what a DTG credential is and about when it
+/// is in date.
+///
+/// Until #1069 this path read neither `validFrom` nor `validUntil`, so a VRC
+/// that had already expired became a permanent edge — permanent because the
+/// graph is read without re-checking dates, and because per D7 a VRC has no
+/// `credentialStatus` to retract it with. The only removal is the issuer (or an
+/// admin) calling `DELETE /v1/relationships/{id}`.
+fn check_vrc_shape(vrc: &JsonValue, now: chrono::DateTime<Utc>) -> Result<(), AppError> {
     crate::credentials::ingress::require_dtg_type(
         vrc,
         dtg_credentials::DTGCredentialType::Relationship,
+        now,
         "this endpoint publishes relationship edges",
     )
 }
@@ -821,7 +834,7 @@ mod tests {
         let now = Utc::now();
         let vrc =
             DTGCredential::new_vrc("did:peer:2.zR1".into(), "did:peer:2.zR2".into(), now, None);
-        check_vrc_shape(&body(&vrc)).expect("a catalog-minted VRC must be publishable");
+        check_vrc_shape(&body(&vrc), now).expect("a catalog-minted VRC must be publishable");
 
         // Same catalog, different subtype — this endpoint publishes
         // relationship edges, and a membership edge has different issuance
@@ -833,11 +846,46 @@ mod tests {
             None,
             false,
         );
-        let err = check_vrc_shape(&body(&vmc)).expect_err("a VMC must not publish as a VRC");
+        let err = check_vrc_shape(&body(&vmc), now).expect_err("a VMC must not publish as a VRC");
         assert!(
             format!("{err:?}").contains("relationship edges"),
             "unexpected rejection: {err:?}"
         );
+    }
+
+    /// #1069: this endpoint read neither `validFrom` nor `validUntil`, so an
+    /// expired VRC became a permanent edge — and per D7 a VRC has no
+    /// `credentialStatus`, so nothing downstream would ever retract it.
+    ///
+    /// Asserted at the route's own gate rather than only in
+    /// `credentials::ingress`, because the gap was this call site not doing
+    /// the check, not the check being wrong.
+    #[test]
+    fn refuses_a_vrc_whose_validity_window_has_passed() {
+        use chrono::Duration;
+        use dtg_credentials::DTGCredential;
+
+        use crate::test_support::dtg_json as body;
+
+        let now = Utc::now();
+        let expired = DTGCredential::new_vrc(
+            "did:peer:2.zR1".into(),
+            "did:peer:2.zR2".into(),
+            now - Duration::days(30),
+            Some(now - Duration::days(1)),
+        );
+        let err = check_vrc_shape(&body(&expired), now)
+            .expect_err("an expired VRC must not enter the graph");
+        assert!(
+            format!("{err:?}").contains("expired at"),
+            "unexpected rejection: {err:?}"
+        );
+
+        // Same credential, evaluated while it was still in date: publishable.
+        // Without this, a check that rejected everything would pass the test
+        // above.
+        check_vrc_shape(&body(&expired), now - Duration::days(2))
+            .expect("the same VRC inside its window is publishable");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1069 (conformance audit F9).

`routes/relationships.rs` read neither `validFrom` nor `validUntil`, so a VRC
that had already expired became a permanent edge in the community trust graph.
Permanent because the graph is read back without re-checking dates, and because
per planning-review D7 a VRC carries no `credentialStatus` — the only removal is
the issuer or an admin calling `DELETE /v1/relationships/{id}`.

## What changed

`credentials::ingress` — the module that already owns the DTG common-structure
check — gains `check_validity_window`, and `require_dtg_type` now runs it. The
VRC publish path calls `require_dtg_type` (via `check_vrc_shape`), so it picks
the check up from there rather than growing a third bespoke copy. A future
ingress point that calls the same gate gets it for free.

`vtc-service/src/routes/relationships.rs:146-154` now reads `now` once per
request and passes it in, so a test can choose the instant.

## How strong a claim this is

The requirement sits in DTG Credentials §Security Considerations 2, which is
marked *informative*. So this is a conformance expectation, not a normative
MUST. It is still worth closing: the VRC is the longest-lived credential in the
graph and it was the one path that never looked.

## What I deliberately left alone

- **`classify_dtg` stays structure-only.** `routes/recognise.rs:329` uses it as
  a *filter* over a presentation's `verifiableCredential` array, skipping
  entries that are not DTG credentials, since a VP may legitimately carry
  others. Folding the window check in would turn an expired VEC into a silently
  skipped entry and downgrade the error from `recognition::verify`'s "VEC
  validUntil … is in the past" to "presentation has no EndorsementCredential".

- **The VIC path** (`credentials/invitation_verify.rs:361-373`) **and the
  recognition path** (`recognition/verify.rs:198-228`) **are untouched.** Both
  already implement the same half-open window, and each carries semantics the
  shared check does not: recognition additionally *clamps* the minted session
  TTL to the earliest `validUntil` across the VEC/VMC pair
  (`routes/recognise.rs:408-417`), and both *require* `validUntil` to be
  present at all. Routing them through the shared check would either duplicate
  their logic or weaken it. Three implementations was the problem; replacing
  two working ones with a weaker one is not the fix.

- **VRCs still carry no `credentialStatus`.** That is D7, not an oversight.
  Stated explicitly in the `check_validity_window` doc comment so a reader
  comparing this code against the specification does not log it as a second
  finding.

## Judgement calls

**Absent bounds are not enforced.** Both properties are optional in W3C VC 2.0,
and this checks only the bounds a credential actually states. Most VRC fixtures
in this repo (including `tests/relationships.rs::fake_vrc`) carry no
`validUntil` at all. Whether an open-ended edge is acceptable is a community
policy question and belongs in `relationships.rego`, not in a type check.

**No clock-skew tolerance.** These windows are days to years, so a grace period
of any plausible size changes nothing operationally while making "expired" a
fuzzy predicate that disagreed with the two paths this is meant to align with —
both compare exactly. Contrast `PUBLISH_AUTHORIZATION_MAX_AGE_SECS` in the same
route file, which *does* allow skew: it bounds a five-minute freshness window,
where skew is a real fraction of the budget. Justified in a doc comment either
way, as asked.

**Both VC 2.0 and VC 1.1 property names are read.** I checked before deciding:
nothing in this stack *emits* `issuanceDate`/`expirationDate` — the catalog
always serializes the 2.0 names — but `DTGCommon` declares
`#[serde(alias = "issuanceDate")]` / `alias = "expirationDate"`, so a foreign
credential using them still parses, and `policy/extract.rs:104` surfaces
`issuanceDate` to operator policies. Reading only `validUntil` would leave a
1.1-named credential unchecked while every other layer accepted it. A document
stating *both* spellings of one bound is rejected rather than resolved: serde
treats an alias as the same field, so the catalog parser rejects it as a
duplicate field, and ingress must not admit what the catalog cannot parse. A
test asserts that agreement in both directions.

## Tests

Six new tests in `credentials/ingress.rs` plus one in `routes/relationships.rs`,
all minting through the catalog constructors (`DTGCredential::new_vrc`) via
`test_support::dtg_json` — no hand-rolled JSON. Unit tests rather than
integration tests because `dtg-credentials` is a normal dependency of
`vtc-service` and so is not reachable from `tests/`; a `tests/` version would
have to hand-roll fixtures, which is the thing the convention forbids.

`cargo test -p vtc-service` passes; `cargo clippy --workspace --all-targets --
-D warnings` is clean.

## Mutation test

The guard fails when broken, in both directions:

- `valid_until <= now` → `valid_until <= DateTime::<Utc>::MIN_UTC` fails four
  tests: `rejects_a_credential_whose_window_has_passed`,
  `window_boundaries_are_valid_from_inclusive_and_valid_until_exclusive`,
  `enforces_the_window_under_the_vc_1_1_property_names`, and
  `refuses_a_vrc_whose_validity_window_has_passed`.
- `valid_from > now` → `valid_from > DateTime::<Utc>::MAX_UTC` fails
  `rejects_a_credential_not_yet_valid`.

Both reverted; the committed tree is the unmutated one.

---

Based on `main`, not on `test/catalog-validator-roundtrip`: #1072 merged as edec8277 before this branch was cut, so `credentials/ingress.rs` is already on main and no stacking is needed.
