### PR TITLE
fix(vtc): hex digests, and five ways round the extension slot

### DIFF
--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -54,6 +54,22 @@ pub struct AclEntryResponse {
     pub expires_at: Option<String>,
 }
 
+/// `{ entry: … }` — the shape `acl/{grant,show,change-role}/0.1` publish.
+///
+/// All three returned the row bare until #1109. The row itself always
+/// conformed; only the wrapper was missing, which is the same envelope defect
+/// the VTC family carried on eight tasks. It went unseen here for longer
+/// because the shared `spec/{acl,audit,auth,config,policy}/*` families are
+/// outside the conformance table's census — a stated limit, since both daemons
+/// serve them — so no fixture ever described these responses. The
+/// response-conformance layer needed no census: it validated what the handler
+/// sent.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AclEntryEnvelope {
+    pub entry: AclEntryResponse,
+}
+
 /// Unix epoch seconds → RFC3339, for canonical `date-time` fields.
 fn epoch_to_rfc3339(secs: u64) -> String {
     chrono::DateTime::from_timestamp(secs as i64, 0)
@@ -258,7 +274,7 @@ pub struct GrantEntry {
     security(("bearer_jwt" = [])),
     request_body = CreateAclRequest,
     responses(
-        (status = 201, description = "ACL entry created", body = AclEntryResponse),
+        (status = 201, description = "ACL entry created", body = AclEntryEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller lacks manage authority"),
     ),
@@ -267,7 +283,7 @@ pub async fn create_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
     Json(req): Json<CreateAclRequest>,
-) -> Result<(StatusCode, Json<AclEntryResponse>), AppError> {
+) -> Result<(StatusCode, Json<AclEntryEnvelope>), AppError> {
     let req_entry = req.entry;
     // Block non-admin callers from granting Admin — role + context
     // bound checks must run before we touch storage.
@@ -340,7 +356,12 @@ pub async fn create_acl(
         created = status == StatusCode::CREATED,
         "ACL entry granted",
     );
-    Ok((status, Json(AclEntryResponse::from(entry))))
+    Ok((
+        status,
+        Json(AclEntryEnvelope {
+            entry: AclEntryResponse::from(entry),
+        }),
+    ))
 }
 
 // ---------- GET /acl/{did} ----------
@@ -351,7 +372,7 @@ pub async fn create_acl(
     security(("bearer_jwt" = [])),
     params(("did" = String, Path, description = "Subject DID")),
     responses(
-        (status = 200, description = "ACL entry", body = AclEntryResponse),
+        (status = 200, description = "ACL entry", body = AclEntryEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller lacks manage authority"),
         (status = 404, description = "ACL entry not found"),
@@ -361,7 +382,7 @@ pub async fn get_acl(
     auth: ManageAuth,
     State(state): State<AppState>,
     Path(did): Path<String>,
-) -> Result<Json<AclEntryResponse>, AppError> {
+) -> Result<Json<AclEntryEnvelope>, AppError> {
     let acl = state.acl_ks.clone();
     let entry = get_acl_entry(&acl, &did)
         .await?
@@ -372,7 +393,9 @@ pub async fn get_acl(
         )));
     }
     info!(did = %did, "ACL entry retrieved");
-    Ok(Json(AclEntryResponse::from(entry)))
+    Ok(Json(AclEntryEnvelope {
+        entry: AclEntryResponse::from(entry),
+    }))
 }
 
 // ---------- PATCH /acl/{did} ----------
@@ -408,7 +431,7 @@ pub struct UpdateAclRequest {
     params(("did" = String, Path, description = "Subject DID")),
     request_body = UpdateAclRequest,
     responses(
-        (status = 200, description = "Updated ACL entry", body = AclEntryResponse),
+        (status = 200, description = "Updated ACL entry", body = AclEntryEnvelope),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
         (status = 404, description = "ACL entry not found"),
@@ -422,7 +445,7 @@ pub async fn update_acl(
     State(state): State<AppState>,
     Path(did): Path<String>,
     Json(req): Json<UpdateAclRequest>,
-) -> Result<Json<AclEntryResponse>, AppError> {
+) -> Result<Json<AclEntryEnvelope>, AppError> {
     let acl = state.acl_ks.clone();
     let mut entry = get_acl_entry(&acl, &did)
         .await?
@@ -505,7 +528,9 @@ pub async fn update_acl(
         reason = req.reason.as_deref().unwrap_or(""),
         "ACL role changed",
     );
-    Ok(Json(AclEntryResponse::from(entry)))
+    Ok(Json(AclEntryEnvelope {
+        entry: AclEntryResponse::from(entry),
+    }))
 }
 
 // ---------- DELETE /acl/{did} ----------

--- a/vtc-service/src/routes/audit.rs
+++ b/vtc-service/src/routes/audit.rs
@@ -150,13 +150,35 @@ pub struct AuditEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
     pub schema_version: u32,
-    /// Hex, matching the encoding `audit/verify` uses for `head` — a
-    /// caller comparing the two must not have to reconcile hex against
-    /// the base64 the stored envelope uses.
+    /// Multibase-wrapped multihash, which is what the canonical schema's
+    /// digest pattern accepts: `^(z[1-9A-HJ-NP-Za-km-z]+|u[A-Za-z0-9_-]+)$`.
+    ///
+    /// These were bare hex until #1110, chosen so a caller need not reconcile
+    /// against the base64 the *stored* envelope uses. That reasoning was about
+    /// two internal encodings and overlooked the third — the one the published
+    /// schema requires. A bare digest is also self-describing in neither its
+    /// hash function nor its encoding, which is the problem multihash and
+    /// multibase each exist to solve.
+    ///
+    /// The chain is untouched: the stored envelope still holds `[u8; 32]` and
+    /// hashes over bytes. This is the wire view only.
     pub prev_hash: String,
     pub entry_hash: String,
     pub detail: serde_json::Value,
     pub ext: serde_json::Value,
+}
+
+/// A raw SHA-256 digest as multibase-wrapped multihash — `0x12 0x20` then the
+/// 32 bytes, base58btc.
+///
+/// The same recipe `credentials::ingress::digest_multibase` uses; that one
+/// digests a JSON document, this one wraps a digest already computed over the
+/// audit chain's bytes.
+fn digest_multibase(hash: &[u8; 32]) -> String {
+    let mut multihash = Vec::with_capacity(34);
+    multihash.extend_from_slice(&[0x12, 0x20]);
+    multihash.extend_from_slice(hash);
+    multibase::encode(multibase::Base::Base58Btc, multihash)
 }
 
 impl From<&AuditEnvelope> for AuditEntry {
@@ -175,15 +197,19 @@ impl From<&AuditEnvelope> for AuditEntry {
             actor: env.actor_did_plain.clone(),
             target: env.target_did_plain.clone(),
             schema_version: env.schema_version,
-            prev_hash: hex::encode(env.prev_hash),
-            entry_hash: hex::encode(env.entry_hash),
+            prev_hash: digest_multibase(&env.prev_hash),
+            entry_hash: digest_multibase(&env.entry_hash),
             detail,
+            // `org.openvtc`, not `vtc`. SPEC §4.5.1 requires each immediate
+            // `ext` key to be a reverse-DNS namespace — at least two segments,
+            // `^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$` — and a bare `vtc` claims a
+            // name nobody owns, which is the collision the rule prevents.
             ext: serde_json::json!({
-                "vtc": {
+                "org.openvtc": {
                     "eventVersion": env.event_version,
                     "auditKeyId": env.audit_key_id.to_string(),
-                    "actorDidHash": hex::encode(env.actor_did_hash),
-                    "targetDidHash": env.target_did_hash.map(hex::encode),
+                    "actorDidHash": digest_multibase(&env.actor_did_hash),
+                    "targetDidHash": env.target_did_hash.as_ref().map(digest_multibase),
                 }
             }),
         }
@@ -356,7 +382,16 @@ pub struct VerifyResponse {
     pub chain_break: Option<ChainBreakReport>,
     /// Signed-checkpoint verification (#708) — the half of this endpoint that
     /// a store-level adversary cannot satisfy.
-    pub checkpoints: CheckpointReport,
+    ///
+    /// Carried under `ext` since #1110. The canonical response is
+    /// `additionalProperties: false` and defines no checkpoint member, so a
+    /// top-level one made every verify response non-conformant. This is
+    /// genuinely load-bearing evidence rather than a nicety, so it is not
+    /// dropped — `ext` is the framework's sanctioned slot for exactly this,
+    /// and the member is worth proposing upstream so it need not live in an
+    /// extension at all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ext: Option<serde_json::Value>,
 }
 
 /// Signed-checkpoint verification result.
@@ -706,9 +741,13 @@ pub async fn verify_audit_chain(
         entries_verified: verifier.verified(),
         legacy_skipped: verifier.skipped_legacy(),
         unparseable_skipped: unparseable,
-        head: verifier.head().map(hex::encode),
+        // Multibase, matching `audit/list`'s hashes — the two are meant to be
+        // compared, and the schema requires this form on both.
+        head: verifier.head().as_ref().map(digest_multibase),
         chain_break,
-        checkpoints,
+        ext: Some(serde_json::json!({
+            "org.openvtc": { "checkpoints": checkpoints }
+        })),
     };
 
     // Warn, not info, on failure: a broken audit chain is the kind of

--- a/vtc-service/src/routes/policies/admin.rs
+++ b/vtc-service/src/routes/policies/admin.rs
@@ -162,9 +162,16 @@ pub struct ActivateResponse {
     /// Canonical name for the id of the policy now in force.
     pub activated: Uuid,
     pub purpose: PolicyPurpose,
-    /// VTC extension: the activated module's source hash, so an
-    /// operator can confirm what went live without a second fetch.
-    pub sha256: String,
+    /// The activated module's source hash, under `ext`.
+    ///
+    /// It was a top-level `sha256` until #1110 — and its own doc called it a
+    /// "VTC extension", which is exactly what the framework's `ext` slot is
+    /// for. The response is `additionalProperties: false`, so an extension
+    /// carried beside the canonical members is not an extension, it is a
+    /// violation; `ext` is the sanctioned place and costs one level of
+    /// nesting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ext: Option<JsonValue>,
     /// Predecessor active policy id for this purpose. `null` for
     /// the first activation under a given purpose.
     pub previous_policy_id: Option<Uuid>,
@@ -387,7 +394,9 @@ pub async fn activate(
     Ok(Json(ActivateResponse {
         activated: id,
         purpose: policy.purpose,
-        sha256: sha256_hex,
+        ext: Some(serde_json::json!({
+            "org.openvtc": { "sha256": sha256_hex }
+        })),
         previous_policy_id: previous,
     }))
 }

--- a/vtc-service/src/routes/policies/read.rs
+++ b/vtc-service/src/routes/policies/read.rs
@@ -102,9 +102,12 @@ pub const PURPOSE_EXT_KEY: &str = "org.openvtc.purpose";
 /// - `updatedAt` is the activation time when the row has been
 ///   activated, else its creation time. A VTC revision is immutable, so
 ///   activation is the only thing that can change it after write.
-/// - `sha256` / `authorDid` / the intrinsic `purpose` have no canonical
+/// - `sha256` / `author-did` / the intrinsic `purpose` have no canonical
 ///   home and ride in `ext` (the canonical type is
-///   `additionalProperties: false`).
+///   `additionalProperties: false`). Every `ext` key is spelled in the
+///   lowercase-and-hyphen form SPEC §4.5.1 requires — a capital letter makes
+///   the key itself invalid, which is a framework violation rather than a
+///   style preference.
 ///
 /// `appliesTo` / `priority` / `enabled` are deliberately **not**
 /// emitted: VTC does no `appliesTo`/`priority` selection, and emitting
@@ -139,7 +142,13 @@ impl From<&Policy> for PolicyModuleResponse {
             ext: serde_json::json!({
                 PURPOSE_EXT_KEY: p.purpose.as_str(),
                 "org.openvtc.sha256": hex::encode(p.sha256),
-                "org.openvtc.authorDid": p.author_did,
+                // `author-did`, not `authorDid`. SPEC §4.5.1 constrains every
+                // immediate `ext` key to `^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$`,
+                // so the capital `D` made this key invalid — the one key of
+                // the five here that did not match, and invalid for the
+                // framework rather than merely off-convention. Hyphenated to
+                // match the `match-code` and `step-up` keys already in use.
+                "org.openvtc.author-did": p.author_did,
             }),
         }
     }

--- a/vtc-service/tests/acl_canonical.rs
+++ b/vtc-service/tests/acl_canonical.rs
@@ -173,12 +173,13 @@ async fn grant_with_the_same_role_rewrites_the_entry() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "rewrite, not create: {body}");
-    assert_eq!(body["scopes"], json!(["ctx-a", "ctx-b"]));
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-a", "ctx-b"]));
     assert!(
-        body["updatedAt"].as_str().is_some(),
+        body["entry"]["updatedAt"].as_str().is_some(),
         "a rewrite must stamp updatedAt: {body}"
     );
-    assert_eq!(body["updatedBy"], "did:key:z6MkAdmin");
+    assert_eq!(body["entry"]["updatedBy"], "did:key:z6MkAdmin");
 }
 
 #[tokio::test]
@@ -214,8 +215,9 @@ async fn change_role_enforces_the_from_role_guard() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "{body}");
-    assert_eq!(body["role"], "moderator");
-    assert!(body["updatedAt"].as_str().is_some(), "{body}");
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["role"], "moderator");
+    assert!(body["entry"]["updatedAt"].as_str().is_some(), "{body}");
 }
 
 /// Canonical revoke has two modes. `scopes` reduces; omitting it
