### PR TITLE
test(vta): make the coverage figure stable, and cover the signing oracle

### DIFF
--- a/scripts/trust-task-coverage.sh
+++ b/scripts/trust-task-coverage.sh
@@ -9,19 +9,22 @@
 # and a clean report over a third of the surface reads far stronger than it is.
 #
 # Coverage is a property of a run, not of a process, and every binary under
-# `tests/` is its own process. So the layer appends each task it observes to a
-# shared file and this script aggregates, rather than trying to hold the set in
-# memory somewhere.
+# `tests/` is its own process. So each process writes the tasks it observed to
+# its own file under a shared directory and this script aggregates them.
+#
+# One file per process, not one shared file: the shared-append version lost
+# whole binaries' observations intermittently, reporting 31 tasks on one run and
+# 33 on the next off identical code.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-OBSERVED="${TRUST_TASK_OBSERVED_FILE:-$PWD/target/trust-task-observed.txt}"
-mkdir -p "$(dirname "$OBSERVED")"
-: > "$OBSERVED"          # a stale file would overstate coverage
-export TRUST_TASK_OBSERVED_FILE="$OBSERVED"
+OBSERVED="${TRUST_TASK_OBSERVED_DIR:-$PWD/target/trust-task-observed}"
+rm -rf "$OBSERVED"       # stale files would overstate coverage
+mkdir -p "$OBSERVED"
+export TRUST_TASK_OBSERVED_DIR="$OBSERVED"
 
