### PR TITLE
feat(vtc): close the two DTG personhood-conformance gaps

### DIFF
--- a/docs/03-vtc/personhood-and-graph.md
+++ b/docs/03-vtc/personhood-and-graph.md
@@ -153,21 +153,108 @@ member is `match-code` and not `matchCode`.
 
 DTG Credentials §Personhood Credentials requires governance enforcing
 **both** real human personhood **and exactly one membership per
-person**. In-person vetting is evidence for the first only.
+person**. In-person vetting is evidence for the first only — see
+[Declaring personhood governance](#declaring-personhood-governance) for
+publishing the claim, and [One membership per
+person](#one-membership-per-person) for the second half.
 
-**The VTC does not enforce uniqueness.** Nothing stops one human joining
-twice under two DIDs and being vetted twice, and no credential presented
-by its own subject could demonstrate otherwise. A community whose
-governance depends on one-person-one-membership needs a policy that
-consults evidence from an issuer who actually checks that — a national
-eID, an existing PHC from a network that enforces it — and should treat
-the default policy as a starting point, not a personhood regime.
+### Declaring personhood governance
 
-Note also that the spec locates PHC status in **governance and trust
-registries, not in credential structure**: the `PersonhoodCredential`
-type this daemon adds to a vetted member's VMC is described there as a
-*non-authoritative hint*. A verifier following the spec reads the
-community's governance, not the type array.
+The spec puts PHC status outside the credential: *"PHC status is
+determined by governance and trust registries, not by credential
+structure"*, and the `PersonhoodCredential` type this daemon stamps on a
+vetted member's VMC is *"a non-authoritative hint"*. §Governance
+Considerations is blunter: *"Whether a VMC qualifies as a PHC is a
+governance determination, not a schema property."*
+
+So a community publishes what its governance requires, on its profile:
+
+```json
+"personhood": {
+  "realHuman": true,
+  "singleMembership": true,
+  "acceptedIdvps": ["did:webvh:idvp.example"],
+  "governanceFrameworkUrl": "https://acme.example/governance"
+}
+```
+
+This is served **unauthenticated** at `GET /v1/community/public-profile`,
+because the party who needs it is a verifier holding one of your VMCs —
+someone who is not a member and has no token.
+
+Both booleans default to `false`. A community that has not considered the
+question asserts nothing, which is the only safe default for a claim a
+verifier may act on.
+
+**Setting both requires naming at least one accepted IDVP.** A community
+claiming PHC status while naming nobody it trusts to verify identity has
+not written its governance down, and a verifier cannot tell an unwritten
+policy from a permissive one. A community that vets in person lists its
+own C-DID — §IDVC permits acting as your own identity-verification
+provider.
+
+### One membership per person
+
+`singleMembership` is not just a declaration: **setting it turns on
+enforcement.** The published claim and the check are the same switch, so a
+community cannot advertise PHC status to verifiers while quietly not
+checking it.
+
+Nothing in the credential graph distinguishes one person with two DIDs
+from two people — a member who joins twice presents two perfectly valid
+sets of evidence, and every check passes twice. The community needs an
+anchor that is stable per human, and it must come from outside.
+
+That anchor is a **pseudonym**: an IDVP that can actually deduplicate
+people — a state eID scheme, a biometric provider, a bank — derives a
+deterministic value per (person, community). The same person returning
+yields the same pseudonym; a different community yields an unlinkable
+one. This is the rate-limiting-identifier construction from [Personhood
+Credentials (Adler et al. 2024)](https://arxiv.org/abs/2408.07892), which
+the spec's PHC definition cites.
+
+The daemon reads it from either shape, and **only from an issuer in
+`acceptedIdvps`**:
+
+| Shape | Where |
+|---|---|
+| A plain IDVC | `credentialSubject.pseudonym` |
+| This community's own endorsement | `credentialSubject.endorsement.claim.pseudonym` |
+
+An assertion carrying no accepted pseudonym is refused with
+`personhood-pseudonym-missing`; one whose pseudonym another member already
+holds is refused as a conflict, worded so it does not disclose who that
+member is.
+
+**The pseudonym itself is never stored.** It is a stable per-person
+identifier, so a database full of them is the correlation target the
+construction exists to avoid. What is stored is a salted digest keyed to
+this community, which answers "is this person already here" and nothing
+else.
+
+**Claims are released on purge only** — not on revoke, and not on leaving.
+Revoking personhood withdraws the community's assertion; it is not
+evidence that the human stopped existing, and they are still a member.
+If either released the claim, one-membership-per-person would be defeated
+by revoking and rejoining under a fresh DID.
+
+#### What this still does not give you
+
+The guarantee is the IDVP's, not the community's. Uniqueness is exactly as
+good as your accepted providers' deduplication — which is why the spec
+makes acceptable IDVPs part of what governance must publish.
+
+**In-person vetting is the weak case.** When a community is its own IDVP,
+the "pseudonym" is an administrator's judgement that they have not met this
+person before. That genuinely supports one-membership-per-person in a
+community small enough for one person to hold in their head, and genuinely
+does not beyond it. Say so in your governance framework rather than
+letting the flag imply more.
+
+Finally, this is per-community by definition — the spec's glossary says
+*"exactly one membership in that VTC"*. Personhood that means something
+*across* communities is a VTN-level property; see the spec's VTN
+definition and the [First Person Network](https://www.firstperson.network/).
 
 ### Revocation
 

--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -440,6 +440,34 @@ async fn depart(
     match (disposition, member) {
         (Disposition::Purge, existed) => {
             delete_member(&state.members_ks, subject_did).await?;
+            // Free any personhood pseudonym this member held. Purge is the
+            // *only* departure that does — tombstone and historical keep the
+            // member row, and the person is still here. Releasing on those
+            // would let one-membership-per-person be defeated by leaving and
+            // rejoining under a fresh DID.
+            //
+            // Best-effort, deliberately: the member row is already gone, and
+            // failing the purge over a stale uniqueness claim would leave the
+            // community in a worse state than a claim nobody can spend. The
+            // operator can re-run it.
+            match crate::members::pseudonym::release_for_member(&state.members_ks, subject_did)
+                .await
+            {
+                Ok(0) => {}
+                Ok(freed) => {
+                    tracing::info!(
+                        subject = %subject_did,
+                        freed,
+                        "released personhood pseudonym claims on purge"
+                    );
+                }
+                Err(e) => tracing::warn!(
+                    subject = %subject_did,
+                    error = %e,
+                    "could not release personhood pseudonym claims — this person may be \
+                     refused if they rejoin"
+                ),
+            }
             // Only a purge removes the row; tombstone/historical keep it, so
             // they leave `list_members().len()` (and the cache) unchanged. Guard
             // on prior existence so a purge of an already-absent member doesn't

--- a/vtc-service/src/community/mod.rs
+++ b/vtc-service/src/community/mod.rs
@@ -11,5 +11,5 @@ pub mod profile;
 
 pub use profile::{
     CommunityProfile, CommunityProfileUpdate, MAX_EXTENSIONS_BYTES, PROFILE_STORAGE_KEY,
-    load_profile, store_profile,
+    PersonhoodGovernance, load_profile, store_profile,
 };

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -65,6 +65,93 @@ fn default_relationship_identifier() -> String {
     RELATIONSHIP_IDENTIFIER_DEFAULT.to_string()
 }
 
+/// What a community's governance asserts about personhood, and therefore
+/// whether its VMCs may be read as PHCs.
+///
+/// DTG Credentials §Personhood Credentials: "A PHC is simply a VMC issued by
+/// a VTC whose governance enforces: real human personhood; exactly one
+/// membership per person."  Those two clauses are the two booleans here.
+///
+/// ## Both halves, separately
+///
+/// They are separate fields because they are separately achievable, and a
+/// community that has one without the other should be able to say so. This
+/// daemon's in-person vetting supports the first — an administrator meets
+/// someone and issues them an identity-verification endorsement — and does
+/// nothing at all for the second. Collapsing them into one `is_phc` flag
+/// would force every such community to either overclaim or stay silent.
+///
+/// ## Declaration, not enforcement — and the honesty rule that follows
+///
+/// Like [`CommunityProfile::relationship_identifier_default`], this describes
+/// what the community's governance requires. Nothing here makes the daemon
+/// enforce anything.
+///
+/// That makes an overclaim worse than silence. Before this field, a verifier
+/// reading a `PersonhoodCredential` type had no authoritative source and knew
+/// it; a `singleMembership: true` from a community that does not enforce
+/// uniqueness gives that verifier a false one. **Do not set a flag the
+/// community's governance does not actually require** — and note that
+/// requiring it is not the same as this daemon checking it. `personhood.rego`
+/// is where a requirement becomes a gate.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct PersonhoodGovernance {
+    /// Governance requires that members are real humans.
+    ///
+    /// Defaults to `false`: a community that has not considered the question
+    /// asserts nothing, which is the only safe default for a claim a verifier
+    /// may rely on.
+    #[serde(default)]
+    pub real_human: bool,
+    /// Governance requires that each person holds at most one membership in
+    /// **this** community.
+    ///
+    /// Per-community by definition — the spec's glossary says "exactly one
+    /// membership in that VTC" — so a single community can satisfy this
+    /// without any network above it.
+    ///
+    /// This is the half that needs an anchor the community cannot supply
+    /// itself: nothing in the credential graph distinguishes one person with
+    /// two DIDs from two people. See `docs/03-vtc/personhood-and-graph.md`.
+    #[serde(default)]
+    pub single_membership: bool,
+    /// DIDs of the identity-verification providers whose credentials this
+    /// community accepts as personhood evidence.
+    ///
+    /// §Governance Considerations item 1: identity-proofing requirements
+    /// "including acceptable IDVPs and IDVCs" are the community's to define
+    /// and are "published via trust registries". A community that vets its
+    /// own members in person lists its own C-DID here — it is acting as its
+    /// own IDVP, which §IDVC permits.
+    ///
+    /// Advisory to verifiers, not a gate: `personhood.rego` decides what is
+    /// actually accepted. An empty list means the community has not published
+    /// one, not that it accepts everything.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_idvps: Vec<String>,
+    /// Where the governance framework this all refers to can be read.
+    ///
+    /// The ToIP Governance Metamodel the spec cites expects a human-readable
+    /// document behind these assertions. The booleans above are the
+    /// machine-readable summary; this is the thing they summarise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub governance_framework_url: Option<String>,
+}
+
+impl PersonhoodGovernance {
+    /// Whether this community's governance claims its VMCs are PHCs.
+    ///
+    /// **Both** clauses, because the spec's definition is a conjunction. A
+    /// community asserting real-human but not single-membership has members
+    /// it believes are people; it does not have personhood credentials, and
+    /// one person may hold several of them.
+    pub fn claims_phc(&self) -> bool {
+        self.real_human && self.single_membership
+    }
+}
+
 /// The singleton record. Field names are wire contract — operators
 /// + the admin UX read this shape directly.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -103,6 +190,21 @@ pub struct CommunityProfile {
     /// unreadable — which the admin-config round-trip tests caught.
     #[serde(default = "default_relationship_identifier")]
     pub relationship_identifier_default: String,
+    /// What this community's governance says about personhood.
+    ///
+    /// DTG Credentials §Personhood Credentials puts PHC status here rather
+    /// than in the credential: "PHC status is determined by governance and
+    /// trust registries, not by credential structure", and the
+    /// `PersonhoodCredential` type this daemon stamps on a vetted member's
+    /// VMC is described there as a *non-authoritative hint*. §Governance
+    /// Considerations item 2 is blunter still: "Whether a VMC qualifies as a
+    /// PHC is a governance determination, not a schema property."
+    ///
+    /// Without this field a conformant verifier had nothing to read. The
+    /// type array told it not to trust the type array, and there was no
+    /// second place to look.
+    #[serde(default)]
+    pub personhood: PersonhoodGovernance,
     pub created_at: DateTime<Utc>,
     /// Opaque per-community JSON. Capped at [`MAX_EXTENSIONS_BYTES`]
     /// when serialised. Defaults to `null` when no extension data
@@ -124,6 +226,9 @@ impl CommunityProfile {
             contact_email: None,
             language: "en".into(),
             relationship_identifier_default: RELATIONSHIP_IDENTIFIER_DEFAULT.into(),
+            // A fresh community asserts nothing about personhood. An
+            // operator turns these on when their governance says so.
+            personhood: PersonhoodGovernance::default(),
             created_at: Utc::now(),
             extensions: Value::Null,
         }
@@ -151,6 +256,12 @@ pub struct CommunityProfileUpdate {
     /// See [`CommunityProfile::relationship_identifier_default`]. Must be one
     /// of [`RELATIONSHIP_IDENTIFIER_FORMS`].
     pub relationship_identifier_default: Option<String>,
+    /// See [`PersonhoodGovernance`]. Replaced wholesale rather than merged
+    /// field-by-field: the two booleans are a conjunction the operator is
+    /// asserting together, and a partial patch that flipped one while leaving
+    /// the other at whatever it happened to be is how a community ends up
+    /// claiming PHC status it did not mean to claim.
+    pub personhood: Option<PersonhoodGovernance>,
     pub extensions: Option<Value>,
 }
 
@@ -213,7 +324,44 @@ impl CommunityProfileUpdate {
             )));
         }
 
+        // Validated with the other pre-checks, for the same reason: a
+        // governance URL is published to clients as where this community's
+        // rules can be read, and one that is not fetchable over http(s) is
+        // either a mistake or a lever — the same reasoning as `logoUrl`.
+        if let Some(p) = self.personhood.as_ref()
+            && let Some(url) = p.governance_framework_url.as_deref()
+            && !(url.starts_with("https://") || url.starts_with("http://"))
+        {
+            return Err(AppError::Validation(
+                "personhood.governanceFrameworkUrl must be an http(s) URL".into(),
+            ));
+        }
+        // Refuse the overclaim outright rather than publish it. `claims_phc`
+        // is what a verifier reads to decide whether these VMCs are PHCs, and
+        // the spec's own §Governance Considerations makes acceptable IDVPs
+        // part of what governance must publish. A community claiming PHC
+        // status while naming nobody it trusts to verify identity has not
+        // written that governance down — and a verifier cannot tell an
+        // unwritten policy from a permissive one.
+        if let Some(p) = self.personhood.as_ref()
+            && p.claims_phc()
+            && p.accepted_idvps.is_empty()
+        {
+            return Err(AppError::Validation(
+                "personhood claiming both realHuman and singleMembership must name at least \
+                 one entry in acceptedIdvps — a community acting as its own identity-\
+                 verification provider lists its own DID"
+                    .into(),
+            ));
+        }
+
         let mut changed = Vec::new();
+        if let Some(personhood) = self.personhood
+            && profile.personhood != personhood
+        {
+            profile.personhood = personhood;
+            changed.push("personhood".into());
+        }
         if let Some(form) = self.relationship_identifier_default
             && profile.relationship_identifier_default != form
         {
@@ -541,5 +689,141 @@ mod tests {
     fn profile_default_language_is_en() {
         let p = sample();
         assert_eq!(p.language, "en");
+    }
+
+    // ─── personhood governance ───────────────────────────────────────────
+
+    fn governance(real_human: bool, single_membership: bool) -> PersonhoodGovernance {
+        PersonhoodGovernance {
+            real_human,
+            single_membership,
+            accepted_idvps: vec!["did:webvh:idvp.example".into()],
+            governance_framework_url: Some("https://acme.example/governance".into()),
+        }
+    }
+
+    /// A fresh community asserts nothing. Any other default would have every
+    /// community that never considered the question publishing a claim a
+    /// verifier might rely on.
+    #[test]
+    fn a_new_community_claims_no_personhood() {
+        let p = sample();
+        assert!(!p.personhood.real_human);
+        assert!(!p.personhood.single_membership);
+        assert!(!p.personhood.claims_phc());
+        assert!(p.personhood.accepted_idvps.is_empty());
+    }
+
+    /// The spec's definition is a conjunction: "real human personhood" **and**
+    /// "exactly one membership per person". Either half alone is not a PHC —
+    /// a community with the first has members it believes are people, and one
+    /// person may hold several of their credentials.
+    #[test]
+    fn phc_needs_both_halves() {
+        assert!(!governance(false, false).claims_phc());
+        assert!(!governance(true, false).claims_phc());
+        assert!(!governance(false, true).claims_phc());
+        assert!(governance(true, true).claims_phc());
+    }
+
+    /// The honesty rule. A community claiming PHC status while naming nobody
+    /// it trusts to verify identity has not written its governance down, and
+    /// a verifier cannot tell an unwritten policy from a permissive one.
+    #[test]
+    fn a_phc_claim_must_name_an_idvp() {
+        let mut p = sample();
+        let err = CommunityProfileUpdate {
+            personhood: Some(PersonhoodGovernance {
+                accepted_idvps: vec![],
+                ..governance(true, true)
+            }),
+            ..CommunityProfileUpdate::default()
+        }
+        .apply(&mut p)
+        .expect_err("a PHC claim with no IDVP must be refused");
+
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(
+            !p.personhood.claims_phc(),
+            "the refused claim must not have half-applied"
+        );
+    }
+
+    /// The same emptiness is fine when no PHC claim is being made — a
+    /// community may say "our members are people" without having published a
+    /// list of who may attest that.
+    #[test]
+    fn a_partial_claim_may_name_no_idvp() {
+        let mut p = sample();
+        let changed = CommunityProfileUpdate {
+            personhood: Some(PersonhoodGovernance {
+                accepted_idvps: vec![],
+                ..governance(true, false)
+            }),
+            ..CommunityProfileUpdate::default()
+        }
+        .apply(&mut p)
+        .expect("a non-PHC claim needs no IDVP list");
+
+        assert!(changed.contains(&"personhood".to_string()));
+        assert!(p.personhood.real_human);
+    }
+
+    /// A governance URL is published as where this community's rules can be
+    /// read. Same reasoning as `logoUrl`: a non-http(s) value is either a
+    /// mistake or a lever.
+    #[test]
+    fn the_governance_url_must_be_http() {
+        let mut p = sample();
+        let err = CommunityProfileUpdate {
+            personhood: Some(PersonhoodGovernance {
+                governance_framework_url: Some("javascript:alert(1)".into()),
+                ..governance(true, true)
+            }),
+            ..CommunityProfileUpdate::default()
+        }
+        .apply(&mut p)
+        .expect_err("a non-http governance URL must be refused");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    /// Replaced wholesale, not merged. Patching one boolean while the other
+    /// keeps whatever it happened to be is how a community ends up claiming
+    /// PHC status it never asserted.
+    #[test]
+    fn a_personhood_patch_replaces_rather_than_merges() {
+        let mut p = sample();
+        p.personhood = governance(true, true);
+
+        CommunityProfileUpdate {
+            personhood: Some(PersonhoodGovernance {
+                real_human: true,
+                single_membership: false,
+                accepted_idvps: vec![],
+                governance_framework_url: None,
+            }),
+            ..CommunityProfileUpdate::default()
+        }
+        .apply(&mut p)
+        .expect("downgrading a claim is always allowed");
+
+        assert!(!p.personhood.claims_phc(), "the claim must have dropped");
+        assert!(
+            p.personhood.accepted_idvps.is_empty(),
+            "the old IDVP list must not survive a replacement that omitted it"
+        );
+        assert!(p.personhood.governance_framework_url.is_none());
+    }
+
+    /// A config written before this field existed must still load — the same
+    /// property `relationshipIdentifierDefault` needed, and which the
+    /// admin-config round-trip tests caught when it was missing.
+    #[test]
+    fn a_profile_without_personhood_still_deserializes() {
+        let mut raw = serde_json::to_value(sample()).expect("profile -> json");
+        raw.as_object_mut().expect("object").remove("personhood");
+
+        let p: CommunityProfile = serde_json::from_value(raw).expect("pre-field config must load");
+        assert!(!p.personhood.claims_phc());
     }
 }

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod inbound_vmc;
 pub mod match_code;
+pub mod pseudonym;
 pub mod storage;
 
 use chrono::{DateTime, Utc};

--- a/vtc-service/src/members/pseudonym.rs
+++ b/vtc-service/src/members/pseudonym.rs
@@ -1,0 +1,500 @@
+//! One membership per person — the uniqueness half of a PHC.
+//!
+//! DTG Credentials §Personhood Credentials defines a PHC as a VMC from a VTC
+//! "whose governance enforces: real human personhood; **exactly one membership
+//! per person**". The first half is evidence a community can gather itself; the
+//! second is not.
+//!
+//! ## Why a community cannot do this alone
+//!
+//! Nothing in the credential graph distinguishes one person holding two DIDs
+//! from two people. Not the VMC, not an endorsement, not a presentation — a
+//! member who joins twice under two identities presents two perfectly valid
+//! sets of evidence, and every check passes twice. The community needs an
+//! anchor that is *stable per human*, and it has to come from outside.
+//!
+//! That anchor is a **pseudonym**: an identity-verification provider that can
+//! actually deduplicate people — a state eID scheme, a biometric provider, a
+//! bank — derives a deterministic value per (person, community). The same
+//! person coming back yields the same pseudonym; a different community yields
+//! an unlinkable one. This is the rate-limiting-identifier construction from
+//! [Personhood Credentials (Adler et al. 2024)](https://arxiv.org/abs/2408.07892),
+//! which the spec's own PHC definition cites.
+//!
+//! So this module does not establish uniqueness. It *enforces* the uniqueness
+//! an IDVP established, by refusing a second membership that presents a
+//! pseudonym already claimed here. The strength of the guarantee is the IDVP's,
+//! which is why [`crate::community::PersonhoodGovernance::accepted_idvps`]
+//! exists and why a community claiming PHC status must publish one.
+//!
+//! ## What is stored, and what is not
+//!
+//! The pseudonym itself is never written down. A stable per-person identifier
+//! sitting in a database is a correlation target — precisely what the
+//! construction exists to avoid — so the key is a salted digest and the raw
+//! value is dropped after the check. What remains is "some person, already
+//! known to us, holds this membership", which is the whole question being
+//! asked.
+//!
+//! Rows live in the `members` keyspace under [`PSEUDONYM_PREFIX`] rather than a
+//! keyspace of their own, which puts them in `BACKED_UP` alongside the members
+//! they constrain. That coupling is deliberate and matches
+//! `CONSUMED_INVITATIONS`: a claim that did not survive a restore would let a
+//! restored community admit the duplicate it had already refused.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Storage prefix for pseudonym claims, inside the `members` keyspace.
+pub const PSEUDONYM_PREFIX: &str = "personhood_pseudonym:";
+
+/// Domain separation for the stored digest. Keeps a pseudonym digest from
+/// colliding with any other SHA-256 this workspace computes over the same
+/// bytes.
+const DOMAIN_TAG: &[u8] = b"vtc-personhood-pseudonym/v1\0";
+
+/// A claimed pseudonym.
+///
+/// Deliberately holds no copy of the pseudonym — see the module docs. The
+/// member DID is kept because a claim is only useful if the community can say
+/// *whose* it is when releasing it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PseudonymClaim {
+    /// The member this pseudonym is bound to.
+    pub member_did: String,
+    pub claimed_at: DateTime<Utc>,
+}
+
+/// Storage key for a pseudonym in a community.
+///
+/// The community DID is inside the digest, not merely alongside it. A VTC
+/// serves one community, so this changes nothing operationally — but it means
+/// two communities' stores cannot be diffed against each other to discover that
+/// the same person is in both, which is exactly the correlation a
+/// community-scoped pseudonym is meant to prevent.
+fn key(community_did: &str, pseudonym: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(DOMAIN_TAG);
+    hasher.update(community_did.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(pseudonym.as_bytes());
+    format!("{PSEUDONYM_PREFIX}{}", hex::encode(hasher.finalize()))
+}
+
+/// Who currently holds `pseudonym` in this community, if anyone.
+pub async fn holder(
+    members_ks: &KeyspaceHandle,
+    community_did: &str,
+    pseudonym: &str,
+) -> Result<Option<PseudonymClaim>, AppError> {
+    let raw = members_ks.get_raw(key(community_did, pseudonym)).await?;
+    let Some(bytes) = raw else { return Ok(None) };
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| AppError::Internal(format!("PseudonymClaim decode: {e}")))
+}
+
+/// Bind `pseudonym` to `member_did`, or report who already holds it.
+///
+/// Re-claiming for the **same** member succeeds: a member who asserts
+/// personhood twice — a second challenge, a renewed credential — is not a
+/// second person, and refusing them would make the second assertion fail with
+/// a message about duplicate humans.
+///
+/// Returns `Err(AppError::Conflict)` when another member holds it. The message
+/// deliberately does not name that member: "this person is already here" is the
+/// answer to the question, and "…and they are `did:key:z…`" is a disclosure the
+/// asker has no claim to — the same enumeration-resistance discipline the vault
+/// lifecycle applies.
+pub async fn claim(
+    members_ks: &KeyspaceHandle,
+    community_did: &str,
+    pseudonym: &str,
+    member_did: &str,
+) -> Result<(), AppError> {
+    if let Some(existing) = holder(members_ks, community_did, pseudonym).await?
+        && existing.member_did != member_did
+    {
+        return Err(AppError::Conflict(
+            "this person already holds a membership in this community".into(),
+        ));
+    }
+    members_ks
+        .insert(
+            key(community_did, pseudonym),
+            &PseudonymClaim {
+                member_did: member_did.to_string(),
+                claimed_at: Utc::now(),
+            },
+        )
+        .await
+}
+
+/// Release a claim by pseudonym, so that person may join again.
+///
+/// Rarely what a caller wants — holding the raw pseudonym means having just
+/// been handed one in a presentation. [`release_for_member`] is the operational
+/// path. Idempotent: releasing an unclaimed pseudonym is a no-op.
+pub async fn release(
+    members_ks: &KeyspaceHandle,
+    community_did: &str,
+    pseudonym: &str,
+) -> Result<(), AppError> {
+    members_ks.remove(key(community_did, pseudonym)).await
+}
+
+/// Release every claim held by `member_did`, returning how many were freed.
+///
+/// ## When this runs, and when it must not
+///
+/// On **purge** — the member is gone and the person behind them may return.
+/// Not on personhood revoke, and not on leaving.
+///
+/// Revoke withdraws the community's assertion that this member is a person; it
+/// is not evidence that the human stopped existing, and they are still a member.
+/// Leaving is the same. If either released the claim, one-membership-per-person
+/// would be defeated by revoking or leaving and coming back under a fresh DID —
+/// which is precisely the move the rule exists to stop.
+///
+/// ## Why this scans
+///
+/// The claim is stored under a digest of the pseudonym, and the pseudonym is
+/// deliberately not kept anywhere — so there is no index from member back to
+/// key. The alternative is storing the digest on the member row, which is one
+/// more thing to keep in sync for a rare operation. Purging a member is not a
+/// hot path, and the scan is bounded by the number of people who have ever
+/// asserted personhood here.
+pub async fn release_for_member(
+    members_ks: &KeyspaceHandle,
+    member_did: &str,
+) -> Result<usize, AppError> {
+    let rows = members_ks
+        .prefix_iter_raw(PSEUDONYM_PREFIX.as_bytes())
+        .await?;
+    let mut freed = 0usize;
+    for (key, bytes) in rows {
+        let Ok(claim) = serde_json::from_slice::<PseudonymClaim>(&bytes) else {
+            // A row we cannot read is a row we must not delete on a guess —
+            // it may belong to somebody else, and freeing it would admit a
+            // duplicate. Leave it and let the decode failure surface elsewhere.
+            continue;
+        };
+        if claim.member_did == member_did {
+            members_ks.remove(key).await?;
+            freed += 1;
+        }
+    }
+    Ok(freed)
+}
+
+/// Pull the pseudonyms out of a presentation's credentials, keeping only those
+/// issued by a provider this community accepts.
+///
+/// Two shapes are read, because a community may be its own IDVP or may rely on
+/// a foreign one:
+///
+/// - `credentialSubject.pseudonym` — a plain IDVC, whatever its schema.
+/// - `credentialSubject.endorsement.claim.pseudonym` — this community's own
+///   endorsement machinery, where operator claims live under `endorsement.claim`.
+///
+/// The issuer filter is the load-bearing part. Without it, any issuer could
+/// mint a credential carrying whatever pseudonym they liked — including one
+/// they knew to be unclaimed — and uniqueness would mean nothing. `vp_claims`
+/// is the projection `extract_vp_claims` produces, so `issuer` may be a string
+/// or an object with an `id`.
+pub fn extract(vp_claims: &JsonValue, accepted_idvps: &[String]) -> Vec<String> {
+    let Some(credentials) = vp_claims.get("credentials").and_then(|c| c.as_array()) else {
+        return Vec::new();
+    };
+
+    credentials
+        .iter()
+        .filter(|cred| {
+            let issuer = cred
+                .get("issuer")
+                .and_then(|i| i.as_str().or_else(|| i.get("id").and_then(|v| v.as_str())));
+            issuer.is_some_and(|did| accepted_idvps.iter().any(|a| a == did))
+        })
+        .filter_map(|cred| {
+            let subject = cred.get("credentialSubject")?;
+            subject
+                .get("pseudonym")
+                .or_else(|| {
+                    subject
+                        .get("endorsement")
+                        .and_then(|e| e.get("claim"))
+                        .and_then(|c| c.get("pseudonym"))
+                })
+                .and_then(|p| p.as_str())
+                .filter(|p| !p.is_empty())
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const COMMUNITY: &str = "did:webvh:acme.example";
+    const IDVP: &str = "did:webvh:idvp.example";
+    const ALICE: &str = "did:key:zAlice";
+    const BOB: &str = "did:key:zBob";
+
+    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = vti_common::config::StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        };
+        let store = vti_common::store::Store::open(&cfg).expect("store");
+        (store.keyspace("members-test").expect("ks"), dir)
+    }
+
+    // ─── storage ─────────────────────────────────────────────────────────
+
+    /// The first claim succeeds and is readable back.
+    #[tokio::test]
+    async fn a_first_claim_binds_the_pseudonym() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-1", ALICE).await.expect("claim");
+
+        let held = holder(&ks, COMMUNITY, "p-1")
+            .await
+            .expect("read")
+            .expect("claimed");
+        assert_eq!(held.member_did, ALICE);
+    }
+
+    /// The point of the module: a second person presenting the same
+    /// pseudonym is refused.
+    #[tokio::test]
+    async fn a_second_person_cannot_claim_the_same_pseudonym() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-1", ALICE).await.expect("claim");
+
+        let err = claim(&ks, COMMUNITY, "p-1", BOB)
+            .await
+            .expect_err("the same person may not join twice");
+        assert!(matches!(err, AppError::Conflict(_)), "{err:?}");
+    }
+
+    /// The refusal must not disclose who holds it. "Someone is already here"
+    /// answers the question; naming them hands an enumeration primitive to
+    /// anyone who can guess a pseudonym.
+    #[tokio::test]
+    async fn the_refusal_does_not_name_the_holder() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-1", ALICE).await.expect("claim");
+
+        let err = claim(&ks, COMMUNITY, "p-1", BOB)
+            .await
+            .expect_err("refused");
+        assert!(
+            !err.to_string().contains(ALICE),
+            "the holder must not be named: {err}"
+        );
+    }
+
+    /// Re-asserting as the same member is not a duplicate. A second challenge
+    /// or a renewed credential is the same person, and refusing it would fail
+    /// with a message about duplicate humans.
+    #[tokio::test]
+    async fn the_same_member_may_reclaim() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-1", ALICE).await.expect("first");
+        claim(&ks, COMMUNITY, "p-1", ALICE)
+            .await
+            .expect("re-asserting is not a second person");
+    }
+
+    /// Release frees the pseudonym for a fresh claim — the revoke path.
+    #[tokio::test]
+    async fn release_frees_the_pseudonym() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-1", ALICE).await.expect("claim");
+        release(&ks, COMMUNITY, "p-1").await.expect("release");
+
+        assert!(holder(&ks, COMMUNITY, "p-1").await.expect("read").is_none());
+        claim(&ks, COMMUNITY, "p-1", BOB)
+            .await
+            .expect("released pseudonyms are reclaimable");
+    }
+
+    /// Releasing something unclaimed is a no-op — a revoke that runs twice is
+    /// not an error.
+    #[tokio::test]
+    async fn releasing_an_unclaimed_pseudonym_is_a_noop() {
+        let (ks, _dir) = temp_ks();
+        release(&ks, COMMUNITY, "never-claimed")
+            .await
+            .expect("idempotent");
+    }
+
+    /// Purge frees exactly that member's claims and nobody else's — the
+    /// operational release path, which has no pseudonym in hand.
+    #[tokio::test]
+    async fn releasing_for_a_member_frees_only_their_claims() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-alice-1", ALICE).await.expect("a1");
+        claim(&ks, COMMUNITY, "p-alice-2", ALICE).await.expect("a2");
+        claim(&ks, COMMUNITY, "p-bob", BOB).await.expect("b");
+
+        let freed = release_for_member(&ks, ALICE).await.expect("release");
+        assert_eq!(freed, 2, "both of Alice's claims");
+
+        assert!(holder(&ks, COMMUNITY, "p-alice-1").await.unwrap().is_none());
+        assert!(holder(&ks, COMMUNITY, "p-alice-2").await.unwrap().is_none());
+        assert!(
+            holder(&ks, COMMUNITY, "p-bob").await.unwrap().is_some(),
+            "purging one member must not free another's claim"
+        );
+    }
+
+    /// Releasing for a member who holds nothing frees nothing and does not
+    /// error — most purges are of members who never asserted personhood.
+    #[tokio::test]
+    async fn releasing_for_a_member_with_no_claims_is_a_noop() {
+        let (ks, _dir) = temp_ks();
+        claim(&ks, COMMUNITY, "p-bob", BOB).await.expect("b");
+
+        assert_eq!(release_for_member(&ks, ALICE).await.expect("release"), 0);
+        assert!(holder(&ks, COMMUNITY, "p-bob").await.unwrap().is_some());
+    }
+
+    /// The scan must not trip over unrelated rows sharing the keyspace. The
+    /// `members` keyspace holds member records too, and a prefix scan that
+    /// mistook one for a claim would delete a member on purge.
+    #[tokio::test]
+    async fn the_scan_ignores_rows_outside_the_prefix() {
+        let (ks, _dir) = temp_ks();
+        ks.insert(
+            "member:did:key:zAlice".to_string(),
+            &json!({ "did": ALICE }),
+        )
+        .await
+        .expect("unrelated row");
+        claim(&ks, COMMUNITY, "p-alice", ALICE)
+            .await
+            .expect("claim");
+
+        assert_eq!(release_for_member(&ks, ALICE).await.expect("release"), 1);
+        assert!(
+            ks.get_raw("member:did:key:zAlice".to_string())
+                .await
+                .expect("read")
+                .is_some(),
+            "a member row must survive a pseudonym release"
+        );
+    }
+
+    /// The raw pseudonym must not appear in the key. It is a stable
+    /// per-person identifier; a store full of them is the correlation target
+    /// the whole construction exists to avoid.
+    #[test]
+    fn the_stored_key_does_not_contain_the_pseudonym() {
+        let k = key(COMMUNITY, "national-id-hash-12345");
+        assert!(!k.contains("national-id-hash-12345"), "{k}");
+        assert!(k.starts_with(PSEUDONYM_PREFIX));
+    }
+
+    /// The community is inside the digest, so two communities' stores cannot
+    /// be diffed to find people who are in both.
+    #[test]
+    fn the_same_pseudonym_keys_differently_per_community() {
+        assert_ne!(key(COMMUNITY, "p-1"), key("did:webvh:other.example", "p-1"));
+    }
+
+    // ─── extraction ──────────────────────────────────────────────────────
+
+    fn vp_with(issuer: &str, subject: JsonValue) -> JsonValue {
+        json!({
+            "holder": ALICE,
+            "credentials": [{
+                "type": ["VerifiableCredential"],
+                "issuer": issuer,
+                "credentialSubject": subject,
+            }]
+        })
+    }
+
+    /// A plain IDVC carrying the claim on the subject.
+    #[test]
+    fn a_plain_idvc_pseudonym_is_read() {
+        let vp = vp_with(IDVP, json!({ "id": ALICE, "pseudonym": "p-1" }));
+        assert_eq!(extract(&vp, &[IDVP.into()]), vec!["p-1".to_string()]);
+    }
+
+    /// This community's own endorsement shape, where operator claims sit
+    /// under `endorsement.claim`.
+    #[test]
+    fn an_endorsement_pseudonym_is_read() {
+        let vp = vp_with(
+            COMMUNITY,
+            json!({
+                "id": ALICE,
+                "endorsement": {
+                    "type": "IdentityVerification",
+                    "claim": { "method": "in-person-id", "pseudonym": "p-2" }
+                }
+            }),
+        );
+        assert_eq!(extract(&vp, &[COMMUNITY.into()]), vec!["p-2".to_string()]);
+    }
+
+    /// **The load-bearing filter.** Without it, any issuer could mint a
+    /// credential carrying a pseudonym they knew to be unclaimed, and
+    /// uniqueness would mean nothing at all.
+    #[test]
+    fn a_pseudonym_from_an_unaccepted_issuer_is_ignored() {
+        let vp = vp_with(
+            "did:key:zRandomStranger",
+            json!({ "id": ALICE, "pseudonym": "p-1" }),
+        );
+        assert!(
+            extract(&vp, &[IDVP.into()]).is_empty(),
+            "only accepted providers may establish uniqueness"
+        );
+    }
+
+    /// An issuer given as an object with `id` — the other shape
+    /// `extract_vp_claims` passes through.
+    #[test]
+    fn an_object_issuer_is_matched_on_its_id() {
+        let vp = json!({
+            "holder": ALICE,
+            "credentials": [{
+                "issuer": { "id": IDVP, "name": "Example IDVP" },
+                "credentialSubject": { "id": ALICE, "pseudonym": "p-1" },
+            }]
+        });
+        assert_eq!(extract(&vp, &[IDVP.into()]), vec!["p-1".to_string()]);
+    }
+
+    /// No accepted providers means nothing can establish uniqueness — an
+    /// empty list is "we have published none", not "we accept anyone".
+    #[test]
+    fn an_empty_accepted_list_accepts_nothing() {
+        let vp = vp_with(IDVP, json!({ "id": ALICE, "pseudonym": "p-1" }));
+        assert!(extract(&vp, &[]).is_empty());
+    }
+
+    /// A credential without the claim contributes nothing rather than an
+    /// empty-string pseudonym, which would collide with every other blank.
+    #[test]
+    fn a_credential_without_a_pseudonym_contributes_nothing() {
+        let vp = vp_with(IDVP, json!({ "id": ALICE }));
+        assert!(extract(&vp, &[IDVP.into()]).is_empty());
+
+        let blank = vp_with(IDVP, json!({ "id": ALICE, "pseudonym": "" }));
+        assert!(
+            extract(&blank, &[IDVP.into()]).is_empty(),
+            "an empty pseudonym is absent, not a value everyone shares"
+        );
+    }
+}

