### PR TITLE
feat(vtc)!: reach personhood over messaging, and bind its challenge to something signed

### DIFF
--- a/vtc-service/src/members/match_code.rs
+++ b/vtc-service/src/members/match_code.rs
@@ -114,6 +114,23 @@ mod tests {
         assert_eq!(derive(id), derive(id));
     }
 
+    /// **The cross-implementation pin.** A member's client derives this code
+    /// independently — `openvtc-core`'s `personhood::match_code` pins the
+    /// same vector — because the whole mechanism is that both sides compute
+    /// the same characters from the same challenge id.
+    ///
+    /// Nothing else would catch the two drifting apart. Change the domain
+    /// tag, the alphabet, or the bit order on either side and you still get
+    /// eight plausible characters; they simply never match, which reads to
+    /// the two people in the room as "this is the wrong ceremony" rather
+    /// than "your software disagrees with itself". Two repos pinning one
+    /// vector is what turns that into a failing test.
+    #[test]
+    fn derivation_matches_the_vector_the_client_pins() {
+        let id = Uuid::parse_str("6f1c4f9e-7c2a-4f4b-9a3e-2b1d0c5e8a77").expect("uuid");
+        assert_eq!(derive(id), "5CY1-GZEE");
+    }
+
     /// Shape a human reads aloud: `XXXX-XXXX`, all characters from
     /// Crockford's alphabet.
     #[test]

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -13,7 +13,11 @@
 //! 2. `POST .../personhood/assert` — accepts a VP signed by the
 //!    member's `#key-0`. Flow:
 //!    - Consume the challenge (single-use; refuses on missing /
-//!      expired / wrong-DID).
+//!      expired / wrong-DID). The challenge must appear **both** at
+//!      `proof.challenge` (what the published task names) and at
+//!      top-level `nonce` (what the holder's signature actually
+//!      covers) — see step 1a in [`assert_inner`] for why one
+//!      without the other is not a binding at all.
 //!    - Verify the VP's `DataIntegrityProof` against the
 //!      member's resolved `#key-0`.
 //!    - Verify each embedded VC's proof against its issuer's
@@ -47,6 +51,16 @@
 //! - **Revoke**: Admin OR caller's session DID matches path DID.
 //!   Self-revoke is canonical (RTBF-style "I no longer want this
 //!   claim asserted").
+//!
+//! ## Not only REST
+//!
+//! `challenge` and `assert` are also routed by the messaging Trust
+//! Task dispatcher (`crate::trust_tasks`), so a member client that
+//! speaks DIDComm or TSP and holds no bearer token — `openvtc` — can
+//! run the ceremony. Both transports call the same
+//! [`challenge_inner`] / [`assert_inner`]; only the caller-identity
+//! gate differs, because a session and a proven sender are different
+//! things. See the handlers there for what each one checks.
 
 use std::sync::Arc;
 
@@ -163,10 +177,27 @@ pub async fn challenge(
     State(state): State<AppState>,
     Path(member_did): Path<String>,
 ) -> Result<(StatusCode, Json<ChallengeResponse>), AppError> {
-    vti_common::identifier::validate_did("did", &member_did)?;
+    Ok((
+        StatusCode::OK,
+        Json(challenge_inner(&state, &member_did).await?),
+    ))
+}
+
+/// Mint a personhood challenge for `member_did`.
+///
+/// Transport-free so both front ends share one implementation: the REST
+/// route above, and the `members/personhood/challenge` Trust Task the
+/// messaging dispatcher routes. A member on DIDComm or TSP is running
+/// the same ceremony as a member on REST, and a divergence between the
+/// two would be a security difference nothing tests.
+pub(crate) async fn challenge_inner(
+    state: &AppState,
+    member_did: &str,
+) -> Result<ChallengeResponse, AppError> {
+    vti_common::identifier::validate_did("did", member_did)?;
     // Member must exist — minting a challenge for a non-member
     // is operator-confusing and serves no purpose.
-    let _ = get_acl_entry(&state.acl_ks, &member_did)
+    let _ = get_acl_entry(&state.acl_ks, member_did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("no ACL row for {member_did}")))?;
 
