### PR TITLE
chore(vtc): install/claim 0.2, and a drift note that blamed the wrong side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a0af73c76b6b2bac3f941daf0649eb4dfedaab99a1195675fd65a525a80a7b"
+checksum = "f96229d3db0943b7fd704dfadb3363ac2586baf5ee4e9339cf0c6d8d87730949"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.10", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.11", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/vtc-service/admin-ui/src/pages/Install.tsx
+++ b/vtc-service/admin-ui/src/pages/Install.tsx
@@ -21,9 +21,9 @@ import {
 } from "@/lib/webauthn";
 
 const TRUST_TASK_START =
-  "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
+  "https://trusttasks.org/spec/vtc/install/claim/start/0.2";
 const TRUST_TASK_FINISH =
-  "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
+  "https://trusttasks.org/spec/vtc/install/claim/finish/0.2";
 const TRUST_TASK_BOOTSTRAP =
   "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
 

--- a/vtc-service/src/routes/install.rs
+++ b/vtc-service/src/routes/install.rs
@@ -4,8 +4,8 @@
 //! Implements **M0.5.2** of the VTC MVP Phase 0 plan. The flow:
 //!
 //! ```text
-//! operator  ──install_token──▶  start  ──ccr+did_binding_challenge──▶ operator
-//! operator  ──finish(webauthn_response, did_binding_signature)──▶  finish
+//! operator  ──install_token──▶  start  ──registration_id + ccr──▶ operator
+//! operator  ──finish(webauthn_response)──▶  finish
 //! finish    ──admin_did + setup_session_token──▶  operator
 //! ```
 //!
@@ -27,6 +27,18 @@
 //! binding signature). The previous design required a raw Ed25519
 //! signature over a server challenge, which is impossible to produce
 //! in a real browser (WebAuthn never exposes the private key).
