### PR TITLE
fix(vtc): an invalid ext key, and three acl responses missing their envelope

### DIFF
--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -54,6 +54,22 @@ pub struct AclEntryResponse {
     pub expires_at: Option<String>,
 }
 
+/// `{ entry: … }` — the shape `acl/{grant,show,change-role}/0.1` publish.
+///
+/// All three returned the row bare until #1109. The row itself always
+/// conformed; only the wrapper was missing, which is the same envelope defect
+/// the VTC family carried on eight tasks. It went unseen here for longer
+/// because the shared `spec/{acl,audit,auth,config,policy}/*` families are
+/// outside the conformance table's census — a stated limit, since both daemons
+/// serve them — so no fixture ever described these responses. The
+/// response-conformance layer needed no census: it validated what the handler
+/// sent.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AclEntryEnvelope {
+    pub entry: AclEntryResponse,
+}
+
 /// Unix epoch seconds → RFC3339, for canonical `date-time` fields.
 fn epoch_to_rfc3339(secs: u64) -> String {
     chrono::DateTime::from_timestamp(secs as i64, 0)
@@ -258,7 +274,7 @@ pub struct GrantEntry {
     security(("bearer_jwt" = [])),
     request_body = CreateAclRequest,
     responses(
-        (status = 201, description = "ACL entry created", body = AclEntryResponse),
+        (status = 201, description = "ACL entry created", body = AclEntryEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller lacks manage authority"),
     ),
@@ -267,7 +283,7 @@ pub async fn create_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
-) -> Result<(StatusCode, Json<AclEntryResponse>), AppError> {
+) -> Result<(StatusCode, Json<AclEntryEnvelope>), AppError> {
     let req_entry = req.entry;
     // Block non-admin callers from granting Admin — role + context
     // bound checks must run before we touch storage.
@@ -340,7 +356,12 @@ pub async fn create_acl(
         created = status == StatusCode::CREATED,
         "ACL entry granted",
     );
-    Ok((status, Json(AclEntryResponse::from(entry))))
+    Ok((
+        status,
+        Json(AclEntryEnvelope {
+            entry: AclEntryResponse::from(entry),
+        }),
+    ))
 }
 
 // ---------- GET /acl/{did} ----------
@@ -351,7 +372,7 @@ pub async fn create_acl(
     security(("bearer_jwt" = [])),
     params(("did" = String, Path, description = "Subject DID")),
     responses(
-        (status = 200, description = "ACL entry", body = AclEntryResponse),
+        (status = 200, description = "ACL entry", body = AclEntryEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller lacks manage authority"),
         (status = 404, description = "ACL entry not found"),
@@ -361,7 +382,7 @@ pub async fn get_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
     Path(did): Path<String>,
-) -> Result<Json<AclEntryResponse>, AppError> {
+) -> Result<Json<AclEntryEnvelope>, AppError> {
     let acl = state.acl_ks.clone();
     let entry = get_acl_entry(&acl, &did)
         .await?
@@ -372,7 +393,9 @@ pub async fn get_acl(
         )));
     }
     info!(did = %did, "ACL entry retrieved");
-    Ok(Json(AclEntryResponse::from(entry)))
+    Ok(Json(AclEntryEnvelope {
+        entry: AclEntryResponse::from(entry),
+    }))
 }
 
 // ---------- PATCH /acl/{did} ----------
@@ -408,7 +431,7 @@ pub struct UpdateAclRequest {
     params(("did" = String, Path, description = "Subject DID")),
     request_body = UpdateAclRequest,
     responses(
-        (status = 200, description = "Updated ACL entry", body = AclEntryResponse),
+        (status = 200, description = "Updated ACL entry", body = AclEntryEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "ACL entry not found"),
@@ -422,7 +445,7 @@ pub async fn update_acl(
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateAclRequest>,
-) -> Result<Json<AclEntryResponse>, AppError> {
+) -> Result<Json<AclEntryEnvelope>, AppError> {
     let acl = state.acl_ks.clone();
     let mut entry = get_acl_entry(&acl, &did)
         .await?
@@ -505,7 +528,9 @@ pub async fn update_acl(
         reason = req.reason.as_deref().unwrap_or(""),
         "ACL role changed",
     );
-    Ok(Json(AclEntryResponse::from(entry)))
+    Ok(Json(AclEntryEnvelope {
+        entry: AclEntryResponse::from(entry),
+    }))
 }
 
 // ---------- DELETE /acl/{did} ----------

--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -102,9 +102,12 @@ pub const PURPOSE_EXT_KEY: &str = "org.openvtc.purpose";
 /// - `updatedAt` is the activation time when the row has been
 ///   activated, else its creation time. A VTC revision is immutable, so
 ///   activation is the only thing that can change it after write.
-/// - `sha256` / `authorDid` / the intrinsic `purpose` have no canonical
+/// - `sha256` / `author-did` / the intrinsic `purpose` have no canonical
 ///   home and ride in `ext` (the canonical type is
-///   `additionalProperties: false`).
+///   `additionalProperties: false`). Every `ext` key is spelled in the
+///   lowercase-and-hyphen form SPEC §4.5.1 requires — a capital letter makes
+///   the key itself invalid, which is a framework violation rather than a
+///   style preference.
 ///
 /// `appliesTo` / `priority` / `enabled` are deliberately **not**
 /// emitted: VTC does no `appliesTo`/`priority` selection, and emitting
@@ -139,7 +142,13 @@ impl From<&Policy> for PolicyModuleResponse {
             ext: serde_json::json!({
                 PURPOSE_EXT_KEY: p.purpose.as_str(),
                 "org.openvtc.sha256": hex::encode(p.sha256),
-                "org.openvtc.authorDid": p.author_did,
+                // `author-did`, not `authorDid`. SPEC §4.5.1 constrains every
+                // immediate `ext` key to `^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$`,
+                // so the capital `D` made this key invalid — the one key of
+                // the five here that did not match, and invalid for the
+                // framework rather than merely off-convention. Hyphenated to
+                // match the `match-code` and `step-up` keys already in use.
+                "org.openvtc.author-did": p.author_did,
             }),
         }
     }

--- a/vtc-service/tests/acl_canonical.rs
+++ b/vtc-service/tests/acl_canonical.rs
@@ -173,12 +173,13 @@ async fn grant_with_the_same_role_rewrites_the_entry() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "rewrite, not create: {body}");
-    assert_eq!(body["scopes"], json!(["ctx-a", "ctx-b"]));
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-a", "ctx-b"]));
     assert!(
-        body["updatedAt"].as_str().is_some(),
+        body["entry"]["updatedAt"].as_str().is_some(),
         "a rewrite must stamp updatedAt: {body}"
     );
-    assert_eq!(body["updatedBy"], "did:key:z6MkAdmin");
+    assert_eq!(body["entry"]["updatedBy"], "did:key:z6MkAdmin");
 }
 
 #[tokio::test]
