### PR TITLE
fix(vtc)!: send the envelope and the casing the schemas ask for

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -49,22 +49,22 @@ export interface RegistryTransport {
 }
 
 export interface DiagnosticsResponse {
-  registry_status: string;
-  queue_depth: number;
-  rtbf_batched_count: number;
-  failed_count: number;
-  oldest_pending_age_seconds?: number;
-  last_success_at?: string;
-  last_failure_at?: string;
-  last_error?: string;
-  vta_did?: string;
-  mediator_url?: string;
-  mediator_did?: string;
-  syncer_enabled: boolean;
-  syncer_running: boolean;
-  syncer_restarts: number;
-  messaging_status?: string;
-  registry_transport?: RegistryTransport;
+  registryStatus: string;
+  queueDepth: number;
+  rtbfBatchedCount: number;
+  failedCount: number;
+  oldestPendingAgeSeconds?: number;
+  lastSuccessAt?: string;
+  lastFailureAt?: string;
+  lastError?: string;
+  vtaDid?: string;
+  mediatorUrl?: string;
+  mediatorDid?: string;
+  syncerEnabled: boolean;
+  syncerRunning: boolean;
+  syncerRestarts: number;
+  messagingStatus?: string;
+  registryTransport?: RegistryTransport;
   transports?: TransportStatus[];
 }
 

--- a/vtc-service/admin-ui/src/plugins/dashboard.tsx
+++ b/vtc-service/admin-ui/src/plugins/dashboard.tsx
@@ -20,17 +20,17 @@ export function Dashboard() {
   });
 
   const status = health.data?.status;
-  const mediatorDid = diagnostics.data?.mediator_did;
-  const vtaDid = diagnostics.data?.vta_did;
-  const registry = diagnostics.data?.registry_transport;
-  const registryStatus = diagnostics.data?.registry_status;
+  const mediatorDid = diagnostics.data?.mediatorDid;
+  const vtaDid = diagnostics.data?.vtaDid;
+  const registry = diagnostics.data?.registryTransport;
+  const registryStatus = diagnostics.data?.registryStatus;
 
   // The two queue states worth interrupting the dashboard for. Failed rows are
   // terminal — the syncer has given up, so they never clear on their own — and
   // a queue an hour behind is the spec's degraded SLI. Plain depth is not
   // trouble: a burst of joins drains.
-  const failed = diagnostics.data?.failed_count ?? 0;
-  const oldestPending = diagnostics.data?.oldest_pending_age_seconds;
+  const failed = diagnostics.data?.failedCount ?? 0;
+  const oldestPending = diagnostics.data?.oldestPendingAgeSeconds;
   const queueTrouble =
     failed > 0
       ? `${failed} sync job${failed === 1 ? "" : "s"} failed`

--- a/vtc-service/admin-ui/src/plugins/recognition.tsx
+++ b/vtc-service/admin-ui/src/plugins/recognition.tsx
@@ -52,7 +52,7 @@ export function Recognition() {
   });
 
   const result = lookup.data;
