### PR TITLE
fix(vtc): a null, and a revoke replying under the wrong task

### DIFF
--- a/vtc-service/src/join/mod.rs
+++ b/vtc-service/src/join/mod.rs
@@ -118,7 +118,12 @@ pub struct JoinRequest {
     /// Community-defined extensions slot (spec §3-M). Bounded by
     /// `JOIN_REQUEST_EXTENSIONS_MAX_BYTES` (16 KiB) at the route
     /// layer.
-    #[serde(default)]
+    /// Omitted when null. The canonical `JoinRequest` component types this
+    /// `object` and does not require it, so absent is how "none" is spelled
+    /// and `null` is a type error — the same shape as `policyDecision` in
+    /// #1099. Found by the response-conformance layer on real traffic; the
+    /// fixture set a non-empty object and so never saw it.
+    #[serde(default, skip_serializing_if = "JsonValue::is_null")]
     pub extensions: JsonValue,
     /// Why this request was refused, for the applicant.
     ///

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -613,14 +613,27 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(members::personhood::challenge),
             "https://trusttasks.org/spec/vtc/members/personhood/challenge/0.1",
         ))
+        // POST and DELETE each carry their own task. They shared
+        // `personhood/assert/0.1` "pending per-method selectors" — a
+        // workaround that outlived its reason: `task_routes` has supported
+        // one task per verb on a shared path since
+        // `per_method_tasks_on_one_path_are_enforced_independently` landed in
+        // `vti_common::trust_task::openapi`, and registering the path twice
+        // merges the operations rather than overwriting them.
+        //
+        // It was not cosmetic. A revoke replied under the *assert* task, so a
+        // client was told the wrong task for the document it received, and
+        // the response could not satisfy the schema it claimed: assert
+        // requires `personhood: const true` plus `vmc` and `roleVec`, and a
+        // revoke legitimately sends `false` with neither. The
+        // response-conformance layer found it on real traffic.
         .routes(tt(
-            routes!(members::personhood::assert, members::personhood::revoke), // POST + DELETE share `personhood/assert/1.0` at
-            // the router layer pending per-method selectors;
-            // the standalone `personhood/revoke/1.0` Trust Task
-            // exists on disk + in index.json so the soft-gate
-            // surface stays complete. (Same workaround as
-            // members/{did}'s show + update + admin-remove.)
+            routes!(members::personhood::assert),
             "https://trusttasks.org/spec/vtc/members/personhood/assert/0.1",
+        ))
+        .routes(tt(
+            routes!(members::personhood::revoke),
+            "https://trusttasks.org/spec/vtc/members/personhood/revoke/0.1",
         ))
         // Phase 4 M4.6 — VRC trust-graph endpoints. The
         // per-member list mounts under /v1/members/{did}/

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -1160,15 +1160,28 @@ fn table() -> Vec<Conformance> {
             s::members::personhood::assert::v0_1::Response,
             // `AssertBody` — routes/members/personhood.rs:196.
             json!({ "did": DID, "presentation": { "type": ["VerifiablePresentation"] } }),
-            // `AssertResponse` — routes/members/personhood.rs:206. NOTE the
-            // DELETE on the same mount answers with `personhood: false`,
-            // which is `members/personhood/revoke/0.1`'s shape, not this
-            // one's — the two verbs share a Trust Task because the router
-            // has no per-method selector here. That collapse is #710's
-            // shared-mount workaround, not a conformance defect of this URI,
-            // so the witness carries the POST.
+            // `AssertResponse` — routes/members/personhood.rs:206.
+            //
+            // This note used to explain that the DELETE on the same mount
+            // answered under *this* URI with `personhood: false`, and called
+            // the collapse a shared-mount workaround rather than a defect of
+            // this task. That was honest and it was also the problem: the
+            // witness carried the POST, so nothing here ever saw the DELETE,
+            // and a client was told the wrong task for the document it got.
+            // The response-conformance layer saw it on real traffic. #1108
+            // gives each verb its own task; `revoke` is witnessed below.
             json!({ "did": DID, "personhood": true,
                     "vmc": credential(), "roleVec": credential() })
+        ),
+        checked!(
+            s::members::personhood::revoke::v0_1::Payload,
+            s::members::personhood::revoke::v0_1::Response,
+            json!({ "did": DID }),
+            // `RevokeResponse` — routes/members/personhood.rs:526. `vmc` and
+            // `roleVec` are `skip_serializing_if`, so a revoke that re-mints
+            // nothing sends neither; the component makes both optional and
+            // pins `personhood` to `const false`.
+            json!({ "did": DID, "personhood": false })
         ),
         checked!(
             s::members::vmc::v0_1::Payload,

--- a/vtc-service/tests/personhood.rs
+++ b/vtc-service/tests/personhood.rs
@@ -36,6 +36,7 @@ use vtc_service::test_support::TestVtc;
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const CHALLENGE_TASK: &str = "https://trusttasks.org/spec/vtc/members/personhood/challenge/0.1";
 const ASSERT_TASK: &str = "https://trusttasks.org/spec/vtc/members/personhood/assert/0.1";
+const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/members/personhood/revoke/0.1";
 const MEMBER_DID: &str = "did:key:zPerson1";
 const OTHER_MEMBER_DID: &str = "did:key:zPerson2";
 const ADMIN_DID: &str = "did:key:zPersonAdmin";
@@ -414,7 +415,7 @@ async fn revoke_admin_flips_member_row_and_emits_audit() {
         .method("DELETE")
         .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
         .header("authorization", format!("Bearer {}", fix.admin_token))
-        .header("trust-task", ASSERT_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
@@ -462,7 +463,7 @@ async fn revoke_self_emits_audit_reason_self() {
         .method("DELETE")
         .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
         .header("authorization", format!("Bearer {}", fix.member_token))
-        .header("trust-task", ASSERT_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
@@ -500,7 +501,7 @@ async fn revoke_unauthorized_when_member_revokes_someone_else() {
         .method("DELETE")
         .uri(format!("/v1/members/{OTHER_MEMBER_DID}/personhood"))
         .header("authorization", format!("Bearer {}", fix.member_token))
-        .header("trust-task", ASSERT_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
@@ -516,7 +517,7 @@ async fn revoke_already_false_is_idempotent_noop() {
         .method("DELETE")
         .uri(format!("/v1/members/{MEMBER_DID}/personhood"))
         .header("authorization", format!("Bearer {}", fix.member_token))
-        .header("trust-task", ASSERT_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();
@@ -548,7 +549,7 @@ async fn revoke_returns_404_for_unknown_member() {
         .method("DELETE")
         .uri("/v1/members/did:key:zStranger/personhood")
         .header("authorization", format!("Bearer {}", fix.admin_token))
-        .header("trust-task", ASSERT_TASK)
+        .header("trust-task", REVOKE_TASK)
         .body(Body::empty())
         .unwrap();
     let resp = fix.router.clone().oneshot(req).await.unwrap();


### PR DESCRIPTION
Three of the five VTC-family violations #1107's response layer found on real
handler output. The remaining two point at the specification rather than this
service, and are described at the end rather than guessed at.

## `join-requests` sent `extensions: null`

`JoinRequest.extensions` is `JsonValue` with `#[serde(default)]` and no
`skip_serializing_if`, so a request with no extensions serialised `null`. The
canonical component types it `object` and does not require it, so absent is how
"none" is spelled and `null` is a type error — the same shape as
`policyDecision` in #1099, and the third member of this family to have it.

## `personhood/revoke` replied under the *assert* task

This is the substantial one, and it was not a serialisation slip.

`POST` and `DELETE` shared one mount, with a comment saying the collapse was
"pending per-method selectors". **That workaround had outlived its reason.**
`task_routes` has supported one task per verb on a shared path since
`per_method_tasks_on_one_path_are_enforced_independently` landed in
`vti_common::trust_task::openapi`, and registering the path twice merges the
OpenAPI operations rather than overwriting them — which is what
`per_method_split_keeps_both_operations_in_the_spec` exists to prove.

The consequence was real. A revoke response went out labelled
`members/personhood/assert/0.1`, so a client was told the wrong task for the
document it received — and the response could not satisfy the schema it
claimed: assert requires `personhood: const true` plus `vmc` and `roleVec`,
while a revoke legitimately sends `false` with neither.

`members/personhood/revoke/0.1` has been published upstream the whole time, and
its shape matches `RevokeResponse` exactly: `personhood: const false`, both
credentials optional. Each verb now carries its own task.

### The witness knew, and that is the point

The assert entry's own comment said the DELETE answered under that URI with the
wrong shape, and called it "a shared-mount workaround, not a conformance defect
of this URI, so the witness carries the POST."

Every clause of that is true. It is also how the defect survived: the witness
was told to look at the POST, so nothing in the table ever saw the DELETE, and
a fixture cannot notice a response it was instructed not to examine. The
response layer had no such instruction — it validated whatever the handler
actually sent.

An honest note about a known gap is still a gap. This is the fourth time this
week the table's prose described something accurately and nothing acted on it.

## The census caught the follow-on

Binding a newly published URI made
`every_bound_published_uri_has_a_witness` fail, exactly as designed —
`personhood/revoke/0.1` had no entry. Added as `checked!`; the table is now 59
tasks, drift still 0.

## Not fixed here

Two remain, and both look like the **specification** being stale rather than
this service being wrong — which is the question this repository has now got
backwards three times, so I am not guessing:

- **`relationships/list`** sends `vrcDigestMultibase`; the schema requires
  `vrcSha256`. Multibase-wrapped multihash was a deliberate decision taken in
  this workspace; the service moved and the published schema never followed.
- **`relationships/graph`** returns `complete` / `endpoints` / `halves` — a
  materially richer shape than the schema's flat `id` / `issuerDid` /
  `subjectDid` / `createdAt`.

Both want an upstream `0.2` if the service's shape is the intended one, and
someone who knows the graph design should confirm that before a spec change is
proposed for it.

The eighteen shared-family tasks (`acl`, `audit`, `auth/passkey`, `policy`)
also remain, still pending the canonical-shape decision the witness header
names. One of those is worth surfacing early because it is a framework
violation rather than a shape mismatch: `policy/upsert` emits an `ext` key of
`org.openvtc.authorDid`, which fails the reverse-DNS namespace pattern in
SPEC §4.5.1 — the structure belongs *inside* `org.openvtc`, not flattened into
the key.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`

Refs #1059
