### PR TITLE
docs(vtc): retire four local tasks the index had already retired

### DIFF
--- a/trust-tasks/admin/config/export/1.0/spec.md
+++ b/trust-tasks/admin/config/export/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/export/1.0
 title: VTC Admin — Export Config
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/config/export/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/admin/config/import/1.0/spec.md
+++ b/trust-tasks/admin/config/import/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/admin/config/import/1.0
 title: VTC Admin — Import Config
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/config/import/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/policies/test/1.0/spec.md
+++ b/trust-tasks/policies/test/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/policies/test/1.0
 title: VTC Policies — Test
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/policies/test/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org

--- a/trust-tasks/website/files/delete/1.0/spec.md
+++ b/trust-tasks/website/files/delete/1.0/spec.md
@@ -1,7 +1,8 @@
 ---
 id: https://trusttasks.org/openvtc/vtc/website/files/delete/1.0
 title: VTC — Website file delete
-status: draft
+status: retired
+supersededBy: https://trusttasks.org/spec/vtc/website/files/delete/0.1
 version: "1.0"
 authors:
   - did:webvh:openvtc.org


### PR DESCRIPTION
Four local task documents said `status: draft`. `trust-tasks/index.json` had
already recorded all four as `retired`, with correct `supersededBy` targets.
The index and the documents had disagreed, silently, for some time.

## What the audit found

The question was whether these four were genuinely VTI-specific tasks needing a
local home, or leftovers from the migration to published specs. They are
leftovers:

| local document | live route binds |
|---|---|
| `openvtc/vtc/policies/test/1.0` | `spec/vtc/policies/test/0.1` |
| `openvtc/vtc/admin/config/export/1.0` | `spec/vtc/config/export/0.1` |
| `openvtc/vtc/admin/config/import/1.0` | `spec/vtc/config/import/0.1` |
| `openvtc/vtc/website/files/delete/1.0` | `spec/vtc/website/files/delete/0.1` |

All four have published upstream equivalents, all four are in the conformance
table against those published specs, and **no route, test or client references
the local URIs** — the only mentions are the documents themselves, the index,
and one historical CHANGELOG line.

So there was nothing to publish. The migration finished in the code; four
documents were never updated to say so.

## The fix

Four one-line front-matter corrections, taking each `draft` to `retired` with
the `supersededBy` the index already names. Local task documents are now
**64 retired, 0 draft**.

## Why this matters beyond tidiness

A `draft` document is an invitation. Anyone reading `trust-tasks/` for the
shape of, say, config export would have found a live-looking local definition
that nothing implements, alongside a published one that everything does — and
no signal about which is real except the index, which is a different file.

It also settles a question worth recording: there are **no VTI-specific tasks
left that need a local definition**. The four candidates were the whole
remaining case for reintroducing locally-defined trust tasks, and none of them
survives inspection. Publishing upstream is what lets both sides validate
against one definition — which is how four defects were found in the specs
themselves this week, rather than in this service. A locally-defined task
cannot produce that: conformance against your own definition is a mirror.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, no failures
- `cargo fmt --all --check`

`tests/trust_task_manifest.rs`, which reads these documents, passes unchanged.
