### PR TITLE
fix(vta)!: take keyId from the wire instead of minting one

### DIFF
--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -43,6 +43,7 @@ impl VtaClient {
         // meaningless to any other maintainer.
         let body = crate::protocols::key_management::create::CreateKeyBody {
             internal: req.internal,
+            key_id: req.key_id.clone(),
             key_type: req.key_type.clone(),
             derivation_path: req.derivation_path.clone(),
             mnemonic: req.mnemonic.clone(),

--- a/vta-sdk/src/protocols/key_management/create.rs
+++ b/vta-sdk/src/protocols/key_management/create.rs
@@ -9,6 +9,15 @@ use crate::keys::{KeyOrigin, KeyStatus, KeyType};
 pub struct CreateKeyBody {
     #[serde(alias = "key_type")]
     pub key_type: KeyType,
+    /// Durable identifier to give the new key.
+    ///
+    /// Optional: for a derived key the maintainer defaults it to
+    /// `derivation_path`, which is what this workspace does. It is **not**
+    /// optional in practice for `internal: true` — such a key has no
+    /// derivation path to be named after — which is the gap that put it in
+    /// `keys/create/0.1` (dtgwg-trust-tasks-tf#275, `trust-tasks-rs` 0.12.1).
+    #[serde(default, alias = "key_id", skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<String>,
     /// Optional, as `keys/create/0.1` says: "omitting it leaves the choice to
     /// the custodian".
     ///
@@ -137,6 +146,7 @@ mod null_member_tests {
         let minimal = CreateKeyBody {
             internal: None,
             key_type: KeyType::Ed25519,
+            key_id: None,
             derivation_path: None,
             mnemonic: None,
             label: None,
@@ -162,6 +172,7 @@ mod null_member_tests {
         let labelled = CreateKeyBody {
             internal: None,
             key_type: KeyType::Ed25519,
+            key_id: None,
             derivation_path: Some("m/26'/2'/0'/1'".into()),
             mnemonic: None,
             label: Some("persona-signing".into()),

--- a/vta-sdk/tests/protocol_debug_redaction.rs
+++ b/vta-sdk/tests/protocol_debug_redaction.rs
@@ -83,6 +83,7 @@ fn create_did_webvh_result_body_debug_redacts_mnemonic() {
 #[test]
 fn create_key_body_debug_redacts_mnemonic() {
     let body = CreateKeyBody {
+        key_id: None,
         internal: None,
         key_type: vta_sdk::keys::KeyType::Ed25519,
         derivation_path: Some("m/0'".into()),

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -930,6 +930,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::keys::create::v0_1::Payload,
                 specs::keys::create::v0_1::Response,
                 to_v(CreateKeyBody {
+                    key_id: None,
                     internal: None,
                     key_type: KeyType::Ed25519,
                     derivation_path: Some("m/26'/2'/0'/1'".into()),

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -78,31 +78,16 @@ pub(super) async fn handle_create(
             internal: req.internal.unwrap_or(false),
             key_type: req.key_type,
             derivation_path: req.derivation_path,
-            // A derived key takes its id from the derivation path, so `None`
-            // is right for it. An **internal** key has no derivation path to
-            // be named after and the operation layer refuses one without an
-            // id — so over this binding, where the request carries no `keyId`
-            // member to supply, the binding mints one.
+            // Straight from the request. `keys/create/0.1` publishes `keyId` as
+            // of `trust-tasks-rs` 0.12.1 (dtgwg-trust-tasks-tf#275), so the
+            // binding no longer has to mint one for an internal key — which it
+            // did between #1118 and this change, because an internal key has no
+            // derivation path to be named after and the operation layer refuses
+            // one without an id.
             //
-            // `keyId` is published in `keys/create/0.1` as of `trust-tasks-rs`
-            // 0.12.1 (dtgwg-trust-tasks-tf#275), and this workspace cannot
-            // move to 0.12 yet: `affinidi-messaging-sdk` 0.19.12 pins
-            // `trust-tasks-rs ^0.11` and `vta_sdk::acl_setup` hands it a
-            // generated `MediatorAcl`, so two nodes in one graph fail to
-            // compile. **When that bump lands, take `key_id` from the request
-            // and delete this branch** — the specification says a maintainer
-            // that offers internal keys and receives no `keyId` SHOULD reject,
-            // and minting one is a deliberate deviation taken because the
-            // alternative is a security feature that cannot be used at all.
-            //
-            // The consumer is not left guessing: the id is returned on the
-            // response record, the CLI prints it, and `keys/rename/0.1` can
-            // change it.
-            key_id: if req.internal.unwrap_or(false) {
-                Some(format!("internal-{}", uuid::Uuid::new_v4()))
-            } else {
-                None
-            },
+            // `None` stays right for a derived key: the operation layer names
+            // it after the derivation path.
+            key_id: req.key_id,
             mnemonic: req.mnemonic,
             label: req.label,
             context_id: req.context_id,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2327,10 +2327,22 @@ mod response_coverage {
         let p = ok(
             &state,
             t::TASK_KEYS_CREATE_0_1,
-            json!({ "keyType": "ed25519", "internal": true, "label": "unexportable" }),
+            // `keyId` is supplied by the caller now, as `keys/create/0.1`
+            // publishes it. An internal key has no derivation path to be named
+            // after, so this is the only name it can have.
+            json!({
+                "keyType": "ed25519",
+                "internal": true,
+                "keyId": "cov-unexportable",
+                "label": "unexportable",
+            }),
         )
         .await;
         let record = p.get("key").unwrap_or(&p);
+        assert_eq!(
+            record["keyId"], "cov-unexportable",
+            "the caller's `keyId` must be honoured, not replaced: {p}"
+        );
         assert_eq!(
             record["origin"], "internal",
             "the key must come back marked internal — a `derived` here is \


### PR DESCRIPTION
First of the three stopgaps #1121 unblocked. `keys/create/0.1` publishes `keyId`
as of `trust-tasks-rs` 0.12.1
([dtgwg-trust-tasks-tf#275](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/275)),
so the caller can name a key and the trust-task binding no longer has to invent
one.

## What is deleted

#1118 minted an id at the binding:

```rust
key_id: if req.internal.unwrap_or(false) {
    Some(format!("internal-{}", uuid::Uuid::new_v4()))
} else {
    None
},
```

That was a **deliberate deviation from a SHOULD in the specification** — one I
wrote in #275, which says a maintainer offering internal keys and receiving no
`keyId` SHOULD reject. It was taken because the alternative was a security
feature nobody could use: an internal key has no derivation path to be named
after, the operation layer refuses one without an id, and the wire had no
member to carry it.

The comment at that site said to delete it when the bump landed. It is deleted.

Now `key_id: req.key_id` — straight from the request. `None` stays correct for
a derived key, which the operation layer names after its derivation path.

## The client stops dropping it too

`VtaClient::create_key` never read `CreateKeyRequest::key_id`. That was the
third of the three fields #1118 found being dropped between the CLI and the
wire; the other two were fixed there, and this one had nowhere to go until now.

## The test asserts the caller's name survives

`an_internal_key_is_actually_internal` now supplies `keyId` and asserts it comes
back unchanged, alongside the existing `origin == "internal"` check. The two
answer different questions — *was the request honoured*, and *was the name I
chose the name I got* — and a maintainer that silently renamed a key would pass
the first.

## Still open, from the same unblock

- the hand-rolled freshness bounds from #1117, in favour of `FreshnessPolicy` /
  `TrustTask::validate_freshness`;
- `replay::check_and_record`, in favour of `ReplayGuard`.

Those two go together: `ConsumeChecks` bundles freshness and replay in one
argument on purpose, because SPEC §7.2 makes the acceptance window and the
replay record's retention *the same bound*, and splitting them is how a
deployment ends up with a five-minute record and an unbounded window believing
it has a replay defence.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites green, **0 violations**, coverage 48/109
- `cargo fmt --all --check`

BREAKING CHANGE: `CreateKeyBody` gains `key_id`. `keys/create/0.1` with
`internal: true` now requires the caller to supply `keyId`; the binding no
longer mints one.

Refs #1059
