### PR TITLE
chore(vtc)!: recognise and submit 0.2 — drift reaches zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96229d3db0943b7fd704dfadb3363ac2586baf5ee4e9339cf0c6d8d87730949"
+checksum = "c5fc43e5bf18f0562ab419e2ba25beaa76ac2103fde5753665d927e2770d1633"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.11", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.12", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
@@ -381,6 +381,20 @@ keyring-core = "1"
 apple-native-keyring-store = { version = "1", default-features = false, features = ["keychain"] }
 windows-native-keyring-store = "1"
 dbus-secret-service-keyring-store = { version = "1", default-features = false, features = ["crypto-rust"] }
+
+[profile.dev]
+# macOS defaults this profile to `split-debuginfo = "unpacked"`, which leaves one
+# DWARF-bearing .o file per codegen unit in target/debug/deps. Across this
+# workspace's 903-crate graph that reached 746,803 loose object files and 372G,
+# at which point cargo's own fingerprint/GC pass cost 9m26s on a NO-OP
+# `cargo check` (12% CPU — all filesystem, no compilation). The same check in a
+# clean target dir is 0.21s. Keep debuginfo cheap so it cannot rebuild to that.
+debug = "line-tables-only"
+split-debuginfo = "packed"
+
+# Dependencies are not stepped through; their debug symbols were most of the bulk.
+[profile.dev.package."*"]
+debug = false
 
 [profile.release]
 lto = "thin"

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -43,12 +43,12 @@ use uuid::Uuid;
 /// Trust Task `type` for a join-request submission (the ceremony `request`
 /// verb). Payload [`JoinRequestSubmitBody`]; response [`VerdictResponse`].
 pub const JOIN_REQUEST_SUBMIT_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/join-requests/submit/0.1";
+    "https://trusttasks.org/spec/vtc/join-requests/submit/0.2";
 
 /// `#response` variant of [`JOIN_REQUEST_SUBMIT_TYPE`] — the type of the
 /// success document `respond_with` mints; carries a [`VerdictResponse`].
 pub const JOIN_REQUEST_SUBMIT_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/join-requests/submit/0.1#response";
+    "https://trusttasks.org/spec/vtc/join-requests/submit/0.2#response";
 
 /// Reply `type` used by the **credential-exchange** join close-the-loop
 /// (`credential-exchange/present`), which results in a join and echoes this
@@ -236,8 +236,20 @@ pub const ADMIN_REJECT_CODE: &str = "admin-reject";
 /// **refused** a well-formed, verified request — it is NOT how framework
 /// errors (invalid VIC, expired, malformed) are signalled; those are
 /// `trust-task-error` documents (see the module docs).
+/// Serialises **lowerCamelCase** — `requestMore`, not `request_more` — because
+/// a verdict effect is a specification-defined decision value, which
+/// SPEC §4.10 rule 4 says is lowerCamelCase, and
+/// `vtc/_shared/0.1/ceremony#VerdictEffect` enumerates it that way.
+///
+/// The snake_case form is kept as a deserialisation alias on purpose. Rego is
+/// where verdicts are *authored* — operator-written policy returns
+/// `{"effect": "request_more", …}` — and snake_case is that language's idiom,
+/// not a mistake to correct. The two vocabularies are allowed to differ; this
+/// type is the boundary where the policy's spelling becomes the wire's, the
+/// same split `EndorsementRow` and `GenerationRow` draw between storage and
+/// wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum VerdictEffect {
     /// Admitted. `with` carries the granted role + obligations and the
@@ -250,6 +262,7 @@ pub enum VerdictEffect {
     Refer,
     /// More evidence required. `with` carries `needs` +
     /// `presentationDefinition`; the applicant continues over `present`.
+    #[serde(alias = "request_more")]
     RequestMore,
 }
 

--- a/vta-sdk/src/trust_task_sign.rs
+++ b/vta-sdk/src/trust_task_sign.rs
@@ -171,7 +171,7 @@ mod tests {
         (did, multibase::encode(multibase::Base::Base58Btc, &buf))
     }
 