@@ -247,7 +249,8 @@ async fn revoke_with_scopes_reduces_rather_than_removes() {
     // The entry must survive, minus that one scope.
     let (status, body) = call(&fix, "GET", "/v1/acl/did:key:z6MkErin", SHOW, &token, None).await;
     assert_eq!(status, StatusCode::OK, "entry must survive: {body}");
-    assert_eq!(body["scopes"], json!(["ctx-b"]));
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-b"]));
 }
 
 #[tokio::test]
@@ -293,7 +296,8 @@ async fn revoking_every_scope_is_refused_rather_than_unscoping() {
 
     let (status, body) = call(&fix, "GET", "/v1/acl/did:key:z6MkGina", SHOW, &token, None).await;
     assert_eq!(status, StatusCode::OK, "entry must be untouched: {body}");
-    assert_eq!(body["scopes"], json!(["ctx-a"]));
+    // `{entry: …}` — the shape these tasks publish (#1109).
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-a"]));
 }
 
 #[tokio::test]

--- a/vtc-service/tests/audit_list.rs
+++ b/vtc-service/tests/audit_list.rs
@@ -110,7 +110,7 @@ async fn response_and_entries_are_the_canonical_shape() {
     assert!(entry.get("actor_did_hash").is_none(), "{entry}");
     assert!(entry.get("timestamp").is_none(), "{entry}");
     assert!(
-        entry["ext"]["vtc"].get("actorDidHash").is_some(),
+        entry["ext"]["org.openvtc"].get("actorDidHash").is_some(),
         "keyed hash should ride in ext: {entry}"
     );
     // action is the serde tag; detail is the variant payload.
@@ -118,10 +118,15 @@ async fn response_and_entries_are_the_canonical_shape() {
     assert!(entry["detail"].is_object(), "{entry}");
 }
 
-/// `verify` reports `head` as hex; a caller comparing it against the
-/// newest entry's `entryHash` must not have to reconcile encodings.
+/// `verify`'s `head` and `list`'s newest `entryHash` must be the same string.
+///
+/// The invariant is that the two agree, not what they are encoded as — this
+/// test was named `..._are_hex_...` and its doc asserted hex, which is how a
+/// test comes to pin an encoding nobody chose deliberately. Both are now
+/// multibase-wrapped multihash, which is what the canonical schema's digest
+/// pattern accepts; the agreement is unchanged and is the thing worth testing.
 #[tokio::test]
-async fn entry_hashes_are_hex_matching_audit_verify_head() {
+async fn entry_hash_and_audit_verify_head_agree() {
     let fix = build().await;
     let token = super_admin_token(&fix).await;
     seed(&fix, &token, 2).await;

--- a/vtc-service/tests/audit_verify.rs
+++ b/vtc-service/tests/audit_verify.rs
@@ -117,9 +117,14 @@ async fn a_real_chain_verifies_and_reports_its_head() {
     );
     assert_eq!(body["legacySkipped"], 0);
     assert_eq!(body["unparseableSkipped"], 0);
+    // Multibase-wrapped multihash: `z` (base58btc) over `0x12 0x20` + the 32
+    // digest bytes. Asserting the prefix and a plausible length says what the
+    // encoding *is*; the previous `len() == 64` only said "some hex-ish
+    // string", which a base64 digest of the wrong thing would also satisfy.
+    let head = body["head"].as_str().expect("head present");
     assert!(
-        body["head"].as_str().is_some_and(|h| h.len() == 64),
-        "head is a hex-encoded SHA-256"
+        head.starts_with('z') && head.len() > 40,
+        "head must be a base58btc multibase multihash, got {head}"
     );
 }
 
@@ -264,7 +269,11 @@ async fn a_log_with_no_checkpoints_says_so_rather_than_looking_clean() {
     assert_eq!(body["verified"], true, "body: {body}");
     // ...but nothing has attested to it, and that must be visible.
     assert_eq!(
-        body["checkpoints"]["status"], "noCheckpoints",
+        // Checkpoints ride in `ext`: the canonical verify response is
+        // `additionalProperties: false` and defines no checkpoint member
+        // (#1110). Worth taking upstream so they need not be an extension.
+        body["ext"]["org.openvtc"]["checkpoints"]["status"],
+        "noCheckpoints",
         "body: {body}"
     );
 }
@@ -283,9 +292,18 @@ async fn a_checkpointed_log_verifies_as_consistent() {
     let (status, body) = verify(&fix, &token).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["verified"], true, "body: {body}");
-    assert_eq!(body["checkpoints"]["status"], "consistent", "body: {body}");
-    assert_eq!(body["checkpoints"]["verifiedCheckpoints"], 1);
-    assert_eq!(body["checkpoints"]["unattestedEntries"], 0);
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "consistent",
+        "body: {body}"
+    );
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["verifiedCheckpoints"],
+        1
+    );
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["unattestedEntries"],
+        0
+    );
 }
 
 /// **The whole point of #708.**
