### PR TITLE
test(vtc): expect the HTTPS binding's flat 422 for refused documents

### DIFF
--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -389,8 +389,12 @@ async fn rest_submit_dedups_an_open_request_for_the_same_applicant() {
 #[tokio::test]
 async fn rest_submit_rejects_a_foreign_recipient() {
     // The replay binding is the document `recipient`: a document addressed to a
-    // different community is rejected `wrongRecipient` (403), replacing the
+    // different community is rejected `wrongRecipient` (422), replacing the
     // bespoke `audience` field.
+    //
+    // 422, not 403: the HTTPS binding spec §4 puts every "understood,
+    // well-formed, and refused" code in one flat bucket, so a prober cannot
+    // tell wrongRecipient from expired from proofInvalid by status line alone.
     let fix = build_fixture().await;
     let vp = json!({});
     let (_did, mut doc) = submit_doc(&vp).await;
@@ -399,7 +403,7 @@ async fn rest_submit_rejects_a_foreign_recipient() {
     let (status, body) = post_tt(&fix.router, doc).await;
     assert_eq!(
         status,
-        StatusCode::FORBIDDEN,
+        StatusCode::UNPROCESSABLE_ENTITY,
         "a document addressed to another community must be rejected: {body}"
     );
     assert_eq!(tt_error_code(&body), "wrongRecipient");
@@ -408,7 +412,8 @@ async fn rest_submit_rejects_a_foreign_recipient() {
 #[tokio::test]
 async fn rest_submit_rejects_an_expired_document() {
     // Freshness is the document `expiresAt`: a stale (expired) document is
-    // rejected `expired` (400), replacing the bespoke `created` window.
+    // rejected `expired` (422), replacing the bespoke `created` window. Same
+    // flat bucket as `wrongRecipient` above — see that test for why.
     let fix = build_fixture().await;
     let vp = json!({});
     let (_did, mut doc) = submit_doc(&vp).await;
@@ -417,7 +422,7 @@ async fn rest_submit_rejects_an_expired_document() {
     let (status, body) = post_tt(&fix.router, doc).await;
     assert_eq!(
         status,
-        StatusCode::BAD_REQUEST,
+        StatusCode::UNPROCESSABLE_ENTITY,
         "an expired document must be rejected: {body}"
     );
     assert_eq!(tt_error_code(&body), "expired");


### PR DESCRIPTION
`main`'s `Test` job still fails after #1124, on two different tests:

```
rest_submit_rejects_a_foreign_recipient   join_requests.rs:400   left: 422  right: 403
rest_submit_rejects_an_expired_document   join_requests.rs:418   left: 422  right: 400
```

**These were already broken, not newly broken.** `cargo test --workspace` aborts at the first failing test binary; the `vta-sdk` webvh tests that #1124 fixed were failing ahead of these, so this binary never ran. Fixing webvh let the run reach the next failure — which is the argument for keeping `main` green: a red baseline hides whatever is behind it.

## Cause

`trust-tasks-https` aligned `status_for_code` to the binding spec's §4 status table, which maps `wrongRecipient`, `expired`, `proofRequired`, `proofInvalid`, `unsupportedType`/`unsupportedVersion`, `identityMismatch`, `cancelled` and `taskFailed` all to **422**. VTI picked that up in #1121's upgrade to `trust-tasks-https` 0.12. Both assertions here encoded the pre-alignment 403/400.

The library is right and the tests were stale. The flat bucket is deliberate: a finer split lets an unauthenticated prober distinguish `wrongRecipient` from `expired` from `proofInvalid` by status line alone, which is exactly the identity oracle the table closes. Both `vtc-service` and `vta-service` route their error responses through `status_for_code` (`helpers.rs:152` and `:188`), so adopting that helper means adopting the property.

The error **codes** in the response bodies are unchanged and still asserted — only the status line moved.

## Verification

`cargo test -p vtc-service --test join_requests` — **50 passed, 0 failed**.

I also swept both services' test suites for other assertions pairing a refused-document code with 403/400; these two were the only ones.