### PR TITLE
fix(vtc)!: return the response shapes the specs publish

### DIFF
--- a/vtc-service/src/routes/backup.rs
+++ b/vtc-service/src/routes/backup.rs
@@ -8,7 +8,7 @@
 
 use axum::Json;
 use axum::extract::State;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::auth::SuperAdminAuth;
 use crate::backup::{self, BackupEnvelope, ImportResult};
@@ -28,6 +28,16 @@ pub struct ExportRequest {
     /// can be large and carry plaintext DIDs.
     #[serde(default)]
     pub include_audit: bool,
+}
+
+/// `{ envelope: … }` — the shape `vtc/backup/export/0.1` publishes.
+///
+/// The handler returned the bare `BackupEnvelope` until #1059's witness put it
+/// beside its own schema. The inner object always conformed member for member;
+/// only the wrapper was missing.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ExportResponse {
+    pub envelope: BackupEnvelope,
 }
 
 /// `POST /v1/backup/import` body.
@@ -59,7 +69,7 @@ pub async fn export(
     SuperAdminAuth(auth): SuperAdminAuth,
     State(state): State<AppState>,
     Json(req): Json<ExportRequest>,
-) -> Result<Json<BackupEnvelope>, AppError> {
+) -> Result<Json<ExportResponse>, AppError> {
     let store = create_secret_store(&*state.config.read().await)?;
     let envelope =
         backup::export_backup(&state, store.as_ref(), &req.password, req.include_audit).await?;
@@ -75,7 +85,7 @@ pub async fn export(
             )
             .await?;
     }
-    Ok(Json(envelope))
+    Ok(Json(ExportResponse { envelope }))
 }
 
 #[utoipa::path(

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -342,7 +342,18 @@ pub async fn show(
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct RevokeResponse {
-    pub id: String,
+    pub endorsement_id: String,
+    pub revocation: RevocationDetail,
+    pub status_list_index: u32,
+}
+
+/// The credential the revocation applies to, and when it took effect.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct RevocationDetail {
+    pub credential_id: String,
+    pub revoked_at: String,
 }
 
 #[utoipa::path(
@@ -389,9 +400,21 @@ pub async fn revoke(
         ));
     }
 
-    // Idempotent no-op.
+    // Idempotent no-op — and it answers with the same shape as a first
+    // revoke, reading the timestamp already on the row rather than inventing
+    // a fresh one.
     if row.is_revoked() {
-        return Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })));
+        return Ok((
+            StatusCode::OK,
+            Json(RevokeResponse {
+                endorsement_id: id.to_string(),
+                revocation: RevocationDetail {
+                    credential_id: row.vec_id.clone(),
+                    revoked_at: rfc3339(row.revoked_at.unwrap_or_else(Utc::now)),
+                },
+                status_list_index: row.status_list_index,
+            }),
+        ));
     }
 
     // Flip the status-list bit — locked RMW so a concurrent allocate/flip
@@ -445,9 +468,20 @@ pub async fn revoke(
         by = %auth.did,
         "custom endorsement revoked"
     );
-    let _ = updated;
-
-    Ok((StatusCode::OK, Json(RevokeResponse { id: id.to_string() })))
+    // Every member the spec asks for was already in hand here: the handler
+    // replied with `{id}` alone and dropped the rest, including `updated`,
+    // which it had bound and then discarded with `let _ = updated;`.
+    Ok((
+        StatusCode::OK,
+        Json(RevokeResponse {
+            endorsement_id: id.to_string(),
+            revocation: RevocationDetail {
+                credential_id: row.vec_id.clone(),
+                revoked_at: rfc3339(updated.revoked_at.unwrap_or_else(Utc::now)),
+            },
+            status_list_index: row.status_list_index,
+        }),
+    ))
 }
 
 fn rfc3339(t: chrono::DateTime<Utc>) -> String {

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -227,7 +227,7 @@ pub struct RemovedMember {
 pub async fn list_removed(
     _auth: AdminAuth,
     State(state): State<AppState>,
-) -> Result<Json<Vec<RemovedMember>>, AppError> {
+) -> Result<Json<RemovedMembersResponse>, AppError> {
     let mut removed: Vec<RemovedMember> = crate::members::list_members(&state.members_ks)
         .await?
         .into_iter()
@@ -241,7 +241,16 @@ pub async fn list_removed(
         })
         .collect();
     removed.sort_by_key(|b| std::cmp::Reverse(b.removed_at));
-    Ok(Json(removed))
+    Ok(Json(RemovedMembersResponse { removed }))
+}
+
+/// `{ removed: [...] }` — the shape `vtc/members/removed/0.1` publishes.
+///
+/// The handler returned a top-level array until #1059's witness compared it
+/// with its schema. The rows themselves always conformed.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct RemovedMembersResponse {
+    pub removed: Vec<RemovedMember>,
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/routes/website/files.rs
+++ b/vtc-service/src/routes/website/files.rs
@@ -342,7 +342,7 @@ pub async fn delete(
     _admin: AdminAuth,
     State(state): State<AppState>,
     AxumPath(path): AxumPath<String>,
-) -> Result<StatusCode, AppError> {
+) -> Result<Json<DeleteResponse>, AppError> {
     let resolved = resolve_or_400(&state, &path).await?;
     tokio::fs::remove_file(&resolved)
         .await
@@ -357,7 +357,20 @@ pub async fn delete(
             )
             .await;
     }
-    Ok(StatusCode::OK)
+    Ok(Json(DeleteResponse {
+        path,
+        deleted: true,
+    }))
+}
+
+/// `{ path, deleted }` — the shape `vtc/website/files/delete/0.1` publishes.
+/// The handler returned 200 with zero bytes until #1059, discarding both
+/// values it had in hand. `deleted` is always true here: the remove is
+/// propagated as an error above if it fails.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct DeleteResponse {
+    pub path: String,
+    pub deleted: bool,
 }
 
 /// Map a [`PathError`] from the create-path validator to the HTTP

