### PR TITLE
test(vta): gate response conformance, and measure the coverage that qualifies it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1df21614ad88d15fa17236478a4b7526258b35bc84cf545b13a09fc4997e9b"
+checksum = "fa956c8b25b1aa486209d573794cfe9d30ba3cae3ff66f29777b57087f63f982"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.15", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.16", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/scripts/trust-task-coverage.sh
+++ b/scripts/trust-task-coverage.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Report how much of the VTA's Trust Task response surface the test suite
+# actually exercises.
+#
+# The conformance layer in `vta-service/src/test_support/response_conformance.rs`
+# validates every response a test provokes. It can only validate what it sees,
+# so "zero violations" is meaningful only against the number this script
+# prints — the first time it ran, the suite touched 29 of 79 checkable tasks,
+# and a clean report over a third of the surface reads far stronger than it is.
+#
+# Coverage is a property of a run, not of a process, and every binary under
+# `tests/` is its own process. So the layer appends each task it observes to a
+# shared file and this script aggregates, rather than trying to hold the set in
+# memory somewhere.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OBSERVED="${TRUST_TASK_OBSERVED_FILE:-$PWD/target/trust-task-observed.txt}"
+mkdir -p "$(dirname "$OBSERVED")"
+: > "$OBSERVED"          # a stale file would overstate coverage
+export TRUST_TASK_OBSERVED_FILE="$OBSERVED"
+
+echo "==> running the vta-service suite (observations -> $OBSERVED)"
+# `--no-fail-fast` so a failing binary still contributes what it exercised:
+# coverage of a partial run is a floor, and a floor beats no number.
+cargo test -p vta-service --no-fail-fast "$@" || true
+
+echo "==> coverage"
+cargo test -p vta-service --lib -- --ignored --nocapture report_task_coverage

--- a/vta-service/src/test_support/response_conformance.rs
+++ b/vta-service/src/test_support/response_conformance.rs
@@ -4,8 +4,8 @@
 //! ## Why this is a layer and not a fixture
 //!
 //! `trust_tasks::conformance` checks example documents typed by hand into the
-//! witness table. That table reports **79 tasks at zero drift**, and the number
-//! is true — of the fixtures. It says nothing about what a handler emits,
+//! witness table. That table reports **zero drift across every task it
+//! covers**, and the number is true — of the fixtures. It says nothing about what a handler emits,
 //! because a fixture is written separately from the thing it describes.
 //!
 //! The VTC ran exactly this experiment. Its witness also read zero drift; the
@@ -33,11 +33,12 @@
 //!
 //! ## What it does not do
 //!
-//! - **It does not fail the build.** This is deliberately a reporting layer:
-//!   see [`KNOWN_VIOLATIONS`] for the inventory it was landed to make visible,
-//!   and the module's own tests for the properties that *are* asserted. Turning
-//!   it into a gate is a follow-up, once the inventory is closed — the same two
-//!   steps the VTC took across #1107 and #1111.
+//! - **It fails the build.** It did not when it landed in #1113: it reported,
+//!   so the four violations it found could be read off a run rather than
+//!   blocking one. That inventory is now empty, so the layer gates — a
+//!   violation replaces the response with an error document, and the test that
+//!   provoked it fails on its own assertion. Same two steps the VTC took across
+//!   #1107 and #1112.
 //! - **Error responses are exempt.** A non-success outcome is a framework
 //!   reject document, not the task's response payload; validating it against
 //!   the success schema would fail for the wrong reason.
@@ -47,39 +48,36 @@
 //!   evidence of a violation, and treating it as one would make the layer fail
 //!   loudest on the routes it understands least.
 //! - **It sees only what a test exercises**, and that is the headline number:
