### PR TITLE
fix(vtc)!: wrap the last three responses the schemas nest

### DIFF
--- a/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
+++ b/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
@@ -64,9 +64,13 @@ const TRUST_TASK_CEREMONIES =
   "https://trusttasks.org/spec/vtc/ceremonies/list/0.1";
 
 export async function fetchCeremonies(): Promise<CeremonyManifest[]> {
-  return getJson<CeremonyManifest[]>("/v1/ceremonies", {
-    trustTask: TRUST_TASK_CEREMONIES,
-  });
+  // `vtc/ceremonies/list/0.1` wraps the array as `{ceremonies: […]}`; the
+  // daemon sent a bare array until #1094.
+  const body = await getJson<{ ceremonies: CeremonyManifest[] }>(
+    "/v1/ceremonies",
+    { trustTask: TRUST_TASK_CEREMONIES },
+  );
+  return body.ceremonies;
 }
 
 /** The default value map for a ceremony's simulator form. */

--- a/vtc-service/admin-ui/src/plugins/profile.tsx
+++ b/vtc-service/admin-ui/src/plugins/profile.tsx
@@ -17,11 +17,12 @@ const TRUST_TASK =
 const TRUST_TASK_UPDATE =
   "https://trusttasks.org/spec/vtc/community/profile/update/0.1";
 
