### PR TITLE
test(vta): cover the contexts, app-state and memory families

### DIFF
--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2177,6 +2177,114 @@ mod response_coverage {
             .to_owned()
     }
 
+    /// A context to hang scoped state off. Also covers
+    /// `vta/contexts/create/1.0`.
+    async fn a_context(state: &crate::server::AppState, id: &str) {
+        ok(
+            state,
+            t::TASK_CONTEXTS_CREATE_1_0,
+            json!({ "id": id, "name": id }),
+        )
+        .await;
+    }
+
+    /// The context family's read and write paths.
+    #[tokio::test]
+    async fn contexts_lifecycle() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        a_context(&state, "cov-contexts").await;
+        ok(&state, t::TASK_CONTEXTS_LIST_1_0, json!({})).await;
+        ok(
+            &state,
+            t::TASK_CONTEXTS_GET_1_0,
+            json!({ "id": "cov-contexts" }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_CONTEXTS_UPDATE_1_0,
+            json!({ "id": "cov-contexts", "name": "renamed" }),
+        )
+        .await;
+        // Preview before delete: the pair exists so an operator can see what a
+        // delete would take with it, so cover them in that order.
+        ok(
+            &state,
+            t::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
+            json!({ "id": "cov-contexts" }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_CONTEXTS_DELETE_1_0,
+            json!({ "id": "cov-contexts" }),
+        )
+        .await;
+    }
+
+    /// The app-state key/value family, single and batch.
+    #[tokio::test]
+    async fn app_state_lifecycle() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        a_context(&state, "cov-appstate").await;
+        let base = json!({ "contextId": "cov-appstate", "namespace": "cov", "key": "k1" });
+
+        let mut put = base.clone();
+        put["value"] = json!({ "hello": "world" });
+        ok(&state, t::TASK_VTA_APP_STATE_PUT_1_0, put).await;
+        ok(&state, t::TASK_VTA_APP_STATE_GET_1_0, base.clone()).await;
+        ok(
+            &state,
+            t::TASK_VTA_APP_STATE_LIST_1_0,
+            json!({ "contextId": "cov-appstate", "includeValues": true }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_VTA_APP_STATE_PUT_MANY_1_0,
+            json!({
+                "contextId": "cov-appstate",
+                "namespace": "cov",
+                // `writes`, not `entries` — and each write is a put payload
+                // minus the context and namespace the batch supplies.
+                "writes": [{ "key": "k2", "value": {"n": 1} }],
+            }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_VTA_APP_STATE_GET_MANY_1_0,
+            json!({ "contextId": "cov-appstate", "namespace": "cov", "keys": ["k1", "k2"] }),
+        )
+        .await;
+        ok(&state, t::TASK_VTA_APP_STATE_DELETE_1_0, base).await;
+    }
+
+    /// The agent-memory family.
+    #[tokio::test]
+    async fn memory_lifecycle() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        a_context(&state, "cov-memory").await;
+        ok(
+            &state,
+            t::TASK_VTA_MEMORY_PUT_0_1,
+            json!({ "contextId": "cov-memory", "key": "m1", "value": "remembered" }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_VTA_MEMORY_LIST_0_1,
+            json!({ "contextId": "cov-memory" }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_VTA_MEMORY_DELETE_0_1,
+            json!({ "contextId": "cov-memory", "key": "m1" }),
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn keys_show_and_sign() {
         let (state, _dir) = build_signing_test_app_state().await;


### PR DESCRIPTION
Takes the VTA's Trust Task response coverage from **34/109 to 48/109 (31% →
44%)** — three test functions covering fourteen tasks. Zero violations, zero
failures.

## Why coverage, again

The conformance gate validates real handler output, so it is evidence only
about tasks a test actually exercises. Every previous batch found a defect the
moment it looked: covering `keys/{show,sign,…}` immediately surfaced
`contextId: null` on the shared `KeyRecord`, which six tasks return.

This batch found none, which is also worth recording — `vta/contexts/*`,
`vta/app-state/*` and `vta/memory/*` were already conformant.

## What is covered

| family | tasks |
|---|---|
| `vta/contexts/*` | `create`, `list`, `get`, `update`, `preview-delete`, `delete` |
| `vta/app-state/*` | `put`, `get`, `list`, `put-many`, `get-many`, `delete` |
| `vta/memory/*` | `put`, `list`, `delete` |

Each test walks a lifecycle rather than poking one endpoint, so the reads see
state a write actually made — a `get` against an empty store exercises the
not-found path, not the response shape this gate is about. `preview-delete` is
covered immediately before `delete` because that pair exists so an operator can
see what a delete would take with it.

## Why `vault/{release,proxy-login,sign-trust-task}` are still uncovered

Worth stating, because it explains a shape in the remaining 61.

`vault_trust_task.rs` already has tests named `*_reaches_handler_past_gate` for
all three. They deliberately name a **missing** entry: their subject is gate
ordering, so they assert on a reject and never produce a success document.
That is correct for what they test, and it is exactly why the gate has never
seen these tasks.

I tried to add success paths and hit a real constraint rather than a gap in the
tests: `vault/release` seals its secret into a DIDComm envelope, so it fails in
the unit fixture with *"ATM not configured — server cannot pack DIDComm
envelopes"*. Covering it needs the mediator-backed `transport-harness`, which
is its own change. `vault/release/0.1` is also deprecated in favour of `0.2`,
so the coverage is better spent on the successor.

So the remaining 61 are not uniformly cheap: some are one lifecycle test like
these, and some need real transport infrastructure standing up.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites green, **0 violations**, coverage **48/109**
- `cargo fmt --all --check`

Refs #1059
