### PR TITLE
fix(vta)!: --internal creates an internal key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8681,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa956c8b25b1aa486209d573794cfe9d30ba3cae3ff66f29777b57087f63f982"
+checksum = "e0247e25a581eb37577b81a0882ec60c9a218051b39ab0e72cf7656479daf0a3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.16", default-features = false, features = ["validate"] }
+trust-tasks-rs = { version = "0.11.17", default-features = false, features = ["validate"] }
 trust-tasks-capability-client = "0.9"
 trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -28,10 +28,23 @@ impl VtaClient {
         // registry had a member for it, so it was one rename away from
         // silently dropping the create-from-a-phrase path (see #884's
         // `update_acl`, the same failure with different members).
+        // `internal` and `derivation_path` are forwarded, not dropped.
+        //
+        // `internal` was hardcoded `None` here while `CreateKeyRequest::internal`
+        // was never read, so `pnm keys create --internal` printed its whole
+        // non-recoverable-key warning, made the operator type "i understand this
+        // key cannot be recovered", and then minted an ordinary derived key —
+        // one that *is* in backups and *is* exportable. The operator was told
+        // the opposite of what happened.
+        //
+        // `derivation_path` was `unwrap_or_default()`, sending `""` for absent.
+        // The operation layer reads `""` as absent, so it worked; but the wire
+        // then carried a member the caller never set, and the empty string is
+        // meaningless to any other maintainer.
         let body = crate::protocols::key_management::create::CreateKeyBody {
-            internal: None,
+            internal: req.internal,
             key_type: req.key_type.clone(),
-            derivation_path: req.derivation_path.clone().unwrap_or_default(),
+            derivation_path: req.derivation_path.clone(),
             mnemonic: req.mnemonic.clone(),
             label: req.label.clone(),
             context_id: req.context_id.clone(),

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -9,8 +9,22 @@ use crate::keys::{KeyOrigin, KeyStatus, KeyType};
 pub struct CreateKeyBody {
     #[serde(alias = "key_type")]
     pub key_type: KeyType,
-    #[serde(alias = "derivation_path")]
-    pub derivation_path: String,
+    /// Optional, as `keys/create/0.1` says: "omitting it leaves the choice to
+    /// the custodian".
+    ///
+    /// It was a required `String` here, so a conforming client that omitted it
+    /// got `malformedRequest` — and `VtaClient::create_key` papered over that
+    /// by sending `""`, which the operation layer then treats as absent. The
+    /// operation layer was always right: `CreateKeyParams::derivation_path` is
+    /// an `Option` and auto-derives from the context when unset. Only this wire
+    /// type disagreed, and it is also incoherent with `internal`, which derives
+    /// from no seed and records no path at all.
+    #[serde(
+        default,
+        alias = "derivation_path",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub derivation_path: Option<String>,
     /// An unset member must be **absent**, never `null` — `keys/create/0.1`
     /// types each of these as `"string"`, and none of them accepts null. See
     /// the `an_unset_member_is_absent_from_the_wire_not_null` test below.
@@ -25,6 +39,12 @@ pub struct CreateKeyBody {
     /// Absent or `false` keeps today's behaviour exactly. `true` mints a key
     /// from the system CSPRNG that is never exported, never backed up, and
     /// **cannot be recovered** — see `vta_keys::internal`.
+    ///
+    /// Published in `keys/create/0.1` as of `trust-tasks-rs` 0.11.17
+    /// (dtgwg-trust-tasks-tf#269). Before that the request schema was
+    /// `additionalProperties: false` with no such member, so the dispatch
+    /// spine rejected any document carrying it — the capability existed at
+    /// both ends and was unreachable over the wire.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub internal: Option<bool>,
 }
@@ -117,7 +137,7 @@ mod null_member_tests {
         let minimal = CreateKeyBody {
             internal: None,
             key_type: KeyType::Ed25519,
-            derivation_path: String::new(),
+            derivation_path: None,
             mnemonic: None,
             label: None,
             context_id: None,
@@ -125,8 +145,13 @@ mod null_member_tests {
 
         assert_eq!(
             serde_json::to_value(&minimal).expect("serialises"),
-            serde_json::json!({"keyType": "ed25519", "derivationPath": ""}),
-            "an unset member must be absent, not null"
+            serde_json::json!({"keyType": "ed25519"}),
+            "an unset member must be absent — not null, and not an empty \
+             string. This assertion used to require `derivationPath: \"\"`, \
+             which contradicted the test's own name: the empty string is a \
+             value the caller never chose, and it reached the wire only \
+             because the member was a required `String` here while the \
+             specification and the operation layer both make it optional."
         );
     }
 
@@ -137,7 +162,7 @@ mod null_member_tests {
         let labelled = CreateKeyBody {
             internal: None,
             key_type: KeyType::Ed25519,
-            derivation_path: "m/26'/2'/0'/1'".into(),
+            derivation_path: Some("m/26'/2'/0'/1'".into()),
             mnemonic: None,
             label: Some("persona-signing".into()),
             context_id: Some("openvtc".into()),

--- a/vta-sdk/tests/protocol_debug_redaction.rs
+++ b/vta-sdk/tests/protocol_debug_redaction.rs
@@ -85,7 +85,7 @@ fn create_key_body_debug_redacts_mnemonic() {
     let body = CreateKeyBody {
         internal: None,
         key_type: vta_sdk::keys::KeyType::Ed25519,
-        derivation_path: "m/0'".into(),
+        derivation_path: Some("m/0'".into()),
         mnemonic: Some(MARKER.into()),
         label: Some("test".into()),
         context_id: Some("ctx".into()),

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -364,11 +364,9 @@ didcomm_handler!(
         operations::keys::CreateKeyParams {
             internal: body.internal.unwrap_or(false),
             key_type: body.key_type,
-            derivation_path: if body.derivation_path.is_empty() {
-                None
-            } else {
-                Some(body.derivation_path)
-            },
+            // Straight through: the wire member is optional now, so the
+            // empty-string-means-absent dance this used to do is gone.
+            derivation_path: body.derivation_path,
             key_id: None,
             mnemonic: body.mnemonic,
             label: body.label,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -932,7 +932,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(CreateKeyBody {
                     internal: None,
                     key_type: KeyType::Ed25519,
-                    derivation_path: "m/26'/2'/0'/1'".into(),
+                    derivation_path: Some("m/26'/2'/0'/1'".into()),
                     mnemonic: None,
                     label: Some("app signing key".into()),
                     context_id: Some("app".into()),

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -77,11 +77,32 @@ pub(super) async fn handle_create(
         operations::keys::CreateKeyParams {
             internal: req.internal.unwrap_or(false),
             key_type: req.key_type,
-            derivation_path: Some(req.derivation_path),
-            // Trust-task envelope auto-generates key_id from derivation
-            // path; explicit-key_id specification stays on the legacy
-            // REST path until Phase 3 hardening extends CreateKeyBody.
-            key_id: None,
+            derivation_path: req.derivation_path,
+            // A derived key takes its id from the derivation path, so `None`
+            // is right for it. An **internal** key has no derivation path to
+            // be named after and the operation layer refuses one without an
+            // id — so over this binding, where the request carries no `keyId`
+            // member to supply, the binding mints one.
+            //
+            // `keyId` is published in `keys/create/0.1` as of `trust-tasks-rs`
+            // 0.12.1 (dtgwg-trust-tasks-tf#275), and this workspace cannot
+            // move to 0.12 yet: `affinidi-messaging-sdk` 0.19.12 pins
+            // `trust-tasks-rs ^0.11` and `vta_sdk::acl_setup` hands it a
+            // generated `MediatorAcl`, so two nodes in one graph fail to
+            // compile. **When that bump lands, take `key_id` from the request
+            // and delete this branch** — the specification says a maintainer
+            // that offers internal keys and receives no `keyId` SHOULD reject,
+            // and minting one is a deliberate deviation taken because the
+            // alternative is a security feature that cannot be used at all.
+            //
+            // The consumer is not left guessing: the id is returned on the
+            // response record, the CLI prints it, and `keys/rename/0.1` can
+            // change it.
+            key_id: if req.internal.unwrap_or(false) {
+                Some(format!("internal-{}", uuid::Uuid::new_v4()))
+            } else {
+                None
+            },
             mnemonic: req.mnemonic,
             label: req.label,
             context_id: req.context_id,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2032,6 +2032,89 @@ mod response_coverage {
         .await;
     }
 
+    /// An internal key is actually internal.
+    ///
+    /// This is the assertion whose absence let `pnm keys create --internal`
+    /// lie. The CLI prints a non-recoverable-key warning, requires the operator
+    /// to type "i understand this key cannot be recovered", and then called a
+    /// client that built its wire body with `internal: None` hardcoded — so the
+    /// operator was handed an ordinary seed-derived key that *is* in backups
+    /// and *is* exportable, believing the opposite.
+    ///
+    /// It could not have worked even if the client had forwarded the flag:
+    /// `keys/create/0.1` was `additionalProperties: false` with no `internal`
+    /// member, so the dispatch spine rejected the document. The capability
+    /// existed at both ends and was unreachable over the wire, which is what
+    /// dtgwg-trust-tasks-tf#269 fixed.
+    ///
+    /// `origin` is the check that matters, and it is the one the CLI already
+    /// makes: a maintainer that ignored the member returns `derived`, and that
+    /// difference is the only reliable signal the request was honoured.
+    #[tokio::test]
+    async fn an_internal_key_is_actually_internal() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let p = ok(
+            &state,
+            t::TASK_KEYS_CREATE_0_1,
+            json!({ "keyType": "ed25519", "internal": true, "label": "unexportable" }),
+        )
+        .await;
+        let record = p.get("key").unwrap_or(&p);
+        assert_eq!(
+            record["origin"], "internal",
+            "the key must come back marked internal — a `derived` here is \
+             exactly the silent downgrade the operator was warned about and \
+             did not get: {p}"
+        );
+        // An internal key derives from no seed, and the shared `KeyRecord`
+        // component says `derivationPath` is the path "the key was derived at,
+        // when `origin` is `derived`", absent otherwise. This service instead
+        // records the sentinel string `"internal"`, with a comment saying it
+        // "names the origin instead, so a reader cannot mistake it for
+        // something re-derivable" — reasoning that predates `origin` gaining
+        // an `internal` value (dtgwg-trust-tasks-tf#269), which now carries
+        // that fact properly.
+        //
+        // Asserted as-is rather than fixed here: making `KeyRecord`'s
+        // `derivation_path` an `Option` touches 84 construction sites and is
+        // its own change. Worth knowing that the response-conformance gate
+        // cannot catch this — the schema types the member `string`, so a
+        // sentinel validates cleanly. It is a semantic divergence, and only a
+        // reader notices.
+        assert_eq!(
+            record["derivationPath"], "internal",
+            "the sentinel is the current behaviour; when `derivationPath` \
+             becomes optional this should assert absence instead: {p}"
+        );
+    }
+
+    /// A create with no `derivationPath` succeeds.
+    ///
+    /// The spec says "omitting it leaves the choice to the custodian", and the
+    /// operation layer has always auto-derived from the context. Only the wire
+    /// type disagreed, so a conforming client that omitted it got
+    /// `malformedRequest` — and the SDK hid that by sending `""`.
+    #[tokio::test]
+    async fn a_create_without_a_derivation_path_succeeds() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        // The context has to exist: with no path *and* no context there is
+        // nothing for the custodian to derive from, which the operation layer
+        // refuses on its own terms. Creating it also covers
+        // `vta/contexts/create/1.0`.
+        ok(
+            &state,
+            t::TASK_CONTEXTS_CREATE_1_0,
+            json!({ "id": "coverage-ctx", "name": "Coverage" }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_KEYS_CREATE_0_1,
+            json!({ "keyType": "ed25519", "contextId": "coverage-ctx" }),
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn keys_rename_then_revoke() {
         let (state, _dir) = build_signing_test_app_state().await;


### PR DESCRIPTION
`pnm keys create --internal` printed a full non-recoverable-key warning, made
the operator type `i understand this key cannot be recovered`, and then
**created an ordinary seed-derived key** — one that *is* recoverable from the
mnemonic, *is* included in backups, and *is* exportable. The operator was told
the opposite of what happened.

## Three fields, dropped in the middle

`CreateKeyRequest` carries `internal`, `key_id` and `derivation_path`. The CLI
sets them. `VtaClient::create_key` built its wire body like this:

```rust
let body = CreateKeyBody {
    internal: None,                                       // hardcoded
    derivation_path: req.derivation_path.clone().unwrap_or_default(),  // "" for absent
    …                                                     // key_id never read
};
```

`req.internal` and `req.key_id` were never read. The operation layer was always
correct — `CreateKeyParams::derivation_path` is an `Option` that auto-derives,
and `internal` short-circuits to a CSPRNG key that records no path. Only the
wire types disagreed.

## And it could not have worked anyway

Even with the flag forwarded, it failed twice more:

1. **The spine rejected it.** `keys/create/0.1` was `additionalProperties:
   false` with no `internal` member, so the document never reached a handler.
   Fixed upstream in
   [#269](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/269), which
   also added `internal` to `KeyOrigin` — the value that makes the outcome
   *checkable*.
2. **An internal key needs an explicit `key_id`**, having no derivation path to
   be named after, and neither the wire type nor the specification had one.
   Fixed upstream in
   [#275](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/275).

So the capability existed at both ends and was unreachable by three
independent routes.

## What this PR does

- Forwards `internal` and `derivation_path` from the request instead of
  dropping them.
- Makes `CreateKeyBody::derivation_path` an `Option<String>`, matching both the
  specification ("omitting it leaves the choice to the custodian") and the
  operation layer. The old `unwrap_or_default()` sent `""`, which worked only
  because the op reads `""` as absent — a workaround that hid the type error.
- Mints a `key_id` for an internal key **at the trust-task binding**, since
  that binding has no `keyId` member to carry one yet.

### The minted id is a deliberate, temporary deviation

`keyId` is published as of `trust-tasks-rs` **0.12.1**, and this workspace
cannot move to 0.12: `affinidi-messaging-sdk` 0.19.12 pins `trust-tasks-rs
^0.11` and `vta_sdk::acl_setup` hands it a generated `MediatorAcl`, so two
nodes in one graph fail to compile. The specification says a maintainer that
offers internal keys and receives no `keyId` **SHOULD** reject — I wrote that
text, and this deviates from it, because the alternative is a security feature
that cannot be used at all until an external crate publishes.

The consumer is not left guessing: the id comes back on the response record,
the CLI prints it, and `keys/rename/0.1` can change it. **When the 0.12 bump
lands, take `key_id` from the request and delete the branch** — the comment
says so at the site.

## Tests

`an_internal_key_is_actually_internal` asserts `origin == "internal"`. That is
the check the CLI already made and that always silently failed, and it is the
only reliable signal: a maintainer that ignored the member returns `derived`,
and the two records are otherwise identical.

`a_create_without_a_derivation_path_succeeds` covers the other half, and
creating its context also covers `vta/contexts/create/1.0` — coverage 33 → 34.

## Found on the way, not fixed here

An internal key's record carries `derivationPath: "internal"`. The shared
`KeyRecord` component says that member is the path "the key was derived at,
when `origin` is `derived`", absent otherwise — so a sentinel there claims a
derivation that does not exist. The comment justifying it predates `origin`
gaining an `internal` value, which now carries the fact properly.

Not fixed here because making `derivation_path` an `Option` touches **84
construction sites**. Worth noting that the response-conformance gate *cannot*
catch this: the schema types the member `string`, so a sentinel validates
cleanly. It is a semantic divergence, and only a reader notices — a useful
reminder of where that gate's evidence stops.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites green, 0 violations, coverage **34/109**
- `cargo fmt --all --check`

BREAKING CHANGE: `CreateKeyBody::derivation_path` is `Option<String>` and is
omitted when unset instead of sent as `""`. `keys/create/0.1` requests now
carry `internal` when the caller set it.

Refs #1059
