### PR TITLE
fix(vtc): a false green, and the fixture that caused it

### DIFF
--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -365,19 +365,26 @@ fn member_response() -> Value {
 /// The `CommunityProfile` this service serialises
 /// (`community/profile.rs:73`). Carried by profile show/update and by the
 /// config export document.
+/// The `CommunityProfile` this service serialises.
+///
+/// Built from the **real struct**, not hand-written. The hand-written version
+/// omitted `personhood`, which the type always serialises — and that omission
+/// promoted `config/export` and `config/import` to `checked!` in #1097 on a
+/// shape the service does not send. A fixture can understate as easily as it
+/// can overstate, and understating is the dangerous direction: it makes a
+/// non-conformant route look green. Constructing the type means the compiler
+/// refuses to let this drift again.
 fn community_profile() -> Value {
-    json!({
-        "communityDid": COMMUNITY_DID,
-        "name": "Example Community",
-        "description": "A demo community.",
-        "logoUrl": "https://community.example/logo.png",
-        "publicUrl": "https://community.example",
-        "contactEmail": "ops@community.example",
-        "language": "en",
-        "relationshipIdentifierDefault": "pairwise",
-        "createdAt": TS,
-        "extensions": { "tier": "gold" },
-    })
+    let mut p = crate::community::CommunityProfile::new(COMMUNITY_DID, "Example Community");
+    p.description = "A demo community.".into();
+    p.logo_url = Some("https://community.example/logo.png".into());
+    p.public_url = Some("https://community.example".into());
+    p.contact_email = Some("ops@community.example".into());
+    p.language = "en".into();
+    p.relationship_identifier_default = "pairwise".into();
+    p.created_at = TS.parse().expect("fixture timestamp");
+    p.extensions = json!({ "tier": "gold" });
+    serde_json::to_value(p).expect("CommunityProfile serialises")
 }
 
 /// The `BackupEnvelope` (`backup.rs:63`) — canonical, and the same object on
@@ -523,13 +530,22 @@ fn uuid() -> uuid::Uuid {
 ///    issue call hands back, which the spec's `Endorsement` component has
 ///    nowhere to put. These close upstream, not here.
 ///
+/// **A hand-written fixture can understate as well as overstate.** #1097
+/// promoted `config/export` and `config/import` to `checked!` on a
+/// `community_profile()` that omitted `personhood` — a member the real type
+/// always serialises. That is a *false green*: a non-conformant route
+/// reported as conforming, which is the one direction this table must never
+/// fail in. The fixture is now built from the struct, so the compiler
+/// refuses the omission; do the same for any fixture you touch. Roughly
+/// twenty remain hand-written.
+///
 /// **Read the pin before reading this number.** Nine entries closed on the
 /// `trust-tasks-rs` 0.11.2 → 0.11.8 bump alone, because
 /// trustoverip/dtgwg-trust-tasks-tf#256–#260 had already merged and shipped
 /// while these notes still described the older schemas. A note that says
 /// "take it upstream" can be stale in the good direction; check the released
 /// schema before writing the spec PR it asks for.
-const KNOWN_DRIFT_COUNT: usize = 12;
+const KNOWN_DRIFT_COUNT: usize = 14;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -724,12 +740,17 @@ fn table() -> Vec<Conformance> {
             "the `{profile: …}` nesting is right as of #1094, and \
              `registryStatus` moved inside the profile object — beside it, \
              the `additionalProperties: false` response would have rejected \
-             it. What remains is `communityDid` and `createdAt` inside the \
-             profile, which the canonical `CommunityProfile` component does \
-             not define. `relationshipIdentifierDefault` was the third and \
-             is defined as of trust-tasks-rs 0.11.8. `communityDid` is the \
-             one member a consumer most needs; both go upstream and close \
-             this row together with `update`"
+             it. What remains is `communityDid`, `createdAt` and \
+             `personhood`, none of which the canonical `CommunityProfile` \
+             component defines. `personhood` is taken upstream in \
+             trustoverip/dtgwg-trust-tasks-tf#261. The other two are a \
+             design question rather than a missing member: that component is \
+             the **update-facing** view and omits `communityDid` on purpose, \
+             so that a patch cannot re-point a community's identity — \
+             `config-portability`'s `CommunityProfileSnapshot` says so in \
+             prose. A read needs the DID and an update must refuse it, so \
+             the fix is a read-shaped view for `show`, not another member on \
+             the update view"
         ),
         drift!(
             s::community::profile::update::v0_1::Payload,
@@ -751,17 +772,19 @@ fn table() -> Vec<Conformance> {
             "the request conforms as of trust-tasks-rs 0.11.8, which carries \
              `relationshipIdentifierDefault` from \
              trustoverip/dtgwg-trust-tasks-tf#257. What remains is \
-             `communityDid` and `createdAt` inside the profile — the two \
-             members #257 did not cover. `fieldsChanged` is *not* a \
-             divergence: the response schema defines it, and an earlier \
-             version of this note said otherwise because a serde parse stops \
-             at the first unknown member and never reaches the rest. Those \
-             two go upstream and close this row together with `show`"
+             `communityDid`, `createdAt` and `personhood` inside the \
+             profile; `personhood` is taken upstream in #261 and the other \
+             two are the read-vs-update view question described on `show`. \
+             `fieldsChanged` is *not* a divergence: the response schema \
+             defines it, and an earlier version of this note said otherwise \
+             because a serde parse stops at the first unknown member and \
+             never reaches the rest"
         ),
         // ─── config ──────────────────────────────────────────────────
-        checked!(
+        drift!(
             s::config::export::v0_1::Payload,
             s::config::export::v0_1::Response,
+            Side::Response,
             json!({}),
             // `ExportResponse` / `ConfigExportDocument` —
             // routes/admin/config.rs:476 / :460.
@@ -772,11 +795,20 @@ fn table() -> Vec<Conformance> {
                     "communityProfile": community_profile(),
                     "configOverrides": { "log.level": "debug", "server.port": 8200 },
                 }
-            })
+            }),
+            "the embedded profile carries `personhood`, which \
+             `CommunityProfileSnapshot` does not define (`additionalProperties: \
+             false`). This entry was promoted to `checked!` in #1097 on a \
+             fixture that omitted the member — a false green, and the \
+             opposite failure to the stale notes that PR fixed: a hand-written \
+             fixture can understate what the service sends as easily as it \
+             can overstate it. Closes on the trust-tasks-rs release carrying \
+             trustoverip/dtgwg-trust-tasks-tf#261"
         ),