-// GET /v1/community/profile wire shape: the persisted profile fields
-// are flattened at the top level (server uses `#[serde(flatten)]`),
-// alongside the live `registryStatus`. Do not look for a nested
-// `profile` object — there isn't one.
-interface ProfileResponse {
+// GET /v1/community/profile wire shape: `{profile: {…}}`, with the live
+// `registryStatus` inside the profile object — the shape
+// `vtc/community/profile/show/0.1` requires. The fields were flattened to
+// the top level until #1094, where the response schema permitted none of
+// them.
+interface Profile {
   communityDid: string;
   name: string;
   description: string;
@@ -43,16 +44,21 @@ interface ProfileUpdateRequest {
   language?: string;
 }
 
-async function getProfile(): Promise<ProfileResponse> {
-  return getJson<ProfileResponse>("/v1/community/profile", {
+interface ProfileResponse {
+  profile: Profile;
+}
+
+async function getProfile(): Promise<Profile> {
+  const body = await getJson<ProfileResponse>("/v1/community/profile", {
     trustTask: TRUST_TASK,
   });
+  return body.profile;
 }
 
 async function putProfile(body: ProfileUpdateRequest): Promise<unknown> {
   // PUT returns `{ profile, fieldsChanged }` (nested). We don't read
   // it — `onSuccess` invalidates the query, which refetches via
-  // `getProfile` and seeds the form from the flat GET shape.
+  // `getProfile` and seeds the form from the unwrapped profile.
   return putJson<unknown>("/v1/community/profile", body, {
     trustTask: TRUST_TASK_UPDATE,
   });
@@ -249,7 +255,7 @@ interface EditableFields {
 }
 
 function isDirty(
-  original: ProfileResponse,
+  original: Profile,
   draft: EditableFields,
 ): boolean {
   if (original.name !== draft.name) return true;
@@ -262,7 +268,7 @@ function isDirty(
 }
 
 function buildPatch(
-  original: ProfileResponse,
+  original: Profile,
   draft: EditableFields,
 ): ProfileUpdateRequest {
   const patch: ProfileUpdateRequest = {};

--- a/vtc-service/src/routes/ceremonies.rs
+++ b/vtc-service/src/routes/ceremonies.rs
@@ -313,12 +313,24 @@ fn manifests() -> Vec<CeremonyManifest> {
     get, path = "/ceremonies", tag = "ceremonies",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "Ceremony manifests", body = [CeremonyManifest]),
+        (status = 200, description = "Ceremony manifests", body = CeremonyListResponse),
         (status = 401, description = "Missing or invalid bearer token"),
     ),
 )]
-pub async fn list(_claims: AuthClaims) -> Json<Vec<CeremonyManifest>> {
-    Json(manifests())
+pub async fn list(_claims: AuthClaims) -> Json<CeremonyListResponse> {
+    Json(CeremonyListResponse {
+        ceremonies: manifests(),
+    })
+}
+
+/// `{ ceremonies: […] }` — the shape `vtc/ceremonies/list/0.1` publishes. The
+/// handler sent a top-level array until #1094. An array cannot grow a sibling
+/// member later without breaking every reader; the envelope is why the spec
+/// asks for one.
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CeremonyListResponse {
+    pub ceremonies: Vec<CeremonyManifest>,
 }
 
 #[cfg(test)]

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -37,8 +37,23 @@ use crate::server::AppState;
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct CommunityProfileResponse {
-    /// The persisted profile fields. Flattened on the wire so
-    /// existing consumers see no shape change.
+    /// Nested, because `vtc/community/profile/show/0.1` requires a
+    /// `profile` member and is `additionalProperties: false`. This was
+    /// `#[serde(flatten)]` until #1094, which put every profile field at the
+    /// top level — where the schema permits none of them.
+    pub profile: ProfileWithStatus,
+}
+
+/// The persisted profile plus the one field that is computed per request.
+///
+/// `registryStatus` sits *inside* the profile object rather than beside it,
+/// because that is where the canonical `CommunityProfile` component defines
+/// it ("Populated on reads; not settable"). Un-flattening alone would have
+/// left it a sibling of `profile`, which the response schema forbids.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct ProfileWithStatus {
     #[serde(flatten)]
     pub profile: CommunityProfile,
     /// Trust-registry reachability — `"active"` when the last
@@ -197,8 +212,10 @@ pub async fn get_profile(
         .ok_or_else(|| AppError::NotFound("community profile not initialised".into()))?;
     let registry_status = state.registry_health.status().await;
     Ok(Json(CommunityProfileResponse {
-        profile,
-        registry_status,
+        profile: ProfileWithStatus {
+            profile,
+            registry_status,
+        },
     }))
 }
 

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -48,7 +48,7 @@ use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry};
 use crate::auth::{AdminAuth, session::now_epoch};
 use crate::error::AppError;
 use crate::members::{Disposition, Member, get_member, store_member};
-use crate::routes::members::read::MemberResponse;
+use crate::routes::members::read::{MemberEnvelope, MemberResponse};
 use crate::server::AppState;
 
 /// Serialises admin promotions per-process. Inherited from the retired
@@ -82,7 +82,7 @@ pub struct UpdateMemberRequest {
     params(("did" = String, Path, description = "Member DID")),
     request_body = UpdateMemberRequest,
     responses(
-        (status = 200, description = "Updated member record", body = MemberResponse),
+        (status = 200, description = "Updated member record", body = MemberEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin / role change denied by policy / step-up required for role=admin"),
         (status = 404, description = "Member not found"),
@@ -94,7 +94,7 @@ pub async fn update_member(
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateMemberRequest>,
-) -> Result<Json<MemberResponse>, AppError> {
+) -> Result<Json<MemberEnvelope>, AppError> {
     vti_common::identifier::validate_did("did", &did)?;
 
     let promoting = matches!(req.role, Some(VtcRole::Admin));
@@ -306,7 +306,11 @@ pub async fn update_member(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
 
-    Ok(Json(MemberResponse::from_pair_for_route(acl, member)))
+    // `{member: …}` — the shape `vtc/members/update/0.1` publishes, same as
+    // its `show` sibling. The row was returned bare until #1094.
+    Ok(Json(MemberEnvelope {
+        member: MemberResponse::from_pair_for_route(acl, member),
+    }))
 }
 
 // Re-export `from_pair` under a route-only alias so this module

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -649,9 +649,9 @@ fn table() -> Vec<Conformance> {
             s::ceremonies::list::v0_1::Response,
             Side::Response,
             json!({}),
-            // `list` returns `Json<Vec<CeremonyManifest>>` — a top-level
-            // array (routes/ceremonies.rs:320).
-            json!([{
+            // `CeremonyListResponse` — a top-level array until #1094
+            // (routes/ceremonies.rs:320).
+            json!({ "ceremonies": [{
                 "purpose": "directory",
                 "pkg": "vtc.directory",
                 "nature": "read-only",
@@ -660,12 +660,11 @@ fn table() -> Vec<Conformance> {
                 "blurb": "A member views another member's record.",
                 "fields": [],
                 "factsTemplate": { "purpose": "directory" },
-            }]),
-            "response is a top-level array where the spec says \
-             `{ceremonies: [...]}`, and each manifest carries an unspecced \
-             `factsTemplate`. Two fixes, both here: wrap the array, and take \
-             `factsTemplate` upstream (the admin UI renders the simulator \
-             from it, so dropping it is not an option)"
+            }] }),
+            "the `{ceremonies: […]}` envelope is right as of #1094. Each \
+             manifest still carries an unspecced `factsTemplate`; that half \
+             goes upstream, because the admin UI renders the simulator from \
+             it and dropping it is not an option"
         ),
         // ─── community ───────────────────────────────────────────────
         drift!(
@@ -673,21 +672,23 @@ fn table() -> Vec<Conformance> {
             s::community::profile::show::v0_1::Response,
             Side::Response,
             json!({}),
-            // `CommunityProfileResponse` flattens the profile and appends
-            // `registryStatus` (routes/community/profile.rs:39).
+            // `CommunityProfileResponse` — nested as of #1094, with
+            // `registryStatus` inside the profile where the canonical
+            // component defines it (routes/community/profile.rs:39).
             {
                 let mut v = community_profile();
                 v.as_object_mut()
                     .expect("object")
                     .insert("registryStatus".into(), json!("active"));
-                v
+                json!({ "profile": v })
             },
-            "response flattens the profile to the top level; the spec nests \
-             it under `profile`. The flattened object then also carries \
-             `communityDid`, `createdAt` and `relationshipIdentifierDefault`, \
-             which the canonical `CommunityProfile` component does not \
-             define. Nesting is a fix here; the three extra members need to \
-             go upstream — `communityDid` in particular is the one member a \
+            "the `{profile: …}` nesting is right as of #1094, and \
+             `registryStatus` moved inside the profile object — beside it, \
+             the `additionalProperties: false` response would have rejected \
+             it. The profile still carries `communityDid`, `createdAt` and \
+             `relationshipIdentifierDefault`, which the canonical \
+             `CommunityProfile` component does not define; those three go \
+             upstream — `communityDid` in particular is the one member a \
              consumer most needs"
         ),
         drift!(
@@ -1124,12 +1125,12 @@ fn table() -> Vec<Conformance> {
             json!({ "did": DID, "role": "moderator", "label": "Ada Lovelace",
                     "publishConsent": true, "departurePreference": "historical",
                     "extensions": { "org": "acme" } }),
-            member_response(),
+            json!({ "member": member_response() }),
             "request carries `label`, which the spec's payload does not \
              define — a member's display label is editable here and \
-             unspecified upstream. Response is the bare `MemberResponse` \
-             (spec: `{member: …}`) with the same five unspecced members as \
-             `list`"
+             unspecified upstream. The response's `{member: …}` envelope is \
+             right as of #1094; the row still carries the same five unspecced \
+             members as `list`"
         ),
         checked!(
             s::members::purge::v0_1::Payload,

--- a/vtc-service/tests/ceremonies_list.rs
+++ b/vtc-service/tests/ceremonies_list.rs
@@ -1,0 +1,71 @@
+//! Integration coverage for `GET /v1/ceremonies`.
+//!
+//! The route had **no HTTP-level test at all** before #1094, which is how it
+//! shipped a top-level array past a published schema that wraps it — the same
+//! gap that hid the `endorsements/show` drift in #1093. Exercises the full
+//! router stack: Trust-Task header → auth extractor → handler.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::test_support::TestVtc;
+
+const CEREMONIES_TASK: &str = "https://trusttasks.org/spec/vtc/ceremonies/list/0.1";
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+/// The response is `{ceremonies: […]}`, not a bare array.
+///
+/// Asserts the top level is an *object* and that the array is absent from it,
+/// so removing the envelope fails the test rather than passing on a payload
+/// that merely contains the right manifests.
+#[tokio::test]
+async fn list_wraps_the_manifests_in_a_ceremonies_envelope() {
+    let vtc = TestVtc::builder().build().await;
+    let token = vtc.token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/ceremonies")
+        .header("Trust-Task", CEREMONIES_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = body_value(vtc.router.clone().oneshot(req).await.unwrap()).await;
+
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert!(body.is_object(), "must not be a bare array: {body}");
+
+    let ceremonies = body["ceremonies"]
+        .as_array()
+        .unwrap_or_else(|| panic!("`ceremonies` must be an array: {body}"));
+    let purposes: Vec<&str> = ceremonies
+        .iter()
+        .map(|c| c["purpose"].as_str().unwrap())
+        .collect();
+    assert_eq!(purposes, ["directory", "join", "removal", "roleChange"]);
+}
+
+/// Unauthenticated callers get nothing — the manifests are admin-UI metadata,
+/// not a public surface.
+#[tokio::test]
+async fn list_requires_a_session() {
+    let vtc = TestVtc::builder().build().await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/ceremonies")
+        .header("Trust-Task", CEREMONIES_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = vtc.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -95,6 +95,8 @@ async fn get_returns_profile_when_initialised() {
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     let (status, body) = body_value(resp).await;
     assert_eq!(status, StatusCode::OK);
+    // `show` nests the profile under `profile` (#1094).
+    let body = &body["profile"];
     assert_eq!(body["name"], "Example Community");
     assert_eq!(body["communityDid"], "did:webvh:vtc.example.com:abc");
     assert_eq!(body["language"], "en");

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -357,6 +357,8 @@ async fn end_to_end_install_flow_phase_0_gate() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    // `show` nests the profile under `profile` (#1094).
+    let body = &body["profile"];
     assert_eq!(body["name"], "Example Community");
 
     // Verify ACL admin record matches the bootstrapped DID

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -463,6 +463,8 @@ async fn patch_member_role_member_to_moderator_succeeds_and_emits_audit() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["role"], "moderator");
 
     // Confirm the on-disk ACL row reflects the change.
@@ -538,6 +540,8 @@ async fn patch_member_role_admin_promotes_with_a_live_step_up() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["role"], "admin");
 
     let entry = vtc_service::acl::get_acl_entry(&fix.acl_ks, "did:key:zM1")
@@ -565,6 +569,8 @@ async fn patch_member_profile_only_emits_member_updated() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["publishConsent"], true);
     assert_eq!(body["departurePreference"], "purge");
     // Role unchanged.
@@ -652,6 +658,8 @@ async fn promoting_an_existing_admin_is_an_idempotent_no_op() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["role"], "admin");
 
     let entry = vtc_service::acl::get_acl_entry(&fix.acl_ks, "did:key:zSecondAdmin")


### PR DESCRIPTION
Stacked on #1093, and finishes the envelope family: after this, **no VTC
route returns a bare row or array where its published schema wraps one.**

## `ceremonies/list` — a top-level array

`Json<Vec<CeremonyManifest>>` where `vtc/ceremonies/list/0.1` says
`{ceremonies: […]}`. An array cannot grow a sibling member later without
breaking every reader, which is the whole reason the spec asks for an
envelope. `fetchCeremonies` in the admin SPA moves with it.

## `community/profile/show` — more than an un-flatten

`CommunityProfileResponse` used `#[serde(flatten)]`, putting every profile
field at the top level. Reading the published schema rather than assuming
the fix: the response is `{profile: …}` and **`additionalProperties: false`**,
and `registryStatus` is defined *inside* the canonical `CommunityProfile`
component ("Populated on reads; not settable") — not beside it.

So un-flattening alone would have left `registryStatus` a sibling of
`profile`, which the schema forbids. It now nests inside the profile object,
where the component puts it. The SPA's `ProfileResponse` interface splits
into `Profile` + a `{profile: Profile}` wrapper, and `getProfile` unwraps.

## `members/update` — the bare row

Returned `MemberResponse` where the spec says `{member: …}`. Reuses
`MemberEnvelope` from #1093, so `update` and `show` now publish the same
shape. The admin SPA calls `patchJson<unknown>` and ignores the body, so
nothing there moves.

## Coverage

`GET /v1/ceremonies` had **no HTTP-level test at all** — the same gap that
hid the `endorsements/show` drift in #1093. New `tests/ceremonies_list.rs`
covers it: one test asserts the top level is an object and reads the
manifests through `ceremonies`, so removing the envelope fails rather than
passing on a payload that merely contains the right data; one pins that the
route needs a session.

Six existing tests read the old shapes and failed as soon as the handlers
changed — two profile reads (`community_profile`, `install_flow`) and four
`members_crud` PATCH assertions. All six now read through the envelope and
would fail without it.

## Conformance witness

`KNOWN_DRIFT_COUNT` stays **26**. All three entries keep their row with the
fixture updated to what now ships and the note narrowed to what still
diverges — in every case an unspecced member that belongs upstream, not a
shape this service controls:

- `ceremonies/list` — envelope fixed; each manifest still carries
  `factsTemplate`. The admin UI renders the simulator from it, so dropping
  it is not an option; it goes upstream.
- `community/profile/show` — nesting fixed and `registryStatus` correctly
  placed; the profile still carries `communityDid`, `createdAt` and
  `relationshipIdentifierDefault`, none of which the canonical component
  defines. `communityDid` is the one a consumer most needs, and its absence
  from the component is the same root cause as the `config/export`,
  `config/import` and `profile/update` entries — one upstream change clears
  four rows.
- `members/update` — envelope fixed; request still carries `label` and the
  row still carries the same five unspecced members as `list`.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`
- `npm run lint` in `admin-ui`

Note that `semver checks` fails on this branch as it does on every recent PR
(#1092 and #1093 both). The failing items are identical across all three —
thirteen `vta-sdk` / `vta-service` entries, none touched here. That gate is
skipped on `main`, so nothing ever forces it back to green; worth fixing
separately, because a real API break would currently land invisibly inside
that noise.

BREAKING CHANGE: `GET /v1/ceremonies` returns `{ceremonies: […]}` instead of
a bare array. `GET /v1/community/profile` returns `{profile: {…}}` with
`registryStatus` inside the profile, instead of the profile fields flattened
at the top level. `PATCH /v1/members/{did}` returns `{member: …}` instead of
the bare row. Every in-repo consumer moves with them in this PR; all three
were returning something their published schemas did not describe.

Refs #1059