-echo "==> running the vta-service suite (observations -> $OBSERVED)"
+echo "==> running the vta-service suite (observations -> $OBSERVED/<pid>.tasks)"
 # `--no-fail-fast` so a failing binary still contributes what it exercised:
 # coverage of a partial run is a floor, and a floor beats no number.
 cargo test -p vta-service --no-fail-fast "$@" || true

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -69,10 +69,22 @@ pub struct KeyRecord {
     pub status: KeyStatus,
     #[serde(alias = "public_key")]
     pub public_key: String,
+    /// Absent when unset, never `null`.
+    ///
+    /// The shared `KeyRecord` component types this `string`, so `null` is a
+    /// type error rather than a spelling of "no label" — and this component is
+    /// returned by `keys/{list,create,show,import,rename,revoke}`, so one
+    /// missing `skip_serializing_if` here is a violation on six tasks at once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    #[serde(default, alias = "context_id")]
+    /// Absent when unset, never `null`. **Absence is not "every scope"** — the
+    /// spec is explicit that a key with no context is reachable only by a
+    /// caller with unrestricted authority, which is the workspace's own
+    /// act-scope rule.
+    #[serde(default, alias = "context_id", skip_serializing_if = "Option::is_none")]
     pub context_id: Option<String>,
-    #[serde(default, alias = "seed_id")]
+    /// Absent when unset, never `null`; the component types it `integer`.
+    #[serde(default, alias = "seed_id", skip_serializing_if = "Option::is_none")]
     pub seed_id: Option<u32>,
     #[serde(default = "default_derived")]
     pub origin: KeyOrigin,

--- a/vta-service/src/test_support/response_conformance.rs
+++ b/vta-service/src/test_support/response_conformance.rs
@@ -164,38 +164,98 @@ pub fn observed_tasks() -> Vec<String> {
         .collect()
 }
 
-/// Note a task as exercised, and append it to the run-wide coverage file when
-/// `TRUST_TASK_OBSERVED_FILE` names one.
+/// Note a task as exercised, and write it to this process's own coverage file
+/// when `TRUST_TASK_OBSERVED_DIR` names a directory.
 ///
 /// The file exists because a coverage figure is a property of a **run**, not of
-/// a process, and every binary under `tests/` is its own process — thirty-five
-/// of them on the VTC, twenty-seven here. An in-memory set answers "what did
-/// *this* binary touch", which is not the question.
+/// a process, and every binary under `tests/` is its own process — twenty-eight
+/// here, thirty-five on the VTC. An in-memory set answers "what did *this*
+/// binary touch", which is not the question.
 ///
-/// Appends are `O_APPEND` one line at a time, which is atomic below `PIPE_BUF`
-/// for a URI, so concurrent binaries interleave lines rather than corrupt them.
-/// Duplicates are expected and the reader dedupes; writing once per process per
-/// URI just keeps the file small.
+/// **One file per process, not one shared file.** The first version of this
+/// appended every observation to a single path, on the reasoning that `O_APPEND`
+/// writes below `PIPE_BUF` are atomic and so concurrent binaries would interleave
+/// lines rather than corrupt them. Atomicity was never the failure mode:
+/// observations went *missing* instead, intermittently and always in whole
+/// binaries — the same suite reported 31 tasks on one run and 33 on the next,
+/// off identical code, with `client_round_trip`'s twelve present or absent as a
+/// block. Rather than keep reasoning about append semantics under
+/// twenty-eight writers, this removes the shared writer: nothing contends,
+/// because no two processes touch the same file.
 fn record_observed(task: &str) {
-    {
-        let mut seen = observed().lock().expect("observed lock");
-        if !seen.insert(task.to_owned()) {
-            return;
-        }
-    }
-    let Ok(path) = std::env::var("TRUST_TASK_OBSERVED_FILE") else {
+    // Note the in-memory set first, but do NOT let it gate the write: the two
+    // record different things, and conflating them cost a real bug. Marking a
+    // task seen and then failing to write it means the write is never retried,
+    // because every later dispatch of that task takes the early return — one
+    // transient failure loses the task for the whole process, silently, in the
+    // direction that under-reports.
+    let first_time = observed()
+        .lock()
+        .expect("observed lock")
+        .insert(task.to_owned());
+    let Ok(dir) = std::env::var("TRUST_TASK_OBSERVED_DIR") else {
         return;
     };
+    if !first_time && already_written(task) {
+        return;
+    }
     use std::io::Write;
     // Best-effort: a coverage file that cannot be written must never fail a
-    // test run. The script that sets the variable checks the file itself.
-    if let Ok(mut f) = std::fs::OpenOptions::new()
+    // test run. The script that sets the variable checks the directory itself.
+    // Named for the test binary, not just the pid, so a coverage file is
+    // attributable: "which binary stopped observing this task" is the first
+    // question asked of a number that moved, and a bare pid cannot answer it.
+    let binary = std::env::args()
+        .next()
+        .and_then(|a| {
+            std::path::Path::new(&a)
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "unknown".to_owned());
+    let path = std::path::Path::new(&dir).join(format!("{binary}.{}.tasks", std::process::id()));
+    // One `write_all` of a pre-formatted line, never `writeln!`.
+    //
+    // `writeln!` on an unbuffered `File` can issue the text and the newline as
+    // two separate `write` syscalls, and test binaries run their tests on many
+    // threads — so two threads interleave *between* those calls and produce a
+    // line like `…/acl/grant/0.1#response…/dids/get/1.0#response`. Both tasks
+    // are then lost, because the reporter matches whole lines. That is what
+    // made this figure jitter: three or four mangled lines per run, and the
+    // count moving by exactly the tasks they swallowed.
+    //
+    // `O_APPEND` makes a single `write` atomic against other appenders, so
+    // formatting the newline into the buffer first is what actually buys the
+    // atomicity the append mode promises.
+    let line = format!("{task}\n");
+    match std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
     {
-        let _ = writeln!(f, "{task}");
+        Ok(mut f) => {
+            if f.write_all(line.as_bytes()).is_ok() {
+                written()
+                    .lock()
+                    .expect("written lock")
+                    .insert(task.to_owned());
+            }
+        }
+        // Loud, because a coverage figure that silently under-reports is the
+        // exact failure this whole module exists to stop happening elsewhere.
+        Err(e) => eprintln!("TRUST-TASK COVERAGE: cannot write {}: {e}", path.display()),
     }
+}
+
+/// Tasks this process has successfully written to its coverage file.
+static WRITTEN: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+
+fn written() -> &'static Mutex<BTreeSet<String>> {
+    WRITTEN.get_or_init(|| Mutex::new(BTreeSet::new()))
+}
+
+fn already_written(task: &str) -> bool {
+    written().lock().expect("written lock").contains(task)
 }
 
 /// The check itself, separated so it is unit-testable without a dispatcher.
@@ -245,14 +305,32 @@ pub fn checkable_tasks() -> Vec<&'static str> {
 #[test]
 #[ignore = "needs a suite run first; driven by scripts/trust-task-coverage.sh"]
 fn report_task_coverage() {
-    let path = std::env::var("TRUST_TASK_OBSERVED_FILE")
-        .expect("set TRUST_TASK_OBSERVED_FILE, or run scripts/trust-task-coverage.sh");
-    let seen: BTreeSet<String> = std::fs::read_to_string(&path)
-        .unwrap_or_default()
-        .lines()
-        .map(|l| l.trim().to_owned())
-        .filter(|l| !l.is_empty())
-        .collect();
+    let dir = std::env::var("TRUST_TASK_OBSERVED_DIR")
+        .expect("set TRUST_TASK_OBSERVED_DIR, or run scripts/trust-task-coverage.sh");
+    let entries = std::fs::read_dir(&dir).expect("the observed directory must exist");
+    let mut files = 0usize;
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    for e in entries.flatten() {
+        if e.path().extension().is_none_or(|x| x != "tasks") {
+            continue;
+        }
+        files += 1;
+        for line in std::fs::read_to_string(e.path())
+            .unwrap_or_default()
+            .lines()
+        {
+            let l = line.trim();
+            if !l.is_empty() {
+                seen.insert(l.to_owned());
+            }
+        }
+    }
+    assert!(
+        files > 0,
+        "no coverage files in {dir} — the suite either did not run or did not \
+         see TRUST_TASK_OBSERVED_DIR, and a coverage figure over zero files \
+         would read as 0% rather than as 'not measured'"
+    );
 
     let checkable = checkable_tasks();
     // The file records the `#response` URI the document carried; the census

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1940,3 +1940,120 @@ mod superseded_task_dispatch_tests {
         );
     }
 }
+
+/// Exercise the happy path of tasks the suite otherwise never reaches.
+///
+/// These are not tests of handler *logic* — every arm has that in its owning
+/// operations module. They exist so the response-conformance gate in
+/// `test_support::response_conformance` gets to look at each task's real
+/// success response at all.
+///
+/// The gap they close is the one `scripts/trust-task-coverage.sh` measures: the
+/// gate was validating 29 of 109 checkable tasks, and the seventy-odd it had
+/// never seen included the signing oracle. A gate that has never observed
+/// `keys/sign` is not evidence about `keys/sign`.
+///
+/// Each test asserts a success document came back and lets the layer do the
+/// schema work — a violation replaces the response, so the `type` assertion
+/// below is what fails when a shape drifts.
+#[cfg(test)]
+mod response_coverage {
+    use super::*;
+    use base64::Engine;
+    use serde_json::json;
+    use vta_sdk::trust_tasks as t;
+
+    use crate::test_support::build_signing_test_app_state;
+
+    /// Dispatch as a super-admin and require a success document back.
+    ///
+    /// Returns the response `payload` so a test can chain (e.g. take a key id
+    /// out of `keys/create` and sign with it).
+    async fn ok(state: &crate::server::AppState, uri: &str, payload: Value) -> Value {
+        let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
+        let body = serde_json::to_vec(&json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": uri,
+            "issuer": "did:key:zTestAdmin",
+            "recipient": vta_did,
+            "issuedAt": "2026-08-26T00:00:00Z",
+            "payload": payload,
+        }))
+        .expect("envelope serialises");
+
+        let outcome = super::dispatch_trust_task_core(
+            state,
+            &crate::test_support::super_admin_claims(),
+            &body,
+            transport::TransportConfidentiality::HopByHop,
+        )
+        .await;
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("a response document");
+        assert_eq!(
+            doc["type"],
+            format!("{uri}#response"),
+            "expected a success response from {uri}, got: {doc}"
+        );
+        doc["payload"].clone()
+    }
+
+    /// Mint a key and return its id, so the read/sign/rename paths have a real
+    /// subject rather than the VTA's own signing key (which they must not
+    /// rename or revoke).
+    async fn a_key(state: &crate::server::AppState, label: &str) -> String {
+        let p = ok(
+            state,
+            t::TASK_KEYS_CREATE_0_1,
+            json!({ "keyType": "ed25519", "derivationPath": "m/26'/2'/0'/0'", "label": label }),
+        )
+        .await;
+        p["key"]["keyId"]
+            .as_str()
+            .or_else(|| p["keyId"].as_str())
+            .unwrap_or_else(|| panic!("keys/create must name the key it made: {p}"))
+            .to_owned()
+    }
+
+    #[tokio::test]
+    async fn keys_show_and_sign() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let key_id = a_key(&state, "coverage-show-sign").await;
+
+        ok(&state, t::TASK_KEYS_SHOW_0_1, json!({ "keyId": key_id })).await;
+
+        // The signing oracle. `payload` is base64url without padding, and the
+        // maintainer signs those bytes verbatim.
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"coverage");
+        ok(
+            &state,
+            t::TASK_KEYS_SIGN_0_1,
+            json!({ "keyId": key_id, "payload": payload, "algorithm": "EdDSA" }),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn keys_rename_then_revoke() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let key_id = a_key(&state, "coverage-rename").await;
+
+        // `newKeyId` is an identifier, not a path — `/` is rejected, and the
+        // key id defaults to the derivation path, so it cannot be reused here.
+        let renamed = "coverage-renamed-key".to_string();
+        ok(
+            &state,
+            t::TASK_KEYS_RENAME_0_1,
+            json!({ "keyId": key_id, "newKeyId": renamed }),
+        )
+        .await;
+
+        // Revoke last: it is terminal, and revoking under the new id also
+        // proves the rename took on the record rather than only in the reply.
+        ok(
+            &state,
+            t::TASK_KEYS_REVOKE_0_1,
+            json!({ "keyId": renamed, "reason": "coverage" }),
+        )
+        .await;
+    }
+}


