### PR TITLE
test(vta): cover the did-templates and policy families

### DIFF
--- a/vta-sdk/src/protocols/policy_management.rs
+++ b/vta-sdk/src/protocols/policy_management.rs
@@ -121,6 +121,15 @@ pub struct UpsertPolicyBody {
     pub applies_to: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub priority: Option<i32>,
+    /// Optional on the wire, defaulting to `true`, as `policy/upsert/0.2`
+    /// declares (`"enabled": {"type": "boolean", "default": true}`).
+    ///
+    /// It was a bare `bool` here, so a conforming client that omitted it got
+    /// `malformedRequest` — the same shape as `keys/create`'s `derivationPath`
+    /// before #1123. A policy you bothered to write is one you meant to switch
+    /// on, which is why the specification defaults it that way rather than
+    /// making it required.
+    #[serde(default = "enabled_by_default")]
     pub enabled: bool,
     /// Optimistic concurrency: when present it MUST equal the row's current
     /// version, else the caller is overwriting a revision it never saw.
@@ -163,6 +172,11 @@ pub struct DeletePolicyResultBody {
     pub id: String,
     /// RFC 3339 removal timestamp.
     pub deleted_at: String,
+}
+
+/// `policy/upsert/0.2` declares `enabled` with `"default": true`.
+fn enabled_by_default() -> bool {
+    true
 }
 
 #[cfg(test)]

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2436,6 +2436,112 @@ mod response_coverage {
         .await;
     }
 
+    /// The DID-template family: the operator surface that every
+    /// provision-integration flow renders from.
+    #[tokio::test]
+    async fn did_templates_lifecycle() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        a_context(&state, "cov-templates").await;
+
+        // A minimal template. `document` is the DID-document shape with
+        // `{TOKEN}` placeholders the renderer fills; `requiredVars` is what the
+        // renderer will insist on, so keeping it to one keeps `render` honest
+        // without making the fixture about template authoring.
+        let template = json!({
+            "schemaVersion": 1,
+            "name": "cov-template",
+            "kind": "app",
+            "requiredVars": ["LABEL"],
+            // `document.id` must be the `{DID}` placeholder: the renderer
+            // fills it with the DID it mints, and a template that hardcoded an
+            // id would mint every integration the same identity.
+            "document": {
+                "id": "{DID}",
+                "service": [{ "id": "#cov", "type": "VTARest", "serviceEndpoint": "{LABEL}" }],
+            },
+        });
+
+        ok(
+            &state,
+            t::TASK_DID_TEMPLATES_CREATE_2_0,
+            json!({ "contextId": "cov-templates", "template": template }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_DID_TEMPLATES_LIST_2_0,
+            json!({ "contextId": "cov-templates" }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_DID_TEMPLATES_GET_2_0,
+            json!({ "contextId": "cov-templates", "name": "cov-template" }),
+        )
+        .await;
+
+        let mut updated = template.clone();
+        updated["description"] = json!("renamed");
+        ok(
+            &state,
+            t::TASK_DID_TEMPLATES_UPDATE_2_0,
+            json!({ "contextId": "cov-templates", "name": "cov-template", "template": updated }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_DID_TEMPLATES_RENDER_2_0,
+            json!({
+                "contextId": "cov-templates",
+                "name": "cov-template",
+                // `DID` is a reserved var, not a template bug: `create`
+                // requires `document.id` to be the `{DID}` placeholder, and the
+                // caller supplies the minted DID at render time.
+                "vars": { "LABEL": "https://cov.example", "DID": "did:key:z6MkCovRender" },
+            }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_DID_TEMPLATES_DELETE_2_0,
+            json!({ "contextId": "cov-templates", "name": "cov-template" }),
+        )
+        .await;
+    }
+
+    /// The policy family. `upsert` is `0.2` and `get`/`delete` are `0.1`, which
+    /// is why they are covered together rather than by version.
+    #[tokio::test]
+    async fn policy_lifecycle() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        a_context(&state, "cov-policy").await;
+
+        let created = ok(
+            &state,
+            t::TASK_POLICY_UPSERT_0_2,
+            json!({
+                "name": "cov-policy",
+                // The smallest Rego module that loads: a package and one rule.
+                "module": "package vta.cov\n\ndefault allow := false\n",
+            }),
+        )
+        .await;
+        let id = created["policy"]["id"]
+            .as_str()
+            .or_else(|| created["id"].as_str())
+            .unwrap_or_else(|| panic!("upsert must name the policy it stored: {created}"))
+            .to_owned();
+
+        ok(&state, t::TASK_POLICY_LIST_0_2, json!({})).await;
+        ok(&state, t::TASK_POLICY_GET_0_1, json!({ "id": id })).await;
+        ok(
+            &state,
+            t::TASK_POLICY_DELETE_0_1,
+            json!({ "id": id, "reason": "coverage" }),
+        )
+        .await;
+    }
+
     /// The context family's read and write paths.
     #[tokio::test]
     async fn contexts_lifecycle() {


### PR DESCRIPTION
Coverage **48 → 58 of 109 (44% → 53%)**, past halfway. Two families, one real
defect found.

## The defect: `policy/upsert/0.2` required a member the spec makes optional

`UpsertPolicyBody::enabled` was a bare `bool`. The specification declares
`"enabled": {"type": "boolean", "default": true}` and requires only
`["name", "module"]` — so **a conforming client that omitted it got
`malformedRequest`**.

Same shape as `keys/create`'s `derivationPath` before #1123, and the third of
this class the programme has turned up. It is also the class a response gate
**structurally cannot see**: the request never reaches a handler, so nothing
about the response is wrong. It surfaced only because a coverage test tried to
send what the schema says is legal.

Now `#[serde(default = "enabled_by_default")]`. A policy you bothered to write
is one you meant to switch on, which is why the specification defaults it that
way rather than making it required.

## What is covered

| family | tasks |
|---|---|
| `vta/did-templates/*` | `create`, `list`, `get`, `update`, `render`, `delete` |
| `policy/*` | `upsert` (0.2), `list` (0.2), `get` (0.1), `delete` (0.1) |

The policy family is covered as one test rather than split by version, because
`upsert`/`list` are `0.2` while `get`/`delete` are `0.1` — a lifecycle crosses
both and testing by version would have split a single operator workflow in two.

Each test walks a lifecycle, so reads see state a write actually made. The
did-templates one renders between update and delete: `render` is the step every
provision-integration flow depends on, and covering it after an update proves
the stored template — not the created one — is what gets rendered.

## Two fixture corrections worth recording, because both looked like defects

Neither was:

- **`document.id` must be the `{DID}` placeholder.** `create` rejects a
  template without it, so a template cannot hardcode an id — otherwise every
  integration rendered from it would mint the same identity.
- **`DID` is a reserved template var, not a template bug.** `render` refused my
  first fixture with *"unresolved placeholder(s): DID. This is a bug in the
  template, not a missing --var."* Read alone that contradicts `create`'s rule.
  It is not: `DID` is reserved (`did_templates::mod`), and the caller supplies
  the minted DID at render time. I checked the renderer before claiming a
  contradiction.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **58/109**
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, 0 failures
- `cargo fmt --all --check`

BREAKING CHANGE: `UpsertPolicyBody::enabled` is now optional on the wire and
defaults to `true`, matching `policy/upsert/0.2`.

Refs #1059
