### PR TITLE
feat(vta-mcp): gate operations locally, log every call, and document the bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Layer 4 (the spine + consumers):
 | `vta-cli-common` | Shared CLI command implementations — both CLIs are thin wrappers |
 | `pnm-cli` | Personal Network Manager (single-VTA operator) |
 | `cnm-cli` | Community Network Manager (multi-community operator) |
-| `vta-mcp` | Model Context Protocol server bridging a VTA's agent capabilities (signing oracle, vault, device, discovery) to MCP tools over stdio, so any MCP host (Claude Desktop, agent frameworks) can use a VTA with no custom code. `publish = false` |
+| `vta-mcp` | Model Context Protocol server bridging a VTA's agent capabilities (signing oracle, vault, device, discovery) to MCP tools over stdio, so any MCP host (Claude Desktop, agent frameworks) can use a VTA with no custom code. Carries a **local per-operation guard** (`guard.rs`) because an MCP host approves a *tool*, not a call — once `vta_call` is approved every Trust Task URI rides that approval — plus stderr/JSONL call logging (`observability.rs`). Docs: `docs/02-vta/vta-mcp.md`. `publish = false` |
 | `didcomm-test` | Standalone DIDComm connectivity harness (test tool, `publish = false`) |
 
 Hot spots to know about (file size in source lines, sorted descending):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,6 +6992,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -9329,6 +9330,7 @@ name = "vta-mcp"
 version = "0.1.5"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "rmcp",
  "schemars 1.2.2",