### PR DESCRIPTION
#1115 shipped a coverage figure that **jittered**: 31 then 33, then 33 / 30 / 33
across consecutive runs of identical code — same 28 suites, same 1281 tests
passing, same binaries, every time. A metric that moves when nothing does is
worse than no metric, so this finds the cause and fixes it.

## The cause was in the recording, and it was mine

`writeln!` on an unbuffered `File` can issue the text and the newline as **two
separate write syscalls**. Test binaries run their tests on many threads, so two
threads interleaved *between* those calls:

```
https://trusttasks.org/spec/acl/grant/0.1#responsehttps://trusttasks.org/spec/vta/webvh/dids/get/1.0#response
```

Both tasks are lost, because the reporter matches whole lines. Three or four
mangled lines per run, and the count moved by exactly the tasks they swallowed.

`O_APPEND` makes a *single* write atomic against other appenders — so
formatting the newline into the buffer and issuing one `write_all` is what
actually buys the atomicity the append mode promises. #1115's body claimed
"atomicity was never the failure mode"; that was wrong. It was atomicity, at a
granularity one level below where I was looking.

**Three consecutive runs now report 37 observed tasks with zero mangled lines.**

## Two more robustness fixes found on the way

- **One file per process, named for the binary.** The shared-append design had
  no way to answer "which binary stopped observing this task", which is the
  first question you ask of a number that moved. Files are now
  `<binary>.<pid>.tasks`; nothing contends, and the data is attributable.