-//!   a full suite run observes **29 of the 79 bound tasks**. The other fifty
-//!   produce no success response anywhere in `tests/`, so the inventory below
-//!   is a floor taken over a third of the surface, not a total. The census in
+//!   a full suite run observes **29 of the 109 tasks whose response schema is
+//!   published** — 27%. The other eighty produce no success response anywhere
+//!   in `tests/`, and they are not the quiet corners of the surface: the
+//!   signing oracle (`keys/sign`, `keys/derive-and-sign`, `keys/import`), the
+//!   credential release path (`vault/release`, `vault/proxy-login`), device
+//!   `wipe`, and every `consent/*` ceremony are all in the uncovered set.
+//!
+//!   So any clean report from this layer is a floor over a quarter of the
+//!   surface, not a total. `scripts/trust-task-coverage.sh` prints the figure
+//!   and the uncovered list; run it before quoting a violation count, because
+//!   the two numbers only mean something together. The census in
 //!   `trust_tasks::conformance` is what covers the rest, with the caveat this
 //!   module exists to state: it covers them as fixtures.
 
+use std::collections::BTreeSet;
 use std::sync::{Mutex, OnceLock};
 
-/// Tasks observed emitting a non-conforming response, as of the run that
-/// landed this module.
+/// Tasks known to emit a non-conforming response.
 ///
-/// **This list is an inventory, not an allowlist** — nothing consults it at
-/// runtime. It is here so the work is written down at the point the layer was
-/// added, rather than living in a PR description that nobody reads again, and
-/// so `the_inventory_is_still_accurate` fails when one is fixed and the note
-/// goes stale.
+/// **Empty, and the layer now gates.** It held four entries when #1113 landed
+/// the layer as a reporter, and two after #1114 fixed the ones that needed no
+/// spec change; the last two closed when `trust-tasks-rs` 0.11.16 published the
+/// `VaultEntry` lifecycle members (dtgwg-trust-tasks-tf#268).
 ///
-/// Every entry is a class the VTC hit too, which is the argument for the layer:
-/// these are not exotic, they are what happens to any wire type nothing
-/// observes.
-pub const KNOWN_VIOLATIONS: &[(&str, &str)] = &[
-    (
-        "https://trusttasks.org/spec/vault/get/0.1",
-        "leaks `status` / `graceUntil` / `deletedAt` — the archival lifecycle \
-         was added to the storage row and never to the wire contract. Blocked \
-         on trust-tasks-rs 0.11.16, which carries the upstream amendment \
-         (dtgwg-trust-tasks-tf#268) adding those members to `VaultEntry`",
-    ),
-    (
-        "https://trusttasks.org/spec/vault/list/0.1",
-        "the same lifecycle members as `vault/get/0.1`, and the same blocker",
-    ),
-];
+/// **This is an inventory, not an allowlist** — nothing consults it at runtime,
+/// so re-adding an entry does not make a violation tolerable. It stays as the
+/// place to record a violation that is genuinely blocked on something external,
+/// with the blocker named, and `the_inventory_is_still_accurate` fails when the
+/// count moves so a stale note cannot sit here quietly.
+pub const KNOWN_VIOLATIONS: &[(&str, &str)] = &[];
 
 /// Violations observed during a test run, newest last.
 ///
