### PR TITLE
ci: name the semver job what it is — a report, not a gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,7 +428,16 @@ jobs:
     # this workspace (every crate is 0.x); what matters is that it is KNOWN, so
     # the release moves the compatibility field instead of shipping it as a
     # patch. release-plz enforces that automatically from the same signal.
-    name: semver checks
+    #
+    # The name says "report" because the check list is the only place most
+    # people meet this job, and there it is a bare name next to a red cross.
+    # Called "semver checks" it is indistinguishable from a gate that broke —
+    # which led to a serious proposal to delete it, on the reasoning that a
+    # check failing on every PR protects nothing. The reasoning was sound; the
+    # premise was wrong, and the premise came from the name. A job whose red is
+    # expected should say so where the red is displayed, not only in a comment
+    # nobody opens.
+    name: semver report (informational — never blocks)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
Renames the `semver checks` job to **`semver report (informational — never
blocks)`**. One line of YAML; no behaviour change.

## Why

The job is `continue-on-error: true` and has been since it was written. It
compares each published crate's public API against crates.io and **reports** —
it cannot fail a build. Every crate here is `0.x`, where breaking changes are
expected, and `release-plz.toml` sets `semver_check = true`, so the actual
enforcement happens at release time from the same signal. This job is the
early copy, so the author sees it while the change is still in hand.

All of which the job's comment already said. But the check list is where most
people meet this job, and there it was a bare name beside a red cross on every
single PR.

I proposed deleting it. The reasoning was that a check failing on every PR
protects nothing, so it trains people to ignore red — which is true of a
broken gate, and this is not one. The premise came from the name, and the
name is what the check list shows.

So the fix goes where the problem is: a job whose red is expected should say
so **where the red is displayed**, not only in a comment nobody opens.

## What did not change

- Still `continue-on-error: true`; still cannot block a merge.
- Still runs on pull requests only.
- The eleven standing items are unchanged and are not rot — they are the
  *known* breaking changes across `vti-common`, `vta-sdk` and `vta-service`,
  and reporting them is what lets release-plz move the version instead of
  shipping a break as a patch.

Baselining them to green was the alternative. It would clear the report until
the next genuine break, which is arguably when you most want to see it — but
it changes published version numbers, so it is a release decision rather than
a CI one, and worth taking separately if wanted.

## Checks

`main` is not branch-protected, so the rename does not orphan a required
status check. The only other references to `semver-checks` in the repo are to
the *tool* (`cargo-semver-checks` in `publish.yml` and the run step), which is
unchanged. Workflow YAML parses.