-  const oldestPending = diagnostics.data?.oldest_pending_age_seconds;
+  const oldestPending = diagnostics.data?.oldestPendingAgeSeconds;
 
   return (
     <div className="page">
@@ -75,30 +75,30 @@ export function Recognition() {
           <dl>
             <dt>Status</dt>
             <dd>
-              <code>{diagnostics.data.registry_status}</code>
+              <code>{diagnostics.data.registryStatus}</code>
             </dd>
-            {diagnostics.data.registry_transport?.did && (
+            {diagnostics.data.registryTransport?.did && (
               <>
                 <dt>Registry DID</dt>
                 <dd>
-                  <code>{diagnostics.data.registry_transport.did}</code>
+                  <code>{diagnostics.data.registryTransport.did}</code>
                   <CopyButton
-                    value={diagnostics.data.registry_transport.did}
+                    value={diagnostics.data.registryTransport.did}
                     label="Copy trust registry DID"
                     successMessage="Trust registry DID copied"
                   />
                 </dd>
               </>
             )}
-            {diagnostics.data.registry_transport?.url && (
+            {diagnostics.data.registryTransport?.url && (
               <>
                 <dt>Registry URL</dt>
                 <dd>
-                  <code>{diagnostics.data.registry_transport.url}</code>
+                  <code>{diagnostics.data.registryTransport.url}</code>
                 </dd>
               </>
             )}
-            {diagnostics.data.registry_transport && (
+            {diagnostics.data.registryTransport && (
               <>
                 {/* Advertised is the registry's own claim, read from its DID
                     document; active is what the last call chose. Shown apart
@@ -107,8 +107,8 @@ export function Recognition() {
                 <dt>Advertises</dt>
                 <dd>
                   <code>
-                    {diagnostics.data.registry_transport.advertised.length
-                      ? diagnostics.data.registry_transport.advertised
+                    {diagnostics.data.registryTransport.advertised.length
+                      ? diagnostics.data.registryTransport.advertised
                           .map(protocolName)
                           .join(", ")
                       : "(not resolved)"}
@@ -117,17 +117,17 @@ export function Recognition() {
                 <dt>Connecting over</dt>
                 <dd>
                   <code>
-                    {diagnostics.data.registry_transport.active
-                      ? protocolName(diagnostics.data.registry_transport.active)
+                    {diagnostics.data.registryTransport.active
+                      ? protocolName(diagnostics.data.registryTransport.active)
                       : "(none selected)"}
                   </code>
                 </dd>
               </>
             )}
-            {diagnostics.data.registry_transport?.error && (
+            {diagnostics.data.registryTransport?.error && (
               <>
                 <dt>Last transport error</dt>
-                <dd>{diagnostics.data.registry_transport.error}</dd>
+                <dd>{diagnostics.data.registryTransport.error}</dd>
               </>
             )}
           </dl>
@@ -139,7 +139,7 @@ export function Recognition() {
         <p className="muted">
           Member changes reach the registry through a durable queue with
           exponential backoff. These counts are the only place a stalled
-          reconciler is visible — <code>registry_status</code> reports whether
+          reconciler is visible — <code>registryStatus</code> reports whether
           the registry answers, not whether our writes are landing.
         </p>
         {diagnostics.isPending && <p className="muted">Loading…</p>}
@@ -148,7 +148,7 @@ export function Recognition() {
             <div className="stat-tiles">
               <QueueTile
                 label="Pending"
-                value={diagnostics.data.queue_depth}
+                value={diagnostics.data.queueDepth}
                 foot={
                   oldestPending === undefined
                     ? "nothing waiting"
@@ -165,27 +165,27 @@ export function Recognition() {
               />
               <QueueTile
                 label="Failed"
-                value={diagnostics.data.failed_count}
+                value={diagnostics.data.failedCount}
                 // Terminal rows: the syncer has given up on them, so unlike
                 // pending they will never clear on their own.
                 foot={
-                  diagnostics.data.failed_count > 0
+                  diagnostics.data.failedCount > 0
                     ? "given up — needs operator triage"
                     : "none"
                 }
-                tone={diagnostics.data.failed_count > 0 ? "warn" : "ok"}
+                tone={diagnostics.data.failedCount > 0 ? "warn" : "ok"}
               />
               <QueueTile
                 label="RTBF batched"
-                value={diagnostics.data.rtbf_batched_count}
+                value={diagnostics.data.rtbfBatchedCount}
                 foot="held for the daily flush"
               />
               <QueueTile
                 label="Syncer"
                 value={
-                  !diagnostics.data.syncer_enabled
+                  !diagnostics.data.syncerEnabled
                     ? "off"
-                    : diagnostics.data.syncer_running
+                    : diagnostics.data.syncerRunning
                       ? "running"
                       : "stopped"
                 }
@@ -193,19 +193,19 @@ export function Recognition() {
                 // mid-restart after a panic, or wedged. Rising restarts is the
                 // "keeps crashing" signal.
                 foot={
-                  !diagnostics.data.syncer_enabled
+                  !diagnostics.data.syncerEnabled
                     ? "no registry configured"
-                    : diagnostics.data.syncer_restarts > 0
-                      ? `${diagnostics.data.syncer_restarts} restart${
-                          diagnostics.data.syncer_restarts === 1 ? "" : "s"
+                    : diagnostics.data.syncerRestarts > 0
+                      ? `${diagnostics.data.syncerRestarts} restart${
+                          diagnostics.data.syncerRestarts === 1 ? "" : "s"
                         }`
                       : "no restarts"
                 }
                 tone={
-                  !diagnostics.data.syncer_enabled
+                  !diagnostics.data.syncerEnabled
                     ? "neutral"
-                    : diagnostics.data.syncer_running &&
-                        diagnostics.data.syncer_restarts === 0
+                    : diagnostics.data.syncerRunning &&
+                        diagnostics.data.syncerRestarts === 0
                       ? "ok"
                       : "warn"
                 }
@@ -214,20 +214,20 @@ export function Recognition() {
             <dl>
               <dt>Last success</dt>
               <dd>
-                {diagnostics.data.last_success_at
-                  ? formatIso(diagnostics.data.last_success_at)
+                {diagnostics.data.lastSuccessAt
+                  ? formatIso(diagnostics.data.lastSuccessAt)
                   : "(never)"}
               </dd>
               <dt>Last failure</dt>
               <dd>
-                {diagnostics.data.last_failure_at
-                  ? formatIso(diagnostics.data.last_failure_at)
+                {diagnostics.data.lastFailureAt
+                  ? formatIso(diagnostics.data.lastFailureAt)
                   : "(none)"}
               </dd>
-              {diagnostics.data.last_error && (
+              {diagnostics.data.lastError && (
                 <>
                   <dt>Last error</dt>
-                  <dd>{diagnostics.data.last_error}</dd>
+                  <dd>{diagnostics.data.lastError}</dd>
                 </>
               )}
             </dl>

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -311,7 +311,7 @@ pub async fn list(
     security(("bearer_jwt" = [])),
     params(("id" = String, Path, description = "Endorsement id")),
     responses(
-        (status = 200, description = "Endorsement", body = Endorsement),
+        (status = 200, description = "Endorsement", body = EndorsementEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin or issuer"),
         (status = 404, description = "Endorsement not found"),
@@ -321,7 +321,7 @@ pub async fn show(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<Endorsement>, AppError> {
+) -> Result<Json<EndorsementEnvelope>, AppError> {
     let acl = get_acl_entry(&state.acl_ks, &auth.did)
         .await?
         .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
@@ -333,7 +333,7 @@ pub async fn show(
     let row = get_endorsement(&state.endorsements_ks, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("endorsement {id} not found")))?;
-    Ok(Json(row))
+    Ok(Json(EndorsementEnvelope { endorsement: row }))
 }
 
 // ─── Revoke ──────────────────────────────────────────────
@@ -486,4 +486,11 @@ pub async fn revoke(
 
 fn rfc3339(t: chrono::DateTime<Utc>) -> String {
     t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// `{ endorsement: … }` — the shape `vtc/endorsements/show/0.1` publishes.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EndorsementEnvelope {
+    pub endorsement: Endorsement,
 }

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -11,6 +11,14 @@ use crate::server::AppState;
 
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct HealthResponse {
+    // Deliberately *not* `rename_all = "camelCase"`, unlike
+    // `DiagnosticsResponse` below.
+    //
+    // `/health` is not a bound Trust Task, so no published schema describes
+    // it, and `vtc_did` is read by the default landing page
+    // (`website-default/site.js`). Renaming it would break a page this
+    // service ships, to satisfy a contract that does not exist. R3.1 governs
+    // wire types with schemas; this is an unauth status page.
     status: &'static str,
     version: &'static str,
     /// The VTC's own did:webvh, set during `vtc setup`. Kept on the
@@ -70,6 +78,7 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
 /// running on-call should be able to read this without
 /// holding the super-admin role.
 #[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct DiagnosticsResponse {
     pub registry_status: String,
     pub queue_depth: u64,

--- a/vtc-service/src/routes/join_requests/read.rs
+++ b/vtc-service/src/routes/join_requests/read.rs
@@ -3,7 +3,7 @@
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use vti_common::error::AppError;
@@ -73,7 +73,7 @@ pub async fn list_join_requests(
     security(("bearer_jwt" = [])),
     params(("id" = String, Path, description = "Join request id")),
     responses(
-        (status = 200, description = "Join request", body = JoinRequest),
+        (status = 200, description = "Join request", body = JoinRequestEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "Join request not found"),
@@ -83,9 +83,16 @@ pub async fn show_join_request(
     _admin: AdminAuth,
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<JoinRequest>, AppError> {
+) -> Result<Json<JoinRequestEnvelope>, AppError> {
     let req = get_join_request(&state.join_requests_ks, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("join request not found: {id}")))?;
-    Ok(Json(req))
+    Ok(Json(JoinRequestEnvelope { request: req }))
+}
+
+/// `{ request: … }` — the shape `vtc/join-requests/show/0.1` publishes.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinRequestEnvelope {
+    pub request: JoinRequest,
 }

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -263,7 +263,7 @@ pub struct RemovedMembersResponse {
     security(("bearer_jwt" = [])),
     params(("did" = String, Path, description = "Member DID")),
     responses(
-        (status = 200, description = "Member record", body = MemberResponse),
+        (status = 200, description = "Member record", body = MemberEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "Member not found"),
@@ -273,7 +273,7 @@ pub async fn show_member(
     _auth: AdminAuth,
     State(state): State<AppState>,
     Path(did): Path<String>,
-) -> Result<Json<MemberResponse>, AppError> {
+) -> Result<Json<MemberEnvelope>, AppError> {
     vti_common::identifier::validate_did("did", &did)?;
     let member = get_member(&state.members_ks, &did)
         .await?
@@ -283,7 +283,9 @@ pub async fn show_member(
         // surface as 404 because the *member* isn't presentable.
         AppError::NotFound(format!("member not found (no ACL row): {did}"))
     })?;
-    Ok(Json(MemberResponse::from_pair(acl, member)))
+    Ok(Json(MemberEnvelope {
+        member: MemberResponse::from_pair(acl, member),
+    }))
 }
 
 /// Unused-listing helper kept to ensure `list_acl_entries` stays
@@ -298,4 +300,12 @@ pub(crate) async fn list_admin_dids(state: &AppState) -> Result<Vec<String>, App
         .filter(|e| matches!(e.role, VtcRole::Admin))
         .map(|e| e.did)
         .collect())
+}
+
+/// `{ member: … }` — the shape `vtc/members/show/0.1` publishes. The row was
+/// returned bare until #1093; the row itself always conformed.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberEnvelope {
+    pub member: MemberResponse,
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -863,10 +863,10 @@ fn table() -> Vec<Conformance> {
             s::endorsements::show::v0_1::Response,
             Side::Response,
             json!({ "endorsementId": "11111111-1111-4111-8111-111111111111" }),
-            endorsement(),
-            "bare row where the spec says `{endorsement: …}`, and the row's \
-             members are this service's spelling. Same model disagreement as \
-             `issue`; fix the family together"
+            json!({ "endorsement": endorsement() }),
+            "the `{endorsement: …}` envelope is right as of #1093; the row's \
+             members are still this service's spelling. Same model \
+             disagreement as `issue`; fix the family together"
         ),
         drift!(
             s::endorsements::revoke::v0_1::Payload,
@@ -976,9 +976,9 @@ fn table() -> Vec<Conformance> {
             s::join_requests::show::v0_1::Response,
             Side::Response,
             json!({ "id": REQUEST_ID }),
-            join_request(),
-            "bare `JoinRequest` where the spec says `{request: …}`, plus the \
-             same unspecced `vpClaims` / `decision` as `list`"
+            json!({ "request": join_request() }),
+            "the `{request: …}` envelope is right as of #1093; the row still \
+             carries the same unspecced `vpClaims` / `decision` as `list`"
         ),
         drift!(
             s::join_requests::decide::v0_1::Payload,
@@ -1112,9 +1112,9 @@ fn table() -> Vec<Conformance> {
             s::members::show::v0_1::Response,
             Side::Response,
             json!({ "did": DID }),
-            member_response(),
-            "bare `MemberResponse` where the spec says `{member: …}`, plus \
-             the same five unspecced members as `list`"
+            json!({ "member": member_response() }),
+            "the `{member: …}` envelope is right as of #1093; the row still \
+             carries the same five unspecced members as `list`"
         ),
         drift!(
             s::members::update::v0_1::Payload,
@@ -1270,28 +1270,26 @@ fn table() -> Vec<Conformance> {
             s::registry::diagnostics::v0_1::Response,
             Side::Response,
             json!({}),
-            // `DiagnosticsResponse` — routes/health.rs:73. No `rename_all`.
+            // `DiagnosticsResponse` — routes/health.rs:73, camelCase as of #1093.
             json!({
-                "registry_status": "active",
-                "queue_depth": 3,
-                "rtbf_batched_count": 1,
-                "failed_count": 0,
-                "oldest_pending_age_seconds": 42,
-                "last_success_at": TS,
-                "syncer_enabled": true,
-                "syncer_running": true,
-                "syncer_restarts": 0,
-                "messaging_status": "connected",
+                "registryStatus": "active",
+                "queueDepth": 3,
+                "rtbfBatchedCount": 1,
+                "failedCount": 0,
+                "oldestPendingAgeSeconds": 42,
+                "lastSuccessAt": TS,
+                "syncerEnabled": true,
+                "syncerRunning": true,
+                "syncerRestarts": 0,
+                "messagingStatus": "connected",
                 "transports": [{ "protocol": "rest", "advertised": true, "serviceable": true }],
             }),
-            "every member is snake_case (`registry_status` for \
-             `registryStatus`), so not one of the four required members is \
-             present under the name the spec gives it — the worst single row \
-             in this table. Nine further members (`syncer_*`, \
-             `messaging_status`, `transports`, `registry_transport`, \
-             `vta_did`, `mediator_*`) have no counterpart in the spec at \
-             all. R3.1 casing is a fix here; the transport/messaging half is \
-             genuinely useful diagnostics and should go upstream"
+            "R3.1 casing fixed in #1093 — all four required members now \
+             reach the wire under the spec's name. Nine further members \
+             (`syncer*`, `messagingStatus`, `transports`, \
+             `registryTransport`, `vtaDid`, `mediator*`) still have no \
+             counterpart in the spec at all; that half is genuinely useful \
+             diagnostics and should go upstream, not be deleted"
         ),
         // ─── relationships ───────────────────────────────────────────
         checked!(

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -69,22 +69,21 @@ async fn diagnostics_empty_queue_reports_zero_counts() {
         .unwrap();
     let (status, v) = body_value(resp).await;
     assert_eq!(status, StatusCode::OK, "{v}");
-    assert_eq!(v["queue_depth"], 0);
-    assert_eq!(v["rtbf_batched_count"], 0);
-    assert_eq!(v["failed_count"], 0);
+    assert_eq!(v["queueDepth"], 0);
+    assert_eq!(v["rtbfBatchedCount"], 0);
+    assert_eq!(v["failedCount"], 0);
     // Default RegistryHealth state is "degraded" (no successful
     // probe yet).
-    assert_eq!(v["registry_status"], "degraded");
+    assert_eq!(v["registryStatus"], "degraded");
     assert!(
-        v.get("oldest_pending_age_seconds")
-            .is_none_or(|x| x.is_null()),
+        v.get("oldestPendingAgeSeconds").is_none_or(|x| x.is_null()),
         "empty queue → no oldest_pending_age"
     );
     // Syncer liveness is surfaced (P3.13). The test daemon has no
     // registry client, so the syncer was never spawned.
-    assert_eq!(v["syncer_enabled"], false);
-    assert_eq!(v["syncer_running"], false);
-    assert_eq!(v["syncer_restarts"], 0);
+    assert_eq!(v["syncerEnabled"], false);
+    assert_eq!(v["syncerRunning"], false);
+    assert_eq!(v["syncerRestarts"], 0);
 }
 
 #[tokio::test]
@@ -124,12 +123,12 @@ async fn diagnostics_reports_pending_rtbf_and_failed_counts() {
     assert_eq!(status, StatusCode::OK, "{v}");
     // Pending (1) + RTBF-pending (1) = queue_depth 2; Failed
     // sits outside the active queue.
-    assert_eq!(v["queue_depth"], 2);
-    assert_eq!(v["rtbf_batched_count"], 1);
-    assert_eq!(v["failed_count"], 1);
+    assert_eq!(v["queueDepth"], 2);
+    assert_eq!(v["rtbfBatchedCount"], 1);
+    assert_eq!(v["failedCount"], 1);
     // Pending (dispatchable) job's age is surfaced; RTBF row
     // doesn't count toward "stuck" SLI.
-    assert!(v["oldest_pending_age_seconds"].is_number());
+    assert!(v["oldestPendingAgeSeconds"].is_number());
 }
 
 #[tokio::test]
@@ -175,9 +174,9 @@ async fn health_payload_is_minimal_and_unauth() {
     assert!(v["version"].is_string());
     assert!(v.get("vtc_did").is_some(), "community DID stays public");
     // The recon-sensitive fields are gone from the unauth surface.
-    assert!(v.get("mediator_url").is_none(), "mediator_url leaked: {v}");
-    assert!(v.get("mediator_did").is_none(), "mediator_did leaked: {v}");
-    assert!(v.get("vta_did").is_none(), "vta_did leaked: {v}");
+    assert!(v.get("mediatorUrl").is_none(), "mediator_url leaked: {v}");
+    assert!(v.get("mediatorDid").is_none(), "mediator_did leaked: {v}");
+    assert!(v.get("vtaDid").is_none(), "vta_did leaked: {v}");
 }
 
 #[tokio::test]
@@ -198,7 +197,7 @@ async fn diagnostics_surfaces_mediator_detail_to_admin() {
         .unwrap();
     let (status, v) = body_value(resp).await;
     assert_eq!(status, StatusCode::OK, "{v}");
-    assert_eq!(v["mediator_did"], "did:key:z6MkMediator");
+    assert_eq!(v["mediatorDid"], "did:key:z6MkMediator");
 }
 
 #[tokio::test]

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -33,6 +33,7 @@ const LIST_TYPES_TASK: &str = "https://trusttasks.org/spec/vtc/endorsement-types
 const DELETE_TYPE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsement-types/delete/0.1";
 const ISSUE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/issue/0.1";
 const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
+const SHOW_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/show/0.1";
 const ADMIN_DID: &str = "did:key:zEndAdmin";
 const ISSUER_DID: &str = "did:key:zEndIssuer";
 const MEMBER_DID: &str = "did:key:zEndMember";
@@ -591,4 +592,50 @@ async fn revoke_non_admin_non_issuer_forbidden() {
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+/// `GET /credentials/endorsements/{id}` had **no test at all** before #1093,
+/// which is how it returned the bare row past a published schema that wraps
+/// it. Issue one, read it back, and assert the envelope — `endorsement` is
+/// the member `vtc/endorsements/show/0.1` names.
+#[tokio::test]
+async fn show_wraps_the_row_in_an_endorsement_envelope() {
+    let fix = build().await;
+    let uri = "https://example.com/v1/skills/rust";
+    register_type(&fix, uri).await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/credentials/endorsements")
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", ISSUE_TASK)
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({
+                "subjectDid": SUBJECT_DID,
+                "type": uri,
+                "claim": { "level": "expert" }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let (status, issued) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+    assert_eq!(status, StatusCode::CREATED, "{issued}");
+    let id = issued["id"].as_str().unwrap();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/credentials/endorsements/{id}"))
+        .header("authorization", format!("Bearer {}", fix.issuer_token))
+        .header("trust-task", SHOW_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let (status, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+
+    // The envelope, not the bare row: `v["id"]` must be absent precisely
+    // because the row now sits one level down.
+    assert!(v["id"].is_null(), "row must not be at the top level: {v}");
+    assert_eq!(v["endorsement"]["id"], id);
+    assert_eq!(v["endorsement"]["subjectDid"], SUBJECT_DID);
 }

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -469,6 +469,8 @@ async fn show_returns_full_request_including_vp() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `show` wraps the row as `{request: …}` (#1093).
+    let body = &body["request"];
     assert_eq!(body["status"], "pending");
     assert!(body["vp"].is_object());
 }
@@ -914,6 +916,8 @@ async fn rest_submit_under_default_join_policy_lands_pending_with_vp_claims() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    // `show` wraps the row as `{request: …}` (#1093).
+    let row = &row["request"];
     assert_eq!(row["status"], "pending");
     assert!(
         row["policyDecision"].is_null(),
@@ -958,6 +962,8 @@ async fn rest_submit_under_deny_all_policy_persists_rejected_with_decision() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    // `show` wraps the row as `{request: …}` (#1093).
+    let row = &row["request"];
     assert_eq!(row["status"], "rejected");
     // `policyDecision` now carries the four-valued verdict the policy
     // returned — a deny with the policy's code.

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -403,6 +403,8 @@ async fn show_member_returns_joined_response() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `show` wraps the row as `{member: …}` (#1093).
+    let body = &body["member"];
     assert_eq!(body["did"], "did:key:zM1");
     assert_eq!(body["role"], "issuer");
     assert!(body["joinedAt"].is_string());


### PR DESCRIPTION
Four conformance drift entries where the *envelope* was wrong. All four rows
stay in the drift table — each has a second, separate divergence in its
members — but the half this PR fixes is the half that made the responses
unparseable against their published schema.

## `registry/diagnostics` — the worst row in the table

`DiagnosticsResponse` had no `rename_all`, so every member went out
snake_case. Not one of the four **required** members
(`registryStatus`, `queueDepth`, `rtbfBatchedCount`, `failedCount`) reached
the wire under the name `vtc/registry/diagnostics/0.1` gives it — a
spec-conformant client saw a response with all four required fields missing.
Fixed with `#[serde(rename_all = "camelCase")]` (R3.1).

This is a **breaking wire change**, so the consumers move with it:

- `admin-ui/src/lib/api.ts` — `DiagnosticsResponse` members recased.
- `admin-ui/src/plugins/{recognition,dashboard}.tsx` — every
  `diagnostics.data.*` access, plus the one `<code>` label that names the
  wire field in operator-facing prose.
- `tests/diagnostics.rs` — the assertions now read the shipped names.

`RegistryTransport` and `TransportStatus` are all single-word members, so
they needed no change. No consumer outside this repo: `openvtc` doesn't read
diagnostics.

## Three `show` routes returned the row bare

`members/show`, `endorsements/show` and `join-requests/show` each publish a
wrapped response — `{member: …}`, `{endorsement: …}`, `{request: …}` — and
each returned the row unwrapped. The rows themselves always conformed; only
the envelope was missing. Added `MemberEnvelope`, `EndorsementEnvelope`,
`JoinRequestEnvelope`, and pointed each handler's `utoipa` `body =` at the
envelope so the generated OpenAPI stops advertising a shape the service
doesn't send.

`GET /credentials/endorsements/{id}` turned out to have **no test at all** —
which is how it returned the bare row past a published schema that wraps it.
This PR adds one. It asserts the top-level `id` is *absent*, so it fails if
the envelope is ever removed rather than passing on a shape that merely
contains the right data. The three existing tests that read these rows
(`show_member_returns_joined_response`, `show_returns_full_request_including_vp`,
and two policy tests in `join_requests`) now read through the envelope, and
would fail without it.

## `/health` deliberately left alone

`HealthResponse` still emits `vtc_did`. `/health` is not a bound Trust Task,
and `website-default/site.js:212` reads that member. Renaming it would break
a live page to satisfy a schema that doesn't govern the route. The struct
carries a comment saying so, so the next person doesn't "fix" it.

## Conformance witness

`KNOWN_DRIFT_COUNT` stays **26**. All four entries keep their row with the
fixture updated to what now ships and the note narrowed to what still
diverges:

- `registry/diagnostics` — casing fixed; nine unspecced members
  (`syncer*`, `messagingStatus`, `transports`, `registryTransport`,
  `vtaDid`, `mediator*`) remain. That half is genuinely useful diagnostics
  and should go upstream, not be deleted.
- `members/show` — envelope fixed; same five unspecced members as `list`.
- `endorsements/show` — envelope fixed; row members are still this service's
  spelling (same model disagreement as `issue`).
- `join-requests/show` — envelope fixed; unspecced `vpClaims` / `decision`
  remain, same as `list`.

The witness's `known_drift_entries_still_diverge_where_they_say_they_do`
proves those four are still non-conformant for the stated reason — an
entry that silently started passing would fail the test.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service`
- `cargo fmt --all --check`
- `npm run lint` in `admin-ui`

Prettier is neither a dev-dependency nor a CI gate here and the SPA sources
are not prettier-clean on main, so the TS diff is a pure rename — 57
insertions, 57 deletions — with no reformatting churn.

Drift stays **26** — #1092 brought it 27 → 26 by closing
`endorsement-types/register`; these four rows each keep a live second half,
so none of them closes here.

BREAKING CHANGE: `GET /v1/registry/diagnostics` returns camelCase members
(`registryStatus`, `queueDepth`, `rtbfBatchedCount`, `failedCount`, …)
instead of snake_case. `GET /v1/members/{did}`, `GET /v1/endorsements/{id}`
and `GET /v1/join-requests/{id}` return `{member: …}`, `{endorsement: …}`
and `{request: …}` instead of the bare row. Every in-repo consumer moves
with them in this PR; all four were returning something their published
schemas did not describe.

Refs #1059
