### PR TITLE
test(vtc): validate what handlers actually emit, not what fixtures claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fc43e5bf18f0562ab419e2ba25beaa76ac2103fde5753665d927e2770d1633"
+checksum = "c43a3909671dfa59719e98a836207b51d83bc2f53dfc82281207473354f83aa7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.12", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.13", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/vtc-service/src/community/profile.rs
+++ b/vtc-service/src/community/profile.rs
@@ -209,7 +209,15 @@ pub struct CommunityProfile {
     /// Opaque per-community JSON. Capped at [`MAX_EXTENSIONS_BYTES`]
     /// when serialised. Defaults to `null` when no extension data
     /// is set.
-    #[serde(default)]
+    ///
+    /// Omitted from the wire when null. The canonical `CommunityProfile`
+    /// component types this `object` and does not require it, so absent is the
+    /// conforming way to say "none" and `null` is a type error. It went out as
+    /// `null` until #1107 — the conformance fixture set a non-empty object, so
+    /// a hand-chosen value hid it even after the fixture was built from this
+    /// very struct. Deriving a fixture from the real type only helps for the
+    /// members you do not then hand-set.
+    #[serde(default, skip_serializing_if = "Value::is_null")]
     pub extensions: Value,
 }
 

--- a/vtc-service/src/routes/members/read.rs
+++ b/vtc-service/src/routes/members/read.rs
@@ -36,6 +36,16 @@ pub struct MemberResponse {
     pub status_list_index: Option<u32>,
     pub current_vmc_id: Option<String>,
     pub current_role_vec_id: Option<String>,
+    /// Serialised as `{}` when the member has none.
+    ///
+    /// The canonical component makes `extensions` **required** and types it
+    /// `object`, so `null` is a violation and omitting it is a violation too —
+    /// an empty object is the only conforming way to say "none". A stored
+    /// member that never had extensions holds `JsonValue::Null`, and this went
+    /// out as `null` until #1107. The conformance fixture set
+    /// `{"org": "acme"}`, so a hand-typed non-empty object hid it; the
+    /// response-conformance layer on real traffic is what surfaced it.
+    #[serde(serialize_with = "empty_object_if_null")]
     pub extensions: JsonValue,
     /// Personhood flag (Phase 4 M4.1). Surfaces the Member row's
     /// `personhood` field. Read-only on this response —
@@ -64,6 +74,18 @@ pub struct MemberResponse {
     /// [`Self::member_vmc_id`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub member_vmc_received_at: Option<DateTime<Utc>>,
+}
+
+/// Serialise `JsonValue::Null` as `{}`.
+///
+/// For members the spec requires and types `object`: absent and null are both
+/// refused, so the empty object is the only conforming spelling of "none".
+fn empty_object_if_null<S: serde::Serializer>(v: &JsonValue, s: S) -> Result<S::Ok, S::Error> {
+    use serde::Serialize;
+    match v {
+        JsonValue::Null => serde_json::Map::new().serialize(s),
+        other => other.serialize(s),
+    }
 }
 
 impl MemberResponse {

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -20,6 +20,8 @@
 
 #![cfg(any(test, feature = "test-support"))]
 
+pub mod response_conformance;
+
 use std::sync::Arc;
 
 use base64::Engine;
@@ -380,7 +382,16 @@ impl TestVtcBuilder {
             didcomm: Arc::new(tokio::sync::OnceCell::new()),
         };
 
-        let router = crate::routes::router().with_state(state.clone());
+        // Every response a test provokes is validated against its Trust
+        // Task's published `#response` schema. Here rather than in each
+        // `tests/*.rs` because each is its own crate with its own `send`
+        // helper — one layer at the single point they all build a router
+        // covers all of them, and the next test added inherits it.
+        let router = crate::routes::router()
+            .layer(axum::middleware::from_fn(
+                response_conformance::validate_response,
+            ))
+            .with_state(state.clone());
 
         TestVtc {
             router,

--- a/vtc-service/src/test_support/response_conformance.rs
+++ b/vtc-service/src/test_support/response_conformance.rs
@@ -1,0 +1,120 @@
+//! Validate every response an integration test provokes against the schema
+//! its Trust Task publishes.
+//!
+//! ## Why this is a layer and not a fixture
+//!
+//! `trust_tasks::conformance` checks example documents that are typed by hand
+//! into the witness table. That is a *proxy* for what a handler emits, and the
+//! proxy drifted three separate ways in one week:
+//!
+//! - **stale** — `endorsements/revoke` described a `{id}` response six PRs
+//!   after the handler had stopped sending one;
+//! - **inventing** — a wrapper fixture carried a `totalEstimate` no producer
+//!   in the workspace ever sets;
+//! - **omitting** — the community-profile fixture left out `personhood`, and
+//!   that one reported *two non-conformant routes as conforming*.
+//!
+//! The last is the failure that matters. A fixture can only be wrong in the
+//! flattering direction if it is written separately from the thing it
+//! describes, so the fix is to stop describing and start observing: this layer
+//! reads the `Trust-Task` header the test already sends, looks up that task's
+//! `#response` schema, and validates the bytes the handler actually produced.
+//!
+//! It sits in `test_support` rather than in each test file because every
+//! binary under `tests/` is its own crate with its own `send` helper — thirty-
+//! five of them. One layer at the single point where those routers are built
+//! covers all of them, and cannot be forgotten by the next test that is added.
+//!
+//! ## What it does not do
+//!
+//! - **Error responses are exempt.** A 4xx/5xx body is a framework error
+//!   document, not the task's response payload; validating it against the
+//!   success schema would fail for the wrong reason.
+//! - **Unknown tasks pass.** `schema_for` returning `None` means this build
+//!   knows no spec for that URI — an unpublished or locally-served route. It
+//!   is not evidence of a violation, and treating it as one would make the
+//!   layer fail loudest on the routes it understands least.
+//! - **It sees only what a test exercises.** A route with no integration test
+//!   gets no coverage here, which is exactly how `endorsements/show` and
+//!   `ceremonies/list` drifted. The census in
+//!   `trust_tasks::conformance` is what covers the rest.
+
+use std::sync::{Mutex, OnceLock};
+
+use axum::body::{Body, Bytes};
+use axum::http::{Request, Response, StatusCode};
+use axum::middleware::Next;
+
+/// Violations observed during a test run, for the harness to assert on.
+///
+/// Collected rather than panicked on inside the layer: a panic in middleware
+/// surfaces as a transport error at the call site, which reads as "the request
+/// failed" and hides what actually went wrong.
+static VIOLATIONS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn violations() -> &'static Mutex<Vec<String>> {
+    VIOLATIONS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Every response-schema violation seen so far, newest last.
+pub fn observed_violations() -> Vec<String> {
+    violations().lock().expect("violations lock").clone()
+}
+
+/// Forget everything observed. For a test that deliberately provokes a
+/// violation and wants a clean slate afterwards.
+pub fn clear_violations() {
+    violations().lock().expect("violations lock").clear();
+}
+
+/// Axum middleware: validate a success response against its task's published
+/// `#response` schema.
+pub async fn validate_response(req: Request<Body>, next: Next) -> Response<Body> {
+    let task = req
+        .headers()
+        .get("trust-task")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+
+    let res = next.run(req).await;
+
+    let Some(task) = task else { return res };
+    if !res.status().is_success() {
+        return res;
+    }
+
+    let (parts, body) = res.into_parts();
+    let bytes = match axum::body::to_bytes(body, usize::MAX).await {
+        Ok(b) => b,
+        Err(_) => return Response::from_parts(parts, Body::empty()),
+    };
+
+    check(&task, parts.status, &bytes);
+    Response::from_parts(parts, Body::from(bytes))
+}
+
+/// The check itself, separated so it is unit-testable without a router.
+fn check(task: &str, status: StatusCode, bytes: &Bytes) {
+    // 204 and an empty body carry no payload to validate.
+    if status == StatusCode::NO_CONTENT || bytes.is_empty() {
+        return;
+    }
+    let Some(schema) = trust_tasks_rs::schema_index::schema_for(&format!("{task}#response")) else {
+        return;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return;
+    };
+    // A Trust Task *document* carries its payload under `payload`; a bare REST
+    // response is the payload itself. Validate whichever this is, so the layer
+    // works across both bindings without the test having to say which.
+    let payload = value.get("payload").unwrap_or(&value);
+    if let Err(e) = trust_tasks_rs::validate::against_schema(schema, payload) {
+        let msg = format!("{task}: {e}");
+        // Printed as well as collected. A violation that only accumulates in a
+        // static is invisible to `cargo test`, which is how a conformance
+        // signal quietly stops being one.
+        eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
+        violations().lock().expect("violations lock").push(msg);
+    }
+}


### PR DESCRIPTION
**The conformance table's zero was measuring the wrong thing.** This adds a
layer that validates what handlers actually emit, and the first run found
**134 violations across 23 tasks** — five of them in the VTC family the table
calls fully conformant.

## What it does

One axum layer at `test_support.rs`, where all 35 integration-test binaries
build their router. It reads the `Trust-Task` header the tests already send,
looks up that task's `#response` schema (possible only since
trustoverip/dtgwg-trust-tasks-tf#265 indexed response schemas), and validates
the bytes the handler produced.

A layer rather than a helper per test file because each binary under `tests/`
is its own crate with its own `send` — thirty-five of them. One interception
point covers all of them and cannot be forgotten by the next test added.

## Why fixtures could not have found this

`trust_tasks::conformance` validates example documents typed by hand into the
witness table. That is a proxy, and it has now drifted **four** distinct ways:

| | |
|---|---|
| **stale** | `endorsements/revoke` described a response the handler had stopped sending six PRs earlier |
| **inventing** | a wrapper fixture carried a `totalEstimate` no producer ever sets |
| **omitting** | the profile fixture left out `personhood` — a **false green** on two routes |
| **over-populating** | `extensions` was hand-set to `{"org": "acme"}`, so the `null` real traffic sends was never seen |

The last is new here, and it is the one that survives the obvious fix.
`community_profile()` **was already derived from the real struct** — converted
in #1100 precisely to stop it lying — and it still hid this, because the
derivation was followed by `p.extensions = json!({"tier": "gold"})`. Deriving a
fixture from the real type only protects the members you do not then hand-set.

## Fixed here

- **`MemberResponse.extensions`** went out as `null` on `members/{list,show,update}`.
  The component makes it **required** and types it `object`, so `null` is a
  violation and omitting it would be too — an empty object is the only
  conforming spelling of "none". Now serialised as `{}`.
- **`CommunityProfile.extensions`** — same class on `community/profile/update`
  and `config/export`, but there it is *optional*, so it is now omitted when
  null.

## Not fixed here — the inventory

Reporting-only for now. Making the layer fail the build today would redden
every suite, and the remaining violations split into two groups that need
different decisions.

**Five VTC-family tasks the witness table calls conformant:**

| task | real output |
|---|---|
| `relationships/list` | sends `vrcDigestMultibase`; schema requires `vrcSha256` |
| `relationships/graph` | a different shape entirely — `complete` / `endpoints` / `halves` |
| `members/personhood/assert` | missing required `vmc` / `roleVec`; a `const` unsatisfied |
| `join-requests/list`, `show` | `null` where an object is required |

`relationships/*` looks like the **spec** being stale rather than the service
being wrong: multibase digests were a deliberate decision, and the graph shape
is richer than the schema's. The other three look like service bugs. Each needs
the "which side is wrong" question asked properly — the lesson this repository
has learned three times over.

**Eighteen shared-family tasks** — `acl`, `audit`, `auth/passkey`, `policy`.
The witness header states these 36 URIs are excluded by design, being "served
by both daemons, so witnessing them belongs with a decision about which
service's response shape is canonical". The layer needed no such decision to
*observe* them; acting on them still does.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, no failures
- `cargo fmt --all --check`

`trust-tasks-rs` 0.11.13, for the response-schema index.

## The honest summary

I reported "drift 33 → 0" earlier today. That number was true of the fixtures
and false of the service. This is the tool that says so, and the count it
produces is the one worth trusting, because nothing in it was typed by hand.