--- a/vtc-service/src/routes/website/generations.rs
+++ b/vtc-service/src/routes/website/generations.rs
@@ -8,7 +8,7 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use serde::Serialize;
 
 use vti_common::audit::{AuditEvent, WebsiteGenerationRolledBackData};
 use vti_common::auth::AdminAuth;
@@ -20,7 +20,7 @@ use crate::website::storage::{GenerationEntry, list_managed_generations, swap_cu
 pub async fn list(
     _admin: AdminAuth,
     State(state): State<AppState>,
-) -> Result<Json<Vec<GenerationEntry>>, AppError> {
+) -> Result<Json<GenerationsResponse>, AppError> {
     let cfg = state.config.read().await;
     let root_dir = cfg
         .website
@@ -36,15 +36,28 @@ pub async fn list(
         ));
     }
 
-    let gens = list_managed_generations(&root_dir)?;
-    Ok(Json(gens))
+    let generations = list_managed_generations(&root_dir)?;
+    Ok(Json(GenerationsResponse { generations }))
+}
+
+/// `{ generations: [...] }` — the shape `vtc/website/generations/list/0.1`
+/// publishes. The handler returned a top-level array until #1059's witness
+/// compared it with its schema; the rows always conformed.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct GenerationsResponse {
+    // `GenerationEntry` comes from the website module and derives no
+    // `ToSchema`; typed as an opaque object here rather than deriving it
+    // there, which would pull utoipa into a module that has no other use for
+    // it. The wire shape is unaffected.
+    #[schema(value_type = Vec<Object>)]
+    pub generations: Vec<GenerationEntry>,
 }
 
 pub async fn rollback(
     _admin: AdminAuth,
     State(state): State<AppState>,
     Path(gen_num): Path<u32>,
-) -> Result<StatusCode, AppError> {
+) -> Result<Json<RollbackResponse>, AppError> {
     let cfg = state.config.read().await;
     let root_dir = cfg
         .website
@@ -75,5 +88,30 @@ pub async fn rollback(
             )
             .await;
     }
