### PR TITLE
fix(mcp): look the pnm session up under the key pnm actually writes

### DIFF
--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -63,6 +63,9 @@ Two modes:
   ```bash
   vta-mcp --vta <slug>          # slug = the VTA you logged into with `pnm`
   ```
+  The slug is the name from `pnm vta list`, not the keyring key: `pnm` stores
+  sessions as `vta:<slug>` and `vta_sdk::agent_connect::pnm_session_key` adds
+  that prefix. Passing an already-prefixed value also works.
   Options: `--service-name` (default `pnm-cli`), `--sessions-dir` (default
   `~/.config/pnm`), `--url` (override the resolved REST URL). All have `VTA_MCP_*`
   env equivalents.

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use clap::Parser;
 use rmcp::ServiceExt;
 use rmcp::transport::stdio;
-use vta_sdk::agent_connect::AgentConnect;
+use vta_sdk::agent_connect::{AgentConnect, pnm_session_key};
 use vta_sdk::agent_session::{AgentConfig, AgentSession};
 use vta_sdk::client::VtaClient;
 use vta_sdk::session::TransportChoice;
@@ -193,7 +193,9 @@ fn agent_connect_from(args: &Args) -> AgentConnect {
         mediator_did: args.mediator_did.clone(),
         url: args.url.clone(),
         token: std::env::var("VTA_TOKEN").ok(),
-        session_key: args.vta.clone(),
+        // `pnm` stores sessions as `vta:<slug>`; the bare slug an operator
+        // types finds nothing. See `pnm_session_key`.
+        session_key: args.vta.as_deref().map(pnm_session_key),
         service_name: Some(args.service_name.clone()),
         sessions_dir: args.sessions_dir.clone(),
         transport: TransportChoice::Auto,
@@ -275,7 +277,9 @@ mod tests {
         assert_eq!(
             connect.mode().unwrap(),
             ConnectMode::Session {
-                key: "my-vta".into()
+                // Not "my-vta": `pnm` stores it as `vta:my-vta`, and passing
+                // the bare slug found no session at all.
+                key: "vta:my-vta".into()
             }
         );
     }

--- a/vta-sdk/src/agent_connect.rs
+++ b/vta-sdk/src/agent_connect.rs
@@ -57,6 +57,38 @@ use crate::session::{SessionStore, TransportChoice};
 /// Default service name the `pnm` CLI stores its sessions under.
 pub const DEFAULT_SERVICE_NAME: &str = "pnm-cli";
 
+/// Prefix `pnm` stores its VTA sessions under. `cnm` uses `community:` for the
+/// same reason; neither session backend adds one for you.
+const PNM_SESSION_PREFIX: &str = "vta:";
+
+/// The keyring key a `pnm` login is stored under, given the VTA's local name.
+///
+/// `pnm` writes every session as **`vta:<slug>`** — see `vta_keyring_key` in
+/// `pnm-cli/src/config.rs` — and neither the keyring nor the file backend
+/// prefixes anything on the way in or out. So a bridge that passes the bare
+/// slug an operator typed finds no session at all and reports an
+/// *authentication* failure to somebody who is authenticated. That failure mode
+/// is worth naming because it is indistinguishable, from the operator's side,
+/// from an expired login: they run `pnm auth status`, are told they are fine,
+/// and are none the wiser.
+///
+/// Idempotent — a value already carrying the prefix is returned unchanged, so
+/// an operator who worked the bug out for themselves and passes `vta:mine`
+/// keeps working.
+///
+/// ```
+/// # use vta_sdk::agent_connect::pnm_session_key;
+/// assert_eq!(pnm_session_key("mine"), "vta:mine");
+/// assert_eq!(pnm_session_key("vta:mine"), "vta:mine");
+/// ```
+pub fn pnm_session_key(slug: &str) -> String {
+    if slug.starts_with(PNM_SESSION_PREFIX) {
+        slug.to_string()
+    } else {
+        format!("{PNM_SESSION_PREFIX}{slug}")
+    }
+}
+
 /// Which rung of the ladder a configuration selects. Resolved by
 /// [`AgentConnect::mode`] *before* any network call, so a bridge can log the
 /// mode (and refuse a mode it doesn't support) without connecting first.
@@ -512,6 +544,15 @@ mod tests {
         let bundle = load_bundle(path.to_str().unwrap()).unwrap();
         assert_eq!(bundle.did, "did:webvh:f:example.com:b");
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn pnm_session_keys_carry_the_prefix_and_are_idempotent() {
+        assert_eq!(pnm_session_key("mine"), "vta:mine");
+        assert_eq!(pnm_session_key("vta:mine"), "vta:mine");
+        // A community key is `cnm`'s business, not this function's — it must
+        // not be mistaken for an already-prefixed VTA key.
+        assert_eq!(pnm_session_key("community:acme"), "vta:community:acme");
     }
 
     #[test]


### PR DESCRIPTION
`vta-mcp --vta <slug>` — the invocation its own README documents — could never find a session.

`pnm` stores every login under the keyring key **`vta:<slug>`** (`vta_keyring_key` in `pnm-cli/src/config.rs`); `cnm` uses `community:<slug>` for the same reason. Neither session backend adds a prefix on the way in or out — `keyring.rs` passes the key straight to `Entry::new`, `file.rs` uses it verbatim as a map key. `vta-mcp` passed the **bare slug**, so the lookup missed.

**The operator sees an authentication failure.** That is the part worth fixing rather than documenting around: it is indistinguishable, from their side, from an expired login. They run `pnm auth status`, are told they are fine, and are none the wiser.

## The fix

One definition of the rule — `vta_sdk::agent_connect::pnm_session_key` — placed next to the connect ladder both agent-side bridges already share. It is idempotent, so an operator who worked the bug out for themselves and passes `vta:mine` keeps working.

## How it surfaced

Building a second consumer of `agent_connect` (an agent-memory service) hit exactly this, which is also why the helper belongs in the SDK rather than in either bridge: there are now two callers and the rule is `pnm`'s, not theirs.

## Testing

`cargo test -p vta-sdk --lib agent_connect` — 11 pass, one new covering the prefix, idempotency, and that a `community:` key is not mistaken for an already-prefixed VTA key. `cargo test -p vta-mcp` — 5 pass; the session-mode test now pins `vta:my-vta`. Clippy clean on both. README corrected.