### PR TITLE
fix(common)!: send the pagination wrapper in camelCase, as the schemas always said

### DIFF
--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -125,8 +125,14 @@ pub struct MemberRecord {
 }
 
 /// One page of a cursor-paginated VTC listing. Mirrors the server's
-/// `Paginated<T>` (`items` + `next_cursor`); `total_estimate` is ignored.
+/// `Paginated<T>` (`items` + `nextCursor`); `totalEstimate` is ignored.
+///
+/// The wire names are camelCase, as R3.1 requires and as the published Trust
+/// Task schemas have always said. The server sent `next_cursor` until the
+/// conformance witness (#1059) caught it; this mirror had followed the server
+/// rather than the schema, so both were wrong together and neither noticed.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Page<T> {
     items: Vec<T>,
     next_cursor: Option<String>,
@@ -669,7 +675,7 @@ mod tests {
                 "personhood": false,
                 "joinedViaInvitation": true
             }],
-            "next_cursor": null
+            "nextCursor": null
         });
         let page: Page<MemberRecord> = serde_json::from_value(json).unwrap();
         assert_eq!(page.items.len(), 1);

--- a/vtc-service/admin-ui/src/plugins/joinRequests.tsx
+++ b/vtc-service/admin-ui/src/plugins/joinRequests.tsx
@@ -43,7 +43,7 @@ interface JoinRequestRow {
 
 interface JoinRequestsPage {
   items: JoinRequestRow[];
-  next_cursor: string | null;
+  nextCursor: string | null;
   total_estimate?: number;
 }
 
@@ -221,8 +221,8 @@ function JoinRequestsList() {
           <button
             type="button"
             className="secondary"
-            disabled={!query.data?.next_cursor}
-            onClick={() => setCursor(query.data?.next_cursor ?? null)}
+            disabled={!query.data?.nextCursor}
+            onClick={() => setCursor(query.data?.nextCursor ?? null)}
           >
             Next page <ArrowRight size={12} aria-hidden="true" />
           </button>

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -81,7 +81,7 @@ interface MemberRow {
 
 interface MembersPage {
   items: MemberRow[];
-  next_cursor: string | null;
+  nextCursor: string | null;
   total_estimate?: number;
 }
 
@@ -438,8 +438,8 @@ function MembersList() {
           <button
             type="button"
             className="secondary"
-            disabled={!query.data?.next_cursor}
-            onClick={() => setCursor(query.data?.next_cursor ?? null)}
+            disabled={!query.data?.nextCursor}
+            onClick={() => setCursor(query.data?.nextCursor ?? null)}
           >
             Next page <ArrowRight size={12} aria-hidden="true" />
           </button>

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -401,11 +401,15 @@ fn backup_envelope() -> Value {
     })
 }
 
-/// The `Paginated<T>` wrapper as `vti-common/src/pagination/mod.rs:131`
-/// serialises it. The struct carries **no** `rename_all`, so the wrapper's
-/// own members are snake_case while the items inside are camelCase.
+/// The `Paginated<T>` wrapper as `vti-common/src/pagination/mod.rs` serialises
+/// it — camelCase throughout, wrapper and items alike.
+///
+/// The wrapper carried no `rename_all` until this witness caught it, so it sent
+/// `next_cursor` / `total_estimate` against schemas that have always said
+/// `nextCursor` / `totalEstimate`. One missing attribute, five drifting list
+/// tasks, and a direct R3.1 violation of the same class as #656/#658.
 fn paginated(items: Value) -> Value {
-    json!({ "items": items, "next_cursor": "eyJsYXN0S2V5Ijoi", "total_estimate": 12 })
+    json!({ "items": items, "nextCursor": "eyJsYXN0S2V5Ijoi", "totalEstimate": 12 })
 }
 
 /// A `JoinRequest` as `join/mod.rs:81` serialises one. No member carries
@@ -472,14 +476,21 @@ fn uuid() -> uuid::Uuid {
 /// 1. **No response envelope.** The spec wraps the payload
 ///    (`{ "member": … }`, `{ "removed": [ … ] }`, `{ "envelope": … }`) and the
 ///    handler returns the bare object or a bare array. 12 entries.
-/// 2. **`Paginated<T>` is snake_case** (`vti-common/src/pagination/mod.rs:131`
-///    has no `rename_all`), so every list task sends `next_cursor` where the
-///    spec says `nextCursor`. 5 entries, one fix — and a direct R3.1
-///    violation, the same casing-drift class as #656/#658.
+/// 2. ~~**`Paginated<T>` is snake_case**~~ — **fixed.** The wrapper had no
+///    `rename_all`, so every list task sent `next_cursor` where the spec says
+///    `nextCursor`: a direct R3.1 violation of the same casing-drift class as
+///    #656/#658. One attribute in `vti-common` closed it for all five.
+///
+///    Only `relationships/list` became *fully* conforming, because it was the
+///    only one whose drift was the wrapper alone — the spec types its `items`
+///    as free objects. The other four still diverge at row level and keep
+///    their entries, now describing only what is left. Worth noting when
+///    reading a drift count: closing a shared root cause moves four entries
+///    without closing them.
 /// 3. **Unspecced members on an `additionalProperties: false` response.**
 ///    Usually the service is ahead of the spec (the ceremony verdict
 ///    envelope, `decidedAt`), occasionally behind it (`didBindingChallenge`).
-const KNOWN_DRIFT_COUNT: usize = 33;
+const KNOWN_DRIFT_COUNT: usize = 32;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -810,12 +821,11 @@ fn table() -> Vec<Conformance> {
             Side::Response,
             json!({ "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
             paginated(json!([endorsement_type()])),
-            "`Paginated<T>` (vti-common/src/pagination/mod.rs:131) carries no \
-             `rename_all`, so the page wrapper sends `next_cursor` / \
-             `total_estimate` where the spec says `nextCursor` / \
-             `totalEstimate`; the items also carry the unspecced \
-             `createdByDid`. The wrapper is one R3.1 fix here that clears \
-             five list tasks at once"
+            "the items carry the unspecced `createdByDid` against an \
+             `additionalProperties: false` response. The wrapper's snake_case \
+             casing was the other half of this entry and is now fixed in \
+             `vti-common`; what remains is a row-level decision — publish \
+             `createdByDid` upstream, or stop sending it"
         ),
         checked!(
             s::endorsement_types::delete::v0_1::Payload,
@@ -858,7 +868,7 @@ fn table() -> Vec<Conformance> {
             json!({ "subjectDid": DID, "typeUri": "https://skills.example.com/v1/rust",
                     "includeRevoked": true, "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
             paginated(json!([endorsement()])),
-            "snake_case `Paginated` wrapper, and the rows are this service's \
+            "the wrapper's casing is fixed; what remains is that the rows are this service's \
              `Endorsement` (endorsements/mod.rs:41) — `id` / \
              `endorsementType` / `issuerDid` / `vecId` / `createdAt` — not \
              the spec's (`endorsementId` / `typeUri` / `issued`). Same model \
@@ -970,7 +980,7 @@ fn table() -> Vec<Conformance> {
             Side::Response,
             json!({ "status": "pending", "cursor": "eyJsYXN0S2V5Ijoi", "limit": 25 }),
             paginated(json!([join_request()])),
-            "snake_case `Paginated` wrapper, and each row carries `vpClaims` \
+            "the wrapper's casing is fixed; what remains is that each row carries `vpClaims` \
              and `decision`, which the canonical `JoinRequest` component does \
              not define. `decision` is the admin-reject detail #1058 added — \
              the same members that drifted on `status/0.1`, in a second \
@@ -1104,7 +1114,7 @@ fn table() -> Vec<Conformance> {
             Side::Response,
             json!({ "role": "member", "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
             paginated(json!([member_response()])),
-            "snake_case `Paginated` wrapper, and `MemberResponse` \
+            "the wrapper's casing is fixed; what remains is that `MemberResponse` \
              (routes/members/read.rs:29) carries five members the canonical \
              component does not define: `personhood`, \
              `personhoodAssertedAt`, `joinedViaInvitation`, `memberVmcId`, \
@@ -1297,10 +1307,9 @@ fn table() -> Vec<Conformance> {
              genuinely useful diagnostics and should go upstream"
         ),
         // ─── relationships ───────────────────────────────────────────
-        drift!(
+        checked!(
             s::relationships::list::v0_1::Payload,
             s::relationships::list::v0_1::Response,
-            Side::Response,
             json!({ "did": DID, "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
             // `Relationship` — relationships/mod.rs:59. The spec types the
             // items as free objects, so only the wrapper diverges.
@@ -1311,10 +1320,7 @@ fn table() -> Vec<Conformance> {
                 "vrcJsonld": credential(),
                 "vrcSha256": "3b9f0a1c8d2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3",
                 "createdAt": TS,
-            }])),
-            "snake_case `Paginated` wrapper only — the rows conform, since \
-             the spec types `items` as free objects. Cleared by the one R3.1 \
-             fix in vti-common"
+            }]))
         ),
         checked!(
             s::relationships::graph::v0_1::Payload,

--- a/vti-common/src/pagination/mod.rs
+++ b/vti-common/src/pagination/mod.rs
@@ -10,7 +10,7 @@
 //! → 200 OK
 //! {
 //!   "items":          [...],
-//!   "next_cursor":    "<opaque>" | null,
+//!   "nextCursor":     "<opaque>" | null,
 //!   "total_estimate": <u64 | null>
 //! }
 //! ```
@@ -129,6 +129,7 @@ impl PaginationParams {
 /// (`None` when the caller has reached the end), and an optional
 /// total-count estimate.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Paginated<T> {
     pub items: Vec<T>,


### PR DESCRIPTION
First of the 33 divergences #1076 recorded, and the one with the widest blast
radius per line changed.

## The bug

`Paginated<T>` (`vti-common/src/pagination/mod.rs`) carried no `rename_all`, so
every list task sent `next_cursor` and `total_estimate` against published
schemas that say `nextCursor` and `totalEstimate`.

A direct **R3.1** violation, and the same casing-drift class as #656/#658 —
which your own workspace guidance cites as how an empty `allowed_contexts`
silently minted a super-admin.

## Why nothing caught it

Three parties agreed with each other and none agreed with the contract:

- the service sent `next_cursor`
- `vtc-client`'s `Page<T>` mirrored **the service**, not the schema
- the admin SPA typed its fields from the service too

The module's own doc even documented `"next_cursor"` as the intended wire form.
The conformance witness from #1076 is what finally put implementation and
schema side by side.

Four consumers move together here. `audit.tsx` reads a `cursor` member of a
different shape and is deliberately untouched.

## The count goes 33 → 32, not 33 → 28

This is the part worth reading, and it corrects #1076's own module doc, which
claimed "5 entries, one fix".

Five entries cited the wrapper. **Only `relationships/list` becomes fully
conforming** — it was the only one whose drift was the wrapper *alone*, because
its spec types `items` as free objects. The other four also diverge at row
level (`createdByDid`, `vpClaims`, `MemberResponse` members), so they keep their
entries, rewritten to describe only what is left instead of restating a casing
bug that is now fixed.

**Closing a shared root cause moves four entries without closing them.** A count
that fell by five would have implied more progress than happened.

I did not work that out by reading — I tried 28, and
`known_drift_entries_still_diverge_where_they_say_they_do` refused it and named
the entries that still diverge. The guard earning its keep on its first real use
is a good sign for the remaining 32.

## Verified

- `cargo test -p vtc-service -p vti-common -p vtc-client` — 59 suites, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `tsc -b --noEmit` in `admin-ui` — clean
- All three conformance tests pass at the corrected count

Branched from the #1077 hotfix and rebased onto merged main — deliberately not
cut from a main that would not compile.

## Breaking

`Paginated<T>` now serialises `nextCursor` / `totalEstimate`. `vti-common` is
published, so an external consumer reading the snake_case names breaks — though
what it was reading never matched the published schema. Every in-repo consumer
is updated in this PR.

## What is left, and the decision it needs

31 of the remaining 32 fall into two shapes. The larger is **no response
envelope** (12 entries): the spec wraps the payload and the handler returns the
bare object or array. Unlike this fix, that is twelve separate judgements about
whether the service or the spec is right, and it wants a stated default before
anyone starts — change the service to match the spec, or take the divergence
upstream where the service's shape is the better design.
