### PR TITLE
feat(vtc): let a community vet a member in person and have it count as personhood evidence

### DIFF
--- a/docs/03-vtc/personhood-and-graph.md
+++ b/docs/03-vtc/personhood-and-graph.md
@@ -2,9 +2,13 @@
 
 The VTC ships two member-graph features in Phase 4:
 
-- **Personhood** — an admin/issuer asserts that a member is a
-  unique human (or human-equivalent agent), backed by witness
-  evidence the operator's `personhood.rego` accepts.
+- **Personhood** — a member asserts that they are a human, backed by
+  evidence the operator's `personhood.rego` accepts: a third party's
+  witness credential, or an identity verification this community
+  performed in person. The flag lands as a `PersonhoodCredential` type
+  on the member's VMC, which is what DTG Credentials means by a PHC —
+  read [What this does and does not establish](#what-this-does-and-does-not-establish)
+  before relying on it as one.
 - **VRC graph** — members self-issue Verifiable Relationship
   Credentials declaring trust edges to other members, forming a
   community-internal trust graph.
@@ -39,14 +43,15 @@ sequenceDiagram
 
     A->>VTC: POST /v1/members/{did}/personhood/challenge
     VTC->>VTC: Store nonce in passkey_ks<br/>(10-min TTL, single-use)
-    VTC-->>A: { challenge, expiresAt }
-    A->>M: Out-of-band — share nonce
+    VTC-->>A: { challengeId, expiresAt,<br/>ext: { match-code } }
+    A->>M: Out-of-band — share challengeId
+    Note over A,M: Both derive the same 8-char code<br/>from challengeId and say it aloud
     M->>M: Assemble VP with<br/>witness credentials
     M->>VTC: POST /v1/members/{did}/personhood/assert<br/>(VP, includes challenge nonce)
     VTC->>VTC: 1) Load Member row (404 if missing)
     VTC->>VTC: 2) Consume challenge<br/>(400 on missing/expired/wrong-DID)
     VTC->>VTC: 3) Verify VP.holder == path-DID
