### PR TITLE
fix(vtc): thread `now` into the VPC shape check, unbreaking main

### DIFF
--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -708,9 +708,16 @@ pub async fn attach_persona(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("VRC {id} not found")))?;
 
-    // Shape first: a malformed VPC is a 400 whoever sent it, and rejecting it
-    // here costs nothing and reveals nothing about the edge.
-    check_vpc_shape(&body.vpc)?;
+    // Shape and validity window first: a malformed or expired VPC is a 400
+    // whoever sent it, and rejecting it here costs nothing and reveals nothing
+    // about the edge.
+    //
+    // The window is checked for the same reason it is on the publish path — an
+    // annotation that outlives its own credential would keep asserting a
+    // persona the issuer had stopped standing behind. `now` is read once and
+    // passed in so every check in this request evaluates at one instant.
+    let now = Utc::now();
+    check_vpc_shape(&body.vpc, now)?;
     let persona_did = extract_did_field(&body.vpc, "issuer")?;
     let vpc_subject = extract_subject_id(&body.vpc)?;
 
@@ -990,10 +997,11 @@ fn check_vrc_shape(vrc: &JsonValue, now: chrono::DateTime<Utc>) -> Result<(), Ap
 /// module existed and brought a local `check_dtg_shape` with it; keeping both
 /// would have put two definitions of "is this a DTG credential" in the tree,
 /// which is the condition #1064 was filed about.
-fn check_vpc_shape(vpc: &JsonValue) -> Result<(), AppError> {
+fn check_vpc_shape(vpc: &JsonValue, now: chrono::DateTime<Utc>) -> Result<(), AppError> {
     crate::credentials::ingress::require_dtg_type(
         vpc,
         dtg_credentials::DTGCredentialType::Persona,
+        now,
         "this endpoint attaches a persona annotation",
     )
 }


### PR DESCRIPTION
**`main` at `397d087c` does not compile.** This unbreaks it.

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> vtc-service/src/routes/relationships.rs:994
```

## How three green PRs produced a red main

#1074 added `check_vpc_shape`, which calls `credentials::ingress::require_dtg_type`.
#1075 gave that function a `now` parameter.

Neither diff touched the other's lines, so git merged both cleanly and **both were green on CI** — each having been tested against a `main` that did not yet contain the other. A textual merge and a semantic conflict.

Nothing in the repo would have caught it. CI green on a pull request proves the branch works against the main it was *cut from*, not the main it will *land on*.

## The fix, and the decision inside it

`check_vpc_shape` now takes `now` and threads it through, matching `check_vrc_shape` beside it.

That is not only what the compiler wanted. It answers a question neither PR was positioned to ask: **should a VPC's validity window be checked when it is attached?** It should, for the same reason the window is checked on the publish path — an annotation that outlived its own credential would go on asserting a persona the issuer had stopped standing behind. `now` is read once per request and passed in, so every check in the request evaluates at one instant.

Had this been resolved as a pure compiler fixup, the obvious move would have been to pass a `now` that skips the check. That would have compiled and been wrong.

## Verified

Cut from `397d087c`, so this is against **all three** of #1074, #1075 and #1076 together.

- `cargo check -p vtc-service` — compiles
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- #1076's conformance witness passes on the fixed tree, including `known_drift_entries_still_diverge_where_they_say_they_do`

The full `cargo test -p vtc-service` run was at 51 suites / 0 failures when this PR was opened, and was not waited out — main being red is the more urgent fact, and a full re-test is planned once this lands.

## Worth acting on separately

Two changes to one function signature need one rebased onto the other before either merges, however disjoint their diffs look. A merge queue, or requiring branches to be current before merge, would enforce that mechanically. This PR does not add either — flagging it rather than bundling it.