@@ -110,10 +108,93 @@ pub fn clear_violations() {
 /// spine holds: `TrustTaskOutcome.body` stays raw so the wire output is
 /// byte-identical to direct serialisation, and re-parsing here keeps that
 /// property untouched on the path that matters.
-pub fn observe(status: axum::http::StatusCode, body: &[u8]) {
-    if let Some(msg) = check(status, body) {
-        eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
-        violations().lock().expect("violations lock").push(msg);
+pub fn observe(status: axum::http::StatusCode, body: &[u8]) -> Option<Vec<u8>> {
+    let task = successful_task(status, body)?;
+    record_observed(&task);
+    let msg = check(status, body)?;
+    eprintln!("RESPONSE-CONFORMANCE VIOLATION  {msg}");
+    violations()
+        .lock()
+        .expect("violations lock")
+        .push(msg.clone());
+    // Replace the body rather than panic. A panic at the dispatch spine unwinds
+    // through whichever transport is driving — for DIDComm and TSP that is a
+    // background inbound loop, where it reads as "the peer went away" and names
+    // nothing. Handing back an error document makes the test that provoked it
+    // fail on its own assertion, and print the reason.
+    Some(
+        serde_json::json!({
+            "error": "responseSchemaViolation",
+            "message": msg,
+        })
+        .to_string()
+        .into_bytes(),
+    )
+}
+
+/// The `#response` type URI of a successful dispatch, or `None`.
+///
+/// Separate from [`check`] because coverage and conformance ask different
+/// questions of the same bytes: *was this task exercised at all*, and *did what
+/// it emitted conform*. Conflating them is how "zero violations" came to mean
+/// "fifty tasks were never looked at" — the first number is only readable
+/// against the second.
+fn successful_task(status: axum::http::StatusCode, body: &[u8]) -> Option<String> {
+    if !status.is_success() || body.is_empty() {
+        return None;
+    }
+    let doc = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+    Some(doc.get("type")?.as_str()?.to_owned())
+}
+
+/// Task URIs this process has seen emit a successful response.
+static OBSERVED: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+
+fn observed() -> &'static Mutex<BTreeSet<String>> {
+    OBSERVED.get_or_init(|| Mutex::new(BTreeSet::new()))
+}
+
+/// Every task URI this process has observed, sorted.
+pub fn observed_tasks() -> Vec<String> {
+    observed()
+        .lock()
+        .expect("observed lock")
+        .iter()
+        .cloned()
+        .collect()
+}
+
+/// Note a task as exercised, and append it to the run-wide coverage file when
+/// `TRUST_TASK_OBSERVED_FILE` names one.
+///
+/// The file exists because a coverage figure is a property of a **run**, not of
+/// a process, and every binary under `tests/` is its own process — thirty-five
+/// of them on the VTC, twenty-seven here. An in-memory set answers "what did
+/// *this* binary touch", which is not the question.
+///
+/// Appends are `O_APPEND` one line at a time, which is atomic below `PIPE_BUF`
+/// for a URI, so concurrent binaries interleave lines rather than corrupt them.
+/// Duplicates are expected and the reader dedupes; writing once per process per
+/// URI just keeps the file small.
+fn record_observed(task: &str) {
+    {
+        let mut seen = observed().lock().expect("observed lock");
+        if !seen.insert(task.to_owned()) {
+            return;
+        }
+    }
+    let Ok(path) = std::env::var("TRUST_TASK_OBSERVED_FILE") else {
+        return;
+    };
+    use std::io::Write;
+    // Best-effort: a coverage file that cannot be written must never fail a
+    // test run. The script that sets the variable checks the file itself.
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = writeln!(f, "{task}");
     }
 }
 
@@ -137,6 +218,68 @@ fn check(status: axum::http::StatusCode, body: &[u8]) -> Option<String> {
         return None;
     };
     Some(format!("{ty}: {e}"))
+}
+
+/// Tasks this dispatcher binds whose **response** schema is published — the
+/// set the layer is able to check at all.
+///
+/// Derived from `dispatched_uris()`, never hand-listed, for the same reason
+/// the witness census is: a hand-kept denominator drifts, and a coverage figure
+/// over a drifted denominator is worse than none.
+pub fn checkable_tasks() -> Vec<&'static str> {
+    crate::trust_tasks::dispatched_uris()
+        .into_iter()
+        .filter(|u| trust_tasks_rs::schema_index::schema_for(&format!("{u}#response")).is_some())
+        .collect()
+}
+
+/// Report which checkable tasks a whole run never exercised.
+///
+/// Run by `scripts/trust-task-coverage.sh` **after** the suite, against the
+/// file the suite appended to. Ignored by default because on its own — with no
+/// preceding run — it would report zero coverage and say nothing true.
+///
+/// It reports rather than fails. The gap it measures is fifty-odd tasks wide,
+/// and a gate at that width is a gate nobody can turn on; the number is the
+/// deliverable until the gap is closed enough for a floor to mean something.
+#[test]
+#[ignore = "needs a suite run first; driven by scripts/trust-task-coverage.sh"]
+fn report_task_coverage() {
+    let path = std::env::var("TRUST_TASK_OBSERVED_FILE")
+        .expect("set TRUST_TASK_OBSERVED_FILE, or run scripts/trust-task-coverage.sh");
+    let seen: BTreeSet<String> = std::fs::read_to_string(&path)
+        .unwrap_or_default()
+        .lines()
+        .map(|l| l.trim().to_owned())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let checkable = checkable_tasks();
+    // The file records the `#response` URI the document carried; the census
+    // yields the bare task URI. Compare on the bare form.
+    let seen_bare: BTreeSet<&str> = seen
+        .iter()
+        .map(|u| u.strip_suffix("#response").unwrap_or(u))
+        .collect();
+
+    let mut uncovered: Vec<&str> = checkable
+        .iter()
+        .copied()
+        .filter(|u| !seen_bare.contains(u))
+        .collect();
+    uncovered.sort_unstable();
+
+    let total = checkable.len();
+    let covered = total - uncovered.len();
+    println!(
+        "\nTRUST-TASK RESPONSE COVERAGE  {covered}/{total}          ({:.0}%) — {} never exercised\n",
+        (covered as f64 / total.max(1) as f64) * 100.0,
+        uncovered.len()
+    );
+    for u in &uncovered {
+        println!("  UNCOVERED  {u}");
+    }
+    println!();
 }
 
 #[cfg(test)]
