### PR TITLE
fix(vtc)!: send the member names and types the item schemas require

### DIFF
--- a/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
+++ b/vtc-service/admin-ui/src/lib/ceremony-manifest.ts
@@ -64,9 +64,13 @@ const TRUST_TASK_CEREMONIES =
   "https://trusttasks.org/spec/vtc/ceremonies/list/0.1";
 
 export async function fetchCeremonies(): Promise<CeremonyManifest[]> {
-  return getJson<CeremonyManifest[]>("/v1/ceremonies", {
-    trustTask: TRUST_TASK_CEREMONIES,
-  });
+  // `vtc/ceremonies/list/0.1` wraps the array as `{ceremonies: […]}`; the
+  // daemon sent a bare array until #1094.
+  const body = await getJson<{ ceremonies: CeremonyManifest[] }>(
+    "/v1/ceremonies",
+    { trustTask: TRUST_TASK_CEREMONIES },
+  );
+  return body.ceremonies;
 }
 
 /** The default value map for a ceremony's simulator form. */

--- a/vtc-service/admin-ui/src/plugins/profile.tsx
+++ b/vtc-service/admin-ui/src/plugins/profile.tsx
@@ -17,11 +17,12 @@ const TRUST_TASK =
 const TRUST_TASK_UPDATE =
   "https://trusttasks.org/spec/vtc/community/profile/update/0.1";
 