-    VTC->>VTC: 4) Evaluate personhood.rego<br/>(WitnessCredential check by default)
+    VTC->>VTC: 4) Evaluate personhood.rego<br/>(default: WitnessCredential, or this<br/>community's own IdentityVerification)
     alt policy allows
         VTC->>VTC: Set personhood=true<br/>Set asserted_at=now
         VTC->>VTC: Re-mint VMC with new flag
@@ -62,6 +67,100 @@ Verifiable Presentation. The handler verifies the VP and discards
 it — no `personhood_evidence` JSON field, no separate signed-blob
 shape. The verify-then-discard semantics keep PII out of the
 request log.
+
+### In-person vetting
+
+The default policy accepts a second evidence shape: an
+`IdentityVerification` endorsement **this community issued to this
+member**. That is the in-person ceremony — an administrator meets the
+person, satisfies themselves that the DID they present is theirs, and
+issues the record to that DID. The member later presents it over a
+single-use challenge, and the community's own signature is the evidence.
+
+It needs no new Trust Task and no new credential type. DTG Credentials
+§Identity Verification Credentials defines an IDVC as *"any W3C VC
+satisfying a VTC/VTN's identity-proofing requirements"* and explicitly
+**not** a `DTGCredential` subtype, so a community acting as its own
+identity-verification provider is the simplest case of that. Issuing it
+through the endorsement surface means it is revocable through the
+community's existing status list, like every other endorsement.
+
+**One-time setup** — register the type:
+
+```bash
+# vtc/endorsement-types/register/0.1
+POST /v1/endorsement-types  { "typeUri": "IdentityVerification" }
+```
+
+**Per member** — after meeting them:
+
+```bash
+# vtc/endorsements/issue/0.1
+POST /v1/endorsements
+{
+  "subjectDid": "did:key:zMember...",
+  "type": "IdentityVerification",
+  "claim": { "method": "in-person-id", "verifiedBy": "did:key:zAdmin..." }
+}
+```
+
+The member then runs the normal challenge + assert flow, presenting that
+credential. Three bindings have to hold, and each is enforced by the
+default policy:
+
+| Binding | Why it is there |
+|---|---|
+| `issuer` == this community's DID | An endorsement type is a *name*, not an authority. Without this, any issuer anywhere could mint `IdentityVerification` and unlock personhood here. |
+| `credentialSubject.id` == the asserting member | The route's holder-match binds the *presenter*; this binds the *credential*, so a member cannot present a vetting record about someone else. |
+| `endorsement.type` == `IdentityVerification` | A role VEC is also community-issued and also names the member. Without the type check, every member holding a role credential would satisfy the policy — which is every member. |
+
+#### The spoken match code
+
+`challengeId` is a UUID: fine on a wire, hopeless read aloud. The
+challenge response therefore also carries an eight-character code under
+`ext["org.openvtc.match-code"]`:
+
+```json
+{
+  "challengeId": "6f1c4f9e-7c2a-4f4b-9a3e-2b1d0c5e8a77",
+  "expiresAt": "2026-08-24T10:15:00Z",
+  "ext": { "org.openvtc.match-code": "7F4K-2QX9" }
+}
+```
+
+It is **derived from the challenge id** (`SHA-256`, Crockford base32 —
+no `I`, `L`, `O` or `U`, so nothing in it is mishearable), never
+transmitted as an independent secret and never accepted as one. Both
+parties compute it from the `challengeId` they already hold and say it
+to each other; nothing checks it server-side, because there is nothing
+it could prove that `proof.challenge` does not already prove. It is a
+confirmation channel — a Bluetooth pairing code, not a password.
+
+The code rides in `ext` rather than as a top-level field because
+`vtc/members/personhood/challenge/0.1`'s response schema is
+`additionalProperties: false`; `ext` is what the framework reserves for
+ecosystem-defined members (SPEC §4.5.1), and its key pattern is why the
+member is `match-code` and not `matchCode`.
+
+#### What this does and does not establish
+
+DTG Credentials §Personhood Credentials requires governance enforcing
+**both** real human personhood **and exactly one membership per
+person**. In-person vetting is evidence for the first only.
+
+**The VTC does not enforce uniqueness.** Nothing stops one human joining
+twice under two DIDs and being vetted twice, and no credential presented
+by its own subject could demonstrate otherwise. A community whose
+governance depends on one-person-one-membership needs a policy that
+consults evidence from an issuer who actually checks that — a national
+eID, an existing PHC from a network that enforces it — and should treat
+the default policy as a starting point, not a personhood regime.
+
+Note also that the spec locates PHC status in **governance and trust
+registries, not in credential structure**: the `PersonhoodCredential`
+type this daemon adds to a vetted member's VMC is described there as a
+*non-authoritative hint*. A verifier following the spec reads the
+community's governance, not the type array.
 
 ### Revocation
 

--- a/docs/03-vtc/personhood-and-graph.md
+++ b/docs/03-vtc/personhood-and-graph.md
@@ -96,13 +96,20 @@ POST /v1/endorsement-types  { "typeUri": "IdentityVerification" }
 
 ```bash
 # vtc/endorsements/issue/0.1
-POST /v1/endorsements
+POST /v1/credentials/endorsements
 {
   "subjectDid": "did:key:zMember...",
   "type": "IdentityVerification",
   "claim": { "method": "in-person-id", "verifiedBy": "did:key:zAdmin..." }
 }
 ```
+
+The `claim` body is free-form and opaque to the policy — the default
+rule reads only the endorsement's `type`, its issuer and its subject, so
+what an operator records about *how* they verified is theirs to decide.
+Issuance is admin-or-issuer gated and consumes a revocation status-list
+slot, so withdrawing a vetting later is a `DELETE` on the endorsement
+rather than anything personhood-specific.
 
 The member then runs the normal challenge + assert flow, presenting that
 credential. Three bindings have to hold, and each is enforced by the

--- a/vtc-service/policies/default/personhood.rego
+++ b/vtc-service/policies/default/personhood.rego
@@ -7,12 +7,20 @@
 #
 # ## Minimal-allow semantics
 #
-# The policy returns `allow == true` when the applicant's VP
-# carries at least one `WitnessCredential` from a non-empty
-# issuer. This is intentionally permissive — operators with
-# stricter requirements upload a custom rego. The default lets
-# the workspace's integration tests exercise the assert flow
-# without operator setup.
+# The policy returns `allow == true` on either of two evidence
+# shapes:
+#
+#   - a `WitnessCredential` from a non-empty issuer — a third
+#     party vouching for the applicant; or
+#   - an `IdentityVerification` endorsement **this community
+#     itself issued to this applicant** — the in-person vetting
+#     ceremony, where an administrator met the person and issued
+#     the record to the DID they presented.
+#
+# Both are intentionally permissive — operators with stricter
+# requirements upload a custom rego. The default lets the
+# workspace's integration tests exercise the assert flow without
+# operator setup.
 #
 # ## Input shape
 #
@@ -21,6 +29,7 @@
 # 1. **Assert endpoint** (M4.3):
 #    {
 #      "applicant_did": "<member-did>",
+#      "community_did": "<this community's C-DID>",
 #      "vp_claims": {
 #        "holder": "<member-did>",
 #        "credentials": [ { "type": [...], "issuer": "<did>", ... }, ... ]
@@ -30,6 +39,7 @@
 # 2. **Renewal-time re-evaluation** (M4.2.2):
 #    {
 #      "applicant_did": "<did>",
+#      "community_did": "<this community's C-DID>",
 #      "current_personhood": <bool>,
 #      "asserted_at_seconds_ago": <int | null>,
 #      "vp_claims": { "holder": "<did>", "credentials": [] }
@@ -60,6 +70,56 @@ allow if {
 	cred := input.vp_claims.credentials[i]
 	"WitnessCredential" in cred.type
 	cred.issuer != ""
+}
+
+# ── In-person vetting by this community ────────────────────
+
+# Allow when the applicant presents an endorsement **this community
+# itself issued** recording that a human verified their identity.
+#
+# This is the in-person ceremony: an administrator meets the person,
+# satisfies themselves the DID in front of them is theirs, and issues
+# an identity-verification endorsement to that DID
+# (`vtc/endorsements/issue/0.1`). The member later presents it here,
+# over a single-use challenge, and the community's own signature on the
+# credential is the evidence.
+#
+# Three conditions, and each one is load-bearing:
+#
+#   1. `issuer == input.community_did` — otherwise any issuer anywhere
+#      could mint a credential whose endorsement type happens to read
+#      `IdentityVerification` and unlock personhood in this community.
+#      The endorsement type is a *name*, not an authority.
+#   2. `credentialSubject.id == input.applicant_did` — the credential
+#      names the party asserting, not somebody else. The route's
+#      holder-match already binds the presenter; this binds the
+#      credential, so a member cannot present a vetting record issued
+#      about another member.
+#   3. the endorsement type is the identity-verification one — a role
+#      VEC is also community-issued and also names the member, and must
+#      not double as proof that someone met them.
+#
+# DTG Credentials §Identity Verification Credentials puts this squarely
+# in scope: "IDVCs are **not** DTGCredential subtypes — any W3C VC
+# satisfying a VTC/VTN's identity-proofing requirements". A community
+# acting as its own identity-verification provider is the simplest case
+# of that, and it needs no new credential type and no new Trust Task.
+#
+# Note what this rule does **not** establish. DTG Credentials
+# §Personhood Credentials requires governance enforcing *both* real
+# human personhood *and* exactly one membership per person. This rule
+# is evidence for the first only; uniqueness is not something a
+# credential presented by its own subject can demonstrate, and this
+# daemon does not enforce it. A community whose governance depends on
+# one-membership-per-person needs a rule that consults evidence from an
+# issuer who checks that — see `docs/03-vtc/personhood-and-graph.md`.
+allow if {
+	some i
+	cred := input.vp_claims.credentials[i]
+	"EndorsementCredential" in cred.type
+	cred.issuer == input.community_did
+	cred.credentialSubject.id == input.applicant_did
+	cred.credentialSubject.endorsement.type == "IdentityVerification"
 }
 
 # ── Renewal-time re-eval (preserve existing assertion) ─────

--- a/vtc-service/src/endorsement_types/mod.rs
+++ b/vtc-service/src/endorsement_types/mod.rs
@@ -34,6 +34,29 @@ pub use storage::{
 /// across the reservation boundary aren't broken).
 pub const RESERVED_TYPE_URIS: &[&str] = &["CommunityRole"];
 
+/// The endorsement type the default `personhood.rego` accepts as
+/// in-person vetting evidence.
+///
+/// Deliberately **not** in [`RESERVED_TYPE_URIS`]. Reserved means
+/// "operators may not register this", and the whole flow depends on an
+/// operator registering it: `vtc/endorsement-types/register/0.1` first,
+/// then `vtc/endorsements/issue/0.1` to each vetted member. Reserving it
+/// would make the issuance path refuse the very credential the policy
+/// looks for.
+///
+/// It is a constant here so the Rust side, the default policy module and
+/// the operator docs cannot drift apart — the failure mode of a
+/// mismatched string is a community that vets members correctly and then
+/// denies every assertion, with nothing in the logs naming the typo.
+/// [`crate::policy::default`]'s tests pin the two together.
+///
+/// The name is the DTG spec's, not ours: §Identity Verification
+/// Credentials defines an IDVC as any W3C VC meeting a community's
+/// identity-proofing requirements, explicitly *not* a `DTGCredential`
+/// subtype. Issuing it as an endorsement keeps it a plain W3C VC that
+/// happens to be revocable through the community's existing status list.
+pub const IDENTITY_VERIFICATION_TYPE_URI: &str = "IdentityVerification";
+
 /// A registered endorsement type. Stored verbatim; the
 /// registrar route enforces validation at insert time.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/vtc-service/src/members/match_code.rs
+++ b/vtc-service/src/members/match_code.rs
@@ -1,0 +1,178 @@
+//! Human-readable match code for the personhood challenge.
+//!
+//! ## Why this exists
+//!
+//! The personhood ceremony's security comes from two bindings the
+//! published Trust Task spells out (`vtc/members/personhood/assert/0.1`,
+//! §Authorization): the presentation's `holder` equals the DID being
+//! asserted, and its `proof.challenge` equals the paired `challengeId`.
+//! Neither is negotiable, and `challengeId` is a UUID — 36 characters,
+//! which is fine over a wire and hopeless read aloud.
+//!
+//! The in-person ceremony an operator actually wants is: two people in a
+//! room, one of them holding the admin session, confirming out loud that
+//! the challenge the member's device is about to sign is the challenge
+//! the admin just minted. That is a *confirmation* channel, not a
+//! transfer channel — the same shape as a Bluetooth pairing code or a
+//! Signal safety number.
+//!
+//! So the match code is **derived from the challenge id**, never
+//! transmitted as an independent secret and never accepted as one. Any
+//! party already holding the `challengeId` computes the same eight
+//! characters; a party who does not hold it cannot. Nothing verifies the
+//! match code server-side, because there is nothing it could prove that
+//! `proof.challenge` does not already prove — reading it aloud is how
+//! two humans check they are talking about the same ceremony.
+//!
+//! ## Construction
+//!
+//! ```text
+//! SHA-256(DOMAIN_TAG || challenge_id_bytes) -> first 40 bits
+//!   -> Crockford base32 -> 8 chars -> "XXXX-XXXX"
+//! ```
+//!
+//! Crockford's alphabet omits `I`, `L`, `O` and `U`, so the code has no
+//! character pair a person can mishear or mistranscribe into another
+//! valid code. 40 bits over 8 characters is exactly the alphabet's
+//! capacity — see the test module, which pins the bit budget because an
+//! encoding change that quietly narrowed it would weaken the
+//! confirmation without failing anything else.
+
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+/// Domain separation for the match-code derivation. A code derived here
+/// must never collide with a digest computed for any other purpose over
+/// the same challenge id.
+const DOMAIN_TAG: &[u8] = b"vtc-personhood-match/v1\0";
+
+/// `ext` member the code travels in.
+///
+/// `vtc/members/personhood/challenge/0.1`'s response schema is
+/// `additionalProperties: false`, so a new top-level field would put the
+/// daemon out of conformance with its own published Trust Task. `ext` is
+/// exactly what the framework reserves for ecosystem-defined members
+/// (SPEC §4.5.1), and its `propertyNames` pattern requires a reverse-DNS
+/// key in lowercase — which is why this is `match-code` and not
+/// `matchCode`. Same convention as
+/// [`crate::routes::policies::read::PURPOSE_EXT_KEY`].
+pub const MATCH_CODE_EXT_KEY: &str = "org.openvtc.match-code";
+
+/// Crockford base32 — no `I`, `L`, `O`, `U`.
+const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/// Characters in the code, excluding the separator.
+const CODE_CHARS: usize = 8;
+
+/// Bits consumed from the digest. `CODE_CHARS * 5` — the exact capacity
+/// of eight base32 characters. Pinned by a test.
+const CODE_BITS: usize = CODE_CHARS * 5;
+
+/// Derive the display code for a challenge id, formatted `XXXX-XXXX`.
+///
+/// Deterministic: the admin's session and the member's client both
+/// compute it from the `challengeId` they each already hold, and compare
+/// out loud. No state, no round trip.
+pub fn derive(challenge_id: Uuid) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(DOMAIN_TAG);
+    hasher.update(challenge_id.as_bytes());
+    let digest = hasher.finalize();
+
+    // Take CODE_BITS off the front of the digest, most-significant first,
+    // five at a time. Reading bit-by-bit out of the leading bytes keeps
+    // the mapping independent of `usize` width and of how many bytes we
+    // happen to need.
+    let mut out = String::with_capacity(CODE_CHARS + 1);
+    for (i, bit_offset) in (0..CODE_BITS).step_by(5).enumerate() {
+        let mut idx = 0u8;
+        for bit in 0..5 {
+            let abs = bit_offset + bit;
+            let byte = digest[abs / 8];
+            let taken = (byte >> (7 - (abs % 8))) & 1;
+            idx = (idx << 1) | taken;
+        }
+        if i == 4 {
+            out.push('-');
+        }
+        out.push(CROCKFORD[idx as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The code is a pure function of the challenge id — that is the
+    /// whole mechanism. If this ever stops holding, the admin and the
+    /// member stop seeing the same eight characters and the ceremony
+    /// silently loses its confirmation step without failing anything.
+    #[test]
+    fn derivation_is_deterministic() {
+        let id = Uuid::parse_str("6f1c4f9e-7c2a-4f4b-9a3e-2b1d0c5e8a77").expect("uuid");
+        assert_eq!(derive(id), derive(id));
+    }
+
+    /// Shape a human reads aloud: `XXXX-XXXX`, all characters from
+    /// Crockford's alphabet.
+    #[test]
+    fn shape_is_four_dash_four_from_crockford() {
+        let code = derive(Uuid::new_v4());
+        assert_eq!(code.len(), CODE_CHARS + 1, "code is 8 chars plus separator");
+        assert_eq!(code.as_bytes()[4], b'-', "separator sits in the middle");
+        for c in code.bytes().filter(|c| *c != b'-') {
+            assert!(
+                CROCKFORD.contains(&c),
+                "character {} is outside Crockford's alphabet",
+                c as char
+            );
+        }
+    }
+
+    /// The alphabet must exclude the four characters Crockford drops.
+    /// Re-introducing `I`, `L`, `O` or `U` would put a mishearable pair
+    /// into a code whose entire job is being said out loud correctly.
+    #[test]
+    fn alphabet_omits_mishearable_characters() {
+        for c in *b"ILOU" {
+            assert!(
+                !CROCKFORD.contains(&c),
+                "Crockford omits {} — it is confusable when spoken",
+                c as char
+            );
+        }
+        assert_eq!(CROCKFORD.len(), 32, "base32 needs exactly 32 symbols");
+    }
+
+    /// Pin the bit budget. Eight base32 characters carry 40 bits and the
+    /// derivation must consume all of them — an encoding change that
+    /// narrowed the input (say, hex-then-truncate, which yields 4 bits a
+    /// character) would still produce eight plausible characters while
+    /// quietly halving the space a mismatch has to fall into.
+    #[test]
+    fn bit_budget_is_fully_consumed() {
+        assert_eq!(CODE_BITS, 40, "8 chars x 5 bits");
+        const {
+            assert!(
+                CODE_BITS <= 256,
+                "cannot draw more bits than SHA-256 produces"
+            )
+        };
+    }
+
+    /// Distinct challenges yield distinct codes in practice. Not a
+    /// collision proof — 40 bits is a confirmation channel, not a key —
+    /// but a sweep this size catches a derivation that has collapsed to
+    /// a constant or is reading a fixed slice of the digest.
+    #[test]
+    fn distinct_challenges_yield_distinct_codes() {
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..2_000 {
+            assert!(
+                seen.insert(derive(Uuid::new_v4())),
+                "collision across 2k samples means the derivation lost entropy"
+            );
+        }
+    }
+}

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -27,6 +27,7 @@
 //! call site.
 
 pub mod inbound_vmc;
+pub mod match_code;
 pub mod storage;
 
 use chrono::{DateTime, Utc};

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -881,6 +881,261 @@ mod tests {
         );
     }
 
+    /// Build the in-person vetting evidence: an endorsement the
+    /// community issued to the applicant recording that a human verified
+    /// their identity. Parameterised on issuer / subject / type so each
+    /// test below can break exactly one of the three bindings.
+    fn vetting_input(issuer: &str, subject: &str, endorsement_type: &str) -> serde_json::Value {
+        json!({
+            "applicant_did": "did:key:zApplicant",
+            "community_did": "did:webvh:community.example",
+            "vp_claims": {
+                "holder": "did:key:zApplicant",
+                "credentials": [
+                    {
+                        "type": ["VerifiableCredential", "EndorsementCredential"],
+                        "issuer": issuer,
+                        "credentialSubject": {
+                            "id": subject,
+                            "endorsement": {
+                                "type": endorsement_type,
+                                "communityDid": "did:webvh:community.example"
+                            }
+                        }
+                    }
+                ]
+            }
+        })
+    }
+
+    /// The happy path for the in-person ceremony: the admin met the
+    /// person, issued them an identity-verification endorsement, and the
+    /// member presents it over a challenge.
+    #[test]
+    fn personhood_default_allows_community_issued_identity_verification() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            vetting_input(
+                "did:webvh:community.example",
+                "did:key:zApplicant",
+                crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI,
+            ),
+        )
+        .unwrap();
+        assert!(
+            pluck_bool(&r),
+            "this community's own identity-verification endorsement must allow"
+        );
+    }
+
+    /// The binding that matters most. An endorsement type is a *name*,
+    /// and names are not authority — without the issuer comparison, any
+    /// issuer anywhere could mint `IdentityVerification` and unlock
+    /// personhood in a community that never met the applicant.
+    #[test]
+    fn personhood_default_denies_identity_verification_from_foreign_issuer() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            vetting_input(
+                "did:webvh:someone-else.example",
+                "did:key:zApplicant",
+                crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI,
+            ),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "an identity-verification endorsement from another issuer must not allow"
+        );
+    }
+
+    /// The credential must name the party asserting. The route's
+    /// holder-match binds the presenter; this binds the credential, so a
+    /// member cannot present the vetting record of a different member.
+    #[test]
+    fn personhood_default_denies_identity_verification_about_someone_else() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            vetting_input(
+                "did:webvh:community.example",
+                "did:key:zSomebodyElse",
+                crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI,
+            ),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "a vetting record about another member must not allow"
+        );
+    }
+
+    /// A role VEC is community-issued and names the member too. If the
+    /// type check were dropped, every member holding a role credential
+    /// would satisfy the personhood policy — which is every member.
+    #[test]
+    fn personhood_default_denies_community_issued_role_endorsement() {
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            vetting_input(
+                "did:webvh:community.example",
+                "did:key:zApplicant",
+                "CommunityRole",
+            ),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "a role grant must not double as evidence that someone was met in person"
+        );
+    }
+
+    /// The seam that no other test crosses: a credential the **real
+    /// builder** signed, projected by the **real extractor**, judged by
+    /// the **real policy**.
+    ///
+    /// Every other test here hand-writes the `vp_claims` JSON, which
+    /// means they all agree with each other about a shape none of them
+    /// obtained from the code that actually produces it. If
+    /// `build_custom_endorsement` ever moved `endorsement` out of
+    /// `credentialSubject`, or `extract_vp_claims` stopped copying
+    /// `credentialSubject` verbatim, those tests would keep passing and
+    /// every in-person vetting in production would be denied — with a
+    /// `personhood-policy-denied` and nothing naming the cause.
+    #[tokio::test]
+    async fn real_endorsement_credential_satisfies_the_vetting_rule() {
+        use crate::credentials::{
+            CredentialStatusRef, CustomEndorsementParams, LocalSigner, build_custom_endorsement,
+        };
+        use crate::policy::extract::extract_vp_claims;
+
+        const COMMUNITY_DID: &str = "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG";
+        const APPLICANT_DID: &str = "did:key:zApplicant";
+
+        let signer = LocalSigner::from_ed25519_seed(COMMUNITY_DID.into(), &[7u8; 32]);
+        let vc = build_custom_endorsement(
+            &signer,
+            CustomEndorsementParams::new(
+                APPLICANT_DID,
+                crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI,
+                json!({ "method": "in-person-id", "verifiedBy": "did:key:zAdmin" }),
+                CredentialStatusRef::revocation(
+                    "https://vtc.example.com/v1/status-lists/revocation",
+                    4,
+                ),
+            ),
+        )
+        .await
+        .expect("build identity-verification endorsement");
+
+        // Wrap it the way a member's client would, then project it the
+        // way the assert route does.
+        let vp = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiablePresentation"],
+            "holder": APPLICANT_DID,
+            "verifiableCredential": [serde_json::to_value(&vc).expect("vc -> json")],
+        });
+        let vp_claims = extract_vp_claims(&vp);
+
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": APPLICANT_DID,
+                "community_did": COMMUNITY_DID,
+                "vp_claims": vp_claims,
+            }),
+        )
+        .unwrap();
+        assert!(
+            pluck_bool(&r),
+            "a real community-signed identity-verification endorsement must satisfy \
+             the default personhood policy; builder and policy have drifted"
+        );
+    }
+
+    /// The same real credential, judged against a *different* community.
+    /// Pairs with the test above: it proves the issuer comparison is
+    /// doing work on the real shape, not just on hand-written JSON where
+    /// `issuer` might be a string in one place and an object in another.
+    #[tokio::test]
+    async fn real_endorsement_credential_is_rejected_by_another_community() {
+        use crate::credentials::{
+            CredentialStatusRef, CustomEndorsementParams, LocalSigner, build_custom_endorsement,
+        };
+        use crate::policy::extract::extract_vp_claims;
+
+        const ISSUING_COMMUNITY: &str = "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG";
+        const APPLICANT_DID: &str = "did:key:zApplicant";
+
+        let signer = LocalSigner::from_ed25519_seed(ISSUING_COMMUNITY.into(), &[7u8; 32]);
+        let vc = build_custom_endorsement(
+            &signer,
+            CustomEndorsementParams::new(
+                APPLICANT_DID,
+                crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI,
+                json!({ "method": "in-person-id" }),
+                CredentialStatusRef::revocation(
+                    "https://other.example.com/v1/status-lists/revocation",
+                    1,
+                ),
+            ),
+        )
+        .await
+        .expect("build identity-verification endorsement");
+
+        let vp = json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiablePresentation"],
+            "holder": APPLICANT_DID,
+            "verifiableCredential": [serde_json::to_value(&vc).expect("vc -> json")],
+        });
+
+        let c = compile_default(PolicyPurpose::Personhood);
+        let r = evaluate(
+            &c,
+            "data.vtc.personhood.allow",
+            json!({
+                "applicant_did": APPLICANT_DID,
+                // A different community is doing the evaluating.
+                "community_did": "did:key:zSomeOtherCommunity",
+                "vp_claims": extract_vp_claims(&vp),
+            }),
+        )
+        .unwrap();
+        assert!(
+            !pluck_bool(&r),
+            "one community's vetting must not confer personhood in another"
+        );
+    }
+
+    /// The policy module and the Rust constant name the same type. A
+    /// mismatch here is silent in the worst way: vetting succeeds, the
+    /// credential is issued, and every assertion is then denied with
+    /// nothing in the logs naming the typo.
+    #[test]
+    fn personhood_rego_and_rust_agree_on_the_vetting_type_uri() {
+        let source = super::default_source(PolicyPurpose::Personhood);
+        let expected = format!(
+            "cred.credentialSubject.endorsement.type == \"{}\"",
+            crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI
+        );
+        assert!(
+            source.contains(&expected),
+            "personhood.rego must match on {}; the constant and the module have drifted",
+            crate::endorsement_types::IDENTITY_VERIFICATION_TYPE_URI
+        );
+    }
+
     #[test]
     fn personhood_default_preserves_current_true_on_renewal() {
         // Renewal-time re-eval: when current_personhood is

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -69,7 +69,7 @@ use crate::auth::AuthClaims;
 use crate::credentials::{
     CredentialStatusRef, RoleVecParams, VmcParams, build_role_vec, build_vmc,
 };
-use crate::members::{get_member, store_member};
+use crate::members::{get_member, match_code, store_member};
 use crate::policy::{
     PolicyPurpose, compile as compile_policy, evaluate as evaluate_policy,
     extract::extract_vp_claims, get_active_policy_id, get_policy,
@@ -138,6 +138,12 @@ async fn take_challenge(
 pub struct ChallengeResponse {
     pub challenge_id: Uuid,
     pub expires_at: DateTime<Utc>,
+    /// Vendor-namespaced extension members (SPEC §4.5.1). Carries
+    /// [`match_code::MATCH_CODE_EXT_KEY`] — the eight characters the
+    /// admin and the member read to each other to confirm they are
+    /// looking at the same ceremony. See [`crate::members::match_code`]
+    /// for why the code rides here rather than as a top-level field.
+    pub ext: JsonValue,
 }
 
 /// POST /members/{did}/personhood/challenge — mint a personhood challenge.
@@ -173,9 +179,18 @@ pub async fn challenge(
     };
     store_challenge(&state, &chal).await?;
 
+    // Derived, not stored: any holder of the challenge id computes the
+    // same code, so there is nothing here to persist or to check later.
+    let code = match_code::derive(id);
+
     info!(
         member_did = %member_did,
         challenge_id = %id,
+        // The code is a function of the challenge id, which is already
+        // on this line — logging it leaks nothing further, and an
+        // operator reading the journal can see what the member was
+        // asked to confirm.
+        match_code = %code,
         "personhood challenge minted"
     );
 
@@ -184,6 +199,7 @@ pub async fn challenge(
         Json(ChallengeResponse {
             challenge_id: id,
             expires_at,
+            ext: json!({ match_code::MATCH_CODE_EXT_KEY: code }),
         }),
     ))
 }
@@ -305,7 +321,8 @@ pub async fn assert(
     let vp_claims = extract_vp_claims(&body.presentation);
 
     // 6. Run personhood.rego.
-    let allow = evaluate_personhood_assert(&state, &member_did, &vp_claims).await?;
+    let allow =
+        evaluate_personhood_assert(&state, &member_did, signer.issuer_did(), &vp_claims).await?;
     if !allow {
         return Err(AppError::Forbidden(
             "personhood-policy-denied: active personhood.rego rejected the assertion".into(),
@@ -593,9 +610,19 @@ async fn verify_vp_proof(
 /// ```
 ///
 /// Fail-closed: any error path yields `false`.
+/// Evaluate the active `personhood.rego` over the presented claims.
+///
+/// `community_did` is the DID the community signs its own credentials
+/// with. It is passed in — rather than left for the policy to hardcode —
+/// because the default policy's identity-verification rule has to
+/// distinguish "this community vetted the applicant" from "*somebody*
+/// issued a credential that says `IdentityVerification`". Without the
+/// comparison, any issuer in the world could mint the endorsement that
+/// unlocks personhood here.
 async fn evaluate_personhood_assert(
     state: &AppState,
     applicant_did: &str,
+    community_did: &str,
     vp_claims: &JsonValue,
 ) -> Result<bool, AppError> {
     let Some(id) =
@@ -610,6 +637,7 @@ async fn evaluate_personhood_assert(
     let compiled = compile_policy(&policy.rego_source, policy.id)?;
     let input = json!({
         "applicant_did": applicant_did,
+        "community_did": community_did,
         "vp_claims": vp_claims,
     });
     let result = evaluate_policy(&compiled, "data.vtc.personhood.allow", input)?;

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -297,8 +297,19 @@ async fn evaluate_personhood(
         Some(t) => json!((chrono::Utc::now() - t).num_seconds().max(0)),
         None => JsonValue::Null,
     };
+    // `community_did` is carried here too, even though renewal presents
+    // no credentials for the identity-verification rule to match. One
+    // policy module serves both call sites, so a rule that reads
+    // `input.community_did` must not become undefined — and therefore
+    // silently unsatisfiable — the moment renewal evaluates it.
+    let community_did = state
+        .credential_signer
+        .as_ref()
+        .map(|s| JsonValue::from(s.issuer_did()))
+        .unwrap_or(JsonValue::Null);
     let input = json!({
         "applicant_did": member.did,
+        "community_did": community_did,
         "current_personhood": member.personhood,
         "asserted_at_seconds_ago": asserted_at_seconds_ago,
         "vp_claims": { "holder": member.did, "credentials": [] },

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -1215,7 +1215,12 @@ fn table() -> Vec<Conformance> {
             s::members::personhood::challenge::v0_1::Response,
             json!({ "did": DID }),
             // `ChallengeResponse` — routes/members/personhood.rs:138.
-            json!({ "challengeId": REQUEST_ID, "expiresAt": TS })
+            // The `ext` member carries the spoken match code. The
+            // response schema is `additionalProperties: false`, so this
+            // witness is what proves the code found a conformant home
+            // rather than a new top-level field.
+            json!({ "challengeId": REQUEST_ID, "expiresAt": TS,
+                    "ext": { crate::members::match_code::MATCH_CODE_EXT_KEY: "7F4K-2QX9" } })
         ),
         checked!(
             s::members::personhood::assert::v0_1::Payload,


### PR DESCRIPTION
Personhood already shipped, and it already matches DTG Credentials: a PHC is a VMC, and `new_vmc(personhood: true)` appends `PersonhoodCredential` exactly as the spec's worked example shows. What was missing was the ceremony an operator actually performs — meeting someone, satisfying themselves the DID in front of them is theirs, and having that count.

The default `personhood.rego` accepted one evidence shape: a `WitnessCredential` from some third party. An administrator who did the verifying themselves had nowhere to put it.

## The community's own vetting becomes evidence

DTG Credentials §Identity Verification Credentials defines an IDVC as "any W3C VC satisfying a VTC/VTN's identity-proofing requirements" and explicitly *not* a `DTGCredential` subtype, so a community acting as its own identity-verification provider needs no new credential type. Registering `IdentityVerification` as an endorsement type and issuing it per member reuses `vtc/endorsement-types/register/0.1` and `vtc/endorsements/issue/0.1` verbatim — **no new Trust Task family**, and revocation comes free via the community's existing status list.

`vtc/members/personhood/assert/0.1` is untouched, which was the constraint worth respecting: its Authorization section is explicit that holder-equality and challenge-binding are both load-bearing and neither substitutes for the other. An admin-asserts-directly path would have had to bypass the presentation the task requires, so the vetting is evidence the member presents rather than a gate the admin steps around.

## Three bindings, each with a test that breaks exactly one

| Binding | Why |
|---|---|
| `issuer == community_did` | An endorsement type is a *name*, not an authority. Without this, any issuer anywhere could mint a credential typed `IdentityVerification` and unlock personhood here. This is why `community_did` is now in the policy input at all. |
| `credentialSubject.id == applicant_did` | The route's holder-match binds the presenter; this binds the credential, so a member cannot present a vetting record issued about somebody else. |
| the endorsement type | A role VEC is community-issued and names the member too, so without the type check every member holding a role credential satisfies the policy — which is every member. |

Two further tests run a credential from the **real builder** through the **real extractor** into the **real policy**. Every other test in that file hand-writes `vp_claims`, so they all agree about a shape none of them obtained from the code that produces it; if `build_custom_endorsement` moved `endorsement` out of `credentialSubject`, they would all keep passing while every vetting in production was denied.

## The spoken match code

`challengeId` is a UUID — fine on a wire, hopeless read aloud — so the challenge response now carries eight Crockford base32 characters derived from it (no `I`/`L`/`O`/`U`, nothing mishearable).

It is **derived**, never transmitted as an independent secret and never accepted as one: both parties compute it from the id they already hold and say it to each other. Nothing checks it server-side, because there is nothing it could prove that `proof.challenge` does not already prove. It is a Bluetooth pairing code, not a password.

It rides in `ext` because the response schema is `additionalProperties: false`. A conformance witness now pins that, and the assertion was checked for vacuity — moving the field to the top level does fail the test.

## What this deliberately does not do

**Enforce uniqueness.** DTG Credentials requires governance enforcing both real human personhood *and* exactly one membership per person; this is evidence for the first only. Nothing stops one human joining twice under two DIDs and being vetted twice.

The spec also locates PHC status in **governance and trust registries rather than credential structure** — the `PersonhoodCredential` type is described there as a *non-authoritative hint*, so a verifier following the spec reads the community's governance, not the type array. The VTC publishes no governance statement today.

Both limits are stated in the policy module and in the operator guide rather than left for someone to discover.

## Verification

- `cargo test -p vtc-service` — 30 test binaries, 0 failures
- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p vtc-service --all-targets` — clean
- `cargo fmt --check` — clean