@@ -174,10 +205,10 @@ pub async fn challenge(
     let expires_at = Utc::now() + chrono::Duration::seconds(CHALLENGE_TTL_SECS);
     let chal = PersonhoodChallenge {
         id,
-        member_did: member_did.clone(),
+        member_did: member_did.to_string(),
         expires_at,
     };
-    store_challenge(&state, &chal).await?;
+    store_challenge(state, &chal).await?;
 
     // Derived, not stored: any holder of the challenge id computes the
     // same code, so there is nothing here to persist or to check later.
@@ -194,14 +225,11 @@ pub async fn challenge(
         "personhood challenge minted"
     );
 
-    Ok((
-        StatusCode::OK,
-        Json(ChallengeResponse {
-            challenge_id: id,
-            expires_at,
-            ext: json!({ match_code::MATCH_CODE_EXT_KEY: code }),
-        }),
-    ))
+    Ok(ChallengeResponse {
+        challenge_id: id,
+        expires_at,
+        ext: json!({ match_code::MATCH_CODE_EXT_KEY: code }),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -246,18 +274,41 @@ pub async fn assert(
     Path(member_did): Path<String>,
     Json(body): Json<AssertBody>,
 ) -> Result<(StatusCode, Json<AssertResponse>), AppError> {
-    vti_common::identifier::validate_did("did", &member_did)?;
+    Ok((
+        StatusCode::OK,
+        Json(assert_inner(&state, &member_did, &body.presentation).await?),
+    ))
+}
+
+/// Verify a personhood presentation and, if the active policy allows it,
+/// set the flag and re-issue the member's credentials.
+///
+/// Transport-free, for the same reason as [`challenge_inner`]: the REST
+/// route and the `members/personhood/assert` Trust Task must be the same
+/// ceremony, not two implementations that agree today.
+///
+/// Note what is deliberately *not* a parameter — the caller's identity.
+/// `assert/0.1` §Authorization makes the presentation the gate: holder
+/// equality binds the assertion to the party it is about, and the
+/// single-use challenge binds it to this exchange. Neither is a claim
+/// about who delivered the bytes, so a relaying transport does not get a
+/// say here.
+pub(crate) async fn assert_inner(
+    state: &AppState,
+    member_did: &str,
+    presentation: &JsonValue,
+) -> Result<AssertResponse, AppError> {
+    vti_common::identifier::validate_did("did", member_did)?;
     // Load Member row first — `404` for an unknown subject
     // is the most actionable failure mode.
-    let mut member = get_member(&state.members_ks, &member_did)
+    let mut member = get_member(&state.members_ks, member_did)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("no Member row for {member_did}")))?;
 
     // 1. Extract + consume the challenge before any daemon-
     //    config checks so malformed callers can't observe a
     //    500 (which would otherwise mask their own bad input).
-    let proof = body
-        .presentation
+    let proof = presentation
         .get("proof")
         .ok_or_else(|| AppError::Validation("presentation missing proof block".into()))?;
     let challenge_str = proof
@@ -267,7 +318,43 @@ pub async fn assert(
     let challenge_id: Uuid = challenge_str
         .parse()
         .map_err(|e| AppError::Validation(format!("proof.challenge not a UUID: {e}")))?;
-    let chal = take_challenge(&state, challenge_id)
+
+    // 1a. The challenge must also appear **inside the signed body**.
+    //
+    // `assert/0.1` §Authorization says the challenge binding "establishes
+    // that this presentation was made for this exchange, and is what stops
+    // one captured and replayed into another". W3C Data Integrity gets that
+    // by canonicalising the proof options alongside the document, so
+    // `challenge` is signed — but `affinidi_data_integrity`'s
+    // `DataIntegrityProof` has no `challenge` field, and
+    // [`verify_vp_proof`] verifies over the VP with the whole `proof` block
+    // removed. So `proof.challenge` alone is **unsigned**: anyone holding a
+    // captured VP could mint a fresh challenge for that member, swap the
+    // value in, and replay it — the signature would still verify, because
+    // it never covered the challenge.
+    //
+    // Requiring the same value at top-level `nonce` closes that. `nonce` is
+    // outside the proof block, so it *is* covered by the holder's
+    // signature, and it is the field `vta_sdk::vp::build_di_vp` already
+    // emits. A presentation is now bound to its exchange by something the
+    // holder actually signed.
+    let nonce = presentation
+        .get("nonce")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            AppError::Validation(
+                "presentation missing `nonce` — the challenge must appear inside the signed \
+                 body, not only in the unsigned proof block"
+                    .into(),
+            )
+        })?;
+    if nonce != challenge_str {
+        return Err(AppError::Validation(format!(
+            "presentation nonce ({nonce}) != proof.challenge ({challenge_str}) — the signed \
+             and unsigned copies of the challenge disagree"
+        )));
+    }
+    let chal = take_challenge(state, challenge_id)
         .await?
         .ok_or_else(|| AppError::Validation("challenge not found or already consumed".into()))?;
     if chal.member_did != member_did {
@@ -280,15 +367,19 @@ pub async fn assert(
         return Err(AppError::Validation("challenge expired".into()));
     }
 
-    // 2. Verify the VP's holder field matches.
-    let holder = body
-        .presentation
+    // 2. Verify the VP's holder field matches. `assert/0.1`
+    //    §Authorization: holder equality is what establishes that the
+    //    assertion is about the party making it, and it does not
+    //    substitute for the challenge binding above — a consumer
+    //    checking only one of the two accepts either replays or
+    //    assertions made on someone else's behalf.
+    let holder = presentation
         .get("holder")
         .and_then(|v| v.as_str())
         .ok_or_else(|| AppError::Validation("presentation missing holder".into()))?;
     if holder != member_did {
         return Err(AppError::Validation(format!(
-            "presentation holder ({holder}) != path-DID ({member_did})"
+            "presentation holder ({holder}) != subject DID ({member_did})"
         )));
     }
 
@@ -310,7 +401,7 @@ pub async fn assert(
 
     // 3. Verify the VP's data-integrity proof against the
     //    member's resolved #key-0.
-    verify_vp_proof(&body.presentation, &member_did, &resolver)
+    verify_vp_proof(presentation, member_did, &resolver)
         .await
         .map_err(|e| AppError::Forbidden(format!("personhood-proof-invalid: {e}")))?;
 
@@ -318,11 +409,11 @@ pub async fn assert(
     //    embedded-VC proofs are surfaced to the policy via
     //    extract but not verified at the route — operators
     //    wanting strict VC verification upload custom rego.)
-    let vp_claims = extract_vp_claims(&body.presentation);
+    let vp_claims = extract_vp_claims(presentation);
 
     // 6. Run personhood.rego.
     let allow =
-        evaluate_personhood_assert(&state, &member_did, signer.issuer_did(), &vp_claims).await?;
+        evaluate_personhood_assert(state, member_did, signer.issuer_did(), &vp_claims).await?;
     if !allow {
         return Err(AppError::Forbidden(
             "personhood-policy-denied: active personhood.rego rejected the assertion".into(),
@@ -362,19 +453,19 @@ pub async fn assert(
     let vmc_id = format!("urn:uuid:{}", Uuid::new_v4());
     let vmc = build_vmc(
         signer,
-        VmcParams::new(&member_did)
+        VmcParams::new(member_did)
             .with_id(vmc_id.clone())
             .with_status_ref(status_ref)
             .with_personhood(true),
     )
     .await?;
     let vec_id = format!("urn:uuid:{}", Uuid::new_v4());
-    let acl_row = get_acl_entry(&state.acl_ks, &member_did)
+    let acl_row = get_acl_entry(&state.acl_ks, member_did)
         .await?
         .ok_or_else(|| AppError::Internal("ACL row disappeared mid-assert".into()))?;
     let role_vec = build_role_vec(
         signer,
-        RoleVecParams::new(&member_did, acl_row.role.clone()).with_id(vec_id.clone()),
+        RoleVecParams::new(member_did, acl_row.role.clone()).with_id(vec_id.clone()),
     )
     .await?;
 
@@ -389,8 +480,8 @@ pub async fn assert(
     // 9. Audit.
     audit_writer
         .write(
-            &member_did,
-            Some(&member_did),
+            member_did,
+            Some(member_did),
             AuditEvent::PersonhoodAsserted(PersonhoodAssertedData {
                 vmc_id: vmc_id.clone(),
                 asserted_at: rfc3339(now),
@@ -400,17 +491,14 @@ pub async fn assert(
 
     info!(member_did = %member_did, "personhood asserted");
 
-    Ok((
-        StatusCode::OK,
-        Json(AssertResponse {
-            did: member_did,
-            personhood: true,
-            vmc: serde_json::to_value(&vmc)
-                .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?,
-            role_vec: serde_json::to_value(&role_vec)
-                .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?,
-        }),
-    ))
+    Ok(AssertResponse {
+        did: member_did.to_string(),
+        personhood: true,
+        vmc: serde_json::to_value(&vmc)
+            .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?,
+        role_vec: serde_json::to_value(&role_vec)
+            .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -31,6 +31,13 @@
 //! `show` verbs stay on their existing JWT-gated REST routes and are *not*
 //! routed here. `present` belongs to the `credential-exchange` family and is
 //! handled there.
+//!
+//! The personhood pair (`members/personhood/{challenge,assert}`) is the
+//! member-facing half of a family whose `revoke` verb stays operator-side on
+//! REST. Both carry their own gate — challenge requires the caller to be a
+//! member, assert requires the sender to *be* the subject — because "an
+//! authenticated session", which is what the REST routes rest on, has no
+//! equivalent on a transport that only proves who sent the bytes.
 
 // `pub(crate)` only so sibling modules' tests can take the framework error
 // version from `framework_error_type_uri()` rather than each naming it. The
@@ -46,6 +53,7 @@ pub(crate) mod helpers;
 mod conformance;
 
 use serde_json::Value;
+use trust_tasks_rs::specs::vtc::members::personhood::{assert::v0_1 as pa, challenge::v0_1 as pc};
 use trust_tasks_rs::{RejectReason, TrustTask};
 
 use vti_common::error::AppError;
@@ -132,6 +140,8 @@ pub(crate) async fn dispatch_trust_task_core(
         jr::JOIN_REQUEST_STATUS_TYPE => handle_status(state, ctx, doc).await,
         jr::MEMBER_SELF_REMOVE_TYPE => handle_self_remove(state, ctx, doc).await,
         mem::MEMBER_VMC_TYPE => handle_member_vmc(state, ctx, doc).await,
+        PERSONHOOD_CHALLENGE_TYPE => handle_personhood_challenge(state, ctx, doc).await,
+        PERSONHOOD_ASSERT_TYPE => handle_personhood_assert(state, ctx, doc).await,
         other => reject_with(
             &doc,
             RejectReason::UnsupportedType {
@@ -155,7 +165,17 @@ pub(crate) const DISPATCHED_URIS: &[&str] = &[
     jr::JOIN_REQUEST_STATUS_TYPE,
     jr::MEMBER_SELF_REMOVE_TYPE,
     mem::MEMBER_VMC_TYPE,
+    PERSONHOOD_CHALLENGE_TYPE,
+    PERSONHOOD_ASSERT_TYPE,
 ];
+
+/// `vtc/members/personhood/challenge/0.1` — mint the single-use nonce
+/// the assert presentation must be bound to.
+pub(crate) const PERSONHOOD_CHALLENGE_TYPE: &str =
+    <pc::Payload as trust_tasks_rs::Payload>::TYPE_URI;
+
+/// `vtc/members/personhood/assert/0.1` — present the evidence.
+pub(crate) const PERSONHOOD_ASSERT_TYPE: &str = <pa::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 
 /// Resolve the proven holder DID for a holder-bound verb. DIDComm → the
 /// authcrypt sender; REST → the document proof signer. When the document
@@ -404,6 +424,114 @@ async fn handle_self_remove(
     }
 }
 
+// ─── personhood ──────────────────────────────────────────────────────────
+
+/// `vtc/members/personhood/challenge/0.1` — mint the single-use nonce the
+/// assert presentation must carry.
+///
+/// The caller must be a member of this community: over REST the route sits
+/// behind `AuthClaims`, and the membership check here is what that means on
+/// a transport with no session. The *subject* may be another member, which
+/// is the in-person ceremony — an administrator mints the challenge, reads
+/// the derived match code to the person in front of them, and that person's
+/// own client answers it.
+///
+/// Minting for someone else confers nothing on its own. The nonce is bound
+/// to the subject DID, and the only thing that can spend it is a
+/// presentation signed by that DID's key.
+async fn handle_personhood_challenge(
+    state: &AppState,
+    ctx: &JoinAuthCtx,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let caller = match resolve_holder(ctx, &doc).await {
+        Ok(did) => did,
+        Err(reject) => return reject,
+    };
+    let body: pc::Payload = match parse_payload(&doc) {
+        Ok(b) => b,
+        Err(reject) => return reject,
+    };
+
+    // Membership check on the *caller*, standing in for the REST route's
+    // session. A stranger who can reach the mediator is not a member.
+    match crate::acl::get_acl_entry(&state.acl_ks, &caller).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return reject_with(
+                &doc,
+                RejectReason::PermissionDenied {
+                    reason: format!("{caller} is not a member of this community"),
+                },
+            );
+        }
+        Err(e) => return app_error_to_reject(&doc, &e),
+    }
+
+    match crate::routes::members::personhood::challenge_inner(state, &body.did).await {
+        Ok(res) => success_response(&doc, res),
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
+}
+
+/// `vtc/members/personhood/assert/0.1` — present the evidence and, if the
+/// community's policy accepts it, take the personhood flag.
+///
+/// The proven sender must be the subject. `assert/0.1` declares
+/// `exposure.actsAsSubject: true` — "the asserting member is the subject …
+/// exercising their own authority over their own personhood state" — so on
+/// a transport that proves who sent the bytes, the party executing is the
+/// party being asserted about.
+///
+/// That check is belt-and-braces rather than the gate. The gate is the
+/// presentation, exactly as the published task says: its `holder` must
+/// equal the subject and its `proof.challenge` must be the paired nonce,
+/// and [`challenge_inner`](crate::routes::members::personhood::challenge_inner)'s
+/// counterpart enforces both regardless of who relayed the document.
+async fn handle_personhood_assert(
+    state: &AppState,
+    ctx: &JoinAuthCtx,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let caller = match resolve_holder(ctx, &doc).await {
+        Ok(did) => did,
+        Err(reject) => return reject,
+    };
+    let body: pa::Payload = match parse_payload(&doc) {
+        Ok(b) => b,
+        Err(reject) => return reject,
+    };
+
+    if *body.did != caller {
+        return reject_with(
+            &doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "personhood is asserted by its subject; {caller} cannot assert for {}",
+                    *body.did
+                ),
+            },
+        );
+    }
+
+    let presentation = match serde_json::to_value(&body.presentation) {
+        Ok(v) => v,
+        Err(e) => {
+            return reject_with(
+                &doc,
+                RejectReason::MalformedRequest {
+                    reason: format!("presentation is not representable as JSON: {e}"),
+                },
+            );
+        }
+    };
+
+    match crate::routes::members::personhood::assert_inner(state, &body.did, &presentation).await {
+        Ok(res) => success_response(&doc, res),
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
+}
+
 /// `members/vmc/0.1` as a Trust Task document — a member submits their
 /// reciprocal VMC (the member → community half of the membership pair),
 /// optionally closing an approved join request via `requestId` (the retired
@@ -469,22 +597,34 @@ async fn handle_member_vmc(
 mod tests {
     use super::*;
 
-    /// Every URI the dispatcher declares as routed must be one of the SDK's
-    /// member-facing request URIs, and vice-versa — so a new verb can't be
-    /// added to one side without the other.
+    /// Every URI the dispatcher declares as routed must be a member-facing
+    /// request URI declared elsewhere, and vice-versa — so a new verb can't
+    /// be added to one side without the other.
+    ///
+    /// The two personhood entries come from `trust_tasks_rs::specs` rather
+    /// than `vta_sdk::protocols`: they have no hand-written SDK constant
+    /// because their wire types are generated from the published schema.
+    /// Naming the generated `TYPE_URI` keeps the same property — the URI
+    /// this dispatcher answers on is the one the spec publishes, not a
+    /// string that happens to match today.
     #[test]
     fn dispatcher_routes_every_dispatched_uri() {
-        let sdk = [
+        let declared = [
             jr::JOIN_REQUEST_SUBMIT_TYPE,
             jr::JOIN_REQUEST_MANIFEST_TYPE,
             jr::JOIN_REQUEST_STATUS_TYPE,
             jr::MEMBER_SELF_REMOVE_TYPE,
             mem::MEMBER_VMC_TYPE,
+            <pc::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+            <pa::Payload as trust_tasks_rs::Payload>::TYPE_URI,
         ];
         for u in DISPATCHED_URIS {
-            assert!(sdk.contains(u), "dispatched URI not a known SDK URI: {u}");
+            assert!(
+                declared.contains(u),
+                "dispatched URI is not a declared request URI: {u}"
+            );
         }
-        assert_eq!(DISPATCHED_URIS.len(), sdk.len());
+        assert_eq!(DISPATCHED_URIS.len(), declared.len());
     }
 
     /// The request URIs must parse as framework `TypeUri`s (the `/spec/`
@@ -509,6 +649,145 @@ mod tests {
             assert!(
                 DISPATCHED_URIS.contains(&u),
                 "member verb not reachable over TSP: {u}"
+            );
+        }
+    }
+
+    /// The whole point of routing personhood here: a member client that
+    /// speaks Trust Tasks over messaging can run the ceremony. Before this,
+    /// personhood was REST-only, so `openvtc` — which talks to the VTC over
+    /// DIDComm/TSP and holds no bearer token — could not reach it at all.
+    #[test]
+    fn personhood_verbs_are_dispatched() {
+        for u in [PERSONHOOD_CHALLENGE_TYPE, PERSONHOOD_ASSERT_TYPE] {
+            assert!(
+                DISPATCHED_URIS.contains(&u),
+                "personhood verb not reachable over TSP: {u}"
+            );
+        }
+    }
+
+    mod personhood {
+        use super::*;
+        use crate::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+        use crate::test_support::TestVtc;
+        use serde_json::json;
+
+        const MEMBER: &str = "did:key:zPersonhoodMember";
+        const STRANGER: &str = "did:key:zNotAMember";
+
+        async fn fixture() -> TestVtc {
+            let vtc = TestVtc::builder().with_signers(true).build().await;
+            store_acl_entry(
+                &vtc.state.acl_ks,
+                &VtcAclEntry {
+                    did: MEMBER.into(),
+                    role: VtcRole::Member,
+                    label: None,
+                    allowed_contexts: vec![],
+                    created_at: 0,
+                    created_by: "did:key:vtc-install".into(),
+                    updated_at: None,
+                    updated_by: None,
+                    expires_at: None,
+                },
+            )
+            .await
+            .expect("seed member ACL");
+            vtc
+        }
+
+        /// The fixture leaves `vtc_did` unset, so `validate_basic`'s
+        /// recipient binding is skipped — these tests are about the
+        /// per-verb auth the handlers add, not the framework envelope
+        /// checks that run ahead of every verb alike.
+        fn document(type_uri: &str, payload: serde_json::Value) -> Vec<u8> {
+            let doc = TrustTask::new(
+                uuid::Uuid::new_v4().to_string(),
+                type_uri.parse().expect("dispatched URI parses as TypeUri"),
+                payload,
+            );
+            serde_json::to_vec(&doc).expect("serialize document")
+        }
+
+        /// The reply body as text. `TrustTaskOutcome` keeps raw bytes so the
+        /// wire output is byte-identical to direct serialisation.
+        fn rendered(out: &TrustTaskOutcome) -> String {
+            String::from_utf8_lossy(&out.body).into_owned()
+        }
+
+        /// Happy path over messaging: a member mints their own challenge and
+        /// the reply carries the spoken match code, same as over REST.
+        #[tokio::test]
+        async fn a_member_can_mint_a_challenge_over_messaging() {
+            let vtc = fixture().await;
+            let out = dispatch_trust_task_core(
+                &vtc.state,
+                &JoinAuthCtx::didcomm(MEMBER.into()),
+                &document(PERSONHOOD_CHALLENGE_TYPE, json!({ "did": MEMBER })),
+            )
+            .await;
+
+            let body = rendered(&out);
+            assert!(
+                body.contains("challengeId"),
+                "expected a challenge in the reply, got: {body}"
+            );
+            assert!(
+                body.contains(crate::members::match_code::MATCH_CODE_EXT_KEY),
+                "the messaging reply must carry the match code the REST reply does, got: {body}"
+            );
+        }
+
+        /// The membership check standing in for the REST route's session.
+        /// Without it, anyone who can reach the mediator could mint
+        /// challenges against this community's members.
+        #[tokio::test]
+        async fn a_stranger_cannot_mint_a_challenge() {
+            let vtc = fixture().await;
+            let out = dispatch_trust_task_core(
+                &vtc.state,
+                &JoinAuthCtx::didcomm(STRANGER.into()),
+                &document(PERSONHOOD_CHALLENGE_TYPE, json!({ "did": MEMBER })),
+            )
+            .await;
+
+            let body = rendered(&out);
+            assert!(
+                !body.contains("challengeId"),
+                "a non-member minted a challenge: {body}"
+            );
+            assert!(
+                body.contains("not a member"),
+                "expected a permission refusal naming membership, got: {body}"
+            );
+        }
+
+        /// `assert/0.1` declares `actsAsSubject: true`. On a transport that
+        /// proves the sender, one member must not be able to assert
+        /// personhood in another's name — even though the presentation gate
+        /// would also stop them, because a caller should be refused before
+        /// the daemon starts verifying someone else's credentials.
+        #[tokio::test]
+        async fn one_member_cannot_assert_personhood_for_another() {
+            let vtc = fixture().await;
+            let out = dispatch_trust_task_core(
+                &vtc.state,
+                &JoinAuthCtx::didcomm(STRANGER.into()),
+                &document(
+                    PERSONHOOD_ASSERT_TYPE,
+                    json!({
+                        "did": MEMBER,
+                        "presentation": { "type": ["VerifiablePresentation"], "holder": MEMBER },
+                    }),
+                ),
+            )
+            .await;
+
+            let body = rendered(&out);
+            assert!(
+                body.contains("asserted by its subject"),
+                "expected the subject-binding refusal, got: {body}"
             );
         }
     }

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -277,12 +277,15 @@ async fn assert_without_did_resolver_returns_500() {
     let (_, v) = body_value(resp).await;
     let challenge_id = v["challengeId"].as_str().unwrap().to_string();
 
+    // Both copies of the challenge, so this reaches the resolver rather
+    // than stopping at the signed-nonce check.
     let body = json!({
         "presentation": {
             "@context": ["https://www.w3.org/ns/credentials/v2"],
             "type": ["VerifiablePresentation"],
             "holder": MEMBER_DID,
             "verifiableCredential": [],
+            "nonce": challenge_id,
             "proof": {
                 "type": "DataIntegrityProof",
                 "cryptosuite": "eddsa-jcs-2022",
@@ -306,34 +309,90 @@ async fn assert_without_did_resolver_returns_500() {
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
-#[tokio::test]
-async fn assert_with_unknown_challenge_returns_400() {
-    let fix = build_fixture().await;
-    let body = json!({
-        "presentation": {
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
-            "type": ["VerifiablePresentation"],
-            "holder": MEMBER_DID,
-            "proof": {
-                "type": "DataIntegrityProof",
-                "cryptosuite": "eddsa-jcs-2022",
-                "verificationMethod": format!("{MEMBER_DID}#key-0"),
-                "challenge": uuid::Uuid::new_v4().to_string(),
-                "proofValue": "z00",
-            }
+/// A presentation carrying the challenge in both required places. `nonce`
+/// is the signed copy, `proof.challenge` the one the published task names;
+/// see `assert_inner` step 1a for why both are demanded.
+fn presentation_with(challenge: &str, nonce: &str) -> serde_json::Value {
+    json!({
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "type": ["VerifiablePresentation"],
+        "holder": MEMBER_DID,
+        "nonce": nonce,
+        "proof": {
+            "type": "DataIntegrityProof",
+            "cryptosuite": "eddsa-jcs-2022",
+            "verificationMethod": format!("{MEMBER_DID}#key-0"),
+            "challenge": challenge,
+            "proofValue": "z00",
         }
-    });
+    })
+}
+
+async fn post_assert(fix: &Fixture, presentation: serde_json::Value) -> StatusCode {
     let req = Request::builder()
         .method("POST")
         .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
         .header("authorization", format!("Bearer {}", fix.member_token))
         .header("trust-task", ASSERT_TASK)
         .header("content-type", "application/json")
-        .body(Body::from(body.to_string()))
+        .body(Body::from(
+            json!({ "presentation": presentation }).to_string(),
+        ))
         .unwrap();
-    let resp = fix.router.clone().oneshot(req).await.unwrap();
+    fix.router.clone().oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn assert_with_unknown_challenge_returns_400() {
+    let fix = build_fixture().await;
+    let unknown = uuid::Uuid::new_v4().to_string();
     // AppError::Validation → 400 in this workspace.
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        post_assert(&fix, presentation_with(&unknown, &unknown)).await,
+        StatusCode::BAD_REQUEST
+    );
+}
+
+/// The replay defence. `proof.challenge` sits inside the proof block, which
+/// `verify_vp_proof` strips before verifying — so it is not covered by the
+/// holder's signature. A captured presentation could otherwise be replayed
+/// against a freshly-minted challenge by swapping that one unsigned field.
+///
+/// Refusing a presentation with no signed `nonce` is what makes the
+/// challenge an actual binding rather than a decoration.
+#[tokio::test]
+async fn assert_without_a_signed_nonce_is_refused() {
+    let fix = build_fixture().await;
+    let mut presentation = presentation_with(
+        &uuid::Uuid::new_v4().to_string(),
+        &uuid::Uuid::new_v4().to_string(),
+    );
+    presentation
+        .as_object_mut()
+        .expect("presentation object")
+        .remove("nonce");
+
+    assert_eq!(
+        post_assert(&fix, presentation).await,
+        StatusCode::BAD_REQUEST,
+        "a presentation whose challenge appears only in the unsigned proof block must be refused"
+    );
+}
+
+/// The same defence from the other side: a captured presentation whose
+/// unsigned `proof.challenge` has been swapped for a fresh one no longer
+/// agrees with the signed `nonce` it was made with.
+#[tokio::test]
+async fn assert_with_mismatched_signed_and_unsigned_challenge_is_refused() {
+    let fix = build_fixture().await;
+    let captured_nonce = uuid::Uuid::new_v4().to_string();
+    let swapped_challenge = uuid::Uuid::new_v4().to_string();
+
+    assert_eq!(
+        post_assert(&fix, presentation_with(&swapped_challenge, &captured_nonce)).await,
+        StatusCode::BAD_REQUEST,
+        "swapping the unsigned challenge on a captured presentation must be refused"
+    );
 }
 
 // ─── Revoke endpoint ───────────────────────────────────────


### PR DESCRIPTION
Follow-up to #1085. Companion client PR: **OpenVTC/openvtc#257**.

Personhood was REST-only. `openvtc` — which talks to communities over DIDComm and TSP and holds no bearer token — could not run the ceremony at all, so the member half of the feature had no client that could reach it.

## Reachable over messaging

`members/personhood/{challenge,assert}` now route through the messaging Trust Task dispatcher alongside the join verbs, which also makes them reachable over TSP (the TSP inbound path hands every frame to the same dispatcher).

The route handlers keep their bodies in `challenge_inner` / `assert_inner`, which both transports call. Two implementations of one ceremony is a security difference nothing tests.

Each verb carries its own caller gate, because "an authenticated session" — what the REST routes rest on — has no equivalent on a transport that only proves who sent the bytes:

| Verb | Gate | Why |
|---|---|---|
| `challenge` | caller must be a member | Otherwise anyone who can reach the mediator could mint challenges against this community's members. The *subject* may be another member — that is the in-person ceremony. |
| `assert` | sender must **be** the subject | `assert/0.1` declares `exposure.actsAsSubject: true` — "the asserting member is the subject … exercising their own authority over their own personhood state". |

Minting a challenge for someone else confers nothing: the nonce is bound to the subject, and only a presentation signed by that subject's key can spend it.

## The challenge was not bound to anything

`assert/0.1` §Authorization says the challenge binding "establishes that this presentation was made for this exchange, and is what stops one captured and replayed into another". In W3C Data Integrity that holds because the proof options are canonicalised with the document, so `challenge` is signed.

`affinidi_data_integrity`'s `DataIntegrityProof` **has no `challenge` field**, and `verify_vp_proof` verifies over the presentation with the whole `proof` block removed. So `proof.challenge` was **unsigned**.

Anyone holding a captured presentation — a relaying mediator, anyone with log access — could mint a fresh challenge for that member, swap the one unsigned field, and replay it. The signature still verified, because it had never covered the challenge. For a flag whose revocation is an administrative act, that means a revoked assertion could be restored without the member's participation.

The challenge must now also appear at top-level `nonce`, which is outside the proof block and therefore covered by the holder's signature, and the two copies must agree. This is what the published task already says the binding does; it just did not do it.

Two tests pin it from both sides: a presentation with no signed `nonce` is refused, and one whose unsigned `proof.challenge` has been swapped away from its signed `nonce` is refused.

> [!WARNING]
> **BREAKING CHANGE**: a personhood presentation without a top-level `nonce` equal to `proof.challenge` is refused. No client produced one — `openvtc` had no personhood support and `vtc-client` only reads the flag — so nothing in the ecosystem is affected, and OpenVTC/openvtc#257 emits both copies.

## Match-code vector

Pins `5CY1-GZEE`, which `openvtc-core` pins too. The two derivations agree only because they compute the same digest over the same bytes, and nothing else would catch them drifting: a changed domain tag or alphabet on either side still yields eight plausible characters that simply never match, which reads to the two people in the room as "wrong ceremony" rather than "your software disagrees with itself".

## Verification

Rebased onto merged `main` (so it includes #1082's response-shape changes) and re-run there:

- `cargo test -p vtc-service` — 40 test binaries, 0 failures
- `cargo clippy -p vtc-service --all-targets` — clean
- `cargo fmt --check` — clean

Three new dispatcher tests cover the messaging path: a member mints a challenge and gets the match code back, a non-member is refused, and one member cannot assert for another.