-    const TYPE: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.1";
+    const TYPE: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.2";
 
     /// The signed document verifies under the same `did:key` resolver both
     /// services use, and carries issuer + recipient.

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -1035,7 +1035,7 @@ fn build_unauth_routes(trust_xff: bool) -> OpenApiRouter<AppState> {
         ))
         .routes(tt(
             routes!(recognise::recognise),
-            "https://trusttasks.org/spec/vtc/auth/recognise/0.1",
+            "https://trusttasks.org/spec/vtc/auth/recognise/0.2",
         ))
         // Publishing a relationship edge authenticates by the Trust Task
         // document's own proof rather than a bearer token (#1084), so it

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -230,6 +230,13 @@ struct Witness {
 /// Named per side rather than "something fails" so a debt entry cannot pass
 /// on the wrong evidence — the failure mode the VTA's module docs record for
 /// `acl/update`, where an assertion held for an unrelated reason.
+/// Unconstructed while the drift table is empty. Kept, with the macro below,
+/// because they are the vocabulary for *recording* a divergence — and a table
+/// with no way to say "this diverges, on this side, for this reason" invites
+/// the next author to leave a real divergence unrecorded rather than write the
+/// machinery back. Deleting them would make the zero look permanent instead of
+/// current.
+#[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Side {
     Request,
@@ -260,6 +267,7 @@ enum Conformance {
     /// silently tolerated. Every entry names the drift precisely enough that
     /// the fix needs no re-diagnosis, and carries real fixtures so the sweep
     /// can assert the drift is still there.
+    #[allow(dead_code)]
     KnownDrift {
         reason: &'static str,
         side: Side,
@@ -295,6 +303,7 @@ macro_rules! checked {
 
 /// An annotated divergence. Same fixtures as [`checked!`], plus the side that
 /// is expected to fail and why.
+#[allow(unused_macros)]
 macro_rules! drift {
     ($p:ty, $r:ty, $side:expr, $req:expr, $resp:expr, $reason:expr) => {
         Conformance::KnownDrift {
@@ -511,61 +520,51 @@ fn uuid() -> uuid::Uuid {
 /// not grow unnoticed — the same discipline `UNPUBLISHED_CANONICAL_OK` in
 /// `tests/trust_task_manifest.rs` applies to unpublished URIs.
 ///
-/// **2 of 58**, from 33 when the sweep landed. What is left is not a backlog
-/// of shapes to correct — it is two decisions, and neither is this service's
-/// to make alone:
+/// **0 of 58.** Every Trust Task this service binds now speaks the schema it
+/// publishes, on both sides.
 ///
-/// 1. ~~**`install/claim/start` + `install/claim/finish`**~~ — **closed.**
-///    Worth recording how, because the ledger got this one backwards for a
-///    day. The schemas REQUIRED a `didBindingChallenge` /
-///    `didBindingSignature` pair, this service sent neither, and the entry
-///    was written up — by me — as "the only place the service is behind the
-///    spec on a security control". It was the reverse. The binding was built
-///    in 2026-05, found *test-passable but impossible in a production
-///    browser* (WebAuthn never exposes the credential private key), and
-///    removed. The specification was written two months **later**, still
-///    requiring it, and nothing ever sent or read those members in any
-///    repository. `0.2` (trustoverip/dtgwg-trust-tasks-tf#263) drops them.
+/// It was 33 when the sweep landed on 2026-08-24. Keeping the constant at zero
+/// is the point: it can no longer shrink, so the only thing it can do is catch
+/// a regression, which is what an asserted count is for. A new task that
+/// diverges must add a `drift!` entry and raise this deliberately.
 ///
-///    The lesson is not "the spec was wrong". It is that *"the schema
-///    requires X and the service omits X"* is a true sentence that says
-///    nothing about which side is at fault, and reads as an accusation
-///    against the implementation. Check the history of both before writing
-///    the note.
+/// **How the 33 actually closed**, because the distribution is not what the
+/// sweep predicted:
 ///
-/// 2. **`auth/recognise`** — the payload is two loose credentials; this
-///    service takes one holder-signed VP that embeds both and binds a nonce
-///    and this community's DID as `domain`. The VP carries a holder-binding
-///    proof two loose credentials cannot, so the service's shape is arguably
-///    the stronger one. Changing it upstream replaces a required member, so
-///    it needs a `0.2`, not an in-place edit.
-/// 3. **`join-requests/submit`** — the response is `{requestId, status}` with
-///    `status` a `const: "pending"`; this service returns a four-valued
-///    verdict (allow / deny / refer / request_more) that `pending` can
-///    express one of. Also a replacement, so also a `0.2`.
+/// - **10** by correcting this service's wire shapes — missing envelopes,
+///   wrong member names, a `null` where the schema said `object`.
+/// - **19** on dependency bumps alone, because the specs had already moved and
+///   these notes had not.
+/// - **4** by correcting the *specification*, not the service, once it turned
+///   out the published shape was the weaker one: a binding no browser can
+///   produce, a payload that was a replayable impersonation token, and a
+///   `const` that could express one of four outcomes.
 ///
-/// The three shapes the sweep started with are gone: no route returns a bare
-/// row where its schema wraps one, none sends a wrong member name or type,
-/// and the unspecced members are published (#261, #262).
+/// That last group is the one worth remembering. A conformance table makes
+/// divergence visible but says nothing about which side is wrong, and the
+/// sentence *"the schema requires X and the service omits X"* reads as an
+/// accusation against the implementation. Twice it was the schema. Once —
+/// `install/claim` — the requirement had been built, found impossible in a
+/// browser, and removed two months **before** the specification demanding it
+/// was written, and this table recorded that as the service being behind on a
+/// security control.
 ///
-/// **Two lessons the count itself cannot carry, both learned the hard way.**
+/// **Two failure modes to expect if you extend this table.**
 ///
-/// **Read the pin before believing a note.** Nine entries closed on the
-/// 0.11.2 → 0.11.8 bump alone and ten more on 0.11.10, because the specs had
-/// moved and these notes had not. This table catches the service drifting
+/// *Read the pin before believing a note.* This catches the service drifting
 /// from the spec and is blind to the spec moving toward the service.
 ///
-/// **A hand-written fixture can understate as well as overstate.** #1097
-/// promoted `config/export` and `config/import` on a `community_profile()`
-/// that omitted `personhood` — a false green, the one direction this table
-/// must never fail in. Fixtures built from the real types cannot do that;
-/// roughly twenty remain hand-written.
+/// *A hand-written fixture can understate as well as overstate.* #1097
+/// promoted two entries on a fixture that omitted a member the real type
+/// always sends — a false green, the one direction this table must never fail
+/// in. Fixtures built from the real types cannot do that; roughly twenty
+/// remain hand-written.
 ///
 /// To re-measure rather than re-read: add a throwaway test that walks
-/// `table()` printing the actual parse or schema error for every
-/// `KnownDrift`. `invalid type: string, expected struct IssuedCredential` is
-/// a sentence no amount of re-reading prose will produce.
-const KNOWN_DRIFT_COUNT: usize = 2;
+/// `table()` printing the actual parse or schema error for every entry.
+/// `invalid type: string, expected struct IssuedCredential` is a sentence no
+/// amount of re-reading prose will produce.
+const KNOWN_DRIFT_COUNT: usize = 0;
 
 /// Every bound, published `spec/vtc/*` URI, with the request and response the
 /// VTC actually speaks.
@@ -672,10 +671,9 @@ fn table() -> Vec<Conformance> {
             // `expiresAt` is unix seconds, which is what the spec types.
             json!({ "nonce": "b7c1e0a94f2d4e8ab5c36f01d9e27a3c", "expiresAt": 1_787_654_400_u64 })
         ),
-        drift!(
-            s::auth::recognise::v0_1::Payload,
-            s::auth::recognise::v0_1::Response,
-            Side::Request,
+        checked!(
+            s::auth::recognise::v0_2::Payload,
+            s::auth::recognise::v0_2::Response,
             // `RecogniseRequest` — routes/recognise.rs:82.
             json!({ "presentation": { "type": ["VerifiablePresentation"], "nonce": "b7c1e0" } }),
             // `RecogniseResponse` — routes/recognise.rs:102.
@@ -687,13 +685,7 @@ fn table() -> Vec<Conformance> {
                     "foreignIssuerDid": "did:web:peer.example",
                     "mappedRole": "member",
                 },
-            }),
-            "the spec's payload is two credentials (`vec` + `vmc`, both \
-             required); this service takes one `presentation` VP and pulls \
-             both out of it. Neither shape is obviously wrong — the VP form \
-             carries the holder-binding proof the recognition gate needs, \
-             which two loose credentials do not — so this one is a candidate \
-             for taking upstream rather than changing here"
+            })
         ),
         // ─── backup ──────────────────────────────────────────────────
         checked!(
@@ -1008,10 +1000,9 @@ fn table() -> Vec<Conformance> {
                 }],
             })
         ),
-        drift!(
-            s::join_requests::submit::v0_1::Payload,
-            s::join_requests::submit::v0_1::Response,
-            Side::Response,
+        checked!(
+            s::join_requests::submit::v0_2::Payload,
+            s::join_requests::submit::v0_2::Response,
             // From the SDK producer type, with `extensions` left at its
             // `Default` — the shape a minimal client actually sends.
             to_v(jr::JoinRequestSubmitBody {
@@ -1026,19 +1017,7 @@ fn table() -> Vec<Conformance> {
                 uuid(),
                 "admin-review",
                 "queued for an admin decision (approve/reject)",
-            )),
-            "#1059's first named divergence, CONFIRMED, and the request side \
-             diverges too. Response: the dispatcher returns `VerdictResponse` \
-             — `{requestId, verdict}` — where the spec requires \
-             `{requestId, status}` with `status` a `const: \"pending\"`. The \
-             required `status` is absent and `verdict` is unspecced. The \
-             verdict envelope superseded the published shape and was never \
-             taken upstream, and it is the better design (a submit can \
-             allow / deny / refer / request_more, and `pending` can express \
-             only one of those), so the fix belongs upstream. The request \
-             half — an unset `extensions` serialising as `null` against a \
-             schema that types it `object` — was the one-line vta-sdk fix \
-             this note asked for, applied in #1099"
+            ))
         ),
         checked!(
             s::join_requests::status::v0_1::Payload,

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -35,7 +35,7 @@ use vtc_service::test_support::TestVtc;
 const RP_ORIGIN: &str = "https://vtc.example.com";
 // The holder-facing verbs are now Trust Task **document** types (the `/spec/`
 // canonical form the dispatcher routes on).
-const SUBMIT_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.1";
+const SUBMIT_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.2";
 // `accept` is retired — the join close-the-loop is `members/vmc` with a
 // `requestId` (one credential-delivery path).
 const VMC_TASK: &str = "https://trusttasks.org/spec/vtc/members/vmc/0.1";
@@ -1746,8 +1746,11 @@ decision := {"effect": "request_more", "with": {
     let (_, body) = post_tt(&fix.router, doc).await;
     assert_eq!(
         verdict_effect(&body),
-        "request_more",
-        "expected request_more verdict: {body}"
+        // The policy at line 1737 authors `request_more` — Rego idiom — and
+        // the wire publishes `requestMore`, per SPEC §4.10 rule 4. The two
+        // vocabularies differ on purpose; `VerdictEffect` is the boundary.
+        "requestMore",
+        "expected requestMore verdict: {body}"
     );
     let id = Uuid::parse_str(body["payload"]["requestId"].as_str().unwrap()).unwrap();
 

--- a/vtc-service/tests/recognise.rs
+++ b/vtc-service/tests/recognise.rs
@@ -295,7 +295,7 @@ mod holder_binding {
     use vtc_service::test_support::TestVtc;
 
     const VTC_DID: &str = "did:key:z6MkTestVTC";
-    const RECOGNISE_TASK: &str = "https://trusttasks.org/spec/vtc/auth/recognise/0.1";
+    const RECOGNISE_TASK: &str = "https://trusttasks.org/spec/vtc/auth/recognise/0.2";
     const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/vtc/auth/recognise/challenge/0.1";
 
     async fn test_vtc() -> TestVtc {

--- a/vtc-service/tests/vtc_client_live.rs
+++ b/vtc-service/tests/vtc_client_live.rs
@@ -154,7 +154,7 @@ async fn join_queue_reads_and_decide_reaches_the_handler() {
 }
 
 /// The applicant side, end to end: `submit_join` signs a
-/// `join-requests/submit/0.1` document with the applicant's holder key, posts it
+/// `join-requests/submit/0.2` document with the applicant's holder key, posts it
 /// to the document endpoint with **no bearer token**, and gets the community's
 /// verdict back.
 ///


### PR DESCRIPTION
Retargets `auth/recognise` and `join-requests/submit` to the `0.2` versions
published by trustoverip/dtgwg-trust-tasks-tf#264.

**Drift 2 → 0.** Every Trust Task this service binds now speaks the schema it
publishes, on both sides. It was 33 when the sweep landed yesterday.

## Why these two moved the spec rather than the service

Both were recorded as "the service's shape is arguably stronger". Reading them
properly, one was not arguable at all.

**`auth/recognise/0.1` took `{vec, vmc}` — a replayable impersonation token.**
Both credentials are bearer artifacts, so anyone who obtained the pair from a
relayed join, an audit log, a backup or a compromised device held everything
the payload required, and the recognising community could not distinguish the
subject from someone holding a copy. No proof of key possession, no freshness,
no audience binding: one captured pair worked at every community that
recognised the issuer, indefinitely. This service has required a holder-signed
presentation — nonce, `domain`, holder-is-subject — since P0.2. `0.2` publishes
that.

**`join-requests/submit/0.1` returned `status: const "pending"`** where a
submission has four outcomes. `0.2` returns a verdict.

## One real find in the retarget

`VerdictEffect` serialised **`request_more`**, but I had specced `requestMore`
in #264, and SPEC §4.10 rule 4 is explicit that specification-defined decision
values are lowerCamelCase. So the wire was wrong.

The fix is not to change either vocabulary wholesale, because there are two of
them and both are correct in their own language:

- **Rego authors verdicts.** Operator-written policy returns
  `{"effect": "request_more", …}`, and snake_case is that language's idiom —
  `vtc-service/policies/default/join.rego` and every deployed policy alongside
  it. Re-casing there would break operator policies to satisfy a wire rule
  that does not govern them.
- **The wire publishes `requestMore`**, per §4.10 and the new
  `vtc/_shared/0.1/ceremony#VerdictEffect`.

`VerdictEffect` is the boundary: it now serialises camelCase and keeps
`#[serde(alias = "request_more")]` so anything producing the policy spelling
still deserialises. That is the same storage-versus-wire split `EndorsementRow`
(#1096) and `GenerationRow` (#1095) draw, applied to a policy vocabulary
instead of a keyspace.

The test that caught it now demonstrates the boundary instead of hiding it —
its inline Rego authors `request_more`, and it asserts the wire says
`requestMore`, with a comment saying why both are right.

## The table at zero

`KNOWN_DRIFT_COUNT` stays asserted at `0`. It can no longer shrink, so the only
thing it can do is catch a regression — which is what an asserted count is for.
A new task that diverges must add a `drift!` entry and raise it deliberately.

The `drift!` macro, `Side`, and `Conformance::KnownDrift` are now unconstructed
and kept with `#[allow(dead_code)]` rather than deleted. They are the
vocabulary for *recording* a divergence, and a table with no way to say "this
diverges, on this side, for this reason" invites the next author to leave a
real divergence unrecorded rather than write the machinery back. Deleting them
would make the zero look permanent instead of current.

## The header, rewritten

It described a 33-entry backlog. It now records how the 33 actually closed,
because the distribution is not what the sweep predicted:

| | |
|---|---|
| **10** | by correcting this service's wire shapes |
| **19** | on dependency bumps alone — the specs had moved and the notes had not |
| **4** | by correcting the **specification**, once the published shape turned out to be the weaker one |

That last group is the one worth remembering. A conformance table makes
divergence visible and says nothing about which side is wrong, and *"the schema
requires X and the service omits X"* reads as an accusation against the
implementation. Twice it was the schema. Once — `install/claim` — the
requirement had been built, found impossible in a browser, and removed two
months **before** the specification demanding it was written, and this table
recorded that as the service being behind on a security control.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all --check`

BREAKING CHANGE: `POST /v1/auth/recognise` and `POST /v1/join-requests` bind
the `0.2` task URIs; callers must send the new `Trust-Task` header values. The
verdict `effect` for a request-more outcome is now `requestMore` on the wire
instead of `request_more`; the snake_case form is still accepted on input, and
Rego policies are unchanged.

Refs #1059
