### PR TITLE
fix(vtc)!: accept the install flow's own field names

### DIFF
--- a/vtc-service/admin-ui/src/pages/Install.tsx
+++ b/vtc-service/admin-ui/src/pages/Install.tsx
@@ -82,8 +82,8 @@ export function Install() {
       "/v1/install/claim/start",
       TRUST_TASK_START,
       {
-        install_token: token,
-        claim_secret: code.trim() === "" ? undefined : code.trim(),
+        installToken: token,
+        claimSecret: code.trim() === "" ? undefined : code.trim(),
       },
     );
     if (start.status === 401) {
@@ -180,9 +180,9 @@ export function Install() {
       "/v1/install/claim/finish",
       TRUST_TASK_FINISH,
       {
-        install_token: token,
-        registration_id: startBody.registrationId,
-        webauthn_response: serializeRegistration(credential),
+        installToken: token,
+        registrationId: startBody.registrationId,
+        webauthnResponse: serializeRegistration(credential),
       },
     );
     if (finish.status !== 200) {
@@ -214,7 +214,12 @@ export function Install() {
     const bootstrap = await postJson(
       "/v1/admin/bootstrap",
       TRUST_TASK_BOOTSTRAP,
-      { setup_session_token: finishBody.setupSessionToken },
+      // Passed straight through. `claim/finish` returns `setupSessionToken`
+      // and `admin/bootstrap` now accepts that same name; until the request
+      // structs gained `rename_all` this line had to re-key it to
+      // `setup_session_token`, which is why a client written from the
+      // published schema could not complete the install at all.
+      { setupSessionToken: finishBody.setupSessionToken },
     );
     if (bootstrap.status !== 200 && bootstrap.status !== 409) {
       const b = bootstrap.body as { error?: string; message?: string } | null;

--- a/vtc-service/src/routes/admin/bootstrap.rs
+++ b/vtc-service/src/routes/admin/bootstrap.rs
@@ -36,6 +36,7 @@ use crate::install::InstallTokenSigner;
 use crate::server::AppState;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct BootstrapRequest {
     pub setup_session_token: String,
 }

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -62,6 +62,7 @@ use crate::server::AppState;
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ClaimStartRequest {
     pub install_token: String,
     /// Out-of-band claim code the operator received alongside the
@@ -90,6 +91,7 @@ pub struct ClaimStartResponse {
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ClaimFinishRequest {
     pub install_token: String,
     pub registration_id: String,

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -490,7 +490,7 @@ fn uuid() -> uuid::Uuid {
 /// 3. **Unspecced members on an `additionalProperties: false` response.**
 ///    Usually the service is ahead of the spec (the ceremony verdict
 ///    envelope, `decidedAt`), occasionally behind it (`didBindingChallenge`).
-const KNOWN_DRIFT_COUNT: usize = 32;
+const KNOWN_DRIFT_COUNT: usize = 31;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -529,20 +529,16 @@ fn table() -> Vec<Conformance> {
 
     vec![
         // ─── admin ───────────────────────────────────────────────────
-        drift!(
+        checked!(
             s::admin::bootstrap::v0_1::Payload,
             s::admin::bootstrap::v0_1::Response,
-            Side::Request,
-            // `BootstrapRequest` (routes/admin/bootstrap.rs:38) has no
-            // `rename_all`, so the single member is snake_case.
-            json!({ "setup_session_token": "eyJhbGciOiJFZERTQSJ9.e30.sig" }),
-            json!({ "adminDid": OTHER_DID, "eventId": REQUEST_ID }),
-            "request member is `setup_session_token`; the spec names \
-             `setupSessionToken` and forbids extras. A conforming client's \
-             body deserialises as a missing required field. R3.1 casing \
-             drift — fix here (add `rename_all = \"camelCase\"`), not \
-             upstream; it also breaks the admin SPA's post and needs that \
-             changed in the same commit"
+            // `BootstrapRequest` — routes/admin/bootstrap.rs. Sent
+            // `setup_session_token` until it gained `rename_all`, so a
+            // conforming client's body failed as a missing required field —
+            // and `claim/finish` had been handing that client a
+            // `setupSessionToken` to send.
+            json!({ "setupSessionToken": "eyJhbGciOiJFZERTQSJ9.e30.sig" }),
+            json!({ "adminDid": OTHER_DID, "eventId": REQUEST_ID })
         ),
         checked!(
             s::admin::invites::create::v0_1::Payload,
@@ -905,18 +901,18 @@ fn table() -> Vec<Conformance> {
             s::install::claim::start::v0_1::Response,
             Side::Both,
             // `ClaimStartRequest` — routes/install.rs:65. No `rename_all`.
-            json!({ "install_token": "eyJhbGciOiJFZERTQSJ9.e30.sig",
-                    "claim_secret": "K7QW-3M2X-9PLD" }),
+            json!({ "installToken": "eyJhbGciOiJFZERTQSJ9.e30.sig",
+                    "claimSecret": "K7QW-3M2X-9PLD" }),
             // `ClaimStartResponse` — routes/install.rs:81.
             json!({ "registrationId": REQUEST_ID, "options": { "publicKey": {} } }),
-            "request members are snake_case (`install_token`) and it carries \
-             `claim_secret`, which the spec does not define at all — the \
+            "the request carries \
+             `claimSecret`, which the spec does not define at all — the \
              claim secret is the second factor on the install URL, so the \
              spec is missing a real member. The response omits \
              `didBindingChallenge`, which the spec REQUIRES: this service \
              binds the admin DID at `claim/finish` instead, so the member has \
-             nowhere to come from. Casing is a fix here; the two structural \
-             halves need the spec and the flow reconciled"
+             nowhere to come from. The casing half is fixed; the two \
+             structural halves need the spec and the flow reconciled"
         ),
         drift!(
             s::install::claim::finish::v0_1::Payload,
@@ -924,19 +920,20 @@ fn table() -> Vec<Conformance> {
             Side::Request,
             // `ClaimFinishRequest` — routes/install.rs:93. No `rename_all`.
             json!({
-                "install_token": "eyJhbGciOiJFZERTQSJ9.e30.sig",
-                "registration_id": REQUEST_ID,
-                "webauthn_response": { "id": "AX6nVQ8s", "type": "public-key" },
+                "installToken": "eyJhbGciOiJFZERTQSJ9.e30.sig",
+                "registrationId": REQUEST_ID,
+                "webauthnResponse": { "id": "AX6nVQ8s", "type": "public-key" },
             }),
             // `ClaimFinishResponse` — routes/install.rs:103.
             json!({ "adminDid": OTHER_DID, "setupSessionToken": "eyJhbGciOiJFZERTQSJ9.e30.sig" }),
-            "request members are snake_case, and the spec's fourth required \
+            "the spec's fourth required \
              member `didBindingSignature` is absent — the passkey attestation \
              is the only binding this service checks. Same reconciliation as \
-             `claim/start`: R3.1 casing is a fix here, the missing signature \
-             is a design question. Note the response's `setupSessionToken` is \
-             camelCase and feeds `admin/bootstrap`, which then reads it back \
-             as `setup_session_token`"
+             `claim/start`: the casing half is fixed, the missing signature \
+             is a design question. The response's `setupSessionToken` now \
+             feeds an `admin/bootstrap` that accepts that same name — until \
+             both were fixed, the service issued one spelling and demanded \
+             the other, and only the SPA's hand re-keying bridged it"
         ),
         // ─── invitations ─────────────────────────────────────────────
         checked!(

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -143,7 +143,7 @@ async fn run_claim_ceremony(fix: &Fixture) -> (String, String) {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token }),
+        json!({ "installToken": token }),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
@@ -160,9 +160,9 @@ async fn run_claim_ceremony(fix: &Fixture) -> (String, String) {
         "/v1/install/claim/finish",
         FINISH_TASK,
         json!({
-            "install_token": token,
-            "registration_id": registration_id,
-            "webauthn_response": register_cred,
+            "installToken": token,
+            "registrationId": registration_id,
+            "webauthnResponse": register_cred,
         }),
     )
     .await;
@@ -185,7 +185,7 @@ async fn full_install_to_bootstrap_succeeds() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": session_jwt }),
+        json!({ "setupSessionToken": session_jwt }),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "bootstrap: {body}");
@@ -260,7 +260,7 @@ async fn second_bootstrap_returns_409() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": session_jwt_a }),
+        json!({ "setupSessionToken": session_jwt_a }),
     )
     .await;
     assert_eq!(s1, StatusCode::OK);
@@ -270,7 +270,7 @@ async fn second_bootstrap_returns_409() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": session_jwt_a }),
+        json!({ "setupSessionToken": session_jwt_a }),
     )
     .await;
     assert_eq!(
@@ -291,7 +291,7 @@ async fn bootstrap_rejects_unsigned_token() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": "not.a.real.jwt" }),
+        json!({ "setupSessionToken": "not.a.real.jwt" }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -308,7 +308,7 @@ async fn bootstrap_rejects_install_token_as_setup_token() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": install_jwt }),
+        json!({ "setupSessionToken": install_jwt }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -332,7 +332,7 @@ async fn bootstrap_rejects_when_no_passkey_user_exists() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": session_jwt }),
+        json!({ "setupSessionToken": session_jwt }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -349,7 +349,7 @@ async fn bootstrap_returns_503_when_install_signer_missing() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": "x" }),
+        json!({ "setupSessionToken": "x" }),
     )
     .await;
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
@@ -370,7 +370,7 @@ async fn bootstrap_returns_503_when_audit_writer_missing() {
         &fix.router,
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
-        json!({ "setup_session_token": session_jwt }),
+        json!({ "setupSessionToken": session_jwt }),
     )
     .await;
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
@@ -387,7 +387,7 @@ async fn wrong_trust_task_returns_415() {
         &fix.router,
         "/v1/admin/bootstrap",
         FINISH_TASK,
-        json!({ "setup_session_token": "x" }),
+        json!({ "setupSessionToken": "x" }),
     )
     .await;
     assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
@@ -404,7 +404,7 @@ async fn missing_trust_task_returns_400() {
                 .method("POST")
                 .uri("/v1/admin/bootstrap")
                 .header("content-type", "application/json")
-                .body(Body::from(r#"{"setup_session_token":"x"}"#))
+                .body(Body::from(r#"{"setupSessionToken":"x"}"#))
                 .unwrap(),
         )
         .await

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -555,8 +555,8 @@ async fn fresh_install_url_works_for_claim_start_after_emergency_bootstrap() {
     // time. Without the code the daemon returns 401
     // `claim_secret_required`.
     let body = json!({
-        "install_token": token,
-        "claim_secret": outcome.claim_code,
+        "installToken": token,
+        "claimSecret": outcome.claim_code,
     });
     let res = fix
         .router

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -149,7 +149,7 @@ async fn full_ceremony_completes_end_to_end() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token }),
+        json!({ "installToken": token }),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
@@ -167,9 +167,9 @@ async fn full_ceremony_completes_end_to_end() {
         "/v1/install/claim/finish",
         FINISH_TASK,
         json!({
-            "install_token": token,
-            "registration_id": registration_id,
-            "webauthn_response": register_cred,
+            "installToken": token,
+            "registrationId": registration_id,
+            "webauthnResponse": register_cred,
         }),
     )
     .await;
@@ -188,9 +188,9 @@ async fn full_ceremony_completes_end_to_end() {
         "/v1/install/claim/finish",
         FINISH_TASK,
         json!({
-            "install_token": token,
-            "registration_id": registration_id,
-            "webauthn_response": register_cred,
+            "installToken": token,
+            "registrationId": registration_id,
+            "webauthnResponse": register_cred,
         }),
     )
     .await;
@@ -205,7 +205,7 @@ async fn full_ceremony_completes_end_to_end() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token }),
+        json!({ "installToken": token }),
     )
     .await;
     assert_ne!(
@@ -230,7 +230,7 @@ async fn claim_secret_happy_path_completes_ceremony() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token, "claim_secret": secret }),
+        json!({ "installToken": token, "claimSecret": secret }),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "start with correct secret: {body}");
@@ -247,7 +247,7 @@ async fn claim_secret_missing_returns_required_code() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token }),
+        json!({ "installToken": token }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED, "body: {body}");
@@ -268,7 +268,7 @@ async fn claim_secret_wrong_returns_invalid_code() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token, "claim_secret": "WRONGWRONG" }),
+        json!({ "installToken": token, "claimSecret": "WRONGWRONG" }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED, "body: {body}");
@@ -290,7 +290,7 @@ async fn start_returns_503_when_install_signer_missing() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": "bogus" }),
+        json!({ "installToken": "bogus" }),
     )
     .await;
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
@@ -304,7 +304,7 @@ async fn start_returns_503_when_webauthn_missing() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token }),
+        json!({ "installToken": token }),
     )
     .await;
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
@@ -321,7 +321,7 @@ async fn start_rejects_unsigned_token() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": "not.a.real.jwt" }),
+        json!({ "installToken": "not.a.real.jwt" }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -343,7 +343,7 @@ async fn start_rejects_unknown_jti() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": minted.jwt }),
+        json!({ "installToken": minted.jwt }),
     )
     .await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -358,7 +358,7 @@ async fn second_concurrent_start_within_window_is_conflict() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": &token }),
+        json!({ "installToken": &token }),
     )
     .await;
     assert_eq!(status1, StatusCode::OK);
@@ -367,7 +367,7 @@ async fn second_concurrent_start_within_window_is_conflict() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": &token }),
+        json!({ "installToken": &token }),
     )
     .await;
     assert_eq!(status2, StatusCode::CONFLICT);
@@ -382,7 +382,7 @@ async fn finish_rejects_mismatched_registration_id() {
         &fix.router,
         "/v1/install/claim/start",
         START_TASK,
-        json!({ "install_token": token }),
+        json!({ "installToken": token }),
     )
     .await;
     let ccr = parse_ccr(&body);
@@ -394,9 +394,9 @@ async fn finish_rejects_mismatched_registration_id() {
         "/v1/install/claim/finish",
         FINISH_TASK,
         json!({
-            "install_token": token,
-            "registration_id": Uuid::new_v4().to_string(),
-            "webauthn_response": register_cred,
+            "installToken": token,
+            "registrationId": Uuid::new_v4().to_string(),
+            "webauthnResponse": register_cred,
         }),
     )
     .await;
@@ -426,9 +426,9 @@ async fn finish_without_start_fails() {
         "/v1/install/claim/finish",
         FINISH_TASK,
         json!({
-            "install_token": token,
-            "registration_id": jti.to_string(),
-            "webauthn_response": dummy_cred,
+            "installToken": token,
+            "registrationId": jti.to_string(),
+            "webauthnResponse": dummy_cred,
         }),
     )
     .await;
@@ -450,7 +450,7 @@ async fn missing_trust_task_header_returns_400() {
                 .method("POST")
                 .uri("/v1/install/claim/start")
                 .header("content-type", "application/json")
-                .body(Body::from(r#"{"install_token":"x"}"#))
+                .body(Body::from(r#"{"installToken":"x"}"#))
                 .unwrap(),
         )
         .await
@@ -465,7 +465,7 @@ async fn wrong_trust_task_header_returns_415() {
         &fix.router,
         "/v1/install/claim/start",
         FINISH_TASK, // start endpoint with finish task
-        json!({ "install_token": "x" }),
+        json!({ "installToken": "x" }),
     )
     .await;
     assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -217,7 +217,7 @@ async fn end_to_end_install_flow_phase_0_gate() {
         "/v1/install/claim/start",
         CLAIM_START_TASK,
         None,
-        Some(json!({ "install_token": install_token })),
+        Some(json!({ "installToken": install_token })),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "claim/start: {body}");
@@ -237,9 +237,9 @@ async fn end_to_end_install_flow_phase_0_gate() {
         CLAIM_FINISH_TASK,
         None,
         Some(json!({
-            "install_token": install_token,
-            "registration_id": registration_id,
-            "webauthn_response": register_cred,
+            "installToken": install_token,
+            "registrationId": registration_id,
+            "webauthnResponse": register_cred,
         })),
     )
     .await;
@@ -257,7 +257,7 @@ async fn end_to_end_install_flow_phase_0_gate() {
         "/v1/admin/bootstrap",
         BOOTSTRAP_TASK,
         None,
-        Some(json!({ "setup_session_token": setup_session_token })),
+        Some(json!({ "setupSessionToken": setup_session_token })),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "bootstrap: {body}");
@@ -309,6 +309,9 @@ async fn end_to_end_install_flow_phase_0_gate() {
         ENROLL_FINISH_TASK,
         Some(&admin_token),
         Some(json!({
+            // `RegisterFinishRequest` (routes/admin/passkeys.rs) has no
+            // `rename_all`, so this endpoint is still snake_case. It is a
+            // separate divergence from the install-claim ones fixed here.
             "registration_id": reg_id,
             "register_response": register_response,
             "uv_response": uv_response,
@@ -412,7 +415,7 @@ async fn end_to_end_install_flow_phase_0_gate() {
         "/v1/install/claim/start",
         CLAIM_START_TASK,
         None,
-        Some(json!({ "install_token": install_token })),
+        Some(json!({ "installToken": install_token })),
     )
     .await;
     assert_eq!(


### PR DESCRIPTION
Second batch of the 33. Closes one more entry, but the reason it matters is a
live bug rather than a conformance count.

## The install flow disagreed with itself

`claim/finish` derives `ClaimFinishResponse` **with** `rename_all`, so it
returns `setupSessionToken`. `admin/bootstrap` derived `BootstrapRequest`
**without** one, so it demanded `setup_session_token`.

The service handed a caller one spelling and required the other back.

Only the admin SPA survived it, because `Install.tsx:217` re-keyed the value by
hand between the two calls:

```ts
{ setup_session_token: finishBody.setupSessionToken }
```

**A client written from the published schema could not complete an install at
all** — its body deserialised as a missing required field. The schema has said
`setupSessionToken` all along.

`ClaimStartRequest` and `ClaimFinishRequest` had the same gap, so
`install_token`, `claim_secret`, `registration_id` and `webauthn_response` were
snake_case against schemas naming them in camelCase.

## What changed

All three request structs gain `rename_all = "camelCase"`, and the SPA now
passes the token straight through instead of translating it.

Drift count **32 → 31**. `admin/bootstrap` is promoted to `checked!`. The two
install/claim entries stay, rewritten to describe only what is left of them:
`claimSecret` is a real member the spec does not define, and the response omits
`didBindingChallenge`, which the spec requires because this service binds the
admin DID at `claim/finish` instead. Those are a spec-and-flow reconciliation,
not a casing fix, and they are not attempted here.

## One thing I got wrong and reverted

A first pass swept `RegisterFinishRequest` (`routes/admin/passkeys.rs`) up with
the rest — it is also snake_case. The tests caught it: `register/finish` started
returning 422.

Reverted. It is a different endpoint with its own drift entry, and widening
this change to cover it would have buried a decision inside a mechanical fix.
`install_flow.rs` exercises both flows and now shows the two casings side by
side, with a comment saying why.

## The pattern, third time today

R3.1 casing, after the `Verifiable`-prefixed credential tags (#1071) and the
`Paginated<T>` wrapper (#1078). The common thread is not carelessness about
casing — it is that **a request struct's serde attributes were never compared
to the schema its URI publishes**. The witness from #1076 is the first thing in
this repo that does that, and it has now found three.

## Verified

- `cargo test -p vtc-service` — 53 suites, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `tsc -b --noEmit` in `admin-ui` — clean

## Breaking

`POST /v1/install/claim/start`, `/v1/install/claim/finish` and
`/v1/admin/bootstrap` accept camelCase request members and reject the
snake_case names they previously required. Any caller that worked before did so
by disagreeing with the published schema.