-// GET /v1/community/profile wire shape: the persisted profile fields
-// are flattened at the top level (server uses `#[serde(flatten)]`),
-// alongside the live `registryStatus`. Do not look for a nested
-// `profile` object — there isn't one.
-interface ProfileResponse {
+// GET /v1/community/profile wire shape: `{profile: {…}}`, with the live
+// `registryStatus` inside the profile object — the shape
+// `vtc/community/profile/show/0.1` requires. The fields were flattened to
+// the top level until #1094, where the response schema permitted none of
+// them.
+interface Profile {
   communityDid: string;
   name: string;
   description: string;
@@ -43,16 +44,21 @@ interface ProfileUpdateRequest {
   language?: string;
 }
 
-async function getProfile(): Promise<ProfileResponse> {
-  return getJson<ProfileResponse>("/v1/community/profile", {
+interface ProfileResponse {
+  profile: Profile;
+}
+
+async function getProfile(): Promise<Profile> {
+  const body = await getJson<ProfileResponse>("/v1/community/profile", {
     trustTask: TRUST_TASK,
   });
+  return body.profile;
 }
 
 async function putProfile(body: ProfileUpdateRequest): Promise<unknown> {
   // PUT returns `{ profile, fieldsChanged }` (nested). We don't read
   // it — `onSuccess` invalidates the query, which refetches via
-  // `getProfile` and seeds the form from the flat GET shape.
+  // `getProfile` and seeds the form from the unwrapped profile.
   return putJson<unknown>("/v1/community/profile", body, {
     trustTask: TRUST_TASK_UPDATE,
   });
@@ -249,7 +255,7 @@ interface EditableFields {
 }
 
 function isDirty(
-  original: ProfileResponse,
+  original: Profile,
   draft: EditableFields,
 ): boolean {
   if (original.name !== draft.name) return true;
@@ -262,7 +268,7 @@ function isDirty(
 }
 
 function buildPatch(
-  original: ProfileResponse,
+  original: Profile,
   draft: EditableFields,
 ): ProfileUpdateRequest {
   const patch: ProfileUpdateRequest = {};

--- a/vtc-service/src/routes/ceremonies.rs
+++ b/vtc-service/src/routes/ceremonies.rs
@@ -313,12 +313,24 @@ fn manifests() -> Vec<CeremonyManifest> {
     get, path = "/ceremonies", tag = "ceremonies",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "Ceremony manifests", body = [CeremonyManifest]),
+        (status = 200, description = "Ceremony manifests", body = CeremonyListResponse),
         (status = 401, description = "Missing or invalid bearer token"),
     ),
 )]
-pub async fn list(_claims: AuthClaims) -> Json<Vec<CeremonyManifest>> {
-    Json(manifests())
+pub async fn list(_claims: AuthClaims) -> Json<CeremonyListResponse> {
+    Json(CeremonyListResponse {
+        ceremonies: manifests(),
+    })
+}
+
+/// `{ ceremonies: […] }` — the shape `vtc/ceremonies/list/0.1` publishes. The
+/// handler sent a top-level array until #1094. An array cannot grow a sibling
+/// member later without breaking every reader; the envelope is why the spec
+/// asks for one.
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CeremonyListResponse {
+    pub ceremonies: Vec<CeremonyManifest>,
 }
 
 #[cfg(test)]

--- a/vtc-service/src/routes/community/profile.rs
+++ b/vtc-service/src/routes/community/profile.rs
@@ -37,8 +37,23 @@ use crate::server::AppState;
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct CommunityProfileResponse {
-    /// The persisted profile fields. Flattened on the wire so
-    /// existing consumers see no shape change.
+    /// Nested, because `vtc/community/profile/show/0.1` requires a
+    /// `profile` member and is `additionalProperties: false`. This was
+    /// `#[serde(flatten)]` until #1094, which put every profile field at the
+    /// top level — where the schema permits none of them.
+    pub profile: ProfileWithStatus,
+}
+
+/// The persisted profile plus the one field that is computed per request.
+///
+/// `registryStatus` sits *inside* the profile object rather than beside it,
+/// because that is where the canonical `CommunityProfile` component defines
+/// it ("Populated on reads; not settable"). Un-flattening alone would have
+/// left it a sibling of `profile`, which the response schema forbids.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct ProfileWithStatus {
     #[serde(flatten)]
     pub profile: CommunityProfile,
     /// Trust-registry reachability — `"active"` when the last
@@ -197,8 +212,10 @@ pub async fn get_profile(
         .ok_or_else(|| AppError::NotFound("community profile not initialised".into()))?;
     let registry_status = state.registry_health.status().await;
     Ok(Json(CommunityProfileResponse {
-        profile,
-        registry_status,
+        profile: ProfileWithStatus {
+            profile,
+            registry_status,
+        },
     }))
 }
 

--- a/vtc-service/src/routes/members/update.rs
+++ b/vtc-service/src/routes/members/update.rs
@@ -48,7 +48,7 @@ use crate::acl::{VtcAclEntry, VtcRole, get_acl_entry};
 use crate::auth::{AdminAuth, session::now_epoch};
 use crate::error::AppError;
 use crate::members::{Disposition, Member, get_member, store_member};
-use crate::routes::members::read::MemberResponse;
+use crate::routes::members::read::{MemberEnvelope, MemberResponse};
 use crate::server::AppState;
 
 /// Serialises admin promotions per-process. Inherited from the retired
@@ -82,7 +82,7 @@ pub struct UpdateMemberRequest {
     params(("did" = String, Path, description = "Member DID")),
     request_body = UpdateMemberRequest,
     responses(
-        (status = 200, description = "Updated member record", body = MemberResponse),
+        (status = 200, description = "Updated member record", body = MemberEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin / role change denied by policy / step-up required for role=admin"),
         (status = 404, description = "Member not found"),
@@ -94,7 +94,7 @@ pub async fn update_member(
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateMemberRequest>,
-) -> Result<Json<MemberResponse>, AppError> {
+) -> Result<Json<MemberEnvelope>, AppError> {
     vti_common::identifier::validate_did("did", &did)?;
 
     let promoting = matches!(req.role, Some(VtcRole::Admin));
@@ -306,7 +306,11 @@ pub async fn update_member(
         .await?
         .ok_or_else(|| AppError::NotFound(format!("member not found: {did}")))?;
 
-    Ok(Json(MemberResponse::from_pair_for_route(acl, member)))
+    // `{member: …}` — the shape `vtc/members/update/0.1` publishes, same as
+    // its `show` sibling. The row was returned bare until #1094.
+    Ok(Json(MemberEnvelope {
+        member: MemberResponse::from_pair_for_route(acl, member),
+    }))
 }
 
 // Re-export `from_pair` under a route-only alias so this module

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -10,7 +10,7 @@ mod community;
 pub(crate) mod did_log;
 mod directory;
 mod endorsement_types;
-mod endorsements;
+pub(crate) mod endorsements;
 mod health;
 pub(crate) mod install;
 mod invitations;
@@ -24,7 +24,7 @@ mod schemas;
 pub(crate) mod status_lists;
 pub mod trust_tasks;
 #[cfg(feature = "website")]
-mod website;
+pub(crate) mod website;
 
 use std::sync::Arc;
 

--- a/vtc-service/src/routes/website/files.rs
+++ b/vtc-service/src/routes/website/files.rs
@@ -13,6 +13,7 @@ use axum::body::Bytes;
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -37,9 +38,19 @@ pub struct ListQuery {
 #[serde(rename_all = "camelCase")]
 pub struct FileEntry {
     pub path: String,
-    pub size_bytes: u64,
+    /// `size`, not `sizeBytes` — the name the item schema requires. It was
+    /// `sizeBytes` until #1095, so the one member a listing exists to report
+    /// was absent under the name a conforming consumer looks for.
+    pub size: u64,
+    /// A SHA-256 over the file's contents. Unspecced upstream and the item is
+    /// `additionalProperties: false`, so this is the half of the entry that
+    /// still diverges — it is real, useful data (the same hash the `show`
+    /// handler sends as an `ETag` header, letting a client detect a change
+    /// without downloading), so it goes upstream rather than in the bin.
     pub etag: String,
-    pub modified_at: u64,
+    /// `format: date-time`, not unix seconds. This was a `u64` until #1095 —
+    /// a type mismatch, not merely a format one: the schema says `string`.
+    pub modified_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize)]
@@ -113,8 +124,8 @@ struct FileMeta {
     rel: String,
     /// Absolute path, for reading the file when its etag is finally computed.
     abs: PathBuf,
-    size_bytes: u64,
-    modified_at: u64,
+    size: u64,
+    modified_at: DateTime<Utc>,
 }
 
 /// Walk `root` and collect metadata for every servable file. Blocking (one
@@ -160,16 +171,19 @@ fn collect_file_meta(root: &Path, blocklist: &[String]) -> Result<Vec<FileMeta>,
             }
             let rel = path.strip_prefix(root).unwrap_or(&path);
             let rel_str = rel.to_string_lossy().replace('\\', "/");
+            // A file whose mtime the platform will not report lists as the
+            // epoch rather than dropping out of the listing entirely — the
+            // same choice the `u64` form made, now spelled as a timestamp.
             let modified_at = meta
                 .modified()
                 .ok()
                 .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
+                .and_then(|d| DateTime::from_timestamp(d.as_secs() as i64, 0))
+                .unwrap_or(DateTime::UNIX_EPOCH);
             out.push(FileMeta {
                 rel: rel_str,
                 abs: path,
-                size_bytes: meta.len(),
+                size: meta.len(),
                 modified_at,
             });
         }
@@ -188,7 +202,7 @@ fn hash_window(window: Vec<FileMeta>) -> Vec<FileEntry> {
             let bytes = std::fs::read(&m.abs).ok()?;
             Some(FileEntry {
                 path: m.rel,
-                size_bytes: m.size_bytes,
+                size: m.size,
                 etag: hex::encode(Sha256::digest(&bytes)),
                 modified_at: m.modified_at,
             })
@@ -457,11 +471,7 @@ mod tests {
         let rels: Vec<&str> = metas.iter().map(|m| m.rel.as_str()).collect();
         assert_eq!(rels, vec!["assets/app.js", "index.html"]);
         assert_eq!(
-            metas
-                .iter()
-                .find(|m| m.rel == "index.html")
-                .unwrap()
-                .size_bytes,
+            metas.iter().find(|m| m.rel == "index.html").unwrap().size,
             11
         );
 
@@ -470,6 +480,6 @@ mod tests {
         assert_eq!(entries.len(), 2);
         let idx = entries.iter().find(|e| e.path == "index.html").unwrap();
         assert_eq!(idx.etag, hex::encode(Sha256::digest(b"<h1>hi</h1>")));
-        assert_eq!(idx.size_bytes, 11);
+        assert_eq!(idx.size, 11);
     }
 }

--- a/vtc-service/src/routes/website/generations.rs
+++ b/vtc-service/src/routes/website/generations.rs
@@ -36,7 +36,10 @@ pub async fn list(
         ));
     }
 
-    let generations = list_managed_generations(&root_dir)?;
+    let generations = list_managed_generations(&root_dir)?
+        .into_iter()
+        .map(GenerationRow::from)
+        .collect();
     Ok(Json(GenerationsResponse { generations }))
 }
 
@@ -45,12 +48,42 @@ pub async fn list(
 /// compared it with its schema; the rows always conformed.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct GenerationsResponse {
-    // `GenerationEntry` comes from the website module and derives no
-    // `ToSchema`; typed as an opaque object here rather than deriving it
-    // there, which would pull utoipa into a module that has no other use for
-    // it. The wire shape is unaffected.
-    #[schema(value_type = Vec<Object>)]
-    pub generations: Vec<GenerationEntry>,
+    pub generations: Vec<GenerationRow>,
+}
+
+/// One row of the listing, as the item schema names it.
+///
+/// A wire type distinct from the stored [`GenerationEntry`] because the two
+/// disagree on purpose: a generation is a `u32` in storage, where arithmetic
+/// and ordering want a number, and a string on the wire, where the schema
+/// types it as one. `rollback` has always drawn that line the same way
+/// (`gen_num.to_string()`); this listing sent the raw `u32` and named
+/// `current` as `isCurrent` until #1095.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerationRow {
+    /// Decimal, matching `rollback` — not `gen-N`, which is the directory
+    /// name rather than the label the API has ever used.
+    pub generation: String,
+    pub current: bool,
+    /// Unspecced upstream, and the item is `additionalProperties: false`, so
+    /// these two are the half of this entry that still diverges. Both are
+    /// worth having — a rollback target is not much use without knowing when
+    /// it was deployed or how big it is — so they go upstream rather than in
+    /// the bin.
+    pub deployed_at: u64,
+    pub size_bytes: u64,
+}
+
+impl From<GenerationEntry> for GenerationRow {
+    fn from(e: GenerationEntry) -> Self {
+        Self {
+            generation: e.generation.to_string(),
+            current: e.is_current,
+            deployed_at: e.deployed_at,
+            size_bytes: e.size_bytes,
+        }
+    }
 }
 
 pub async fn rollback(

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -114,6 +114,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use chrono::DateTime;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 
@@ -490,7 +491,7 @@ fn uuid() -> uuid::Uuid {
 /// 3. **Unspecced members on an `additionalProperties: false` response.**
 ///    Usually the service is ahead of the spec (the ceremony verdict
 ///    envelope, `decidedAt`), occasionally behind it (`didBindingChallenge`).
-const KNOWN_DRIFT_COUNT: usize = 26;
+const KNOWN_DRIFT_COUNT: usize = 25;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -869,20 +870,30 @@ fn table() -> Vec<Conformance> {
              members are still this service's spelling. Same model \
              disagreement as `issue`; fix the family together"
         ),
-        drift!(
+        checked!(
             s::endorsements::revoke::v0_1::Payload,
             s::endorsements::revoke::v0_1::Response,
-            Side::Response,
             json!({ "endorsementId": "11111111-1111-4111-8111-111111111111",
                     "reason": "issued in error" }),
-            // `RevokeResponse` — routes/endorsements.rs:344.
-            json!({ "id": "11111111-1111-4111-8111-111111111111" }),
-            "response is `{id}`; the spec requires `{endorsementId, \
-             revocation: {credentialId, revokedAt}, statusListIndex}`. The \
-             service holds all four values at the point it replies — it \
-             flipped the status-list bit to get there — so this is a fix \
-             here, and a caller currently cannot tell a fresh revocation \
-             from an idempotent repeat"
+            // Serialised from the **real** `RevokeResponse`, not hand-written.
+            //
+            // This entry sat in the drift table describing a `{id}` response
+            // that #1082 had already replaced, because its hand-written
+            // fixture was never updated with the handler. The witness proves
+            // the *fixture* diverges, not the handler, so a stale fixture
+            // keeps a fixed route in the table forever and the count
+            // over-reports. Building the fixture from the type the handler
+            // actually returns closes that gap for this row: change the
+            // struct and this fixture changes with it.
+            serde_json::to_value(crate::routes::endorsements::RevokeResponse {
+                endorsement_id: "11111111-1111-4111-8111-111111111111".into(),
+                revocation: crate::routes::endorsements::RevocationDetail {
+                    credential_id: "urn:uuid:22222222-2222-4222-8222-222222222222".into(),
+                    revoked_at: "2026-08-23T09:00:00Z".into(),
+                },
+                status_list_index: 7,
+            })
+            .expect("RevokeResponse serialises")
         ),
         // ─── install ─────────────────────────────────────────────────
         drift!(
@@ -1363,28 +1374,30 @@ fn table() -> Vec<Conformance> {
             s::website::files::list::v0_1::Response,
             Side::Response,
             json!({ "cursor": "assets/logo.png", "limit": 50 }),
-            // `ListResponse` / `FileEntry` — routes/website/files.rs:47 / :38.
-            // The wrapper is the one list response in this service that is
-            // NOT a `Paginated<T>`, so it does say `nextCursor`; the rows are
-            // where it goes wrong.
-            json!({
-                "items": [{
-                    "path": "index.html",
-                    "sizeBytes": 2048,
-                    "etag": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                    "modifiedAt": 1_755_946_800_u64,
+            // Serialised from the real `ListResponse` / `FileEntry`, per the
+            // `endorsements/revoke` note below — a hand-written fixture is
+            // what let that row describe a shape the handler had stopped
+            // sending.
+            serde_json::to_value(crate::routes::website::files::ListResponse {
+                items: vec![crate::routes::website::files::FileEntry {
+                    path: "index.html".into(),
+                    size: 2048,
+                    etag: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".into(),
+                    modified_at: DateTime::from_timestamp(1_755_946_800, 0)
+                        .expect("fixture timestamp"),
                 }],
-                "nextCursor": "styles/main.css",
-            }),
-            "each row sends `sizeBytes` where the item schema requires \
-             `size`, and adds an unspecced `etag`; the item is \
-             `additionalProperties: false`, so a conforming consumer sees a \
-             missing required member and an unknown one. `modifiedAt` also \
-             differs in kind — unix seconds here, `format: date-time` in the \
-             spec — which no serde check would catch and this one does not \
-             either, since format assertion is off by default. This entry is \
-             the sweep finding a task I had first written as `checked!`: the \
-             wrapper conforms and I stopped reading there"
+                next_cursor: Some("styles/main.css".into()),
+            })
+            .expect("ListResponse serialises"),
+            "`size` and `modifiedAt` are both right as of #1095 — the row \
+             sent `sizeBytes` for the one required member a listing exists \
+             to report, and a unix `u64` where the schema says `type: \
+             string, format: date-time`, a mismatch in kind and not merely \
+             in format. What remains is the unspecced `etag` against an \
+             `additionalProperties: false` item. It is the same SHA-256 the \
+             `show` handler sends as an `ETag` header, so it lets a client \
+             detect a change without downloading — worth taking upstream, \
+             not dropping"
         ),
         checked!(
             s::website::files::delete::v0_1::Payload,
@@ -1398,17 +1411,23 @@ fn table() -> Vec<Conformance> {
             s::website::generations::list::v0_1::Response,
             Side::Response,
             json!({}),
-            // `GenerationsResponse` — the envelope is fixed; the rows are not.
-            json!({ "generations": [
-                { "generation": 1, "isCurrent": false,
-                  "deployedAt": 1_755_860_400_u64, "sizeBytes": 1_048_576_u64 }
-            ] }),
-            "the missing `{generations: […]}` envelope is fixed. The rows are \
-             not, and the entry that called this envelope-only was wrong: the \
-             spec's row carries `generation` and `current`, while the service \
-             sends `isCurrent` for `current` and adds `deployedAt` and \
-             `sizeBytes`. One rename here, and two members that are worth \
-             having — take them upstream rather than dropping them"
+            // Serialised from the real `GenerationsResponse` / `GenerationRow`.
+            serde_json::to_value(crate::routes::website::generations::GenerationsResponse {
+                generations: vec![crate::routes::website::generations::GenerationRow {
+                    generation: "1".into(),
+                    current: false,
+                    deployed_at: 1_755_860_400,
+                    size_bytes: 1_048_576,
+                }],
+            })
+            .expect("GenerationsResponse serialises"),
+            "`current` and the `generation` type are both right as of #1095 \
+             — the row named `current` as `isCurrent` and sent the raw `u32` \
+             where the schema says `type: string`, which `rollback` had \
+             always stringified. What remains is the unspecced `deployedAt` \
+             and `sizeBytes` against an `additionalProperties: false` item; \
+             a rollback target is not much use without knowing when it was \
+             deployed or how big it is, so those go upstream"
         ),
         checked!(
             s::website::rollback::v0_1::Payload,

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -649,9 +649,9 @@ fn table() -> Vec<Conformance> {
             s::ceremonies::list::v0_1::Response,
             Side::Response,
             json!({}),
-            // `list` returns `Json<Vec<CeremonyManifest>>` — a top-level
-            // array (routes/ceremonies.rs:320).
-            json!([{
+            // `CeremonyListResponse` — a top-level array until #1094
+            // (routes/ceremonies.rs:320).
+            json!({ "ceremonies": [{
                 "purpose": "directory",
                 "pkg": "vtc.directory",
                 "nature": "read-only",
@@ -660,12 +660,11 @@ fn table() -> Vec<Conformance> {
                 "blurb": "A member views another member's record.",
                 "fields": [],
                 "factsTemplate": { "purpose": "directory" },
-            }]),
-            "response is a top-level array where the spec says \
-             `{ceremonies: [...]}`, and each manifest carries an unspecced \
-             `factsTemplate`. Two fixes, both here: wrap the array, and take \
-             `factsTemplate` upstream (the admin UI renders the simulator \
-             from it, so dropping it is not an option)"
+            }] }),
+            "the `{ceremonies: […]}` envelope is right as of #1094. Each \
+             manifest still carries an unspecced `factsTemplate`; that half \
+             goes upstream, because the admin UI renders the simulator from \
+             it and dropping it is not an option"
         ),
         // ─── community ───────────────────────────────────────────────
         drift!(
@@ -673,21 +672,23 @@ fn table() -> Vec<Conformance> {
             s::community::profile::show::v0_1::Response,
             Side::Response,
             json!({}),
-            // `CommunityProfileResponse` flattens the profile and appends
-            // `registryStatus` (routes/community/profile.rs:39).
+            // `CommunityProfileResponse` — nested as of #1094, with
+            // `registryStatus` inside the profile where the canonical
+            // component defines it (routes/community/profile.rs:39).
             {
                 let mut v = community_profile();
                 v.as_object_mut()
                     .expect("object")
                     .insert("registryStatus".into(), json!("active"));
-                v
+                json!({ "profile": v })
             },
-            "response flattens the profile to the top level; the spec nests \
-             it under `profile`. The flattened object then also carries \
-             `communityDid`, `createdAt` and `relationshipIdentifierDefault`, \
-             which the canonical `CommunityProfile` component does not \
-             define. Nesting is a fix here; the three extra members need to \
-             go upstream — `communityDid` in particular is the one member a \
+            "the `{profile: …}` nesting is right as of #1094, and \
+             `registryStatus` moved inside the profile object — beside it, \
+             the `additionalProperties: false` response would have rejected \
+             it. The profile still carries `communityDid`, `createdAt` and \
+             `relationshipIdentifierDefault`, which the canonical \
+             `CommunityProfile` component does not define; those three go \
+             upstream — `communityDid` in particular is the one member a \
              consumer most needs"
         ),
         drift!(
@@ -1124,12 +1125,12 @@ fn table() -> Vec<Conformance> {
             json!({ "did": DID, "role": "moderator", "label": "Ada Lovelace",
                     "publishConsent": true, "departurePreference": "historical",
                     "extensions": { "org": "acme" } }),
-            member_response(),
+            json!({ "member": member_response() }),
             "request carries `label`, which the spec's payload does not \
              define — a member's display label is editable here and \
-             unspecified upstream. Response is the bare `MemberResponse` \
-             (spec: `{member: …}`) with the same five unspecced members as \
-             `list`"
+             unspecified upstream. The response's `{member: …}` envelope is \
+             right as of #1094; the row still carries the same five unspecced \
+             members as `list`"
         ),
         checked!(
             s::members::purge::v0_1::Payload,

--- a/vtc-service/tests/ceremonies_list.rs
+++ b/vtc-service/tests/ceremonies_list.rs
@@ -1,0 +1,71 @@
+//! Integration coverage for `GET /v1/ceremonies`.
+//!
+//! The route had **no HTTP-level test at all** before #1094, which is how it
+//! shipped a top-level array past a published schema that wraps it — the same
+//! gap that hid the `endorsements/show` drift in #1093. Exercises the full
+//! router stack: Trust-Task header → auth extractor → handler.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vtc_service::test_support::TestVtc;
+
+const CEREMONIES_TASK: &str = "https://trusttasks.org/spec/vtc/ceremonies/list/0.1";
+
+async fn body_value(resp: axum::response::Response) -> (StatusCode, Value) {
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, v)
+}
+
+/// The response is `{ceremonies: […]}`, not a bare array.
+///
+/// Asserts the top level is an *object* and that the array is absent from it,
+/// so removing the envelope fails the test rather than passing on a payload
+/// that merely contains the right manifests.
+#[tokio::test]
+async fn list_wraps_the_manifests_in_a_ceremonies_envelope() {
+    let vtc = TestVtc::builder().build().await;
+    let token = vtc.token("did:key:z6MkAdmin", "admin", vec![]).await;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/ceremonies")
+        .header("Trust-Task", CEREMONIES_TASK)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = body_value(vtc.router.clone().oneshot(req).await.unwrap()).await;
+
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert!(body.is_object(), "must not be a bare array: {body}");
+
+    let ceremonies = body["ceremonies"]
+        .as_array()
+        .unwrap_or_else(|| panic!("`ceremonies` must be an array: {body}"));
+    let purposes: Vec<&str> = ceremonies
+        .iter()
+        .map(|c| c["purpose"].as_str().unwrap())
+        .collect();
+    assert_eq!(purposes, ["directory", "join", "removal", "roleChange"]);
+}
+
+/// Unauthenticated callers get nothing — the manifests are admin-UI metadata,
+/// not a public surface.
+#[tokio::test]
+async fn list_requires_a_session() {
+    let vtc = TestVtc::builder().build().await;
+    let req = Request::builder()
+        .method("GET")
+        .uri("/v1/ceremonies")
+        .header("Trust-Task", CEREMONIES_TASK)
+        .body(Body::empty())
+        .unwrap();
+    let resp = vtc.router.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/vtc-service/tests/community_profile.rs
+++ b/vtc-service/tests/community_profile.rs
@@ -95,6 +95,8 @@ async fn get_returns_profile_when_initialised() {
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     let (status, body) = body_value(resp).await;
     assert_eq!(status, StatusCode::OK);
+    // `show` nests the profile under `profile` (#1094).
+    let body = &body["profile"];
     assert_eq!(body["name"], "Example Community");
     assert_eq!(body["communityDid"], "did:webvh:vtc.example.com:abc");
     assert_eq!(body["language"], "en");

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -357,6 +357,8 @@ async fn end_to_end_install_flow_phase_0_gate() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    // `show` nests the profile under `profile` (#1094).
+    let body = &body["profile"];
     assert_eq!(body["name"], "Example Community");
 
     // Verify ACL admin record matches the bootstrapped DID

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -463,6 +463,8 @@ async fn patch_member_role_member_to_moderator_succeeds_and_emits_audit() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["role"], "moderator");
 
     // Confirm the on-disk ACL row reflects the change.
@@ -538,6 +540,8 @@ async fn patch_member_role_admin_promotes_with_a_live_step_up() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["role"], "admin");
 
     let entry = vtc_service::acl::get_acl_entry(&fix.acl_ks, "did:key:zM1")
@@ -565,6 +569,8 @@ async fn patch_member_profile_only_emits_member_updated() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["publishConsent"], true);
     assert_eq!(body["departurePreference"], "purge");
     // Role unchanged.
@@ -652,6 +658,8 @@ async fn promoting_an_existing_admin_is_an_idempotent_no_op() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "got {body}");
+    // `update` wraps the row as `{member: …}` (#1094).
+    let body = &body["member"];
     assert_eq!(body["role"], "admin");
 
     let entry = vtc_service::acl::get_acl_entry(&fix.acl_ks, "did:key:zSecondAdmin")


### PR DESCRIPTION
Three entries where the service held the right value and named or typed it
wrong — and one that was fixed six PRs ago and nobody told the ledger.

## `endorsements/revoke` was already conformant

The drift entry described a `{id}` response. #1082 replaced that with the
full `{endorsementId, revocation: {credentialId, revokedAt},
statusListIndex}` **and updated four of its five conformance entries.** This
was the fifth. The row has been sitting in the drift table for six PRs
describing a shape the handler stopped sending.

That is worth more than the one-line fix, because of *why* it survived:
**the witness proves the fixture diverges, not the handler.** Fixtures are
hand-written JSON, so one that goes stale keeps a fixed route in the table
forever and the count over-reports — silently, and in the direction that
looks like diligence.

So the fixture for this row is now built from the real `RevokeResponse`
rather than hand-written. Change the struct and the fixture changes with it;
it cannot describe a shape the handler does not send. The two `website`
fixtures below are converted the same way. The remaining hand-written
fixtures are a known follow-up — this PR establishes the pattern rather than
converting all 25 at once.

Drift **26 → 25**.

## `website/files/list` — the one member a listing exists to report

Each row sent `sizeBytes` where the item schema requires `size`. The item is
`additionalProperties: false`, so a conforming consumer saw a required
member missing and an unknown one present.

`modifiedAt` was worse than the entry recorded: it was a unix `u64` where
the schema says `type: string, format: date-time`. That is a mismatch in
*kind*, not merely in format — the old note put it down to format assertion
being off by default, which undersold it. Now an RFC 3339 timestamp. A file
whose mtime the platform will not report still lists, at the epoch, as it
did before.

`etag` stays and remains the row's divergence. It is the same SHA-256 the
`show` handler already sends as an `ETag` header, so it lets a client detect
a change without downloading the file — that goes upstream, not in the bin.

## `website/generations/list` — `current`, and a number that should be a string

The row named `current` as `isCurrent`, and sent `generation` as a raw `u32`
where the schema says `type: string` — which `rollback` has always
stringified, so the two halves of the same API disagreed with each other as
well as with the spec.

Rows now map through a `GenerationRow` wire type distinct from the stored
`GenerationEntry`, because the two disagree on purpose: a generation is a
number in storage, where ordering and arithmetic want one, and a string on
the wire, where the schema types it as one. `deployedAt` and `sizeBytes`
remain the divergence and go upstream — a rollback target is not much use
without knowing when it was deployed or how big it is.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`

`semver checks` fails here as it does on every recent PR (#1092, #1093,
#1094). The failing items are identical across all of them — thirteen
`vta-sdk` / `vta-service` entries, none touched by this work. That gate is
skipped on `main`, so nothing forces it back to green, and a real API break
would currently land invisibly inside that noise. Worth fixing separately.

BREAKING CHANGE: `GET /v1/website/files` sends `size` instead of `sizeBytes`
and `modifiedAt` as an RFC 3339 string instead of unix seconds. `GET
/v1/website/generations` sends `current` instead of `isCurrent` and
`generation` as a string instead of a number. No in-repo consumer reads
either shape; both were sending something their published schemas did not
describe.

Refs #1059