@@ -323,10 +341,16 @@ async fn truncating_the_log_is_caught_even_though_the_chain_still_verifies() {
         body["verified"], true,
         "a truncated prefix is still a valid chain — that is the whole problem: {body}"
     );
-    assert_eq!(body["checkpoints"]["status"], "truncated", "body: {body}");
-    assert_eq!(body["checkpoints"]["attestedEntries"], attested);
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "truncated",
+        "body: {body}"
+    );
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["attestedEntries"],
+        attested
+    );
     assert!(
-        body["checkpoints"]["detail"]
+        body["ext"]["org.openvtc"]["checkpoints"]["detail"]
             .as_str()
             .unwrap_or_default()
             .contains("TRUNCATION"),
@@ -363,9 +387,12 @@ async fn deleting_a_checkpoint_is_itself_detected() {
 
     let (status, body) = verify(&fix, &token).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["checkpoints"]["status"], "chainBroken", "body: {body}");
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "chainBroken",
+        "body: {body}"
+    );
     assert!(
-        body["checkpoints"]["detail"]
+        body["ext"]["org.openvtc"]["checkpoints"]["detail"]
             .as_str()
             .unwrap_or_default()
             .contains("deleted"),
@@ -405,9 +432,12 @@ async fn a_checkpoint_forged_with_a_foreign_key_is_rejected() {
 
     let (status, body) = verify(&fix, &token).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["checkpoints"]["status"], "chainBroken", "body: {body}");
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "chainBroken",
+        "body: {body}"
+    );
     assert!(
-        body["checkpoints"]["detail"]
+        body["ext"]["org.openvtc"]["checkpoints"]["detail"]
             .as_str()
             .unwrap_or_default()
             .contains("invalid signature"),
@@ -428,10 +458,19 @@ async fn entries_written_after_a_checkpoint_are_reported_as_unattested() {
 
     let (status, body) = verify(&fix, &token).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["checkpoints"]["status"], "consistent", "body: {body}");
-    assert_eq!(body["checkpoints"]["attestedEntries"], cp.entry_count);
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "consistent",
+        "body: {body}"
+    );
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["attestedEntries"],
+        cp.entry_count
+    );
     assert!(
-        body["checkpoints"]["unattestedEntries"].as_u64().unwrap() >= 3,
+        body["ext"]["org.openvtc"]["checkpoints"]["unattestedEntries"]
+            .as_u64()
+            .unwrap()
+            >= 3,
         "the post-checkpoint tail must be surfaced: {body}"
     );
 }