-    Ok(StatusCode::OK)
+    // `noop` is the same condition the audit guard above tests: rolling back
+    // to the generation already current changes nothing. The handler computed
+    // it and discarded it, while the spec has always asked for it.
+    Ok(Json(RollbackResponse {
+        generation: gen_num.to_string(),
+        current: true,
+        noop: from == gen_num,
+    }))
+}
+
+/// `{ generation, current, noop }` — the shape `vtc/website/rollback/0.1`
+/// publishes. The handler returned 200 with zero bytes until #1059.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct RollbackResponse {
+    /// A string, as the spec types it — the same way the path segment is
+    /// typed there, while this handler takes it as a `u32`. Rendering it back
+    /// as a string keeps the response conforming; reconciling the two typings
+    /// is a separate question for the spec.
+    pub generation: String,
+    /// Whether this generation is current after the swap. The spec types it
+    /// as a boolean, not as a generation number — it answers "did the
+    /// rollback take", not "which one is live". Always true on success; the
+    /// symlink swap propagates as an error otherwise.
+    pub current: bool,
+    /// True when the target was already current, so nothing moved.
+    pub noop: bool,
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -490,7 +490,7 @@ fn uuid() -> uuid::Uuid {
 /// 3. **Unspecced members on an `additionalProperties: false` response.**
 ///    Usually the service is ahead of the spec (the ceremony verdict
 ///    envelope, `decidedAt`), occasionally behind it (`didBindingChallenge`).
-const KNOWN_DRIFT_COUNT: usize = 31;
+const KNOWN_DRIFT_COUNT: usize = 27;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -629,17 +629,13 @@ fn table() -> Vec<Conformance> {
              for taking upstream rather than changing here"
         ),
         // ─── backup ──────────────────────────────────────────────────
-        drift!(
+        checked!(
             s::backup::export::v0_1::Payload,
             s::backup::export::v0_1::Response,
-            Side::Response,
-            // `ExportRequest` — routes/backup.rs:24.
+            // `ExportRequest` — routes/backup.rs.
             json!({ "password": "correct-horse-battery-staple", "includeAudit": true }),
-            // The handler returns the envelope bare (routes/backup.rs:58).
-            backup_envelope(),
-            "response is the bare `BackupEnvelope`; the spec wraps it as \
-             `{envelope: …}`. Envelope-only mismatch — the inner object \
-             conforms member for member — so fix here"
+            // `ExportResponse` — the envelope was returned bare until #1059.
+            json!({ "envelope": backup_envelope() })
         ),
         checked!(
             s::backup::import::v0_1::Payload,
@@ -1149,17 +1145,14 @@ fn table() -> Vec<Conformance> {
             json!({ "did": DID }),
             json!({ "did": DID, "disposition": "purge", "removed": true })
         ),
-        drift!(
+        checked!(
             s::members::removed::v0_1::Payload,
             s::members::removed::v0_1::Response,
-            Side::Response,
             json!({}),
-            // `list_removed` returns `Json<Vec<RemovedMember>>` — a
-            // top-level array (routes/members/read.rs:227).
-            json!([{ "did": DID, "removedAt": TS, "statusListIndex": 77, "status": "removed" }]),
-            "response is a top-level array where the spec says \
-             `{removed: [...]}`. The rows themselves conform. Envelope-only, \
-             so this is a fix here"
+            // `RemovedMembersResponse` — a top-level array until #1059.
+            json!({ "removed": [
+                { "did": DID, "removedAt": TS, "statusListIndex": 77, "status": "removed" }
+            ] })
         ),
         checked!(
             s::members::renew::v0_1::Payload,
@@ -1383,42 +1376,39 @@ fn table() -> Vec<Conformance> {
              the sweep finding a task I had first written as `checked!`: the \
              wrapper conforms and I stopped reading there"
         ),
-        drift!(
+        checked!(
             s::website::files::delete::v0_1::Payload,
             s::website::files::delete::v0_1::Response,
-            Side::Response,
             json!({ "path": "assets/old-logo.png" }),
-            // The handler returns a bare `StatusCode::OK` — zero bytes
-            // (routes/website/files.rs:341). `{}` flatters it.
-            json!({}),
-            "no response body: the handler returns 200 with zero bytes where \
-             the spec requires `{path, deleted}`. Fix here — both values are \
-             in hand at the point it replies"
+            // `DeleteResponse` — 200 with zero bytes until #1059.
+            json!({ "path": "assets/old-logo.png", "deleted": true })
         ),
         drift!(
             s::website::generations::list::v0_1::Payload,
             s::website::generations::list::v0_1::Response,
             Side::Response,
             json!({}),
-            // `list` returns `Json<Vec<GenerationEntry>>` — a top-level
-            // array (routes/website/generations.rs:20).
-            json!([{ "generation": 1, "isCurrent": false,
-                     "deployedAt": 1_755_860_400_u64, "sizeBytes": 1_048_576_u64 }]),
-            "response is a top-level array where the spec says \
-             `{generations: [...]}`. Envelope-only; fix here"
+            // `GenerationsResponse` — the envelope is fixed; the rows are not.
+            json!({ "generations": [
+                { "generation": 1, "isCurrent": false,
+                  "deployedAt": 1_755_860_400_u64, "sizeBytes": 1_048_576_u64 }
+            ] }),
+            "the missing `{generations: […]}` envelope is fixed. The rows are \
+             not, and the entry that called this envelope-only was wrong: the \
+             spec's row carries `generation` and `current`, while the service \
+             sends `isCurrent` for `current` and adds `deployedAt` and \
+             `sizeBytes`. One rename here, and two members that are worth \
+             having — take them upstream rather than dropping them"
         ),
-        drift!(
+        checked!(
             s::website::rollback::v0_1::Payload,
             s::website::rollback::v0_1::Response,
-            Side::Response,
             // The generation is a path segment, typed `u32` there and
-            // `string` in the spec (routes/website/generations.rs:43).
+            // `string` in the spec — a separate, unfixed mismatch.
             json!({ "generation": "1" }),
-            json!({}),
-            "no response body: the handler returns 200 with zero bytes where \
-             the spec requires `{generation, current, noop}`. It even \
-             computes `noop` (the `from != gen_num` guard that decides \
-             whether to write an audit event) and then discards it. Fix here"
+            // `RollbackResponse` — 200 with zero bytes until #1059, which
+            // discarded a `noop` it had already computed.
+            json!({ "generation": "1", "current": true, "noop": false })
         ),
     ]
 }

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -328,7 +328,9 @@ async fn list_removed_returns_tombstoned_members_and_purge_deletes_them() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    let removed = body.as_array().unwrap();
+    // `{removed: [...]}` since #1059 — the handler returned a bare array
+    // until the witness compared it with its published schema.
+    let removed = body["removed"].as_array().unwrap();
     assert_eq!(removed.len(), 1);
     assert_eq!(removed[0]["did"], "did:key:zGone");
     assert_eq!(removed[0]["status"], "removed");
@@ -355,7 +357,7 @@ async fn list_removed_returns_tombstoned_members_and_purge_deletes_them() {
         None,
     )
     .await;
-    assert!(body.as_array().unwrap().is_empty());
+    assert!(body["removed"].as_array().unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Third batch of the 33, applying the standing direction — **build to spec, not
to what has been built.** Drift **31 → 27**.

Five handlers, all the same kind of defect: each had every value its schema
asks for and replied with something narrower.

| Task | Was | Now |
|---|---|---|
| `backup/export` | bare `BackupEnvelope` | `{envelope: …}` |
| `members/removed` | top-level array | `{removed: […]}` |
| `website/files/delete` | 200, zero bytes | `{path, deleted}` |
| `website/rollback` | 200, zero bytes | `{generation, current, noop}` |
| `endorsements/revoke` | `{id}` | `{endorsementId, revocation: {credentialId, revokedAt}, statusListIndex}` |

`endorsements/revoke` is the one worth looking at: all four members were in
hand. The handler bound `updated` and threw it away with `let _ = updated;`
one line before replying. The idempotent no-op path now answers with the same
shape, reading the timestamp already on the row rather than inventing one.

## Two things the witness taught me that reading would not have

**`website/rollback` types `current` as a boolean and `generation` as a
string.** `current` answers *"did the rollback take"*, not *"which generation is
live"* — I wrote it as the generation number, twice, and the sweep rejected
both. The string typing matches the path segment the spec declares. I would
have shipped an integer called `current` and been confident about it.

**`website/generations/list` is not envelope-only, and its own entry said it
was.** The missing wrapper is fixed here, but the rows diverge too: the spec's
row carries `generation` and `current`, while the service sends `isCurrent` and
adds `deployedAt` and `sizeBytes`. It stays a drift entry with the diagnosis
corrected — one rename belongs here, and two members worth having belong
upstream rather than being dropped.

So one of the 33 notes was wrong about its own shape. Worth knowing when
reading the rest of the table.

## A limit worth restating

The witness compares a **hand-transcribed fixture** with its schema. It proves
the fixture conforms; it does not prove the handler emits the fixture. That is
the transcription gap #1076 documented as its own mutation #6.

The integration tests are the other half, and they did their job — `members_crud`
read the removed list as a bare array in two places and failed until updated.

## Verified

- `cargo test -p vtc-service` — 53 suites, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## Breaking

`POST /v1/backup/export`, `GET /v1/members/removed`,
`DELETE /v1/website/files/{path}`, `POST /v1/website/rollback/{gen}` and
`DELETE /v1/credentials/endorsements/{id}` return the shapes their published
schemas declare. Every one was previously returning something the schema did
not describe.

## What is left

**27.** The remaining `HERE` entry is `auth/admin_session`, which returns 204
and puts its result in two `Set-Cookie` headers where the spec requires
`{sessionId, expiresAt}` — a real behaviour change for the admin SPA, so it
wants its own PR rather than riding along here.

After that the set is 9 upstream (spec should change), 6 mixed, 2 design
questions on the install-claim flow, and 6 I have not classified yet.
