### PR TITLE
fix(vtc)!: issued is a credential receipt, not a timestamp

### DIFF
--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -84,20 +84,41 @@ pub struct EndorsementRow {
     /// `typeUri`, stored as `endorsementType`.
     pub type_uri: String,
     pub subject_did: String,
-    /// `issued`, stored as `createdAt`.
-    pub issued: DateTime<Utc>,
+    /// The issuance receipt — **not** a timestamp.
+    ///
+    /// #1096 read `issued` as "when it was issued" and mapped `createdAt`
+    /// onto it, so this member went out as an RFC 3339 string where the
+    /// component requires an object. `IssuedCredential` is where `vecId` and
+    /// the signed credential belong; #1096 called both of those unspecced
+    /// and proposed taking them upstream, which was wrong — the spec had a
+    /// home for each all along.
+    pub issued: IssuedCredential,
     pub status_list_index: u32,
     pub claim: JsonValue,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revoked_at: Option<DateTime<Utc>>,
-    /// Unspecced upstream, against an `additionalProperties: false`
-    /// component — the half of this family that still diverges. `vecId` is
-    /// the `credentialId` a revocation receipt echoes, so a caller needs it
-    /// to revoke what it just read; `issuerDid` is the community DID, kept
-    /// on the row so a listing need not re-look up the signer. Both go
-    /// upstream rather than in the bin.
-    pub issuer_did: String,
-    pub vec_id: String,
+}
+
+/// The registry-wide issuance receipt: the handle, the credential, and when
+/// it lapses.
+///
+/// `credential` and `expiresAt` are required by the component but are **not
+/// on the stored row** — the `Endorsement` keyspace holds `vecId` and the
+/// mint time, never the signed VEC or its expiry. So `issue`, which has just
+/// minted both, fills the receipt completely, and `list` / `show` cannot.
+/// They send what they hold and stay in the drift table until the row grows
+/// those two members (a storage change and a migration, deliberately not
+/// bundled into a wire fix).
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IssuedCredential {
+    pub credential_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issued_at: Option<DateTime<Utc>>,
 }
 
 impl From<Endorsement> for EndorsementRow {
@@ -106,12 +127,16 @@ impl From<Endorsement> for EndorsementRow {
             endorsement_id: e.id,
             type_uri: e.endorsement_type,
             subject_did: e.subject_did,
-            issued: e.created_at,
+            issued: IssuedCredential {
+                credential_id: e.vec_id,
+                // Neither is on the stored row; only `issue` can fill them.
+                credential: None,
+                expires_at: None,
+                issued_at: Some(e.created_at),
+            },
             status_list_index: e.status_list_index,
             claim: e.claim,
             revoked_at: e.revoked_at,
-            issuer_did: e.issuer_did,
-            vec_id: e.vec_id,
         }
     }
 }
@@ -120,13 +145,13 @@ impl From<Endorsement> for EndorsementRow {
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct IssueResponse {
+    /// The whole response. The signed credential rides inside
+    /// `endorsement.issued.credential`, where the component puts it — #1096
+    /// sent it as a top-level `vec` sibling and recorded the resulting
+    /// divergence as an upstream gap, having misread `issued` as a
+    /// timestamp. The response is `additionalProperties: false`, so that
+    /// sibling could never have been right.
     pub endorsement: EndorsementRow,
-    /// The signed credential just minted. Unspecced, and the response is
-    /// `additionalProperties: false`, so this is what keeps `issue` in the
-    /// drift table — the spec's `Endorsement` component has nowhere to put a
-    /// credential. Handing back the VC is the point of an issue call, so it
-    /// stays and the gap goes upstream.
-    pub vec: JsonValue,
 }
 
 #[utoipa::path(
@@ -301,11 +326,19 @@ pub async fn issue(
     Ok((
         StatusCode::CREATED,
         Json(IssueResponse {
-            // The row just stored, mapped to the names the canonical
-            // `Endorsement` component uses. `id` and `vecId` were the whole
-            // response until #1096; both live on the row now.
-            endorsement: end.into(),
-            vec: vec_value,
+            endorsement: EndorsementRow {
+                // `issue` is the one route that holds the whole receipt: it
+                // just minted the credential and computed its expiry, so it
+                // fills `credential` and `expiresAt` where `list` / `show`
+                // can only send the handle and the mint time.
+                issued: IssuedCredential {
+                    credential_id: vec_id,
+                    credential: Some(vec_value),
+                    expires_at: Some(valid_until),
+                    issued_at: Some(now),
+                },
+                ..end.into()
+            },
         }),
     ))
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -430,23 +430,40 @@ fn join_request() -> Value {
     })
 }
 
