### PR TITLE
docs(vtc): correct the policy comment that said uniqueness was unenforced

### DIFF
--- a/vtc-service/policies/default/personhood.rego
+++ b/vtc-service/policies/default/personhood.rego
@@ -108,11 +108,20 @@ allow if {
 # Note what this rule does **not** establish. DTG Credentials
 # §Personhood Credentials requires governance enforcing *both* real
 # human personhood *and* exactly one membership per person. This rule
-# is evidence for the first only; uniqueness is not something a
-# credential presented by its own subject can demonstrate, and this
-# daemon does not enforce it. A community whose governance depends on
-# one-membership-per-person needs a rule that consults evidence from an
-# issuer who checks that — see `docs/03-vtc/personhood-and-graph.md`.
+# is evidence for the first only — uniqueness is not something a
+# credential presented by its own subject can demonstrate.
+#
+# The second half is **not** a policy rule and cannot be written as one.
+# It lives at the route, gated on the community's own
+# `personhood.singleMembership` declaration, and works by claiming a
+# pseudonym issued by a provider the community published in
+# `personhood.acceptedIdvps`. A rego rule cannot do it: deciding whether
+# a pseudonym is already spoken for is a read against stored state, which
+# a policy evaluated over one presentation has no access to.
+#
+# So a community wanting one-membership-per-person turns that flag on
+# rather than editing this file — see
+# `docs/03-vtc/personhood-and-graph.md`.
 allow if {
 	some i
 	cred := input.vp_claims.credentials[i]


### PR DESCRIPTION
Follow-up to #1089 — a one-line-in-spirit fix I caught after that branch was already pushed.

The default `personhood.rego` carried a note ending **"this daemon does not enforce it"**, written when it was true. #1089 made it false.

A comment inside the file an operator opens to understand personhood is the worst possible place to leave a stale "we don't do that" — someone reading it would conclude they still need to write their own rule, and would not find the governance flag that actually does the work.

Replaced with what is now true, including **why it is not a rego rule and could not be**: deciding whether a pseudonym is already spoken for is a read against stored state, and a policy evaluated over a single presentation has no access to any. So a community wanting one-membership-per-person turns `personhood.singleMembership` on rather than editing this file.

Comment-only — no rule changed. `cargo test -p vtc-service --lib policy::default` green (36 tests, which includes recompiling every shipped default), fmt clean.