### PR TITLE
chore(deps)!: trust-tasks-rs 0.12 and the TDK crates that carry it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.25"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c730f7f9e73817ff7d04eec292d9f63b2848424848d2e48f5befc30ff000fcc7"
+checksum = "5d96b5e9a4f92941ae4262a1d15729e234c49e598bd32598df8bf3db4d160b64"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.22"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3721aba4b156eab55260ec148b6e8058d78a0efed2122a2954868b7fcaa5c0"
+checksum = "88693f20c94894621230e2742661d76a3181455354677f2b2caaf7f7c02b2a50"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5996f7bd090aacad06be16e86a4a9774f45adab1e90c6cab2d15ef6b98bea5ea"
+checksum = "17acd47901b288ce519bc9bd57775babfb9514c359cb337037c855c2a383aaa4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.53"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8fa256525937b8c95cedf5c508558da313663245326e034c49b23720553882"
+checksum = "cd634567ac99feceede0a4e6953e5a7ed530b0771ae5911538ae3a8106546e9b"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efce5081936f04938a5be1c754065036cd66a510a67b2092e464a3a24612728"
+checksum = "a9f857f43d084f1dc5066d73ce6a1702d3ab0d223371ee12e39ddd6406beb92c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -1127,7 +1127,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.122.0"
+version = "1.123.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6141acba66f1db7da2b3c7b2c0ee5178f86240cee676ed5c37cf74b9a2b37b"
+checksum = "dcd10d92058d5da989a7838fd09d70e9457390a81ba672abf5685099f3562bce"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1298,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.116.0"
+version = "1.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484ecdbea2a1cfc0e6eea69ce0a665f93913671b303ba40b2361b1d826544e7e"
+checksum = "83b602641be84ebe5f96606cfefe4b96efaae1fd947c1b34ea8513b8ac0d2d8d"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.113.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fc1d4c623a7b49ad4379fa9872711d0c02b76d5d196c8fd02ea80292ccd094"
+checksum = "f23d9f5b5014b74f4867d029b68d782808b76e5559e20fe6be251f61464bab74"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1350,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.107.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0abd0f89cfe11da5099986dd493e4f94347ce9a4562cb86ddecfe926b6c0"
+checksum = "c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.109.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4075b8a2c8cda4076a3dcc43b9d6dabd93e0c2502abeaaf7e14aaead9bb312b"
+checksum = "72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1402,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.112.0"
+version = "1.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f582002918346a3e685be1b391c7bea155073088cea6bd4e4b7663df9e43b6c"
+checksum = "68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1491,7 +1491,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -2411,7 +2411,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2471,9 +2471,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2879,7 +2879,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2912,7 +2912,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2952,7 +2952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3175,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "did-scid"
-version = "0.1.13"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad53def10fa66e98f129751f37c8ffbca6507cabeb519f689a15c50b2d016743"
+checksum = "68f36397874c3c2b88ba76e39e2e4599bf8a71ca36b9ce0b92b79a84f17d27ff"
 dependencies = [
  "affinidi-did-common",
  "didwebvh-rs",
@@ -3285,7 +3285,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3798,7 +3798,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4194,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4514,7 +4514,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -4811,7 +4811,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4975,9 +4975,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
+checksum = "8edb06feabbd4c3fe17e2572f391510e08a011b92f53a7b76236eeb18191cfbe"
 dependencies = [
  "pest",
  "pest_derive",
@@ -5338,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "match-lookup"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+checksum = "549e39695cc0b640f3cb378053832db3d2133422d49e8dcae5c866a2aaf1f730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6152,7 +6152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -6498,9 +6498,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6805,7 +6805,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6915,7 +6915,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -7006,7 +7006,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7249,7 +7249,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7434,7 +7434,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7445,7 +7445,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7949,9 +7949,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8169,7 +8169,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8264,7 +8264,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8413,7 +8413,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.18",
+ "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -8617,9 +8617,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c744c8389d63e3e4d6bf89a44df0fa6429cc449cf24c70e33bb3f6ef0a10f37"
+checksum = "f307c5a7c3159de3999884eb2bd6e823225042fbfe6138262002a0c8ab690a4e"
 dependencies = [
  "chrono",
  "serde",
@@ -8631,11 +8631,12 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcb2a620b363ca38771125868e36a0e4204a13ea0ca1a756fcd441f5a341330"
+checksum = "4289204b6f77d2037e5371cc9e25008ce54d8e1b8dc12183c64d986c3776c659"
 dependencies = [
  "affinidi-messaging-didcomm",
+ "base64 0.22.1",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -8645,9 +8646,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b05af8774339d7c1fb29bde5ab5c37893221b9b5e95429bdd3db8f4404ae650"
+checksum = "8646a37ec55dcf5e1da713f25800f127e2ec0063ed6f9bcf0e5ae66b5fd8f859"
 dependencies = [
  "axum",
  "chrono",
@@ -8664,9 +8665,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ac669b4bcaa91fd640e2630a4791fc1fb5fe4b38d1d22ab1e4e34d3e8cad9e"
+checksum = "17d77c7462d3e8cdb6e5797af79a7b37c655d87e96fd0738f80f910bdaa2b965"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8681,9 +8682,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.11.17"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0247e25a581eb37577b81a0882ec60c9a218051b39ab0e72cf7656479daf0a3"
+checksum = "4c0564661c0874c7a972aec1f3bef1290898f7ba4933be9a9204caabbc80332c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9436,7 +9437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "syn 3.0.3",
+ "syn 3.0.4",
  "tempfile",
  "thiserror 2.0.20",
  "time",
@@ -10019,7 +10020,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4202f445611df275891e7575aa91b99ae4bedee6241af7020ce0a3c28cabc449"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.8.8",
  "tokio",
 ]
 
@@ -10709,7 +10710,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ uniffi = "0.28"
 # `unpack` rejects plaintext / anoncrypt / forged-`from` envelopes by default.
 # `0.8` would let a fresh resolve on a clean checkout land on a pre-fix 0.8.x,
 # silently moving sender authentication back out of the library. Do not relax it.
-affinidi-tdk = "0.8.5"
+affinidi-tdk = "0.9"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -244,9 +244,9 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.11.17", default-features = false, features = ["validate"] }
-trust-tasks-capability-client = "0.9"
-trust-tasks-https = { version = "0.10", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-rs = { version = "0.12", default-features = false, features = ["validate"] }
+trust-tasks-capability-client = "0.11"
+trust-tasks-https = { version = "0.12", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -257,8 +257,8 @@ trust-tasks-https = { version = "0.10", default-features = false, features = ["s
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.10", default-features = false }
-trust-tasks-proof = { version = "0.10", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.12", default-features = false }
+trust-tasks-proof = { version = "0.11", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }
@@ -451,3 +451,4 @@ type_complexity = "allow"
 # ever reports one, the fix is the same choice we faced here: patch it (fast,
 # and it will break again on the next minor bump) or cut the dependency edge
 # upstream (slower, permanent).
+

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -19,7 +19,7 @@ autobins = false
 
 [dev-dependencies]
 # Embedded mediator fixture from affinidi-tdk-rs.
-affinidi-messaging-test-mediator = { version = "0.2", features = ["tsp"] }
+affinidi-messaging-test-mediator = { version = "0.3", features = ["tsp"] }
 
 # VTA: enable the `test-support` feature so we can stand up complete VTA
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
@@ -31,7 +31,7 @@ vti-common = { path = "../../vti-common" }
 affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
-affinidi-messaging-sdk = "0.19"
+affinidi-messaging-sdk = "0.20"
 affinidi-messaging-didcomm = "0.15"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -244,7 +244,7 @@ futures-util = { workspace = true, optional = true }
 # `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to
 # one instance, the one `affinidi_tdk::messaging` re-exports) so the `tsp`
 # feature can turn its `tsp` on — mirrors what `vta-service` does.
-affinidi-messaging-sdk = { version = "0.19", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.20", optional = true, default-features = false }
 reqwest = { workspace = true, optional = true }
 # Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
 rustls = { workspace = true, optional = true }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -250,7 +250,7 @@ futures-util = "0.3"
 # crate's `tsp` feature and are NOT reachable via `affinidi-tdk/tsp`. The crate
 # is already present transitively via `affinidi-tdk` at the same 0.18.x; this
 # entry adds no new code when `tsp` is off (optional + default-features off).
-affinidi-messaging-sdk = { version = "0.19", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.20", optional = true, default-features = false }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"
 affinidi-did-resolver-cache-sdk = { workspace = true }
@@ -323,7 +323,7 @@ tempfile = { version = "3", optional = true }
 # A real dependency rather than a dev-dependency: `test-support` exists to serve
 # *external* consumers, and a dev-dependency would not be available to them.
 # `tsp` so the mediator routes raw-TSP frames, not just DIDComm.
-affinidi-messaging-test-mediator = { version = "0.2", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.3", optional = true, features = [
     "tsp",
 ] }
 libc = { workspace = true, optional = true }

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -219,7 +219,7 @@ affinidi-messaging-didcomm = "0.15"
 # mediator-side twin of the client-side failure this crate's TSP work is about.
 # Always on (not conditioned on this crate's `tsp`): the harness is test-only,
 # and a mediator that can route TSP is harmless to the DIDComm suite.
-affinidi-messaging-test-mediator = { version = "0.2", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.3", optional = true, features = [
     "tsp",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }

--- a/vtc-service/src/hooks/writer.rs
+++ b/vtc-service/src/hooks/writer.rs
@@ -85,7 +85,19 @@ impl CapabilityWriter for DidcommCapabilityWriter {
         }
 
         match tokio::time::timeout(self.reply_timeout, receiver).await {
-            Ok(Ok(reply)) => capability_client::classify_git_trust_reply(&reply).ok_or_else(|| {
+            // The thread the reply must answer. `capability-client` 0.11 made
+            // this an explicit argument rather than assuming correlation had
+            // already happened: acting on an uncorrelated reply lets whichever
+            // document arrives next decide the fate of a write it has nothing
+            // to do with. Here the `replies` registry already keys the waiter
+            // on `doc.id`, so this is defence in depth — and it is the library's
+            // own SPEC §4.9 rule (`threadId`, falling back to `id`) rather than
+            // this call site's guess at it.
+            Ok(Ok(reply)) => capability_client::classify_git_trust_reply(
+                &reply,
+                capability_client::correlation_thread(&doc),
+            )
+            .ok_or_else(|| {
                 // A reply we correlated but can't classify is a contract bug on
                 // the registry side; retrying can't fix it, but treating it as
                 // permanent would strand the job — surface transient + loud.


### PR DESCRIPTION
Moves the workspace to `trust-tasks-rs` **0.12**, now that
[affinidi/affinidi-tdk-rs#743](https://github.com/affinidi/affinidi-tdk-rs/pull/743)
has published the messaging crates that carry it. This was the blocker on three
separate pieces of work.

## Everything moves together, because two nodes do not compile

| dependency | from | to |
|---|---|---|
| `trust-tasks-rs` | 0.11.17 | **0.12** |
| `trust-tasks-capability-client` | 0.10 | 0.11 |
| `trust-tasks-https` | 0.10 | 0.12 |
| `trust-tasks-didcomm` | 0.10 | 0.12 |
| `trust-tasks-proof` | 0.10 | 0.11 |
| `affinidi-tdk` | 0.8.5 | 0.9 |
| `affinidi-messaging-sdk` | 0.19 | 0.20 |
| `affinidi-messaging-test-mediator` | 0.2 | 0.3 |

These are one change, not eight. `trust-tasks-rs` types reach the public API of
each — `affinidi-messaging-sdk`'s `account_update` takes an
`account::update::v0_1::MediatorAcl` — so a graph holding two versions fails to
compile rather than warn:

```
error[E0308]: mismatched types
   --> vta-sdk/src/acl_setup.rs:147:18
    |                  ^^^ expected `MediatorAcl`, found a different `MediatorAcl`
```

`cargo tree -i trust-tasks-rs` now returns a single node at 0.12.1.

A fourth pin lived in `tests/e2e/Cargo.toml` and is easy to miss: the workspace
resolved clean without it while that crate quietly held
`affinidi-messaging-test-mediator 0.2` — and through it the whole 0.11 chain.

## One source change

`classify_git_trust_reply` gained a required `expected_thread_id` in
capability-client 0.11. The reason is in its own docs: acting on an
uncorrelated reply means "letting whichever document arrives next decide the
fate of a write it has nothing to do with."

`DidcommCapabilityWriter` already registers its waiter on `doc.id`, so this is
defence in depth rather than a live bug — and `correlation_thread` is the
library's own SPEC §4.9 rule (`threadId`, falling back to `id`) rather than
this call site's guess at it.

## Verified before the crates published

The whole chain was checked against a path `[patch.crates-io]` over the TDK
workspace before #743 merged, so the move was known to work rather than hoped
to. This branch has since been re-resolved against the real registry and gives
the same result.

## What this unblocks

Three stopgaps, each of which names this bump at its own site, now become
deletions — deliberately **not** done here, so this change is a dependency move
and nothing else:

- the hand-rolled freshness bounds from #1117, in favour of `FreshnessPolicy` /
  `TrustTask::validate_freshness` (same two rules, same 60s skew, plus the
  `max_age` window);
- the minted `key_id` branch from #1118, in favour of the wire `keyId` that
  `trust-tasks-rs` 0.12.1 publishes;
- this workspace's `replay::check_and_record`, in favour of `ReplayGuard`.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites green, **0 violations**, coverage 48/109 unchanged
- `cargo fmt --all --check`

Refs #1059
