### PR TITLE
feat(sdk): extract the agent-side connect ladder into vta_sdk::agent_connect

### DIFF
--- a/docs/02-vta/personal-ai-agents.md
+++ b/docs/02-vta/personal-ai-agents.md
@@ -217,7 +217,54 @@ pnm approvals require https://trusttasks.org/spec/acl/grant/0.1 --reauth
 When a gated op is initiated, the agent's request returns a step-up challenge;
 the operator approves with a passkey (`auth/passkey-login`), and the op proceeds.
 
-## Step 6 — Credentials (optional)
+## Step 6 — Agent memory (optional, but the reason most agents want a VTA)
+
+An agent that forgets everything between runs is a tool. The VTA carries a
+per-context key/value store for what an agent should remember about its user —
+`vta/memory/{put,list,delete}/0.1` — and because it lives on the VTA rather than
+in the agent runtime, the memory survives the runtime being replaced, is audited
+(`memory.put` / `.list` / `.delete`), and is included in the VTA's encrypted
+backups.
+
+The gate is **context access**, not a capability: `require_context(contextId)`,
+the same check the context-scoped key tasks use. That makes the trust context
+the isolation boundary — a context-A agent cannot read, write, or delete
+context-B memory — and it means the least-privilege grant for a memory-only
+agent is an ACL entry with role `application` naming exactly one context.
+
+```bash
+# One context per agent (or per domain) — this is the isolation boundary.
+pnm contexts create --name my-agent-memory
+
+# Least privilege: NOT admin. For `admin` an empty allowed-contexts list means
+# *unrestricted*; for every other role it means authorized nowhere.
+pnm acl create --did <agent did:key> --role application --contexts my-agent-memory
+```
+
+From a client, `VtaClient::{memory_put, memory_list, memory_delete}` drive the
+three tasks through the generic Trust-Task dispatcher, so they ride TSP, DIDComm
+or REST according to what both DID documents advertise — the agent writes no
+transport code.
+
+Two boundaries worth stating before anything is stored here:
+
+- **Memory is not a secret store.** Tokens, passwords and keys belong in the
+  secrets vault; credentials belong in the credential vault. Those are gated on
+  `VaultRead` / `VaultWrite` / `CredentialWrite` for a reason.
+- **Memory is not application state.** `memory/list/0.1` returns *every* entry
+  in the context — no version, no precondition, no cursor — and, the argument
+  that settles it, *"forget everything" has to stay a safe thing for a user to
+  ask an agent*, which it cannot be if account state lives there. Use
+  `vta/app-state/*/1.0` (versioned, namespaced, with a change feed) instead. See
+  `docs/05-design-notes/appstate-store.md`.
+
+That same "no prefix, no cursor, no search" shape means **retrieval is the
+client's job**: structure the key, keep a short description in the value to rank
+on, and return summaries rather than whole bodies. A worked example is
+[`vta-agent-memory`](https://github.com/OpenVTC/vta-agent-memory), a Claude Code
+plugin built on these three tasks.
+
+## Step 7 — Credentials (optional)
 
 If the agent must hold or present Verifiable Credentials, the
 `credential_exchange` Trust Task slice + `sealed_transfer` are already available.
@@ -238,6 +285,8 @@ Lower priority unless your agents do credential work.
 | `pnm device …` / `pnm vault …` CLI     | **Added** (this change) — `VtaClient::{device_*,vault_*}` + `pnm` commands, both transports |
 | Sealed vault upsert/release            | **Added** — `seal_vault_secret` / `open_sealed_secret` on the DIDComm session |
 | `pnm acl --capabilities` flag          | **Gap** (deferred Phase 3) — capabilities derive from role / are set at `device/register` |
+| Agent memory Trust Tasks               | Exists (`trust_tasks/memory.rs`, `VtaClient::memory_*`) — context-gated, audited |
+| Agent-side connect ladder              | Exists (`vta_sdk::agent_connect::AgentConnect`) — one way in for every agent bridge |
 
 ## References
 
@@ -247,3 +296,5 @@ Lower priority unless your agents do credential work.
 - Trust Tasks (device/vault/push): `vta-service/src/trust_tasks/`,
   `vta-sdk/src/trust_tasks.rs`
 - Mobile/agent architecture (push topology): `docs/05-design-notes/mobile-agent-architecture.md`
+- Agent memory vs. application state: `docs/05-design-notes/appstate-store.md` §1
+- Agent-side connect ladder: `vta-sdk/src/agent_connect.rs`

--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -11,6 +11,10 @@ maps one-to-one onto the session's `VtaClient`. Transport is **stdio** (the host
 spawns the binary and speaks JSON-RPC over stdin/stdout); all logging goes to
 stderr.
 