@@ -188,6 +331,42 @@ mod tests {
         );
     }
 
+    /// A violation now replaces the response, rather than only being noted.
+    #[test]
+    fn a_violation_replaces_the_response() {
+        clear_violations();
+        let body = br#"{
+            "type": "https://trusttasks.org/spec/vault/list/0.1#response",
+            "payload": {"nope": 1}
+        }"#;
+        let out = observe(StatusCode::OK, body).expect("a violation must be fatal");
+        let doc: serde_json::Value = serde_json::from_slice(&out).expect("error document");
+        assert_eq!(doc["error"], "responseSchemaViolation");
+        assert!(
+            doc["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("vault/list")),
+            "the replacement must name the task, or the failing test says nothing"
+        );
+        assert_eq!(
+            observed_violations().len(),
+            1,
+            "it must still be recorded — raising fails one test, recording is \
+             what lets a whole run be swept"
+        );
+    }
+
+    /// A conforming response passes through untouched.
+    #[test]
+    fn a_conforming_response_is_not_replaced() {
+        // `messaging/ping/0.1` is bound and published; an empty payload object
+        // is not valid for it, so use a task whose response really does pass:
+        // the exemption paths are covered above, so assert the shape that
+        // matters here — no violation, no replacement.
+        assert!(observe(StatusCode::NO_CONTENT, b"").is_none());
+        assert!(observe(StatusCode::BAD_REQUEST, b"{}").is_none());
+    }
+
     /// The inventory only shrinks, and its entries stay real.
     ///
     /// Asserted for the reason the VTC's `KNOWN_DRIFT_COUNT` is: a tolerated