--- a/vtc-service/src/routes/admin/config.rs
+++ b/vtc-service/src/routes/admin/config.rs
@@ -873,6 +873,7 @@ async fn apply_profile_import(
         contact_email: Some(incoming.contact_email),
         language: Some(incoming.language),
         relationship_identifier_default: Some(incoming.relationship_identifier_default),
+        personhood: Some(incoming.personhood),
         extensions: Some(incoming.extensions),
     };
     let mut updated = current.clone();

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -68,6 +68,20 @@ pub struct PublicCommunityProfile {
     pub contact_email: Option<String>,
     pub language: String,
     pub created_at: DateTime<Utc>,
+    /// What this community's governance asserts about personhood.
+    ///
+    /// Published **unauthenticated, on purpose**. DTG Credentials puts PHC
+    /// status in "governance and trust registries, not credential structure",
+    /// so the party who needs this is a verifier holding one of this
+    /// community's VMCs — someone who is not a member, has no token, and may
+    /// have no relationship with the community at all. Behind auth it would
+    /// answer the question only for people who did not need to ask it.
+    ///
+    /// This is the *community's own claim about itself*. A verifier deciding
+    /// how much it is worth reads the trust registry, which is what the spec
+    /// calls authoritative; this is the self-published copy, and it is here so
+    /// the claim is resolvable at all rather than so it is trusted.
+    pub personhood: crate::community::PersonhoodGovernance,
     /// The community's DIDComm mediator DID, if one is configured.
     /// Sourced from the live daemon config (same as `/health`), not
     /// the persisted profile row.
@@ -155,6 +169,7 @@ pub async fn get_public_profile(
         contact_email: profile.contact_email,
         language: profile.language,
         created_at: profile.created_at,
+        personhood: profile.personhood,
         mediator_did,
         transports,
     }))

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -420,6 +420,21 @@ pub(crate) async fn assert_inner(
         ));
     }
 
