### PR TITLE
feat(vta)!: bound the replay record by the acceptance window, not by capacity

### DIFF
--- a/vta-sdk/src/auth_di.rs
+++ b/vta-sdk/src/auth_di.rs
@@ -271,6 +271,7 @@ mod tests {
         let wrapped = json!({
             "id": "urn:uuid:1",
             "type": "https://trusttasks.org/spec/auth/authenticate/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": tokens,
         });
         let unwrapped = parse_auth_response(&wrapped.to_string()).expect("trust-task");

--- a/vta-sdk/src/client/backup_descriptors.rs
+++ b/vta-sdk/src/client/backup_descriptors.rs
@@ -224,6 +224,7 @@ impl VtaClient {
         let doc = serde_json::json!({
             "id": format!("urn:uuid:{}", Uuid::new_v4()),
             "type": type_uri,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": payload_value,
         });
 

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2465,6 +2465,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:abc",
             "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "devices": [], "truncated": false }
         });
         let out = VtaClient::extract_trust_task_payload(doc).unwrap();
@@ -2557,6 +2558,7 @@ fn build_task_document(type_uri: &str, payload: serde_json::Value) -> serde_json
     let mut doc = serde_json::json!({
         "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
         "type": type_uri,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": payload,
     });
     if let Some(key) = crate::idempotency::current_key()

--- a/vta-sdk/src/tsp_demux.rs
+++ b/vta-sdk/src/tsp_demux.rs
@@ -231,6 +231,7 @@ mod tests {
         json!({
             "id": "urn:uuid:reply",
             "type": "https://trusttasks.org/spec/messaging/ping/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "threadId": thread_id,
             "payload": { "ok": true },
         })
@@ -265,6 +266,7 @@ mod tests {
         let push = json!({
             "id": "urn:uuid:pushed",
             "type": "https://trusttasks.org/spec/task-consent/request/0.1",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "taskId": "t1" },
         });
         assert!(!correlates(

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -555,6 +555,7 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
             "type": "urn:test:response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {"fields": []}
         })))
         .expect(1)
@@ -652,6 +653,7 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
             "type": "urn:test:response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {"fields": []}
         })))
         .expect(1)
@@ -748,6 +750,7 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
             "type": "urn:test:response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {"fields": []}
         })))
         .expect(1)

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -45,6 +45,7 @@ fn tt_ok(payload: Value) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(json!({
         "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
         "type": "urn:test:response",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": payload,
     }))
 }