@@ -198,7 +377,7 @@ mod tests {
     fn the_inventory_is_still_accurate() {
         assert_eq!(
             KNOWN_VIOLATIONS.len(),
-            2,
+            0,
             "the known-violation inventory changed. Fixed one? Remove its entry \
              and lower this. Found a new one? That is a defect to fix, not an \
              entry to add — this list records what was already true when the \

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -479,7 +479,14 @@ pub(crate) async fn dispatch_trust_task_core(
     // an HTTP-layer check would be blind to both. Compiled out of production
     // builds; see `test_support::response_conformance`.
     #[cfg(any(test, feature = "test-support"))]
-    crate::test_support::response_conformance::observe(outcome.status, &outcome.body);
+    let outcome =
+        match crate::test_support::response_conformance::observe(outcome.status, &outcome.body) {
+            Some(body) => TrustTaskOutcome {
+                status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                body,
+            },
+            None => outcome,
+        };
     outcome
 }
 


### PR DESCRIPTION
Closes the last two violations #1113 found, turns the layer into a gate, and —
the part that matters most — makes the number that qualifies the gate
measurable.

## An empty inventory is not the same as a clean surface

`KNOWN_VIOLATIONS` is now empty and the layer fails the build. That reads like
the end of the job. It is not, and shipping the zero without the second number
would be the misleading move:

```
TRUST-TASK RESPONSE COVERAGE  29/109 (27%) — 80 never exercised
```

A full suite run exercises **29 of the 109 tasks whose response schema is
published**. The other eighty emit no success response anywhere under `tests/`,
so the gate has never looked at them. And they are not the quiet corners:

| uncovered | what it is |
|---|---|
| `keys/sign`, `keys/derive-and-sign`, `keys/derive-and-sign-document`, `keys/import` | the signing oracle |
| `vault/release`, `vault/proxy-login`, `vault/sign-trust-task` | the credential release path |
| `device/wipe`, `device/disable` | remote device control |
| every `consent/*` | the DTTE ceremony |
| `vta/contexts/*`, `vta/did-templates/*`, `vta/app-state/*` | whole families |

That is the highest-stakes surface in the workspace, and the conformance layer
has no opinion about any of it.

## So the coverage figure is now produced, not estimated

`scripts/trust-task-coverage.sh` runs the suite and prints the figure plus the
uncovered list. Two design points:

- **Coverage is a property of a run, not a process.** Every binary under
  `tests/` is its own process (twenty-eight here, thirty-five on the VTC), so an
  in-memory set answers "what did *this* binary touch", which is not the
  question. The layer appends each newly-seen task to a file named by
  `TRUST_TASK_OBSERVED_FILE`; the reporter aggregates. Appends are `O_APPEND`,
  one line at a time, below `PIPE_BUF` — concurrent binaries interleave lines
  rather than corrupt them.
- **The denominator is derived, never hand-listed** — `dispatched_uris()`
  filtered to those whose `#response` schema resolves. A hand-kept denominator
  drifts, and a coverage figure over a drifted denominator is worse than none.

The reporter is `#[ignore]`d: without a preceding suite run it would report zero
coverage and say nothing true.

### A correction to #1113's description

That PR said "29 of the 79 bound tasks". **79 was wrong** — it came from
`grep -c 'checked!'` on the witness table, which counts occurrences of a macro
name, not a census. Measured properly: 132 URIs dispatched, 109 with published
schemas (the bare and `#response` sets coincide exactly), 29 observed. The
coverage fraction is worse than reported, not better.

## The vault pair, closed upstream

`vault/{get,list}/0.1` leaked `status` / `graceUntil` / `deletedAt` — #540's
archival lifecycle, added to the storage row and never to the wire contract.

The fix was upstream, because the specification was inconsistent with itself:
`vault/list/0.1` defines a `status` filter whose `all` value "lists every entry
regardless of lifecycle state", while `VaultEntry` is
`additionalProperties: false` and carried no lifecycle member — so that view
returned a mixed list no consumer could partition.
[dtgwg-trust-tasks-tf#268](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/268)
adds the members; this bumps to the `trust-tasks-rs 0.11.16` that carries them.
No service change was needed: the daemon was already right.

## The gate

A violation now replaces the response with an error document, so the test that
provoked it fails on its own assertion. Not a panic: the spine unwinds through
whichever transport is driving, and for DIDComm and TSP that is a background
inbound loop, where a panic reads as "the peer went away" and names nothing.

`KNOWN_VIOLATIONS` stays as the place to record a violation genuinely blocked on
something external, with the blocker named. Nothing consults it at runtime, so
re-adding an entry does not make a violation tolerable — it only records it.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites green, **0 violations** with the gate live, coverage 29/109
- `cargo fmt --all --check`

Refs #1059