+//!
+//! That reasoning lived only here until 2026-08. The published task
+//! kept requiring the binding for two months after it was removed, and
+//! the conformance sweep then read the gap as this service being behind
+//! the spec on a security control — the opposite of what happened.
+//! `install/claim/{start,finish}/0.2`
+//! (trustoverip/dtgwg-trust-tasks-tf#263) drops it and carries the
+//! argument in the specification itself. Claiming admin under a DID the
+//! operator *already* controls is a separate, genuinely non-redundant
+//! proof — ownership of a verification method in that DID's **active**
+//! document, resolved live and signed outside the WebAuthn ceremony —
+//! and is named there as a future version rather than approximated.
 //!
 //! Per-row state machine is the only gate on claim. A second
 //! `start` on the same token after a successful `finish` returns

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -1023,11 +1023,11 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(tt(
             routes!(install::claim_start),
-            "https://trusttasks.org/spec/vtc/install/claim/start/0.1",
+            "https://trusttasks.org/spec/vtc/install/claim/start/0.2",
         ))
         .routes(tt(
             routes!(install::claim_finish),
-            "https://trusttasks.org/spec/vtc/install/claim/finish/0.1",
+            "https://trusttasks.org/spec/vtc/install/claim/finish/0.2",
         ))
         .routes(tt(
             routes!(recognise::recognise_challenge),

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -511,19 +511,28 @@ fn uuid() -> uuid::Uuid {
 /// not grow unnoticed — the same discipline `UNPUBLISHED_CANONICAL_OK` in
 /// `tests/trust_task_manifest.rs` applies to unpublished URIs.
 ///
-/// **4 of 58**, from 33 when the sweep landed. What is left is no longer a
-/// backlog of shapes to correct — it is four decisions, and three of them are
-/// not this service's to make alone:
+/// **2 of 58**, from 33 when the sweep landed. What is left is not a backlog
+/// of shapes to correct — it is two decisions, and neither is this service's
+/// to make alone:
 ///
-/// 1. **`install/claim/start` + `install/claim/finish`** — the schemas
-///    REQUIRE a `didBindingChallenge` / `didBindingSignature` pair that binds
-///    the candidate `did:key` by proof of possession. This service checks the
-///    passkey attestation alone and issues no challenge. **This is the only
-///    entry where the service is behind the spec on a security control**, and
-///    the fix is here, not upstream. It was deliberately left out of
-///    trustoverip/dtgwg-trust-tasks-tf#262 rather than deleting a required
-///    member so that we would conform — which is the direction that would
-///    have made the ledger green and the system weaker.
+/// 1. ~~**`install/claim/start` + `install/claim/finish`**~~ — **closed.**
+///    Worth recording how, because the ledger got this one backwards for a
+///    day. The schemas REQUIRED a `didBindingChallenge` /
+///    `didBindingSignature` pair, this service sent neither, and the entry
+///    was written up — by me — as "the only place the service is behind the
+///    spec on a security control". It was the reverse. The binding was built
+///    in 2026-05, found *test-passable but impossible in a production
+///    browser* (WebAuthn never exposes the credential private key), and
+///    removed. The specification was written two months **later**, still
+///    requiring it, and nothing ever sent or read those members in any
+///    repository. `0.2` (trustoverip/dtgwg-trust-tasks-tf#263) drops them.
+///
+///    The lesson is not "the spec was wrong". It is that *"the schema
+///    requires X and the service omits X"* is a true sentence that says
+///    nothing about which side is at fault, and reads as an accusation
+///    against the implementation. Check the history of both before writing
+///    the note.
+///
 /// 2. **`auth/recognise`** — the payload is two loose credentials; this
 ///    service takes one holder-signed VP that embeds both and binds a nonce
 ///    and this community's DID as `domain`. The VP carries a holder-binding
@@ -556,7 +565,7 @@ fn uuid() -> uuid::Uuid {
 /// `table()` printing the actual parse or schema error for every
 /// `KnownDrift`. `invalid type: string, expected struct IssuedCredential` is
 /// a sentence no amount of re-reading prose will produce.
-const KNOWN_DRIFT_COUNT: usize = 4;
+const KNOWN_DRIFT_COUNT: usize = 2;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -903,30 +912,18 @@ fn table() -> Vec<Conformance> {
             .expect("RevokeResponse serialises")
         ),
         // ─── install ─────────────────────────────────────────────────
-        drift!(
-            s::install::claim::start::v0_1::Payload,
-            s::install::claim::start::v0_1::Response,
-            Side::Response,
+        checked!(
+            s::install::claim::start::v0_2::Payload,
+            s::install::claim::start::v0_2::Response,
             // `ClaimStartRequest` — routes/install.rs:65. No `rename_all`.
             json!({ "installToken": "eyJhbGciOiJFZERTQSJ9.e30.sig",
                     "claimSecret": "K7QW-3M2X-9PLD" }),
             // `ClaimStartResponse` — routes/install.rs:81.
-            json!({ "registrationId": REQUEST_ID, "options": { "publicKey": {} } }),
-            "the request conforms as of trust-tasks-rs 0.11.10, which \
-             carries `claimSecret` from \
-             trustoverip/dtgwg-trust-tasks-tf#262. The response still omits \
-             `didBindingChallenge`, which the schema REQUIRES — and that \
-             half is this service being **behind** a security control, not \
-             the spec being wrong. The task binds the candidate `did:key` by \
-             having it sign a challenge; this service checks the passkey \
-             attestation alone and never issues one. #262 deliberately left \
-             it alone rather than deleting a required member so we could \
-             conform: the fix belongs here"
+            json!({ "registrationId": REQUEST_ID, "options": { "publicKey": {} } })
         ),
-        drift!(
-            s::install::claim::finish::v0_1::Payload,
-            s::install::claim::finish::v0_1::Response,
-            Side::Request,
+        checked!(
+            s::install::claim::finish::v0_2::Payload,
+            s::install::claim::finish::v0_2::Response,
             // `ClaimFinishRequest` — routes/install.rs:93. No `rename_all`.
             json!({
                 "installToken": "eyJhbGciOiJFZERTQSJ9.e30.sig",
@@ -934,15 +931,7 @@ fn table() -> Vec<Conformance> {
                 "webauthnResponse": { "id": "AX6nVQ8s", "type": "public-key" },
             }),
             // `ClaimFinishResponse` — routes/install.rs:103.
-            json!({ "adminDid": OTHER_DID, "setupSessionToken": "eyJhbGciOiJFZERTQSJ9.e30.sig" }),
-            "the spec's fourth required \
-             member `didBindingSignature` is absent — the passkey attestation \
-             is the only binding this service checks. Same reconciliation as \
-             `claim/start`: the casing half is fixed, the missing signature \
-             is a design question. The response's `setupSessionToken` now \
-             feeds an `admin/bootstrap` that accepts that same name — until \
-             both were fixed, the service issued one spelling and demanded \
-             the other, and only the SPA's hand re-keying bridged it"
+            json!({ "adminDid": OTHER_DID, "setupSessionToken": "eyJhbGciOiJFZERTQSJ9.e30.sig" })
         ),
         // ─── invitations ─────────────────────────────────────────────
         checked!(

--- a/vtc-service/tests/admin_bootstrap.rs
+++ b/vtc-service/tests/admin_bootstrap.rs
@@ -34,8 +34,8 @@ use vtc_service::test_support::TestVtc;
 use common::webauthn_harness::SoftEd25519Authenticator;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
-const FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
+const START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.2";
+const FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.2";
 const BOOTSTRAP_TASK: &str = "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
 
 struct Fixture {

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -59,7 +59,7 @@ use vtc_service::server::AppState;
 use vtc_service::setup::VtcKeyBundle;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
+const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.2";
 
 fn init_jwt_provider() {
     use std::sync::Once;

--- a/vtc-service/tests/install_claim.rs
+++ b/vtc-service/tests/install_claim.rs
@@ -24,8 +24,8 @@ use vtc_service::test_support::TestVtc;
 use common::webauthn_harness::SoftEd25519Authenticator;
 
 const RP_ORIGIN: &str = "https://vtc.example.com";
-const START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
-const FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
+const START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.2";
+const FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.2";
 
 struct Fixture {
     router: axum::Router,

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -42,8 +42,8 @@ use common::webauthn_harness::SoftEd25519Authenticator;
 const RP_ORIGIN: &str = "https://vtc.example.com";
 
 // Trust Tasks ------------------------------------------------------
-const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.1";
-const CLAIM_FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.1";
+const CLAIM_START_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/start/0.2";
+const CLAIM_FINISH_TASK: &str = "https://trusttasks.org/spec/vtc/install/claim/finish/0.2";
 const BOOTSTRAP_TASK: &str = "https://trusttasks.org/spec/vtc/admin/bootstrap/0.1";
 const ENROLL_START_TASK: &str = "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2";
 const ENROLL_FINISH_TASK: &str = "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2";


### PR DESCRIPTION
Moves the install ceremony to `vtc/install/claim/{start,finish}/0.2`, which
trustoverip/dtgwg-trust-tasks-tf#263 published without the DID-binding
challenge and signature. Drift **4 → 2**.

## What this closes, and how the ledger got it backwards

Both entries were recorded — by me, yesterday — as *"the only place the
service is behind the spec on a security control"*, and I kept the requirement
out of #262 on that basis rather than deleting a required member so we could
conform.

That was the reverse of what happened:

| | |
|---|---|
| **2026-05-12** | implementation lands **with** `did_binding_signature` |
| **2026-05-15** | implementation **removes it** — *"test-passable but impossible to complete in a production browser"*, because WebAuthn never exposes the credential private key |
| **2026-07-21** | the **specification** is written, two months later, **still requiring it** |

Nothing in any repository has ever sent or read those members. Verified across
every local clone for all six spellings — `didBindingChallenge`,
`didBindingSignature`, both snake_case forms, the generated type name, and
`bindingInvalid`. Every hit was schema, generated bindings, the published
website, retired local `1.0` documents, or one stale ASCII diagram in this
service's own module doc. The only client is the admin SPA's install page,
which is a browser — the environment that cannot produce the signature at all.

**The lesson is not "the spec was wrong".** It is that *"the schema requires X
and the service omits X"* is a true sentence that says nothing about which
side is at fault, and reads as an accusation against the implementation. Both
histories needed checking before the note was written. That is now recorded in
the `KNOWN_DRIFT_COUNT` header, where the next person to read a drift note
will see it.

## Changes

- Route mounts and the admin SPA's install page retarget to `0.2` — four
  sites, no behaviour change, since the service already sent exactly what
  `0.2` describes.
- Both conformance entries promoted to `checked!`.
- Seven trust-task constants across four integration suites
  (`install_flow`, `install_claim`, `admin_bootstrap`,
  `emergency_bootstrap`) retarget to `0.2`. They failed on the first gate run
  — the header no longer matched the mount, which is the Trust-Task binding
  doing exactly its job.
- `routes/install.rs`'s module doc: the ASCII flow diagram still showed
  `did_binding_challenge` / `did_binding_signature` on the wire. Corrected,
  and the paragraph explaining the 2026-05 removal now records that the
  reasoning lived only in that comment for two months while the published
  task said otherwise.

## What is deliberately still absent

`0.2` states what the ceremony does *not* prove: the admin DID is **assigned
by** it, not **asserted by** the installer, and nothing demonstrates control
of a pre-existing identity.

Letting an operator claim admin under a DID they already hold is a genuinely
different proof — ownership of a **verification method present in that DID's
active DID document**, resolved live rather than taken from the request, and
signed outside the WebAuthn ceremony by the key that backs the DID. That
restores the distinction `0.1` was reaching for, because the passkey and the
DID key would then actually be different keys. It is named in the spec as a
future version rather than approximated here.

## The two that remain

Neither is a shape to fix; both need a `0.2` upstream because they replace
required members, and in both the service's shape looks like the stronger one:

1. **`auth/recognise`** — the payload is two loose credentials; this service
   takes one holder-signed VP embedding both, binding a nonce and this
   community's DID as `domain`. The VP carries a holder-binding proof two
   loose credentials cannot.
2. **`join-requests/submit`** — the response is `{requestId, status}` with
   `status` a `const: "pending"`; this service returns a four-valued verdict
   (allow / deny / refer / request_more) of which `pending` expresses one.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all --check`
- `npm run lint` in `admin-ui`

Refs #1059
