### PR TITLE
fix(vta)!: re-case the extended error codes the Trust Tasks registry moved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -775,7 +775,7 @@ new flow, update both this section and the relevant `docs/*.md`.
   webvh op (`request_uri`, `register_did_atomic`, `publish_did`,
   `delete_did`, `check_path`). The remote `did-hosting-control`
   resolves: explicit → caller's ACL default on the host →
-  system default → reject with `did-management:unknown_domain`.
+  system default → reject with `did-management:unknownDomain`.
   Wire types `CreateDidWebvhBody/Request/Params` and
   `RegisterDidWithServerBody/Params` carry the field; v0.7
   callers and hosts that don't yet understand it serialise

--- a/docs/02-vta/runtime-service-management.md
+++ b/docs/02-vta/runtime-service-management.md
@@ -501,7 +501,7 @@ under the right domain instead.
 ### Error contract
 
 `--domain <name>` against an unknown / inactive domain returns
-the framework-spec error code `did-management:unknown_domain`.
+the framework-spec error code `did-management:unknownDomain`.
 The CLI surfaces the code unchanged so an operator can correlate
 against the [`did-management/_shared/0.1/CONVENTIONS.md`](https://github.com/trustoverip/dtgwg-trust-tasks-tf/blob/draft-did-management-category/specs/did-management/_shared/0.1/CONVENTIONS.md)
 spec. `list-domains` against the same server tells you which

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -707,7 +707,7 @@ pub(crate) enum WebvhCommands {
         /// remote backplane serves multiple tenant domains, name the
         /// one this DID should live on; otherwise the server resolves
         /// via your ACL default → its system default. An unknown
-        /// domain comes back as a `did-management:unknown_domain`
+        /// domain comes back as a `did-management:unknownDomain`
         /// error. Use `pnm did-mgmt list-domains --server <id>` to
         /// see what's configured. Ignored in serverless mode.
         #[arg(long)]

--- a/pnm-cli/src/commands/webvh.rs
+++ b/pnm-cli/src/commands/webvh.rs
@@ -245,7 +245,7 @@ async fn cmd_list_domains(
 /// not a TTY (CI / scripted use) so the call proceeds with the
 /// server's own resolution chain. Network failures and empty domain
 /// lists also fall back to `Ok(None)` rather than blocking the
-/// operation — the server's `did-management:unknown_domain` error
+/// operation — the server's `did-management:unknownDomain` error
 /// surfaces any real misconfiguration downstream.
 async fn prompt_domain_if_interactive(
     client: &VtaClient,

--- a/vta-sdk/src/agent_session.rs
+++ b/vta-sdk/src/agent_session.rs
@@ -315,9 +315,25 @@ impl AgentSession {
 
 /// Treat a `device/register` conflict as "already enrolled". The reject surfaces
 /// differently per transport (a `Conflict` over REST, a `Protocol` reject
-/// carrying `already_registered` over DIDComm), so match on both.
+/// carrying `device/register:alreadyRegistered` over DIDComm), so match on both.
+///
+/// This is a **matcher**: the code arrives from whatever VTA the agent enrolled
+/// against, and this SDK cannot control that maintainer's deploy order. The
+/// registry re-cased the local part to lowerCamelCase
+/// (trustoverip/dtgwg-trust-tasks-tf#279), so both spellings are accepted —
+/// a VTA that has not yet shipped the re-cased emitter still sends
+/// `already_registered`, and failing to match it turns a benign re-enrolment
+/// into a hard error rather than a crash, which no smoke test would catch.
+///
+/// TODO: drop the `already_registered` arm once every VTA this SDK talks to is
+/// on a build that emits the re-cased code — i.e. one release after the
+/// service-side change ships.
 fn is_already_registered(e: &VtaError) -> bool {
-    matches!(e, VtaError::Conflict(_)) || e.to_string().contains("already_registered")
+    if matches!(e, VtaError::Conflict(_)) {
+        return true;
+    }
+    let msg = e.to_string();
+    msg.contains("alreadyRegistered") || msg.contains("already_registered")
 }
 
 #[cfg(test)]
@@ -380,10 +396,31 @@ mod tests {
     fn already_registered_is_detected_across_transports() {
         assert!(is_already_registered(&VtaError::Conflict("dup".into())));
         assert!(is_already_registered(&VtaError::Protocol(
-            "trust task rejected: device/register:already_registered — ...".into()
+            "trust task rejected: device/register:alreadyRegistered — ...".into()
         )));
         assert!(!is_already_registered(&VtaError::Protocol(
             "something else".into()
         )));
+    }
+
+    /// The property that makes the deploy order safe, pinned as a test rather
+    /// than a comment: this matcher accepts **both** spellings of
+    /// `device/register:alreadyRegistered`. A VTA still emitting the pre-#279
+    /// snake_case local part must keep being recognised as "already enrolled",
+    /// because a missed match does not crash — it fails open into a hard error
+    /// on every re-enrolment, which a smoke test would not catch.
+    #[test]
+    fn already_registered_accepts_both_registry_spellings() {
+        for code in [
+            "device/register:alreadyRegistered",
+            "device/register:already_registered",
+        ] {
+            assert!(
+                is_already_registered(&VtaError::Protocol(format!(
+                    "trust task rejected: {code} — a DeviceBinding already exists for did:key:zA"
+                ))),
+                "matcher must accept {code}"
+            );
+        }
     }
 }

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2482,11 +2482,11 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:def",
             "type": "https://trusttasks.org/spec/vault/get/0.1#reject",
-            "reason": "vault/get:not_found — no such entry"
+            "reason": "vault/get:notFound — no such entry"
         });
         let err = VtaClient::extract_trust_task_payload(doc).unwrap_err();
         match err {
-            VtaError::Protocol(msg) => assert!(msg.contains("not_found"), "got: {msg}"),
+            VtaError::Protocol(msg) => assert!(msg.contains("notFound"), "got: {msg}"),
             other => panic!("expected Protocol error, got {other:?}"),
         }
     }

--- a/vta-sdk/src/protocols/did_management/create.rs
+++ b/vta-sdk/src/protocols/did_management/create.rs
@@ -120,7 +120,7 @@ pub struct CreateDidWebvhBody {
     /// supply this to direct the new DID at a specific one;
     /// otherwise the server resolves via caller's ACL default →
     /// system default. An unknown domain on the server is rejected
-    /// with `did-management:unknown_domain`. Ignored in serverless
+    /// with `did-management:unknownDomain`. Ignored in serverless
     /// mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,

--- a/vta-sdk/src/protocols/did_management/servers.rs
+++ b/vta-sdk/src/protocols/did_management/servers.rs
@@ -197,7 +197,7 @@ pub struct RegisterDidWithServerBody {
     /// the server hosts multiple tenant domains, this directs the
     /// register call at a specific one; otherwise the remote
     /// resolves via caller's ACL default → system default. An
-    /// unknown domain is rejected with `did-management:unknown_domain`.
+    /// unknown domain is rejected with `did-management:unknownDomain`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub domain: Option<String>,
 }

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -68,7 +68,7 @@ pub mod problem_report_codes {
     /// or its own contexts state. The problem-report body's `args`
     /// carries `candidates: Vec<String>` so the relayer can surface
     /// the list to the operator and retry with an explicit choice.
-    pub const PROVISION_CONTEXT_REQUIRED: &str = "provision/integration:context_required";
+    pub const PROVISION_CONTEXT_REQUIRED: &str = "provision/integration:contextRequired";
 }
 
 /// Extract code and comment from a problem-report message body.

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -43,7 +43,7 @@ pub struct ProvisionIntegrationRequest {
     ///    `allowed_contexts`) AND the maintainer has exactly one
     ///    context registered → use it.
     /// 3. Otherwise the maintainer refuses with
-    ///    `provision/integration:context_required` and `details.
+    ///    `provision/integration:contextRequired` and `details.
     ///    candidates: Vec<String>` listing the plausible contexts.
     ///
     /// Wallet-class consumers SHOULD omit; integration-class consumers

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -47,7 +47,7 @@ pub async fn register_device(
     // at enrolment). No entry → no pending enrolment.
     let mut entry = get_acl_entry(acl_ks, &did).await?.ok_or_else(|| {
         AppError::NotFound(format!(
-            "device/register:no_pending_enrolment — DID {did} is not in the ACL; \
+            "device/register:noPendingEnrolment — DID {did} is not in the ACL; \
              complete provision-integration + acl/swap-key first"
         ))
     })?;
@@ -55,7 +55,7 @@ pub async fn register_device(
     // Re-registration is intentionally not idempotent (spec): rotate keys + retry.
     if entry.device.is_some() {
         return Err(AppError::Conflict(format!(
-            "device/register:already_registered — a DeviceBinding already exists for {did}"
+            "device/register:alreadyRegistered — a DeviceBinding already exists for {did}"
         )));
     }
 
@@ -113,12 +113,12 @@ pub async fn heartbeat_device(
     let did = auth.did.clone();
     let mut entry = get_acl_entry(acl_ks, &did).await?.ok_or_else(|| {
         AppError::NotFound(format!(
-            "device/heartbeat:not_registered — no DeviceBinding for {did}"
+            "device/heartbeat:notRegistered — no DeviceBinding for {did}"
         ))
     })?;
     let binding = entry.device.as_mut().ok_or_else(|| {
         AppError::NotFound(format!(
-            "device/heartbeat:not_registered — no DeviceBinding for {did}"
+            "device/heartbeat:notRegistered — no DeviceBinding for {did}"
         ))
     })?;
 
@@ -353,12 +353,12 @@ pub async fn set_wake_device(
     let did = auth.did.clone();
     let mut entry = get_acl_entry(acl_ks, &did).await?.ok_or_else(|| {
         AppError::NotFound(format!(
-            "device/set-wake:not_registered — no DeviceBinding for {did}"
+            "device/set-wake:notRegistered — no DeviceBinding for {did}"
         ))
     })?;
     if entry.device.is_none() {
         return Err(AppError::NotFound(format!(
-            "device/set-wake:not_registered — no DeviceBinding for {did}"
+            "device/set-wake:notRegistered — no DeviceBinding for {did}"
         )));
     }
 

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -363,7 +363,7 @@ pub struct CreateDidWebvhParams {
     /// Honored only for server-managed DIDs (when `server_id` is set);
     /// ignored in serverless mode. Resolution chain on the remote:
     /// explicit → caller's ACL default on the server → server's
-    /// system default → reject with `did-management:unknown_domain`.
+    /// system default → reject with `did-management:unknownDomain`.
     /// Enables a VTA managing slots across multiple tenant domains
     /// on one shared `did-hosting-control` backplane to direct
     /// provisioning at the right tenant.

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -21,7 +21,7 @@ use super::ProvisionIntegrationDeps;
 /// retry with an explicit choice.
 ///
 /// The caller renders this differently per transport: the DIDComm
-/// handler emits a `provision/integration:context_required` problem
+/// handler emits a `provision/integration:contextRequired` problem
 /// report with `args = candidates`; the REST handler returns a 400
 /// with the message and candidates inlined.
 #[derive(Debug)]
@@ -171,7 +171,7 @@ pub async fn ensure_target_context_or_create(
 pub enum ResolveContextError {
     /// Inference couldn't pick a single target — carries the candidates so the
     /// transport can surface them (REST: 400 with candidates inlined; DIDComm:
-    /// `provision/integration:context_required` problem report, `args =
+    /// `provision/integration:contextRequired` problem report, `args =
     /// candidates`).
     Ambiguous(AmbiguousContext),
     /// Any other failure — storage error, no-context-at-all `NotFound`, the

--- a/vta-service/src/operations/vault/upsert.rs
+++ b/vta-service/src/operations/vault/upsert.rs
@@ -12,7 +12,7 @@ use affinidi_tdk::messaging::ATM;
 use vti_common::vault::VaultSecret;
 
 /// Why unsealing a `didcomm-authcrypt` sealed secret failed. The route maps
-/// each onto the canonical `vault/upsert:sealed_secret_invalid` reject (sender
+/// each onto the canonical `vault/upsert:sealedSecretInvalid` reject (sender
 /// mismatch is `permission_denied`).
 pub enum UnsealError {
     /// The ATM failed to unpack the JWE.

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -762,7 +762,7 @@ mod provision {
         // Resolve + ensure the target context via the shared preamble. On
         // ambiguity we collapse into Validation here — REST clients (pnm-cli,
         // scripts) get the message + candidates inline. The DIDComm path emits
-        // the canonical `provision/integration:context_required` code so
+        // the canonical `provision/integration:contextRequired` code so
         // structured clients can branch on it; REST's typed-error vocabulary
         // wasn't designed for arbitrary new codes, so we stay with the existing
         // 400 shape. `--create-context` (super-admin gate inside

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -114,7 +114,7 @@ pub(super) async fn verify_did_signed_gate(
 }
 
 /// A `task_failed` reject carrying a spec error code (e.g.
-/// `auth/step-up/approve-response:challenge_unknown`) as the reason.
+/// `auth/step-up/approve-response:challengeUnknown`) as the reason.
 fn step_up_failure(code: &str) -> RejectReason {
     RejectReason::TaskFailed {
         reason: code.to_string(),
@@ -134,9 +134,9 @@ fn acr_rank(acr: &str) -> u8 {
 
 fn gate_err_to_reject(e: GateError) -> RejectReason {
     match e {
-        GateError::NoGate => step_up_failure("auth/step-up/approve-response:no_gate"),
+        GateError::NoGate => step_up_failure("auth/step-up/approve-response:noGate"),
         GateError::SubjectMismatch => {
-            step_up_failure("auth/step-up/approve-response:subject_mismatch")
+            step_up_failure("auth/step-up/approve-response:subjectMismatch")
         }
         GateError::ProofInvalid(_) => {
             step_up_failure("auth/step-up/approve-response:proof_invalid")
@@ -178,7 +178,7 @@ async fn verify_webauthn_gate(
     })?;
     let resolver = VtaVmResolver::new(did_resolver);
 
-    let invalid = || step_up_failure("auth/step-up/approve-response:assertion_invalid");
+    let invalid = || step_up_failure("auth/step-up/approve-response:assertionInvalid");
     let dec = |s: &str| {
         general_purpose::URL_SAFE_NO_PAD
             .decode(s.as_bytes())
@@ -273,7 +273,7 @@ pub(super) async fn handle_approve_response(
     let Some(issuer) = doc.issuer.as_deref().map(str::to_string) else {
         return reject_with(
             &doc,
-            step_up_failure("auth/step-up/approve-response:subject_mismatch"),
+            step_up_failure("auth/step-up/approve-response:subjectMismatch"),
         );
     };
     if auth.did != issuer {
@@ -291,13 +291,13 @@ pub(super) async fn handle_approve_response(
         Ok(ConsumeOutcome::NotFound) => {
             return reject_with(
                 &doc,
-                step_up_failure("auth/step-up/approve-response:challenge_unknown"),
+                step_up_failure("auth/step-up/approve-response:challengeUnknown"),
             );
         }
         Ok(ConsumeOutcome::Expired) => {
             return reject_with(
                 &doc,
-                step_up_failure("auth/step-up/approve-response:challenge_expired"),
+                step_up_failure("auth/step-up/approve-response:challengeExpired"),
             );
         }
         Err(e) => {
@@ -313,7 +313,7 @@ pub(super) async fn handle_approve_response(
     if pending.subject != subject || pending.session_id != session_id {
         return reject_with(
             &doc,
-            step_up_failure("auth/step-up/approve-response:subject_mismatch"),
+            step_up_failure("auth/step-up/approve-response:subjectMismatch"),
         );
     }
 
@@ -329,7 +329,7 @@ pub(super) async fn handle_approve_response(
             _ => {
                 return reject_with(
                     &doc,
-                    step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+                    step_up_failure("auth/step-up/approve-response:approverUnauthorized"),
                 );
             }
         };
@@ -338,14 +338,14 @@ pub(super) async fn handle_approve_response(
             _ => {
                 return reject_with(
                     &doc,
-                    step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+                    step_up_failure("auth/step-up/approve-response:approverUnauthorized"),
                 );
             }
         };
         if !delegated_any_approver_covers(&issuer_entry, &subject_entry) {
             return reject_with(
                 &doc,
-                step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+                step_up_failure("auth/step-up/approve-response:approverUnauthorized"),
             );
         }
     } else {
@@ -361,7 +361,7 @@ pub(super) async fn handle_approve_response(
         if issuer != authorized_signer {
             return reject_with(
                 &doc,
-                step_up_failure("auth/step-up/approve-response:approver_unauthorized"),
+                step_up_failure("auth/step-up/approve-response:approverUnauthorized"),
             );
         }
     }
@@ -412,7 +412,7 @@ pub(super) async fn handle_approve_response(
     if acr_rank(target) > acr_rank(granted) {
         return reject_with(
             &doc,
-            step_up_failure("auth/step-up/approve-response:acr_unsatisfied"),
+            step_up_failure("auth/step-up/approve-response:acrUnsatisfied"),
         );
     }
 
@@ -422,7 +422,7 @@ pub(super) async fn handle_approve_response(
         Ok(None) => {
             return reject_with(
                 &doc,
-                step_up_failure("auth/step-up/approve-response:challenge_unknown"),
+                step_up_failure("auth/step-up/approve-response:challengeUnknown"),
             );
         }
         Err(e) => {

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -168,7 +168,7 @@ pub(super) async fn handle_decision(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "task-consent/decision:no_pending".into(),
+                    reason: "task-consent/decision:noPending".into(),
                     details: Some(json!({ "payloadDigest": payload.payload_digest })),
                 },
             );
@@ -283,7 +283,7 @@ pub(super) async fn handle_decision(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "task-consent/decision:no_pending".into(),
+                    reason: "task-consent/decision:noPending".into(),
                     details: None,
                 },
             );

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -497,7 +497,7 @@ fn vault_not_found(doc: &TrustTask<Value>, verb: &str, id: &str) -> TrustTaskOut
     reject_with(
         doc,
         RejectReason::TaskFailed {
-            reason: format!("vault/{verb}:not_found — no entry at id {id}"),
+            reason: format!("vault/{verb}:notFound — no entry at id {id}"),
             details: None,
         },
     )
@@ -516,7 +516,7 @@ fn check_expected_version(
             doc,
             RejectReason::TaskFailed {
                 reason: format!(
-                    "vault/{verb}:version_conflict — expectedVersion {v} != current version {current}"
+                    "vault/{verb}:versionConflict — expectedVersion {v} != current version {current}"
                 ),
                 details: Some(serde_json::json!({ "currentVersion": current })),
             },
@@ -582,12 +582,12 @@ fn refuse_if_not_active(
         entry_id = %entry.id,
         status = ?entry.status,
         op = %op,
-        "vault: refusing a non-active entry on a use path (reported to caller as not_found)"
+        "vault: refusing a non-active entry on a use path (reported to caller as notFound)"
     );
     Some(reject_with(
         doc,
         RejectReason::TaskFailed {
-            reason: format!("vault/{op}:not_found — no entry at id {}", entry.id),
+            reason: format!("vault/{op}:notFound — no entry at id {}", entry.id),
             details: None,
         },
     ))
@@ -767,7 +767,7 @@ pub(super) async fn handle_upsert(
             &doc,
             RejectReason::TaskFailed {
                 reason: format!(
-                    "vault/upsert:not_found — no entry at id {}",
+                    "vault/upsert:notFound — no entry at id {}",
                     req.id.as_deref().unwrap_or("(none)")
                 ),
                 details: None,
@@ -813,7 +813,7 @@ pub(super) async fn handle_upsert(
             &doc,
             RejectReason::TaskFailed {
                 reason: format!(
-                    "vault/upsert:context_change_forbidden — entry {} is in context {}; cannot move to {}. Delete and recreate instead.",
+                    "vault/upsert:contextChangeForbidden — entry {} is in context {}; cannot move to {}. Delete and recreate instead.",
                     e.entry.id, e.entry.context_id, req.context_id
                 ),
                 details: Some(serde_json::json!({
@@ -832,7 +832,7 @@ pub(super) async fn handle_upsert(
             &doc,
             RejectReason::TaskFailed {
                 reason: format!(
-                    "vault/upsert:version_conflict — expectedVersion {v} != current version {}",
+                    "vault/upsert:versionConflict — expectedVersion {v} != current version {}",
                     e.entry.version
                 ),
                 details: Some(serde_json::json!({ "currentVersion": e.entry.version })),
@@ -897,7 +897,7 @@ pub(super) async fn handle_upsert(
                             &doc,
                             RejectReason::PermissionDenied {
                                 reason: format!(
-                                    "vault/upsert:sealed_secret_invalid — TSP sender {sender} does not match authenticated caller {caller}"
+                                    "vault/upsert:sealedSecretInvalid — TSP sender {sender} does not match authenticated caller {caller}"
                                 ),
                             },
                         );
@@ -907,7 +907,7 @@ pub(super) async fn handle_upsert(
                             &doc,
                             RejectReason::TaskFailed {
                                 reason: format!(
-                                    "vault/upsert:sealed_secret_invalid — TSP unpack: {e}"
+                                    "vault/upsert:sealedSecretInvalid — TSP unpack: {e}"
                                 ),
                                 details: Some(serde_json::json!({ "reason": "unpack_failed" })),
                             },
@@ -918,7 +918,7 @@ pub(super) async fn handle_upsert(
                             &doc,
                             RejectReason::TaskFailed {
                                 reason:
-                                    "vault/upsert:sealed_secret_invalid — TSP message has no sender"
+                                    "vault/upsert:sealedSecretInvalid — TSP message has no sender"
                                         .into(),
                                 details: Some(serde_json::json!({ "reason": "missing_sender" })),
                             },
@@ -929,7 +929,7 @@ pub(super) async fn handle_upsert(
                             &doc,
                             RejectReason::TaskFailed {
                                 reason: format!(
-                                    "vault/upsert:sealed_secret_invalid — cleartext not a VaultSecret: {e}"
+                                    "vault/upsert:sealedSecretInvalid — cleartext not a VaultSecret: {e}"
                                 ),
                                 details: Some(
                                     serde_json::json!({ "reason": "cleartext_schema_invalid" }),
@@ -946,7 +946,7 @@ pub(super) async fn handle_upsert(
                         &doc,
                         RejectReason::TaskFailed {
                             reason: format!(
-                                "vault/upsert:envelope_unsupported — received {kind}; this maintainer accepts only didcomm-authcrypt in M2A",
+                                "vault/upsert:envelopeUnsupported — received {kind}; this maintainer accepts only didcomm-authcrypt in M2A",
                                 kind = other.kind_name()
                             ),
                             details: Some(serde_json::json!({
@@ -977,7 +977,7 @@ pub(super) async fn handle_upsert(
                         &doc,
                         RejectReason::PermissionDenied {
                             reason: format!(
-                                "vault/upsert:sealed_secret_invalid — JWE sender {sender} does not match authenticated caller {caller}"
+                                "vault/upsert:sealedSecretInvalid — JWE sender {sender} does not match authenticated caller {caller}"
                             ),
                         },
                     );
@@ -987,7 +987,7 @@ pub(super) async fn handle_upsert(
                         &doc,
                         RejectReason::TaskFailed {
                             reason: format!(
-                                "vault/upsert:sealed_secret_invalid — DIDComm unpack: {e}"
+                                "vault/upsert:sealedSecretInvalid — DIDComm unpack: {e}"
                             ),
                             details: Some(serde_json::json!({ "reason": "unpack_failed" })),
                         },
@@ -997,7 +997,7 @@ pub(super) async fn handle_upsert(
                     return reject_with(
                         &doc,
                         RejectReason::TaskFailed {
-                            reason: "vault/upsert:sealed_secret_invalid — JWE has no sender (from)"
+                            reason: "vault/upsert:sealedSecretInvalid — JWE has no sender (from)"
                                 .into(),
                             details: Some(serde_json::json!({ "reason": "missing_sender" })),
                         },
@@ -1008,7 +1008,7 @@ pub(super) async fn handle_upsert(
                         &doc,
                         RejectReason::TaskFailed {
                             reason: format!(
-                                "vault/upsert:sealed_secret_invalid — cleartext not a VaultSecret: {e}"
+                                "vault/upsert:sealedSecretInvalid — cleartext not a VaultSecret: {e}"
                             ),
                             details: Some(
                                 serde_json::json!({ "reason": "cleartext_schema_invalid" }),
@@ -1024,7 +1024,7 @@ pub(super) async fn handle_upsert(
                 &doc,
                 RejectReason::TaskFailed {
                     reason: format!(
-                        "vault/upsert:secret_required — secretKind {:?} needs `sealedSecret` on create",
+                        "vault/upsert:secretRequired — secretKind {:?} needs `sealedSecret` on create",
                         req.secret_kind
                     ),
                     details: None,
@@ -1038,7 +1038,7 @@ pub(super) async fn handle_upsert(
             &doc,
             RejectReason::TaskFailed {
                 reason: format!(
-                    "vault/upsert:sealed_secret_invalid — declared secretKind {:?} does not match secret variant {:?}",
+                    "vault/upsert:sealedSecretInvalid — declared secretKind {:?} does not match secret variant {:?}",
                     req.secret_kind,
                     secret.kind()
                 ),
@@ -1418,7 +1418,7 @@ pub(super) async fn handle_release(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: format!("vault/release:not_found — no entry at id {}", req.entry_id),
+                    reason: format!("vault/release:notFound — no entry at id {}", req.entry_id),
                     details: None,
                 },
             );
@@ -1584,7 +1584,7 @@ pub(super) async fn handle_proxy_login(
                 &doc,
                 RejectReason::TaskFailed {
                     reason: format!(
-                        "vault/proxy-login:not_found — no entry at id {}",
+                        "vault/proxy-login:notFound — no entry at id {}",
                         req.entry_id
                     ),
                     details: None,
@@ -1677,7 +1677,7 @@ pub(super) async fn handle_proxy_login(
             &doc,
             RejectReason::TaskFailed {
                 reason:
-                    "vault/proxy-login:not_proxyable — password entry has no loginConfig; use vault/release for browser-fill"
+                    "vault/proxy-login:notProxyable — password entry has no loginConfig; use vault/release for browser-fill"
                         .into(),
                 details: Some(serde_json::json!({
                     "secretKind": "password",
@@ -1769,7 +1769,7 @@ pub(super) async fn handle_sign_trust_task(
                 &doc,
                 RejectReason::TaskFailed {
                     reason: format!(
-                        "vault/sign-trust-task:not_found — no entry at id {}",
+                        "vault/sign-trust-task:notFound — no entry at id {}",
                         req.entry_id
                     ),
                     details: None,
@@ -1811,7 +1811,7 @@ pub(super) async fn handle_sign_trust_task(
                 &doc,
                 RejectReason::TaskFailed {
                     reason: format!(
-                        "vault/sign-trust-task:not_signable — entry kind '{kind}' has no DID-based signing identity"
+                        "vault/sign-trust-task:notSignable — entry kind '{kind}' has no DID-based signing identity"
                     ),
                     details: Some(serde_json::json!({ "secretKind": kind })),
                 },
@@ -1821,7 +1821,7 @@ pub(super) async fn handle_sign_trust_task(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "vault/sign-trust-task:envelope_invalid — unsignedEnvelope must be a JSON object".into(),
+                    reason: "vault/sign-trust-task:envelopeInvalid — unsignedEnvelope must be a JSON object".into(),
                     details: None,
                 },
             );
@@ -1831,7 +1831,7 @@ pub(super) async fn handle_sign_trust_task(
                 &doc,
                 RejectReason::TaskFailed {
                     reason: format!(
-                        "vault/sign-trust-task:envelope_invalid — missing required field '{field}'"
+                        "vault/sign-trust-task:envelopeInvalid — missing required field '{field}'"
                     ),
                     details: Some(serde_json::json!({ "missing": field })),
                 },
@@ -1841,7 +1841,7 @@ pub(super) async fn handle_sign_trust_task(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "vault/sign-trust-task:envelope_invalid — issuer must be a string"
+                    reason: "vault/sign-trust-task:envelopeInvalid — issuer must be a string"
                         .into(),
                     details: None,
                 },
@@ -1851,7 +1851,7 @@ pub(super) async fn handle_sign_trust_task(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "vault/sign-trust-task:envelope_already_proofed — strip the existing proof and resubmit".into(),
+                    reason: "vault/sign-trust-task:envelopeAlreadyProofed — strip the existing proof and resubmit".into(),
                     details: None,
                 },
             );
@@ -1863,7 +1863,7 @@ pub(super) async fn handle_sign_trust_task(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "vault/sign-trust-task:envelope_issuer_mismatch — envelope.issuer must equal the entry's principalDid".into(),
+                    reason: "vault/sign-trust-task:envelopeIssuerMismatch — envelope.issuer must equal the entry's principalDid".into(),
                     details: Some(serde_json::json!({
                         "envelopeIssuer": envelope_issuer,
                         "expectedIssuer": expected,
@@ -1875,7 +1875,7 @@ pub(super) async fn handle_sign_trust_task(
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: "vault/sign-trust-task:envelope_invalid — expiresAt must be an RFC 3339 timestamp".into(),
+                    reason: "vault/sign-trust-task:envelopeInvalid — expiresAt must be an RFC 3339 timestamp".into(),
                     details: Some(serde_json::json!({ "expiresAt": value })),
                 },
             );
@@ -1885,7 +1885,7 @@ pub(super) async fn handle_sign_trust_task(
                 &doc,
                 RejectReason::TaskFailed {
                     reason:
-                        "vault/sign-trust-task:envelope_expired — envelope.expiresAt is in the past"
+                        "vault/sign-trust-task:envelopeExpired — envelope.expiresAt is in the past"
                             .into(),
                     details: Some(serde_json::json!({ "expiresAt": value })),
                 },
@@ -1937,7 +1937,7 @@ fn password_post_error_to_reject(
         PasswordPostError::NonSuccessStatus { status } if (400..500).contains(status) => {
             RejectReason::TaskFailed {
                 reason: format!(
-                    "vault/proxy-login:credential_rejected — third party returned HTTP {status} for entry {entry_id}"
+                    "vault/proxy-login:credentialRejected — third party returned HTTP {status} for entry {entry_id}"
                 ),
                 details: Some(serde_json::json!({
                     "status": status,
@@ -1947,12 +1947,12 @@ fn password_post_error_to_reject(
         }
         PasswordPostError::NonSuccessStatus { status } => RejectReason::TaskFailed {
             reason: format!(
-                "vault/proxy-login:target_unreachable — third party returned HTTP {status}"
+                "vault/proxy-login:targetUnreachable — third party returned HTTP {status}"
             ),
             details: Some(serde_json::json!({ "status": status, "retryable": true })),
         },
         PasswordPostError::Transport { url, source } => RejectReason::TaskFailed {
-            reason: format!("vault/proxy-login:target_unreachable — {source} ({url})"),
+            reason: format!("vault/proxy-login:targetUnreachable — {source} ({url})"),
             details: Some(serde_json::json!({ "url": url, "retryable": true })),
         },
         PasswordPostError::InvalidLoginUrl(msg) => RejectReason::MalformedRequest {

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -431,7 +431,7 @@ impl<'a> WebvhDIDCommClient<'a> {
     /// VTA-managed `did-hosting-control` backplane), the operator
     /// supplies the target; otherwise the remote falls back to the
     /// caller's ACL default → system default. An unknown domain is
-    /// rejected with `did-management:unknown_domain`.
+    /// rejected with `did-management:unknownDomain`.
     pub async fn request_uri(
         &self,
         path: Option<&str>,

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -858,8 +858,8 @@ async fn unauthorized_approver_cannot_elevate() {
     assert!(
         serde_json::to_string(&v)
             .unwrap()
-            .contains("approver_unauthorized"),
-        "expected approver_unauthorized, got: {v}"
+            .contains("approverUnauthorized"),
+        "expected approverUnauthorized, got: {v}"
     );
     let stored = get_session(&ctx.sessions_ks, &session_id)
         .await

--- a/vta-service/tests/vault_trust_task.rs
+++ b/vta-service/tests/vault_trust_task.rs
@@ -402,7 +402,7 @@ async fn archive_hides_and_blocks_then_unarchive_restores() {
     assert_ne!(
         rel_status,
         StatusCode::OK,
-        "archived entry refuses release (not_found)"
+        "archived entry refuses release (notFound)"
     );
 
     // Double-archive is rejected.

--- a/vta-webvh/src/webvh_client.rs
+++ b/vta-webvh/src/webvh_client.rs
@@ -557,7 +557,7 @@ impl WebvhClient {
     /// CLI `--domain`) supplies the target; otherwise the remote
     /// resolves through caller's ACL default → system default. An
     /// unknown domain on the remote is rejected as
-    /// `did-management:unknown_domain`.
+    /// `did-management:unknownDomain`.
     pub async fn request_uri(
         &self,
         path: Option<&str>,
@@ -645,7 +645,7 @@ impl WebvhClient {
     /// The `domain` argument is accepted for disambiguation on hosts
     /// that run per-domain mnemonic namespaces. Hosts with a flat
     /// namespace ignore it on lookup; a mismatched explicit domain is
-    /// surfaced as `did-management:unknown_domain`.
+    /// surfaced as `did-management:unknownDomain`.
     pub async fn publish_did(
         &self,
         mnemonic: &str,


### PR DESCRIPTION
`trustoverip/dtgwg-trust-tasks-tf#279` re-cased 200 extended error-code local
parts to lowerCamelCase per SPEC §4.10 rule 4 — `vault/upsert:version_conflict`
→ `vault/upsert:versionConflict`. Only the part after the `:` moved; the
namespace is unchanged. This repo still produced (and in one place read) the old
spelling for **32** of them.

Verified against `trustoverip/dtgwg-trust-tasks-tf@main` (543 declared codes
from `grep -rhoE 'code: …' specs --include=spec.md`). Every code below is
declared by the registry in the new spelling; only `did-management:unknownDomain`
is *also* still declared in the old one, and only by retired specs.

## Emitter vs matcher

The distinction governs every edit:

- **Emitter** — this repo decides what to send, and the registry decides what is
  correct to send. Moves to the new spelling, no compatibility arm.
- **Matcher** — this repo reads a code a peer produced, and cannot control that
  peer's deploy order. Accepts **both** spellings, with a `TODO` naming when the
  old arm can go.

**31 emitter codes, 1 matcher.** Commits are split so the two are reviewable
apart: `fix(vta)!` is the emitter side, `fix(vta-sdk)` is the matcher.

### Emitters (31 codes)

| Namespace | Local parts moved to camelCase |
|---|---|
| `auth/step-up/approve-response` | `acrUnsatisfied`, `approverUnauthorized`, `assertionInvalid`, `challengeExpired`, `challengeUnknown`, `noGate`, `subjectMismatch` |
| `device/heartbeat` | `notRegistered` |
| `device/register` | `alreadyRegistered`, `noPendingEnrolment` |
| `device/set-wake` | `notRegistered` |
| `did-management` | `unknownDomain` (prose only — see below) |
| `provision/integration` | `contextRequired` (`PROVISION_CONTEXT_REQUIRED`) |
| `task-consent/decision` | `noPending` |
| `vault/get` | `notFound` |
| `vault/proxy-login` | `credentialRejected`, `notFound`, `notProxyable`, `targetUnreachable` |
| `vault/release` | `notFound` |
| `vault/sign-trust-task` | `envelopeAlreadyProofed`, `envelopeExpired`, `envelopeInvalid`, `envelopeIssuerMismatch`, `notFound`, `notSignable` |
| `vault/upsert` | `contextChangeForbidden`, `envelopeUnsupported`, `notFound`, `sealedSecretInvalid`, `secretRequired`, `versionConflict` |

### Matcher (1)

`vta_sdk::agent_session::is_already_registered` reads
`device/register:alreadyRegistered` off whatever VTA the agent enrolled
against, so it now accepts both spellings. It matters more than its size
suggests: a missed match does not crash, it **falls open into a hard error** on
re-enrolment, and a smoke test that enrols once against a clean VTA never takes
the branch. `already_registered_accepts_both_registry_spellings` pins the
dual-accept as a property rather than trusting the comment beside it.

## ⚠️ Deploy order: the plugin PR must ship before this service

`PROVISION_CONTEXT_REQUIRED` now makes this service emit
`provision/integration:contextRequired`. `OpenVTC/vta-browser-plugin` matches
only the old spelling in users' browsers today — `onboard-view.tsx:307` gates
the onboarding context picker on an **exact equality**, so the picker would
silently stop appearing. A sibling change makes the plugin dual-accept.

**Ship the plugin PR, and let it reach users, before deploying this service.**

## Corrections to the code census

Two findings beyond the original list:

- **Three vault emitters build their namespace by interpolation**, so their
  codes appear as a literal nowhere and a flat grep misses them:
  `vault/{verb}:not_found` and `vault/{verb}:version_conflict`
  (`vault_not_found`, `check_expected_version`) and `vault/{op}:not_found`
  (`refuse_if_not_active`). Those helpers are what actually emit
  `vault/delete:notFound` and **`vault/delete:versionConflict`** — the code the
  census placed in the browser-plugin's set. It is emitted here too, and is
  fixed here.
- **`did-management:unknownDomain` splits 18 draft / 8 retired**, not 21/5. All
  eight snake_case declarations are `status: retired`; all eighteen camelCase
  ones are `status: draft`.

## How `did-management:unknown_domain` was handled

Both spellings are legitimately live, so the deciding question is which side
each site describes — and in this repo the answer is easy, because **there is no
emitter and no matcher for it here**. All eleven occurrences are prose.

- Ten describe register / publish / delete against a live hosting backplane.
  Their specs (`did-management/did/register`, `domain/assign`, and
  `did/publish`, which is retired and `supersededBy: did-management/did/register`)
  are draft and declare `unknownDomain`. Those move.
- The `CHANGELOG.md` entry is history and is left as written.

No dual-accept is needed for a code this repo neither sends nor reads.

## Deliberately not touched

Reported rather than changed:

- **`vault/credentials/*`** and the `LifecycleError::code()` tokens
  (`not_active`, `not_archived`, `already_deleted`, `not_deleted`,
  `grace_expired`) — the registry declares neither namespace in either casing.
  Re-casing them would invent a spelling rather than follow one.
- **Codes emitted into a registry namespace the registry does not declare them
  in** — `auth/step-up/approve-response:proof_invalid` (`step_up.rs:142`),
  `vault/proxy-login:{invalid_login_url,not_implemented,no_audience}`
  (`vault.rs:1671,1692,1959,1962`). A conforming consumer cannot branch on any
  of these. This is a spec gap, not a casing bug.
- **`vault/get` emits a bare `AppError::NotFound("vault entry {id} not found")`**
  (`vault.rs:706`) carrying no code at all, though the registry declares
  `vault/get:notFound`. Also a gap, and also out of scope here.
- **`password_post.rs:94-100`** writes `vault/proxy-login: credential_rejected`
  — namespace, *space*, token. Not a `ns:localPart` code, and the real emitter
  for that path is `password_post_error_to_reject` in `vault.rs`, which is
  fixed.
- **This repo's own vocabularies**: `auth:step_up_required`,
  `auth:consent_required`, `denied:no_pending`, `bbs:*`, `bootstrap:*`,
  `webauthn-vti-v1:*`, and the `not_registered` / `step_up_required` REST
  `error` fields on mediator drain-cancel (`protocol.rs:1218`,
  `api_integration.rs:3794`) and in `vtc-service`.

## Verification

Run with `CARGO_TARGET_DIR` inside the worktree, on the CI command set from
`.github/workflows/ci.yml`:

- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — `Finished dev profile`, no warnings
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — passing, **except two failures that predate this
  branch**: `vta-sdk --test client_rest` `get_did_webvh_returns_record` and
  `get_did_webvh_log_returns_log`, both `missing field \`record\``, fallout from
  the #1114 `dids/get` response fold. Reproduced identically on a detached
  `origin/main` with no changes applied.

Refs #1059