-/// An `Endorsement` row as `endorsements/mod.rs:41` serialises one.
-fn endorsement() -> Value {
-    // Serialised from the real `EndorsementRow`, not hand-written — see the
-    // `endorsements/revoke` note in the table (#1095) for why that matters.
-    serde_json::to_value(crate::routes::endorsements::EndorsementRow {
+const VEC_ID: &str = "urn:uuid:11111111-1111-4111-8111-111111111111";
+
+/// One row, with whatever issuance receipt the caller can supply.
+///
+/// Serialised from the real `EndorsementRow`, not hand-written — see the
+/// `endorsements/revoke` note in the table (#1095) for why that matters.
+fn endorsement_row(
+    issued: crate::routes::endorsements::IssuedCredential,
+) -> crate::routes::endorsements::EndorsementRow {
+    crate::routes::endorsements::EndorsementRow {
         endorsement_id: "11111111-1111-4111-8111-111111111111"
             .parse()
             .expect("fixture uuid"),
         type_uri: "https://skills.example.com/v1/rust".into(),
         subject_did: DID.into(),
-        issued: TS.parse().expect("fixture timestamp"),
+        issued,
         status_list_index: 42,
         claim: json!({ "level": "expert" }),
         revoked_at: None,
-        issuer_did: COMMUNITY_DID.into(),
-        vec_id: "urn:uuid:11111111-1111-4111-8111-111111111111".into(),
-    })
+    }
+}
+
+/// The row a `list` / `show` sends: the handle and the mint time. `credential`
+/// and `expiresAt` are required by the component but are not on the stored
+/// row, so only `issue` can fill them.
+fn endorsement() -> Value {
+    serde_json::to_value(endorsement_row(
+        crate::routes::endorsements::IssuedCredential {
+            credential_id: VEC_ID.into(),
+            credential: None,
+            expires_at: None,
+            issued_at: Some(TS.parse().expect("fixture timestamp")),
+        },
+    ))
     .expect("EndorsementRow serialises")
 }
 
@@ -502,7 +519,7 @@ fn uuid() -> uuid::Uuid {
 /// while these notes still described the older schemas. A note that says
 /// "take it upstream" can be stale in the good direction; check the released
 /// schema before writing the spec PR it asks for.
-const KNOWN_DRIFT_COUNT: usize = 16;
+const KNOWN_DRIFT_COUNT: usize = 15;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -816,10 +833,9 @@ fn table() -> Vec<Conformance> {
             json!({ "typeUri": "https://skills.example.com/v1/rust" })
         ),
         // ─── endorsements ────────────────────────────────────────────
-        drift!(
+        checked!(
             s::endorsements::issue::v0_1::Payload,
             s::endorsements::issue::v0_1::Response,
-            Side::Response,
             // `IssueBody` — routes/endorsements.rs:57, `typeUri` as of #1096.
             json!({
                 "subjectDid": DID,
@@ -827,20 +843,18 @@ fn table() -> Vec<Conformance> {
                 "claim": { "level": "expert" },
                 "validitySeconds": 2_592_000_u64,
             }),
-            // `IssueResponse` — routes/endorsements.rs:70.
-            json!({
-                "endorsement": endorsement(),
-                "vec": credential(),
-            }),
-            "the request conforms as of #1096 — it named the type `type` \
-             against a spec that says `typeUri`. The response now returns \
-             the row under `endorsement`, so the model disagreement the old \
-             note described is settled in the spec's favour. What remains is \
-             `vec`, the signed credential, against an \
-             `additionalProperties: false` response whose `Endorsement` \
-             component has nowhere to put a credential. Handing back the VC \
-             it just minted is the point of an issue call, so it stays and \
-             the gap goes upstream"
+            // `IssueResponse` with the receipt filled — `issue` is the one
+            // route holding the credential and its expiry, so it is the one
+            // that can supply `credential` and `expiresAt`.
+            serde_json::to_value(crate::routes::endorsements::IssueResponse {
+                endorsement: endorsement_row(crate::routes::endorsements::IssuedCredential {
+                    credential_id: VEC_ID.into(),
+                    credential: Some(credential()),
+                    expires_at: Some(TS.parse().expect("fixture timestamp")),
+                    issued_at: Some(TS.parse().expect("fixture timestamp")),
+                },),
+            })
+            .expect("IssueResponse serialises")
         ),
         drift!(
             s::endorsements::list::v0_1::Payload,
@@ -849,13 +863,16 @@ fn table() -> Vec<Conformance> {
             json!({ "subjectDid": DID, "typeUri": "https://skills.example.com/v1/rust",
                     "includeRevoked": true, "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
             paginated(json!([endorsement()])),
-            "the rows speak the canonical `Endorsement` component as of \
-             #1096 — `endorsementId` / `typeUri` / `issued`, where they said \
-             `id` / `endorsementType` / `createdAt`. What remains is the \
-             unspecced `issuerDid` and `vecId` against an \
-             `additionalProperties: false` component; `vecId` is the \
-             `credentialId` a revocation echoes, so a caller needs it to \
-             revoke what it just listed. Both go upstream"
+            "one member missing, and it is a storage question rather than a \
+             spec one. `issued` is an `IssuedCredential` receipt — #1096 \
+             misread it as a timestamp and sent `createdAt`; #1098 corrects \
+             that. The receipt requires `credential` and `expiresAt`, and \
+             the stored `Endorsement` keeps neither: the keyspace holds the \
+             `vecId` and the mint time, never the signed VEC or its expiry. \
+             So this row sends the handle and `issuedAt` and stops. Closing \
+             it means storing the credential and its expiry on the row — a \
+             migration, deliberately not bundled into a wire fix. \
+             `endorsements/issue` conforms because it has just minted both"
         ),
         drift!(
             s::endorsements::show::v0_1::Payload,
@@ -863,9 +880,10 @@ fn table() -> Vec<Conformance> {
             Side::Response,
             json!({ "endorsementId": "11111111-1111-4111-8111-111111111111" }),
             json!({ "endorsement": endorsement() }),
-            "the envelope was fixed in #1093 and the row's members in \
-             #1096. What remains is the same unspecced `issuerDid` / \
-             `vecId` as `list` — one upstream change closes both"
+            "the envelope was fixed in #1093, the row's names in #1096 and \
+             the `issued` receipt in #1098. What remains is the same missing \
+             `credential` / `expiresAt` as `list`, for the same reason: \
+             neither is on the stored row. One storage change closes both"
         ),
         checked!(
             s::endorsements::revoke::v0_1::Payload,

--- a/vtc-service/tests/endorsements.rs
+++ b/vtc-service/tests/endorsements.rs
@@ -404,7 +404,18 @@ async fn issue_happy_path_issuer_mints_credential() {
     let (status, v) = body_value(resp).await;
     assert_eq!(status, StatusCode::CREATED, "{v}");
     assert!(v["endorsement"]["endorsementId"].is_string());
-    assert!(v["vec"].is_object());
+    // The credential rides inside the issuance receipt, where the
+    // `IssuedCredential` component puts it — it was a top-level `vec`
+    // sibling until #1098, against an `additionalProperties: false`
+    // response that could never have accepted one.
+    let issued = &v["endorsement"]["issued"];
+    assert!(v["vec"].is_null(), "credential must not be a sibling: {v}");
+    assert!(issued["credential"].is_object(), "got {v}");
+    let cred_id = issued["credentialId"].as_str().expect("credentialId");
+    assert!(cred_id.starts_with("urn:uuid:"), "got {cred_id}");
+    // The receipt's handle names the credential it carries.
+    assert_eq!(issued["credential"]["id"], issued["credentialId"]);
+    assert!(issued["expiresAt"].is_string(), "got {v}");
 
     // Audit: CustomEndorsementIssued + VecIssued both emitted.
     let pairs = fix.audit_ks.prefix_iter_raw(Vec::new()).await.unwrap();


### PR DESCRIPTION
**#1096 shipped a defect and I wrote the wrong explanation into the ledger
alongside it.** This fixes both.

## What went wrong

`Endorsement.issued` is not a timestamp. It is an `IssuedCredential`
receipt — *"the registry-wide issuance receipt — credentialId, the signed
VEC, and expiry"*:

```
issued: { credentialId, credential, expiresAt, issuedAt? }   // first three required
```

#1096 read it as "when it was issued" and mapped `createdAt` onto it, so
every endorsement row has been sending `"issued": "2026-08-23T00:00:00Z"`
where a required object belongs. That is worse than the shape it replaced:
the old row did not claim to speak the canonical model, and this one does
while getting a required member's type wrong.

Two claims in #1096's description are false as a result:

- *"`vecId` is unspecced"* — it is `issued.credentialId`.
- *"the spec's `Endorsement` component has nowhere to put a credential, so
  `vec` stays and the gap goes upstream"* — it is `issued.credential`.
  There was no upstream gap.

The sweep's original note had said exactly this — *"the spec returns the
stored row with the credential nested under `issued`"* — and #1096 replaced
a correct note with a misreading, then recorded the misreading as settled.

## The fix

`issued` becomes an `IssuedCredential`. The mapping the spec actually asks
for:

| spec | service |
|---|---|
| `issued.credentialId` | `vecId` |
| `issued.credential` | the signed VEC |
| `issued.expiresAt` | `validUntil` |
| `issued.issuedAt` | `createdAt` |

`issue` holds all four at the moment it replies — it has just minted the
credential and computed its expiry — so it fills the receipt completely and
**now conforms outright.** The top-level `vec` sibling is gone; it rides
inside the receipt, which is where an `additionalProperties: false` response
could always have accepted it and never could have accepted a sibling.

`issuerDid` is dropped from the wire. It is the community DID — the same
value on every row of every listing, derivable from the community profile —
so it bought nothing and was the last thing keeping `issue` out of
conformance. The stored row keeps it; it is a real storage optimisation
there, saving a signer lookup per listing.

Drift **16 → 15**.

## What `list` and `show` still need, and why it is not here

Both are now blocked on exactly one thing: `credential` and `expiresAt` are
required by the receipt and **are not on the stored row**. The `Endorsement`
keyspace holds the `vecId` and the mint time, never the signed VEC or its
expiry. So those two routes send the handle and `issuedAt` and stop.

Closing them means storing the credential and its expiry on the row —
larger rows plus a migration for existing ones. That is a storage decision,
not a wire fix, and bundling it into this correction would hide it. The
entries now say so precisely, instead of the old note's claim that an
upstream change would close them.

## How this was found

Not by re-reading notes. A throwaway probe walked the drift table printing
the *actual* parse or schema error for every entry, which said
`invalid type: string "2026-08-23T00:00:00Z", expected struct
IssuedCredential` — a sentence no amount of re-reading my own prose would
have produced. The same probe showed `list` / `show` failing on
`missing field credential`, which is what scoped the storage question above.

Worth keeping as a habit: the ledger's notes are prose and can be wrong in
either direction. The schemas are not.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`

`semver checks` fails as it has on every recent PR — thirteen standing items
across three crates, none touched here.

BREAKING CHANGE: endorsement rows send `issued` as an object
(`{credentialId, credential?, expiresAt?, issuedAt?}`) instead of a
timestamp string, and no longer send `issuerDid`. `POST
/v1/credentials/endorsements` returns the signed credential at
`endorsement.issued.credential` instead of a top-level `vec`. The `issued`
change corrects a shape #1096 shipped that no conforming consumer could
accept.

Refs #1059