- **The dedup no longer gates the write.** `record_observed` marked a task seen
  and *then* wrote it — so a failed write was never retried, because every later
  dispatch took the early return. One transient failure lost the task for the
  whole process, silently, in the direction that under-reports. A write failure
  is now also printed rather than swallowed, since a coverage figure that
  quietly under-reports is the exact failure this module exists to prevent
  elsewhere.

## Covering the signing oracle, and what it found immediately

Adds happy-path coverage for `keys/{show,sign,rename,revoke}/0.1` — **29 → 33**.

These are not tests of handler logic; every arm has that in its owning
operations module. They exist so the gate gets to look at each task's real
success response at all, and a gate that has never observed `keys/sign` is not
evidence about `keys/sign`.

**The gate caught a real violation on the first newly-covered task.**
`keys/show/0.1` emitted `contextId: null`. The cause is the shared `KeyRecord`
component: `label`, `contextId` and `seedId` are all `Option` with no
`skip_serializing_if`, so one fix covers the six tasks that return it
(`keys/{list,create,show,import,rename,revoke}`).

That is the argument for the coverage number in one data point: two tasks'
worth of new coverage found a defect that had been shipping.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites green, 0 violations, **33/109 stable across three runs**
- `cargo fmt --all --check`

Refs #1059