@@ -446,9 +485,12 @@ async fn a_vtc_with_no_signing_key_cannot_claim_checkpoint_health() {
 
     let (status, body) = verify(&fix, &token).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["checkpoints"]["status"], "chainBroken", "body: {body}");
+    assert_eq!(
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "chainBroken",
+        "body: {body}"
+    );
     assert!(
-        body["checkpoints"]["detail"]
+        body["ext"]["org.openvtc"]["checkpoints"]["detail"]
             .as_str()
             .unwrap_or_default()
             .contains("no community signing key"),
@@ -503,11 +545,13 @@ async fn a_checkpoint_naming_an_unknown_key_is_not_verified_against_the_live_one
     let (status, body) = verify(&fix, &token).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        body["checkpoints"]["status"], "chainBroken",
+        body["ext"]["org.openvtc"]["checkpoints"]["status"], "chainBroken",
         "a checkpoint naming a key the signer does not own must not verify \
          against the live key: {body}"
     );
-    let detail = body["checkpoints"]["detail"].as_str().unwrap_or_default();
+    let detail = body["ext"]["org.openvtc"]["checkpoints"]["detail"]
+        .as_str()
+        .unwrap_or_default();
     assert!(
         detail.contains("key-retired") && detail.contains("could not be resolved"),
         "the finding must name the unresolvable key and say so, rather than \


### PR DESCRIPTION
Stacked on #1109. Closes `audit/*` and `policy/activate` — **68 → ~22
violations**, all remaining ones needing a decision rather than a fix.

## Hex digests where the schema requires multibase

`audit/list` sent `prevHash` / `entryHash` as bare hex; the canonical digest
pattern is `^(z[1-9A-HJ-NP-Za-km-z]+|u[A-Za-z0-9_-]+)$` — multibase-wrapped
multihash. `audit/verify`'s `head` moved with them, so the two still agree,
which is the property that actually matters and is now what the test asserts.

The old comment justified hex as *"matching the encoding `audit/verify` uses
for `head` — a caller comparing the two must not have to reconcile hex against
the base64 the stored envelope uses."* Every word true, and it reconciled the
**two internal** encodings while overlooking the third: the one the published
schema requires. A bare digest is also self-describing in neither its hash
function nor its encoding, which is what multihash and multibase each exist to
fix.

**The chain is untouched.** Stored envelopes still hold `[u8; 32]` and hash
over bytes; this is the wire view only.

## Three more ways to bypass the extension slot

With #1109's invalid key and #1107's flattened key, that makes **five distinct
ways** `ext` was worked around in this service, each locally reasonable and
none checked against SPEC §4.5.1:

| where | what was wrong |
|---|---|
| `policy/*` (#1109) | `org.openvtc.authorDid` — capital letter, invalid key |
| `audit/list` | `"vtc"` — one segment, where reverse-DNS needs two |
| `policy/activate` | `sha256` at the top level of a closed response |
| `audit/verify` | `checkpoints` at the top level of a closed response |

The last two are the interesting pair. `sha256`'s own doc called it *"VTC
extension"* — the word was right there and the member was not in `ext`. Both
now sit under `org.openvtc`.

`checkpoints` is not a nicety: it is the signed-checkpoint evidence "a
store-level adversary cannot satisfy", so it is carried rather than dropped —
and it is worth proposing upstream so it need not live in an extension at all.

`"vtc"` as a namespace deserves a note: a single-segment key claims a name
nobody owns, which is the collision reverse-DNS exists to prevent.

## A test that pinned an encoding nobody chose

`entry_hashes_are_hex_matching_audit_verify_head` asserted `h.len() == 64`.
The body's real invariant is that `verify`'s `head` and `list`'s newest
`entryHash` are the same string — true before and after. The name and the
length check pinned hex, which nothing had decided deliberately.

Renamed `entry_hash_and_audit_verify_head_agree`, and the format assertion in
`audit_verify` now checks the `z` prefix rather than a character count —
`len() == 64` would also accept a base64 digest of the wrong thing.

## What remains, and why it is not here

**`auth/passkey/*` — six tasks**, and not a wrapper problem: the models
genuinely differ (`passkeys` vs `credentials`; missing `subject`,
`enrollmentId`, `registeredAt`). These are shared-family tasks served by both
daemons, which is exactly the "which service's response shape is canonical"
decision the witness header names. Picking a side here would be guessing.

**`vtc/relationships/{list,graph}`** — the *spec* looks stale, not the
service: `list` sends `vrcDigestMultibase` where the schema still says
`vrcSha256` (this workspace moved to multibase deliberately), and `graph`
returns a materially richer shape. Both want an upstream `0.2`, with the graph
shape confirmed by whoever designed it.

**`auth/whoami`** — one violation, unexamined.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast`
- `cargo fmt --all --check`

BREAKING CHANGE: `GET /v1/audit` returns `prevHash` / `entryHash` and `GET
/v1/audit/verify` returns `head` as multibase-wrapped multihash instead of
hex. `audit/list` carries its VTC members under `ext["org.openvtc"]` instead
of `ext["vtc"]`. `policy/activate`'s `sha256` and `audit/verify`'s
`checkpoints` move into `ext["org.openvtc"]`.

Refs #1059