+The four ways in below are not implemented here — they are
+`vta_sdk::agent_connect::AgentConnect`, shared with every other agent-side
+bridge. `build_client` is a pure args → `AgentConnect` mapping.
+
 ## Tools
 
 The **full** VTA management surface is reachable via two generic tools, plus

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -34,10 +34,10 @@ use std::sync::Arc;
 use clap::Parser;
 use rmcp::ServiceExt;
 use rmcp::transport::stdio;
+use vta_sdk::agent_connect::AgentConnect;
 use vta_sdk::agent_session::{AgentConfig, AgentSession};
 use vta_sdk::client::VtaClient;
-use vta_sdk::did_secrets::DidSecretsBundle;
-use vta_sdk::session::SessionStore;
+use vta_sdk::session::TransportChoice;
 
 use server::VtaMcp;
 
@@ -181,191 +181,102 @@ async fn main() -> anyhow::Result<()> {
     served
 }
 
-/// Resolve the four did:key DIDComm-mode params. Returns `Some(..)` when all
-/// four are set, `None` when none are, and an error when only some are — so a
-/// half-configured invocation fails fast instead of silently falling through to
-/// another auth mode.
-fn didkey_didcomm_params(
-    agent_did: Option<String>,
-    agent_key: Option<String>,
-    vta_did: Option<String>,
-    mediator_did: Option<String>,
-) -> anyhow::Result<Option<(String, String, String, String)>> {
-    match (agent_did, agent_key, vta_did, mediator_did) {
-        (Some(a), Some(k), Some(v), Some(m)) => Ok(Some((a, k, v, m))),
-        (None, None, None, None) => Ok(None),
-        _ => anyhow::bail!(
-            "did:key DIDComm mode needs all of --agent-did, --agent-key, \
-             --vta-did, --mediator-did (or none of them)"
-        ),
+/// Translate the CLI/env args into the SDK's connect ladder. Keeping this a
+/// pure mapping (no I/O) is what lets the test below assert the *mode* a set of
+/// flags selects without a VTA to connect to.
+fn agent_connect_from(args: &Args) -> AgentConnect {
+    AgentConnect {
+        agent_secrets: args.agent_secrets.clone(),
+        agent_did: args.agent_did.clone(),
+        agent_key: args.agent_key.clone(),
+        vta_did: args.vta_did.clone(),
+        mediator_did: args.mediator_did.clone(),
+        url: args.url.clone(),
+        token: std::env::var("VTA_TOKEN").ok(),
+        session_key: args.vta.clone(),
+        service_name: Some(args.service_name.clone()),
+        sessions_dir: args.sessions_dir.clone(),
+        transport: TransportChoice::Auto,
     }
-}
-
-/// Load a [`DidSecretsBundle`] from the `--agent-secrets` argument, which is
-/// either a path to a JSON file or the inline JSON itself. A value that parses
-/// as JSON is taken inline; otherwise it is read as a file path.
-fn load_agent_bundle(raw: &str) -> anyhow::Result<DidSecretsBundle> {
-    let json = if std::path::Path::new(raw).exists() {
-        std::fs::read_to_string(raw)
-            .map_err(|e| anyhow::anyhow!("reading agent secrets bundle from `{raw}`: {e}"))?
-    } else {
-        raw.to_string()
-    };
-    serde_json::from_str(&json).map_err(|e| {
-        anyhow::anyhow!("parsing agent secrets bundle (path or inline JSON expected): {e}")
-    })
 }
 
 /// Build an authenticated [`VtaClient`] from the args/env (see module docs).
+///
+/// The four-rung ladder itself lives in `vta_sdk::agent_connect` — every
+/// agent-side bridge needs the same one, and a second copy is how they drift.
 async fn build_client(args: &Args) -> anyhow::Result<VtaClient> {
-    // The two DIDComm agent-identity modes are mutually exclusive.
-    if args.agent_secrets.is_some() && (args.agent_did.is_some() || args.agent_key.is_some()) {
-        anyhow::bail!(
-            "--agent-secrets (did:webvh bundle) and --agent-did/--agent-key (did:key) are \
-             mutually exclusive — pass one identity, not both"
-        );
-    }
-
-    // did:webvh DIDComm mode: authenticate a scoped agent via a hosted-DID
-    // secrets bundle (#key-0 Ed25519 + #key-1 X25519). Requires --vta-did +
-    // --mediator-did. Takes precedence when configured.
-    if let Some(raw) = args.agent_secrets.as_deref() {
-        let bundle = load_agent_bundle(raw)?;
-        let (vta_did, mediator_did) = match (args.vta_did.as_deref(), args.mediator_did.as_deref())
-        {
-            (Some(v), Some(m)) => (v, m),
-            _ => anyhow::bail!(
-                "did:webvh DIDComm mode (--agent-secrets) needs --vta-did and --mediator-did"
-            ),
-        };
-        tracing::info!(agent_did = %bundle.did, %mediator_did, "using did:webvh DIDComm mode");
-        return VtaClient::connect_didcomm_bundle(&bundle, vta_did, mediator_did, args.url.clone())
-            .await
-            .map_err(|e| anyhow::anyhow!("connecting to VTA over DIDComm: {e}"));
-    }
-
-    // did:key DIDComm mode: authenticate a scoped agent did:key directly over
-    // DIDComm (the canonical transport — works against DIDComm-only VTAs that
-    // expose no REST endpoint). Takes precedence when fully configured.
-    if let Some((agent_did, agent_key, vta_did, mediator_did)) = didkey_didcomm_params(
-        args.agent_did.clone(),
-        args.agent_key.clone(),
-        args.vta_did.clone(),
-        args.mediator_did.clone(),
-    )? {
-        tracing::info!(%agent_did, %mediator_did, "using did:key DIDComm mode");
-        return VtaClient::connect_didcomm(
-            &agent_did,
-            &agent_key,
-            &vta_did,
-            &mediator_did,
-            args.url.clone(),
-        )
+    let connect = agent_connect_from(args);
+    let mode = connect.mode()?;
+    tracing::info!(mode = mode.label(), "connecting to VTA");
+    connect
+        .connect()
         .await
-        .map_err(|e| anyhow::anyhow!("connecting to VTA over DIDComm: {e}"));
-    }
-
-    // Token mode: explicit URL + bearer token.
-    if let (Some(url), Ok(token)) = (args.url.as_deref(), std::env::var("VTA_TOKEN"))
-        && !token.is_empty()
-    {
-        let client = VtaClient::new(url);
-        client.set_token_async(token).await;
-        tracing::info!(%url, "using token-mode REST client");
-        return Ok(client);
-    }
-
-    // Session mode: reuse an existing pnm/cnm login (auto-refreshing).
-    let key = args.vta.as_deref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "no session selected: pass --vta <slug> (an existing `pnm` login) \
-             or set VTA_URL + VTA_TOKEN"
-        )
-    })?;
-    let sessions_dir = match &args.sessions_dir {
-        Some(d) => d.clone(),
-        None => default_sessions_dir()?,
-    };
-    tracing::info!(
-        key,
-        service = args.service_name,
-        "using session-mode client"
-    );
-    SessionStore::new(&args.service_name, sessions_dir)
-        .connect(key, args.url.as_deref(), None)
-        .await
-        .map_err(|e| anyhow::anyhow!("connecting to VTA: {e}"))
-}
-
-fn default_sessions_dir() -> anyhow::Result<PathBuf> {
-    let home =
-        std::env::var("HOME").map_err(|_| anyhow::anyhow!("HOME not set; pass --sessions-dir"))?;
-    Ok(PathBuf::from(home).join(".config").join("pnm"))
+        .map_err(|e| anyhow::anyhow!("connecting to VTA ({}): {e}", mode.label()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vta_sdk::agent_connect::ConnectMode;
+
+    /// Args with everything unset — the base every case below varies from.
+    fn args() -> Args {
+        Args::parse_from(["vta-mcp"])
+    }
 
     #[test]
-    fn didkey_didcomm_params_all_set_returns_some() {
-        let got = didkey_didcomm_params(
-            Some("did:key:zAgent".into()),
-            Some("zKey".into()),
-            Some("did:key:zVta".into()),
-            Some("did:key:zMed".into()),
-        )
-        .unwrap();
+    fn didkey_flags_select_didkey_didcomm_mode() {
+        let mut a = args();
+        a.agent_did = Some("did:key:zAgent".into());
+        a.agent_key = Some("zKey".into());
+        a.vta_did = Some("did:key:zVta".into());
+        a.mediator_did = Some("did:key:zMed".into());
         assert_eq!(
-            got,
-            Some((
-                "did:key:zAgent".into(),
-                "zKey".into(),
-                "did:key:zVta".into(),
-                "did:key:zMed".into(),
-            ))
+            agent_connect_from(&a).mode().unwrap(),
+            ConnectMode::DidKey {
+                agent_did: "did:key:zAgent".into(),
+                mediator_did: "did:key:zMed".into(),
+            }
         );
     }
 
     #[test]
-    fn didkey_didcomm_params_none_set_returns_none() {
-        assert_eq!(didkey_didcomm_params(None, None, None, None).unwrap(), None);
-    }
-
-    #[test]
-    fn load_agent_bundle_parses_inline_json() {
-        let json = r#"{"did":"did:webvh:abc:example.com:a","secrets":[
-            {"key_id":"did:webvh:abc:example.com:a#key-0","key_type":"ed25519","private_key_multibase":"z6Mksign"}
-        ]}"#;
-        let bundle = load_agent_bundle(json).unwrap();
-        assert_eq!(bundle.did, "did:webvh:abc:example.com:a");
-        assert_eq!(bundle.secrets.len(), 1);
+    fn agent_secrets_flag_selects_the_bundle_mode() {
+        let mut a = args();
+        a.agent_secrets = Some(r#"{"did":"did:webvh:abc:example.com:a","secrets":[]}"#.into());
+        a.vta_did = Some("did:key:zVta".into());
+        a.mediator_did = Some("did:key:zMed".into());
         assert_eq!(
-            bundle.secrets[0].key_id,
-            "did:webvh:abc:example.com:a#key-0"
+            agent_connect_from(&a).mode().unwrap(),
+            ConnectMode::DidWebvhBundle {
+                agent_did: "did:webvh:abc:example.com:a".into(),
+                mediator_did: "did:key:zMed".into(),
+            }
         );
     }
 
     #[test]
-    fn load_agent_bundle_reads_file_path() {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("vta-mcp-bundle-{}.json", std::process::id()));
-        std::fs::write(&path, r#"{"did":"did:webvh:f:example.com:b","secrets":[]}"#).unwrap();
-        let bundle = load_agent_bundle(path.to_str().unwrap()).unwrap();
-        assert_eq!(bundle.did, "did:webvh:f:example.com:b");
-        assert!(bundle.secrets.is_empty());
-        let _ = std::fs::remove_file(&path);
+    fn a_half_configured_agent_identity_fails_rather_than_using_the_session() {
+        let mut a = args();
+        a.agent_did = Some("did:key:zAgent".into());
+        a.vta = Some("my-vta".into());
+        let err = agent_connect_from(&a).mode().unwrap_err();
+        assert!(err.to_string().contains("agent_key"), "{err}");
     }
 
     #[test]
-    fn didkey_didcomm_params_partial_is_error() {
-        let err = didkey_didcomm_params(
-            Some("did:key:zAgent".into()),
-            None,
-            Some("did:key:zVta".into()),
-            None,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("all of"));
+    fn the_vta_slug_alone_selects_session_mode() {
+        let mut a = args();
+        a.vta = Some("my-vta".into());
+        // Guard against a `VTA_TOKEN` in the developer's own environment
+        // silently turning this into the token rung.
+        let mut connect = agent_connect_from(&a);
+        connect.token = None;
+        assert_eq!(
+            connect.mode().unwrap(),
+            ConnectMode::Session {
+                key: "my-vta".into()
+            }
+        );
     }
 }

--- a/vta-sdk/src/agent_connect.rs
+++ b/vta-sdk/src/agent_connect.rs
@@ -1,0 +1,528 @@
+//! One connect ladder for agent-side bridges.
+//!
+//! Every tool that runs *beside* a user and talks to their VTA on their behalf
+//! — an MCP bridge, an agent-memory service, a desktop helper — needs the same
+//! four ways in, in the same order, with the same fail-fast rules. That ladder
+//! was written once inside `vta-mcp`'s `main.rs` and then had nowhere else to
+//! live, so the next bridge either copied 110 lines or invented a fifth way in.
+//! This module is that ladder as SDK surface.
+//!
+//! The order, highest precedence first:
+//!
+//! 1. **did:webvh bundle** — [`AgentConnect::agent_secrets`], a
+//!    [`DidSecretsBundle`](crate::did_secrets::DidSecretsBundle) (path or inline
+//!    JSON) whose `#key-0` (Ed25519) signs and `#key-1` (X25519) decrypts.
+//!    Needs `vta_did` + `mediator_did`.
+//! 2. **did:key** — [`AgentConnect::agent_did`] + `agent_key`, a scoped agent
+//!    key authenticating directly over DIDComm. Needs `vta_did` +
+//!    `mediator_did`. Works against DIDComm-only VTAs with no REST endpoint.
+//! 3. **Token** — `url` + `token`, a bearer-token REST client. No refresh;
+//!    testing and short-lived use.
+//! 4. **Session** — `session_key`, reusing an existing `pnm`/`cnm` login from
+//!    the keyring/session store. Auto-refreshing, and the only rung that runs
+//!    [`TransportChoice::Auto`], so it inherits the workspace preference order
+//!    (TSP > DIDComm > REST) from what both DID documents advertise.
+//!
+//! Two rules the ladder enforces rather than documents:
+//!
+//! - The two DIDComm identity modes are **mutually exclusive** — passing both a
+//!   bundle and a did:key is an error, not a silent precedence win.
+//! - A **half-configured** rung fails fast. Three of the four did:key fields
+//!   set is an error naming the missing one, never a quiet fall-through to
+//!   session mode, which is how a misconfigured bridge ends up authenticated as
+//!   the operator instead of as the scoped agent it was meant to be.
+//!
+//! ```no_run
+//! # async fn run() -> Result<(), vta_sdk::error::VtaError> {
+//! use vta_sdk::agent_connect::AgentConnect;
+//!
+//! let client = AgentConnect::default()
+//!     .agent_did("did:key:z6Mk…")
+//!     .agent_key("z3u2…")
+//!     .vta_did("did:webvh:…")
+//!     .mediator_did("did:web:mediator.example")
+//!     .connect()
+//!     .await?;
+//! # let _ = client;
+//! # Ok(()) }
+//! ```
+
+use std::path::PathBuf;
+
+use crate::client::VtaClient;
+use crate::did_secrets::DidSecretsBundle;
+use crate::error::VtaError;
+use crate::session::{SessionStore, TransportChoice};
+
+/// Default service name the `pnm` CLI stores its sessions under.
+pub const DEFAULT_SERVICE_NAME: &str = "pnm-cli";
+
+/// Which rung of the ladder a configuration selects. Resolved by
+/// [`AgentConnect::mode`] *before* any network call, so a bridge can log the
+/// mode (and refuse a mode it doesn't support) without connecting first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectMode {
+    /// did:webvh secrets bundle over DIDComm.
+    DidWebvhBundle {
+        /// The bundle's DID — the authenticated agent identity.
+        agent_did: String,
+        /// The mediator the agent receives through.
+        mediator_did: String,
+    },
+    /// Scoped `did:key` over DIDComm.
+    DidKey {
+        /// The agent's `did:key`.
+        agent_did: String,
+        /// The mediator the agent receives through.
+        mediator_did: String,
+    },
+    /// Bearer-token REST client.
+    Token {
+        /// The VTA's REST base URL.
+        url: String,
+    },
+    /// An existing `pnm`/`cnm` login, replayed from the session store.
+    Session {
+        /// The session key (VTA slug) selected.
+        key: String,
+    },
+}
+
+impl ConnectMode {
+    /// A short, stable label for logs and diagnostics.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::DidWebvhBundle { .. } => "did:webvh-didcomm",
+            Self::DidKey { .. } => "did:key-didcomm",
+            Self::Token { .. } => "token-rest",
+            Self::Session { .. } => "session",
+        }
+    }
+
+    /// Whether this mode authenticates as a **dedicated agent identity** rather
+    /// than as the operator. Bridges that enroll themselves as a managed device
+    /// — attaching a device binding to the authenticated DID's ACL entry —
+    /// should only do so when this is true; doing it in session mode binds the
+    /// device to the *operator's* entry, which is not what the operator asked
+    /// for and is awkward to undo.
+    pub fn is_dedicated_agent(&self) -> bool {
+        matches!(self, Self::DidWebvhBundle { .. } | Self::DidKey { .. })
+    }
+}
+
+/// Connection inputs for an agent-side bridge. Build with the chained setters
+/// (or construct the struct directly — every field is public), then call
+/// [`connect`](Self::connect).
+///
+/// Bridges are expected to populate this from their own CLI/env layer; the SDK
+/// deliberately reads no environment variables of its own, so a library
+/// embedding a bridge can't be reconfigured behind its back.
+#[derive(Debug, Clone, Default)]
+pub struct AgentConnect {
+    /// did:webvh agent secrets bundle: a path to a JSON `DidSecretsBundle`, or
+    /// the inline JSON itself.
+    pub agent_secrets: Option<String>,
+    /// Agent `did:key` to authenticate as.
+    pub agent_did: Option<String>,
+    /// The agent's Ed25519 signing key, multibase-encoded.
+    pub agent_key: Option<String>,
+    /// The VTA's DID (DIDComm modes).
+    pub vta_did: Option<String>,
+    /// The mediator DID to route through (DIDComm modes).
+    pub mediator_did: Option<String>,
+    /// VTA REST URL. Required in token mode; an optional override elsewhere.
+    pub url: Option<String>,
+    /// Bearer token (token mode).
+    pub token: Option<String>,
+    /// Session key / VTA slug of an existing `pnm` login (session mode).
+    pub session_key: Option<String>,
+    /// Service name the session was stored under. Defaults to
+    /// [`DEFAULT_SERVICE_NAME`].
+    pub service_name: Option<String>,
+    /// Directory holding stored sessions. Defaults to `~/.config/pnm`.
+    pub sessions_dir: Option<PathBuf>,
+    /// Transport choice for **session mode**. The DIDComm rungs are DIDComm by
+    /// construction and token mode is REST by construction, so this only
+    /// applies to the session rung. Defaults to [`TransportChoice::Auto`].
+    pub transport: TransportChoice,
+}
+
+macro_rules! setter {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        pub fn $name(mut self, v: impl Into<String>) -> Self {
+            self.$name = Some(v.into());
+            self
+        }
+    };
+}
+
+impl AgentConnect {
+    setter!(
+        agent_secrets,
+        "Set the did:webvh secrets bundle (path or inline JSON)."
+    );
+    setter!(agent_did, "Set the agent `did:key`.");
+    setter!(agent_key, "Set the agent Ed25519 signing key (multibase).");
+    setter!(vta_did, "Set the VTA's DID.");
+    setter!(mediator_did, "Set the mediator DID.");
+    setter!(url, "Set the VTA REST URL.");
+    setter!(token, "Set the bearer token (token mode).");
+    setter!(
+        session_key,
+        "Set the session key / VTA slug (session mode)."
+    );
+    setter!(
+        service_name,
+        "Set the service name sessions are stored under."
+    );
+
+    /// Set the sessions directory (default `~/.config/pnm`).
+    pub fn sessions_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.sessions_dir = Some(dir.into());
+        self
+    }
+
+    /// Set the transport choice used by **session mode**.
+    pub fn transport(mut self, transport: TransportChoice) -> Self {
+        self.transport = transport;
+        self
+    }
+
+    /// Which rung this configuration selects, resolved without any I/O.
+    ///
+    /// Returns [`VtaError::Validation`] for a contradictory configuration (both
+    /// DIDComm identity modes) or a half-configured one (some but not all of a
+    /// rung's required fields), naming what is missing.
+    pub fn mode(&self) -> Result<ConnectMode, VtaError> {
+        let has_didkey_identity = self.agent_did.is_some() || self.agent_key.is_some();
+        if self.agent_secrets.is_some() && has_didkey_identity {
+            return Err(VtaError::Validation(
+                "agent_secrets (did:webvh bundle) and agent_did/agent_key (did:key) are \
+                 mutually exclusive — supply one identity, not both"
+                    .into(),
+            ));
+        }
+
+        // 1. did:webvh bundle over DIDComm.
+        if let Some(raw) = self.agent_secrets.as_deref() {
+            let bundle = load_bundle(raw)?;
+            let (_, mediator_did) = self.require_didcomm_targets("did:webvh (agent_secrets)")?;
+            return Ok(ConnectMode::DidWebvhBundle {
+                agent_did: bundle.did,
+                mediator_did,
+            });
+        }
+
+        // 2. did:key over DIDComm. All four fields, or none.
+        match (
+            self.agent_did.as_deref(),
+            self.agent_key.as_deref(),
+            self.vta_did.as_deref(),
+            self.mediator_did.as_deref(),
+        ) {
+            (Some(agent_did), Some(_), Some(_), Some(mediator_did)) => {
+                return Ok(ConnectMode::DidKey {
+                    agent_did: agent_did.to_string(),
+                    mediator_did: mediator_did.to_string(),
+                });
+            }
+            (None, None, _, _) if !has_didkey_identity => {}
+            _ => {
+                return Err(VtaError::Validation(format!(
+                    "did:key DIDComm mode needs all of agent_did, agent_key, vta_did, \
+                     mediator_did (or none of them); missing: {}",
+                    missing_fields(&[
+                        ("agent_did", self.agent_did.is_some()),
+                        ("agent_key", self.agent_key.is_some()),
+                        ("vta_did", self.vta_did.is_some()),
+                        ("mediator_did", self.mediator_did.is_some()),
+                    ])
+                )));
+            }
+        }
+
+        // 3. Token mode: explicit URL + non-empty bearer token.
+        if let (Some(url), Some(token)) = (self.url.as_deref(), self.token.as_deref())
+            && !token.is_empty()
+        {
+            return Ok(ConnectMode::Token {
+                url: url.to_string(),
+            });
+        }
+
+        // 4. Session mode.
+        let key = self.session_key.as_deref().ok_or_else(|| {
+            VtaError::Validation(
+                "no connection configured: supply a session_key (an existing `pnm` login), \
+                 url + token, or an agent identity (agent_did + agent_key + vta_did + \
+                 mediator_did)"
+                    .into(),
+            )
+        })?;
+        Ok(ConnectMode::Session {
+            key: key.to_string(),
+        })
+    }
+
+    /// Resolve the mode and connect, returning an authenticated [`VtaClient`].
+    ///
+    /// The returned client owns whatever transport its rung selected. A DIDComm
+    /// or TSP client holds a live mediator socket that `Drop` cannot close —
+    /// call [`VtaClient::shutdown`] before dropping it. (`shutdown` is
+    /// idempotent and a no-op on a REST client, so a bridge can call it
+    /// unconditionally on its way out.)
+    pub async fn connect(&self) -> Result<VtaClient, VtaError> {
+        match self.mode()? {
+            ConnectMode::DidWebvhBundle { .. } => {
+                let raw = self.agent_secrets.as_deref().expect("mode checked");
+                let bundle = load_bundle(raw)?;
+                let (vta_did, mediator_did) =
+                    self.require_didcomm_targets("did:webvh (agent_secrets)")?;
+                VtaClient::connect_didcomm_bundle(
+                    &bundle,
+                    &vta_did,
+                    &mediator_did,
+                    self.url.clone(),
+                )
+                .await
+            }
+            ConnectMode::DidKey { .. } => {
+                VtaClient::connect_didcomm(
+                    self.agent_did.as_deref().expect("mode checked"),
+                    self.agent_key.as_deref().expect("mode checked"),
+                    self.vta_did.as_deref().expect("mode checked"),
+                    self.mediator_did.as_deref().expect("mode checked"),
+                    self.url.clone(),
+                )
+                .await
+            }
+            ConnectMode::Token { url } => {
+                let client = VtaClient::new(&url);
+                client
+                    .set_token_async(self.token.clone().expect("mode checked"))
+                    .await;
+                Ok(client)
+            }
+            ConnectMode::Session { key } => {
+                let service = self
+                    .service_name
+                    .as_deref()
+                    .unwrap_or(DEFAULT_SERVICE_NAME)
+                    .to_string();
+                let dir = match &self.sessions_dir {
+                    Some(d) => d.clone(),
+                    None => default_sessions_dir()?,
+                };
+                SessionStore::new(&service, dir)
+                    .connect_with_transport(&key, self.url.as_deref(), None, self.transport)
+                    .await
+                    // `SessionStore::connect` predates the typed error surface and
+                    // returns a boxed `dyn Error`; its messages are already
+                    // operator-facing (they name the `auth login` command to run),
+                    // so carry the text rather than replacing it.
+                    .map_err(|e| VtaError::Auth(e.to_string()))
+            }
+        }
+    }
+
+    /// Both DIDComm targets, or a `Validation` error naming the missing one.
+    fn require_didcomm_targets(&self, mode: &str) -> Result<(String, String), VtaError> {
+        match (self.vta_did.as_deref(), self.mediator_did.as_deref()) {
+            (Some(v), Some(m)) => Ok((v.to_string(), m.to_string())),
+            _ => Err(VtaError::Validation(format!(
+                "{mode} DIDComm mode needs vta_did and mediator_did; missing: {}",
+                missing_fields(&[
+                    ("vta_did", self.vta_did.is_some()),
+                    ("mediator_did", self.mediator_did.is_some()),
+                ])
+            ))),
+        }
+    }
+}
+
+/// Comma-joined names of the fields that are absent.
+fn missing_fields(fields: &[(&str, bool)]) -> String {
+    let missing: Vec<&str> = fields
+        .iter()
+        .filter(|(_, present)| !present)
+        .map(|(name, _)| *name)
+        .collect();
+    if missing.is_empty() {
+        "(none)".to_string()
+    } else {
+        missing.join(", ")
+    }
+}
+
+/// Load a [`DidSecretsBundle`] from a path or inline JSON. A value naming an
+/// existing file is read from disk; anything else is parsed as JSON directly.
+fn load_bundle(raw: &str) -> Result<DidSecretsBundle, VtaError> {
+    let json = if std::path::Path::new(raw).exists() {
+        std::fs::read_to_string(raw).map_err(|e| {
+            VtaError::Validation(format!("reading agent secrets bundle from `{raw}`: {e}"))
+        })?
+    } else {
+        raw.to_string()
+    };
+    serde_json::from_str(&json).map_err(|e| {
+        VtaError::Validation(format!(
+            "parsing agent secrets bundle (path or inline JSON expected): {e}"
+        ))
+    })
+}
+
+/// `~/.config/pnm`, the directory `pnm` stores sessions in by default.
+fn default_sessions_dir() -> Result<PathBuf, VtaError> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| {
+            VtaError::Validation(
+                "HOME (or USERPROFILE) is not set; set sessions_dir explicitly".into(),
+            )
+        })?;
+    Ok(PathBuf::from(home).join(".config").join("pnm"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn didkey() -> AgentConnect {
+        AgentConnect::default()
+            .agent_did("did:key:zAgent")
+            .agent_key("zKey")
+            .vta_did("did:key:zVta")
+            .mediator_did("did:key:zMed")
+    }
+
+    #[test]
+    fn didkey_mode_needs_all_four_fields() {
+        assert_eq!(
+            didkey().mode().unwrap(),
+            ConnectMode::DidKey {
+                agent_did: "did:key:zAgent".into(),
+                mediator_did: "did:key:zMed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn half_configured_didkey_is_an_error_naming_the_gap() {
+        // The important half of this: it must NOT fall through to session mode.
+        // A bridge that silently authenticated as the operator because one flag
+        // was missing is the failure this rung exists to prevent.
+        let err = AgentConnect::default()
+            .agent_did("did:key:zAgent")
+            .session_key("my-vta")
+            .mode()
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("agent_key"), "{msg}");
+        assert!(msg.contains("vta_did"), "{msg}");
+        assert!(!msg.contains("session"), "must not fall through: {msg}");
+    }
+
+    #[test]
+    fn bundle_and_didkey_together_are_rejected() {
+        let err = AgentConnect::default()
+            .agent_secrets(r#"{"did":"did:webvh:a:b","secrets":[]}"#)
+            .agent_did("did:key:zAgent")
+            .mode()
+            .unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn bundle_mode_reports_the_bundle_did() {
+        let mode = AgentConnect::default()
+            .agent_secrets(r#"{"did":"did:webvh:abc:example.com:a","secrets":[]}"#)
+            .vta_did("did:key:zVta")
+            .mediator_did("did:key:zMed")
+            .mode()
+            .unwrap();
+        assert_eq!(
+            mode,
+            ConnectMode::DidWebvhBundle {
+                agent_did: "did:webvh:abc:example.com:a".into(),
+                mediator_did: "did:key:zMed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn bundle_without_targets_names_them() {
+        let err = AgentConnect::default()
+            .agent_secrets(r#"{"did":"did:webvh:a:b","secrets":[]}"#)
+            .mode()
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("vta_did"), "{msg}");
+        assert!(msg.contains("mediator_did"), "{msg}");
+    }
+
+    #[test]
+    fn token_mode_beats_session_mode() {
+        let mode = AgentConnect::default()
+            .url("https://vta.example")
+            .token("jwt")
+            .session_key("my-vta")
+            .mode()
+            .unwrap();
+        assert_eq!(
+            mode,
+            ConnectMode::Token {
+                url: "https://vta.example".into()
+            }
+        );
+    }
+
+    #[test]
+    fn empty_token_falls_through_to_session() {
+        // An exported-but-empty `VTA_TOKEN` is the common shell accident; it
+        // must not select token mode and then fail at the first request.
+        let mode = AgentConnect::default()
+            .url("https://vta.example")
+            .token("")
+            .session_key("my-vta")
+            .mode()
+            .unwrap();
+        assert_eq!(
+            mode,
+            ConnectMode::Session {
+                key: "my-vta".into()
+            }
+        );
+    }
+
+    #[test]
+    fn nothing_configured_names_every_way_in() {
+        let err = AgentConnect::default().mode().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("session_key"), "{msg}");
+        assert!(msg.contains("token"), "{msg}");
+        assert!(msg.contains("agent_did"), "{msg}");
+    }
+
+    #[test]
+    fn bundle_loads_from_a_file_path() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("agent-connect-bundle-{}.json", std::process::id()));
+        std::fs::write(&path, r#"{"did":"did:webvh:f:example.com:b","secrets":[]}"#).unwrap();
+        let bundle = load_bundle(path.to_str().unwrap()).unwrap();
+        assert_eq!(bundle.did, "did:webvh:f:example.com:b");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn only_the_didcomm_modes_are_dedicated_agents() {
+        assert!(didkey().mode().unwrap().is_dedicated_agent());
+        assert!(
+            !AgentConnect::default()
+                .session_key("my-vta")
+                .mode()
+                .unwrap()
+                .is_dedicated_agent()
+        );
+    }
+}

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -96,6 +96,8 @@ pub mod approvals;
 #[cfg(feature = "acl-setup")]
 pub mod acl_setup;
 #[cfg(feature = "session")]
+pub mod agent_connect;
+#[cfg(feature = "session")]
 pub mod agent_session;
 #[cfg(feature = "attest-verify")]
 pub mod attestation;


### PR DESCRIPTION
Every tool that runs *beside* a user and talks to their VTA on their behalf needs the same four ways in — did:webvh bundle, scoped did:key, bearer token, existing `pnm` session — in the same order, with the same fail-fast rules. That ladder existed only inside `vta-mcp`'s `main.rs`, so the next bridge had to copy 110 lines or invent a fifth way in.

`vta_sdk::agent_connect::AgentConnect` is that ladder as SDK surface.

- `mode()` resolves the rung with **no I/O**, so a bridge can log it — and refuse a rung it does not support — before connecting. `ConnectMode::is_dedicated_agent()` makes the operator-vs-agent distinction available to callers deciding whether to enroll as a managed device.
- `connect()` returns the authenticated `VtaClient`.
- Session mode keeps `TransportChoice::Auto`, so it inherits the workspace preference order (TSP > DIDComm > REST) from what both DID documents advertise.

Two rules are **enforced rather than documented**, both carried over from the `vta-mcp` original:

1. The two DIDComm identity modes are mutually exclusive — a bundle *and* a did:key is an error, not a silent precedence win.
2. A half-configured rung errors naming the missing fields instead of falling through to session mode. A bridge silently authenticating as the operator rather than as its scoped agent identity is the failure this exists to prevent, and there is a test asserting the error mentions the gap and *not* the session.

`vta-mcp` is refactored onto it, which is what proves the extraction: `build_client` is now a pure args → `AgentConnect` mapping plus a connect, and its tests assert which rung a set of flags selects — something the old inline ladder had no way to test.

## Motivation

The first consumer beyond `vta-mcp` is an agent-memory service (a Claude Code plugin over `vta/memory/*`), which needs exactly these four rungs and nothing else. It currently pulls `vta-sdk` from this branch via `[patch.crates-io]`.

## Testing

- 10 new unit tests on `agent_connect` covering rung selection, precedence, mutual exclusion, half-configuration, empty-token fall-through, and bundle loading from a path or inline JSON.
- 4 new tests in `vta-mcp` mapping CLI flags to rungs.
- `cargo clippy` clean on both crates.