### PR TITLE
fix(vta)!: three of the four responses the conformance layer found

### DIFF
--- a/docs/05-design-notes/trust-task-uri-registry.md
+++ b/docs/05-design-notes/trust-task-uri-registry.md
@@ -196,7 +196,7 @@ dispatcher's `KNOWN_FEATURE_GATED_URIS` allowlist for builds where
 | `spec/vta/webvh/dids/list/1.0` | DIDs hosted/known to this VTA | implemented |
 | `spec/vta/webvh/dids/create/1.0` | Mint new DID via template + register with host | implemented |
 | `spec/vta/webvh/dids/get/1.0` | | implemented |
-| ~`spec/vta/webvh/dids/get-log/1.0`~ | `GET /webvh/dids/{did}/log` (authed) | **folded into `dids/get/1.0`** — same `{did}`, same lookup, same context check; the representation is now the `includeLog` flag. The REST path stays (its response is a superset of the old `{did, log}`) |
+| ~`spec/vta/webvh/dids/get-log/1.0`~ | `GET /webvh/dids/{did}/log` (authed) | **folded into `dids/get/1.0`** — same `{did}`, same lookup, same context check; the representation is now the `includeLog` flag. The REST path stays. Its response was a flat superset of the old `{did, log}` until the record moved under `record` to match the published schema, which no client could read while it was flattened |
 | ~`spec/vta/webvh/dids/get-log-public/1.0`~ | `GET /did/{did}/log` (unauthed mirror) | **REST-only forever** (load-bearing as the DID-resolver failover path; wrapping it in a trust-task envelope would defeat the failover) |
 | `spec/vta/webvh/dids/delete/1.0` | | implemented |
 | `spec/vta/webvh/dids/update/1.0` | DID-doc patch (trust-task envelope carries `did` in payload — no path) | implemented |

--- a/vta-sdk/src/client/webvh.rs
+++ b/vta-sdk/src/client/webvh.rs
@@ -10,6 +10,8 @@ use crate::error::VtaError;
 use crate::protocols::did_management;
 #[cfg(feature = "client")]
 use crate::protocols::did_management::agent_name;
