### PR TITLE
fix(vtc)!: speak the endorsement model the spec defines

### DIFF
--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -20,7 +20,7 @@
 use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
@@ -56,7 +56,10 @@ const CLAIM_MAX_BYTES: usize = 8 * 1024;
 #[derive(utoipa::ToSchema)]
 pub struct IssueBody {
     pub subject_did: String,
-    #[serde(rename = "type")]
+    /// `typeUri`, the name the payload schema gives it. This carried an
+    /// explicit `#[serde(rename = "type")]` until #1096 — a deliberate
+    /// rename that simply disagreed with the spec.
+    #[serde(rename = "typeUri")]
     pub endorsement_type: String,
     pub claim: JsonValue,
     /// Optional override; defaults to 30d.
@@ -64,12 +67,65 @@ pub struct IssueBody {
     pub validity_seconds: Option<u64>,
 }
 
+/// One endorsement as the canonical `Endorsement` component names it.
+///
+/// A wire type distinct from the stored [`Endorsement`] because renaming the
+/// stored fields would rewrite the persisted fjall rows — `Endorsement`
+/// derives `Deserialize` and serialises `camelCase`, so `id` /
+/// `endorsementType` / `createdAt` are the on-disk keys of every row already
+/// written. Mapping at the boundary keeps the wire correct without a data
+/// migration, the same split `GenerationRow` uses (#1095).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct EndorsementRow {
+    /// `endorsementId`, stored as `id`.
+    pub endorsement_id: Uuid,
+    /// `typeUri`, stored as `endorsementType`.
+    pub type_uri: String,
+    pub subject_did: String,
+    /// `issued`, stored as `createdAt`.
+    pub issued: DateTime<Utc>,
+    pub status_list_index: u32,
+    pub claim: JsonValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<DateTime<Utc>>,
+    /// Unspecced upstream, against an `additionalProperties: false`
+    /// component — the half of this family that still diverges. `vecId` is
+    /// the `credentialId` a revocation receipt echoes, so a caller needs it
+    /// to revoke what it just read; `issuerDid` is the community DID, kept
+    /// on the row so a listing need not re-look up the signer. Both go
+    /// upstream rather than in the bin.
+    pub issuer_did: String,
+    pub vec_id: String,
+}
+
+impl From<Endorsement> for EndorsementRow {
+    fn from(e: Endorsement) -> Self {
+        Self {
+            endorsement_id: e.id,
+            type_uri: e.endorsement_type,
+            subject_did: e.subject_did,
+            issued: e.created_at,
+            status_list_index: e.status_list_index,
+            claim: e.claim,
+            revoked_at: e.revoked_at,
+            issuer_did: e.issuer_did,
+            vec_id: e.vec_id,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct IssueResponse {
-    pub id: Uuid,
-    pub vec_id: String,
+    pub endorsement: EndorsementRow,
+    /// The signed credential just minted. Unspecced, and the response is
+    /// `additionalProperties: false`, so this is what keeps `issue` in the
+    /// drift table — the spec's `Endorsement` component has nowhere to put a
+    /// credential. Handing back the VC is the point of an issue call, so it
+    /// stays and the gap goes upstream.
     pub vec: JsonValue,
 }
 
@@ -245,8 +301,10 @@ pub async fn issue(
     Ok((
         StatusCode::CREATED,
         Json(IssueResponse {
-            id,
-            vec_id,
+            // The row just stored, mapped to the names the canonical
+            // `Endorsement` component uses. `id` and `vecId` were the whole
+            // response until #1096; both live on the row now.
+            endorsement: end.into(),
             vec: vec_value,
         }),
     ))
@@ -267,7 +325,7 @@ pub struct ListQuery {
     security(("bearer_jwt" = [])),
     params(ListQuery),
     responses(
-        (status = 200, description = "Paginated list of endorsements", body = Paginated<Endorsement>),
+        (status = 200, description = "Paginated list of endorsements", body = Paginated<EndorsementRow>),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin or issuer"),
     ),
@@ -276,7 +334,7 @@ pub async fn list(
     auth: AuthClaims,
     State(state): State<AppState>,
     Query(query): Query<ListQuery>,
-) -> Result<Json<Paginated<Endorsement>>, AppError> {
+) -> Result<Json<Paginated<EndorsementRow>>, AppError> {
     let acl = get_acl_entry(&state.acl_ks, &auth.did)
         .await?
         .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
@@ -301,7 +359,7 @@ pub async fn list(
         .map_err(|e| AppError::Validation(format!("invalid cursor: {e}")))?;
     let page =
         list_endorsements(&state.endorsements_ks, &audit_key, cursor.as_ref(), limit).await?;
-    Ok(Json(page))
+    Ok(Json(page.map_items(EndorsementRow::from)))
 }
 
 // ─── Show ────────────────────────────────────────────────
@@ -333,7 +391,9 @@ pub async fn show(
     let row = get_endorsement(&state.endorsements_ks, id)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("endorsement {id} not found")))?;
-    Ok(Json(EndorsementEnvelope { endorsement: row }))
+    Ok(Json(EndorsementEnvelope {
+        endorsement: row.into(),
+    }))
 }
 
 // ─── Revoke ──────────────────────────────────────────────
@@ -492,5 +552,5 @@ fn rfc3339(t: chrono::DateTime<Utc>) -> String {
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EndorsementEnvelope {
-    pub endorsement: Endorsement,
+    pub endorsement: EndorsementRow,
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -432,17 +432,22 @@ fn join_request() -> Value {
 
 /// An `Endorsement` row as `endorsements/mod.rs:41` serialises one.
 fn endorsement() -> Value {
-    json!({
-        "id": "11111111-1111-4111-8111-111111111111",
-        "endorsementType": "https://skills.example.com/v1/rust",
-        "issuerDid": COMMUNITY_DID,
-        "subjectDid": DID,
-        "claim": { "level": "expert" },
-        "statusListIndex": 42,
-        "vecId": "urn:uuid:11111111-1111-4111-8111-111111111111",
-        "createdAt": TS,
-        "revokedAt": null,
+    // Serialised from the real `EndorsementRow`, not hand-written — see the
+    // `endorsements/revoke` note in the table (#1095) for why that matters.
+    serde_json::to_value(crate::routes::endorsements::EndorsementRow {
+        endorsement_id: "11111111-1111-4111-8111-111111111111"
+            .parse()
+            .expect("fixture uuid"),
+        type_uri: "https://skills.example.com/v1/rust".into(),
+        subject_did: DID.into(),
+        issued: TS.parse().expect("fixture timestamp"),
+        status_list_index: 42,
+        claim: json!({ "level": "expert" }),
+        revoked_at: None,
+        issuer_did: COMMUNITY_DID.into(),
+        vec_id: "urn:uuid:11111111-1111-4111-8111-111111111111".into(),
     })
+    .expect("EndorsementRow serialises")
 }
 
 /// An `EndorsementType` row as `endorsement_types/mod.rs:42` serialises one.
@@ -824,28 +829,28 @@ fn table() -> Vec<Conformance> {
         drift!(
             s::endorsements::issue::v0_1::Payload,
             s::endorsements::issue::v0_1::Response,
-            Side::Both,
-            // `IssueBody` — routes/endorsements.rs:57. `endorsement_type` is
-            // renamed to `type`, and the rename beats `rename_all`.
+            Side::Response,
+            // `IssueBody` — routes/endorsements.rs:57, `typeUri` as of #1096.
             json!({
                 "subjectDid": DID,
-                "type": "https://skills.example.com/v1/rust",
+                "typeUri": "https://skills.example.com/v1/rust",
                 "claim": { "level": "expert" },
                 "validitySeconds": 2_592_000_u64,
             }),
             // `IssueResponse` — routes/endorsements.rs:70.
             json!({
-                "id": "11111111-1111-4111-8111-111111111111",
-                "vecId": "urn:uuid:11111111-1111-4111-8111-111111111111",
+                "endorsement": endorsement(),
                 "vec": credential(),
             }),
-            "the request names the endorsement type `type`; the spec names it \
-             `typeUri`. The response is `{id, vecId, vec}` against a spec \
-             that says `{endorsement: {endorsementId, typeUri, subjectDid, \
-             issued, statusListIndex}}` — a different model, not a naming \
-             slip: the spec returns the stored row with the credential \
-             nested under `issued`, this returns the credential and two ids. \
-             Needs a decision on which model wins before either side moves"
+            "the request conforms as of #1096 — it named the type `type` \
+             against a spec that says `typeUri`. The response now returns \
+             the row under `endorsement`, so the model disagreement the old \
+             note described is settled in the spec's favour. What remains is \
+             `vec`, the signed credential, against an \
+             `additionalProperties: false` response whose `Endorsement` \
+             component has nowhere to put a credential. Handing back the VC \
+             it just minted is the point of an issue call, so it stays and \
+             the gap goes upstream"
         ),
         drift!(
             s::endorsements::list::v0_1::Payload,
@@ -854,11 +859,13 @@ fn table() -> Vec<Conformance> {
             json!({ "subjectDid": DID, "typeUri": "https://skills.example.com/v1/rust",
                     "includeRevoked": true, "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
             paginated(json!([endorsement()])),
-            "the wrapper's casing is fixed; what remains is that the rows are this service's \
-             `Endorsement` (endorsements/mod.rs:41) — `id` / \
-             `endorsementType` / `issuerDid` / `vecId` / `createdAt` — not \
-             the spec's (`endorsementId` / `typeUri` / `issued`). Same model \
-             disagreement as `issue`"
+            "the rows speak the canonical `Endorsement` component as of \
+             #1096 — `endorsementId` / `typeUri` / `issued`, where they said \
+             `id` / `endorsementType` / `createdAt`. What remains is the \
+             unspecced `issuerDid` and `vecId` against an \
+             `additionalProperties: false` component; `vecId` is the \
+             `credentialId` a revocation echoes, so a caller needs it to \
+             revoke what it just listed. Both go upstream"
         ),
         drift!(
             s::endorsements::show::v0_1::Payload,
@@ -866,9 +873,9 @@ fn table() -> Vec<Conformance> {
             Side::Response,
             json!({ "endorsementId": "11111111-1111-4111-8111-111111111111" }),
             json!({ "endorsement": endorsement() }),
-            "the `{endorsement: …}` envelope is right as of #1093; the row's \
-             members are still this service's spelling. Same model \
-             disagreement as `issue`; fix the family together"
+            "the envelope was fixed in #1093 and the row's members in \
+             #1096. What remains is the same unspecced `issuerDid` / \
+             `vecId` as `list` — one upstream change closes both"
         ),
         checked!(
             s::endorsements::revoke::v0_1::Payload,

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -347,7 +347,7 @@ async fn issue_rejects_unregistered_type() {
         .body(Body::from(
             json!({
                 "subjectDid": SUBJECT_DID,
-                "type": "https://unregistered.example/t",
+                "typeUri": "https://unregistered.example/t",
                 "claim": { "x": 1 }
             })
             .to_string(),
@@ -370,7 +370,7 @@ async fn issue_rejects_non_issuer_non_admin() {
         .body(Body::from(
             json!({
                 "subjectDid": SUBJECT_DID,
-                "type": "https://example.com/v1/skills/rust",
+                "typeUri": "https://example.com/v1/skills/rust",
                 "claim": { "level": "expert" }
             })
             .to_string(),
@@ -394,7 +394,7 @@ async fn issue_happy_path_issuer_mints_credential() {
         .body(Body::from(
             json!({
                 "subjectDid": SUBJECT_DID,
-                "type": uri,
+                "typeUri": uri,
                 "claim": { "level": "expert", "since": "2020" }
             })
             .to_string(),
@@ -403,7 +403,7 @@ async fn issue_happy_path_issuer_mints_credential() {
     let resp = fix.router.clone().oneshot(req).await.unwrap();
     let (status, v) = body_value(resp).await;
     assert_eq!(status, StatusCode::CREATED, "{v}");
-    assert!(v["id"].is_string());
+    assert!(v["endorsement"]["endorsementId"].is_string());
     assert!(v["vec"].is_object());
 
     // Audit: CustomEndorsementIssued + VecIssued both emitted.
@@ -440,7 +440,7 @@ async fn issue_rejects_unknown_subject() {
         .body(Body::from(
             json!({
                 "subjectDid": "did:key:zStranger",
-                "type": uri,
+                "typeUri": uri,
                 "claim": { "x": 1 }
             })
             .to_string(),
@@ -465,7 +465,7 @@ async fn delete_type_refused_while_live_endorsement_exists() {
         .body(Body::from(
             json!({
                 "subjectDid": SUBJECT_DID,
-                "type": uri,
+                "typeUri": uri,
                 "claim": { "level": "expert" }
             })
             .to_string(),
@@ -501,11 +501,14 @@ async fn revoke_issuer_can_retract() {
         .header("trust-task", ISSUE_TASK)
         .header("content-type", "application/json")
         .body(Body::from(
-            json!({ "subjectDid": SUBJECT_DID, "type": uri, "claim": { "x": 1 } }).to_string(),
+            json!({ "subjectDid": SUBJECT_DID, "typeUri": uri, "claim": { "x": 1 } }).to_string(),
         ))
         .unwrap();
     let (_, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
-    let id = v["id"].as_str().unwrap().to_string();
+    let id = v["endorsement"]["endorsementId"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let req = Request::builder()
         .method("DELETE")
@@ -546,11 +549,14 @@ async fn revoke_idempotent_on_already_revoked() {
         .header("trust-task", ISSUE_TASK)
         .header("content-type", "application/json")
         .body(Body::from(
-            json!({ "subjectDid": SUBJECT_DID, "type": uri, "claim": { "x": 1 } }).to_string(),
+            json!({ "subjectDid": SUBJECT_DID, "typeUri": uri, "claim": { "x": 1 } }).to_string(),
         ))
         .unwrap();
     let (_, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
-    let id = v["id"].as_str().unwrap().to_string();
+    let id = v["endorsement"]["endorsementId"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     for _ in 0..2 {
         let req = Request::builder()
@@ -577,11 +583,14 @@ async fn revoke_non_admin_non_issuer_forbidden() {
         .header("trust-task", ISSUE_TASK)
         .header("content-type", "application/json")
         .body(Body::from(
-            json!({ "subjectDid": SUBJECT_DID, "type": uri, "claim": { "x": 1 } }).to_string(),
+            json!({ "subjectDid": SUBJECT_DID, "typeUri": uri, "claim": { "x": 1 } }).to_string(),
         ))
         .unwrap();
     let (_, v) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
-    let id = v["id"].as_str().unwrap().to_string();
+    let id = v["endorsement"]["endorsementId"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
     let req = Request::builder()
         .method("DELETE")
@@ -613,7 +622,7 @@ async fn show_wraps_the_row_in_an_endorsement_envelope() {
         .body(Body::from(
             json!({
                 "subjectDid": SUBJECT_DID,
-                "type": uri,
+                "typeUri": uri,
                 "claim": { "level": "expert" }
             })
             .to_string(),
@@ -621,7 +630,7 @@ async fn show_wraps_the_row_in_an_endorsement_envelope() {
         .unwrap();
     let (status, issued) = body_value(fix.router.clone().oneshot(req).await.unwrap()).await;
     assert_eq!(status, StatusCode::CREATED, "{issued}");
-    let id = issued["id"].as_str().unwrap();
+    let id = issued["endorsement"]["endorsementId"].as_str().unwrap();
 
     let req = Request::builder()
         .method("GET")
@@ -636,6 +645,6 @@ async fn show_wraps_the_row_in_an_endorsement_envelope() {
     // The envelope, not the bare row: `v["id"]` must be absent precisely
     // because the row now sits one level down.
     assert!(v["id"].is_null(), "row must not be at the top level: {v}");
-    assert_eq!(v["endorsement"]["id"], id);
+    assert_eq!(v["endorsement"]["endorsementId"], id);
     assert_eq!(v["endorsement"]["subjectDid"], SUBJECT_DID);
 }

--- a/vti-common/src/pagination/mod.rs
+++ b/vti-common/src/pagination/mod.rs
@@ -138,6 +138,23 @@ pub struct Paginated<T> {
     pub total_estimate: Option<u64>,
 }
 
+impl<T> Paginated<T> {
+    /// Map every item to a different type, carrying the cursor and estimate
+    /// through untouched.
+    ///
+    /// For routes whose stored row and wire row are deliberately different
+    /// types — a listing that must publish the names its schema gives while
+    /// storage keeps the names already on disk. Rebuilding the wrapper by
+    /// hand at each call site is where a `next_cursor` gets dropped.
+    pub fn map_items<U, F: FnMut(T) -> U>(self, f: F) -> Paginated<U> {
+        Paginated {
+            items: self.items.into_iter().map(f).collect(),
+            next_cursor: self.next_cursor,
+            total_estimate: self.total_estimate,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Cursor — internal payload + signed wire form
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The endorsement family — `issue`, `list`, `show` — spoke a different model
from the one the spec defines. Three renames, one per row, and a request
member that had been deliberately renamed away from the spec's name.

| canonical `Endorsement` | this service sent |
|---|---|
| `endorsementId` | `id` |
| `typeUri` | `endorsementType` |
| `issued` | `createdAt` |
| `subjectDid`, `statusListIndex`, `claim`, `revokedAt` | already matched |

## Mapping at the boundary, not renaming storage

The stored `Endorsement` derives `Deserialize` and serialises `camelCase`,
so `id` / `endorsementType` / `createdAt` are the on-disk keys of every row
already written. Renaming those fields would rewrite the persisted fjall
format and need a migration — for a naming problem that only exists on the
wire.

So `EndorsementRow` is a wire type mapping from the stored row, the same
split `GenerationRow` uses (#1095). Storage keeps the names it has; the API
publishes the names the spec gives.

`Paginated::map_items` is new in `vti-common` for the `list` path — carrying
the cursor and estimate through by hand at each call site is where a
`nextCursor` gets dropped. Additive, so no semver break.

## `issue`'s request conformed all along, except for one rename

`IssueBody::endorsement_type` carried an explicit `#[serde(rename = "type")]`
against a spec that says `typeUri` — a deliberate rename that simply
disagreed. Everything else on the request (`subjectDid`, `claim`,
`validitySeconds`) already matched. The request side of this entry now
conforms outright.

The witness caught that for me: the entry was recorded as `Side::Both`, and
`known_drift_entries_still_diverge_where_they_say_they_do` failed with *"the
recorded drift says the request diverges, but it actually conforms"*. Now
`Side::Response`.

## What still diverges, and why it stays

**`issuerDid` and `vecId`** on the row, against an `additionalProperties:
false` component. `vecId` is the `credentialId` a revocation receipt echoes,
so a caller needs it to revoke what it just read; `issuerDid` is the
community DID, kept on the row so a listing need not re-look up the signer.
One upstream change closes `list` and `show` together.

**`vec` on the issue response** — the signed credential just minted. The
spec's response is `additionalProperties: false` and its `Endorsement`
component has nowhere to put a credential. Handing back the VC is the point
of an issue call, so it stays and the gap goes upstream. The old note called
this "a different model, not a naming slip" and said it needed a decision
before either side moved; the decision here is that the spec's model wins
for the row, and the one thing the spec cannot express is what gets raised.

Drift stays **25** — all three entries keep a live second half.

## Fixtures

The `endorsement()` helper now serialises a real `EndorsementRow` rather
than hand-writing JSON, continuing what #1095 started after the
`endorsements/revoke` row spent six PRs describing a response the handler
had stopped sending.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`

`semver checks` fails as it has on #1092–#1095; the same thirteen
`vta-sdk` / `vta-service` items, none touched here.

BREAKING CHANGE: `POST /v1/credentials/endorsements` takes `typeUri` instead
of `type`, and returns `{endorsement: {…}, vec}` instead of `{id, vecId,
vec}`. `GET /v1/credentials/endorsements` and
`GET /v1/credentials/endorsements/{id}` send `endorsementId` / `typeUri` /
`issued` instead of `id` / `endorsementType` / `createdAt`. Stored rows are
untouched — this is a wire change only, with no migration.

Refs #1059
