### PR TITLE
fix(vtc)!: return a response body where the spec asks for one

### DIFF
--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -390,11 +390,23 @@ pub struct AdminSessionRequest {
 /// access token, which it could use directly as a bearer; this only mirrors
 /// it into the cookie the browser SPA expects. Browser-only by nature: the
 /// CSRF layer's same-origin check carries the (cookie-less) first call.
+/// `{ sessionId, expiresAt }` — the shape `vtc/auth/admin-session/0.1`
+/// publishes, and which this route did not return until #1059's witness put
+/// the handler beside its own schema.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminSessionResponse {
+    pub session_id: String,
+    /// Unix seconds, from the token's own expiry — the same value the
+    /// cookies' `Max-Age` is derived from, so the two cannot disagree.
+    pub expires_at: u64,
+}
+
 #[utoipa::path(
     post, path = "/auth/admin-session", tag = "auth",
     request_body = AdminSessionRequest,
     responses(
-        (status = 204, description = "Admin session + CSRF cookies set"),
+        (status = 200, description = "Admin session + CSRF cookies set", body = AdminSessionResponse),
         (status = 401, description = "Invalid or expired access token"),
     ),
 )]
@@ -428,7 +440,26 @@ pub async fn admin_session(
     let session_cookie = build_session_cookie(&req.access_token, max_age);
     let csrf_cookie = build_csrf_cookie(&csrf, max_age);
 
-    let mut response = StatusCode::NO_CONTENT.into_response();
+    // The spec's response is `{sessionId, expiresAt}`, and this handler
+    // returned 204 with both values only in `Set-Cookie` headers.
+    //
+    // A cookie is not a Trust Task response. Nothing but a browser can read
+    // one, so every non-browser caller — the CLIs, a DIDComm binding, any
+    // integration — could authenticate here and learn nothing about the
+    // session it had just been given. The cookies stay, because the admin SPA
+    // relies on them; the body is what makes the route usable by anything
+    // else.
+    let mut response = (
+        StatusCode::OK,
+        Json(AdminSessionResponse {
+            session_id: claims.session_id.clone(),
+            // Unix seconds, as the schema types it — the same value the
+            // cookies' `Max-Age` is derived from, so the body and the headers
+            // cannot disagree about when this session ends.
+            expires_at: claims.exp,
+        }),
+    )
+        .into_response();
     let headers = response.headers_mut();
     headers.append(
         SET_COOKIE,
@@ -1268,6 +1299,9 @@ pub async fn sign_out(
     }
     info!(did = %auth.did, session_id = %auth.session_id, "sign-out");
 
+    // Sign-out has nothing to report: the session it names is gone, so 204
+    // is the honest status and the cookie-clearing headers are the whole
+    // effect.
     let mut response = StatusCode::NO_CONTENT.into_response();
     let headers = response.headers_mut();
     let session_clear = format!(

--- a/vtc-service/src/routes/endorsement_types.rs
+++ b/vtc-service/src/routes/endorsement_types.rs
@@ -70,7 +70,7 @@ pub async fn register(
     auth: AdminAuth,
     State(state): State<AppState>,
     Json(body): Json<RegisterBody>,
-) -> Result<(StatusCode, Json<EndorsementType>), AppError> {
+) -> Result<(StatusCode, Json<RegisterResponse>), AppError> {
     let audit_writer = state
         .audit_writer
         .as_ref()
@@ -119,7 +119,21 @@ pub async fn register(
 
     info!(type_uri = %uri, by = %auth.0.did, "endorsement type registered");
 
-    Ok((StatusCode::CREATED, Json(row)))
+    Ok((
+        StatusCode::CREATED,
+        Json(RegisterResponse {
+            endorsement_type: row,
+        }),
+    ))
+}
+
+/// `{ endorsementType: … }` — the shape `vtc/endorsement-types/register/0.1`
+/// publishes. The handler returned the bare row until #1059's witness
+/// compared it with its own schema; the row itself conformed.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterResponse {
+    pub endorsement_type: EndorsementType,
 }
 
 // ─── List ────────────────────────────────────────────────

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -490,7 +490,7 @@ fn uuid() -> uuid::Uuid {
 /// 3. **Unspecced members on an `additionalProperties: false` response.**
 ///    Usually the service is ahead of the spec (the ceremony verdict
 ///    envelope, `decidedAt`), occasionally behind it (`didBindingChallenge`).
-const KNOWN_DRIFT_COUNT: usize = 27;
+const KNOWN_DRIFT_COUNT: usize = 26;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -580,22 +580,14 @@ fn table() -> Vec<Conformance> {
             json!({ "jti": REQUEST_ID })
         ),
         // ─── auth ────────────────────────────────────────────────────
-        drift!(
+        checked!(
             s::auth::admin_session::v0_1::Payload,
             s::auth::admin_session::v0_1::Response,
-            Side::Response,
-            // `AdminSessionRequest` — routes/auth.rs:364.
             json!({ "accessToken": "eyJhbGciOiJFZERTQSJ9.e30.sig" }),
-            // There is no response type: the handler (routes/auth.rs:401)
-            // returns 204 with an EMPTY body. `{}` is the closest JSON there
-            // is, and it already flatters the real wire form.
-            json!({}),
-            "no response body at all — the handler returns 204 and puts its \
-             result in two Set-Cookie headers, where the spec requires \
-             `{sessionId, expiresAt}`. A cookie is not a Trust Task response \
-             and no non-browser transport can read one, so this is a real \
-             hole rather than a naming mismatch: fix here by returning the \
-             body as well as the cookies"
+            // `AdminSessionResponse` — the handler returned 204 and nothing
+            // else until #1059. The cookies remain; the body is what makes
+            // the route usable by anything that is not a browser.
+            json!({ "sessionId": REQUEST_ID, "expiresAt": 1_787_500_800_u64 })
         ),
         checked!(
             s::auth::recognise::challenge::v0_1::Payload,
@@ -799,13 +791,13 @@ fn table() -> Vec<Conformance> {
                 "claimSchema": { "type": "object" },
                 "description": "Rust proficiency",
             }),
-            // The handler returns the row bare (routes/endorsement_types.rs:69).
-            endorsement_type(),
-            "response is the bare `EndorsementType`; the spec wraps it as \
-             `{endorsementType: …}`. The row also carries `createdByDid`, \
-             which the canonical component omits — that one is worth taking \
-             upstream (who registered a type is audit-relevant), the wrapper \
-             is a fix here"
+            // `RegisterResponse` — the row was returned bare until #1059.
+            json!({ "endorsementType": endorsement_type() }),
+            "the missing `{endorsementType: …}` wrapper is fixed. What remains \
+             is the row's `createdByDid`, which the canonical component does \
+             not define — taken upstream in \
+             trustoverip/dtgwg-trust-tasks-tf#260, so this closes on the next \
+             `trust-tasks-rs` release rather than on any change here"
         ),
         drift!(
             s::endorsement_types::list::v0_1::Payload,

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -200,7 +200,12 @@ async fn register_happy_path() {
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     let (status, v) = body_value(resp).await;
     assert_eq!(status, StatusCode::CREATED, "{v}");
-    assert_eq!(v["typeUri"], "https://example.com/v1/skills/rust");
+    // `{endorsementType: …}` since #1059 — the row was returned bare until
+    // the witness compared the handler with its own schema.
+    assert_eq!(
+        v["endorsementType"]["typeUri"],
+        "https://example.com/v1/skills/rust"
+    );
 }
 
 #[tokio::test]

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -318,9 +318,12 @@ async fn admin_session_bridges_bearer_to_cookie_and_authenticates() {
         )
         .await
         .unwrap();
-    assert_eq!(res.status(), StatusCode::NO_CONTENT);
+    // 200 with `{sessionId, expiresAt}` since #1059 — it was 204 with the
+    // result only in `Set-Cookie`, which no non-browser caller could read.
+    assert_eq!(res.status(), StatusCode::OK);
 
-    // The session cookie must be set; capture it for the follow-up call.
+    // The session cookie must still be set; capture it for the follow-up
+    // call. The body is additive — the browser path is unchanged.
     let set_cookies: Vec<String> = res
         .headers()
         .get_all(axum::http::header::SET_COOKIE)


### PR DESCRIPTION
Two more from #1076, and one of them is a hole rather than a shape mismatch.

## `auth/admin-session` had no response body at all

It returned **204** with its result in two `Set-Cookie` headers, where the
schema asks for `{sessionId, expiresAt}`.

A cookie is not a Trust Task response. **Nothing but a browser can read one** —
so every non-browser caller (the CLIs, a DIDComm binding, any integration)
could authenticate here and learn nothing about the session it had just been
given. That is a route that only works for one client by accident of what that
client happens to be.

The cookies stay, because the admin SPA relies on them. The body is what makes
the route usable by anything else.

**`expiresAt` is Unix seconds**, because that is how the schema types it. I
wrote it as RFC 3339 first and the witness rejected it — "the spec asks for a
timestamp" is not the same as knowing *which* one, and reading the schema beat
assuming the convention.

## `endorsement-types/register` returned the bare row

The spec wraps it as `{endorsementType: …}`; the row itself always conformed.

Its other half — the unspecced `createdByDid` — was taken upstream in
trustoverip/dtgwg-trust-tasks-tf#260, so the entry stays and now describes only
what is left, naming what will close it.

## Drift 27 → 26, and what the rest are waiting on

**Twelve of the remaining twenty-six close on a `trust-tasks-rs` release**
carrying #257–#260, not on any change here. The entries say so explicitly, so
nobody goes hunting for code to write against them.

That leaves roughly fourteen genuinely actionable, and the upstream bucket is
now empty — every entry whose recorded disposition was "take it upstream" has
been taken.

## Verified

- `cargo test -p vtc-service` — 53 suites, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- All three conformance tests pass at the corrected count

Two integration tests moved with the change: one asserted 204 from
admin-session, one read the endorsement type off the bare row. Both updated
with a note saying what changed and why, rather than silently.

## Breaking

`POST /v1/auth/admin-session` returns 200 with `{sessionId, expiresAt}` instead
of 204. `POST /v1/endorsement-types` returns `{endorsementType: …}` instead of
the bare row. Both additive for the admin SPA — it ignored the first entirely
and reads the second through a field it already had — and both were previously
returning something their published schemas did not describe.