+#[cfg(feature = "client")]
+use crate::protocols::did_management::get::GetDidWebvhResultBody;
 
 #[cfg(feature = "client")]
 impl VtaClient {
@@ -203,27 +205,42 @@ impl VtaClient {
     }
 
     pub async fn get_did_webvh(&self, did: &str) -> Result<crate::webvh::WebvhDidRecord, VtaError> {
-        // `spec/vta/webvh/dids/get/1.0` returns the record flattened (a
-        // strict superset of the bare `WebvhDidRecord`), so the same decode
-        // serves both legs.
-        self.rpc_tt(
-            crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
-            serde_json::json!({ "did": did }),
-            30,
-        )
-        .await
+        // `spec/vta/webvh/dids/get/1.0` carries the record under `record`, so
+        // decode the envelope and hand back the record itself — this method's
+        // return type is the record, and callers should not have to know the
+        // task grew a `log` sibling.
+        //
+        // It decoded straight into `WebvhDidRecord` while the response was
+        // flattened. That worked only because `WebvhDidRecord` does not set
+        // `deny_unknown_fields`, which is precisely the fragility
+        // `webvh_get_did_round_trips_after_the_get_log_fold` was written to
+        // warn about.
+        let body: GetDidWebvhResultBody = self
+            .rpc_tt(
+                crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
+                serde_json::json!({ "did": did }),
+                30,
+            )
+            .await?;
+        Ok(body.record)
     }
 
     pub async fn get_did_webvh_log(&self, did: &str) -> Result<GetDidLogResponse, VtaError> {
         // The dedicated get-log task folded into `dids/get` + `includeLog`
-        // (see `GetDidWebvhBody`); the flattened response is a superset of
-        // `GetDidLogResponse`, so the decode is unchanged.
-        self.rpc_tt(
-            crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
-            serde_json::json!({ "did": did, "includeLog": true }),
-            30,
-        )
-        .await
+        // (see `GetDidWebvhBody`). `did` now lives on the nested record and
+        // `log` beside it, so this projects the envelope onto the two-member
+        // shape this method has always returned.
+        let body: GetDidWebvhResultBody = self
+            .rpc_tt(
+                crate::trust_tasks::TASK_WEBVH_DIDS_GET_1_0,
+                serde_json::json!({ "did": did, "includeLog": true }),
+                30,
+            )
+            .await?;
+        Ok(GetDidLogResponse {
+            did: body.record.did,
+            log: body.log,
+        })
     }
 
     pub async fn delete_did_webvh(&self, did: &str) -> Result<(), VtaError> {

--- a/vta-sdk/src/protocols/did_management/get.rs
+++ b/vta-sdk/src/protocols/did_management/get.rs
@@ -25,14 +25,24 @@ pub struct GetDidWebvhBody {
 
 /// Response for `spec/vta/webvh/dids/get/1.0`.
 ///
-/// The record is flattened, so this is a strict **superset** of both
-/// shapes it replaces — the bare `WebvhDidRecord` this task used to
-/// return, and the `{did, log}` of the retired `dids/get-log`. Callers
-/// of either keep reading the fields they already read.
+/// The record is carried under `record`, as `spec/vta/webvh/dids/get/1.0`
+/// requires.
+///
+/// It was `#[serde(flatten)]` from #849 until now, to make the folded task a
+/// strict superset of the two shapes it replaced — the bare `WebvhDidRecord`
+/// this task returned, and the `{did, log}` of the retired `dids/get-log`. That
+/// bought a migration window at a price nothing had measured: a flattened
+/// record cannot satisfy a response that is `additionalProperties: false`, so
+/// **no conforming client could read any of the eleven members**, and the `ext`
+/// slot was unreachable too.
+///
+/// Its own sibling is the argument. `dids/list` carries the same component
+/// under `dids` and has always conformed, so flattening made `get` the one
+/// outlier in its family — and a `log` member at the top level beside a
+/// flattened record is a name collision waiting for the record to grow one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetDidWebvhResultBody {
-    #[serde(flatten)]
     pub record: WebvhDidRecord,
     /// The raw `did.jsonl`, when `includeLog` was set.
     ///

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -173,7 +173,16 @@ pub struct ProvisionSummary {
     /// Name of the admin template, when one was used (i.e. the
     /// request used `adminTemplate` rollover *or* the `AdminRotation`
     /// ask).
-    #[serde(default, alias = "admin_template_name")]
+    ///
+    /// Omitted rather than sent as `null`: the schema types it `string`, and
+    /// its three `Option<String>` siblings above already skip. It was the odd
+    /// one out, which is why `provision/integration/0.2` could not satisfy its
+    /// own response schema.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "admin_template_name"
+    )]
     pub admin_template_name: Option<String>,
     #[serde(alias = "bundle_id_hex")]
     pub bundle_id_hex: String,
@@ -186,7 +195,13 @@ pub struct ProvisionSummary {
     /// means self-hosted at the URL — i.e. no `WEBVH_SERVER` template
     /// var was set, or it was explicitly null. Older VTAs that
     /// pre-date this field omit it on the wire; deserialize as `None`.
-    #[serde(default, alias = "webvh_server_id")]
+    /// Omitted rather than sent as `null`, for the same reason as
+    /// `admin_template_name`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "webvh_server_id"
+    )]
     pub webvh_server_id: Option<String>,
     /// `true` when the target context didn't exist before this call
     /// and was created inline because the caller passed

--- a/vta-service/src/test_support/response_conformance.rs
+++ b/vta-service/src/test_support/response_conformance.rs
@@ -69,23 +69,15 @@ use std::sync::{Mutex, OnceLock};
 /// observes.
 pub const KNOWN_VIOLATIONS: &[(&str, &str)] = &[
     (
-        "https://trusttasks.org/spec/vta/webvh/dids/get/1.0",
-        "returns its eleven members flat; the schema requires them under \
-         `record`, which is a required property the response omits entirely",
-    ),
-    (
         "https://trusttasks.org/spec/vault/get/0.1",
         "leaks `status` / `graceUntil` / `deletedAt` — the archival lifecycle \
-         was added to the storage row and never to the wire contract",
+         was added to the storage row and never to the wire contract. Blocked \
+         on trust-tasks-rs 0.11.16, which carries the upstream amendment \
+         (dtgwg-trust-tasks-tf#268) adding those members to `VaultEntry`",
     ),
     (
         "https://trusttasks.org/spec/vault/list/0.1",
-        "the same three lifecycle members as `vault/get/0.1`",
-    ),
-    (
-        "https://trusttasks.org/spec/provision/integration/0.2",
-        "sends `null` for two members the schema types as `string`; the \
-         `null`-for-absent class, which wants `skip_serializing_if`",
+        "the same lifecycle members as `vault/get/0.1`, and the same blocker",
     ),
 ];
 
@@ -206,7 +198,7 @@ mod tests {
     fn the_inventory_is_still_accurate() {
         assert_eq!(
             KNOWN_VIOLATIONS.len(),
-            4,
+            2,
             "the known-violation inventory changed. Fixed one? Remove its entry \
              and lower this. Found a new one? That is a defect to fix, not an \
              entry to add — this list records what was already true when the \

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -443,12 +443,19 @@ async fn audit_cursor_is_bound_to_its_filters() {
 /// into `dids/get`.
 ///
 /// This is the compatibility claim the fold rests on, and it is exactly
-/// the kind that fails silently. The merged response flattens the
-/// record and adds an optional `log`, making it a superset of both old
-/// shapes — but "superset" only helps because neither client type sets
-/// `deny_unknown_fields`. If either did, or if the flatten were dropped
-/// for a nested `record` object, both calls would fail at runtime while
-/// every mocked test stayed green.
+/// the kind that fails silently. The merged response flattened the
+/// record and added an optional `log`, making it a superset of both old
+/// shapes — but "superset" only helped because neither client type sets
+/// `deny_unknown_fields`.
+///
+/// **The flatten has since been dropped for a nested `record`**, which is
+/// the second failure this comment predicted, and it happened for a reason
+/// the comment did not anticipate: a flattened record cannot satisfy a
+/// response that is `additionalProperties: false`, so the shape that was a
+/// superset of both *old* client types was readable by no *conforming* one.
+/// Both client methods now project the envelope, and this test still asserts
+/// what it always did — that values survive rather than merely parse, which
+/// is what makes it catch the runtime break the comment warned of.
 #[tokio::test]
 async fn webvh_get_did_round_trips_after_the_get_log_fold() {
     use vta_sdk::webvh::WebvhDidRecord;
@@ -513,12 +520,16 @@ async fn webvh_get_did_round_trips_after_the_get_log_fold() {
         }
     };
     let without = raw("").await;
-    assert_eq!(without["did"], did);
+    // Under `record`, not at the top level — the REST route shares its
+    // response type with the Trust Task, so both surfaces moved together.
+    assert_eq!(without["record"]["did"], did);
     assert!(
         without.get("log").is_none(),
         "the log must be omitted unless requested: {without}"
     );
     let with = raw("?includeLog=true").await;
+    // `log` is a sibling of `record`, not a member of it: it is not part of
+    // the record the VTA stores, it is the DID's own history.
     assert_eq!(
         with["log"], "{\"state\":{}}",
         "includeLog=true must return the log: {with}"
@@ -533,7 +544,7 @@ async fn webvh_get_did_round_trips_after_the_get_log_fold() {
     assert_eq!(
         log.log.as_deref(),
         Some("{\"state\":{}}"),
-        "the log must survive the merge into the flattened record"
+        "the log must survive the merge into the record envelope"
     );
 }
 


### PR DESCRIPTION
Closes three of the four violations #1113's layer reported. The inventory goes
**4 → 2**, and the two that remain are blocked on a dependency rather than on a
decision here.

## `vta/webvh/dids/get/1.0` — a flatten that no conforming client could read

The record has been under `#[serde(flatten)]` since #849, which folded
`dids/get-log` into `dids/get`. The stated reason was good: flattening made the
merged response a strict superset of both shapes it replaced — the bare
`WebvhDidRecord` this task used to return, and the `{did, log}` of the retired
task — so callers of either kept working.

That superset was a superset of the two *old client types*, and of nothing
else. The published response is `additionalProperties: false`, so a flattened
record fails on **all eleven members at once** and omits `record`, which is
required. The `ext` slot was unreachable too.

The spec (#240, 19 Aug) postdates the flatten (#849, 29 Jul), so which side
should move is a real question and not an assumption — this repository has
guessed it the wrong way three times. **Its own sibling settles it.**
`dids/list` carries the same `WebvhDidRecord` component nested under `dids` and
has always conformed. Flattening made `get` the one outlier in its family, and
a top-level `log` beside a flattened record is a name collision waiting for the
record to grow one.

### The compiler could not see this, and the test could

Both SDK client methods decoded the flat response *directly* into their return
types — `get_did_webvh` into `WebvhDidRecord`, `get_did_webvh_log` into
`GetDidLogResponse`. Unflattening breaks both at runtime, and
`cargo build --workspace --all-targets` stays green throughout, because the
break is in serde, not in types.

`webvh_get_did_round_trips_after_the_get_log_fold` was written for precisely
this. Its doc comment reads:

> "superset" only helps because neither client type sets
> `deny_unknown_fields`. If either did, **or if the flatten were dropped for a
> nested `record` object, both calls would fail at runtime while every mocked
> test stayed green.**

It was right, and it caught it — for a reason it did not anticipate. The
comment expected the flatten to be dropped by choice; it was dropped because
the shape could not conform. Both client methods now project the envelope, and
the test still asserts what it always did: that values *survive*, not merely
parse, which is the property that made it catch this.

The REST route shares the response type, so `GET /webvh/dids/{did}` moved with
the Trust Task. The registry note claiming the REST response "is a superset of
the old `{did, log}`" is updated rather than left to rot.

## `provision/integration/0.2` — two nulls out of five

`adminTemplateName` and `webvhServerId` were the only two of five
`Option<String>` members without `skip_serializing_if`, so they serialised as
`null` against members the schema types `string`. Their three siblings already
skipped, which is what makes this a slip rather than a decision.

This is the sixth member in the programme to ship `null`-for-absent.

## Not here: the vault pair, and why it became a spec change

`vault/{get,list}/0.1` leak `status` / `graceUntil` / `deletedAt` — #540's
archival lifecycle, added to the storage row and never to the wire contract.

The fix is upstream, in
[dtgwg-trust-tasks-tf#268](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/268),
because the specification is inconsistent with itself: `vault/list/0.1` already
defines a `status` request filter whose `all` value "lists every entry
regardless of lifecycle state", while `VaultEntry` is
`additionalProperties: false` and carries no lifecycle member. A consumer that
asks for every state gets a mixed list it cannot partition. Same shape as the
`extensions` gap in #267, found the same way.

Two notes from doing it, both of which would have been easy to get wrong:

- It adds **four** members, not the three observed. `archivedAt` is
  `skip_serializing_if` and simply had no test that archives then reads.
  Fixing only what the probe saw would have repeated the coverage gap the layer
  exists to expose.
- `status` deliberately declares **no JSON Schema `default`**. Writing
  `"default": "active"` is the natural thing and the first version did; codegen
  materialises a declared default into a non-`Option` field, so an absent
  `status` came back as an explicit `"active"` and broke round-trip idempotence
  for `vault/list`'s own response example.

The two entries stay in `KNOWN_VIOLATIONS` with the blocker named, and
`the_inventory_is_still_accurate` moves from 4 to 2 with them.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `cargo test -p vta-service --no-fail-fast` — 27 suites, only the two blocked vault violations reported
- `cargo fmt --all --check`

BREAKING CHANGE: `vta/webvh/dids/get/1.0` and `GET /webvh/dids/{did}` return the
record under `record` instead of flattened at the top level.
`provision/integration/0.2` omits `adminTemplateName` and `webvhServerId`
instead of sending them as `null`.

Refs #1059