--- a/docs/02-vta/examples/agent-memory-with-vta-mcp.md
+++ b/docs/02-vta/examples/agent-memory-with-vta-mcp.md
@@ -1,0 +1,289 @@
+# Worked example — `vta-agent-memory` and `vta-mcp` side by side
+
+Two MCP servers, one VTA, two identities that cannot reach each other's data.
+
+- **[`vta-agent-memory`](https://github.com/OpenVTC/vta-agent-memory)** gives an
+  agent host durable memory — six `memory_*` tools plus a skill that says *when*
+  to save and recall, four slash commands, and a `SessionStart` hook that loads
+  memories before you type anything. It speaks exactly three Trust Tasks
+  (`vta/memory/{put,list,delete}/0.1`).
+- **[`vta-mcp`](../vta-mcp.md)** gives the same host the rest of the VTA —
+  contexts, keys, ACL, DID management, vault, audit — through one generic
+  `vta_call` gateway plus typed convenience tools.
+
+They are separate on purpose, and the reason is the point of this guide.
+
+---
+
+## 1. Why two servers rather than one
+
+`vta-mcp` can technically do memory: `vta_call` reaches
+`vta/memory/put/0.1` like it reaches everything else. Running
+`vta-agent-memory` anyway buys three things `vta_call` structurally cannot:
+
+- **Retrieval.** `memory/list/0.1` returns *every entry in the context* — no
+  prefix, no cursor, no search. Making that useful means structured keys,
+  one-line descriptions, and ranking that returns summaries rather than bodies.
+  That work lives on the client side, in `vta-agent-memory`. A raw `vta_call`
+  would paste every body into the context window.
+- **Policy about memory.** The `agent-memory` skill — what is worth saving, what
+  must never go in — is most of the value. Tools are the easy part.
+- **A different blast radius.** This is the real reason. Read on.
+
+The inverse also holds: `vta-agent-memory` deliberately cannot do anything but
+memory, so it is not a way to manage your VTA.
+
+## 2. The identity model
+
+Each server gets **its own `did:key`, in its own trust context**, with role
+`application`. The trust context is the isolation boundary the VTA enforces —
+`vta/memory/*` is gated on `require_context(contextId)`, the same check the
+context-scoped key tasks use — so a memory agent scoped to `agent-memory`
+physically cannot read `mcp-bridge` data, and vice versa.
+
+```
+                     ┌──────────────────────────────┐
+   Claude Code ──────┤ vta-agent-memory             │
+   (one host,        │  did:key:zMem…               │──┐
+    two servers)     │  context: agent-memory       │  │
+                     │  tools: memory_*             │  │   one VTA
+                     └──────────────────────────────┘  │   two ACL entries
+                     ┌──────────────────────────────┐  │   two contexts
+                     ┤ vta-mcp                      │  │
+                     │  did:key:zMcp…               │──┘
+                     │  context: mcp-bridge         │
+                     │  tools: vta_call, sign, …    │
+                     └──────────────────────────────┘
+```
+
+What this buys you, concretely: revoking the memory agent is one
+`pnm acl delete <did>` that does not touch the bridge, and a prompt-injection
+that persuades the model to call `vta_call` cannot reach a single memory.
+
+Do **not** give both servers the same identity, and do not give either one your
+`pnm` operator login. `vta-mcp` warns at every boot when you do
+([why](../vta-mcp.md#24-run-it-as-a-dedicated-agent-not-as-yourself)).
+
+---
+
+## 3. Set it up
+
+### Prerequisites
+
+- A running VTA whose DID you know, and which advertises a DIDComm mediator.
+- Somebody who can run `pnm contexts create` and `pnm acl create` — **not
+  necessarily on this machine**. Both tools are built so the grant can be made
+  anywhere: another laptop, CI, a colleague reading it off a ticket.
+- Rust 1.95+ to build both.
+
+Identify the VTA by **DID**, never by its `pnm` slug. A slug is a nickname
+chosen on one machine and means nothing on any other.
+
+### 3.1 The memory server
+
+`vta-agent-memory` has a two-phase flow so that the machine holding your
+memories never needs an operator credential:
+
+```bash
+git clone https://github.com/OpenVTC/vta-agent-memory
+cd vta-agent-memory && scripts/install.sh
+
+bin/vta-agent-memory init \
+  --vta-did did:webvh:abc:vta.example.com:mine \
+  --context agent-memory
+```
+
+It mints a throwaway `did:key`, parks it in the OS keyring, and prints the grant
+to run wherever you hold admin:
+
+```bash
+pnm contexts create --id agent-memory --name "Agent memory"
+pnm acl create --did did:key:zTemp… --role application \
+  --contexts agent-memory --label vta-agent-memory
+```
+
+Then, back on the agent machine:
+
+```bash
+bin/vta-agent-memory connect
+```
+
+`connect` rotates: on first successful authentication it swaps the throwaway key
+for a fresh one, mirrors the ACL entry onto the new DID, and drops the temp
+entry — so the DID that travelled through a ticket stops being an authenticator
+once it has done its job. It then proves the rotated identity can actually read
+the context before writing any config.
+
+```bash
+bin/vta-agent-memory doctor      # config, vta, context, identity, transport, count
+```
+
+### 3.2 The bridge
+
+`vta-mcp` has no `init` of its own — mint its key with whatever you already use
+for scoped agents (`pnm setup`-style ephemeral keys, a `did:webvh` bundle from
+`vta create-did-webvh --export-secrets`, or the `ai-agent` DID template from
+[personal AI agents](../personal-ai-agents.md#step-2--agent-identity-via-the-ai-agent-template-operator-per-agent)).
+Whichever route, the ACL grant looks the same:
+
+```bash
+pnm contexts create --id mcp-bridge --name "MCP bridge"
+pnm acl create --did did:key:zMcp… --role application \
+  --contexts mcp-bridge --label vta-mcp --expires 30d
+```
+
+Build it and check it starts:
+
+```bash
+cargo build --release -p vta-mcp     # in the VTI workspace
+```
+
+### 3.3 Wire both into the host
+
+Claude Code reads `.mcp.json` in the project (or `~/.claude.json` for user
+scope); Claude Desktop uses `claude_desktop_config.json`. The shape is the same:
+
+```json
+{
+  "mcpServers": {
+    "vta-memory": {
+      "command": "/Users/me/.cargo/bin/vta-agent-memory",
+      "args": ["serve"]
+    },
+    "vta": {
+      "command": "/Users/me/devel/verifiable-trust-infrastructure/target/release/vta-mcp",
+      "args": [
+        "--agent-did", "did:key:zMcp…",
+        "--vta-did", "did:webvh:abc:vta.example.com:mine",
+        "--mediator-did", "did:web:mediator.example.com",
+        "--enroll",
+        "--confirm", "sensitive",
+        "--deny", "vta/seeds/*,vta/backup/*",
+        "--audit-log", "/Users/me/.local/state/vta-mcp/audit.jsonl"
+      ],
+      "env": { "VTA_MCP_AGENT_KEY": "z3u2…" }
+    }
+  }
+}
+```
+
+Notes on the `vta` block, each of which is doing something:
+
+- `--enroll` puts the bridge in `pnm device list`, so
+  `pnm device disable <id>` is a kill switch the VTA enforces at
+  authentication.
+- `--confirm sensitive` asks you before anything that signs, releases a secret,
+  or moves authority — restoring per-call consent that the host's one-time
+  "always allow **vta_call**" would otherwise give away.
+- `--deny` keeps the master seed and full-state backups unreachable through this
+  bridge regardless of what its ACL would permit.
+- `--audit-log` is the only record that outlives the process.
+- The key is in `env`, not `args`: command-line arguments are readable by every
+  process on the machine.
+
+If a plugin already provides `vta-agent-memory` (it ships one, with the hook and
+slash commands), install it that way instead of hand-writing the first block:
+
+```bash
+claude plugin marketplace add OpenVTC/vta-agent-memory
+claude plugin install vta-agent-memory@vta-agent-memory
+```
+
+---
+
+## 4. Check it works
+
+Restart the host, then ask for each in turn.
+
+**The bridge, first — because it can tell you about itself:**
+
+> Call `vta_status`.
+
+```json
+{
+  "connected": true,
+  "identity": { "mode": "did:key-didcomm", "agentDid": "did:key:zMcp…",
+                "dedicatedAgent": true },
+  "transports": { "trustTasks": "DIDComm", "protocolMessages": "DIDComm" },
+  "policy": { "summary": "confirm=sensitive deny=[vta/seeds/*,vta/backup/*]" },
+  "calls": { "ok": 1, "errors": 0, "denied": 0, "declined": 0 }
+}
+```
+
+`"dedicatedAgent": true` is the line to look for. If it is `false`, the bridge
+is running as you.
+
+**Then the memory server:**
+
+> Remember that this project pins its MCP servers in `.mcp.json`, not user scope.
+
+…then in a fresh session:
+
+> What do you know about this project's MCP setup?
+
+**Then prove the isolation.** Ask the bridge to read the memory context:
+
+> Call `vta_call` with operation
+> `https://trusttasks.org/spec/vta/memory/list/0.1` and payload
+> `{"contextId": "agent-memory"}`.
+
+The VTA refuses it — the bridge's ACL entry names `mcp-bridge`, not
+`agent-memory`. That refusal is the design working, and it comes from the VTA,
+not from the bridge's local policy.
+
+---
+
+## 5. If you would rather run one server
+
+You can serve memory through `vta-mcp` alone, at the cost of the retrieval and
+policy layers in §1. Give the bridge the memory context and lock it to that
+family:
+
+```bash
+vta-mcp --agent-did did:key:zMem… \
+  --vta-did did:webvh:… --mediator-did did:web:… \
+  --allow 'vta/memory/*' --confirm never
+```
+
+`--allow` makes everything outside `vta/memory/*` refused locally, so a
+mis-scoped ACL entry does not become a mis-scoped bridge. This is a reasonable
+setup for a machine that should only ever hold memory — but the model now has to
+do its own ranking against a full context dump, and nothing tells it what is
+worth remembering.
+
+---
+
+## 6. Revoking
+
+| What | Command | Effect |
+|---|---|---|
+| The memory agent | `pnm acl delete did:key:zMem…` | Memory tools stop working at the next call; memories stay on the VTA |
+| The bridge | `pnm acl delete did:key:zMcp…` | Every `vta-mcp` tool stops working |
+| The bridge, temporarily | `pnm device disable <device-id>` | Enforced at authentication (`--enroll` is what puts it in `pnm device list`) |
+| A stolen machine | `pnm device wipe <device-id> --reason "stolen" --scope full` | Records the reason and marks the binding wiped |
+
+Neither revocation touches the other identity. That is the whole reason they are
+two identities.
+
+---
+
+## 7. Auditing what happened
+
+Three places, in increasing durability:
+
+```bash
+# 1. What the bridge did, from inside the session
+#    → ask the model to call vta_status, or read `vta://calls/recent`
+
+# 2. What the bridge did, on this machine, after the fact
+jq -r 'select(.outcome != "ok") | [.ts, .tool, .operation, .outcome] | @tsv' \
+  ~/.local/state/vta-mcp/audit.jsonl
+
+# 3. What the VTA saw — the authoritative record, per identity
+pnm audit list --actor did:key:zMcp…
+pnm audit list --actor did:key:zMem…
+```
+
+The third is the one that matters in an incident: the bridge's own log is on the
+machine you are trying to make claims about. The VTA's audit rows carry the
+agent's DID as the actor, which is exactly why each server has its own.

--- a/docs/02-vta/personal-ai-agents.md
+++ b/docs/02-vta/personal-ai-agents.md
@@ -150,7 +150,7 @@ pnm vault release <entry-id>                     # opens the sealed reply, print
 pnm vault sign-trust-task --file envelope.json   # sign as the entry's principal
 
 # What did the agent do? (the agent's DID is the audit actor)
-pnm audit --actor <agent-did>
+pnm audit list --actor <agent-did>
 ```
 
 `vault upsert` and `vault release` seal/open `didcomm-authcrypt` envelopes with
@@ -298,3 +298,5 @@ Lower priority unless your agents do credential work.
 - Mobile/agent architecture (push topology): `docs/05-design-notes/mobile-agent-architecture.md`
 - Agent memory vs. application state: `docs/05-design-notes/appstate-store.md` §1
 - Agent-side connect ladder: `vta-sdk/src/agent_connect.rs`
+- Using a VTA from an MCP host: [vta-mcp](vta-mcp.md), and the worked
+  two-server example [agent memory + vta-mcp](examples/agent-memory-with-vta-mcp.md)

--- a/docs/02-vta/vta-mcp.md
+++ b/docs/02-vta/vta-mcp.md
@@ -1,0 +1,399 @@
+# vta-mcp — using a VTA from an MCP host
+
+`vta-mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server
+that exposes a Verifiable Trust Agent as MCP tools, so any MCP-speaking host —
+Claude Code, Claude Desktop, an IDE, an agent framework — can drive a VTA with
+no custom integration code.
+
+It is a **bridge, not an authority**. Every tool call becomes a Trust Task on an
+authenticated `VtaClient`, and the VTA decides what actually happens. This
+document is mostly about the consequences of that sentence.
+
+- Crate: `vta-mcp/` (`publish = false`; build it yourself)
+- Transport: **stdio** — the host spawns the binary and speaks JSON-RPC over
+  stdin/stdout
+- Related: [personal AI agents](personal-ai-agents.md) (how to provision the
+  identity this bridge should run as), [approvals](approvals.md) (server-side
+  gating), [example: agent memory + vta-mcp](examples/agent-memory-with-vta-mcp.md)
+
+---
+
+## 1. What it exposes
+
+Two generic tools cover the entire VTA management surface, and the rest are
+conveniences with typed schemas:
+
+| Tool | What it does | Risk class |
+|---|---|---|
+| `vta_list_operations` | The catalog of every Trust Task URI `vta_call` can reach, each with its risk class **and this bridge's policy decision** | read-only |
+| `vta_call` | Invoke any operation by URI with a JSON payload | *per operation* |
+| `vta_status` | What this bridge is: identity, transports, policy, counters, recent calls | read-only |
+| `vta_supported_tasks` | Which Trust Tasks the connected VTA actually serves (glob-filterable) | read-only |
+| `list_keys` | The VTA's signing keys | read-only |
+| `sign` | Sign UTF-8 text with a VTA-held key (the private key never leaves the VTA) | sensitive |
+| `vault_list` / `vault_get` | Secrets-vault entry metadata — no secret material | read-only |
+| `vault_release` | Release a secret sealed to this client and **return the cleartext** | sensitive |
+| `device_heartbeat` | Check in; returns queued operations | mutating |
+| `resolve_did` | Resolve any DID via the shared resolver cache | read-only |
+| `issue_vp` | Build a holder-bound OID4VP `vp_token`, signed locally | sensitive |
+
+Three read-only **resources** are published alongside them, so a host can read
+the bridge's own state without spending a tool call:
+
+| Resource | Contents |
+|---|---|
+| `vta://status` | The same document `vta_status` returns |
+| `vta://operations` | The annotated operation catalog |
+| `vta://calls/recent` | The last 100 calls this bridge served, redacted |
+
+Every tool carries MCP **tool annotations** (`readOnlyHint`, `destructiveHint`,
+`idempotentHint`, `openWorldHint`). Hosts render these, and some gate on them. A
+test asserts each annotation agrees with the risk class of the operation the
+tool actually calls, so they cannot quietly drift apart.
+
+---
+
+## 2. The security model
+
+### 2.1 Four layers, and which one is load-bearing
+
+1. **Process spawn is the authentication boundary.** stdio means no listener, no
+   port, and no authentication *on the MCP channel itself*. Whoever can spawn
+   the process — or read the host's MCP config — inherits the full authority of
+   the configured identity.
+2. **The connect ladder decides whose authority that is.** Four rungs (§4).
+   The important distinction is *dedicated agent identity* versus *replayed
+   operator login*.
+3. **The VTA is the policy decision point.** Role, ACL, context scope, the
+   `signable_keys` policy on each context, and — where
+   `policy.enforcement = true` — the [approvals / DTTE](approvals.md) gate. None
+   of that is reimplemented here.
+4. **The bridge's own local policy** (§3) refuses or confirms individual
+   operations before they are sent.
+
+Layer 3 is the real one. Layers 1, 2 and 4 exist to keep layer 3's decisions
+meaningful.
+
+### 2.2 The gap layer 4 closes
+
+**An MCP host approves a tool, not a call.** The moment an operator answers
+"always allow" to `vta_call`, `contexts/delete/1.0` rides the same approval as
+`contexts/list/1.0` — the host sees one tool name and cannot tell them apart.
+
+So `vta-mcp` classifies each Trust Task URI itself and decides per call:
+
+| Class | Meaning | Examples |
+|---|---|---|
+| `read-only` | Reads state | `acl/list`, `vta/contexts/get`, `vta/contexts/preview-delete` |
+| `mutating` | Additive and reversible | `vta/contexts/create`, `device/register`, `vta/memory/put` |
+| `sensitive` | Exercises key authority, emits secret material, or moves authority | `keys/sign`, `vault/release`, `acl/grant`, `vta/seeds/export-mnemonic` |
+| `destructive` | Removes state or access | `vta/contexts/delete`, `acl/revoke`, `device/wipe`, `vta/seeds/rotate` |
+
+A URI whose verb this build has never seen classifies as `mutating` — never
+read-only. The catalog grows outside this crate; a `--read-only` bridge must not
+pass through something it does not recognise. A census test fails the build when
+a new verb appears, so "unknown" cannot become the common case.
+
+The convenience tools are gated under the **URI they actually send**, so
+`--read-only` cannot be walked around by calling `sign` instead of `vta_call`.
+`issue_vp` is gated as `keys/sign` even though it never reaches the VTA — a
+read-only bridge must not be a signing oracle by another name.
+
+### 2.3 What the bridge does not protect you from
+
+Stated plainly, because the mitigations are operational, not technical:
+
+- **`vta_call` is a full gateway.** There is no built-in allowlist beyond what
+  you configure. Point it at a `pnm` admin session and the model on the other
+  end of the pipe holds admin. The mitigation is §2.4, not a flag.
+- **Two paths move secret material out of the VTA.** `vault_release` returns
+  cleartext as tool output — it enters the model's context and the host's
+  transcript. `issue_vp` signs with `VTA_MCP_HOLDER_KEY`, a raw Ed25519 key held
+  in process memory, outside the signing oracle entirely.
+- **Least privilege is coarse.** Capabilities derive from the ACL **role** or
+  are set at `device/register`; per-entry capability overrides are still a
+  deferred gap. Pick the role whose derived set is closest to what you want.
+- **A compromised host with a legitimate credential is a legitimate caller.**
+  No authorization model fixes that; only splitting identities per process does.
+  See `docs/05-design-notes/multi-tenant-signing.md` §Finding 2.
+
+### 2.4 Run it as a dedicated agent, not as yourself
+
+This is the single most important setting, and it is not a flag — it is which
+identity you start the process with.
+
+```bash
+# 1. One context per agent. This is the isolation boundary.
+pnm contexts create --id my-mcp-agent --name "MCP bridge"
+
+# 2. Least privilege: role `application`, scoped to exactly one context.
+#    NOT admin — for `admin` an empty allowed-contexts list means *unrestricted*;
+#    for every other role it means authorized nowhere.
+pnm acl create --did <agent did:key> --role application \
+  --contexts my-mcp-agent --label vta-mcp --expires 30d
+
+# 3. Run the bridge as that identity, over DIDComm.
+VTA_MCP_AGENT_KEY=<multibase> vta-mcp \
+  --agent-did did:key:z6Mk… \
+  --vta-did did:webvh:example.com:vta \
+  --mediator-did did:key:z6Mk… \
+  --enroll
+```
+
+If the bridge needs the signing oracle at all, narrow it at the ACL rather than
+here: `pnm acl create … --allowed-keys key-1,key-2` restricts which key ids that
+DID may name in `keys/sign`. It intersects with `--contexts` — it can only
+narrow, never widen — and unlike `--read-only` it is enforced by the VTA, so it
+survives someone restarting the bridge with different flags.
+
+`--enroll` registers the bridge as an `ai-agent` device, so it shows up in
+`pnm device list` and `pnm device disable` / `pnm device wipe` revoke it — the
+VTA enforces that at authentication, not just in the listing. **`--enroll` is
+refused in session mode**, because the binding would attach to the *operator's*
+ACL entry rather than the agent's.
+
+Session mode still works and is convenient, but the bridge logs a warning at
+every boot when it holds an operator credential rather than a scoped agent
+identity. That warning is the whole of §2.3's first bullet, said out loud.
+
+### 2.5 Key material on the command line
+
+`--agent-key`, `--holder-key` and an inline `--agent-secrets` JSON blob are all
+readable by any process on the machine via `ps` / `/proc/<pid>/cmdline`. The
+flags stay supported, and the bridge warns when it sees one. Prefer the matching
+`VTA_MCP_*` environment variable, or a **file path** for `--agent-secrets`.
+
+---
+
+## 3. Hardening flags
+
+| Flag | Env | Effect |
+|---|---|---|
+| `--read-only` | `VTA_MCP_READ_ONLY` | Refuse anything not `read-only`, whatever the ACL permits |
+| `--allow <glob>` | `VTA_MCP_ALLOW` | Permit only these slug globs. Repeatable; comma-separated in the env var. When set, everything else is refused |
+| `--deny <glob>` | `VTA_MCP_DENY` | Always refuse these. Checked **before** `--allow`, so a deny cannot be undone by an allow |
+| `--confirm <level>` | `VTA_MCP_CONFIRM` | Which classes need a human: `never`, `destructive` (default), `sensitive`, `always` |
+
+Globs are deliberately minimal — `*`, a family (`acl/*`), or an exact slug.
+Patterns match the **slug**, the part after `https://trusttasks.org/spec/`, so
+you write `vta/memory/*`, not the full URI.
+
+### Confirmation
+
+`--confirm` puts the risky tail back in front of a person using **MCP
+elicitation**: the host shows a yes/no prompt naming the operation and its risk
+class, and the call proceeds only on an explicit yes.
+
+Two behaviours worth knowing:
+
+- **Read-only calls are never confirmed**, even at `--confirm always`. A bridge
+  that prompts before every `list` gets its prompts clicked through unread.
+- **If the host cannot ask, the call is refused**, not waved through — a
+  confirmation gate that fails open is not a gate. Hosts that do not implement
+  elicitation get an error naming `--confirm never` and `--allow` as the fixes.
+
+The default is `destructive`, not `sensitive`, on the reasoning that the host
+already prompts once per tool: the local gate earns its keep exactly where a
+tool-level approval is too coarse to mean anything. Raise it to `sensitive` for
+any bridge holding an operator session.
+
+### Recipes
+
+```bash
+# Read-only inspection — the safest thing you can hand a model.
+vta-mcp --vta my-vta --read-only
+
+# A memory-only agent: three operations, nothing else reachable.
+vta-mcp --agent-did … --allow 'vta/memory/*' --confirm never
+
+# An operator session, hardened: keep the seed and backups off-limits entirely,
+# and ask before anything that signs or moves authority.
+vta-mcp --vta my-vta \
+  --deny 'vta/seeds/*,vta/backup/*,acl/*' \
+  --confirm sensitive
+```
+
+Invalid policy values are **fatal at startup** — a typo in `--confirm` must not
+degrade to a permissive default. Connectivity failures are not fatal; see §5.
+
+---
+
+## 4. Authentication modes
+
+The ladder lives in `vta_sdk::agent_connect::AgentConnect`, shared with every
+other agent-side bridge. Highest precedence first:
+
+| # | Mode | Flags | Notes |
+|---|---|---|---|
+| 1 | did:webvh bundle | `--agent-secrets <PATH\|JSON>` + `--vta-did` + `--mediator-did` | A `DidSecretsBundle`; `#key-0` signs, `#key-1` decrypts. Dedicated agent |
+| 2 | did:key | `--agent-did` + `--agent-key` + `--vta-did` + `--mediator-did` | Scoped agent over DIDComm. Works against DIDComm-only VTAs with no REST endpoint. Dedicated agent |
+| 3 | Token | `VTA_URL` + `VTA_TOKEN` | REST bearer token. No refresh; testing and short-lived use |
+| 4 | Session | `--vta <slug>` | Replays an existing `pnm`/`cnm` login, auto-refreshing. **Operator authority** |
+
+Two rules the ladder enforces rather than documents:
+
+- The two DIDComm identity modes are **mutually exclusive** — passing both is an
+  error, not a silent precedence win.
+- A **half-configured** rung fails fast naming the missing field, never falling
+  through to session mode. That fall-through is how a misconfigured bridge ends
+  up authenticated as the operator instead of as the scoped agent it was meant
+  to be.
+
+> **Session slugs.** `pnm` stores sessions under the keyring key `vta:<slug>`;
+> passing the bare slug used to find no session at all and report *"not
+> authenticated"* to somebody who is. `--vta` adds the prefix for you, and an
+> already-prefixed value still works.
+
+Session mode needs the `keyring` feature, which is on by default. Building
+`--no-default-features` is only for token or DIDComm mode.
+
+---
+
+## 5. Seeing what it is doing
+
+The original complaint this section answers: an MCP server is a subprocess with
+its stdout wired to the protocol, so by default you cannot see anything it does.
+
+### stderr — the runtime log
+
+**On by default at `info`.** (It previously used `EnvFilter::from_default_env()`
+with no fallback, so an operator who had not set `RUST_LOG` got silence: no
+startup line, no call log, no error.) Every call logs twice:
+
+```
+INFO vta_mcp::server: call start seq=3 tool="vta_call"
+  operation="…/vta/contexts/delete/1.0" risk="destructive" decision="deny"
+  args={"operation":"…","payload":{"id":"x"}}
+WARN vta_mcp::server: call failed seq=3 … outcome="denied" duration_ms=0
+  error="'vta/contexts/delete' is destructive and this bridge runs with --read-only…"
+```
+
+- `--log-level <level>` / `VTA_MCP_LOG_LEVEL` — `RUST_LOG` still wins when set.
+- `--log-format json` — one JSON object per line, for a log pipeline.
+
+In Claude Code, this lands in the MCP server logs (`/mcp` shows server state;
+the logs are under `~/.cache/claude-cli-nodejs/<project>/mcp-logs-*`). Claude
+Desktop writes them under its own logs directory.
+
+### `--audit-log <path>` — the durable record
+
+One redacted JSON object per line, appended, created **owner-only (0600)**:
+
+```json
+{"ts":"2026-08-25T03:30:20.963Z","seq":3,"tool":"vta_call",
+ "operation":"https://trusttasks.org/spec/vta/contexts/delete/1.0",
+ "risk":"destructive","decision":"confirm","outcome":"denied","durationMs":0,
+ "args":{"operation":"…","payload":{"id":"x"}},"error":"…"}
+```
+
+`outcome` is one of `ok`, `error`, `denied` (local policy refused) or `declined`
+(a human said no). The records name operations, DIDs, context ids and key ids —
+not secrets, but a map of what this VTA holds and who touches it, which is worth
+0600 on its own.
+
+### `vta_status` and `vta://calls/recent` — from inside the session
+
+The last 100 calls are kept in memory whether or not `--audit-log` was passed,
+because by the time you want to know what the bridge has been doing, you will
+not have passed it. Ask the model to call `vta_status`, or read the resource.
+
+### Redaction
+
+Both logs pass every payload through the same filter, whose rule is that
+**strings are guilty until named innocent**. Numbers and booleans pass; strings
+pass only under an allowlisted key name (`id`, `did`, `contextId`, `keyId`,
+`role`, `limit`, …). So `text` (what `sign` signs), `mnemonic`, `privateKey`,
+`jwe` and every field of a released credential are elided without this crate
+needing to know those names exist.
+
+### Degraded mode
+
+If the bridge cannot connect — no credentials configured, a typo'd env var, an
+unreachable mediator, an expired session — **it serves MCP anyway**. A server
+that exits before speaking the protocol appears in the host as *no tools at
+all*: the model cannot even report the problem, and the operator sees an empty
+tool list with no explanation. Instead, `vta_status` answers with the failure
+and every other tool returns it verbatim:
+
+```
+this vta-mcp bridge is not connected to its VTA: no usable VTA credentials:
+… supply a session_key (an existing `pnm` login), url + token, or an agent
+identity (agent_did + agent_key + vta_did + mediator_did). Fix the connection
+and restart the MCP server; `vta_status` reports the configuration it tried.
+```
+
+Reconnection is not automatic — fix the configuration and restart the server.
+
+---
+
+## 6. Host configuration
+
+Claude Code (`.mcp.json` in the project, or `claude mcp add`), Claude Desktop
+(`claude_desktop_config.json`) and most other hosts take the same shape:
+
+```json
+{
+  "mcpServers": {
+    "vta": {
+      "command": "vta-mcp",
+      "args": [
+        "--agent-did", "did:key:z6Mk…",
+        "--vta-did", "did:webvh:example.com:vta",
+        "--mediator-did", "did:key:z6Mk…",
+        "--confirm", "sensitive",
+        "--deny", "vta/seeds/*,vta/backup/*",
+        "--audit-log", "/Users/me/.local/state/vta-mcp/audit.jsonl"
+      ],
+      "env": { "VTA_MCP_AGENT_KEY": "z3u2…" }
+    }
+  }
+}
+```
+
+Keep the key in `env`, not `args` (§2.5). Everything configurable by flag has a
+`VTA_MCP_*` environment equivalent if you would rather configure it that way.
+
+---
+
+## 7. MCP protocol surface
+
+Built on `rmcp` 3.x, which negotiates up to protocol revision `2026-07-28`.
+What is used, and what is deliberately not:
+
+| Capability | Status |
+|---|---|
+| `tools` | Used, with full annotations |
+| `resources` | Used — `vta://status`, `vta://operations`, `vta://calls/recent` |
+| elicitation *(client capability)* | Used for `--confirm` |
+| `logging` | **Deliberately not used** — deprecated by SEP-2577 and slated for removal. The runtime log goes to stderr, which hosts already capture, and the call record is readable as a resource |
+| `completions` | Not used — MCP completions target prompt arguments and resource templates; there is no `ref/tool`, so `vta_call`'s `operation` argument cannot be completed |
+| `prompts` | Not used |
+| sampling / roots | Not used (also SEP-2577-deprecated) |
+| tasks (SEP-2663) | Not used — no operation here is long-running enough to need it |
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| The host lists **no tools** | The server exited before speaking MCP — a bad `--confirm` value, an unopenable `--audit-log`, or a `--enroll` refusal | Read the host's MCP server log; those three are fatal by design |
+| Every tool returns "not connected to its VTA" | Degraded mode (§5) | The message names the missing configuration; fix and restart |
+| `'…' is not in this bridge's --allow list` | Local policy | Add the slug, or drop `--allow` |
+| `this MCP host cannot ask you (it does not support elicitation)` | `--confirm` needs a prompt the host cannot show | `--confirm never`, or `--allow` the specific slug |
+| A call fails as a transport timeout | The VTA does not serve that URI | Ask `vta_supported_tasks` first — an unserved URI times out rather than erroring cleanly |
+| `vault_release` fails with `UnsupportedTransport` | It opens a `didcomm-authcrypt` envelope with this client's own keys | Use a DIDComm mode (rung 1 or 2), not REST/token |
+| `issue_vp is unavailable` | No holder identity | Set `VTA_MCP_HOLDER_DID` + `VTA_MCP_HOLDER_KEY` |
+| "Not authenticated" but `pnm auth status` is fine | Session store lookup | Pass the slug as `pnm` knows it; `--vta` handles the `vta:` prefix |
+
+---
+
+## 9. What this is not
+
+- **Not a policy engine.** The VTA holds that. The local guard gates on URI
+  shape only; duplicating the VTA's policy here would be a second source of
+  truth that drifts.
+- **Not a substitute for ACL scoping.** `--read-only` on a bridge holding an
+  admin credential is one restart away from not being read-only. Scope the
+  identity.
+- **Not a place for a long-lived operator credential.** See §2.4.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ VTA via the `vtc-host` DID template.
 | Pick where to store the master seed | [VTA secret backends](02-vta/secret-backends.md) |
 | Deploy a VTA inside a Nitro Enclave | [TEE architecture](02-vta/tee-architecture.md) |
 | Build an app that uses a VTA | [VTA integration guide](02-vta/integration-guide.md) |
+| Use a VTA from Claude Code / Claude Desktop | [vta-mcp](02-vta/vta-mcp.md) |
 | Provision a mediator / webvh-host / custom integration | [Provision-integration](02-vta/provision-integration.md) |
 | Require a second person to approve an operation | [Approvals](02-vta/approvals.md) |
 | Understand the consent ceremony (DTTE) end to end | [Task consent](02-vta/task-consent.md) |
@@ -115,8 +116,15 @@ How to operate, deploy, and integrate against a VTA.
   [task-consent-infographic.html](02-vta/task-consent-infographic.html).
 - **[DID:WebVH update](02-vta/did-webvh-update.md)** — log-entry
   format, rotation, hosting.
+- **[Personal AI agents](02-vta/personal-ai-agents.md)** — provisioning
+  an agent its own identity, context, capabilities and kill switch.
+- **[vta-mcp](02-vta/vta-mcp.md)** — using a VTA from an MCP host
+  (Claude Code, Claude Desktop, an agent framework): what it exposes,
+  the security model, hardening flags, and how to see what it is doing.
 - **[Setup example](02-vta/examples/vta-setup.example.toml)** —
   worked TOML for `vta setup --from`.
+- **[Example: agent memory + vta-mcp](02-vta/examples/agent-memory-with-vta-mcp.md)** —
+  two MCP servers, two identities, two contexts, one VTA.
 
 ### Part III — VTC
 

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -25,8 +25,14 @@ config-session = ["vta-sdk/config-session"]
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
 vta-sdk = { path = "../vta-sdk", version = "0.28", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
-rmcp = { version = "3", features = ["server", "transport-io", "macros", "schemars"] }
+# `elicitation` is what lets the bridge put a destructive operation back in
+# front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
+# every Trust Task URI rides that one approval, so per-operation consent has to
+# be asked for from this side. Without the feature there is no `Peer::elicit`
+# and `--confirm` could only ever deny.
+rmcp = { version = "3", features = ["server", "transport-io", "macros", "schemars", "elicitation"] }
 schemars = "1"
+chrono = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-mcp/README.md
+++ b/vta-mcp/README.md
@@ -2,118 +2,142 @@
 
 A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
 a Verifiable Trust Agent's capabilities as MCP tools, so any MCP-speaking agent
-host (Claude Desktop, an agent framework, an IDE) can use a VTA — signing
-oracle, secrets vault, device check-in, discovery — with **no custom
-integration code**.
+host (Claude Code, Claude Desktop, an IDE, an agent framework) can use a VTA —
+signing oracle, secrets vault, device check-in, the whole management surface —
+with **no custom integration code**.
 
-It's a thin bridge built on `vta_sdk::agent_session::AgentSession`: each tool
-maps one-to-one onto the session's `VtaClient`. Transport is **stdio** (the host
-spawns the binary and speaks JSON-RPC over stdin/stdout); all logging goes to
-stderr.
+Transport is **stdio**: the host spawns the binary and speaks JSON-RPC over
+stdin/stdout, so all logging goes to stderr.
 
-The four ways in below are not implemented here — they are
-`vta_sdk::agent_connect::AgentConnect`, shared with every other agent-side
-bridge. `build_client` is a pure args → `AgentConnect` mapping.
+> **Full documentation: [`docs/02-vta/vta-mcp.md`](../docs/02-vta/vta-mcp.md)** —
+> the security model, every flag, the observability story, troubleshooting.
+> Worked example running it alongside `vta-agent-memory`:
+> [`docs/02-vta/examples/agent-memory-with-vta-mcp.md`](../docs/02-vta/examples/agent-memory-with-vta-mcp.md).
 
-## Tools
+## Quick start
 
-The **full** VTA management surface is reachable via two generic tools, plus
-convenience tools for the most common operations and the client-side bits.
+Run it as a **dedicated, context-scoped agent** — not as your operator login:
 
-**Generic gateway (covers everything):**
+```bash
+pnm contexts create --id my-mcp-agent --name "MCP bridge"
+pnm acl create --did <agent did:key> --role application \
+  --contexts my-mcp-agent --label vta-mcp --expires 30d
 
-| Tool | What it does |
-|---|---|
-| `vta_list_operations` | The catalog of every Trust Task operation URI (contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, …) |
-| `vta_call` | Invoke any operation by URI with a JSON payload — the gateway to the whole management surface |
+VTA_MCP_AGENT_KEY=<multibase> vta-mcp \
+  --agent-did did:key:z6Mk… \
+  --vta-did did:webvh:example.com:vta \
+  --mediator-did did:key:z6Mk… \
+  --enroll --confirm sensitive
+```
 
-**Convenience tools (typed, for common ops):**
-
-| Tool | What it does | Capability required |
-|---|---|---|
-| `vta_capabilities` | Discover the VTA's features, services, WebVH servers, DID modes | any auth |
-| `list_keys` | List the VTA's signing keys | any auth |
-| `sign` | Sign UTF-8 text with a VTA-held key (private key never leaves the VTA) | `Sign` |
-| `vault_list` | List secrets-vault entry metadata (no secrets) | `VaultRead` |
-| `vault_get` | One entry's metadata by id (no secret) | `VaultRead` |
-| `vault_release` | Release a secret sealed to this client; returns cleartext | `FillRelease` (DIDComm only) |
-| `device_heartbeat` | Check the device in; returns queued operations | any auth |
-| `resolve_did` | Resolve any DID to its DID document (via the resolver cache) | any auth |
-| `issue_vp` | Build a holder-bound OID4VP `vp_token` from supplied held credentials, signed with the agent's holder key | holder identity configured |
-
-All access is bounded by the bridge identity's VTA **role / ACL** — scope that
-role to what the agent should be allowed to do (`vta_call` can reach destructive
-operations like `contexts/delete` if the role permits them).
-
-`vault_release` opens a `didcomm-authcrypt` envelope with the client's own keys,
-so it requires the **DIDComm transport** (session mode); on a REST/token client
-it returns a clear `UnsupportedTransport` error.
-
-`issue_vp` signs locally with the agent's holder key — set `VTA_MCP_HOLDER_DID` +
-`VTA_MCP_HOLDER_KEY` (multibase; optional `VTA_MCP_HOLDER_VM_FRAGMENT`, default
-`key-0`). The key stays in the process and is never sent over MCP; without it the
-tool returns a clear "not configured" error.
-
-## Auth
-
-Two modes:
-
-- **Session (default)** — reuse an existing `pnm`/`cnm` login. The client
-  auto-refreshes its token.
-  ```bash
-  vta-mcp --vta <slug>          # slug = the VTA you logged into with `pnm`
-  ```
-  The slug is the name from `pnm vta list`, not the keyring key: `pnm` stores
-  sessions as `vta:<slug>` and `vta_sdk::agent_connect::pnm_session_key` adds
-  that prefix. Passing an already-prefixed value also works.
-  Options: `--service-name` (default `pnm-cli`), `--sessions-dir` (default
-  `dirs::config_dir()/pnm` — `~/Library/Application Support/pnm` on macOS,
-  `%APPDATA%\pnm` on Windows, `~/.config/pnm` on Linux, matching where `pnm`
-  itself writes), `--url` (override the resolved REST URL). All have
-  `VTA_MCP_*` env equivalents.
-
-- **Token** — a REST client with a bearer token (simple; for testing /
-  short-lived use; no auto-refresh):
-  ```bash
-  VTA_URL=https://vta.example.com VTA_TOKEN=<jwt> vta-mcp
-  ```
-
-## Use from Claude Desktop
-
-Add to the host's MCP server config:
+In a host config:
 
 ```json
 {
   "mcpServers": {
     "vta": {
       "command": "vta-mcp",
-      "args": ["--vta", "my-vta"]
+      "args": ["--vta", "my-vta", "--read-only"]
     }
   }
 }
 ```
 
-## Enrolling the bridge as a managed device
+## Tools
 
-Pass `--enroll` (or `VTA_MCP_ENROLL=1`) to register vta-mcp as an `ai-agent`
-device at startup, so it shows up in `pnm device list` and can be revoked with
-`pnm device disable` / `pnm device wipe` (the revocation is enforced at auth).
-Set the binding name with `--device-name` (default `vta-mcp`).
+The **full** VTA management surface is reachable through two generic tools, plus
+convenience tools for the common operations and the client-side bits.
 
-Only use `--enroll` when vta-mcp runs as a **dedicated agent identity** — it
-attaches a device binding to the authenticated DID's ACL entry, so don't point it
-at an operator/admin login. Enrolment runs once before serving; the bridge does
-not run a concurrent heartbeat/wake loop (that would race the tool RPCs on the
-same DIDComm session).
+| Tool | What it does | Risk class |
+|---|---|---|
+| `vta_list_operations` | Every Trust Task URI `vta_call` can reach, with its risk class and this bridge's policy decision | read-only |
+| `vta_call` | Invoke any operation by URI with a JSON payload | per operation |
+| `vta_status` | Identity, transports, policy, call counters, recent calls | read-only |
+| `vta_supported_tasks` | Which Trust Tasks the VTA actually serves (glob-filterable) | read-only |
+| `list_keys` | The VTA's signing keys | read-only |
+| `sign` | Sign UTF-8 text with a VTA-held key (private key never leaves the VTA) | sensitive |
+| `vault_list` / `vault_get` | Vault entry metadata — no secret material | read-only |
+| `vault_release` | Release a secret sealed to this client; returns cleartext | sensitive |
+| `device_heartbeat` | Check in; returns queued operations | mutating |
+| `resolve_did` | Resolve any DID via the resolver cache | read-only |
+| `issue_vp` | Build a holder-bound OID4VP `vp_token`, signed locally | sensitive |
+
+Plus three read-only resources: `vta://status`, `vta://operations`,
+`vta://calls/recent`.
+
+## Security
+
+All access is bounded by the bridge identity's VTA **role / ACL** — scope that
+role to what the agent should be allowed to do. On top of that the bridge
+applies its own local policy, because **an MCP host approves a tool, not a
+call**: once `vta_call` is approved, every operation rides that one approval.
+
+| Flag | Effect |
+|---|---|
+| `--read-only` | Refuse anything not read-only, whatever the ACL permits |
+| `--allow <glob>` | Permit only these slug globs (`vta/memory/*`, `acl/list`) |
+| `--deny <glob>` | Always refuse these; checked before `--allow` |
+| `--confirm <level>` | Ask a human via MCP elicitation: `never`, `destructive` (default), `sensitive`, `always` |
+
+The convenience tools are gated under the URI they actually send, so
+`--read-only` cannot be walked around by calling `sign` instead of `vta_call`.
+If the host cannot show a confirmation prompt, the call is **refused**, not
+waved through.
+
+`--enroll` registers the bridge as an `ai-agent` device so `pnm device disable` /
+`pnm device wipe` revoke it (enforced at authentication). It is refused in
+session mode, where the binding would attach to the operator's ACL entry.
+
+`vault_release` returns cleartext into the model's context; `issue_vp` signs with
+a holder key held in this process. Both are deliberate, and both are the two
+places where "secrets never leave the VTA" stops being true.
+
+## Seeing what it does
+
+- **stderr** — on by default at `info`; one line at call start, one at finish
+  with outcome and duration. `--log-level`, `--log-format json`; `RUST_LOG` wins
+  when set.
+- **`--audit-log <path>`** — one redacted JSON object per line, appended, 0600.
+- **`vta_status` / `vta://calls/recent`** — the last 100 calls, kept in memory
+  whether or not an audit log was configured.
+- Payloads pass through a redactor whose rule is that **strings are guilty until
+  named innocent**, so signing input, mnemonics, private keys and JWEs are elided
+  without this crate needing to know those field names.
+
+If the bridge cannot connect it **serves MCP anyway**, in degraded mode: a server
+that exits before speaking the protocol shows up in the host as *no tools at
+all*, and then nothing can explain why.
+
+## Auth
+
+Four modes, highest precedence first (the ladder is
+`vta_sdk::agent_connect::AgentConnect`, shared with every agent-side bridge):
+
+1. **did:webvh bundle** — `--agent-secrets <PATH|JSON>` + `--vta-did` +
+   `--mediator-did`.
+2. **did:key** — `--agent-did` + `--agent-key` + `--vta-did` + `--mediator-did`.
+   Works against DIDComm-only VTAs with no REST endpoint.
+3. **Token** — `VTA_URL` + `VTA_TOKEN`. REST, no refresh; testing only.
+4. **Session** — `--vta <slug>`, replaying a `pnm`/`cnm` login. **Operator
+   authority** — the bridge warns at boot.
+
+The two DIDComm modes are mutually exclusive, and a half-configured rung fails
+fast naming the missing field rather than falling through to session mode.
+
+`--vta` takes the slug from `pnm vta list`; `pnm` stores sessions as
+`vta:<slug>` and the prefix is added for you.
+
+Every flag has a `VTA_MCP_*` environment equivalent. Prefer the environment for
+`--agent-key` / `--holder-key`: command-line arguments are readable by every
+process on the machine, and the bridge warns when it sees one.
 
 ## Notes
 
 - Build: `cargo build -p vta-mcp` (or `--release`). `publish = false`.
-- **Session mode needs the `keyring` feature**, which is on by default. It is
-  what compiles a session backend in; without one, `SessionStore` reads return
-  `None` and the bridge reports "not authenticated" whatever the state of your
-  login. Build `--no-default-features` only if you are using token or DIDComm
-  mode.
-- The agent's least-privilege capability set comes from its VTA **role** / ACL —
-  the MCP server inherits whatever the authenticated identity is allowed to do.
-- See `docs/02-vta/personal-ai-agents.md` for the broader agent-enablement story.
+- **Session mode needs the `keyring` feature**, on by default — it is what
+  compiles a session backend in. Build `--no-default-features` only for token or
+  DIDComm mode.
+- MCP surface: tools (fully annotated) + resources + elicitation. The MCP
+  `logging` capability is deliberately unused — it is deprecated by SEP-2577.
+- See [`docs/02-vta/personal-ai-agents.md`](../docs/02-vta/personal-ai-agents.md)
+  for the broader agent-enablement story.

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -1,0 +1,606 @@
+//! What this bridge is *allowed* to do, independent of what its VTA identity
+//! could do.
+//!
+//! The VTA is the authority: every call is gated server-side on the bridge
+//! identity's role, ACL, context scope and — where enabled — the approvals /
+//! DTTE policy. This module is a **second, local** gate in front of it, and it
+//! exists because of a specific gap in how MCP hosts grant permission.
+//!
+//! A host approves a *tool*, not a *call*. Once an operator answers "always
+//! allow" to `vta_call`, every Trust Task URI the VTA serves is reachable with
+//! no further prompt — `contexts/delete/1.0` on the same approval as
+//! `contexts/list/1.0`. The host cannot tell those apart; it sees one tool
+//! name. So the per-operation decision has to be made here, where the URI is
+//! known.
+//!
+//! Three mechanisms, cheapest first:
+//!
+//! 1. **Risk classification** ([`Risk`]) — every Trust Task URI is read-only,
+//!    mutating, sensitive, or destructive. Unknown verbs classify as
+//!    [`Risk::Mutating`], never read-only: a URI this build has never heard of
+//!    must not slip through `--read-only`.
+//! 2. **Allow / deny globs** — operator-supplied slug patterns. Deny always
+//!    wins; a non-empty allow list makes everything else denied.
+//! 3. **Confirmation** — the risky tail is put back in front of a human via MCP
+//!    elicitation, restoring per-call consent the host's per-tool approval gave
+//!    away.
+//!
+//! The convenience tools route through the same gate under their canonical URI
+//! (`sign` → `keys/sign/0.1`), so `--read-only` cannot be walked around by
+//! calling `sign` instead of `vta_call`.
+
+use std::fmt;
+
+/// The Trust Task URI prefix every catalog entry carries. Patterns are written
+/// against the **slug** — the part after this — so an operator types
+/// `acl/*`, not the full URI.
+pub const SPEC_PREFIX: &str = "https://trusttasks.org/spec/";
+
+/// How much damage an operation can do, judged from the URI alone.
+///
+/// Deliberately coarse. This is a gate on *shape*, not a policy engine — the
+/// VTA holds the policy engine, and duplicating it here would be a second
+/// source of truth that drifts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Risk {
+    /// Reads state. Safe to call on a whim; the only class `--read-only`
+    /// permits.
+    ReadOnly,
+    /// Changes state additively and reversibly (create, update, register).
+    Mutating,
+    /// Exercises key authority, emits secret material, or moves authority
+    /// between principals. Not destructive — but a compromised host calling
+    /// these is the whole threat model.
+    Sensitive,
+    /// Removes something, or removes someone's access. Irreversible, or
+    /// reversible only by an operator with more authority than the bridge.
+    Destructive,
+}
+
+impl Risk {
+    /// The lowercase name used in logs, audit records and the `vta_status`
+    /// tool. Stable — external log processing keys on it.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::Mutating => "mutating",
+            Self::Sensitive => "sensitive",
+            Self::Destructive => "destructive",
+        }
+    }
+
+    /// What a tool wrapping an operation of this class must declare as its MCP
+    /// `readOnlyHint` / `destructiveHint`. Hosts render both and some gate on
+    /// them, so a tool whose annotation disagrees with its operation's class is
+    /// a security bug rather than a cosmetic one — which is what
+    /// `server::tests::tool_annotations_agree_with_the_risk_classifier` pins.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the annotation census test")
+    )]
+    pub fn hints(self) -> (bool, bool) {
+        (self == Self::ReadOnly, self == Self::Destructive)
+    }
+}
+
+impl fmt::Display for Risk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Slugs whose risk the verb alone gets wrong.
+///
+/// Every entry is here because the bare verb is shared with operations of a
+/// different class: `acl/grant` and `contexts/create` are both "add a row", but
+/// only one of them hands out authority.
+const SLUG_OVERRIDES: &[(&str, Risk)] = &[
+    // Key authority, exercised.
+    ("keys/sign", Risk::Sensitive),
+    ("keys/derive-and-sign", Risk::Sensitive),
+    ("keys/derive-and-sign-document", Risk::Sensitive),
+    ("keys/import", Risk::Sensitive),
+    ("vault/sign-trust-task", Risk::Sensitive),
+    // Secret material, emitted.
+    ("vault/release", Risk::Sensitive),
+    ("vault/proxy-login", Risk::Sensitive),
+    ("vta/seeds/export-mnemonic", Risk::Sensitive),
+    // Authority, moved.
+    ("acl/grant", Risk::Sensitive),
+    ("acl/update", Risk::Sensitive),
+    ("acl/change-role", Risk::Sensitive),
+    ("policy/upsert", Risk::Sensitive),
+    ("config/patch", Risk::Sensitive),
+    ("vta/credentials/issue", Risk::Sensitive),
+    ("vta/passkey-vms/enroll-submit", Risk::Sensitive),
+    ("did-management/registry/admin-register", Risk::Sensitive),
+    ("did-management/domain/set-default", Risk::Sensitive),
+    ("provision/integration", Risk::Sensitive),
+    // Reads that a verb rule would misread.
+    ("vta/contexts/preview-delete", Risk::ReadOnly),
+    ("vta/webvh/agent-name/check", Risk::ReadOnly),
+    ("trust-task-discovery", Risk::ReadOnly),
+    // A backup export is a full-state dump — sensitive in both directions.
+    ("vta/backup/initiate-export", Risk::Sensitive),
+    ("vta/backup/complete-export", Risk::Sensitive),
+];
+
+/// Final-segment verbs that only ever read.
+const READ_VERBS: &[&str] = &[
+    "list",
+    "get",
+    "get-many",
+    "show",
+    "info",
+    "whoami",
+    "check",
+    "check-name",
+    "health",
+    "query",
+    "domains",
+    "render",
+    "report",
+    "status",
+    "ping",
+    "explain",
+    "get-retention",
+    "approver-list",
+];
+
+/// Final-segment verbs that remove state or access.
+const DESTRUCTIVE_VERBS: &[&str] = &[
+    "delete",
+    "purge",
+    "remove",
+    "revoke",
+    "revoke-session",
+    "wipe",
+    "disable",
+    "deregister",
+    "unassign",
+    "retire-orphan",
+    "rollback",
+    "rotate",
+    "rotate-keys",
+    "swap-key",
+    "change-owner",
+    "abort",
+    "initiate-import",
+    "finalize-import",
+    "reload-services",
+];
+
+/// The slug of a Trust Task URI — the part after [`SPEC_PREFIX`], with the
+/// trailing version segment removed. `…/spec/acl/grant/0.1` → `acl/grant`.
+///
+/// Returns `None` for anything that is not a versioned task URI, including the
+/// bare family-namespace constants (`…/spec/acl/`), so callers can refuse
+/// rather than guess.
+pub fn slug_of(uri: &str) -> Option<&str> {
+    let rest = uri.strip_prefix(SPEC_PREFIX)?;
+    let (slug, version) = rest.rsplit_once('/')?;
+    // A version segment is digits and dots; a trailing `/` leaves it empty.
+    if version.is_empty() || !version.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return None;
+    }
+    (!slug.is_empty()).then_some(slug)
+}
+
+/// Classify a Trust Task URI.
+///
+/// Unknown verbs are [`Risk::Mutating`]. That is the safe default in both
+/// directions: `--read-only` refuses them, and confirmation is not demanded for
+/// something that may well be a harmless create. The census test below is what
+/// stops "unknown" from becoming the common case as the catalog grows.
+pub fn classify(uri: &str) -> Risk {
+    let Some(slug) = slug_of(uri) else {
+        // Not a task URI. The dispatcher will refuse it; classify high so a
+        // read-only bridge does not pass it along on the way to that refusal.
+        return Risk::Mutating;
+    };
+    if let Some((_, risk)) = SLUG_OVERRIDES.iter().find(|(s, _)| *s == slug) {
+        return *risk;
+    }
+    let verb = slug.rsplit('/').next().unwrap_or(slug);
+    if DESTRUCTIVE_VERBS.contains(&verb) {
+        Risk::Destructive
+    } else if READ_VERBS.contains(&verb) {
+        Risk::ReadOnly
+    } else {
+        Risk::Mutating
+    }
+}
+
+/// How much of the risky tail is put back in front of a human.
+///
+/// Cumulative: each level confirms everything the level below it confirms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConfirmLevel {
+    /// Confirm nothing. The host's per-tool approval is the only gate.
+    Never,
+    /// Confirm [`Risk::Destructive`] only. The default — the host already
+    /// prompts per tool, so this adds a prompt exactly where a tool-level
+    /// approval is too coarse to be meaningful.
+    #[default]
+    Destructive,
+    /// Also confirm [`Risk::Sensitive`] — signing, secret release, mnemonic
+    /// export, ACL changes. The right setting for a bridge holding an operator
+    /// session rather than a scoped agent identity.
+    Sensitive,
+    /// Confirm every call that changes anything. Read-only calls still run
+    /// unprompted.
+    Always,
+}
+
+impl ConfirmLevel {
+    /// Parse the `--confirm` flag.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "never" | "none" | "off" => Ok(Self::Never),
+            "destructive" => Ok(Self::Destructive),
+            "sensitive" => Ok(Self::Sensitive),
+            "always" | "all" => Ok(Self::Always),
+            other => Err(format!(
+                "unknown --confirm value '{other}' (expected never, destructive, sensitive or always)"
+            )),
+        }
+    }
+
+    /// The label used in logs and `vta_status`.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::Destructive => "destructive",
+            Self::Sensitive => "sensitive",
+            Self::Always => "always",
+        }
+    }
+
+    fn wants(self, risk: Risk) -> bool {
+        match self {
+            Self::Never => false,
+            Self::Destructive => risk == Risk::Destructive,
+            Self::Sensitive => matches!(risk, Risk::Destructive | Risk::Sensitive),
+            Self::Always => risk != Risk::ReadOnly,
+        }
+    }
+}
+
+/// What the guard decided about one call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// Run it.
+    Allow,
+    /// Run it only if a human says yes, using the carried prompt.
+    Confirm(String),
+    /// Refuse, with an operator-facing reason that names the flag which would
+    /// have permitted it.
+    Deny(String),
+}
+
+impl Decision {
+    /// The label recorded in the audit log.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Confirm(_) => "confirm",
+            Self::Deny(_) => "deny",
+        }
+    }
+}
+
+/// The operator-configured local policy.
+#[derive(Debug, Clone, Default)]
+pub struct Guard {
+    /// Refuse anything that is not [`Risk::ReadOnly`].
+    pub read_only: bool,
+    /// Slug globs; when non-empty, a call must match one of these.
+    pub allow: Vec<String>,
+    /// Slug globs that are always refused, checked before `allow`.
+    pub deny: Vec<String>,
+    /// How much of the risky tail needs a human.
+    pub confirm: ConfirmLevel,
+}
+
+impl Guard {
+    /// Decide one call. `uri` is the canonical Trust Task URI — for the
+    /// convenience tools, the URI they wrap.
+    pub fn decide(&self, uri: &str) -> Decision {
+        let risk = classify(uri);
+        let slug = slug_of(uri).unwrap_or(uri);
+
+        if let Some(p) = self.deny.iter().find(|p| glob_match(p, slug)) {
+            return Decision::Deny(format!(
+                "'{slug}' is denied by this bridge's --deny '{p}'. Remove that pattern to allow it."
+            ));
+        }
+        if !self.allow.is_empty() && !self.allow.iter().any(|p| glob_match(p, slug)) {
+            return Decision::Deny(format!(
+                "'{slug}' is not in this bridge's --allow list ({}). Add it, or drop --allow to \
+                 fall back to the risk rules.",
+                self.allow.join(", ")
+            ));
+        }
+        if self.read_only && risk != Risk::ReadOnly {
+            return Decision::Deny(format!(
+                "'{slug}' is {risk} and this bridge runs with --read-only. Restart it without \
+                 --read-only to permit it."
+            ));
+        }
+        if self.confirm.wants(risk) {
+            return Decision::Confirm(format!("Approve {risk} VTA operation '{slug}'?"));
+        }
+        Decision::Allow
+    }
+
+    /// A one-line summary for the startup banner and `vta_status`.
+    pub fn summary(&self) -> String {
+        let mut parts = vec![format!("confirm={}", self.confirm.label())];
+        if self.read_only {
+            parts.push("read-only".into());
+        }
+        if !self.allow.is_empty() {
+            parts.push(format!("allow=[{}]", self.allow.join(",")));
+        }
+        if !self.deny.is_empty() {
+            parts.push(format!("deny=[{}]", self.deny.join(",")));
+        }
+        parts.join(" ")
+    }
+}
+
+/// Slug-glob match, the same shape `vta_supported_tasks` patterns use: `*`
+/// matches everything, a trailing `/*` matches a family, anything else is an
+/// exact slug.
+///
+/// Deliberately not a full glob. A pattern language with more corners than this
+/// is a pattern language an operator gets subtly wrong while believing they
+/// denied something.
+pub fn glob_match(pattern: &str, slug: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    match pattern.strip_suffix("/*") {
+        // `acl/*` matches `acl/grant` but not `acl` itself.
+        Some(prefix) => slug
+            .strip_prefix(prefix)
+            .is_some_and(|r| r.starts_with('/')),
+        None => pattern == slug,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACL_GRANT: &str = "https://trusttasks.org/spec/acl/grant/0.1";
+    const CONTEXTS_LIST: &str = "https://trusttasks.org/spec/vta/contexts/list/1.0";
+    const CONTEXTS_DELETE: &str = "https://trusttasks.org/spec/vta/contexts/delete/1.0";
+    const KEYS_SIGN: &str = "https://trusttasks.org/spec/keys/sign/0.1";
+
+    #[test]
+    fn slug_strips_the_prefix_and_the_version() {
+        assert_eq!(slug_of(ACL_GRANT), Some("acl/grant"));
+        assert_eq!(slug_of(CONTEXTS_LIST), Some("vta/contexts/list"));
+        assert_eq!(
+            slug_of("https://trusttasks.org/spec/trust-task-discovery/0.1"),
+            Some("trust-task-discovery")
+        );
+    }
+
+    #[test]
+    fn a_family_namespace_is_not_a_task() {
+        // These constants exist in the SDK catalog module; treating one as a
+        // task would classify it by a verb that is really a family name.
+        assert_eq!(slug_of("https://trusttasks.org/spec/acl/"), None);
+        assert_eq!(slug_of("https://trusttasks.org/spec/vta/"), None);
+        assert_eq!(slug_of("not-a-uri"), None);
+    }
+
+    #[test]
+    fn verbs_classify() {
+        assert_eq!(classify(CONTEXTS_LIST), Risk::ReadOnly);
+        assert_eq!(classify(CONTEXTS_DELETE), Risk::Destructive);
+        assert_eq!(
+            classify("https://trusttasks.org/spec/vta/contexts/create/1.0"),
+            Risk::Mutating
+        );
+        assert_eq!(classify(KEYS_SIGN), Risk::Sensitive);
+        assert_eq!(classify(ACL_GRANT), Risk::Sensitive);
+    }
+
+    #[test]
+    fn preview_delete_is_a_read_not_a_delete() {
+        // The verb ends in "delete" but the operation only reports what a
+        // delete would remove. Substring matching on the verb would have made
+        // a preview refuse under --read-only.
+        assert_eq!(
+            classify("https://trusttasks.org/spec/vta/contexts/preview-delete/1.0"),
+            Risk::ReadOnly
+        );
+    }
+
+    #[test]
+    fn an_unknown_verb_is_mutating_never_read_only() {
+        // The catalog grows without this crate. A URI it has never seen must
+        // not be handed through a --read-only bridge.
+        let unknown = "https://trusttasks.org/spec/vta/frobnicate/twiddle/9.9";
+        assert_eq!(classify(unknown), Risk::Mutating);
+        let guard = Guard {
+            read_only: true,
+            ..Guard::default()
+        };
+        assert!(matches!(guard.decide(unknown), Decision::Deny(_)));
+    }
+
+    /// Census: every URI the generic `vta_call` gateway can reach must classify
+    /// off an override or a known verb. A new verb landing in the SDK catalog
+    /// fails here rather than quietly defaulting to `Mutating` forever.
+    #[test]
+    fn every_dispatchable_uri_has_a_known_verb() {
+        let mut unknown: Vec<&str> = Vec::new();
+        for uri in vta_sdk::trust_tasks::dispatch_routed_uris() {
+            let Some(slug) = slug_of(uri) else {
+                unknown.push(uri);
+                continue;
+            };
+            if SLUG_OVERRIDES.iter().any(|(s, _)| *s == slug) {
+                continue;
+            }
+            let verb = slug.rsplit('/').next().unwrap_or(slug);
+            let known = READ_VERBS.contains(&verb)
+                || DESTRUCTIVE_VERBS.contains(&verb)
+                || MUTATING_VERBS.contains(&verb);
+            if !known {
+                unknown.push(uri);
+            }
+        }
+        assert!(
+            unknown.is_empty(),
+            "unclassified Trust Task verbs — add each to READ_VERBS, DESTRUCTIVE_VERBS, \
+             MUTATING_VERBS or SLUG_OVERRIDES in guard.rs: {unknown:#?}"
+        );
+    }
+
+    /// The verbs that are deliberately `Mutating`. Only the census test reads
+    /// this — `classify` defaults to `Mutating` without consulting it, so a
+    /// runtime miss is safe and a compile-time miss is loud.
+    const MUTATING_VERBS: &[&str] = &[
+        "create",
+        "update",
+        "update-did",
+        "update-retention",
+        "upsert",
+        "put",
+        "put-many",
+        "register",
+        "register-with-server",
+        "admin-register",
+        "enable",
+        "set",
+        "set-wake",
+        "set-default",
+        "assign",
+        "receive",
+        "archive",
+        "unarchive",
+        "restore",
+        "heartbeat",
+        "reconcile",
+        "publish",
+        "cancel",
+        "decision",
+        "request",
+        "approver-set",
+        "start",
+        "finish",
+        "approve-response",
+        "enroll-challenge",
+        "enroll-submit",
+        "issue",
+        "import",
+        "sign",
+        "sign-trust-task",
+        "derive-and-sign",
+        "derive-and-sign-document",
+        "release",
+        "proxy-login",
+        "grant",
+        "change-role",
+        "patch",
+        "integration",
+        "problem-report",
+        "stats-sync",
+        "refresh",
+        "authenticate",
+        "challenge",
+        "export-mnemonic",
+        "initiate-export",
+        "complete-export",
+        "rename",
+    ];
+
+    #[test]
+    fn deny_beats_allow() {
+        let guard = Guard {
+            allow: vec!["*".into()],
+            deny: vec!["vta/contexts/*".into()],
+            confirm: ConfirmLevel::Never,
+            ..Guard::default()
+        };
+        assert!(matches!(guard.decide(CONTEXTS_LIST), Decision::Deny(_)));
+        assert_eq!(guard.decide(ACL_GRANT), Decision::Allow);
+    }
+
+    #[test]
+    fn a_non_empty_allow_list_denies_everything_else() {
+        let guard = Guard {
+            allow: vec!["vta/memory/*".into()],
+            confirm: ConfirmLevel::Never,
+            ..Guard::default()
+        };
+        assert_eq!(
+            guard.decide("https://trusttasks.org/spec/vta/memory/list/0.1"),
+            Decision::Allow
+        );
+        match guard.decide(CONTEXTS_LIST) {
+            Decision::Deny(msg) => assert!(msg.contains("--allow"), "{msg}"),
+            other => panic!("expected deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn confirm_levels_are_cumulative() {
+        let destructive = Guard::default();
+        assert_eq!(destructive.confirm, ConfirmLevel::Destructive);
+        assert_eq!(destructive.decide(KEYS_SIGN), Decision::Allow);
+        assert!(matches!(
+            destructive.decide(CONTEXTS_DELETE),
+            Decision::Confirm(_)
+        ));
+
+        let sensitive = Guard {
+            confirm: ConfirmLevel::Sensitive,
+            ..Guard::default()
+        };
+        assert!(matches!(sensitive.decide(KEYS_SIGN), Decision::Confirm(_)));
+        assert!(matches!(
+            sensitive.decide(CONTEXTS_DELETE),
+            Decision::Confirm(_)
+        ));
+        assert_eq!(sensitive.decide(CONTEXTS_LIST), Decision::Allow);
+
+        let always = Guard {
+            confirm: ConfirmLevel::Always,
+            ..Guard::default()
+        };
+        // Even at `always`, reads run unprompted — a bridge that asks before
+        // every `list` gets its prompts clicked through unread.
+        assert_eq!(always.decide(CONTEXTS_LIST), Decision::Allow);
+        assert!(matches!(
+            always.decide("https://trusttasks.org/spec/vta/contexts/create/1.0"),
+            Decision::Confirm(_)
+        ));
+    }
+
+    #[test]
+    fn globs_match_families_not_prefixes() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("acl/*", "acl/grant"));
+        assert!(!glob_match("acl/*", "acl"));
+        // `vault/*` must not swallow `vault-other/…`.
+        assert!(!glob_match("vault/*", "vault-other/get"));
+        assert!(glob_match("vault/credentials/get", "vault/credentials/get"));
+        assert!(!glob_match("vault/credentials/get", "vault/credentials"));
+    }
+
+    #[test]
+    fn confirm_level_parses_and_rejects() {
+        assert_eq!(ConfirmLevel::parse("never").unwrap(), ConfirmLevel::Never);
+        assert_eq!(
+            ConfirmLevel::parse("SENSITIVE").unwrap(),
+            ConfirmLevel::Sensitive
+        );
+        assert!(ConfirmLevel::parse("sometimes").is_err());
+    }
+}

--- a/vta-mcp/src/main.rs
+++ b/vta-mcp/src/main.rs
@@ -25,7 +25,15 @@
 //!   the "log in with pnm, then run vta-mcp" path.
 //! - **Token**: set `VTA_URL` + `VTA_TOKEN` for a REST client with a bearer
 //!   token (simple, for testing / short-lived use; no auto-refresh; REST only).
+//!
+//! Security posture: the VTA is the authority — every call is gated there on
+//! the bridge identity's role, ACL and context scope. On top of that this
+//! process applies a **local** policy ([`guard`]), because an MCP host approves
+//! a *tool* and `vta_call` is one tool that reaches the entire management
+//! surface. See `docs/02-vta/vta-mcp.md`.
 
+mod guard;
+mod observability;
 mod server;
 
 use std::path::PathBuf;
@@ -34,12 +42,14 @@ use std::sync::Arc;
 use clap::Parser;
 use rmcp::ServiceExt;
 use rmcp::transport::stdio;
-use vta_sdk::agent_connect::{AgentConnect, pnm_session_key};
+use vta_sdk::agent_connect::{AgentConnect, ConnectMode, pnm_session_key};
 use vta_sdk::agent_session::{AgentConfig, AgentSession};
 use vta_sdk::client::VtaClient;
 use vta_sdk::session::TransportChoice;
 
-use server::VtaMcp;
+use guard::{ConfirmLevel, Guard};
+use observability::{LogFormat, Recorder};
+use server::{BridgeIdentity, VtaMcp};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -84,7 +94,8 @@ struct Args {
     agent_did: Option<String>,
 
     /// Agent Ed25519 signing key (multibase) for did:key DIDComm mode. Stays in
-    /// this process; never sent over MCP.
+    /// this process; never sent over MCP. Prefer the environment variable — a
+    /// command-line argument is readable by every process on the machine.
     #[arg(long, env = "VTA_MCP_AGENT_KEY")]
     agent_key: Option<String>,
 
@@ -98,8 +109,8 @@ struct Args {
 
     /// Register this bridge as an `ai-agent` device at startup, so it appears in
     /// `pnm device list` and can be revoked with `pnm device {disable,wipe}`.
-    /// Only use this when vta-mcp runs as a *dedicated* agent identity — it
-    /// attaches a device binding to the authenticated DID's ACL entry. Idempotent.
+    /// Refused in session mode — it would attach a device binding to the
+    /// *operator's* ACL entry. Idempotent.
     #[arg(long, env = "VTA_MCP_ENROLL")]
     enroll: bool,
 
@@ -113,7 +124,7 @@ struct Args {
     holder_did: Option<String>,
 
     /// Holder Ed25519 signing key (multibase) for `issue_vp`. Stays in this
-    /// process; never sent over MCP.
+    /// process; never sent over MCP. Prefer the environment variable.
     #[arg(long, env = "VTA_MCP_HOLDER_KEY")]
     holder_key: Option<String>,
 
@@ -121,6 +132,44 @@ struct Args {
     /// `verificationMethod` (`{holder_did}#{fragment}`).
     #[arg(long, env = "VTA_MCP_HOLDER_VM_FRAGMENT", default_value = "key-0")]
     holder_vm_fragment: String,
+
+    /// Refuse every operation that is not read-only. The strongest single
+    /// setting: the bridge can inspect the VTA and nothing else, whatever its
+    /// ACL would permit.
+    #[arg(long, env = "VTA_MCP_READ_ONLY")]
+    read_only: bool,
+
+    /// Only permit operations matching these slug globs (`acl/*`,
+    /// `vta/memory/*`, or an exact slug). Repeatable; comma-separated in the
+    /// environment variable. When set, everything else is refused.
+    #[arg(long, env = "VTA_MCP_ALLOW", value_delimiter = ',')]
+    allow: Vec<String>,
+
+    /// Always refuse operations matching these slug globs. Checked before
+    /// `--allow`, so a deny cannot be undone by an allow.
+    #[arg(long, env = "VTA_MCP_DENY", value_delimiter = ',')]
+    deny: Vec<String>,
+
+    /// Which operations need a human to approve them, via MCP elicitation:
+    /// `never`, `destructive` (default), `sensitive` (also signing, secret
+    /// release, ACL changes) or `always`.
+    #[arg(long, env = "VTA_MCP_CONFIRM", default_value = "destructive")]
+    confirm: String,
+
+    /// stderr log level for this crate (`error`, `warn`, `info`, `debug`,
+    /// `trace`). `RUST_LOG`, when set, wins.
+    #[arg(long, env = "VTA_MCP_LOG_LEVEL", default_value = "info")]
+    log_level: String,
+
+    /// stderr log format: `text` (default) or `json`.
+    #[arg(long, env = "VTA_MCP_LOG_FORMAT", default_value = "text")]
+    log_format: String,
+
+    /// Append a redacted JSON record of every call to this file (created
+    /// owner-only). Independent of the stderr log, and the only record that
+    /// outlives the process.
+    #[arg(long, env = "VTA_MCP_AUDIT_LOG")]
+    audit_log: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -138,26 +187,190 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "keyring")]
     vta_sdk::keyring_init::install_default_store_or_exit("vta-mcp");
 
-    // stdout is the MCP JSON-RPC channel — logs MUST go to stderr.
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
-
     let args = Args::parse();
-    let client = build_client(&args).await?;
 
-    // Wrap the connected client in an AgentSession — the unified handle the MCP
-    // tools route through. Optionally enroll as a managed device first (one-shot,
-    // before serving — never concurrently with tool RPCs on a DIDComm session).
+    // stdout is the MCP JSON-RPC channel — logs MUST go to stderr. Installed
+    // before anything else can want to log, and *on* by default: a bridge that
+    // says nothing unless RUST_LOG happens to be set is one nobody can debug.
+    let log_format = LogFormat::parse(&args.log_format).map_err(|e| anyhow::anyhow!(e))?;
+    observability::init_tracing(&args.log_level, log_format);
+
+    // Two kinds of startup failure, handled differently on purpose:
+    //
+    // - **Policy** (an unparseable `--confirm`, an audit log that will not
+    //   open) is fatal. Degrading here would run the bridge under a policy the
+    //   operator did not ask for, which is the one outcome worse than not
+    //   starting.
+    // - **Connectivity** (no auth configured, mediator unreachable, expired
+    //   session) serves in degraded mode below, because those are the field
+    //   failures and an exited server is invisible to the model.
+    let guard = Guard {
+        read_only: args.read_only,
+        allow: args.allow.clone(),
+        deny: args.deny.clone(),
+        confirm: ConfirmLevel::parse(&args.confirm).map_err(|e| anyhow::anyhow!(e))?,
+    };
+    let recorder = match &args.audit_log {
+        Some(path) => Arc::new(
+            Recorder::with_file(path)
+                .map_err(|e| anyhow::anyhow!("opening --audit-log {}: {e}", path.display()))?,
+        ),
+        None => Arc::new(Recorder::default()),
+    };
+
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        policy = %guard.summary(),
+        audit_log = recorder
+            .audit_path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "-".into()),
+        "vta-mcp starting"
+    );
+    warn_about_argv_secrets();
+    let connect = agent_connect_from(&args);
+    let holder = holder_identity(&args);
+
+    // A misconfigured rung — nothing set at all, a typo'd env var, three of the
+    // four did:key fields — is the single most common way this bridge fails,
+    // and it fails before any network call. Serve it degraded like any other
+    // connection failure so the operator can *ask* what went wrong.
+    let mode = match connect.mode() {
+        Ok(mode) => mode,
+        Err(e) => {
+            let message = format!("no usable VTA credentials: {e}");
+            tracing::error!(error = %message, "serving in degraded mode — tools will report this");
+            let identity = BridgeIdentity {
+                // Not the empty string a `Default` would leave: `vta_status`
+                // renders this, and a blank mode reads as a bug in the bridge
+                // rather than as the operator having configured nothing.
+                mode: "unconfigured".to_string(),
+                ..BridgeIdentity::default()
+            };
+            return serve(
+                VtaMcp::degraded(message, holder, identity, guard, recorder),
+                None,
+            )
+            .await;
+        }
+    };
+    let identity = identity_of(&args, &mode);
+
+    if args.enroll && !mode.is_dedicated_agent() {
+        // Enrolment attaches a device binding to the *authenticated* DID's ACL
+        // entry. In session mode that DID is the operator's, so `--enroll`
+        // would silently bind this bridge to an operator credential — and the
+        // binding is awkward to undo. Refuse rather than do the wrong thing.
+        anyhow::bail!(
+            "--enroll needs a dedicated agent identity, but this bridge is running in {} mode. \
+             Run it with --agent-did/--agent-key (or --agent-secrets) so the device binding \
+             attaches to the agent's own ACL entry, or drop --enroll.",
+            mode.label()
+        );
+    }
+
+    tracing::info!(
+        mode = mode.label(),
+        dedicated_agent = mode.is_dedicated_agent(),
+        agent_did = identity.agent_did.as_deref().unwrap_or("-"),
+        vta_did = identity.vta_did.as_deref().unwrap_or("-"),
+        "connecting to VTA"
+    );
+    if !mode.is_dedicated_agent() {
+        // Worth saying out loud every boot: in session mode the model on the
+        // other end of the pipe holds whatever the operator holds, which for a
+        // `pnm` admin login is everything.
+        tracing::warn!(
+            mode = mode.label(),
+            "this bridge holds an operator credential, not a scoped agent identity — every tool \
+             runs with the operator's role and ACL. See docs/02-vta/vta-mcp.md for the \
+             least-privilege setup."
+        );
+    }
+
+    // Connect, but never let a failed connect stop the server from serving.
+    // An MCP server that exits before speaking the protocol shows up in the
+    // host as *no tools at all*, so the operator gets an empty tool list and no
+    // explanation. Degraded mode keeps `vta_status` answering.
+    let attached = match connect.connect().await {
+        Ok(client) => attach(client, &args).await,
+        Err(e) => Err(format!("connecting to VTA ({}): {e}", mode.label())),
+    };
+    let (bridge, session) = match attached {
+        Ok(agent) => {
+            tracing::info!("connected to VTA; serving MCP over stdio");
+            (
+                VtaMcp::new(agent.clone(), holder, identity, guard, recorder),
+                Some(agent),
+            )
+        }
+        Err(message) => {
+            tracing::error!(error = %message, "serving in degraded mode — tools will report this");
+            (
+                VtaMcp::degraded(message, holder, identity, guard, recorder),
+                None,
+            )
+        }
+    };
+    serve(bridge, session).await
+}
+
+/// Serve MCP over stdio until the host disconnects, then tear the DIDComm
+/// session down.
+///
+/// The teardown is why `session` is passed separately: a DIDComm `VtaClient`
+/// owns a live, auto-reconnecting mediator socket that `Drop` cannot close, so
+/// leaking it trips a debug-assert and duels the mediator on reconnect. Serve
+/// and wait, then `shutdown()` unconditionally (idempotent, a no-op for
+/// REST/token clients) *before* propagating any error — a bare `?` on
+/// `waiting()` would skip the cleanup on the common EOF/disconnect path.
+async fn serve(bridge: VtaMcp, session: Option<Arc<AgentSession>>) -> anyhow::Result<()> {
+    let served = async {
+        let service = bridge.serve(stdio()).await?;
+        service.waiting().await?;
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    if let Some(agent) = session {
+        agent.shutdown().await;
+    }
+    served
+}
+
+/// Wrap the connected client in an `AgentSession` — the unified handle the MCP
+/// tools route through. Optionally enroll as a managed device first (one-shot,
+/// before serving — never concurrently with tool RPCs on a DIDComm session).
+///
+/// A failed enrolment is returned, not logged and shrugged off. The operator
+/// asked for the bridge to be revocable through `pnm device disable`; serving
+/// anyway would hand them a bridge that quietly is not.
+async fn attach(client: VtaClient, args: &Args) -> Result<Arc<AgentSession>, String> {
     let agent = AgentSession::from_client(client, AgentConfig::for_attach(&args.device_name));
+    if args.enroll
+        && let Err(e) = agent.ensure_enrolled().await
+    {
+        // Tear the session down before returning. The degraded path drops this
+        // `AgentSession`, and a dropped DIDComm client leaves a live,
+        // auto-reconnecting mediator socket behind — one duelling socket per
+        // start, holding the mediator's one-per-DID slot.
+        agent.shutdown().await;
+        return Err(format!(
+            "enrolling as device '{}': {e}. The bridge asked to be revocable via \
+             `pnm device disable`, so it will not serve without that binding — fix the \
+             enrolment or drop --enroll.",
+            args.device_name
+        ));
+    }
     if args.enroll {
-        agent.ensure_enrolled().await?;
         tracing::info!(device = %args.device_name, "vta-mcp enrolled as a managed device");
     }
-    // Optional holder identity for the `issue_vp` tool (signs presentations
-    // locally; the key never crosses MCP).
-    let holder = match (&args.holder_did, &args.holder_key) {
+    Ok(Arc::new(agent))
+}
+
+/// Optional holder identity for the `issue_vp` tool (signs presentations
+/// locally; the key never crosses MCP).
+fn holder_identity(args: &Args) -> Option<Arc<server::HolderIdentity>> {
+    match (&args.holder_did, &args.holder_key) {
         (Some(did), Some(key)) => {
             tracing::info!(%did, "issue_vp enabled with configured holder identity");
             Some(Arc::new(server::HolderIdentity {
@@ -167,26 +380,54 @@ async fn main() -> anyhow::Result<()> {
             }))
         }
         _ => None,
-    };
-
-    tracing::info!("vta-mcp connected to VTA; serving MCP over stdio");
-
-    // Keep a handle so the client's DIDComm session can be closed cleanly once
-    // serving ends — however it ends. A DIDComm `VtaClient` owns a live,
-    // auto-reconnecting mediator socket that `Drop` can't close; leaking it
-    // trips a debug-assert and duels the mediator on reconnect. We run serve +
-    // wait, then `shutdown()` unconditionally (idempotent, a no-op for
-    // REST/token clients) *before* propagating any error — a bare `?` on
-    // `waiting()` would skip the cleanup on the common EOF/disconnect path.
-    let agent = Arc::new(agent);
-    let served = async {
-        let service = VtaMcp::new(agent.clone(), holder).serve(stdio()).await?;
-        service.waiting().await?;
-        Ok::<(), anyhow::Error>(())
     }
-    .await;
-    agent.shutdown().await;
-    served
+}
+
+/// What the bridge will report about itself, resolved before connecting so it
+/// is available even when the connect fails.
+fn identity_of(args: &Args, mode: &ConnectMode) -> BridgeIdentity {
+    let (agent_did, mediator_did) = match mode {
+        ConnectMode::DidWebvhBundle {
+            agent_did,
+            mediator_did,
+        }
+        | ConnectMode::DidKey {
+            agent_did,
+            mediator_did,
+        } => (Some(agent_did.clone()), Some(mediator_did.clone())),
+        _ => (None, args.mediator_did.clone()),
+    };
+    BridgeIdentity {
+        mode: mode.label().to_string(),
+        agent_did,
+        vta_did: args.vta_did.clone(),
+        mediator_did,
+        dedicated_agent: mode.is_dedicated_agent(),
+    }
+}
+
+/// Warn when key material arrived as a command-line argument.
+///
+/// `/proc/<pid>/cmdline` and `ps` are readable by other processes on the same
+/// machine; the environment is not, on any platform this runs on. The flags
+/// stay supported — an operator scripting a one-off should not have to export
+/// variables — but they should know.
+fn warn_about_argv_secrets() {
+    const SECRET_FLAGS: &[&str] = &["--agent-key", "--holder-key", "--agent-secrets"];
+    let args: Vec<String> = std::env::args().collect();
+    for flag in SECRET_FLAGS {
+        if args
+            .iter()
+            .any(|a| a == flag || a.starts_with(&format!("{flag}=")))
+        {
+            tracing::warn!(
+                flag,
+                "key material passed as a command-line argument is visible to every process on \
+                 this machine (ps / /proc/<pid>/cmdline) — prefer the matching VTA_MCP_* \
+                 environment variable, or a file path for --agent-secrets"
+            );
+        }
+    }
 }
 
 /// Translate the CLI/env args into the SDK's connect ladder. Keeping this a
@@ -210,24 +451,9 @@ fn agent_connect_from(args: &Args) -> AgentConnect {
     }
 }
 
-/// Build an authenticated [`VtaClient`] from the args/env (see module docs).
-///
-/// The four-rung ladder itself lives in `vta_sdk::agent_connect` — every
-/// agent-side bridge needs the same one, and a second copy is how they drift.
-async fn build_client(args: &Args) -> anyhow::Result<VtaClient> {
-    let connect = agent_connect_from(args);
-    let mode = connect.mode()?;
-    tracing::info!(mode = mode.label(), "connecting to VTA");
-    connect
-        .connect()
-        .await
-        .map_err(|e| anyhow::anyhow!("connecting to VTA ({}): {e}", mode.label()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vta_sdk::agent_connect::ConnectMode;
 
     /// Args with everything unset — the base every case below varies from.
     fn args() -> Args {
@@ -290,5 +516,60 @@ mod tests {
                 key: "vta:my-vta".into()
             }
         );
+    }
+
+    #[test]
+    fn the_default_policy_is_confirm_destructive_and_nothing_else() {
+        let a = args();
+        assert!(!a.read_only);
+        assert!(a.allow.is_empty());
+        assert!(a.deny.is_empty());
+        assert_eq!(
+            ConfirmLevel::parse(&a.confirm).unwrap(),
+            ConfirmLevel::Destructive
+        );
+    }
+
+    #[test]
+    fn allow_and_deny_accept_repeated_and_comma_separated_values() {
+        let a = Args::parse_from([
+            "vta-mcp",
+            "--allow",
+            "vta/memory/*",
+            "--allow",
+            "acl/list",
+            "--deny",
+            "vta/seeds/*,vta/backup/*",
+        ]);
+        assert_eq!(a.allow, ["vta/memory/*", "acl/list"]);
+        assert_eq!(a.deny, ["vta/seeds/*", "vta/backup/*"]);
+    }
+
+    #[test]
+    fn identity_carries_the_agent_did_in_didcomm_modes() {
+        let mut a = args();
+        a.agent_did = Some("did:key:zAgent".into());
+        a.agent_key = Some("zKey".into());
+        a.vta_did = Some("did:webvh:example.com:vta".into());
+        a.mediator_did = Some("did:key:zMed".into());
+        let mode = agent_connect_from(&a).mode().unwrap();
+        let identity = identity_of(&a, &mode);
+        assert_eq!(identity.agent_did.as_deref(), Some("did:key:zAgent"));
+        assert_eq!(
+            identity.vta_did.as_deref(),
+            Some("did:webvh:example.com:vta")
+        );
+        assert!(identity.dedicated_agent);
+    }
+
+    #[test]
+    fn session_mode_is_not_a_dedicated_agent() {
+        let mut a = args();
+        a.vta = Some("my-vta".into());
+        let mut connect = agent_connect_from(&a);
+        connect.token = None;
+        let mode = connect.mode().unwrap();
+        // The fact `--enroll` is refused on, and the startup warning fires on.
+        assert!(!identity_of(&a, &mode).dedicated_agent);
     }
 }

--- a/vta-mcp/src/observability.rs
+++ b/vta-mcp/src/observability.rs
@@ -1,0 +1,535 @@
+//! Seeing what the bridge is doing.
+//!
+//! An MCP server is a subprocess with its stdout wired to the protocol. The
+//! only channels back to a human are **stderr**, which the host captures into
+//! its own log files, and whatever the server writes to disk itself. This
+//! module owns both.
+//!
+//! Three separate things, on purpose:
+//!
+//! - **stderr tracing** — the runtime log. On by default at `info`, because the
+//!   previous behaviour (`EnvFilter::from_default_env()` with no fallback) meant
+//!   an operator who had not set `RUST_LOG` got *silence*: no startup line, no
+//!   call log, no error. A bridge you cannot observe is a bridge you cannot
+//!   trust.
+//! - **the audit log** (`--audit-log`) — one JSON object per line per call,
+//!   durable, owner-only, machine-readable. This is the record you read *after*
+//!   something happened; stderr is what you watch while it happens.
+//! - **redaction** — both of the above pass every payload through [`redact`]
+//!   first. The bridge handles signing input, released secrets and holder keys,
+//!   and none of that may reach a log file.
+//!
+//! ## Why not MCP's `logging` capability
+//!
+//! MCP has a server→client logging channel (`notifications/message`), and it
+//! would put these lines in the host's UI. It is **deprecated** as of SEP-2577
+//! and slated for removal — `rmcp` marks every logging type `#[deprecated]`.
+//! Building the observability story on it would mean rebuilding it. stderr is
+//! where MCP hosts already look, and the audit file is where an operator can
+//! grep six months later.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde_json::{Map, Value, json};
+
+/// How the stderr log is rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LogFormat {
+    /// Human-readable lines. The default — a person is usually reading these
+    /// out of a host's log pane.
+    #[default]
+    Text,
+    /// One JSON object per line, for shipping into a log pipeline.
+    Json,
+}
+
+impl LogFormat {
+    /// Parse the `--log-format` flag.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "text" | "plain" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            other => Err(format!(
+                "unknown --log-format value '{other}' (expected text or json)"
+            )),
+        }
+    }
+}
+
+/// Install the stderr subscriber.
+///
+/// `RUST_LOG` still wins when set, so existing debugging habits keep working;
+/// otherwise the filter is `vta_mcp=<level>` plus a quieter floor for the SDK,
+/// whose DIDComm layer is chatty at `debug` and would bury the bridge's own
+/// lines.
+///
+/// stdout is the MCP JSON-RPC channel. Nothing may ever be written there —
+/// a single stray `println!` corrupts the stream and the host reports a broken
+/// server with no further explanation.
+pub fn init_tracing(level: &str, format: LogFormat) {
+    let filter = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+        format!("vta_mcp={level},vta_sdk=warn,affinidi_messaging_sdk=warn,rmcp=warn")
+    });
+    let filter = tracing_subscriber::EnvFilter::new(filter);
+    let builder = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(filter)
+        .with_target(true);
+    match format {
+        LogFormat::Text => builder.init(),
+        LogFormat::Json => builder.json().flatten_event(true).init(),
+    }
+}
+
+/// Payload keys whose values are safe to record verbatim.
+///
+/// An allowlist, not a denylist: a denylist has to predict every name a secret
+/// might arrive under, and `vta_call` takes arbitrary payloads for operations
+/// this build has never heard of. Anything not named here is elided.
+const SAFE_KEYS: &[&str] = &[
+    "algorithm",
+    "alg",
+    "agentDid",
+    "audience",
+    "clientDid",
+    "context",
+    "contextId",
+    "deviceId",
+    "did",
+    "displayName",
+    "domain",
+    "entryId",
+    "format",
+    "id",
+    "keyId",
+    "kind",
+    "label",
+    "limit",
+    "name",
+    "offset",
+    "operation",
+    "platform",
+    "purpose",
+    "reason",
+    "role",
+    "scope",
+    "server",
+    "serverId",
+    "serviceKind",
+    "status",
+    "tag",
+    "template",
+    "type",
+    "uri",
+    "vtaDid",
+];
+
+/// How deep [`redact`] walks before collapsing a subtree.
+const MAX_DEPTH: usize = 4;
+/// How many array elements survive; the rest become a count marker.
+const MAX_ARRAY: usize = 8;
+
+/// Strip anything that could be secret out of a payload, keeping the shape.
+///
+/// The rule is that **strings are guilty until named innocent**. Numbers and
+/// booleans pass — a key id's index or a `force: true` is worth having in the
+/// log and neither can carry key material. Strings pass only under a
+/// [`SAFE_KEYS`] name, so `text` (what `sign` signs), `secret`, `privateKey`,
+/// `mnemonic`, `jwe` and every field of a released credential are elided
+/// without this module needing to know they exist.
+pub fn redact(value: &Value) -> Value {
+    redact_at(value, 0, false)
+}
+
+fn redact_at(value: &Value, depth: usize, key_is_safe: bool) -> Value {
+    if depth > MAX_DEPTH {
+        return json!("<elided:depth>");
+    }
+    match value {
+        Value::Object(map) => {
+            let mut out = Map::new();
+            for (k, v) in map {
+                let safe = SAFE_KEYS.contains(&k.as_str());
+                out.insert(k.clone(), redact_at(v, depth + 1, safe));
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => {
+            let mut out: Vec<Value> = items
+                .iter()
+                .take(MAX_ARRAY)
+                .map(|v| redact_at(v, depth + 1, key_is_safe))
+                .collect();
+            if items.len() > MAX_ARRAY {
+                out.push(json!(format!("<elided:{} more>", items.len() - MAX_ARRAY)));
+            }
+            Value::Array(out)
+        }
+        Value::String(_) if !key_is_safe => json!("<elided>"),
+        other => other.clone(),
+    }
+}
+
+/// One completed tool call, as recorded.
+#[derive(Debug, Clone)]
+pub struct CallRecord {
+    /// Monotonic per-process call number, also emitted on the stderr line so
+    /// the two logs can be joined.
+    pub seq: u64,
+    /// The MCP tool name.
+    pub tool: &'static str,
+    /// The Trust Task URI the call resolved to, where there is one.
+    pub operation: Option<String>,
+    /// The [`crate::guard::Risk`] label.
+    pub risk: &'static str,
+    /// The [`crate::guard::Decision`] label.
+    pub decision: &'static str,
+    /// `ok`, `error`, `denied` or `declined`.
+    pub outcome: &'static str,
+    /// Wall-clock duration of the call.
+    pub duration_ms: u128,
+    /// Redacted arguments.
+    pub args: Value,
+    /// The error message, when `outcome` is not `ok`.
+    pub error: Option<String>,
+}
+
+impl CallRecord {
+    fn to_json(&self, ts: String) -> Value {
+        json!({
+            "ts": ts,
+            "seq": self.seq,
+            "tool": self.tool,
+            "operation": self.operation,
+            "risk": self.risk,
+            "decision": self.decision,
+            "outcome": self.outcome,
+            "durationMs": self.duration_ms,
+            "args": self.args,
+            "error": self.error,
+        })
+    }
+}
+
+/// Running totals, surfaced by the `vta_status` tool.
+#[derive(Debug, Default)]
+pub struct Counters {
+    /// Calls that reached the VTA (or a local handler) and returned.
+    pub ok: AtomicU64,
+    /// Calls that reached the VTA and failed.
+    pub errors: AtomicU64,
+    /// Calls the local guard refused outright.
+    pub denied: AtomicU64,
+    /// Calls a human was asked about and declined.
+    pub declined: AtomicU64,
+}
+
+impl Counters {
+    /// Snapshot for rendering.
+    pub fn snapshot(&self) -> Value {
+        json!({
+            "ok": self.ok.load(Ordering::Relaxed),
+            "errors": self.errors.load(Ordering::Relaxed),
+            "denied": self.denied.load(Ordering::Relaxed),
+            "declined": self.declined.load(Ordering::Relaxed),
+        })
+    }
+
+    /// Record one outcome by its label.
+    pub fn record(&self, outcome: &str) {
+        let counter = match outcome {
+            "ok" => &self.ok,
+            "denied" => &self.denied,
+            "declined" => &self.declined,
+            _ => &self.errors,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// An append-only JSONL record of every call.
+///
+/// Held behind a `std::sync::Mutex` rather than an async one: the critical
+/// section is a `writeln!` of a few hundred bytes with no `.await` inside it,
+/// which is the only shape of blocking lock that is safe on an async executor.
+#[derive(Debug)]
+pub struct AuditLog {
+    file: Mutex<std::fs::File>,
+    path: PathBuf,
+}
+
+impl AuditLog {
+    /// Open (or create) the audit file, owner-only.
+    ///
+    /// The records name operations, DIDs, context ids and key ids — not
+    /// secrets, but a map of what this VTA holds and who touches it. That is
+    /// worth 0600 on its own.
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(path)?;
+        // `mode` only applies at creation; an existing file keeps whatever
+        // permissions it had, so tighten it explicitly.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(Self {
+            file: Mutex::new(file),
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Where this log is being written — reported by `vta_status` so an
+    /// operator does not have to remember the flag they passed.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append one already-rendered record. A failed write is logged and
+    /// swallowed: losing an audit line is bad, but failing a VTA call because a
+    /// disk filled up is worse, and the stderr log still carries the same event.
+    pub fn append(&self, line: &Value) {
+        let Ok(mut file) = self.file.lock() else {
+            tracing::error!("audit log mutex poisoned; record dropped");
+            return;
+        };
+        if let Err(e) = writeln!(file, "{line}") {
+            tracing::error!(error = %e, "writing audit record");
+        }
+    }
+}
+
+/// UTC timestamp in RFC 3339, the format the VTA's own audit rows use.
+pub fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+/// Monotonic call ids, shared by the stderr and audit logs.
+#[derive(Debug, Default)]
+pub struct CallSeq(AtomicU64);
+
+impl CallSeq {
+    /// The next call id.
+    pub fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::Relaxed) + 1
+    }
+}
+
+/// How many recent calls stay in memory for the `vta://calls/recent` resource.
+const RING_CAPACITY: usize = 100;
+
+/// Everything that remembers what the bridge did: the call counter, the
+/// running totals, the in-memory ring the host can read back, and the optional
+/// on-disk audit file.
+///
+/// The ring exists so that "what has this thing been doing?" is answerable
+/// **without** the operator having thought to pass `--audit-log` beforehand —
+/// which, by the time they are asking the question, they will not have.
+#[derive(Debug, Default)]
+pub struct Recorder {
+    seq: CallSeq,
+    counters: Counters,
+    ring: Mutex<std::collections::VecDeque<Value>>,
+    file: Option<AuditLog>,
+}
+
+impl Recorder {
+    /// A recorder writing to `path` as well as memory.
+    pub fn with_file(path: &Path) -> std::io::Result<Self> {
+        Ok(Self {
+            file: Some(AuditLog::open(path)?),
+            ..Self::default()
+        })
+    }
+
+    /// The next call id.
+    pub fn next_seq(&self) -> u64 {
+        self.seq.next()
+    }
+
+    /// Running totals.
+    pub fn counters(&self) -> &Counters {
+        &self.counters
+    }
+
+    /// The audit file path, if one is configured.
+    pub fn audit_path(&self) -> Option<&Path> {
+        self.file.as_ref().map(AuditLog::path)
+    }
+
+    /// Record a completed call: totals, ring, and the file if configured.
+    pub fn record(&self, record: &CallRecord) {
+        self.counters.record(record.outcome);
+        let line = record.to_json(now_rfc3339());
+        if let Some(file) = &self.file {
+            file.append(&line);
+        }
+        if let Ok(mut ring) = self.ring.lock() {
+            if ring.len() == RING_CAPACITY {
+                ring.pop_front();
+            }
+            ring.push_back(line);
+        }
+    }
+
+    /// The most recent calls, newest last, capped at [`RING_CAPACITY`].
+    pub fn recent(&self, limit: usize) -> Vec<Value> {
+        let Ok(ring) = self.ring.lock() else {
+            return Vec::new();
+        };
+        let skip = ring.len().saturating_sub(limit);
+        ring.iter().skip(skip).cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unnamed_strings_are_elided() {
+        let out = redact(&json!({ "text": "sign me", "keyId": "key-1" }));
+        assert_eq!(out["text"], json!("<elided>"));
+        assert_eq!(out["keyId"], json!("key-1"));
+    }
+
+    #[test]
+    fn numbers_and_booleans_survive() {
+        let out = redact(&json!({ "limit": 50, "force": true, "offset": 0 }));
+        assert_eq!(out["limit"], json!(50));
+        assert_eq!(out["force"], json!(true));
+        assert_eq!(out["offset"], json!(0));
+    }
+
+    #[test]
+    fn secrets_are_elided_without_being_named() {
+        // The point of the allowlist: none of these key names appear anywhere
+        // in this crate, and all of them are still elided.
+        let out = redact(&json!({
+            "mnemonic": "abandon abandon …",
+            "privateKeyMultibase": "z3u2…",
+            "jwe": "eyJhbGciOi…",
+            "password": "hunter2",
+        }));
+        for k in ["mnemonic", "privateKeyMultibase", "jwe", "password"] {
+            assert_eq!(out[k], json!("<elided>"), "{k} leaked");
+        }
+    }
+
+    #[test]
+    fn nested_objects_are_walked_and_bounded() {
+        let deep = json!({"a":{"b":{"c":{"d":{"e":{"f":"secret"}}}}}});
+        let out = redact(&deep).to_string();
+        assert!(!out.contains("secret"), "{out}");
+    }
+
+    #[test]
+    fn long_arrays_are_truncated_with_a_count() {
+        let out = redact(&json!({ "did": (0..20).map(|i| i.to_string()).collect::<Vec<_>>() }));
+        let arr = out["did"].as_array().unwrap();
+        assert_eq!(arr.len(), MAX_ARRAY + 1);
+        assert_eq!(arr[MAX_ARRAY], json!("<elided:12 more>"));
+    }
+
+    #[test]
+    fn a_safe_key_does_not_whitelist_its_whole_subtree() {
+        // `name` is safe, but a nested `secret` under it is not — the flag is
+        // recomputed per key on the way down, not inherited.
+        let out = redact(&json!({ "name": { "secret": "no" } }));
+        assert_eq!(out["name"]["secret"], json!("<elided>"));
+    }
+
+    #[test]
+    fn counters_bucket_by_outcome() {
+        let c = Counters::default();
+        c.record("ok");
+        c.record("denied");
+        c.record("boom");
+        let snap = c.snapshot();
+        assert_eq!(snap["ok"], json!(1));
+        assert_eq!(snap["denied"], json!(1));
+        assert_eq!(snap["errors"], json!(1));
+    }
+
+    fn record(seq: u64) -> CallRecord {
+        CallRecord {
+            seq,
+            tool: "vta_call",
+            operation: Some("https://trusttasks.org/spec/acl/list/0.1".into()),
+            risk: "read-only",
+            decision: "allow",
+            outcome: "ok",
+            duration_ms: 12,
+            args: redact(&json!({"text": "shh"})),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn audit_records_are_one_json_object_per_line() {
+        let dir = std::env::temp_dir().join(format!("vta-mcp-audit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("audit.jsonl");
+        let recorder = Recorder::with_file(&path).unwrap();
+        recorder.record(&record(1));
+        recorder.record(&record(2));
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body.lines().count(), 2);
+        let parsed: Value = serde_json::from_str(body.lines().next().unwrap()).unwrap();
+        assert_eq!(parsed["tool"], json!("vta_call"));
+        assert_eq!(parsed["args"]["text"], json!("<elided>"));
+        assert!(parsed["ts"].as_str().unwrap().ends_with('Z'));
+        assert_eq!(recorder.counters().snapshot()["ok"], json!(2));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_ring_answers_without_an_audit_file() {
+        // The case that matters: nobody passed --audit-log, and the operator
+        // now wants to know what the bridge has been doing.
+        let recorder = Recorder::default();
+        assert!(recorder.audit_path().is_none());
+        for seq in 1..=(RING_CAPACITY as u64 + 10) {
+            recorder.record(&record(seq));
+        }
+        let recent = recorder.recent(5);
+        assert_eq!(recent.len(), 5);
+        // Newest last, and the oldest entries have aged out.
+        assert_eq!(recent[4]["seq"], json!(RING_CAPACITY as u64 + 10));
+        assert_eq!(recorder.recent(1_000).len(), RING_CAPACITY);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_audit_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("vta-mcp-perm-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("audit.jsonl");
+        // Pre-create it world-readable: `mode()` applies only at creation, so
+        // this is the case that needs the explicit set_permissions.
+        std::fs::write(&path, "").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let _log = AuditLog::open(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "audit log left readable by others");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn log_format_parses() {
+        assert_eq!(LogFormat::parse("json").unwrap(), LogFormat::Json);
+        assert_eq!(LogFormat::parse("TEXT").unwrap(), LogFormat::Text);
+        assert!(LogFormat::parse("xml").is_err());
+    }
+}

--- a/vta-mcp/src/server.rs
+++ b/vta-mcp/src/server.rs
@@ -11,19 +11,79 @@
 //! Tools that touch secrets (`vault_release`) seal/open `didcomm-authcrypt`
 //! envelopes and therefore require the underlying client to be on the DIDComm
 //! transport; on REST they surface a clear error rather than failing opaquely.
-//! All access is bounded by the bridge identity's VTA role/ACL.
+//!
+//! ## Three things every call goes through
+//!
+//! 1. **[`crate::guard`]** — the local per-operation gate, because an MCP host
+//!    approves a *tool* and this bridge's most useful tool is "invoke any
+//!    operation". Every convenience tool declares the Trust Task URI it wraps,
+//!    so `--read-only` cannot be side-stepped by calling `sign` instead of
+//!    `vta_call`.
+//! 2. **[`crate::observability`]** — a start line, a finish line with duration
+//!    and outcome, and a redacted record in the ring buffer (and the audit file
+//!    when one is configured).
+//! 3. **The VTA** — which is, and remains, the authority. Everything above is a
+//!    second gate in front of it, never a substitute for it.
+//!
+//! Nothing here grants access. The bridge identity's role, ACL and context
+//! scope decide what actually happens.
 
 use std::sync::Arc;
+use std::time::Instant;
 
+use crate::guard::{Decision, Guard, Risk, classify};
+use crate::observability::{CallRecord, Recorder, redact};
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, ContentBlock, Implementation, ServerCapabilities, ServerInfo};
-use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
+use rmcp::model::{
+    CallToolResult, ContentBlock, Implementation, ListResourcesResult, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResponse, ReadResourceResult, Resource,
+    ResourceContents, ServerCapabilities, ServerInfo,
+};
+use rmcp::service::{Peer, RequestContext};
+use rmcp::{
+    ErrorData as McpError, RoleServer, ServerHandler, elicit_safe, tool, tool_handler, tool_router,
+};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::Value;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use vta_sdk::agent_session::AgentSession;
 use vta_sdk::error::VtaError;
 use vta_sdk::protocols::key_management::sign::SignAlgorithm;
+
+/// The Trust Task URI each convenience tool **actually sends**.
+///
+/// Not "the newest version of that task" — the one the SDK dispatches. The
+/// audit log names the wire version that went out, and the local policy is
+/// applied to the same string the VTA will see, so both have to track
+/// `VtaClient`'s call sites rather than the freshest constant. Several are the
+/// deprecated `0.1` forms for exactly that reason; they move when
+/// `vta_sdk::client` moves, not before.
+#[allow(deprecated)]
+mod wire {
+    use vta_sdk::trust_tasks as t;
+
+    /// `trust-task-discovery/0.1` — what `supported_trust_tasks` asks.
+    pub const DISCOVERY: &str = t::TASK_TRUST_TASK_DISCOVERY_0_1;
+    /// `keys/list/0.1`.
+    pub const KEYS_LIST: &str = t::TASK_KEYS_LIST_0_1;
+    /// `keys/sign/0.1` — the signing oracle.
+    pub const KEYS_SIGN: &str = t::TASK_KEYS_SIGN_0_1;
+    /// `vault/list/0.1`.
+    pub const VAULT_LIST: &str = t::TASK_VAULT_LIST_0_1;
+    /// `vault/get/0.1`.
+    pub const VAULT_GET: &str = t::TASK_VAULT_GET_0_1;
+    /// `vault/release/0.1`.
+    pub const VAULT_RELEASE: &str = t::TASK_VAULT_RELEASE_0_1;
+    /// `device/heartbeat/0.1`.
+    pub const DEVICE_HEARTBEAT: &str = t::TASK_DEVICE_HEARTBEAT_0_1;
+}
+
+/// Resource URI for the bridge's own state.
+const RESOURCE_STATUS: &str = "vta://status";
+/// Resource URI for the dispatchable operation catalog.
+const RESOURCE_OPERATIONS: &str = "vta://operations";
+/// Resource URI for the in-memory record of recent calls.
+const RESOURCE_RECENT: &str = "vta://calls/recent";
 
 /// Map an SDK error onto an MCP tool error. The VTA's typed errors carry the
 /// operator-facing message; surface it verbatim to the agent.
@@ -141,6 +201,28 @@ pub struct IssueVpParams {
     pub audience: String,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct StatusParams {
+    /// How many recent calls to include (default 10, max 100). Pass 0 for none.
+    #[serde(default)]
+    pub recent_calls: Option<usize>,
+}
+
+// A single boolean, deliberately: an elicitation form the operator has to read
+// carefully is one they will stop reading. The *message* carries the operation
+// name and its risk class; the answer is yes or no.
+//
+// Note the doc comment below is not an internal one — `schemars` copies it into
+// the elicitation schema, so the host renders it to the operator. Keep it to
+// what a person answering a prompt needs.
+/// Approve this VTA operation?
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct Approval {
+    /// Approve this operation? Answering no refuses the call.
+    pub approve: bool,
+}
+elicit_safe!(Approval);
+
 /// The agent's own holder identity, used to sign Verifiable Presentations
 /// locally (the key never leaves this process). Configured out-of-band — never
 /// supplied over MCP.
@@ -154,23 +236,258 @@ pub struct HolderIdentity {
     pub key_multibase: String,
 }
 
+/// Who this bridge is authenticated as — resolved before connecting, so it can
+/// be reported even when the connection failed.
+#[derive(Debug, Clone, Default)]
+pub struct BridgeIdentity {
+    /// The [`vta_sdk::agent_connect::ConnectMode`] label.
+    pub mode: String,
+    /// The agent's own DID, in the two DIDComm modes.
+    pub agent_did: Option<String>,
+    /// The VTA being talked to.
+    pub vta_did: Option<String>,
+    /// The mediator DIDComm rides.
+    pub mediator_did: Option<String>,
+    /// Whether this is a dedicated agent identity rather than a replayed
+    /// operator login. Reported because it is the single most important fact
+    /// about how much damage a compromised host could do.
+    pub dedicated_agent: bool,
+}
+
+impl BridgeIdentity {
+    fn to_json(&self) -> Value {
+        json!({
+            "mode": self.mode,
+            "agentDid": self.agent_did,
+            "vtaDid": self.vta_did,
+            "mediatorDid": self.mediator_did,
+            "dedicatedAgent": self.dedicated_agent,
+        })
+    }
+}
+
 /// MCP server bridging to a single authenticated agent session.
 #[derive(Clone)]
 pub struct VtaMcp {
-    agent: Arc<AgentSession>,
+    /// `None` when the initial connect failed — see [`VtaMcp::degraded`].
+    agent: Option<Arc<AgentSession>>,
+    /// Why the connect failed, in degraded mode.
+    connect_error: Option<Arc<str>>,
+    identity: Arc<BridgeIdentity>,
     /// Optional holder identity enabling the `issue_vp` tool.
     holder: Option<Arc<HolderIdentity>>,
+    guard: Arc<Guard>,
+    recorder: Arc<Recorder>,
+    started: Arc<str>,
+}
+
+/// One in-flight guarded call. Created by [`VtaMcp::begin`], consumed by
+/// [`CallGuard::finish`] — which is what writes the finish line and the audit
+/// record, so a tool cannot return without being recorded.
+struct CallGuard {
+    seq: u64,
+    tool: &'static str,
+    operation: Option<String>,
+    risk: Risk,
+    decision: &'static str,
+    args: Value,
+    started: Instant,
+    recorder: Arc<Recorder>,
+}
+
+impl CallGuard {
+    /// Record the outcome and hand back the result unchanged.
+    fn finish(self, result: Result<Value, McpError>) -> Result<CallToolResult, McpError> {
+        let duration_ms = self.started.elapsed().as_millis();
+        let (outcome, error) = match &result {
+            Ok(_) => ("ok", None),
+            Err(e) => ("error", Some(e.message.to_string())),
+        };
+        self.emit(outcome, error, duration_ms);
+        match result {
+            Ok(value) => ok_json(value),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Record a call that never reached the VTA.
+    fn refuse(self, outcome: &'static str, message: String) -> Result<CallToolResult, McpError> {
+        let duration_ms = self.started.elapsed().as_millis();
+        self.emit(outcome, Some(message.clone()), duration_ms);
+        Err(McpError::invalid_request(message, None))
+    }
+
+    fn emit(&self, outcome: &'static str, error: Option<String>, duration_ms: u128) {
+        let record = CallRecord {
+            seq: self.seq,
+            tool: self.tool,
+            operation: self.operation.clone(),
+            risk: self.risk.label(),
+            decision: self.decision,
+            outcome,
+            duration_ms,
+            args: self.args.clone(),
+            error: error.clone(),
+        };
+        match outcome {
+            "ok" => tracing::info!(
+                seq = self.seq,
+                tool = self.tool,
+                operation = self.operation.as_deref().unwrap_or("-"),
+                risk = self.risk.label(),
+                duration_ms = duration_ms as u64,
+                "call ok"
+            ),
+            _ => tracing::warn!(
+                seq = self.seq,
+                tool = self.tool,
+                operation = self.operation.as_deref().unwrap_or("-"),
+                risk = self.risk.label(),
+                duration_ms = duration_ms as u64,
+                outcome,
+                error = error.as_deref().unwrap_or("-"),
+                "call failed"
+            ),
+        }
+        self.recorder.record(&record);
+    }
 }
 
 #[tool_router]
 impl VtaMcp {
-    pub fn new(agent: Arc<AgentSession>, holder: Option<Arc<HolderIdentity>>) -> Self {
-        Self { agent, holder }
+    /// A connected bridge.
+    pub fn new(
+        agent: Arc<AgentSession>,
+        holder: Option<Arc<HolderIdentity>>,
+        identity: BridgeIdentity,
+        guard: Guard,
+        recorder: Arc<Recorder>,
+    ) -> Self {
+        Self {
+            agent: Some(agent),
+            connect_error: None,
+            identity: Arc::new(identity),
+            holder,
+            guard: Arc::new(guard),
+            recorder,
+            started: crate::observability::now_rfc3339().into(),
+        }
     }
 
-    /// The VTA client behind the session — every tool routes through this.
-    fn client(&self) -> &vta_sdk::client::VtaClient {
-        self.agent.client()
+    /// A bridge that failed to connect but serves MCP anyway.
+    ///
+    /// A server that exits before it speaks MCP appears to the host as *no
+    /// tools at all* — the model cannot even report the problem, and the
+    /// operator sees an empty tool list with no explanation. Serving in a
+    /// degraded state means `vta_status` still answers, every other tool
+    /// returns the connect error verbatim, and the failure is legible from
+    /// inside the session that hit it.
+    pub fn degraded(
+        error: String,
+        holder: Option<Arc<HolderIdentity>>,
+        identity: BridgeIdentity,
+        guard: Guard,
+        recorder: Arc<Recorder>,
+    ) -> Self {
+        Self {
+            agent: None,
+            connect_error: Some(error.into()),
+            identity: Arc::new(identity),
+            holder,
+            guard: Arc::new(guard),
+            recorder,
+            started: crate::observability::now_rfc3339().into(),
+        }
+    }
+
+    /// The VTA client behind the session — every tool that talks to the VTA
+    /// routes through this, and it is the single place the degraded state is
+    /// turned into an error a model can read.
+    fn client(&self) -> Result<&vta_sdk::client::VtaClient, McpError> {
+        match &self.agent {
+            Some(agent) => Ok(agent.client()),
+            None => Err(McpError::internal_error(
+                format!(
+                    "this vta-mcp bridge is not connected to its VTA: {}. Fix the connection and \
+                     restart the MCP server; `vta_status` reports the configuration it tried.",
+                    self.connect_error.as_deref().unwrap_or("unknown error")
+                ),
+                None,
+            )),
+        }
+    }
+
+    /// Gate, log and (where the policy asks) confirm one call.
+    ///
+    /// `operation` is the Trust Task URI the tool resolves to — `None` only for
+    /// the two purely local tools. `args` is passed through [`redact`] here, so
+    /// no caller can forget to.
+    async fn begin(
+        &self,
+        tool: &'static str,
+        operation: Option<&str>,
+        args: Value,
+        peer: &Peer<RoleServer>,
+    ) -> Result<CallGuard, Box<Result<CallToolResult, McpError>>> {
+        let seq = self.recorder.next_seq();
+        let risk = operation.map_or(Risk::ReadOnly, classify);
+        let decision = operation.map_or(Decision::Allow, |uri| self.guard.decide(uri));
+
+        let guard = CallGuard {
+            seq,
+            tool,
+            operation: operation.map(str::to_string),
+            risk,
+            decision: decision.label(),
+            args: redact(&args),
+            started: Instant::now(),
+            recorder: self.recorder.clone(),
+        };
+
+        tracing::info!(
+            seq,
+            tool,
+            operation = operation.unwrap_or("-"),
+            risk = risk.label(),
+            decision = decision.label(),
+            args = %guard.args,
+            "call start"
+        );
+
+        match decision {
+            Decision::Allow => Ok(guard),
+            Decision::Deny(reason) => {
+                tracing::warn!(seq, tool, reason = %reason, "call denied by local policy");
+                Err(Box::new(guard.refuse("denied", reason)))
+            }
+            Decision::Confirm(prompt) => match self.confirm(peer, &prompt).await {
+                Ok(true) => Ok(guard),
+                Ok(false) => Err(Box::new(
+                    guard.refuse("declined", format!("{prompt} — declined by the operator.")),
+                )),
+                Err(reason) => Err(Box::new(guard.refuse("denied", reason))),
+            },
+        }
+    }
+
+    /// Ask the human. `Err` means no answer could be obtained at all, which is
+    /// refused rather than waved through — a confirmation gate that fails open
+    /// is not a gate.
+    async fn confirm(&self, peer: &Peer<RoleServer>, prompt: &str) -> Result<bool, String> {
+        match peer.elicit::<Approval>(prompt.to_string()).await {
+            Ok(Some(approval)) => Ok(approval.approve),
+            Ok(None) => Ok(false),
+            Err(rmcp::service::ElicitationError::UserDeclined)
+            | Err(rmcp::service::ElicitationError::UserCancelled)
+            | Err(rmcp::service::ElicitationError::NoContent) => Ok(false),
+            Err(rmcp::service::ElicitationError::CapabilityNotSupported) => Err(format!(
+                "{prompt} — this MCP host cannot ask you (it does not support elicitation), so the \
+                 bridge refused rather than proceeding unconfirmed. Restart vta-mcp with \
+                 `--confirm never` to drop the prompt, or `--allow <slug>` to permit just this \
+                 operation."
+            )),
+            Err(e) => Err(format!("{prompt} — could not obtain confirmation: {e}")),
+        }
     }
 
     /// Replaces the old `vta_capabilities` tool, which #1043 retired along with
@@ -183,101 +500,262 @@ impl VtaMcp {
     /// agent actually needs before calling something is whether the VTA serves
     /// it, and that is a question with a canonical answer.
     #[tool(
-        description = "Discover which Trust Tasks the connected VTA serves. Optionally narrow with                        slug-glob patterns such as 'acl/*' or 'vta/webvh/*'; omit for everything.                        Ask this before assuming an operation exists — calling one the VTA does not                        serve fails as a transport timeout rather than a clear error."
+        description = "Discover which Trust Tasks the connected VTA serves. Optionally narrow with \
+                       slug-glob patterns such as 'acl/*' or 'vta/webvh/*'; omit for everything. \
+                       Ask this before assuming an operation exists — calling one the VTA does not \
+                       serve fails as a transport timeout rather than a clear error.",
+        annotations(
+            title = "Supported Trust Tasks",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn vta_supported_tasks(
         &self,
         Parameters(p): Parameters<SupportedTasksParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let patterns: Vec<&str> = p.patterns.iter().map(String::as_str).collect();
-        let tasks = self
-            .client()
-            .supported_trust_tasks(&patterns)
-            .await
-            .map_err(to_mcp)?;
-        ok_json(tasks)
-    }
-
-    #[tool(description = "List the signing keys available on the VTA.")]
-    async fn list_keys(
-        &self,
-        Parameters(p): Parameters<ListKeysParams>,
-    ) -> Result<CallToolResult, McpError> {
-        let keys = self
-            .client()
-            .list_keys(
-                p.offset.unwrap_or(0),
-                p.limit.unwrap_or(50),
-                p.status.as_deref(),
-                p.context_id.as_deref(),
+        let call = match self
+            .begin(
+                "vta_supported_tasks",
+                Some(wire::DISCOVERY),
+                json!({ "patterns": p.patterns }),
+                &peer,
             )
             .await
-            .map_err(to_mcp)?;
-        ok_json(keys)
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let patterns: Vec<&str> = p.patterns.iter().map(String::as_str).collect();
+        let result = match self.client() {
+            Ok(client) => client
+                .supported_trust_tasks(&patterns)
+                .await
+                .map(|t| json!(t))
+                .map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
     }
 
     #[tool(
-        description = "Sign UTF-8 text with a VTA-held key via the signing oracle (the private key never leaves the VTA). Returns the signature."
+        description = "List the signing keys available on the VTA.",
+        annotations(
+            title = "List keys",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_keys(
+        &self,
+        Parameters(p): Parameters<ListKeysParams>,
+        peer: Peer<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let call = match self
+            .begin(
+                "list_keys",
+                Some(wire::KEYS_LIST),
+                json!({
+                    "offset": p.offset,
+                    "limit": p.limit,
+                    "status": p.status,
+                    "contextId": p.context_id,
+                }),
+                &peer,
+            )
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = match self.client() {
+            Ok(client) => client
+                .list_keys(
+                    p.offset.unwrap_or(0),
+                    p.limit.unwrap_or(50),
+                    p.status.as_deref(),
+                    p.context_id.as_deref(),
+                )
+                .await
+                .map(|k| json!(k))
+                .map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
+    }
+
+    #[tool(
+        description = "Sign UTF-8 text with a VTA-held key via the signing oracle (the private key \
+                       never leaves the VTA). Returns the signature.",
+        annotations(
+            title = "Sign with a VTA key",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn sign(
         &self,
         Parameters(p): Parameters<SignParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        // `text` is deliberately not in the recorded arguments — `redact` elides
+        // it, and what gets signed is the caller's business, not the log's.
+        let call = match self
+            .begin(
+                "sign",
+                Some(wire::KEYS_SIGN),
+                json!({ "keyId": p.key_id, "algorithm": p.algorithm, "text": p.text }),
+                &peer,
+            )
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
         let algorithm = match p.algorithm.as_deref() {
             Some("ES256") | Some("es256") => SignAlgorithm::ES256,
             Some("EdDSA") | Some("eddsa") | None => SignAlgorithm::EdDSA,
             Some(other) => {
-                return Err(McpError::invalid_params(
+                return call.refuse(
+                    "error",
                     format!("unknown algorithm '{other}' (expected EdDSA or ES256)"),
-                    None,
-                ));
+                );
             }
         };
-        let resp = self
-            .client()
-            .sign(&p.key_id, p.text.as_bytes(), algorithm)
-            .await
-            .map_err(to_mcp)?;
-        // `SignResponse` is deserialize-only; project its fields into JSON.
-        ok_json(serde_json::json!({
-            "keyId": resp.key_id,
-            "signature": resp.signature,
-            "algorithm": resp.algorithm,
-        }))
-    }
-
-    #[tool(description = "List secrets-vault entry metadata (no secret material).")]
-    async fn vault_list(
-        &self,
-        Parameters(p): Parameters<VaultListParams>,
-    ) -> Result<CallToolResult, McpError> {
-        let result = self
-            .client()
-            .vault_list(p.filters.unwrap_or_else(|| serde_json::json!({})))
-            .await
-            .map_err(to_mcp)?;
-        ok_json(result)
-    }
-
-    #[tool(description = "Fetch a single vault entry's metadata by id (no secret material).")]
-    async fn vault_get(
-        &self,
-        Parameters(p): Parameters<VaultGetParams>,
-    ) -> Result<CallToolResult, McpError> {
-        let result = self.client().vault_get(&p.id).await.map_err(to_mcp)?;
-        ok_json(result)
+        let result = match self.client() {
+            Ok(client) => client
+                .sign(&p.key_id, p.text.as_bytes(), algorithm)
+                .await
+                .map(|resp| {
+                    // `SignResponse` is deserialize-only; project its fields.
+                    json!({
+                        "keyId": resp.key_id,
+                        "signature": resp.signature,
+                        "algorithm": resp.algorithm,
+                    })
+                })
+                .map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
     }
 
     #[tool(
-        description = "Release a vault secret sealed to this client and return the cleartext. Requires the DIDComm transport (the secret is opened with the client's own keys)."
+        description = "List secrets-vault entry metadata (no secret material).",
+        annotations(
+            title = "List vault entries",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn vault_list(
+        &self,
+        Parameters(p): Parameters<VaultListParams>,
+        peer: Peer<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let filters = p.filters.unwrap_or_else(|| json!({}));
+        let call = match self
+            .begin(
+                "vault_list",
+                Some(wire::VAULT_LIST),
+                json!({ "filters": filters }),
+                &peer,
+            )
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = match self.client() {
+            Ok(client) => client.vault_list(filters).await.map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
+    }
+
+    #[tool(
+        description = "Fetch a single vault entry's metadata by id (no secret material).",
+        annotations(
+            title = "Get a vault entry",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn vault_get(
+        &self,
+        Parameters(p): Parameters<VaultGetParams>,
+        peer: Peer<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let call = match self
+            .begin(
+                "vault_get",
+                Some(wire::VAULT_GET),
+                json!({ "id": p.id }),
+                &peer,
+            )
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = match self.client() {
+            Ok(client) => client.vault_get(&p.id).await.map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
+    }
+
+    #[tool(
+        description = "Release a vault secret sealed to this client and return the cleartext. \
+                       Requires the DIDComm transport (the secret is opened with the client's own \
+                       keys). The cleartext enters the model's context — do not call it to 'check' \
+                       a secret exists; use vault_get for that.",
+        annotations(
+            title = "Release a vault secret",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn vault_release(
         &self,
         Parameters(p): Parameters<VaultReleaseParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let response = self
-            .client()
-            .vault_release_entry(&p.id, p.target)
+        let call = match self
+            .begin(
+                "vault_release",
+                Some(wire::VAULT_RELEASE),
+                json!({ "id": p.id, "target": p.target }),
+                &peer,
+            )
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = self.release_secret(&p).await;
+        call.finish(result)
+    }
+
+    /// The two-step release: ask the VTA for the sealed envelope, then open it
+    /// locally with this client's own keys.
+    async fn release_secret(&self, p: &VaultReleaseParams) -> Result<Value, McpError> {
+        let client = self.client()?;
+        let response = client
+            .vault_release_entry(&p.id, p.target.clone())
             .await
             .map_err(to_mcp)?;
         match response
@@ -285,90 +763,225 @@ impl VtaMcp {
             .and_then(|s| s.get("jwe"))
             .and_then(|j| j.as_str())
         {
-            Some(jwe) => {
-                let secret = self
-                    .client()
-                    .open_sealed_secret(jwe)
-                    .await
-                    .map_err(to_mcp)?;
-                ok_json(secret)
-            }
+            Some(jwe) => client.open_sealed_secret(jwe).await.map_err(to_mcp),
             // No openable envelope (e.g. an unsupported variant) — hand back the
             // raw response so the caller can see what came back.
-            None => ok_json(response),
+            None => Ok(response),
         }
     }
 
     #[tool(
-        description = "Check this device in with the VTA (refreshes last-seen) and return any queued operations."
+        description = "Check this device in with the VTA (refreshes last-seen) and return any \
+                       queued operations.",
+        annotations(
+            title = "Device heartbeat",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn device_heartbeat(
         &self,
         Parameters(p): Parameters<DeviceHeartbeatParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let result = self
-            .client()
-            .device_heartbeat(p.platform.as_deref())
+        let call = match self
+            .begin(
+                "device_heartbeat",
+                Some(wire::DEVICE_HEARTBEAT),
+                json!({ "platform": p.platform }),
+                &peer,
+            )
             .await
-            .map_err(to_mcp)?;
-        ok_json(result)
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = match self.client() {
+            Ok(client) => client
+                .device_heartbeat(p.platform.as_deref())
+                .await
+                .map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
     }
 
     #[tool(
-        description = "List every VTA operation reachable via `vta_call` — the catalog of dispatcher-routed Trust Task URIs (contexts, keys, acl, did-management, webvh, did-templates, device, vault, seeds, audit, backup, discovery, …). Pre-login auth and attestation are excluded (handled by the bridge itself / not vta_call-able)."
+        description = "List every VTA operation reachable via `vta_call` — the catalog of \
+                       dispatcher-routed Trust Task URIs (contexts, keys, acl, did-management, \
+                       webvh, did-templates, device, vault, seeds, audit, backup, discovery, …), \
+                       each with the risk class this bridge assigns it and whether its local \
+                       policy would allow, confirm or refuse it. Pre-login auth and attestation \
+                       are excluded (handled by the bridge itself / not vta_call-able).",
+        annotations(
+            title = "List VTA operations",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
-    async fn vta_list_operations(&self) -> Result<CallToolResult, McpError> {
+    async fn vta_list_operations(
+        &self,
+        peer: Peer<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let call = match self
+            .begin("vta_list_operations", None, json!({}), &peer)
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        call.finish(Ok(self.operations_catalog()))
+    }
+
+    /// The catalog `vta_call` can reach, annotated with this bridge's own view
+    /// of each entry. Shared with the `vta://operations` resource.
+    fn operations_catalog(&self) -> Value {
         // Exactly the set `vta_call` can invoke — ALL_URIS minus the REST-routed
         // (pre-login auth + attestation) operations.
-        let mut ops = vta_sdk::trust_tasks::dispatch_routed_uris();
-        ops.sort_unstable();
-        ok_json(serde_json::json!({ "operations": ops }))
+        let mut uris = vta_sdk::trust_tasks::dispatch_routed_uris();
+        uris.sort_unstable();
+        let operations: Vec<Value> = uris
+            .into_iter()
+            .map(|uri| {
+                json!({
+                    "operation": uri,
+                    "risk": classify(uri).label(),
+                    "policy": self.guard.decide(uri).label(),
+                })
+            })
+            .collect();
+        json!({ "policy": self.guard.summary(), "operations": operations })
     }
 
     #[tool(
-        description = "Invoke ANY VTA Trust Task operation by URI with a JSON payload — the generic gateway to the full management surface (contexts, keys, acl, did-management, device, vault, seeds, audit, backup, …). Use `vta_list_operations` to discover URIs. Subject to the bridge identity's role/ACL."
+        description = "Invoke ANY VTA Trust Task operation by URI with a JSON payload — the \
+                       generic gateway to the full management surface (contexts, keys, acl, \
+                       did-management, device, vault, seeds, audit, backup, …). Use \
+                       `vta_list_operations` to discover URIs and to see which ones this bridge \
+                       will allow. Subject to the bridge identity's role/ACL at the VTA, and to \
+                       the bridge's own local policy.",
+        annotations(
+            title = "Call any VTA operation",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
     )]
     async fn vta_call(
         &self,
         Parameters(p): Parameters<VtaCallParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let payload = p.payload.unwrap_or_else(|| serde_json::json!({}));
-        let result = self
-            .client()
-            .dispatch_trust_task(&p.operation, payload, 30)
+        let payload = p.payload.unwrap_or_else(|| json!({}));
+        let call = match self
+            .begin(
+                "vta_call",
+                Some(&p.operation),
+                json!({ "operation": p.operation, "payload": payload }),
+                &peer,
+            )
             .await
-            .map_err(to_mcp)?;
-        ok_json(result)
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = match self.client() {
+            Ok(client) => client
+                .dispatch_trust_task(&p.operation, payload, 30)
+                .await
+                .map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
     }
 
     #[tool(
-        description = "Resolve any DID to its DID document via the shared resolver cache (independent of the VTA's own identity)."
+        description = "Resolve any DID to its DID document via the shared resolver cache \
+                       (independent of the VTA's own identity).",
+        annotations(
+            title = "Resolve a DID",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn resolve_did(
         &self,
         Parameters(p): Parameters<ResolveDidParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let doc = self.client().resolve_did(&p.did).await.map_err(to_mcp)?;
-        ok_json(doc)
+        let call = match self
+            .begin("resolve_did", None, json!({ "did": p.did }), &peer)
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let result = match self.client() {
+            Ok(client) => client
+                .resolve_did(&p.did)
+                .await
+                .map(|d| json!(d))
+                .map_err(to_mcp),
+            Err(e) => Err(e),
+        };
+        call.finish(result)
     }
 
     #[tool(
-        description = "Issue a holder-bound Verifiable Presentation (OID4VP vp_token) for a verifier's presentation_definition from the supplied held credentials, signed with this agent's holder key. Requires the bridge to be configured with a holder identity."
+        description = "Issue a holder-bound Verifiable Presentation (OID4VP vp_token) for a \
+                       verifier's presentation_definition from the supplied held credentials, \
+                       signed with this agent's holder key. Requires the bridge to be configured \
+                       with a holder identity.",
+        annotations(
+            title = "Issue a Verifiable Presentation",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
     )]
     async fn issue_vp(
         &self,
         Parameters(p): Parameters<IssueVpParams>,
+        peer: Peer<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let holder = self.holder.as_ref().ok_or_else(|| {
-            McpError::invalid_request(
-                "issue_vp is unavailable: no holder identity configured \
-                 (set VTA_MCP_HOLDER_DID + VTA_MCP_HOLDER_KEY)",
-                None,
+        // Not a Trust Task — it never reaches the VTA — but it signs with a key
+        // this process holds, so it is classified and gated as `keys/sign`
+        // would be. A bridge running `--read-only` must not be a signing
+        // oracle by another name.
+        let call = match self
+            .begin(
+                "issue_vp",
+                Some(wire::KEYS_SIGN),
+                json!({ "audience": p.audience, "nonce": p.nonce }),
+                &peer,
             )
-        })?;
-        let held: Vec<vta_sdk::vp::HeldCredential> = serde_json::from_value(p.held_credentials)
-            .map_err(|e| McpError::invalid_params(format!("held_credentials: {e}"), None))?;
-        let vp_token = vta_sdk::vp::issue_vp_token(
+            .await
+        {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let Some(holder) = self.holder.clone() else {
+            return call.refuse(
+                "error",
+                "issue_vp is unavailable: no holder identity configured (set VTA_MCP_HOLDER_DID + \
+                 VTA_MCP_HOLDER_KEY)"
+                    .to_string(),
+            );
+        };
+        let held: Vec<vta_sdk::vp::HeldCredential> =
+            match serde_json::from_value(p.held_credentials) {
+                Ok(held) => held,
+                Err(e) => return call.refuse("error", format!("held_credentials: {e}")),
+            };
+        let result = vta_sdk::vp::issue_vp_token(
             &holder.did,
             &holder.vm_fragment,
             &holder.key_multibase,
@@ -378,8 +991,68 @@ impl VtaMcp {
             &p.audience,
         )
         .await
-        .map_err(|e| McpError::internal_error(format!("issue_vp: {e}"), None))?;
-        ok_json(vp_token)
+        .map(|token| json!(token))
+        .map_err(|e| McpError::internal_error(format!("issue_vp: {e}"), None));
+        call.finish(result)
+    }
+
+    #[tool(
+        description = "Report what this bridge is: which identity it authenticated as, which \
+                       transports it is using, its local operation policy, how many calls it has \
+                       served, and the most recent ones. Ask this first when a VTA tool fails or \
+                       behaves unexpectedly.",
+        annotations(
+            title = "Bridge status",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn vta_status(
+        &self,
+        Parameters(p): Parameters<StatusParams>,
+        peer: Peer<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let call = match self.begin("vta_status", None, json!({}), &peer).await {
+            Ok(call) => call,
+            Err(refused) => return *refused,
+        };
+        let limit = p.recent_calls.unwrap_or(10).min(100);
+        call.finish(Ok(self.status(limit)))
+    }
+
+    /// The status document, shared by the tool and the `vta://status` resource.
+    fn status(&self, recent: usize) -> Value {
+        let transports = match self.agent.as_ref().map(|a| a.client()) {
+            Some(client) => json!({
+                "trustTasks": client.trust_task_transport().to_string(),
+                "protocolMessages": client.protocol_message_transport().to_string(),
+            }),
+            None => Value::Null,
+        };
+        json!({
+            "connected": self.agent.is_some(),
+            "connectError": self.connect_error.as_deref(),
+            "startedAt": &*self.started,
+            "version": env!("CARGO_PKG_VERSION"),
+            "identity": self.identity.to_json(),
+            "transports": transports,
+            "policy": {
+                "summary": self.guard.summary(),
+                "readOnly": self.guard.read_only,
+                "confirm": self.guard.confirm.label(),
+                "allow": self.guard.allow,
+                "deny": self.guard.deny,
+            },
+            "holderIdentity": self.holder.as_ref().map(|h| json!({
+                "did": h.did,
+                "verificationMethod": format!("{}#{}", h.did, h.vm_fragment),
+            })),
+            "calls": self.recorder.counters().snapshot(),
+            "auditLog": self.recorder.audit_path().map(|p| p.display().to_string()),
+            "recentCalls": self.recorder.recent(recent),
+        })
     }
 }
 
@@ -392,24 +1065,103 @@ impl ServerHandler for VtaMcp {
         server_info.name = "vta-mcp".to_string();
         server_info.version = env!("CARGO_PKG_VERSION").to_string();
 
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(server_info)
-            .with_instructions(
-                "Bridges a Verifiable Trust Agent (VTA) to MCP. Convenience tools: \
-                 vta_supported_tasks, list_keys, sign (signing oracle), vault_list, vault_get, \
-                 vault_release (DIDComm only), device_heartbeat, resolve_did, issue_vp. \
-                 For the FULL management surface (contexts, keys, acl, did-management, webvh, \
-                 did-templates, device, vault, seeds, audit, backup, …) use vta_list_operations \
-                 to discover operation URIs and vta_call to invoke any of them. All access is \
-                 bounded by the bridge identity's VTA role/ACL; secrets never leave the VTA \
-                 except via vault_release / issue_vp to this client.",
-            )
+        // Tools and resources only. The MCP `logging` capability would put
+        // these lines in the host's UI, but it is deprecated by SEP-2577 and
+        // slated for removal — the runtime log goes to stderr (which hosts
+        // capture) and the call record is readable as `vta://calls/recent`.
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+        )
+        .with_server_info(server_info)
+        .with_instructions(
+            "Bridges a Verifiable Trust Agent (VTA) to MCP. Convenience tools: \
+             vta_supported_tasks, list_keys, sign (signing oracle), vault_list, vault_get, \
+             vault_release (DIDComm only), device_heartbeat, resolve_did, issue_vp. For the FULL \
+             management surface (contexts, keys, acl, did-management, webvh, did-templates, \
+             device, vault, seeds, audit, backup, …) use vta_list_operations to discover operation \
+             URIs and vta_call to invoke any of them. Call vta_status when anything fails — it \
+             reports the bridge's identity, transports, local policy and recent calls. \
+             All access is bounded by the bridge identity's VTA role/ACL, and additionally by this \
+             bridge's local policy: some operations are refused outright and some ask the operator \
+             to approve them first. Secrets never leave the VTA except via vault_release / \
+             issue_vp to this client, and vault_release puts cleartext in the conversation.",
+        )
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        Ok(ListResourcesResult::with_all_items(vec![
+            Resource::new(RESOURCE_STATUS, "VTA bridge status")
+                .with_description(
+                    "Identity, transports, local policy, call counters and recent calls.",
+                )
+                .with_mime_type("application/json"),
+            Resource::new(RESOURCE_OPERATIONS, "VTA operation catalog")
+                .with_description(
+                    "Every Trust Task URI vta_call can reach, with its risk class and this \
+                     bridge's policy decision.",
+                )
+                .with_mime_type("application/json"),
+            Resource::new(RESOURCE_RECENT, "Recent VTA calls")
+                .with_description(
+                    "The last 100 calls this bridge served, redacted — what it has been doing.",
+                )
+                .with_mime_type("application/json"),
+        ]))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResponse, McpError> {
+        let body = match request.uri.as_str() {
+            RESOURCE_STATUS => self.status(10),
+            RESOURCE_OPERATIONS => self.operations_catalog(),
+            RESOURCE_RECENT => json!({ "calls": self.recorder.recent(100) }),
+            other => {
+                return Err(McpError::resource_not_found(
+                    format!("unknown resource '{other}'"),
+                    None,
+                ));
+            }
+        };
+        let text = serde_json::to_string_pretty(&body)
+            .map_err(|e| McpError::internal_error(format!("serialising resource: {e}"), None))?;
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(text, request.uri)]).into())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::VtaMcp;
+    use super::*;
+    use crate::guard::ConfirmLevel;
+
+    fn bridge() -> VtaMcp {
+        VtaMcp::degraded(
+            "not connected in tests".into(),
+            None,
+            BridgeIdentity {
+                mode: "did:key-didcomm".into(),
+                agent_did: Some("did:key:zAgent".into()),
+                vta_did: Some("did:webvh:example.com:vta".into()),
+                mediator_did: Some("did:key:zMed".into()),
+                dedicated_agent: true,
+            },
+            Guard {
+                read_only: true,
+                confirm: ConfirmLevel::Destructive,
+                ..Guard::default()
+            },
+            Arc::new(Recorder::default()),
+        )
+    }
 
     /// The generated tool router must expose exactly the bridge's tool set —
     /// guards against a tool being dropped or renamed without notice.
@@ -428,6 +1180,7 @@ mod tests {
             "vta_call",
             "resolve_did",
             "issue_vp",
+            "vta_status",
         ];
         let have: Vec<String> = router
             .list_all()
@@ -438,5 +1191,134 @@ mod tests {
             assert!(router.has_route(name), "missing tool {name}; have {have:?}");
         }
         assert_eq!(have.len(), expected.len(), "unexpected tool set: {have:?}");
+    }
+
+    /// The Trust Task URI each tool routes through, or `None` for the two that
+    /// never leave the process. A second copy of what the tool bodies pass to
+    /// `begin` — deliberately, so that changing one without the other is caught
+    /// here rather than in production.
+    const TOOL_OPERATIONS: &[(&str, Option<&str>)] = &[
+        ("vta_supported_tasks", Some(wire::DISCOVERY)),
+        ("list_keys", Some(wire::KEYS_LIST)),
+        ("sign", Some(wire::KEYS_SIGN)),
+        ("vault_list", Some(wire::VAULT_LIST)),
+        ("vault_get", Some(wire::VAULT_GET)),
+        ("vault_release", Some(wire::VAULT_RELEASE)),
+        ("device_heartbeat", Some(wire::DEVICE_HEARTBEAT)),
+        ("vta_list_operations", None),
+        ("vta_call", None), // classified per call, from the URI the caller names
+        ("resolve_did", None),
+        ("issue_vp", Some(wire::KEYS_SIGN)),
+        ("vta_status", None),
+    ];
+
+    /// Hosts render `readOnlyHint` and some gate on it, so a mutating tool
+    /// claiming to be read-only is a security bug, not a cosmetic one. Each
+    /// annotation is checked against the *classifier's* verdict on the URI the
+    /// tool actually calls, so the two cannot drift apart.
+    #[test]
+    fn tool_annotations_agree_with_the_risk_classifier() {
+        for tool in VtaMcp::tool_router().list_all() {
+            let annotations = tool
+                .annotations
+                .as_ref()
+                .unwrap_or_else(|| panic!("tool {} has no annotations", tool.name));
+            assert!(
+                annotations.title.is_some(),
+                "tool {} has no annotation title",
+                tool.name
+            );
+            let (_, operation) = TOOL_OPERATIONS
+                .iter()
+                .find(|(name, _)| *name == &*tool.name)
+                .unwrap_or_else(|| panic!("tool {} missing from TOOL_OPERATIONS", tool.name));
+            let claims_read_only = annotations.read_only_hint.unwrap_or(false);
+            match operation {
+                Some(uri) => {
+                    let risk = classify(uri);
+                    let (read_only, destructive) = risk.hints();
+                    assert_eq!(
+                        claims_read_only, read_only,
+                        "tool {} claims readOnlyHint={claims_read_only} but {uri} classifies as \
+                         {risk}",
+                        tool.name
+                    );
+                    assert_eq!(
+                        annotations.destructive_hint.unwrap_or(true),
+                        destructive,
+                        "tool {} destructiveHint disagrees with {uri} being {risk}",
+                        tool.name
+                    );
+                }
+                // The local-only tools: two reads and the generic gateway,
+                // which is annotated destructive because it can be.
+                None => assert_eq!(
+                    claims_read_only,
+                    tool.name != "vta_call",
+                    "tool {} readOnlyHint is wrong for a local-only tool",
+                    tool.name
+                ),
+            }
+        }
+    }
+
+    /// Every tool that reaches the VTA must declare the URI it wraps, or the
+    /// local policy is unenforceable on it. The two local-only tools are the
+    /// documented exceptions.
+    #[test]
+    fn the_convenience_tools_are_gated_under_a_real_uri() {
+        let bridge = bridge();
+        // `sign` is Sensitive, so a --read-only bridge refuses it even though
+        // the operator never typed `keys/sign`.
+        assert!(matches!(
+            bridge.guard.decide(wire::KEYS_SIGN),
+            Decision::Deny(_)
+        ));
+        assert!(matches!(
+            bridge.guard.decide(wire::VAULT_RELEASE),
+            Decision::Deny(_)
+        ));
+        // Reads still pass.
+        assert_eq!(bridge.guard.decide(wire::KEYS_LIST), Decision::Allow);
+    }
+
+    #[test]
+    fn status_reports_the_degraded_state_rather_than_hiding_it() {
+        let bridge = bridge();
+        let status = bridge.status(10);
+        assert_eq!(status["connected"], json!(false));
+        assert_eq!(status["connectError"], json!("not connected in tests"));
+        assert_eq!(status["identity"]["dedicatedAgent"], json!(true));
+        assert_eq!(status["policy"]["readOnly"], json!(true));
+        assert_eq!(status["transports"], Value::Null);
+    }
+
+    #[test]
+    fn a_degraded_bridge_explains_itself_instead_of_panicking() {
+        let bridge = bridge();
+        // `VtaClient` is not `Debug`, so `unwrap_err` is unavailable.
+        let Err(err) = bridge.client() else {
+            panic!("a degraded bridge must not hand out a client");
+        };
+        assert!(err.message.contains("not connected in tests"), "{err:?}");
+        assert!(err.message.contains("vta_status"), "{err:?}");
+    }
+
+    #[test]
+    fn the_operations_catalog_carries_risk_and_policy() {
+        let bridge = bridge();
+        let catalog = bridge.operations_catalog();
+        let ops = catalog["operations"].as_array().unwrap();
+        assert!(!ops.is_empty());
+        for op in ops {
+            assert!(op["risk"].is_string(), "{op}");
+            assert!(op["policy"].is_string(), "{op}");
+        }
+        // A --read-only bridge must say so in the catalog, not only at call
+        // time — the model reads this to decide what to attempt.
+        assert!(
+            ops.iter()
+                .any(|o| o["policy"] == json!("deny") && o["risk"] == json!("destructive"))
+        );
     }
 }


### PR DESCRIPTION
An MCP host approves a *tool*, not a *call*. The moment an operator answers
"always allow" to `vta_call` — the tool that reaches the entire VTA management
surface — `contexts/delete/1.0` rides the same approval as `contexts/list/1.0`,
because the host sees one tool name and cannot tell them apart. And until now
the bridge said nothing at all about what it did with that approval: it
installed `EnvFilter::from_default_env()` with no fallback, so an operator who
had not set `RUST_LOG` got silence — no startup line, no call log, no error.

Three things, plus the documentation that was missing.

## A local per-operation guard (`guard.rs`)

Every Trust Task URI classifies as read-only, mutating, sensitive or
destructive; `--read-only`, `--allow`/`--deny` slug globs and
`--confirm {never,destructive,sensitive,always}` decide from that. Confirmation
uses MCP elicitation, so the risky tail goes back in front of a human.

- An unknown verb classifies as **mutating, never read-only** — the catalog
  grows outside this crate, and a census test over `dispatch_routed_uris()`
  fails the build when a new verb appears rather than letting "unknown" become
  the common case.
- The convenience tools are gated under the URI they actually send, so
  `--read-only` cannot be walked around by calling `sign` instead of `vta_call`;
  `issue_vp` is gated as `keys/sign` even though it never reaches the VTA.
- If the host cannot show a prompt the call is **refused**, not waved through —
  a confirmation gate that fails open is not a gate.
- Policy parse errors are fatal; degrading there would run the bridge under a
  policy nobody asked for. Connectivity failures degrade instead (below).

This is a second gate *in front of* the VTA, never a substitute for it. The
VTA's role/ACL/context scope and the approvals-DTTE policy remain the authority,
and none of it is reimplemented here.

## Observability (`observability.rs`)

- stderr logging on by default at `info` — one line at call start, one at finish
  with outcome and duration. `--log-level`, `--log-format json`; `RUST_LOG`
  still wins when set.
- `--audit-log <path>`: an owner-only (0600) JSONL record that outlives the
  process.
- The last 100 calls are kept in memory regardless, because by the time you want
  to know what the bridge has been doing you will not have passed the flag.
- Both paths redact on the rule that **strings are guilty until named
  innocent**, so signing input, mnemonics, private keys and JWEs are elided
  without this crate knowing those field names exist.

## Failures that can be seen

A bridge that cannot connect now serves MCP anyway and reports the reason from
every tool — a server that exits before speaking the protocol appears in the
host as *no tools at all*, and then nothing can explain why. `vta_status` and
three resources (`vta://status`, `vta://operations`, `vta://calls/recent`)
answer from inside the session.

`--enroll` is refused in session mode, where the device binding would attach to
the *operator's* ACL entry. A failed enrolment refuses to serve rather than
quietly dropping the kill switch the operator asked for, and shuts the DIDComm
session down on the way out so it does not leave a duelling mediator socket.

## MCP surface

`rmcp` 3.1.4 is current and was already in use, but only the `tools` capability
was. Now: tools with full annotations (`readOnlyHint`/`destructiveHint`/…,
tested against the classifier's verdict on the URI each tool calls, so the two
cannot drift), resources, and elicitation.

Deliberately **not** adopted, each for a reason:

- `logging` — deprecated by SEP-2577 and slated for removal; building the
  observability story on it would mean rebuilding it. stderr is where hosts
  already look.
- `completions` — `Reference` has only `ref/prompt` and `ref/resource`, so a
  tool argument such as `vta_call`'s `operation` is not completable.
- sampling / roots — also SEP-2577-deprecated. tasks (SEP-2663) — nothing here
  is long-running enough to need it.

## Docs

- `docs/02-vta/vta-mcp.md` — what it exposes, the security model, hardening
  flags, the observability story, host configuration, troubleshooting, and an
  honest section on what the bridge does *not* protect you from.
- `docs/02-vta/examples/agent-memory-with-vta-mcp.md` — a worked example running
  it alongside `vta-agent-memory` on two identities in two contexts, including
  why you would still run the memory server when `vta_call` can reach
  `vta/memory/*`.
- The README's stale `vta_capabilities` tool (retired in #1043) and "two auth
  modes" (there are four) are corrected.
- One drive-by fix: `pnm audit --actor` → `pnm audit list --actor` in
  `personal-ai-agents.md`; `audit` takes a subcommand.

## Two judgment calls worth a reviewer's opinion

1. `--confirm` defaults to `destructive`, not `sensitive`, so `sign` does not
   prompt on every call — the host already prompts once per tool, and the local
   gate earns its keep where a tool-level approval is too coarse. Bridges
   holding an operator session should raise it.
2. `--enroll` in session mode is now a hard error rather than the warning the
   docs previously carried.

## Test plan

- `cargo test -p vta-mcp` — 36 tests, including the URI-verb census, the
  annotation/classifier agreement check, redaction (secrets elided without being
  named), audit-file permissions, and the guard's precedence rules.
- `cargo clippy -p vta-mcp --all-targets` clean; `cargo fmt --all -- --check`
  clean; `cargo check --workspace --all-targets` clean.
- Driven over real stdio JSON-RPC with a scripted client: tool/resource listing,
  `vta_status` in degraded mode, a `--read-only` denial, and the elicitation
  path for all three outcomes (approve proceeds, `approve:false` declines,
  `action:"decline"` declines) plus the no-elicitation-support refusal.
- `--audit-log` verified to land 0600 with redacted records.

Not exercised against a live VTA — every VTA-side path here is unchanged; what
is new sits in front of the client.
