### PR TITLE
test(vtc)!: make response conformance fail the build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43a3909671dfa59719e98a836207b51d83bc2f53dfc82281207473354f83aa7"
+checksum = "09d00a1209aa2b7c0d5a012371ac356355b67511af00da974050aa8e61743987"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.13", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.14", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod members;
 pub(crate) mod policies;
 pub mod recognise;
 mod recognition_admin;
-mod relationships;
+pub(crate) mod relationships;
 mod schemas;
 pub(crate) mod status_lists;
 pub mod trust_tasks;
@@ -641,12 +641,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // (same path-trie precedence as personhood).
         .routes(tt(
             routes!(members::relationships::list),
-            "https://trusttasks.org/spec/vtc/relationships/list/0.1",
+            "https://trusttasks.org/spec/vtc/relationships/list/0.2",
         ))
         // Admin connections-graph view — the member-relationship (VRC) graph.
         .routes(tt(
             routes!(relationships::graph),
-            "https://trusttasks.org/spec/vtc/relationships/graph/0.1",
+            "https://trusttasks.org/spec/vtc/relationships/graph/0.2",
         ))
         .routes(tt(
             routes!(relationships::revoke),

--- a/vtc-service/src/test_support/response_conformance.rs
+++ b/vtc-service/src/test_support/response_conformance.rs
@@ -45,11 +45,42 @@ use axum::body::{Body, Bytes};
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
 
+/// Tasks whose responses are known not to conform, and may not fail the build
+/// yet.
+///
+/// **This list may only shrink.** It is the same discipline as
+/// `KNOWN_DRIFT_COUNT` in `trust_tasks::conformance`, for the same reason: a
+/// tolerated defect that nothing counts becomes a permanent one. Every entry
+/// names a task and why it is still here, and
+/// `the_allowlist_only_shrinks` fails if the count goes up.
+///
+/// Every entry below is an `auth/*` task in the shared families both daemons
+/// serve. The models genuinely differ — `passkeys` against `credentials`,
+/// and `whoami`'s session shape needs an `issuedAt` this service does not
+/// currently carry — so closing them means deciding whose shape is canonical
+/// and, where the spec cannot serve one of the daemons, amending the spec
+/// carefully rather than bending either implementation to fit.
+const ALLOWED: &[&str] = &[
+    "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2",
+    "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2",
+    "https://trusttasks.org/spec/auth/passkey/login/start/0.2",
+    "https://trusttasks.org/spec/auth/passkey/login/finish/0.2",
+    "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1",
+    "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1",
+    "https://trusttasks.org/spec/auth/passkey/list/0.1",
+    "https://trusttasks.org/spec/auth/whoami/0.1",
+];
+
+/// The number of allowlisted tasks, asserted so the list cannot grow quietly.
+pub const ALLOWED_COUNT: usize = 8;
+
 /// Violations observed during a test run, for the harness to assert on.
 ///
 /// Collected rather than panicked on inside the layer: a panic in middleware
 /// surfaces as a transport error at the call site, which reads as "the request
-/// failed" and hides what actually went wrong.
+/// failed" and hides what actually went wrong. The failure is raised at the
+/// end of the request instead, as a `500` carrying the reason, so the test
+/// that provoked it is the test that fails.
 static VIOLATIONS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 
 fn violations() -> &'static Mutex<Vec<String>> {
@@ -89,32 +120,115 @@ pub async fn validate_response(req: Request<Body>, next: Next) -> Response<Body>
         Err(_) => return Response::from_parts(parts, Body::empty()),
     };
 
-    check(&task, parts.status, &bytes);
-    Response::from_parts(parts, Body::from(bytes))
+    match check(&task, parts.status, &bytes) {
+        None => Response::from_parts(parts, Body::from(bytes)),
+        // Replace the response rather than panic. A panic in middleware
+        // surfaces at the call site as a transport error — "the request
+        // failed" — which says nothing about why. A 500 carrying the schema
+        // error makes the test that provoked it fail on its own status
+        // assertion, and print the reason.
+        Some(msg) => Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "error": "responseSchemaViolation",
+                    "message": msg,
+                })
+                .to_string(),
+            ))
+            .expect("static response builds"),
+    }
 }
 
 /// The check itself, separated so it is unit-testable without a router.