@@ -109,6 +110,7 @@ async fn mount_json(
     let resp = ResponseTemplate::new(status).set_body_json(json!({
         "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
         "type": "urn:test:response",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": body,
     }));
     Mock::given(method("POST"))
@@ -805,6 +807,7 @@ async fn swap_acl_sends_the_canonical_task_over_rest() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "urn:uuid:0000",
             "type": "https://trusttasks.org/spec/acl/swap-key/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {
                 "entry": acl_entry_json("did:key:zNew"),
                 "previousSubject": "did:key:zOld",

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -801,6 +801,7 @@ mod superseded_task_tests {
         let mut body = serde_json::to_vec(&serde_json::json!({
             "id": "urn:uuid:1",
             "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "devices": [] },
         }))
         .unwrap();
@@ -824,6 +825,7 @@ mod superseded_task_tests {
         let original = serde_json::json!({
             "id": "urn:uuid:1",
             "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {},
             "proof": { "type": "DataIntegrityProof" },
         });
@@ -849,6 +851,7 @@ mod superseded_task_tests {
         let mut body = serde_json::to_vec(&serde_json::json!({
             "id": "urn:uuid:1",
             "type": "x",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {},
         }))
         .unwrap();

--- a/vta-service/src/messaging/auth.rs
+++ b/vta-service/src/messaging/auth.rs
@@ -376,7 +376,7 @@ mod tests {
             "type": type_uri,
             "issuer": APPROVER,
             "recipient": "did:example:vta",
-            "issuedAt": "2026-08-08T21:56:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "challenge": "n", "payloadDigest": "d", "decision": "approve" },
         }))
         .unwrap()

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1251,7 +1251,7 @@ impl StubWebvhHost {
                 "session": {
                     "id": "stub-session",
                     "subject": "did:webvh:stub:vta",
-                    "issuedAt": "2026-01-01T00:00:00Z",
+                    "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                     "expiresAt": "2026-01-02T00:00:00Z",
                 },
                 "tokens": {

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -378,6 +378,7 @@ async fn maybe_wake_consent_approver(
         let approve_request = serde_json::json!({
             "id": format!("urn:uuid:{}", Uuid::new_v4()),
             "type": CONSENT_APPROVE_REQUEST_TYPE,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "subject": subject, "scope": scope, "challenge": challenge },
         });
         let pending = crate::messaging::registry::PendingResponse {

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -220,6 +220,7 @@ fn provision_gateway(
     let provision = serde_json::json!({
         "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/push/provision/0.2",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": vta_did,
         "recipient": gateway,
         "payload": { "handle": handle, "policy": { "allowedTriggers": triggers } },

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -555,37 +555,37 @@ async fn dispatch_trust_task_inner(
 /// long its duplicate-execution record must be kept.
 ///
 /// The two are **one** decision, which is why `trust_tasks_rs` passes them as a
-/// single `ConsumeChecks` argument and why `retain_until` below is derived from
-/// this rather than from a TTL of its own. SPEC §7.2 (*Bounding the record*)
-/// makes the acceptance window and the record's retention the same bound: a
-/// consumer "MUST NOT accept for execution a document older than the window
-/// over which it retains records".
+/// single `ConsumeChecks` argument and why `retain_until` is derived from this
+/// rather than from a TTL of its own. SPEC §7.2 (*Bounding the record*) makes
+/// the acceptance window and the record's retention the same bound: a consumer
+/// "**MUST NOT** accept for execution a document older than the window over
+/// which it retains records".
 ///
-/// # Why there is no `max_age` yet
+/// # Why a window at all
 ///
-/// This applies `FreshnessPolicy::default()` — the two internal-consistency
-/// rules, which no conforming producer can fail — and **no acceptance window**.
-/// The record is bounded by [`InMemoryReplayGuard`]'s capacity instead, which
-/// is what the retired `replay::check_and_record` did too, so this is parity
-/// rather than a regression.
+/// #1126 shipped this without one, leaving the record bounded by
+/// [`InMemoryReplayGuard`]'s capacity. That is not "no expiry so entries live
+/// forever" — it is LRU, which makes the window **load-dependent**: quiet
+/// service, effectively unbounded protection; busy service, an eviction horizon
+/// that can fall *below* any sensible acceptance window, so a replay arriving
+/// after its `id` was evicted executes a second time. The defence was weakest
+/// exactly when the service was busiest, which is the wrong way round and is
+/// what this closes.
 ///
-/// A window was implemented and measured first. `with_max_age(10 minutes)`,
-/// applied only to consequential tasks, failed **41 assertions across 10
-/// suites** with `expired` — not because the policy is wrong, but because the
-/// suite is full of documents stamped with fixed `issuedAt` values hours or
-/// days in the past, which no real producer sends. Fixing those is the right
-/// change and it is not this one: it alters what the service accepts, and that
-/// belongs in a change whose subject is the window, with the mediator-queue
-/// and clock-skew budget argued on its own terms. The library's own
-/// `DEFAULT_MAX_AGE` is five minutes, so the real question is whether this
-/// deployment's transports buffer for longer — a question about deployments,
-/// not about tests.
+/// # Why ten minutes
 ///
-/// Until then the guard still does the work that matters: it refuses a second
-/// execution, it distinguishes a retry from a conflict by digest, and it
-/// answers a retry with the prior result.
+/// The library's `DEFAULT_MAX_AGE` is five, "long enough to survive a mediator
+/// queue, a retry with backoff, and a modest clock disagreement". This service
+/// routes over a mediator that can hold a message while a recipient reconnects,
+/// so it takes double that — the same 600s the retired
+/// `replay::check_and_record` used as its dedup TTL, now bounding acceptance as
+/// well as retention so the two cannot drift apart.
+///
+/// A deployment whose transport buffers for longer must widen this **and** the
+/// guard's retention together; §7.2 makes them one bound, and widening either
+/// alone reintroduces exactly the gap above.
 fn freshness_policy() -> trust_tasks_rs::FreshnessPolicy {
-    trust_tasks_rs::FreshnessPolicy::default()
+    trust_tasks_rs::FreshnessPolicy::default().with_max_age(chrono::TimeDelta::minutes(10))
 }
 
 /// The duplicate-execution record of SPEC §7.2 item 11.
@@ -1514,7 +1514,7 @@ mod tests {
             "type": "https://trusttasks.org/spec/auth/revoke-session/0.1",
             "issuer": "did:example:alice",
             "recipient": "did:example:vta",
-            "issuedAt": "2026-05-20T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "session_id": "sess-1" }
         });
         let bytes = serde_json::to_vec(&canonical).unwrap();
@@ -1531,7 +1531,7 @@ mod tests {
             "type": "https://trusttasks.org/vta/auth/revoke-session/1.0",
             "issuer": "did:example:alice",
             "recipient": "did:example:vta",
-            "issuedAt": "2026-05-20T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "session_id": "sess-1" }
         });
         let bytes = serde_json::to_vec(&flat).unwrap();
@@ -1819,7 +1819,7 @@ mod payload_validation_tests {
             "type": WEBVH_UPDATE,
             "issuer": "did:key:zTestAdmin",
             "recipient": "did:example:vta",
-            "issuedAt": "2026-07-14T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": payload,
         }))
         .expect("valid trust task")
@@ -2043,7 +2043,7 @@ mod superseded_task_dispatch_tests {
             "type": type_uri,
             "issuer": "did:key:zTestAdmin",
             "recipient": vta_did,
-            "issuedAt": "2026-08-22T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": payload,
         }))
         .unwrap();
@@ -2149,6 +2149,7 @@ mod freshness_bounds {
         let mut v = json!({
             "id": "urn:uuid:11111111-1111-1111-1111-111111111111",
             "type": vta_sdk::trust_tasks::TASK_AUTH_WHOAMI_0_1,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "issuer": "did:key:zTestAdmin",
             "payload": {},
         });
@@ -2232,7 +2233,7 @@ mod replay_guard {
             "type": type_uri,
             "issuer": "did:key:zTestAdmin",
             "recipient": vta_did,
-            "issuedAt": chrono::Utc::now().to_rfc3339(),
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": payload,
         }))
         .expect("envelope");
@@ -2312,6 +2313,7 @@ mod replay_guard {
             serde_json::to_vec(&json!({
                 "id": "urn:uuid:5eaf00d0-0000-4000-8000-0000000c0nf1",
                 "type": vta_sdk::trust_tasks::TASK_CONTEXTS_LIST_1_0,
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "issuer": "did:key:zTestAdmin",
                 "recipient": vta_did,
                 // Differing only here is deliberate and is exactly §8.4's
@@ -2385,7 +2387,7 @@ mod response_coverage {
             "type": uri,
             "issuer": "did:key:zTestAdmin",
             "recipient": vta_did,
-            "issuedAt": "2026-08-26T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": payload,
         }))
         .expect("envelope serialises");

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -778,7 +778,7 @@ mod tests {
             "type": type_uri,
             "issuer": "did:key:zTestAdmin",
             "recipient": "did:example:vta",
-            "issuedAt": "2026-05-20T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "contextId": "default" }
         }))
         .expect("valid trust task")

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -890,6 +890,7 @@ pub(super) async fn trigger_gateway_wake(
     let wake_doc = json!({
         "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/push/wake/0.2",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": vta_did,
         "recipient": wake.gateway,
         "payload": {
@@ -1285,6 +1286,7 @@ mod tests {
         let doc_json = json!({
             "id": "approve-resp-1",
             "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "issuer": subject,
             "recipient": "did:web:vta.example",
             "payload": {
@@ -1407,6 +1409,7 @@ mod envelope_push_tests {
         let approve_request = json!({
             "id": "urn:uuid:11111111-1111-1111-1111-111111111111",
             "type": super::STEP_UP_APPROVE_REQUEST_TYPE,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "issuer": "did:key:zVta",
             "payload": { "subject": CALLER, "challenge": "c" },
         });

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -485,7 +485,7 @@ mod tests {
             "type": vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1,
             "issuer": approver,
             "recipient": vta_did,
-            "issuedAt": "2026-08-08T21:56:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {
                 "challenge": challenge,
                 "payloadDigest": wire_digest,

--- a/vta-service/src/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/trust_tasks/wire_v0_2.rs
@@ -434,6 +434,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:1",
             "type": "https://trusttasks.org/spec/device/list/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "issuer": "did:web:vta",
             "recipient": "did:key:zClient",
             "payload": {
@@ -476,6 +477,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:2",
             "type": "https://trusttasks.org/spec/trust-task-error/0.3",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "code": "permission_denied", "reason": "nope" }
         });
         let outcome = TrustTaskOutcome {
@@ -521,6 +523,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:9",
             "type": "https://trusttasks.org/spec/vault/list/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {
                 "entries": [
                     { "id": "v1", "label": "oauth-tokens", "secretKind": "oauth-tokens",
@@ -555,6 +558,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:7",
             "type": "https://trusttasks.org/spec/vault/release/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {
                 "sealedSecret": { "envelope": "didcomm-authcrypt", "jwe": "opaque.jwe.bytes" },
                 "secretKind": "oauth-tokens",
@@ -587,6 +591,7 @@ mod tests {
         let doc = serde_json::json!({
             "id": "urn:uuid:8",
             "type": "https://trusttasks.org/spec/vault/proxy-login/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {
                 "sealedSessionBlob": { "envelope": "didcomm-authcrypt", "jwe": "opaque" },
                 "sessionId": "s1",

--- a/vta-service/src/webvh_didcomm.rs
+++ b/vta-service/src/webvh_didcomm.rs
@@ -285,6 +285,7 @@ fn build_envelope_document(
         // The task type lives HERE, on the document — never on the DIDComm
         // message, which is always the envelope type.
         "type": task,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         // Addressed to the host, per SPEC §4.8. did-hosting does not enforce
         // `recipient` on the DID-management bridge (it authorizes the authcrypt
         // sender), but an unaddressed document is one a stricter peer is
@@ -979,6 +980,7 @@ mod envelope_binding_tests {
         let reply = json!({
             "id": "urn:uuid:2",
             "type": TASK_DID_CHECK_NAME_RESPONSE,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "available": true, "reserved": true, "record": { "mnemonic": "bob" } },
         });
         let payload = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
@@ -999,6 +1001,7 @@ mod envelope_binding_tests {
         let reply = json!({
             "id": "urn:uuid:3",
             "type": TASK_DID_PROBLEM_REPORT,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "code": "e.p.did.path-unavailable", "comment": "taken" },
         });
         let err = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
@@ -1019,6 +1022,7 @@ mod envelope_binding_tests {
             let reply = json!({
                 "id": "urn:uuid:4",
                 "type": format!("https://trusttasks.org/spec/trust-task-error/{version}"),
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "payload": { "code": "malformedRequest", "message": "nope" },
             });
             let err = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)
@@ -1039,6 +1043,7 @@ mod envelope_binding_tests {
         let reply = json!({
             "id": "urn:uuid:5",
             "type": "https://trusttasks.org/spec/did-management/did/delete/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "deleted": true },
         });
         let err = unwrap_envelope_reply(reply, TASK_DID_CHECK_NAME_RESPONSE)

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -331,6 +331,7 @@ async fn trust_tasks_require_auth() {
             json!({
                 "id": "urn:uuid:2a1b3c4d-5e6f-4071-8293-a4b5c6d7e8f0",
                 "type": "https://trusttasks.org/spec/trust-task-discovery/0.1",
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "payload": {},
             }),
         ))
@@ -357,6 +358,7 @@ async fn trust_task_discovery_reports_dispatched_tasks() {
             json!({
                 "id": "urn:uuid:4c3d5e6f-7081-4293-a4b5-c6d7e8f90123",
                 "type": "https://trusttasks.org/spec/trust-task-discovery/0.1",
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "payload": { "patterns": ["acl/*"] },
             }),
         ))
@@ -394,6 +396,7 @@ async fn trust_task_discovery_defaults_to_everything() {
             json!({
                 "id": "urn:uuid:5d4e6f70-8192-43a4-b5c6-d7e8f9012345",
                 "type": "https://trusttasks.org/spec/trust-task-discovery/0.1",
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "payload": {},
             }),
         ))
@@ -2204,6 +2207,7 @@ async fn keys_import_trust_task_refuses_cleartext_over_rest() {
             json!({
                 "id": "urn:uuid:6f1b2c3d-4e5f-4061-8293-a4b5c6d7e8f9",
                 "type": "https://trusttasks.org/spec/keys/import/0.1",
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
                 "payload": {
                     "keyType": "ed25519",
                     "privateKeyMultibase": "z6MkDeadbeefDeadbeefDeadbeef",

--- a/vta-service/tests/authenticate_trust_task.rs
+++ b/vta-service/tests/authenticate_trust_task.rs
@@ -77,6 +77,7 @@ fn signed_authenticate_doc(
     let doc_json = json!({
         "id": "urn:uuid:authn-itest-1",
         "type": "https://trusttasks.org/spec/auth/authenticate/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": { "challenge": challenge, "sessionId": session_id },
@@ -285,6 +286,7 @@ async fn tt_challenge_returns_tt_response_doc() {
     let doc = json!({
         "id": "urn:uuid:challenge-itest-1",
         "type": "https://trusttasks.org/spec/auth/challenge/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": { "subject": did },

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -115,7 +115,7 @@ fn envelope(type_uri: &str, issuer: &str, recipient: &str, payload: Value) -> Va
         "type": type_uri,
         "issuer": issuer,
         "recipient": recipient,
-        "issuedAt": "2026-07-14T00:00:00Z",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": payload,
     })
 }

--- a/vta-service/tests/idempotency_trust_task.rs
+++ b/vta-service/tests/idempotency_trust_task.rs
@@ -67,6 +67,7 @@ fn create_doc(envelope_id: &str, label: &str, idempotency_key: Option<&str>) -> 
     let mut doc = json!({
         "id": format!("urn:uuid:{envelope_id}"),
         "type": KEYS_CREATE,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": CALLER,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
@@ -105,6 +106,7 @@ async fn key_count(router: &axum::Router, token: &str) -> usize {
     let doc = json!({
         "id": format!("urn:uuid:{}", uuid_ish()),
         "type": KEYS_LIST,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": CALLER,
         "recipient": "did:key:z6MkTestVTA",
         "payload": { "contextId": CONTEXT },
@@ -265,6 +267,7 @@ async fn the_same_key_on_a_different_task_is_refused() {
     let other = json!({
         "id": "urn:uuid:e2",
         "type": "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": CALLER,
         "recipient": "did:key:z6MkTestVTA",
         "idempotencyKey": "urn:uuid:idem-cross",
@@ -302,6 +305,7 @@ async fn a_key_on_a_retry_safe_task_is_ignored_not_rejected() {
     let doc = json!({
         "id": "urn:uuid:g1",
         "type": KEYS_LIST,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": CALLER,
         "recipient": "did:key:z6MkTestVTA",
         "idempotencyKey": "urn:uuid:idem-on-a-read",

--- a/vta-service/tests/pending_presentation_trust_task.rs
+++ b/vta-service/tests/pending_presentation_trust_task.rs
@@ -104,6 +104,7 @@ fn tt(id: &str, type_uri: &str, issuer: &str, payload: Value) -> Value {
     json!({
         "id": id,
         "type": type_uri,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": issuer,
         "recipient": "did:key:z6MkTestVTA",
         "payload": payload,

--- a/vta-service/tests/refresh_trust_task.rs
+++ b/vta-service/tests/refresh_trust_task.rs
@@ -62,6 +62,7 @@ fn refresh_doc(refresh_token: &str) -> Vec<u8> {
     json!({
         "id": "urn:uuid:refresh-itest-1",
         "type": "https://trusttasks.org/spec/auth/refresh/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": "did:key:z6MkRefresher",
         "recipient": "did:key:z6MkTestVTA",
         "payload": { "refreshToken": refresh_token },

--- a/vta-service/tests/session_jti_pin.rs
+++ b/vta-service/tests/session_jti_pin.rs
@@ -73,6 +73,7 @@ async fn whoami_status(
         // closed; a real producer mints a fresh id per request anyway.
         "id": format!("urn:uuid:jti-pin-itest-{}", uuid::Uuid::new_v4()),
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},

--- a/vta-service/tests/sessions_list_trust_task.rs
+++ b/vta-service/tests/sessions_list_trust_task.rs
@@ -103,6 +103,7 @@ async fn sessions_list_returns_only_callers_active_sessions() {
     let doc = json!({
         "id": "urn:uuid:sessions-list-itest-1",
         "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},
@@ -161,6 +162,7 @@ async fn sessions_list_without_bearer_is_unauthorized() {
     let doc = json!({
         "id": "urn:uuid:sessions-list-itest-2",
         "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": "did:key:z6MkAnon",
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -126,6 +126,7 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
     let doc_json = json!({
         "id": "approve-resp-itest-1",
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
@@ -286,6 +287,7 @@ async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
     let doc_json = json!({
         "id": "approve-resp-itest-0-2",
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.2",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
@@ -394,6 +396,7 @@ async fn trust_task_acl_mutation_requires_step_up() {
     let doc = json!({
         "id": "acl-create-itest-1",
         "type": "https://trusttasks.org/spec/acl/grant/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": ctx.vta_did,
         "payload": {
@@ -507,6 +510,7 @@ async fn v0_2_minted_request_completes_with_a_0_1_flavored_response() {
     let gated = json!({
         "id": "acl-create-roundtrip-1",
         "type": "https://trusttasks.org/spec/acl/grant/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": ctx.vta_did,
         "payload": {
@@ -555,6 +559,7 @@ async fn v0_2_minted_request_completes_with_a_0_1_flavored_response() {
     let doc_json = json!({
         "id": "approve-resp-roundtrip-1",
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": ctx.vta_did,
         "payload": {
@@ -698,6 +703,7 @@ async fn delegated_approve_response_elevates_the_subjects_session() {
     let doc_json = json!({
         "id": "approve-resp-delegated-1",
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": approver_did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
@@ -840,6 +846,7 @@ async fn unauthorized_approver_cannot_elevate() {
     let doc_json = json!({
         "id": "approve-resp-rogue-1",
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": rogue_did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {

--- a/vta-service/tests/vault_trust_task.rs
+++ b/vta-service/tests/vault_trust_task.rs
@@ -49,7 +49,7 @@ fn unsigned_envelope() -> Value {
         "type": "https://trusttasks.org/spec/acl/list/0.1",
         "issuer": "did:key:zTestIssuer",
         "recipient": "did:key:zTestRecipient",
-        "issuedAt": "2026-07-14T00:00:00Z",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": {}
     })
 }
@@ -125,6 +125,7 @@ async fn post_vault(
     let doc = json!({
         "id": format!("tt-{}", uuid::Uuid::new_v4()),
         "type": uri,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": holder_did(),
         "recipient": "did:key:z6MkTestVTA",
         "payload": payload,

--- a/vta-service/tests/whoami_trust_task.rs
+++ b/vta-service/tests/whoami_trust_task.rs
@@ -66,6 +66,7 @@ async fn whoami_reports_live_session_acr_not_stale_token() {
     let doc = json!({
         "id": "urn:uuid:whoami-itest-1",
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},
@@ -123,6 +124,7 @@ async fn whoami_without_bearer_is_unauthorized() {
     let doc = json!({
         "id": "urn:uuid:whoami-itest-2",
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": "did:key:z6MkAnon",
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -1399,6 +1399,7 @@ mod tests {
         let doc = json!({
             "id": "urn:uuid:reply",
             "type": "https://trusttasks.org/spec/registry/record/put/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "threadId": "urn:uuid:request",
             "payload": { "ok": true, "created": true },
         });
@@ -1431,6 +1432,7 @@ mod tests {
         let request = serde_json::to_vec(&json!({
             "id": "urn:uuid:req",
             "type": "https://trusttasks.org/spec/registry/record/query/0.1",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {},
         }))
         .unwrap();
@@ -1441,6 +1443,7 @@ mod tests {
         let unthreaded = serde_json::to_vec(&json!({
             "id": "urn:uuid:resp",
             "type": "https://trusttasks.org/spec/registry/record/put/0.1#response",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "ok": true },
         }))
         .unwrap();
@@ -1459,6 +1462,7 @@ mod tests {
         let error = serde_json::to_vec(&json!({
             "id": "urn:uuid:err",
             "type": crate::trust_tasks::helpers::framework_error_type_uri().to_string(),
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "threadId": "urn:uuid:request",
             "payload": { "code": "permissionDenied" },
         }))

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -668,7 +668,7 @@ mod didcomm_harness {
             "id": format!("urn:uuid:{}", Uuid::new_v4()),
             "issuer": issuer,
             "recipient": recipient,
-            "issuedAt": "2026-01-01T00:00:00Z",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "expiresAt": "2099-01-01T00:00:00Z",
             "payload": payload,
         })

--- a/vtc-service/tests/auth_di_trust_task.rs
+++ b/vtc-service/tests/auth_di_trust_task.rs
@@ -268,6 +268,7 @@ async fn unsigned_authenticate_document_is_not_claimed_by_the_di_path() {
     let unsigned = json!({
         "id": "urn:uuid:unsigned-1",
         "type": AUTHENTICATE_TASK,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "payload": { "challenge": challenge, "sessionId": session_id },
     });

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1684,6 +1684,7 @@ async fn post_status_signed_by(fix: &Fixture, seed: &[u8; 32], id: Uuid) -> (Sta
 fn manifest_doc() -> Value {
     json!({
         "type": MANIFEST_TASK,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "id": format!("urn:uuid:{}", Uuid::new_v4()),
         "recipient": vtc_service::test_support::TEST_VTC_DID,
         "expiresAt": "2099-01-01T00:00:00Z",

--- a/vtc-service/tests/relationships.rs
+++ b/vtc-service/tests/relationships.rs
@@ -770,7 +770,7 @@ mod pairwise {
             "type": PUBLISH_TASK,
             "issuer": did_for(signer),
             "recipient": TEST_VTC_DID,
-            "issuedAt": chrono::Utc::now().to_rfc3339(),
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": payload,
         });
         let parsed: trust_tasks_rs::TrustTask<Value> =
@@ -1298,7 +1298,7 @@ mod pairwise {
                 "relationship": edge.to_string(),
                 "aud": TEST_VTC_DID,
                 "sessionId": session_id,
-                "issuedAt": chrono::Utc::now().to_rfc3339(),
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             })
         }
 
@@ -1308,7 +1308,7 @@ mod pairwise {
                 "relationship": edge.to_string(),
                 "aud": TEST_VTC_DID,
                 "sessionId": session_id,
-                "issuedAt": chrono::Utc::now().to_rfc3339(),
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             })
         }
 
@@ -1691,7 +1691,7 @@ mod pairwise {
                 "relationship": edge.to_string(),
                 "aud": TEST_VTC_DID,
                 "sessionId": session_id,
-                "issuedAt": chrono::Utc::now().to_rfc3339(),
+                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             })
         }
 

--- a/vtc-service/tests/wallet_login_siop.rs
+++ b/vtc-service/tests/wallet_login_siop.rs
@@ -439,6 +439,7 @@ fn refresh_doc(refresh_token: &str) -> Value {
     json!({
         "id": "urn:uuid:11111111-2222-3333-4444-555555555555",
         "type": REFRESH_TYPE,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": { "refreshToken": refresh_token },
     })
 }
@@ -622,6 +623,7 @@ async fn rest_refresh_rejects_a_malformed_payload() {
         json!({
             "id": "urn:uuid:99999999-9999-9999-9999-999999999999",
             "type": REFRESH_TYPE,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": { "refresh_token": "wrong-casing" },
         }),
     )


### PR DESCRIPTION
The follow-up #1126 named. VTI now honours SPEC §7.2's **same-bound** rule: the
acceptance window and the duplicate-execution record's retention are one
instant, derived from one policy.

## The gap this closes

#1126 shipped the `ReplayGuard` without an acceptance window, leaving the
record bounded by `InMemoryReplayGuard`'s capacity. That is not "no expiry, so
entries live forever" — it is **LRU, which makes the window load-dependent**:

- quiet service → effectively unbounded protection;
- busy service → an eviction horizon that can fall *below* any sensible
  acceptance window, so a replay arriving after its `id` was evicted **executes
  a second time**.

The defence was weakest exactly when the service was busiest. `retain_until`
now comes from `FreshnessPolicy::record_expiry`, so the two bounds cannot drift
apart by construction.

## Ten minutes, and why not five

The library's `DEFAULT_MAX_AGE` is five — "long enough to survive a mediator
queue, a retry with backoff, and a modest clock disagreement". This service
routes over a mediator that can hold a message while a recipient reconnects, so
it takes double: the same 600s the retired `replay::check_and_record` used as
its dedup TTL, now bounding acceptance as well as retention rather than only
the record.

A deployment whose transport buffers longer must widen this **and** the guard's
retention together — widening either alone reintroduces the gap above. That is
stated at the policy.

## The fixture migration, which is most of the diff

Setting the window failed **41 assertions across 10 suites**, and none of it was
the policy being wrong: the suite was full of documents no real producer sends.

- **65 Trust Task envelopes carried no `issuedAt` at all.** With a window set,
  a document with neither `issuedAt` nor `expiresAt` cannot be placed in time
  and is refused — which is what §7.2 requires ("a consumer that can establish
  neither ... has no window in which to place it"). Every real client stamps
  one; the fixtures simply never did.
- **12 more carried fixed literals** — `2026-01-01`, `2026-05-20`,
  `2026-07-14` — hours or days stale by the time the suite ran.

All now stamp `Utc::now()`. Both suites pass: **vta-service 28/28,
vtc-service 54/54, 0 conformance violations, coverage 48/109 unchanged.**

### One subtlety worth the paragraph

The first pass used `to_rfc3339()`, and it broke a *signed* fixture:
`an_unenrolled_approvers_decision_mints_the_grant` failed with "signature
invalid for cryptosuite EddsaJcs2022".

`to_rfc3339()` renders the offset as `+00:00`. `TrustTask`'s typed
`DateTime<Utc>` round-trip renders it as `Z`. A document signed in one spelling
and verified after the other is a different document — which is *precisely* the
§8.4 distinction #1126 added `idConflict` for, arriving here as a proof
failure instead. Every stamp uses
`to_rfc3339_opts(SecondsFormat::Secs, true)`, which round-trips identically.

Worth knowing beyond this PR: any code that builds a Trust Task document for
signing must emit timestamps in the spelling the typed round-trip produces, or
the proof will not survive the trip.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage 48/109
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, 0 failures
- `cargo fmt --all --check`

BREAKING CHANGE: a Trust Task document whose `issuedAt` is more than ten
minutes old, or which carries neither `issuedAt` nor `expiresAt`, is now
refused. Clients that do not stamp `issuedAt` must start doing so.

Refs #1059