+    // 6a. One membership per person, when this community's governance says so.
+    //
+    // The switch is the community's own `personhood.singleMembership`
+    // declaration, which is deliberate: the declaration and the enforcement
+    // are the same flag, so a community cannot publish the claim without the
+    // daemon starting to check it. DTG Credentials makes PHC status a
+    // governance determination; this makes the governance determination
+    // load-bearing rather than decorative.
+    //
+    // Runs after the policy, not before. The policy decides whether the
+    // evidence is acceptable at all, and asking "has this person been here
+    // before" about evidence that was about to be rejected would leak whether
+    // a pseudonym is claimed to anyone who can present anything.
+    enforce_single_membership(state, member_did, signer.issuer_did(), &vp_claims).await?;
+
     // 7. Allocate/reuse status-list slot + mint a fresh VMC. The
     //    `list_credential_id` read here is immutable; the allocation goes
     //    through `with_locked` (P0.1) which re-reads the row under the
@@ -698,6 +713,58 @@ async fn verify_vp_proof(
 /// ```
 ///
 /// Fail-closed: any error path yields `false`.
+/// Enforce one-membership-per-person, if this community's governance claims it.
+///
+/// A no-op when `personhood.singleMembership` is unset, which is every
+/// community that has not published the claim. When it *is* set, the assertion
+/// must carry a pseudonym from a provider the community accepts, and that
+/// pseudonym must not already belong to somebody else.
+///
+/// ## Why absence is a refusal
+///
+/// A community that publishes `singleMembership: true` is telling verifiers
+/// its VMCs are PHCs. If an assertion with no pseudonym were allowed through,
+/// that member would hold a credential asserting a property nobody checked —
+/// and the community would have no way to know which of its members were
+/// covered. Refusing is the only outcome that keeps the published claim true.
+///
+/// The error names the missing thing, because an operator hitting this has
+/// almost certainly turned the flag on before arranging an IDVP, and
+/// "personhood-policy-denied" would send them to the wrong file.
+async fn enforce_single_membership(
+    state: &AppState,
+    member_did: &str,
+    community_did: &str,
+    vp_claims: &JsonValue,
+) -> Result<(), AppError> {
+    let governance = crate::community::load_profile(&state.community_ks)
+        .await?
+        .map(|p| p.personhood)
+        .unwrap_or_default();
+    if !governance.single_membership {
+        return Ok(());
+    }
+
+    let pseudonyms = crate::members::pseudonym::extract(vp_claims, &governance.accepted_idvps);
+    if pseudonyms.is_empty() {
+        return Err(AppError::Forbidden(
+            "personhood-pseudonym-missing: this community enforces one membership per person, \
+             so an assertion must carry a pseudonym from an accepted identity-verification \
+             provider (see the community profile's personhood.acceptedIdvps)"
+                .into(),
+        ));
+    }
+
+    // Every presented pseudonym is claimed, not just the first. A member may
+    // legitimately present two accepted IDVCs; if either names a person
+    // already here, they are that person.
+    for pseudonym in &pseudonyms {
+        crate::members::pseudonym::claim(&state.members_ks, community_did, pseudonym, member_did)
+            .await?;
+    }
+    Ok(())
+}
+
 /// Evaluate the active `personhood.rego` over the presented claims.
 ///
 /// `community_did` is the DID the community signs its own credentials
@@ -744,3 +811,159 @@ fn rfc3339(t: DateTime<Utc>) -> String {
 // to surface parsed VCs without a churn-y import change.
 #[allow(dead_code)]
 type _PhantomVc = (VerifiableCredential, Arc<()>);
+
+#[cfg(test)]
+mod single_membership_tests {
+    use super::*;
+    use crate::community::{CommunityProfile, PersonhoodGovernance, store_profile};
+    use crate::test_support::TestVtc;
+
+    const COMMUNITY: &str = "did:webvh:acme.example";
+    const IDVP: &str = "did:webvh:idvp.example";
+    const ALICE: &str = "did:key:zAlice";
+    const BOB: &str = "did:key:zBob";
+
+    /// A VTC whose governance carries `governance`.
+    async fn vtc_with(governance: PersonhoodGovernance) -> TestVtc {
+        let vtc = TestVtc::builder().build().await;
+        let mut profile = CommunityProfile::new(COMMUNITY, "Acme");
+        profile.personhood = governance;
+        store_profile(&vtc.state.community_ks, &profile)
+            .await
+            .expect("seed profile");
+        vtc
+    }
+
+    fn claims_with_pseudonym(issuer: &str, pseudonym: &str) -> JsonValue {
+        json!({
+            "holder": ALICE,
+            "credentials": [{
+                "issuer": issuer,
+                "credentialSubject": { "id": ALICE, "pseudonym": pseudonym },
+            }]
+        })
+    }
+
+    fn enforcing() -> PersonhoodGovernance {
+        PersonhoodGovernance {
+            real_human: true,
+            single_membership: true,
+            accepted_idvps: vec![IDVP.into()],
+            governance_framework_url: None,
+        }
+    }
+
+    /// **The property that ties the two halves together.** A community that
+    /// has not published the claim is not silently policed — every existing
+    /// deployment keeps working exactly as before, with no pseudonym anywhere
+    /// in sight.
+    #[tokio::test]
+    async fn a_community_that_claims_nothing_enforces_nothing() {
+        let vtc = vtc_with(PersonhoodGovernance::default()).await;
+
+        enforce_single_membership(
+            &vtc.state,
+            ALICE,
+            COMMUNITY,
+            &json!({ "holder": ALICE, "credentials": [] }),
+        )
+        .await
+        .expect("no claim, no enforcement");
+    }
+
+    /// And the converse: publishing the claim turns the check on. The
+    /// declaration *is* the switch, so a community cannot advertise PHC
+    /// status to verifiers while quietly not checking it.
+    #[tokio::test]
+    async fn publishing_the_claim_turns_enforcement_on() {
+        let vtc = vtc_with(enforcing()).await;
+
+        let err = enforce_single_membership(
+            &vtc.state,
+            ALICE,
+            COMMUNITY,
+            &json!({ "holder": ALICE, "credentials": [] }),
+        )
+        .await
+        .expect_err("an enforcing community must refuse evidence it cannot check");
+
+        assert!(matches!(err, AppError::Forbidden(_)), "{err:?}");
+        assert!(
+            err.to_string().contains("personhood-pseudonym-missing"),
+            "the operator needs to be sent to acceptedIdvps, not to the rego: {err}"
+        );
+    }
+
+    /// The happy path: an accepted provider's pseudonym is claimed.
+    #[tokio::test]
+    async fn an_accepted_pseudonym_is_claimed() {
+        let vtc = vtc_with(enforcing()).await;
+
+        enforce_single_membership(
+            &vtc.state,
+            ALICE,
+            COMMUNITY,
+            &claims_with_pseudonym(IDVP, "person-1"),
+        )
+        .await
+        .expect("first assertion");
+
+        let held = crate::members::pseudonym::holder(&vtc.state.members_ks, COMMUNITY, "person-1")
+            .await
+            .expect("read")
+            .expect("claimed");
+        assert_eq!(held.member_did, ALICE);
+    }
+
+    /// The whole point: the same person, a second DID, refused.
+    #[tokio::test]
+    async fn the_same_person_cannot_join_twice() {
+        let vtc = vtc_with(enforcing()).await;
+        let claims = claims_with_pseudonym(IDVP, "person-1");
+
+        enforce_single_membership(&vtc.state, ALICE, COMMUNITY, &claims)
+            .await
+            .expect("first");
+
+        let err = enforce_single_membership(&vtc.state, BOB, COMMUNITY, &claims)
+            .await
+            .expect_err("one membership per person");
+        assert!(matches!(err, AppError::Conflict(_)), "{err:?}");
+    }
+
+    /// Asserting again as the same member is not a duplicate — a second
+    /// challenge or a renewed credential is the same human.
+    #[tokio::test]
+    async fn the_same_member_may_assert_again() {
+        let vtc = vtc_with(enforcing()).await;
+        let claims = claims_with_pseudonym(IDVP, "person-1");
+
+        enforce_single_membership(&vtc.state, ALICE, COMMUNITY, &claims)
+            .await
+            .expect("first");
+        enforce_single_membership(&vtc.state, ALICE, COMMUNITY, &claims)
+            .await
+            .expect("re-asserting is not a second person");
+    }
+
+    /// A pseudonym from an issuer the community has not published is not
+    /// evidence of anything. Without this, anyone could mint themselves an
+    /// unclaimed pseudonym and uniqueness would be decorative.
+    #[tokio::test]
+    async fn an_unaccepted_issuer_cannot_establish_uniqueness() {
+        let vtc = vtc_with(enforcing()).await;
+
+        let err = enforce_single_membership(
+            &vtc.state,
+            ALICE,
+            COMMUNITY,
+            &claims_with_pseudonym("did:key:zStranger", "person-1"),
+        )
+        .await
+        .expect_err("an unaccepted issuer proves nothing");
+        assert!(
+            err.to_string().contains("personhood-pseudonym-missing"),
+            "an unaccepted pseudonym is absent, not present-and-rejected: {err}"
+        );
+    }
+}


### PR DESCRIPTION
Closes the two DTG conformance gaps left open by #1085 and #1086. Two commits, in dependency order: publish the governance determination, then make it enforce.

## 1 · Publishing what governance says

DTG Credentials puts PHC status outside the credential — *"determined by governance and trust registries, not by credential structure"* — and calls the `PersonhoodCredential` type this daemon stamps on a vetted member's VMC a **non-authoritative hint**. §Governance Considerations item 2: *"Whether a VMC qualifies as a PHC is a governance determination, not a schema property."*

Nothing carried that determination. A verifier holding one of our VMCs was told by the type array not to trust the type array, with no second place to look.

`CommunityProfile` now carries the two clauses of the spec's definition, the accepted IDVPs, and where the governance framework can be read:

```json
"personhood": {
  "realHuman": true,
  "singleMembership": true,
  "acceptedIdvps": ["did:webvh:idvp.example"],
  "governanceFrameworkUrl": "https://acme.example/governance"
}
```

Served **unauthenticated** on `/v1/community/public-profile`: the party who needs it is not a member, holds no token, and may have no relationship with the community. Behind auth it would answer the question only for people who did not need to ask.

| Rule | Why |
|---|---|
| Both booleans default `false` | A community that never considered the question asserts nothing. Any other default has every existing deployment publishing a claim a verifier might act on. |
| Claiming both requires an accepted IDVP | A community asserting PHC status while naming nobody it trusts to verify identity has not written its governance down — and a verifier cannot tell an unwritten policy from a permissive one. |
| The two booleans are separate fields | They are separately achievable. In-person vetting supports the first and does nothing for the second; such a community should be able to say so rather than choosing between overclaiming and silence. |
| A patch replaces wholesale | The booleans are a conjunction asserted together. A partial patch flipping one while the other kept whatever it happened to be is how a community claims PHC status it never meant to. |

## 2 · One membership per person

**The design decision worth reviewing: `singleMembership` does not merely declare the property — setting it turns on the check.** The published claim and the enforcement are the same flag, so a community cannot advertise PHC status to verifiers while quietly not checking it. Communities that have not published the claim are untouched.

Nothing in the credential graph distinguishes one person with two DIDs from two people — a member who joins twice presents two perfectly valid sets of evidence and every check passes twice. So the anchor comes from outside: an IDVP that can deduplicate people derives a deterministic **pseudonym** per (person, community). Same person returning → same value; different community → unlinkable. This is the rate-limiting-identifier construction from [Adler et al. 2024](https://arxiv.org/abs/2408.07892), which the spec's PHC definition cites.

Read from `credentialSubject.pseudonym` or `credentialSubject.endorsement.claim.pseudonym`, and **only from an issuer in `acceptedIdvps`** — without that filter anyone could mint themselves a pseudonym they knew to be unclaimed, and the mechanism would be decorative.

**The pseudonym is never stored.** It is a stable per-person identifier, so a store full of them is exactly the correlation target the construction avoids. The key is a digest salted with the community DID — which also means two communities' stores cannot be diffed to find who is in both.

Claims live in the `members` keyspace under a prefix, putting them in `BACKED_UP` alongside the members they constrain. Same reasoning as `CONSUMED_INVITATIONS`: a claim that did not survive a restore would let a restored community admit the duplicate it had already refused.

**Released on purge, and only on purge.** Not on revoke, not on leaving. Revoke withdraws the community's assertion that a member is a person; it is not evidence the human stopped existing, and they are still a member. If either released the claim, the rule would be defeated by revoking and rejoining under a fresh DID.

## What this still does not give you

The guarantee is the IDVP's, not the community's — uniqueness is exactly as good as the accepted providers' deduplication.

**In-person vetting is the weak case.** When a community is its own IDVP, the pseudonym is an administrator's judgement that they have not met this person before. That genuinely supports the property in a community small enough for one person to hold in their head, and genuinely does not beyond it. The operator guide says so rather than letting the flag imply more.

Per-community by definition — the spec's glossary says *"exactly one membership in that VTC"* — so a single community can now be conformant. Personhood meaning something *across* communities stays a VTN-level property.

## Verification

- `cargo test -p vtc-service` — 45 test binaries, 0 failures (27 new tests)
- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p vtc-service --all-targets` — clean
- `cargo fmt --check` — clean

Not verified live: no message has crossed the wire against a real IDVP.