@@ -214,8 +215,9 @@ async fn change_role_enforces_the_from_role_guard() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "{body}");
-    assert_eq!(body["role"], "moderator");
-    assert!(body["updatedAt"].as_str().is_some(), "{body}");
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["role"], "moderator");
+    assert!(body["entry"]["updatedAt"].as_str().is_some(), "{body}");
 }
 
 /// Canonical revoke has two modes. `scopes` reduces; omitting it
@@ -247,7 +249,8 @@ async fn revoke_with_scopes_reduces_rather_than_removes() {
     // The entry must survive, minus that one scope.
     let (status, body) = call(&fix, "GET", "/v1/acl/did:key:z6MkErin", SHOW, &token, None).await;
     assert_eq!(status, StatusCode::OK, "entry must survive: {body}");
-    assert_eq!(body["scopes"], json!(["ctx-b"]));
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-b"]));
 }
 
 #[tokio::test]
@@ -293,7 +296,8 @@ async fn revoking_every_scope_is_refused_rather_than_unscoping() {
 
     let (status, body) = call(&fix, "GET", "/v1/acl/did:key:z6MkGina", SHOW, &token, None).await;
     assert_eq!(status, StatusCode::OK, "entry must be untouched: {body}");
-    assert_eq!(body["scopes"], json!(["ctx-a"]));
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-a"]));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Two classes from #1107's inventory, both in the shared task families the
conformance table's census deliberately excludes. **134 → 68 violations.**

## An `ext` key that was invalid, not merely unconventional

`policy/*` emitted `org.openvtc.authorDid`. SPEC §4.5.1 constrains every
immediate `ext` key to `^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$`, so the capital `D`
made the key itself invalid — a framework violation, not a style preference.

Worth being precise about the scope: it was the **only one of five**
`org.openvtc.*` keys in the workspace that failed. `purpose`, `sha256`,
`match-code` and `step-up` are all multi-segment lowercase and legal. Renamed
to `author-did`, matching the hyphenated keys already in use.

## Three `acl` responses missing their envelope

`acl/grant`, `acl/show` and `acl/change-role` returned a bare row where all
three schemas require `{entry: …}`. The rows themselves always conformed; only
the wrapper was absent — the same defect the VTC family carried on eight
tasks and closed in #1082/#1093/#1094.

**These survived longer for a structural reason.** The witness header states
that the 36 URIs in the shared `spec/{acl,audit,auth,config,policy}/*`
families are outside its census, because both daemons serve them and
witnessing them "belongs with a decision about which service's response shape
is canonical". That is a defensible limit, and its cost is that **no fixture
ever described these responses**, so nothing could have caught this.

The response-conformance layer needed no census and no canonical-shape
decision to *observe* the divergence — it validated what the handler actually
sent. Acting on the rest still needs that decision; this one did not, because
a missing required envelope is wrong under any reading.

## What remains — 68, unchanged in character

| | |
|---|---|
| `policy/activate` (20), `audit/verify` (13), `audit/list` (7) | shared-family shapes |
| `auth/passkey/*` (16 across 6 tasks), `auth/whoami` (1) | shared-family shapes |
| `vtc/relationships/graph` (4), `list` (2) | **spec-side** — see below |

The two `relationships` entries still look like the *specification* being
stale rather than this service being wrong: `list` sends
`vrcDigestMultibase` where the schema requires `vrcSha256` — multibase-wrapped
multihash was a deliberate decision in this workspace and the schema never
followed — and `graph` returns a materially richer shape than the schema's
flat row. Both want an upstream `0.2`, and the graph shape wants confirmation
from whoever designed it before a spec change is proposed.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, no failures
- `cargo fmt --all --check`

BREAKING CHANGE: `POST /v1/acl`, `GET /v1/acl/{did}` and `PATCH /v1/acl/{did}`
return `{entry: …}` instead of the bare row. `policy/*` responses spell the
extension key `org.openvtc.author-did` instead of `org.openvtc.authorDid`;
the old spelling was not a valid `ext` key.

Refs #1059
