### PR TITLE
fix(sdk): look for pnm sessions where pnm actually writes them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9420,6 +9420,7 @@ dependencies = [
  "curve25519-dalek",
  "dbus-secret-service-keyring-store",
  "didwebvh-rs",
+ "dirs",
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.4.3",

--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -67,8 +67,10 @@ Two modes:
   sessions as `vta:<slug>` and `vta_sdk::agent_connect::pnm_session_key` adds
   that prefix. Passing an already-prefixed value also works.
   Options: `--service-name` (default `pnm-cli`), `--sessions-dir` (default
-  `~/.config/pnm`), `--url` (override the resolved REST URL). All have `VTA_MCP_*`
-  env equivalents.
+  `dirs::config_dir()/pnm` — `~/Library/Application Support/pnm` on macOS,
+  `%APPDATA%\pnm` on Windows, `~/.config/pnm` on Linux, matching where `pnm`
+  itself writes), `--url` (override the resolved REST URL). All have
+  `VTA_MCP_*` env equivalents.
 
 - **Token** — a REST client with a bearer token (simple; for testing /
   short-lived use; no auto-refresh):

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -98,6 +98,9 @@ client = [
 session = [
   "client",
   "didcomm",
+  # `default_sessions_dir` must agree with where `pnm` actually writes, which
+  # is `dirs::config_dir()` — not the XDG path on macOS or Windows.
+  "dep:dirs",
   "dep:affinidi-did-resolver-cache-sdk",
   "dep:tokio",
   # Rotation of a temp-provisioned did:key on first successful auth needs
@@ -226,6 +229,7 @@ affinidi-openid4vp = { workspace = true }
 affinidi-openid4vci = { workspace = true }
 base64 = { workspace = true }
 multibase = { workspace = true }
+dirs = { version = "6", optional = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 affinidi-tdk = { workspace = true, optional = true }

--- a/vta-sdk/src/agent_connect.rs
+++ b/vta-sdk/src/agent_connect.rs
@@ -404,16 +404,24 @@ fn load_bundle(raw: &str) -> Result<DidSecretsBundle, VtaError> {
     })
 }
 
-/// `~/.config/pnm`, the directory `pnm` stores sessions in by default.
+/// Where `pnm` stores its sessions by default.
+///
+/// **`dirs::config_dir()/pnm`, which is not `~/.config/pnm` everywhere.** On
+/// macOS it is `~/Library/Application Support/pnm`; on Windows, `%APPDATA%\pnm`.
+/// `pnm` itself uses `dirs::config_dir()` — see `config_dir` in
+/// `pnm-cli/src/config.rs` — so a bridge that assumes the XDG path finds no
+/// session on either platform and reports an *authentication* failure to an
+/// operator who is authenticated. That is indistinguishable, from their side,
+/// from an expired login: they run `pnm auth status`, are told they are fine,
+/// and are none the wiser.
 fn default_sessions_dir() -> Result<PathBuf, VtaError> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_err(|_| {
+    Ok(dirs::config_dir()
+        .ok_or_else(|| {
             VtaError::Validation(
-                "HOME (or USERPROFILE) is not set; set sessions_dir explicitly".into(),
+                "could not determine the user config directory; set sessions_dir explicitly".into(),
             )
-        })?;
-    Ok(PathBuf::from(home).join(".config").join("pnm"))
+        })?
+        .join("pnm"))
 }
 
 #[cfg(test)]
@@ -544,6 +552,19 @@ mod tests {
         let bundle = load_bundle(path.to_str().unwrap()).unwrap();
         assert_eq!(bundle.did, "did:webvh:f:example.com:b");
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn the_default_sessions_dir_follows_pnm_rather_than_assuming_xdg() {
+        // `pnm` uses `dirs::config_dir()`, which is NOT `~/.config` on macOS or
+        // Windows. Assuming XDG found no session on either, and reported it as
+        // an authentication failure.
+        let dir = default_sessions_dir().expect("a config dir");
+        assert_eq!(dir.file_name().expect("pnm"), "pnm");
+        assert_eq!(
+            dir.parent().expect("parent"),
+            dirs::config_dir().expect("config dir")
+        );
     }
 
     #[test]


### PR DESCRIPTION
`agent_connect::default_sessions_dir` returned `~/.config/pnm`. `pnm` uses `dirs::config_dir()` (see `config_dir` in `pnm-cli/src/config.rs`), which is:

| Platform | Actual path |
|---|---|
| macOS | `~/Library/Application Support/pnm` |
| Windows | `%APPDATA%\pnm` |
| Linux | `~/.config/pnm` |

So on macOS and Windows a bridge in session mode finds **no session** — and reports an *authentication* failure to an operator who is authenticated. That is indistinguishable, from their side, from an expired login: they run `pnm auth status`, are told they are fine, and are none the wiser.

This is the second half of the same defect as [#1083](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1083), which fixed the keyring *key* (`vta:<slug>`) and left the *directory*. Both halves were in the original `vta-mcp` code and were carried into the SDK unchanged when #1081 extracted the ladder — so **`vta-mcp --vta <slug>`, the invocation its own README documents, has never worked on macOS.**

## How it surfaced

Running a downstream consumer of `agent_connect` on a real macOS machine. It reported "no VTA is configured" against a `pnm` install that was working perfectly, with the config sitting in `~/Library/Application Support/pnm` the entire time.

That is also why the new test asserts against `dirs::config_dir()` rather than a literal path — the whole bug was a literal path that looked right.

## Scope

`dirs` is **optional**, pulled only by the `session` feature, so nothing that does not already speak to a session store gains a dependency.

`vta-mcp`'s README is corrected; it documented the wrong default too.

## Testing

`cargo test -p vta-sdk --lib agent_connect` — 12 pass, one new. `cargo test -p vta-mcp` — 5 pass. `cargo check -p pnm-cli -p cnm-cli` clean. Clippy clean.