### PR TITLE
fix(vtc)!: follow the spec on every auth response, and close the conformance gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d00a1209aa2b7c0d5a012371ac356355b67511af00da974050aa8e61743987"
+checksum = "7e1df21614ad88d15fa17236478a4b7526258b35bc84cf545b13a09fc4997e9b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43a3909671dfa59719e98a836207b51d83bc2f53dfc82281207473354f83aa7"
+checksum = "09d00a1209aa2b7c0d5a012371ac356355b67511af00da974050aa8e61743987"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.13", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.14", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.14", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.15", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/vta-backup/src/ops/descriptors.rs
+++ b/vta-backup/src/ops/descriptors.rs
@@ -604,6 +604,7 @@ mod tests {
             allowed_contexts: Vec::new(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -616,6 +617,7 @@ mod tests {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-backup/src/test_support.rs
+++ b/vta-backup/src/test_support.rs
@@ -99,6 +99,7 @@ pub fn super_admin_claims() -> AuthClaims {
         allowed_contexts: Vec::new(),
         session_id: "test-session".into(),
         access_expires_at: 0,
+        issued_at: 0,
         amr: Vec::new(),
         acr: String::new(),
     }

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -179,6 +179,11 @@ pub async fn auth_from_did(
         session_id: session.session_id,
         // Intrinsic-sender auth carries no JWT, hence no access-token expiry.
         access_expires_at: 0,
+        // The session's own creation, not "now". These sessions are persistent
+        // and DID-keyed, so every message from a peer resolves the same row —
+        // stamping the arrival time would make each message look like a fresh
+        // login, which is the opposite of what this row exists to record.
+        issued_at: session.created_at,
         // Trust the session's persisted assurance level. A freshly-created
         // session is `aal1` with a single `did` factor; an elevated one reports
         // `aal2` until its window lapses.

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -1048,6 +1048,7 @@ mod tests {
             allowed_contexts: contexts.iter().map(|s| s.to_string()).collect(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -1870,6 +1871,7 @@ mod tests {
             allowed_contexts: Vec::new(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -1906,6 +1908,7 @@ mod tests {
             allowed_contexts: Vec::new(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2044,6 +2047,7 @@ mod tests {
             allowed_contexts: vec!["ctx-shared".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2101,6 +2105,7 @@ mod tests {
             allowed_contexts: Vec::new(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -616,6 +616,7 @@ mod tests {
             allowed_contexts: vec![],
             session_id: "s".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -758,6 +759,7 @@ mod tests {
             allowed_contexts: vec![],
             session_id: "s".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -2011,6 +2011,7 @@ mod tests {
             allowed_contexts: vec!["ctx-a".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2036,6 +2037,7 @@ mod tests {
             allowed_contexts: vec!["ctx-b".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -365,6 +365,7 @@ mod tests {
             allowed_contexts: vec!["vta".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -340,6 +340,7 @@ mod tests {
             allowed_contexts: Vec::new(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -1465,6 +1465,7 @@ mod tests {
                 allowed_contexts: vec![], // empty = super admin
                 session_id: "test-session".into(),
                 access_expires_at: 0,
+                issued_at: 0,
                 amr: Vec::new(),
                 acr: String::new(),
             }
@@ -2036,6 +2037,7 @@ mod tests {
             allowed_contexts: vec!["locked-ctx".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2158,6 +2160,7 @@ mod tests {
             allowed_contexts: vec!["test-ctx".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2297,6 +2300,7 @@ mod tests {
             allowed_contexts: vec!["test-ctx".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2444,6 +2448,7 @@ mod tests {
             allowed_contexts: vec!["domain-b".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2549,6 +2554,7 @@ mod tests {
             allowed_contexts: vec!["some-ctx".to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2630,6 +2636,7 @@ mod tests {
             allowed_contexts: vec!["test-ctx".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -2668,6 +2675,7 @@ mod tests {
             allowed_contexts: vec!["test-ctx".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };

--- a/vta-service/src/operations/policy.rs
+++ b/vta-service/src/operations/policy.rs
@@ -330,6 +330,7 @@ mod tests {
             allowed_contexts: Vec::new(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/src/operations/protocol/list.rs
+++ b/vta-service/src/operations/protocol/list.rs
@@ -215,6 +215,7 @@ mod tests {
             allowed_contexts: vec!["vta".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -371,6 +371,7 @@ mod tests {
             // shape used by `AuthClaims::synthesize` for DIDComm-only
             // callers in the codebase.
             access_expires_at: 0,
+            issued_at: 0,
             amr: vec!["synth".into()],
             acr: String::new(),
         }

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -183,6 +183,7 @@ pub fn super_admin_claims() -> AuthClaims {
         allowed_contexts: Vec::new(),
         session_id: "test-session".into(),
         access_expires_at: 0,
+        issued_at: 0,
         amr: Vec::new(),
         acr: String::new(),
     }

--- a/vta-service/src/trust_tasks/app_state.rs
+++ b/vta-service/src/trust_tasks/app_state.rs
@@ -489,6 +489,7 @@ mod tests {
             allowed_contexts: vec![ctx.to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/src/trust_tasks/ceremony.rs
+++ b/vta-service/src/trust_tasks/ceremony.rs
@@ -154,8 +154,10 @@ pub(crate) fn ceremony_claims(sender_did: &str) -> AuthClaims {
         allowed_contexts: Vec::new(),
         session_id: sender_did.to_string(),
         // No JWT, hence no access-token expiry — same as every other
-        // intrinsic-sender caller.
+        // intrinsic-sender caller. `issued_at` is 0 for the stronger reason
+        // that no session row exists at all: there is nothing that was issued.
         access_expires_at: 0,
+        issued_at: 0,
         amr: vec!["did".to_string()],
         acr: "aal1".to_string(),
     }

--- a/vta-service/src/trust_tasks/memory.rs
+++ b/vta-service/src/trust_tasks/memory.rs
@@ -137,6 +137,7 @@ mod tests {
             allowed_contexts: vec![ctx.to_string()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/src/trust_tasks/messaging.rs
+++ b/vta-service/src/trust_tasks/messaging.rs
@@ -90,6 +90,7 @@ mod tests {
             allowed_contexts: vec![],
             session_id: "didcomm:did:key:zPinger".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: vec!["did".into()],
             acr: "aal1".into(),
         };

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -1983,6 +1983,7 @@ mod context_scope_tests {
             allowed_contexts: contexts.iter().map(|c| c.to_string()).collect(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vta-service/tests/security.rs
+++ b/vta-service/tests/security.rs
@@ -15,6 +15,7 @@ mod auth_enforcement {
             allowed_contexts: vec![],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -27,6 +28,7 @@ mod auth_enforcement {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -39,6 +41,7 @@ mod auth_enforcement {
             allowed_contexts: vec![],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -51,6 +54,7 @@ mod auth_enforcement {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -121,6 +125,7 @@ mod auth_enforcement {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -133,6 +138,7 @@ mod auth_enforcement {
             allowed_contexts: vec![],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -236,6 +242,7 @@ mod acl_validation {
             allowed_contexts: vec![],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }

--- a/vtc-service/admin-ui/src/plugins/myPasskeys.tsx
+++ b/vtc-service/admin-ui/src/plugins/myPasskeys.tsx
@@ -37,27 +37,36 @@ const TRUST_TASK_REVOKE_FINISH =
   "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1";
 
 
-interface RegisteredPasskey {
+// The shared `RegisteredCredential` component of `auth/passkey/list/0.1`.
+// `deviceLabel` and `lastUsedAt` are both genuinely optional: the schema is
+// explicit that a consumer must not invent a label, "because an invented one is
+// indistinguishable from a chosen one to somebody deciding which credential to
+// revoke", so an unlabelled credential renders as unlabelled.
+interface RegisteredCredential {
   credentialId: string;
-  label: string;
+  deviceLabel?: string;
   transports: string[];
   registeredAt: string;
-  lastUsedAt: string | null;
+  lastUsedAt?: string;
 }
 
 interface ListResponse {
-  passkeys: RegisteredPasskey[];
+  credentials: RegisteredCredential[];
 }
 
+// `enroll/start/0.2` sends the *inner* WebAuthn options — the value that goes
+// in `navigator.credentials.create({ publicKey: … })` — not the wrapper. The
+// daemon used to send `{publicKey: …}` and this file unwrapped it only to
+// re-wrap it one line later; #1112 removed that round trip.
 interface RegisterStartResponse {
-  registrationId: string;
-  registerOptions: { publicKey: JsonPublicKeyOptions };
-  uvOptions: { publicKey: JsonPublicKeyOptions };
+  enrollmentId: string;
+  options: JsonPublicKeyOptions;
+  uvOptions: JsonPublicKeyOptions;
 }
 
 interface RevokeStartResponse {
   revocationId: string;
-  uvOptions: { publicKey: JsonPublicKeyOptions };
+  uvOptions: JsonPublicKeyOptions;
 }
 
 async function fetchPasskeys(): Promise<ListResponse> {
@@ -80,7 +89,7 @@ async function registerPasskey(args: {
   );
 
   const createPublicKey = decodePublicKeyOptions(
-    start.registerOptions.publicKey,
+    start.options,
   ) as PublicKeyCredentialCreationOptions;
   const newCred = (await navigator.credentials.create({
     publicKey: createPublicKey,
@@ -90,7 +99,7 @@ async function registerPasskey(args: {
   }
 
   const uvPublicKey = decodePublicKeyOptions(
-    start.uvOptions.publicKey,
+    start.uvOptions,
   ) as PublicKeyCredentialRequestOptions;
   const uvCred = (await navigator.credentials.get({
     publicKey: uvPublicKey,
@@ -102,7 +111,7 @@ async function registerPasskey(args: {
   await postJson<unknown>(
     "/v1/admin/passkeys/register/finish",
     {
-      registration_id: start.registrationId,
+      registration_id: start.enrollmentId,
       register_response: serializeRegistration(newCred),
       uv_response: serializeAssertion(uvCred),
       label: args.label,
@@ -122,7 +131,7 @@ async function revokePasskey(args: {
   );
 
   const uvPublicKey = decodePublicKeyOptions(
-    start.uvOptions.publicKey,
+    start.uvOptions,
   ) as PublicKeyCredentialRequestOptions;
   const uvCred = (await navigator.credentials.get({
     publicKey: uvPublicKey,
@@ -168,7 +177,7 @@ export function MyPasskeys() {
     },
   });
 
-  const passkeys = query.data?.passkeys ?? [];
+  const passkeys = query.data?.credentials ?? [];
   const onlyOne = passkeys.length === 1;
 
   return (
@@ -295,7 +304,7 @@ export function MyPasskeys() {
             )}
             {passkeys.map((p) => (
               <tr key={p.credentialId}>
-                <td>{p.label}</td>
+                <td>{p.deviceLabel ?? <span className="muted">—</span>}</td>
                 <td>
                   <code className="truncate" title={p.credentialId}>
                     {p.credentialId}
@@ -321,7 +330,9 @@ export function MyPasskeys() {
                     }
                     onClick={async () => {
                       const ok = await confirm({
-                        title: `Revoke "${p.label}"?`,
+                        title: p.deviceLabel
+                          ? `Revoke "${p.deviceLabel}"?`
+                          : "Revoke this passkey?",
                         message:
                           "You'll need to verify with another passkey. The revoked passkey can no longer sign in.",
                         confirmLabel: "Revoke",

--- a/vtc-service/src/routes/admin/passkeys.rs
+++ b/vtc-service/src/routes/admin/passkeys.rs
@@ -33,7 +33,7 @@
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::info;
@@ -45,10 +45,7 @@ use vti_common::auth::passkey::store::{
     store_registration_state, take_auth_state, take_registration_state,
 };
 use vti_common::error::AppError;
-use webauthn_rs::prelude::{
-    CreationChallengeResponse, Passkey, PublicKeyCredential, RegisterPublicKeyCredential,
-    RequestChallengeResponse, Webauthn,
-};
+use webauthn_rs::prelude::{Passkey, PublicKeyCredential, RegisterPublicKeyCredential, Webauthn};
 
 use crate::acl::admin::{AdminEntry, RegisteredPasskey, get_admin_entry, store_admin_entry};
 use crate::server::AppState;
@@ -69,22 +66,83 @@ static ADMIN_PASSKEY_LOCK: Mutex<()> = Mutex::const_new(());
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct ListResponse {
-    pub passkeys: Vec<RegisteredPasskey>,
+    /// `credentials`, the name `auth/passkey/list/0.1` publishes. It was
+    /// `passkeys` until #1112 — the same object under a name the schema does
+    /// not define, so no conforming client could find it.
+    pub credentials: Vec<RegisteredCredential>,
+}
+
+/// The wire view of a passkey, as `auth/passkey/list/0.1` publishes it.
+///
+/// Separate from [`RegisteredPasskey`] because that type is a **storage row**:
+/// it is `Deserialize`d out of the `admin:<did>` record, so its member names
+/// are the on-disk format and renaming them would orphan every passkey already
+/// enrolled. The two shapes disagree in exactly the two ways the schema cares
+/// about, and both differences are the storage row's to keep:
+///
+/// - `label` is published as `deviceLabel`, and is **absent** rather than empty
+///   when nobody chose one. The schema is explicit that a consumer must not
+///   synthesize a label, "because an invented one is indistinguishable from a
+///   chosen one to somebody deciding which credential to revoke" — and `""` is
+///   an invented one.
+/// - `lastUsedAt` is omitted when unset. Sending `null` is a type error against
+///   a `date-time` member, and the schema notes it deliberately does not
+///   distinguish "never used" from "not tracked", since no binding could carry
+///   the difference anyway.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(utoipa::ToSchema)]
+pub struct RegisteredCredential {
+    pub credential_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_label: Option<String>,
+    pub transports: Vec<String>,
+    pub registered_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<DateTime<Utc>>,
+}
+
+impl From<&RegisteredPasskey> for RegisteredCredential {
+    fn from(p: &RegisteredPasskey) -> Self {
+        Self {
+            credential_id: p.credential_id.clone(),
+            device_label: (!p.label.is_empty()).then(|| p.label.clone()),
+            transports: p.transports.clone(),
+            registered_at: p.registered_at,
+            last_used_at: p.last_used_at,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct RegisterStartResponse {
-    /// Opaque id the operator passes back to `register/finish`.
-    pub registration_id: String,
-    /// `navigator.credentials.create()` options — EdDSA-restricted.
+    /// Opaque id the operator passes back to `enroll/finish`.
+    ///
+    /// `enrollmentId`, the name the task publishes — it was `registrationId`
+    /// until #1112.
+    pub enrollment_id: String,
+    /// The value for `navigator.credentials.create({ publicKey: … })`.
+    ///
+    /// The **inner** options, not webauthn-rs's `{publicKey: …}` wrapper.
+    /// `CredentialCreationOptions` in the published schema describes itself as
+    /// "server-issued options for `navigator.credentials.create({ publicKey:
+    /// ... })`" — the value that goes *inside* the key, not the object
+    /// containing it.
+    ///
+    /// The wrapper was pure ceremony: the admin SPA unwrapped it with
+    /// `start.registerOptions.publicKey` and immediately re-wrapped it as
+    /// `create({ publicKey: … })`. Sending the inner object means the client
+    /// writes `create({ publicKey: start.options })` and nothing is undone on
+    /// the way.
     #[schema(value_type = Object)]
-    pub register_options: CreationChallengeResponse,
-    /// `navigator.credentials.get()` options for the step-up UV
-    /// assertion against an existing passkey.
+    pub options: webauthn_rs_proto::PublicKeyCredentialCreationOptions,
+    /// The value for `navigator.credentials.get({ publicKey: … })` for the
+    /// step-up assertion against an existing passkey. Unwrapped for the same
+    /// reason as `options`.
     #[schema(value_type = Object)]
-    pub uv_options: RequestChallengeResponse,
+    pub uv_options: webauthn_rs_proto::PublicKeyCredentialRequestOptions,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -105,6 +163,17 @@ pub struct RegisterFinishRequest {
 #[derive(utoipa::ToSchema)]
 pub struct RegisterFinishResponse {
     pub credential_id: String,
+    /// The DID this passkey now authenticates.
+    ///
+    /// Required by `auth/passkey/enroll/finish/0.2` and absent until #1112.
+    /// A caller enrolling on behalf of someone else had no way to confirm
+    /// *whose* credential it just created — the response named the credential
+    /// and not the subject, which is the half that matters for an audit trail.
+    pub subject: String,
+    /// When the credential was registered. Required by the task, and the same
+    /// instant recorded on the stored `RegisteredPasskey`, so a client need
+    /// not re-list to learn it.
+    pub registered_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -118,7 +187,10 @@ pub struct RevokeStartRequest {
 pub struct RevokeStartResponse {
     pub revocation_id: String,
     #[schema(value_type = Object)]
-    pub uv_options: RequestChallengeResponse,
+    /// Unwrapped, as everywhere else in this family — the value for
+    /// `navigator.credentials.get({ publicKey: … })`.
+    #[schema(value_type = Object)]
+    pub uv_options: webauthn_rs_proto::PublicKeyCredentialRequestOptions,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -133,6 +205,16 @@ pub struct RevokeFinishRequest {
 #[derive(utoipa::ToSchema)]
 pub struct RevokeFinishResponse {
     pub credential_id: String,
+    /// When the credential was revoked.
+    pub revoked_at: DateTime<Utc>,
+    /// How many passkeys the subject has left.
+    ///
+    /// Required by `auth/passkey/revoke/finish/0.1` and absent until #1112.
+    /// It is the number the caller most needs and the one this endpoint is
+    /// uniquely placed to give: the last-passkey guard refuses to leave an
+    /// admin at zero, so a client that cannot see the count cannot tell
+    /// whether the next revoke will succeed without attempting it.
+    pub remaining: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -165,7 +247,7 @@ pub async fn list(
         .await?
         .ok_or_else(|| AppError::NotFound("no admin entry for caller".into()))?;
     Ok(Json(ListResponse {
-        passkeys: entry.passkeys,
+        credentials: entry.passkeys.iter().map(Into::into).collect(),
     }))
 }
 
@@ -218,9 +300,9 @@ pub async fn register_start(
     info!(%did, %registration_id, "passkey register ceremony started");
 
     Ok(Json(RegisterStartResponse {
-        registration_id,
-        register_options,
-        uv_options,
+        enrollment_id: registration_id,
+        options: register_options.public_key,
+        uv_options: uv_options.public_key,
     }))
 }
 
@@ -277,11 +359,12 @@ pub async fn register_finish(
     let mut admin_entry = get_admin_entry(&state.passkey_ks, &did)
         .await?
         .unwrap_or_else(|| AdminEntry::new(did.clone()));
+    let registered_at = Utc::now();
     admin_entry.passkeys.push(RegisteredPasskey {
         credential_id: new_cred_id_hex.clone(),
         label: req.label.clone(),
         transports: req.transports.clone(),
-        registered_at: Utc::now(),
+        registered_at,
         last_used_at: None,
     });
     store_admin_entry(&state.passkey_ks, &admin_entry).await?;
@@ -304,6 +387,8 @@ pub async fn register_finish(
         StatusCode::OK,
         Json(RegisterFinishResponse {
             credential_id: new_cred_id_hex,
+            subject: did.clone(),
+            registered_at,
         }),
     ))
 }
@@ -368,7 +453,7 @@ pub async fn revoke_start(
 
     Ok(Json(RevokeStartResponse {
         revocation_id,
-        uv_options,
+        uv_options: uv_options.public_key,
     }))
 }
 
@@ -475,6 +560,8 @@ pub async fn revoke_finish(
 
     Ok(Json(RevokeFinishResponse {
         credential_id: target_cred_id,
+        revoked_at: Utc::now(),
+        remaining: admin_entry.passkeys.len(),
     }))
 }
 

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -2,6 +2,7 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use trust_tasks_rs::TrustTask;
 use trust_tasks_rs::specs::auth::passkey::login::start::v0_2 as start_spec;
@@ -495,7 +496,11 @@ pub async fn admin_session(
 pub struct PasskeyLoginStartResponse {
     pub auth_id: String,
     #[schema(value_type = Object)]
-    pub options: webauthn_rs::prelude::RequestChallengeResponse,
+    /// The value for `navigator.credentials.get({ publicKey: … })` — the
+    /// inner options, not webauthn-rs's `{publicKey: …}` wrapper. See
+    /// `admin::passkeys::RegisterStartResponse::options` for why the wrapper
+    /// went.
+    pub options: webauthn_rs_proto::PublicKeyCredentialRequestOptions,
 }
 
 /// Request body for `passkey-login/start`, per
@@ -627,7 +632,7 @@ pub async fn passkey_login_start(
 
     Ok(Json(PasskeyLoginStartResponse {
         auth_id,
-        options: rcr,
+        options: rcr.public_key,
     }))
 }
 
@@ -775,7 +780,13 @@ pub async fn passkey_login_finish(
     let csrf = hex::encode(csrf_bytes);
     let csrf_cookie = build_csrf_cookie(&csrf, max_age);
 
-    let resp = AuthenticateResponse {
+    let resp = PasskeyLoginResponse {
+        // Required by `login/finish/0.2`, and not merely decorative: `start`
+        // decides the purpose, so the client learns which branch answered only
+        // from this member. Without it a caller must infer the branch from the
+        // presence of `tokens`, which is exactly the shape-sniffing the enum
+        // exists to remove.
+        purpose: "login".to_string(),
         session: WireSession {
             id: session_id.clone(),
             subject: user.did.clone(),
@@ -837,6 +848,22 @@ async fn credentials_for(
 /// one passkey gesture from authorising every future privileged operation on
 /// the session.
 const STEP_UP_ELEVATION_TTL_SECS: u64 = 900; // 15m
+
+/// `purpose: login` response — a new session plus its tokens.
+///
+/// Not `AuthenticateResponse`, which this handler used to reuse: that type
+/// serves `auth/authenticate/0.1`, whose schema is closed and has no `purpose`.
+/// One struct cannot satisfy both tasks, and reusing it here is what left
+/// `login/finish/0.2` short of a required member — the two responses look alike
+/// but answer different questions.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PasskeyLoginResponse {
+    /// Always `"login"`. The sibling of [`PasskeyStepUpResponse::purpose`].
+    pub purpose: String,
+    pub session: WireSession,
+    pub tokens: TokenBundle,
+}
 
 /// `purpose: stepUp` response — the elevated session, no tokens. Per
 /// `spec/auth/passkey/login/finish/0.2`: the caller's existing tokens remain
@@ -1224,11 +1251,39 @@ impl From<Session> for SessionSummary {
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct WhoamiResponse {
-    pub did: String,
-    pub role: String,
-    pub session_id: String,
-    pub access_expires_at: u64,
-    pub allowed_contexts: Vec<String>,
+    /// The caller's session, under the member the task publishes.
+    ///
+    /// This response was a flat `{did, role, sessionId, accessExpiresAt,
+    /// allowedContexts}` until #1112 — every member outside the canonical
+    /// vocabulary, on a response that is `additionalProperties: false`. No
+    /// conforming client could read any of it.
+    pub session: SessionView,
+    /// The caller's roles. Plural because the component says so: a single
+    /// role is one entry, and a deployment that grows to several does not
+    /// need a new response shape.
+    pub roles: Vec<String>,
+    /// The contexts this session may act in — `allowedContexts` under the
+    /// canonical name.
+    pub scopes: Vec<String>,
+}
+
+/// The canonical `Session` shape.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionView {
+    pub id: String,
+    /// The DID this session authenticates.
+    pub subject: String,
+    /// When the session was issued — the JWT's `iat`, required by the
+    /// component and simply never surfaced before.
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    /// Authentication methods per RFC 8176, when the token records any.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub amr: Vec<String>,
+    /// Authentication context class per OIDC Core §2, when recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acr: Option<String>,
 }
 
 /// `GET /v1/auth/whoami` — returns the caller's identity claims
@@ -1245,12 +1300,24 @@ pub struct WhoamiResponse {
 )]
 pub async fn whoami(auth: AuthClaims) -> Json<WhoamiResponse> {
     Json(WhoamiResponse {
-        did: auth.did,
-        role: auth.role.to_string(),
-        session_id: auth.session_id,
-        access_expires_at: auth.access_expires_at,
-        allowed_contexts: auth.allowed_contexts,
+        session: SessionView {
+            id: auth.session_id,
+            subject: auth.did,
+            issued_at: epoch_to_datetime(auth.issued_at),
+            expires_at: epoch_to_datetime(auth.access_expires_at),
+            amr: auth.amr,
+            acr: Some(auth.acr).filter(|a| !a.is_empty()),
+        },
+        roles: vec![auth.role.to_string()],
+        scopes: auth.allowed_contexts,
     })
+}
+
+/// Unix seconds to a `DateTime`, for the `format: date-time` members the
+/// canonical components use. Out-of-range input clamps to the epoch rather
+/// than panicking — a malformed timestamp should not take the endpoint down.
+fn epoch_to_datetime(secs: u64) -> DateTime<Utc> {
+    DateTime::from_timestamp(secs as i64, 0).unwrap_or(DateTime::UNIX_EPOCH)
 }
 
 // ---------- POST /auth/sign-out ----------

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod members;
 pub(crate) mod policies;
 pub mod recognise;
 mod recognition_admin;
-mod relationships;
+pub(crate) mod relationships;
 mod schemas;
 pub(crate) mod status_lists;
 pub mod trust_tasks;
@@ -641,12 +641,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // (same path-trie precedence as personhood).
         .routes(tt(
             routes!(members::relationships::list),
-            "https://trusttasks.org/spec/vtc/relationships/list/0.1",
+            "https://trusttasks.org/spec/vtc/relationships/list/0.2",
         ))
         // Admin connections-graph view — the member-relationship (VRC) graph.
         .routes(tt(
             routes!(relationships::graph),
-            "https://trusttasks.org/spec/vtc/relationships/graph/0.1",
+            "https://trusttasks.org/spec/vtc/relationships/graph/0.2",
         ))
         .routes(tt(
             routes!(relationships::revoke),

--- a/vtc-service/src/test_support/response_conformance.rs
+++ b/vtc-service/src/test_support/response_conformance.rs
@@ -54,25 +54,16 @@ use axum::middleware::Next;
 /// names a task and why it is still here, and
 /// `the_allowlist_only_shrinks` fails if the count goes up.
 ///
-/// Every entry below is an `auth/*` task in the shared families both daemons
-/// serve. The models genuinely differ — `passkeys` against `credentials`,
-/// and `whoami`'s session shape needs an `issuedAt` this service does not
-/// currently carry — so closing them means deciding whose shape is canonical
-/// and, where the spec cannot serve one of the daemons, amending the spec
-/// carefully rather than bending either implementation to fit.
-const ALLOWED: &[&str] = &[
-    "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2",
-    "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2",
-    "https://trusttasks.org/spec/auth/passkey/login/start/0.2",
-    "https://trusttasks.org/spec/auth/passkey/login/finish/0.2",
-    "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1",
-    "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1",
-    "https://trusttasks.org/spec/auth/passkey/list/0.1",
-    "https://trusttasks.org/spec/auth/whoami/0.1",
-];
+/// **The list is empty.** Every route this suite exercises now conforms to the
+/// schema its task publishes, so the layer is an unconditional gate rather than
+/// a report with exceptions. The machinery stays because the discipline is the
+/// point: a task that starts failing must be *fixed*, and if it genuinely
+/// cannot be, adding it back here is a visible decision that shows up in a
+/// diff — not a silent one.
+const ALLOWED: &[&str] = &[];
 
 /// The number of allowlisted tasks, asserted so the list cannot grow quietly.
-pub const ALLOWED_COUNT: usize = 8;
+pub const ALLOWED_COUNT: usize = 0;
 
 /// Violations observed during a test run, for the harness to assert on.
 ///
@@ -194,22 +185,29 @@ mod tests {
         );
     }
 
-    /// An allowlisted task is still *reported*, just not fatal — otherwise
-    /// closing one would mean first discovering it all over again.
+    /// A violation is *recorded* as well as raised.
+    ///
+    /// The two are separate on purpose. Raising fails the one test that
+    /// provoked it; recording is what lets a run be swept for every violation
+    /// at once, which is how the original inventory of 134 was taken. If the
+    /// allowlist ever gains an entry again, that entry is reported and not
+    /// raised — recording is the half that keeps it visible.
     #[test]
-    fn an_allowlisted_violation_is_recorded_but_not_fatal() {
+    fn a_violation_is_recorded_as_well_as_raised() {
         clear_violations();
-        let before = observed_violations().len();
         let out = check(
             "https://trusttasks.org/spec/auth/whoami/0.1",
             StatusCode::OK,
             &Bytes::from_static(b"{\"nope\":1}"),
         );
-        assert!(out.is_none(), "an allowlisted task must not fail the build");
+        assert!(
+            out.is_some(),
+            "a non-allowlisted violation must fail the build"
+        );
         assert_eq!(
             observed_violations().len(),
-            before + 1,
-            "it must still be recorded, or the allowlist hides the work"
+            1,
+            "it must also be recorded, or a run cannot be swept for all of them"
         );
     }
 

--- a/vtc-service/src/test_support/response_conformance.rs
+++ b/vtc-service/src/test_support/response_conformance.rs
@@ -45,11 +45,42 @@ use axum::body::{Body, Bytes};
 use axum::http::{Request, Response, StatusCode};
 use axum::middleware::Next;
 
+/// Tasks whose responses are known not to conform, and may not fail the build
+/// yet.
+///
+/// **This list may only shrink.** It is the same discipline as
+/// `KNOWN_DRIFT_COUNT` in `trust_tasks::conformance`, for the same reason: a
+/// tolerated defect that nothing counts becomes a permanent one. Every entry
+/// names a task and why it is still here, and
+/// `the_allowlist_only_shrinks` fails if the count goes up.
+///
+/// Every entry below is an `auth/*` task in the shared families both daemons
+/// serve. The models genuinely differ — `passkeys` against `credentials`,
+/// and `whoami`'s session shape needs an `issuedAt` this service does not
+/// currently carry — so closing them means deciding whose shape is canonical
+/// and, where the spec cannot serve one of the daemons, amending the spec
+/// carefully rather than bending either implementation to fit.
+const ALLOWED: &[&str] = &[
+    "https://trusttasks.org/spec/auth/passkey/enroll/start/0.2",
+    "https://trusttasks.org/spec/auth/passkey/enroll/finish/0.2",
+    "https://trusttasks.org/spec/auth/passkey/login/start/0.2",
+    "https://trusttasks.org/spec/auth/passkey/login/finish/0.2",
+    "https://trusttasks.org/spec/auth/passkey/revoke/start/0.1",
+    "https://trusttasks.org/spec/auth/passkey/revoke/finish/0.1",
+    "https://trusttasks.org/spec/auth/passkey/list/0.1",
+    "https://trusttasks.org/spec/auth/whoami/0.1",
+];
+
+/// The number of allowlisted tasks, asserted so the list cannot grow quietly.
+pub const ALLOWED_COUNT: usize = 8;
+
 /// Violations observed during a test run, for the harness to assert on.
 ///
 /// Collected rather than panicked on inside the layer: a panic in middleware
 /// surfaces as a transport error at the call site, which reads as "the request
-/// failed" and hides what actually went wrong.
+/// failed" and hides what actually went wrong. The failure is raised at the
+/// end of the request instead, as a `500` carrying the reason, so the test
+/// that provoked it is the test that fails.
 static VIOLATIONS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 
 fn violations() -> &'static Mutex<Vec<String>> {
@@ -89,32 +120,115 @@ pub async fn validate_response(req: Request<Body>, next: Next) -> Response<Body>
         Err(_) => return Response::from_parts(parts, Body::empty()),
     };
 
-    check(&task, parts.status, &bytes);
-    Response::from_parts(parts, Body::from(bytes))
+    match check(&task, parts.status, &bytes) {
+        None => Response::from_parts(parts, Body::from(bytes)),
+        // Replace the response rather than panic. A panic in middleware
+        // surfaces at the call site as a transport error — "the request
+        // failed" — which says nothing about why. A 500 carrying the schema
+        // error makes the test that provoked it fail on its own status
+        // assertion, and print the reason.
+        Some(msg) => Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "error": "responseSchemaViolation",
+                    "message": msg,
+                })
+                .to_string(),
+            ))
+            .expect("static response builds"),
+    }
 }
 
 /// The check itself, separated so it is unit-testable without a router.
-fn check(task: &str, status: StatusCode, bytes: &Bytes) {
+///
+/// Returns the failure message when the response does not conform **and** the
+/// task is not allowlisted; `None` otherwise.
+fn check(task: &str, status: StatusCode, bytes: &Bytes) -> Option<String> {
     // 204 and an empty body carry no payload to validate.
     if status == StatusCode::NO_CONTENT || bytes.is_empty() {
-        return;
+        return None;
     }
-    let Some(schema) = trust_tasks_rs::schema_index::schema_for(&format!("{task}#response")) else {
-        return;
-    };
-    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
-        return;
-    };
+    let schema = trust_tasks_rs::schema_index::schema_for(&format!("{task}#response"))?;
+    let value = serde_json::from_slice::<serde_json::Value>(bytes).ok()?;
     // A Trust Task *document* carries its payload under `payload`; a bare REST
     // response is the payload itself. Validate whichever this is, so the layer
     // works across both bindings without the test having to say which.
     let payload = value.get("payload").unwrap_or(&value);
-    if let Err(e) = trust_tasks_rs::validate::against_schema(schema, payload) {
-        let msg = format!("{task}: {e}");
-        // Printed as well as collected. A violation that only accumulates in a
-        // static is invisible to `cargo test`, which is how a conformance
-        // signal quietly stops being one.
-        eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
-        violations().lock().expect("violations lock").push(msg);
+    let Err(e) = trust_tasks_rs::validate::against_schema(schema, payload) else {
+        return None;
+    };
+    let msg = format!("{task}: {e}");
+    eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
+    violations()
+        .lock()
+        .expect("violations lock")
+        .push(msg.clone());
+    if ALLOWED.contains(&task) {
+        return None;
+    }
+    Some(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The allowlist may only shrink.
+    ///
+    /// Asserted for the same reason `KNOWN_DRIFT_COUNT` is: a tolerated defect
+    /// that nothing counts becomes a permanent one, and the cheapest way to
+    /// make a failing check pass is to add a line to a list nobody is
+    /// watching. Closing an entry means deleting it *and* lowering this.
+    #[test]
+    fn the_allowlist_only_shrinks() {
+        assert_eq!(
+            ALLOWED.len(),
+            ALLOWED_COUNT,
+            "the response-conformance allowlist changed. Removing a task? \
+             Lower ALLOWED_COUNT with it. Adding one? That needs a reason in \
+             review, not a quiet edit — a route whose response does not match \
+             its published schema is a defect, and this list exists to record \
+             the ones already known, not to absorb new ones."
+        );
+    }
+
+    /// An allowlisted task is still *reported*, just not fatal — otherwise
+    /// closing one would mean first discovering it all over again.
+    #[test]
+    fn an_allowlisted_violation_is_recorded_but_not_fatal() {
+        clear_violations();
+        let before = observed_violations().len();
+        let out = check(
+            "https://trusttasks.org/spec/auth/whoami/0.1",
+            StatusCode::OK,
+            &Bytes::from_static(b"{\"nope\":1}"),
+        );
+        assert!(out.is_none(), "an allowlisted task must not fail the build");
+        assert_eq!(
+            observed_violations().len(),
+            before + 1,
+            "it must still be recorded, or the allowlist hides the work"
+        );
+    }
+
+    /// A task with no published schema is not a violation. Treating "unknown"
+    /// as "bad" would fail loudest on the routes this build understands least.
+    #[test]
+    fn an_unknown_task_is_not_a_violation() {
+        assert!(
+            check(
+                // Deliberately not a `trusttasks.org/spec/` URI:
+                // `every_bound_canonical_task_exists_in_the_registry` scans
+                // this crate for bound canonical URIs and would read a fake
+                // one here as a real binding — which it did, on the first
+                // run of this test.
+                "https://example.invalid/not/a/task/9.9",
+                StatusCode::OK,
+                &Bytes::from_static(b"{}"),
+            )
+            .is_none()
+        );
     }
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -1240,30 +1240,53 @@ fn table() -> Vec<Conformance> {
         ),
         // ─── relationships ───────────────────────────────────────────
         checked!(
-            s::relationships::list::v0_1::Payload,
-            s::relationships::list::v0_1::Response,
+            s::relationships::list::v0_2::Payload,
+            s::relationships::list::v0_2::Response,
             json!({ "did": DID, "cursor": "eyJsYXN0S2V5Ijoi", "limit": 50 }),
-            // `Relationship` — relationships/mod.rs:59. The spec types the
-            // items as free objects, so only the wrapper diverges.
+            // This fixture said `vrcSha256` — the `0.1` member — while the
+            // service had already moved to a multibase digest. The table
+            // called the task conformant on that basis for as long as both
+            // were wrong together, which is what a hand-written fixture buys
+            // you. `0.2` (trustoverip/dtgwg-trust-tasks-tf#266) publishes the
+            // multibase form the service sends.
             paginated(json!([{
                 "id": REQUEST_ID,
                 "issuerDid": DID,
                 "subjectDid": OTHER_DID,
                 "vrcJsonld": credential(),
-                "vrcSha256": "3b9f0a1c8d2e4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3",
+                "vrcDigestMultibase": "zQmbGXRT3v1RmfWkQ7Y3Z5Uj9pKq2NcXhLd8sVtA4eB6nMw",
                 "createdAt": TS,
             }]))
         ),
         checked!(
-            s::relationships::graph::v0_1::Payload,
-            s::relationships::graph::v0_1::Response,
+            s::relationships::graph::v0_2::Payload,
+            s::relationships::graph::v0_2::Response,
             json!({}),
-            // `RelationshipsGraph` — routes/relationships.rs:773.
-            json!({
-                "nodes": [{ "did": DID }, { "did": OTHER_DID }],
-                "edges": [{ "id": REQUEST_ID, "issuerDid": DID,
-                            "subjectDid": OTHER_DID, "createdAt": TS }],
+            // Serialised from the real graph types. The hand-written version
+            // described `0.1`'s flat edge — one row per credential — which
+            // the service has never emitted: it groups halves by endpoint
+            // pair and says whether the edge is reciprocated. Two wrongs
+            // agreeing is what let this read as conformant.
+            serde_json::to_value(crate::routes::relationships::RelationshipsGraph {
+                nodes: vec![
+                    crate::routes::relationships::GraphNode { did: DID.into() },
+                    crate::routes::relationships::GraphNode {
+                        did: OTHER_DID.into()
+                    },
+                ],
+                edges: vec![crate::routes::relationships::GraphEdge {
+                    endpoints: vec![DID.into(), OTHER_DID.into()],
+                    halves: vec![crate::routes::relationships::GraphHalf {
+                        id: REQUEST_ID.into(),
+                        issuer_did: DID.into(),
+                        subject_did: OTHER_DID.into(),
+                        created_at: TS.into(),
+                        persona_did: None,
+                    }],
+                    complete: false,
+                }],
             })
+            .expect("RelationshipsGraph serialises")
         ),
         checked!(
             s::relationships::publish::v0_2::Payload,

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -33,6 +33,17 @@ use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
+/// Re-wrap the inner WebAuthn options as webauthn-rs's `{publicKey: …}`.
+///
+/// `enroll/start/0.2` and its siblings send the *inner* options — the value a
+/// browser passes as `create({ publicKey: … })` — because that is what the
+/// canonical `CredentialCreationOptions` describes. The soft-authenticator
+/// harness deserialises webauthn-rs's wrapper type, so the test does the same
+/// re-wrap a real client does, one line before calling the authenticator.
+fn wrap_options<T: serde::de::DeserializeOwned>(inner: &serde_json::Value) -> T {
+    serde_json::from_value(serde_json::json!({ "publicKey": inner })).expect("options re-wrap")
+}
+
 const RP_ORIGIN: &str = "https://vtc.example.com";
 // Canonical `auth/passkey/*` tasks (trust-tasks-tf#145). Each ceremony leg
 // carries its own task; the retired `admin/passkeys/{register,revoke}/1.0`
@@ -262,9 +273,12 @@ async fn list_returns_bootstrap_passkey() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    let arr = body["passkeys"].as_array().unwrap();
+    // `credentials`, the name `auth/passkey/list/0.1` publishes (#1112).
+    let arr = body["credentials"].as_array().unwrap();
     assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["label"], "install");
+    // `deviceLabel`, the name the shared `RegisteredCredential` component
+    // publishes — `label` was the storage row's name, never the wire's.
+    assert_eq!(arr[0]["deviceLabel"], "install");
 }
 
 #[tokio::test]
@@ -318,11 +332,9 @@ async fn register_succeeds_with_step_up_uv() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
-    let registration_id = body["registrationId"].as_str().unwrap().to_string();
-    let register_options: CreationChallengeResponse =
-        serde_json::from_value(body["registerOptions"].clone()).unwrap();
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let registration_id = body["enrollmentId"].as_str().unwrap().to_string();
+    let register_options: CreationChallengeResponse = wrap_options(&body["options"]);
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
 
     // harness signs both
     let (register_response, _new_pub) = fix.authenticator.register(&register_options, RP_ORIGIN);
@@ -408,9 +420,8 @@ async fn register_rejects_when_uv_signed_by_wrong_authenticator() {
         Some(json!({})),
     )
     .await;
-    let registration_id = body["registrationId"].as_str().unwrap().to_string();
-    let register_options: CreationChallengeResponse =
-        serde_json::from_value(body["registerOptions"].clone()).unwrap();
+    let registration_id = body["enrollmentId"].as_str().unwrap().to_string();
+    let register_options: CreationChallengeResponse = wrap_options(&body["options"]);
 
     // New device produced by the legitimate harness (so the register
     // half passes), but the UV signed by a foreign authenticator
@@ -452,8 +463,7 @@ async fn register_rejects_when_uv_signed_by_wrong_authenticator() {
     // Approach: take the start's UV options + the foreign cred id
     // and craft an obviously-wrong PublicKeyCredential. The server
     // will fail signature verification.
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
     let cred_id_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .encode(uv_options.public_key.allow_credentials[0].id.as_ref() as &[u8]);
     let bogus_uv = json!({
@@ -513,8 +523,7 @@ async fn revoke_last_passkey_returns_409_last_passkey_protected() {
     .await;
     assert_eq!(status, StatusCode::OK, "revoke start: {body}");
     let revocation_id = body["revocationId"].as_str().unwrap().to_string();
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
     let uv_response = fix.authenticator.authenticate(&uv_options, RP_ORIGIN);
 
     // finish — must be rejected with 409 because this would leave 0 passkeys
@@ -550,11 +559,9 @@ async fn revoke_after_register_succeeds_and_emits_audit_event() {
         Some(json!({})),
     )
     .await;
-    let reg_id = body["registrationId"].as_str().unwrap().to_string();
-    let register_options: CreationChallengeResponse =
-        serde_json::from_value(body["registerOptions"].clone()).unwrap();
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let reg_id = body["enrollmentId"].as_str().unwrap().to_string();
+    let register_options: CreationChallengeResponse = wrap_options(&body["options"]);
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
     let (register_response, _) = fix.authenticator.register(&register_options, RP_ORIGIN);
     let uv_response = fix.authenticator.authenticate(&uv_options, RP_ORIGIN);
     let (status, body) = request(
@@ -599,8 +606,7 @@ async fn revoke_after_register_succeeds_and_emits_audit_event() {
     )
     .await;
     let revocation_id = body["revocationId"].as_str().unwrap().to_string();
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
     let uv_response = fix.authenticator.authenticate(&uv_options, RP_ORIGIN);
 
     let (status, body) = request(
@@ -727,11 +733,9 @@ async fn register_returns_503_when_audit_writer_missing() {
         Some(json!({})),
     )
     .await;
-    let registration_id = body["registrationId"].as_str().unwrap().to_string();
-    let register_options: CreationChallengeResponse =
-        serde_json::from_value(body["registerOptions"].clone()).unwrap();
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let registration_id = body["enrollmentId"].as_str().unwrap().to_string();
+    let register_options: CreationChallengeResponse = wrap_options(&body["options"]);
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
     let (register_response, _) = fix.authenticator.register(&register_options, RP_ORIGIN);
     let uv_response = fix.authenticator.authenticate(&uv_options, RP_ORIGIN);
     let (status, _body) = request(

--- a/vtc-service/tests/install_flow.rs
+++ b/vtc-service/tests/install_flow.rs
@@ -39,6 +39,17 @@ use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
+/// Re-wrap the inner WebAuthn options as webauthn-rs's `{publicKey: …}`.
+///
+/// The `auth/passkey/*/start` tasks send the *inner* options — the value a
+/// browser passes as `get({ publicKey: … })` — because that is what the
+/// canonical `CredentialRequestOptions` component describes. The
+/// soft-authenticator harness deserialises webauthn-rs's wrapper type, so the
+/// test does the same re-wrap a real client does.
+fn wrap_options<T: serde::de::DeserializeOwned>(inner: &serde_json::Value) -> T {
+    serde_json::from_value(serde_json::json!({ "publicKey": inner })).expect("options re-wrap")
+}
+
 const RP_ORIGIN: &str = "https://vtc.example.com";
 
 // Trust Tasks ------------------------------------------------------
@@ -221,6 +232,8 @@ async fn end_to_end_install_flow_phase_0_gate() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "claim/start: {body}");
+    // `install/claim/start` is untouched by this PR: it is not one of the
+    // `auth/passkey/*` tasks, and it still sends the wrapper under `options`.
     let registration_id = body["registrationId"].as_str().unwrap().to_string();
     let ccr: CreationChallengeResponse = serde_json::from_value(body["options"].clone()).unwrap();
 
@@ -293,11 +306,9 @@ async fn end_to_end_install_flow_phase_0_gate() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "register/start: {body}");
-    let reg_id = body["registrationId"].as_str().unwrap().to_string();
-    let register_options: CreationChallengeResponse =
-        serde_json::from_value(body["registerOptions"].clone()).unwrap();
-    let uv_options: RequestChallengeResponse =
-        serde_json::from_value(body["uvOptions"].clone()).unwrap();
+    let reg_id = body["enrollmentId"].as_str().unwrap().to_string();
+    let register_options: CreationChallengeResponse = wrap_options(&body["options"]);
+    let uv_options: RequestChallengeResponse = wrap_options(&body["uvOptions"]);
 
     let (register_response, _new_pub) = authenticator.register(&register_options, RP_ORIGIN);
     let uv_response = authenticator.authenticate(&uv_options, RP_ORIGIN);
@@ -335,11 +346,12 @@ async fn end_to_end_install_flow_phase_0_gate() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    let passkeys = body["passkeys"].as_array().unwrap();
+    // `credentials`, the name `auth/passkey/list/0.1` publishes (#1112).
+    let passkeys = body["credentials"].as_array().unwrap();
     assert_eq!(passkeys.len(), 2, "expected 2 passkeys, got {passkeys:?}");
     let labels: std::collections::HashSet<_> = passkeys
         .iter()
-        .map(|p| p["label"].as_str().unwrap().to_string())
+        .map(|p| p["deviceLabel"].as_str().unwrap().to_string())
         .collect();
     assert!(labels.contains("install"));
     assert!(labels.contains("second device"));

--- a/vtc-service/tests/passkey_step_up.rs
+++ b/vtc-service/tests/passkey_step_up.rs
@@ -40,6 +40,17 @@ use vtc_service::test_support::TestVtc;
 
 use common::webauthn_harness::SoftEd25519Authenticator;
 
+/// Re-wrap the inner WebAuthn options as webauthn-rs's `{publicKey: …}`.
+///
+/// The `auth/passkey/*/start` tasks send the *inner* options — the value a
+/// browser passes as `get({ publicKey: … })` — because that is what the
+/// canonical `CredentialRequestOptions` component describes. The
+/// soft-authenticator harness deserialises webauthn-rs's wrapper type, so the
+/// test does the same re-wrap a real client does.
+fn wrap_options<T: serde::de::DeserializeOwned>(inner: &serde_json::Value) -> T {
+    serde_json::from_value(serde_json::json!({ "publicKey": inner })).expect("options re-wrap")
+}
+
 const RP_ORIGIN: &str = "https://vtc.example.com";
 const START_TASK: &str = "https://trusttasks.org/spec/auth/passkey/login/start/0.2";
 const FINISH_TASK: &str = "https://trusttasks.org/spec/auth/passkey/login/finish/0.2";
@@ -243,8 +254,7 @@ async fn step_up_elevates_the_session_in_place() {
     let (status, body) = step_up_start(&fix, Some(&token)).await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
     let auth_id = body["authId"].as_str().unwrap().to_string();
-    let options: RequestChallengeResponse =
-        serde_json::from_value(body["options"].clone()).unwrap();
+    let options: RequestChallengeResponse = wrap_options(&body["options"]);
     let assertion = fix.authenticator.authenticate(&options, RP_ORIGIN);
 
     let (status, body) = request(
@@ -323,8 +333,7 @@ async fn step_up_refuses_another_subjects_passkey() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "other start: {other_body}");
-    let other_options: RequestChallengeResponse =
-        serde_json::from_value(other_body["options"].clone()).unwrap();
+    let other_options: RequestChallengeResponse = wrap_options(&other_body["options"]);
     let foreign_assertion = fix.authenticator.authenticate(&other_options, RP_ORIGIN);
 
     // Spend the *step-up* auth_id with the foreign assertion. The WebAuthn
@@ -354,8 +363,7 @@ async fn step_up_is_bound_to_the_session_that_started_it() {
     let (status, body) = step_up_start(&fix, Some(&bound_token)).await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
     let auth_id = body["authId"].as_str().unwrap().to_string();
-    let options: RequestChallengeResponse =
-        serde_json::from_value(body["options"].clone()).unwrap();
+    let options: RequestChallengeResponse = wrap_options(&body["options"]);
     let assertion = fix.authenticator.authenticate(&options, RP_ORIGIN);
 
     let (status, _body) = request(
@@ -413,8 +421,7 @@ async fn plain_login_is_unchanged_by_the_purpose_field() {
     .await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
     let auth_id = body["authId"].as_str().unwrap().to_string();
-    let options: RequestChallengeResponse =
-        serde_json::from_value(body["options"].clone()).unwrap();
+    let options: RequestChallengeResponse = wrap_options(&body["options"]);
     let assertion = fix.authenticator.authenticate(&options, RP_ORIGIN);
 
     let (status, body) = request(
@@ -486,8 +493,7 @@ async fn a_step_up_authorises_the_promotion_it_was_run_for() {
     let (status, body) = step_up_start(&fix, Some(&token)).await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
     let auth_id = body["authId"].as_str().unwrap().to_string();
-    let options: RequestChallengeResponse =
-        serde_json::from_value(body["options"].clone()).unwrap();
+    let options: RequestChallengeResponse = wrap_options(&body["options"]);
     let assertion = fix.authenticator.authenticate(&options, RP_ORIGIN);
     let (status, _) = request(
         &fix.router,
@@ -523,8 +529,7 @@ async fn a_step_up_ceremony_cannot_be_replayed() {
     let (status, body) = step_up_start(&fix, Some(&token)).await;
     assert_eq!(status, StatusCode::OK, "start: {body}");
     let auth_id = body["authId"].as_str().unwrap().to_string();
-    let options: RequestChallengeResponse =
-        serde_json::from_value(body["options"].clone()).unwrap();
+    let options: RequestChallengeResponse = wrap_options(&body["options"]);
     let assertion = fix.authenticator.authenticate(&options, RP_ORIGIN);
 
     let finish = json!({ "auth_id": auth_id, "credential": assertion });

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -34,8 +34,8 @@ use vtc_service::test_support::TestVtc;
 
 const PUBLIC_URL: &str = "https://vtc.example.com";
 const PUBLISH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/publish/0.2";
-const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/list/0.1";
-const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
+const LIST_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/list/0.2";
+const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.2";
 const REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/revoke/0.1";
 const ISSUER_DID: &str = "did:key:zVrcIssuer";
 const SUBJECT_DID: &str = "did:key:zVrcSubject";
@@ -247,7 +247,19 @@ async fn seed_relationship(fix: &Fixture, issuer: &str, subject: &str) -> Uuid {
         issuer_did: issuer.into(),
         subject_did: subject.into(),
         vrc_jsonld: fake_vrc(issuer, subject),
-        vrc_digest_multibase: format!("seed-{id}"),
+        // A real multibase-wrapped multihash over the seeded credential, not
+        // `seed-{id}`. The placeholder was unique per row, which is all the
+        // storage layer needed — and it meant no test ever exercised a digest
+        // that looked like a digest, so the response-conformance layer found
+        // the format mismatch that the whole suite had been blind to.
+        vrc_digest_multibase: {
+            use sha2::{Digest, Sha256};
+            let canonical = serde_json_canonicalizer::to_vec(&fake_vrc(issuer, subject))
+                .expect("canonicalizable");
+            let mut mh = vec![0x12, 0x20];
+            mh.extend_from_slice(&Sha256::digest(&canonical));
+            multibase::encode(multibase::Base::Base58Btc, mh)
+        },
         created_at: chrono::Utc::now(),
         persona: None,
     };
@@ -1256,7 +1268,7 @@ mod pairwise {
         const GRAPH_ADMIN: u8 = 0x7A;
 
         const PERSONA_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/persona/0.1";
-        const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
+        const GRAPH_TASK: &str = "https://trusttasks.org/spec/vtc/relationships/graph/0.2";
 
         /// A signed VPC: issued under `persona_seed`'s P-DID, naming
         /// `counterparty_seed` as the subject. DTG Credentials §VPC.

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -354,7 +354,9 @@ async fn admin_session_bridges_bearer_to_cookie_and_authenticates() {
     assert_eq!(res.status(), StatusCode::OK);
     let who: Value =
         serde_json::from_slice(&res.into_body().collect().await.unwrap().to_bytes()).unwrap();
-    assert_eq!(who["did"].as_str(), Some(holder.as_str()));
+    // `auth/whoami/0.1` answers with the canonical `Session`, whose subject
+    // member is `subject`. The flat `did` was this service's own shape.
+    assert_eq!(who["session"]["subject"].as_str(), Some(holder.as_str()));
 }
 
 #[tokio::test]

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -1289,6 +1289,7 @@ mod tests {
             allowed_contexts: vec![],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -1301,6 +1302,7 @@ mod tests {
             allowed_contexts: contexts.iter().map(|s| s.to_string()).collect(),
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         }
@@ -1647,6 +1649,7 @@ mod tests {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -1663,6 +1666,7 @@ mod tests {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };
@@ -1687,6 +1691,7 @@ mod tests {
             allowed_contexts: vec!["ctx1".into()],
             session_id: "test-session".into(),
             access_expires_at: 0,
+            issued_at: 0,
             amr: Vec::new(),
             acr: String::new(),
         };

--- a/vti-common/src/auth/extractor.rs
+++ b/vti-common/src/auth/extractor.rs
@@ -39,6 +39,13 @@ pub struct AuthClaims {
     /// `whoami`-style endpoints can return the access-token
     /// lifetime without re-decoding.
     pub access_expires_at: u64,
+    /// JWT `iat` claim — Unix-second issue time.
+    ///
+    /// Carried for the same reason as `access_expires_at`: the canonical
+    /// `Session` component makes `issuedAt` **required**, and a `whoami` that
+    /// cannot say when the session began describes a session only half way.
+    /// The value was always in the token; it simply was not surfaced.
+    pub issued_at: u64,
     /// Authentication Methods References per [RFC 8176]. Mirrors
     /// `Claims.amr` from the bearer JWT. Handlers gating sensitive
     /// operations check this to decide whether a step-up is needed.
@@ -182,6 +189,7 @@ async fn authenticate_token<S: AuthState>(
                 allowed_contexts: claims.contexts,
                 session_id: claims.session_id,
                 access_expires_at: claims.exp,
+                issued_at: claims.iat,
                 amr: claims.amr,
                 acr: claims.acr,
             },
@@ -229,9 +237,12 @@ impl AuthClaims {
             // CLI synthesis bypasses the session store entirely.
             // The sentinel session_id matches the DID format and
             // `access_expires_at: 0` makes the synthesized claim
-            // visibly "no real expiry" to any log scraper.
+            // visibly "no real expiry" to any log scraper, and
+            // `issued_at: 0` follows the same convention — there is
+            // no JWT here, so there is no `iat` to carry.
             session_id: format!("cli:{channel}"),
             access_expires_at: 0,
+            issued_at: 0,
             // CLI synthesis is a process-local trust boundary; the auth
             // method is the OS user, not a wire factor. Surface `"cli"`
             // in amr so a downstream auditor distinguishes synthesized


### PR DESCRIPTION
Closes the last eight response-conformance violations — all of them in
`auth/passkey/*` and `auth/whoami` — and **empties the allowlist**, so
`test_support/response_conformance.rs` stops being a report with exceptions
and becomes an unconditional gate.

**Violations across the whole 35-binary suite: 0.**

## Where the divergences actually were

The witness table called these "shared-family tasks served by both daemons",
and deferred them as a "which service's shape is canonical" decision. That
framing was wrong, and it is worth saying why: **not one of the eight needed a
canonical-shape ruling.** Seven were this service under-reporting or renaming
members the schema already defines, and the eighth was a genuine gap in the
spec. Nothing had to be decided between two implementations, because the
published component was already the answer in every case.

| task | what diverged |
|---|---|
| `enroll/start/0.2` | sent webauthn-rs's `{publicKey: …}` wrapper; the schema describes the *inner* options |
| `enroll/start/0.2` | schema had no `extensions` — **the one real spec gap**, amended upstream (#267) |
| `enroll/finish/0.2` | missing `subject`, `registeredAt` |
| `list/0.1` | `passkeys` → `credentials`; `label` → `deviceLabel`; `lastUsedAt: null` |
| `login/start/0.2` | the same wrapper problem |
| `login/finish/0.2` | missing the required `purpose` |
| `revoke/start/0.1` | the same wrapper problem |
| `revoke/finish/0.1` | missing `revokedAt`, `remaining` |
| `whoami/0.1` | flat `{did, role, …}`; the schema publishes a `Session` envelope |

## The wrapper, and why unwrapping is the fix

Four tasks sent `{publicKey: {challenge, rp, user, …}}`. That is
`webauthn-rs`'s `CreationChallengeResponse` / `RequestChallengeResponse` — the
shape a *browser API call* takes, not the shape the `CredentialCreationOptions`
component describes. The service was publishing its Rust dependency's
convenience type as its wire contract.

The proof that the wrapper was never load-bearing is in the SPA it serves: it
declared `registerOptions: { publicKey: JsonPublicKeyOptions }`, then did
`decodePublicKeyOptions(start.registerOptions.publicKey)` and re-wrapped the
result one line later for `navigator.credentials.create({ publicKey })`. The
wrapper was unwrapped and re-wrapped in the same function. It is gone from both
ends now.

## `extensions`, and the one careful spec change

`enroll/start` failed on `Additional properties are not allowed
('extensions' was unexpected)` — and here the service was right and the
specification was not. `extensions` is a standard member of
`PublicKeyCredentialCreationOptions`; a schema that closes over it cannot
describe a conforming WebAuthn ceremony at all. Amended upstream in
[#267](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/267), as an
8-insertion / 0-deletion edit to the shared `webauthn.schema.json` rather than a
reserialisation, and this PR moves onto the `trust-tasks-rs 0.11.15` that
carries it.

That is the whole of the "if the spec can't work, update the spec" branch:
**one** member, in a shared component, where the spec described something no
implementation could satisfy. Every other divergence went the other way.

## Storage rows are not wire shapes

`list/0.1` is the interesting one. `RegisteredPasskey` is `Deserialize`d out of
the `admin:<did>` fjall record, so its member names *are* the on-disk format —
renaming `label` to `deviceLabel` on that struct would orphan every passkey
already enrolled. So it keeps its names, and a `RegisteredCredential` wire view
sits in front of it. Same split as `GenerationRow` / `EndorsementRow` /
`CredentialReference` elsewhere in this service.

Two differences survive that boundary, and both are the schema being more
careful than the storage row:

- **`deviceLabel` is absent, not `""`.** The schema is explicit that a consumer
  must not synthesize a label, "because an invented one is indistinguishable
  from a chosen one to somebody deciding which credential to revoke" — and an
  empty string is an invented one. The SPA renders unlabelled credentials as
  unlabelled rather than as `""`.
- **`lastUsedAt` is omitted, not `null`.** `null` is a type error against a
  `date-time` member. This is the fourth member in this family to have shipped
  `null`-for-absent (`policyDecision` in #1099, `extensions` twice in #1108),
  and the schema notes it deliberately does not distinguish "never used" from
  "not tracked" — no generated binding could carry the difference.

## `whoami` and `AuthClaims.issued_at`

`whoami/0.1` publishes the shared `Session` component, whose `issuedAt` this
service could not produce: `AuthClaims` carried `access_expires_at` but not the
JWT's `iat`, even though the claim had been parsed and thrown away. Added, and
threaded through all 47 construction sites across five crates.

Two of those sites are not tests and took a real decision:

- `messaging::auth::auth_from_did` uses **`session.created_at`, not "now"**.
  These sessions are persistent and DID-keyed, so every message from a peer
  resolves the same row — stamping arrival time would make each message look
  like a fresh login.
- `ceremony_claims` uses `0`, following the existing `access_expires_at: 0`
  sentinel, for the stronger reason that no session row exists at all: there is
  nothing that was issued.

## `login/finish` needed its own response type

The login branch was reusing `AuthenticateResponse`, which serves
`auth/authenticate/0.1` — a closed schema with no `purpose`. One struct cannot
satisfy both tasks, and the reuse is exactly what left `login/finish/0.2` short
of a required member. The step-up branch already had its own
`PasskeyStepUpResponse` and was already conformant; the login branch now has
`PasskeyLoginResponse` beside it.

## The allowlist is empty

`ALLOWED_COUNT` is 0. The machinery stays, because the discipline is the point:
a task that starts failing must be *fixed*, and if one genuinely cannot be,
adding it back is a visible decision in a diff rather than a silent one.
`an_allowlisted_violation_is_recorded_but_not_fatal` had no allowlisted task
left to exercise, so it is now `a_violation_is_recorded_as_well_as_raised` —
guarding the property that survives an empty list: recording and raising are
separate, and recording is what let the original inventory of 134 be taken in
one run.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p vtc-service --no-fail-fast` — 35 binaries, 0 violations
- `cargo fmt --all --check`
- `npx tsc --noEmit` in `admin-ui`

BREAKING CHANGE: `auth/passkey/{enroll,login,revoke}/start` send the inner
WebAuthn options instead of the `{publicKey: …}` wrapper. `auth/passkey/list`
returns `credentials` (was `passkeys`), whose members are `deviceLabel` (was
`label`, now absent when unset) and `lastUsedAt` (now absent rather than null).
`auth/passkey/enroll/start` returns `enrollmentId` (was `registrationId`).
`auth/passkey/{enroll,revoke}/finish` gain `subject`/`registeredAt` and
`revokedAt`/`remaining`. `auth/passkey/login/finish` gains `purpose`.
`auth/whoami` returns `{session, roles, scopes}` instead of a flat object.
`vti_common::auth::AuthClaims` gains `issued_at`.

Refs #1059