-        checked!(
+        drift!(
             s::config::import::v0_1::Payload,
             s::config::import::v0_1::Response,
+            Side::Request,
             // `ImportRequest` — routes/admin/config.rs:524. The document is
             // whatever `export` handed back, so it carries the same extra
             // member.
@@ -796,7 +828,12 @@ fn table() -> Vec<Conformance> {
                 "overrideChanges": [{ "key": "log.level", "newValue": "warn" }],
                 "pendingRestart": ["server.port"],
                 "rejected": [{ "key": "bogus.key", "reason": "unknown config key" }],
-            })
+            }),
+            "request-side half of the `config/export` drift: an import replays \
+             the document an export produced, so it carries the same \
+             unspecced `personhood`. Same false green from #1097, same \
+             cause, and the same upstream PR closes both — \
+             trustoverip/dtgwg-trust-tasks-tf#261"
         ),
         // ─── directory ───────────────────────────────────────────────
         checked!(


### PR DESCRIPTION
Stacked on #1099.

**#1097 promoted `config/export` and `config/import` to `checked!` on a
fixture that understated what the service sends.** Both routes are
non-conformant and were reported as conforming. Drift **12 → 14**, which is
the count moving in the honest direction.

## The false green

`community_profile()` was hand-written JSON and omitted `personhood`. The real
`CommunityProfile` carries it with `#[serde(default)]` and no
`skip_serializing_if`, so it is on the wire of every profile the service
sends — and `CommunityProfileSnapshot` is `additionalProperties: false` and
does not define it. Add the member to the fixture and the entry fails
immediately:

```
config/export/0.1: response is not canonical: unknown field `personhood`,
expected one of `communityDid`, `contactEmail`, `createdAt`, `description`,
`extensions`, `language`, `logoUrl`, `name`, `publicUrl`,
`relationshipIdentifierDefault`
```

This is the **third** distinct way the hand-written fixtures have misled, and
the first one that mattered in the dangerous direction:

| | |
|---|---|
| **stale** (#1095) | `endorsements/revoke` described a response the handler had stopped sending six PRs earlier |
| **inventing** (#1099) | `totalEstimate: 12`, which nothing in the workspace ever sets |
| **omitting** (here) | `personhood`, absent from the fixture and always present on the wire |

The first two made the debt look larger than it was. This one made a
non-conformant route look green, which is the one direction this table must
never fail in — the whole point of the assertion is that debt can shrink but
not grow unnoticed, and an understating fixture shrinks it silently.

## The fix, and the durable part

`community_profile()` now constructs the real `CommunityProfile` and
serialises it, instead of hand-writing the object. The compiler refuses the
omission: add a member to the struct and this fixture carries it whether or
not anyone remembers to.

Both entries go back to `drift!`, naming `personhood` and pointing at
trustoverip/dtgwg-trust-tasks-tf#261, which adds it to
`CommunityProfileSnapshot` and to `CommunityProfile`. They close on the
release carrying it.

`KNOWN_DRIFT_COUNT`'s header gains the lesson, because it warns about the
other two failure modes and not this one.

## The `communityDid` question, which is not a missing member

While preparing #261 I was about to add `communityDid` and `createdAt` to
`CommunityProfile` — the two members the `profile/show` and `profile/update`
notes have been asking for. The sibling schema says not to:

> `vtc/_shared/community`'s `CommunityProfile` … is the update-facing view and
> **deliberately omits `communityDid` so that a patch cannot re-point a
> community's identity**.

That is a documented design decision, and adding the member would defeat it.
The real problem is that `community/profile/show`'s **response** and
`community/profile/update`'s **payload** share one component that was designed
for the update: a read needs the DID, an update must refuse it.
`CommunityProfileSnapshot` already exists as the read-shaped view, with
`communityDid` required.

So the fix is a read-shaped view for `show`, not another member on the update
view — a design question for the working group rather than something to bolt
on. Both notes now say that instead of asking for the member.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`

Refs #1059
