### PR TITLE
fix(mcp): compile a session store in, so session mode can work at all

### DIFF
--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -9,6 +9,16 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
+[features]
+# Session mode reads a `pnm`/`cnm` login out of the OS keyring, and without a
+# session backend compiled in it cannot read anything at all — it fails with
+# "this build has no session store compiled in". That made the default auth
+# mode, and the one this crate's README documents first, impossible. On by
+# default, exactly as `pnm-cli` and `cnm-cli` have it.
+default = ["keyring"]
+keyring = ["vta-sdk/keyring"]
+config-session = ["vta-sdk/config-session"]
+
 [dependencies]
 # `acl-setup` makes `DIDCommSession::connect` set this client's mediator ACL to
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).

--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -109,6 +109,11 @@ same DIDComm session).
 ## Notes
 
 - Build: `cargo build -p vta-mcp` (or `--release`). `publish = false`.
+- **Session mode needs the `keyring` feature**, which is on by default. It is
+  what compiles a session backend in; without one, `SessionStore` reads return
+  `None` and the bridge reports "not authenticated" whatever the state of your
+  login. Build `--no-default-features` only if you are using token or DIDComm
+  mode.
 - The agent's least-privilege capability set comes from its VTA **role** / ACL —
   the MCP server inherits whatever the authenticated identity is allowed to do.
 - See `docs/02-vta/personal-ai-agents.md` for the broader agent-enablement story.

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -129,6 +129,14 @@ async fn main() -> anyhow::Result<()> {
     // see `vta_sdk::crypto_init`. Without this, rustls 0.23 panics on
     // backend auto-detection when both backends are compiled in.
     vta_sdk::crypto_init::install_default_crypto_provider();
+    // Register the platform keyring store before any session is read. The
+    // `keyring` feature compiles a backend in; this is what gives it somewhere
+    // to look. Exits with a diagnostic if no store is usable, matching `pnm`
+    // and `cnm` — a session read from a store that will not open returns
+    // `None`, which is indistinguishable from "never logged in": the bridge
+    // would not fall back, it would forget.
+    #[cfg(feature = "keyring")]
+    vta_sdk::keyring_init::install_default_store_or_exit("vta-mcp");
 
     // stdout is the MCP JSON-RPC channel — logs MUST go to stderr.
     tracing_subscriber::fmt()


### PR DESCRIPTION
`vta-mcp --vta <slug>` — the **default** auth mode, and the first one the README documents — could never work.

Three independent faults, each on its own fatal:

| | |
|---|---|
| 1 | looked up the **bare slug**, where `pnm` writes `vta:<slug>` — fixed in [#1083](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1083) |
| 2 | looked in **`~/.config/pnm`**, where `pnm` uses `dirs::config_dir()` — fixed in [#1087](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1087) |
| 3 | **no session backend compiled in at all** — this PR |

The third is what hid the other two. Without the `keyring` feature the SDK has nowhere to read from, so every attempt failed the same way regardless of key or path:

```console
$ vta-mcp --vta glenn
error: cannot read session — this build has no session store compiled in.
Error: connecting to VTA (session): authentication failed: Not authenticated.
```

`install_default_store` was never called either, so even with the feature there would have been no platform store registered.

## The fix

A features table mirroring `pnm-cli`'s (`default = ["keyring"]`) plus the `install_default_store_or_exit` call both CLIs already make. A session read from a store that will not open returns `None`, which is indistinguishable from "never logged in" — the bridge would not fall back, it would **forget**, so failing loudly at startup is the right behaviour.

## Verified live

Against a `did:webvh` VTA over DIDComm, from a real stored `pnm` session:

```
server: {'name': 'vta-mcp', 'version': '0.1.5'}
tools : 11 tools
list_keys: OK -> { "keys": [ { "keyId": "did:key:z6Mkegvt…",
                               "derivationPath": "m/26'/2'/0'/31'",
                               "keyType": "ed25519", "status": "active", …
```

`--no-default-features` still builds, for token and DIDComm modes.

## How it surfaced

Running it. All three bugs were invisible to `cargo test`, to clippy, and to reading the code — the crate compiles and its tests pass in every one of the broken states. Nothing short of pointing it at a real VTA with a real login would have found any of them.

## Testing

`cargo test -p vta-mcp` — 5 pass. Clippy clean. Builds with and without default features. README notes the feature requirement.