### PR TITLE
test(vta-sdk): mount dids/get responses in the post-fold shape

### DIFF
--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -1341,7 +1341,9 @@ async fn get_did_webvh_returns_record() {
         "GET",
         "/webvh/dids/did:webvh:Qabc:server.example.com:primary",
         200,
-        webvh_did_record_json(did),
+        // `dids/get` carries the record under `record` since the get-log fold
+        // (#1114); the flattened shape this used to mount no longer decodes.
+        json!({ "record": webvh_did_record_json(did) }),
     )
     .await;
     let c = client(&server).await;
@@ -1357,7 +1359,11 @@ async fn get_did_webvh_log_returns_log() {
         "GET",
         "/webvh/dids/did:webvh:abc/log",
         200,
-        json!({"did": "did:webvh:abc", "log": "{\"versionId\":\"1\"}\n"}),
+        // Same fold: `did` now lives on the nested record, `log` beside it.
+        json!({
+            "record": webvh_did_record_json("did:webvh:abc"),
+            "log": "{\"versionId\":\"1\"}\n",
+        }),
     )
     .await;
     let c = client(&server).await;


### PR DESCRIPTION
`main` has been red since #1114. Two tests in `vta-sdk --test client_rest` fail with `missing field \`record\``:

```
get_did_webvh_returns_record   client_rest.rs:1348
get_did_webvh_log_returns_log  client_rest.rs:1364
test result: FAILED. 84 passed; 2 failed
```

**They are not caused by any open branch.** The same two fail identically on #1120 (test coverage for contexts/app-state/memory) and #1122 (error-code casing), neither of which touches the SDK or webvh. I also reproduced them on a detached `origin/main` with nothing applied.

## Cause

#1114 folded the dedicated get-log task into `dids/get` + `includeLog`. The response now carries the record under `record` with `log` beside it, and `get_did_webvh`/`get_did_webvh_log` correctly decode `GetDidWebvhResultBody { record, log }`. The two mocks still returned the pre-fold flattened record, so decoding failed.

The production code is right; only the fixtures were stale. Note `mount_json` ignores its `method`/`path` arguments and always mounts `POST /trust-tasks`, so the payload shape was the only thing to correct.

## Why it matters beyond two tests

Every VTI pull request currently shows a red `Test` check, so a genuine regression is indistinguishable from the inherited failure — reviewers have to know which reds to ignore.

## Verification

`cargo test -p vta-sdk --features client --test client_rest` — **86 passed, 0 failed** (was 84 passed, 2 failed). The suite is `#![cfg(feature = "client")]`, so a plain `cargo test -p vta-sdk` compiles none of it.

Scoped to the test file only.