-fn check(task: &str, status: StatusCode, bytes: &Bytes) {
+///
+/// Returns the failure message when the response does not conform **and** the
+/// task is not allowlisted; `None` otherwise.
+fn check(task: &str, status: StatusCode, bytes: &Bytes) -> Option<String> {
     // 204 and an empty body carry no payload to validate.
     if status == StatusCode::NO_CONTENT || bytes.is_empty() {
-        return;
+        return None;
     }
-    let Some(schema) = trust_tasks_rs::schema_index::schema_for(&format!("{task}#response")) else {
-        return;
-    };
-    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
-        return;
-    };
+    let schema = trust_tasks_rs::schema_index::schema_for(&format!("{task}#response"))?;
+    let value = serde_json::from_slice::<serde_json::Value>(bytes).ok()?;
     // A Trust Task *document* carries its payload under `payload`; a bare REST
     // response is the payload itself. Validate whichever this is, so the layer
     // works across both bindings without the test having to say which.
     let payload = value.get("payload").unwrap_or(&value);
-    if let Err(e) = trust_tasks_rs::validate::against_schema(schema, payload) {
-        let msg = format!("{task}: {e}");
-        // Printed as well as collected. A violation that only accumulates in a
-        // static is invisible to `cargo test`, which is how a conformance
-        // signal quietly stops being one.
-        eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
-        violations().lock().expect("violations lock").push(msg);
+    let Err(e) = trust_tasks_rs::validate::against_schema(schema, payload) else {
+        return None;
+    };
+    let msg = format!("{task}: {e}");
+    eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
+    violations()
+        .lock()
+        .expect("violations lock")
+        .push(msg.clone());
+    if ALLOWED.contains(&task) {
+        return None;
+    }
+    Some(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The allowlist may only shrink.
+    ///
+    /// Asserted for the same reason `KNOWN_DRIFT_COUNT` is: a tolerated defect
+    /// that nothing counts becomes a permanent one, and the cheapest way to
+    /// make a failing check pass is to add a line to a list nobody is
+    /// watching. Closing an entry means deleting it *and* lowering this.
+    #[test]
+    fn the_allowlist_only_shrinks() {
+        assert_eq!(
+            ALLOWED.len(),
+            ALLOWED_COUNT,
+            "the response-conformance allowlist changed. Removing a task? \
+             Lower ALLOWED_COUNT with it. Adding one? That needs a reason in \
+             review, not a quiet edit — a route whose response does not match \
+             its published schema is a defect, and this list exists to record \
+             the ones already known, not to absorb new ones."
+        );
+    }
+
+    /// An allowlisted task is still *reported*, just not fatal — otherwise
+    /// closing one would mean first discovering it all over again.
+    #[test]
+    fn an_allowlisted_violation_is_recorded_but_not_fatal() {
+        clear_violations();
+        let before = observed_violations().len();
+        let out = check(
+            "https://trusttasks.org/spec/auth/whoami/0.1",
+            StatusCode::OK,
+            &Bytes::from_static(b"{\"nope\":1}"),
+        );
+        assert!(out.is_none(), "an allowlisted task must not fail the build");
+        assert_eq!(
+            observed_violations().len(),
+            before + 1,
+            "it must still be recorded, or the allowlist hides the work"
+        );
+    }
+
+    /// A task with no published schema is not a violation. Treating "unknown"
+    /// as "bad" would fail loudest on the routes this build understands least.
+    #[test]
+    fn an_unknown_task_is_not_a_violation() {
+        assert!(
+            check(
+                // Deliberately not a `trusttasks.org/spec/` URI:
+                // `every_bound_canonical_task_exists_in_the_registry` scans
+                // this crate for bound canonical URIs and would read a fake
+                // one here as a real binding — which it did, on the first
+                // run of this test.
+                "https://example.invalid/not/a/task/9.9",
+                StatusCode::OK,
+                &Bytes::from_static(b"{}"),
+            )
+            .is_none()
+        );
     }
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -1240,30 +1240,53 @@ fn table() -> Vec<Conformance> {
         ),
         // ─── relationships ───────────────────────────────────────────
         checked!(
-            s::relationships::list::v0_1::Payload,
-            s::relationships::list::v0_1::Response,
+            s::relationships::list::v0_2::Payload,
+            s::relationships::list::v0_2::Response,
             json!({ "did": DID, "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
-            // `Relationship` — relationships/mod.rs:59. The spec types the
-            // items as free objects, so only the wrapper diverges.
+            // This fixture said `vrcSha256` — the `0.1` member — while the
+            // service had already moved to a multibase digest. The table
+            // called the task conformant on that basis for as long as both
+            // were wrong together, which is what a hand-written fixture buys
+            // you. `0.2` (trustoverip/dtgwg-trust-tasks-tf#266) publishes the
+            // multibase form the service sends.
             paginated(json!([{
                 "id": REQUEST_ID,
                 "issuerDid": DID,
                 "subjectDid": OTHER_DID,
                 "vrcJsonld": credential(),
-                "vrcSha256": "3b9f0a1c8d2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3",
+                "vrcDigestMultibase": "zQmbGXRT3v1RmfWkQ7Y3Z5Uj9pKq2NcXhLd8sVtA4eB6nMw",
                 "createdAt": TS,
             }]))
         ),
         checked!(
-            s::relationships::graph::v0_1::Payload,
-            s::relationships::graph::v0_1::Response,
+            s::relationships::graph::v0_2::Payload,
+            s::relationships::graph::v0_2::Response,
             json!({}),
-            // `RelationshipsGraph` — routes/relationships.rs:773.
-            json!({
-                "nodes": [{ "did": DID }, { "did": OTHER_DID }],
-                "edges": [{ "id": REQUEST_ID, "issuerDid": DID,
-                            "subjectDid": OTHER_DID, "createdAt": TS }],
+            // Serialised from the real graph types. The hand-written version
+            // described `0.1`'s flat edge — one row per credential — which
+            // the service has never emitted: it groups halves by endpoint
+            // pair and says whether the edge is reciprocated. Two wrongs
+            // agreeing is what let this read as conformant.
+            serde_json::to_value(crate::routes::relationships::RelationshipsGraph {
+                nodes: vec![
+                    crate::routes::relationships::GraphNode { did: DID.into() },
+                    crate::routes::relationships::GraphNode {
+                        did: OTHER_DID.into()
+                    },
+                ],
+                edges: vec![crate::routes::relationships::GraphEdge {
+                    endpoints: vec![DID.into(), OTHER_DID.into()],
+                    halves: vec![crate::routes::relationships::GraphHalf {
+                        id: REQUEST_ID.into(),
+                        issuer_did: DID.into(),
+                        subject_did: OTHER_DID.into(),
+                        created_at: TS.into(),
+                        persona_did: None,
+                    }],
+                    complete: false,
+                }],
             })
+            .expect("RelationshipsGraph serialises")
         ),
         checked!(
             s::relationships::publish::v0_2::Payload,

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -34,8 +34,8 @@ use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const PUBLISH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/publish/0.2";
-const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/list/0.1";
-const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
+const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/list/0.2";
+const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.2";
 const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/revoke/0.1";
 const ISSUER_DID: &str = "did:key:zVrcIssuer";
 const SUBJECT_DID: &str = "did:key:zVrcSubject";
@@ -247,7 +247,19 @@ async fn seed_relationship(fix: &Fixture, issuer: &str, subject: &str) -> Uuid {
         issuer_did: issuer.into(),
         subject_did: subject.into(),
         vrc_jsonld: fake_vrc(issuer, subject),
-        vrc_digest_multibase: format!("seed-{id}"),
+        // A real multibase-wrapped multihash over the seeded credential, not
+        // `seed-{id}`. The placeholder was unique per row, which is all the
+        // storage layer needed — and it meant no test ever exercised a digest
+        // that looked like a digest, so the response-conformance layer found
+        // the format mismatch that the whole suite had been blind to.
+        vrc_digest_multibase: {
+            use sha2::{Digest, Sha256};
+            let canonical = serde_json_canonicalizer::to_vec(&fake_vrc(issuer, subject))
+                .expect("canonicalizable");
+            let mut mh = vec![0x12, 0x20];
+            mh.extend_from_slice(&Sha256::digest(&canonical));
+            multibase::encode(multibase::Base::Base58Btc, mh)
+        },
         created_at: chrono::Utc::now(),
         persona: None,
     };
@@ -1256,7 +1268,7 @@ mod pairwise {
         const GRAPH_ADMIN: u8 = 0x7A;
 
         const PERSONA_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/persona/0.1";
-        const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
+        const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.2";
 
         /// A signed VPC: issued under `persona_seed`'s P-DID, naming
         /// `counterparty_seed` as the subject. DTG Credentials §VPC.


### PR DESCRIPTION
The response-conformance layer now **fails the build**. Until this, a green
suite was not evidence of conformance — #1107's own memory note said to grep
the run rather than trust the exit code, which is a signal nobody has to obey.

Also retargets `relationships/{list,graph}` to the `0.2`s published in
trustoverip/dtgwg-trust-tasks-tf#266, closing the last VTC-family violations.

**The VTC family is now clean. Every remaining violation is `auth/*`.**

## The gate

A violation outside the allowlist returns `500` with the schema error, so the
test that provoked it fails on its own status assertion and prints the reason.

Chosen over panicking in middleware deliberately: a panic there surfaces at the
call site as a transport error — "the request failed" — which says nothing
about which task, or why.

## The allowlist, and why it can only shrink

Eight `auth/*` tasks, each listed with `ALLOWED_COUNT` asserted beside them.
Same discipline as `KNOWN_DRIFT_COUNT`, for the same reason: **the cheapest way
to make a failing check pass is to add a line to a list nobody is watching.**
Closing an entry means deleting it *and* lowering the count; adding one needs a
reason in review.

An allowlisted violation is still *reported*, just not fatal — pinned by a
test, because a list that suppressed the evidence would mean rediscovering each
entry before it could be closed.

## Two guards caught me, both correctly

**The allowlist named `login/{start,finish}/0.1`; the service binds `0.2`.**
Those two entries protected nothing, and the gate failed six step-up tests on
the first run. I had built the list from the violation *output* — which prints
whatever the request header said — rather than from the route mounts. Now taken
from `routes/mod.rs`.

**`every_bound_canonical_task_exists_in_the_registry` flagged a fake URI in my
own unit test.** I had used `trusttasks.org/spec/not/a/task/9.9` to exercise
the unknown-task path; that guard scans the crate for bound canonical URIs and
was exactly right that *"binding a `trusttasks.org/spec/` URI asserts the
registry serves it"*. Now `example.invalid`, with a comment saying why — a
guard that scans source for a URL pattern will find your fixtures too, and the
fix is to make the fixture obviously-not-real rather than to weaken the guard.

## A seeder that could never have caught a digest bug

`relationships/list` still failed after the `0.2` retarget, and it was not the
service: `seed_relationship` wrote `seed-{uuid}` into `vrcDigestMultibase`.
Unique per row, which is all the storage layer needed — and it meant **no test
ever exercised a digest that looked like a digest**, so the whole suite was
structurally blind to the format. It now computes a real multibase multihash
over the seeded credential.

## What remains

Eight `auth/*` tasks, all in the shared families both daemons serve. The models
genuinely differ (`passkeys` against `credentials`; `whoami`'s session needs an
`issuedAt` this service does not currently record).

The direction is settled: **follow the spec**, and where the spec cannot serve
one of the daemons, amend the spec — carefully — rather than bend an
implementation to fit. Each of the eight gets that question asked individually;
`whoami` is not a case of the spec being wrong but of this service not
recording something it should.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, no failures
- `cargo fmt --all --check`

`trust-tasks-rs` 0.11.14.

Refs #1059
