### PR TITLE
test(vta): cover the services and webvh read paths

### DIFF
--- a/vta-service/src/operations/did_webvh/update/orchestrator.rs
+++ b/vta-service/src/operations/did_webvh/update/orchestrator.rs
@@ -206,7 +206,13 @@ async fn hosted_agent_name_context(
         .map_err(|e| UpdateDidWebvhError::Forbidden(e.to_string()))?;
 
     if record.server_id == "serverless" {
-        return Err(UpdateDidWebvhError::Publish(
+        // `InvalidDocument`, not `Publish`. `Publish` renders as
+        // `internalError` with `retryable: true`, which tells the producer to
+        // send the identical request again — and it will fail identically every
+        // time, because a serverless DID does not become hosted by waiting. The
+        // caller has to register it with a server first, which is an action, not
+        // a delay.
+        return Err(UpdateDidWebvhError::InvalidDocument(
             "agent names require a hosted DID; this DID is serverless \
              (register it with a server first)"
                 .to_string(),

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2436,6 +2436,71 @@ mod response_coverage {
         .await;
     }
 
+    /// The runtime service-management read paths.
+    ///
+    /// Only the reads: `enable`/`update`/`disable`/`rollback` publish a new
+    /// WebVH LogEntry and run a live DIDComm handshake against the running
+    /// service, so their success path needs the mediator-backed harness rather
+    /// than this fixture. Covering the reads is what the gate can see today.
+    #[tokio::test]
+    async fn services_read_paths() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        ok(&state, t::TASK_SERVICES_LIST_1_0, json!({})).await;
+        ok(
+            &state,
+            t::TASK_SERVICES_GET_1_0,
+            json!({ "service": "rest" }),
+        )
+        .await;
+        // Drain is DIDComm-only and empty here; an empty list is still a
+        // response shape, and an empty one is the shape most likely to be got
+        // wrong (`[]` against absent).
+        ok(&state, t::TASK_SERVICES_DRAIN_LIST_1_0, json!({})).await;
+    }
+
+    /// The webvh read paths that need no hosting server.
+    ///
+    /// `dids/{create,delete,register-with-server,rotate-keys}`, every
+    /// `servers/*` task, and — less obviously — every `agent-name/*` task
+    /// reach out to or require a hosting server, so their success paths belong
+    /// with the stub-host tests rather than here.
+    #[tokio::test]
+    async fn webvh_read_paths() {
+        let (state, _dir) = build_signing_test_app_state().await;
+
+        // Seed a webvh record. Agent names are keyed on one, and the VTA's own
+        // `did:key` is not — it is a self-resolving signing identity, not a
+        // hosted DID. Seeding also makes `dids/list` answer with content rather
+        // than an empty array, which is the more interesting response shape.
+        let did = "did:webvh:example.com:coverage";
+        let record = vta_sdk::webvh::WebvhDidRecord {
+            did: did.to_string(),
+            server_id: "serverless".into(),
+            mnemonic: "coverage-slot".into(),
+            scid: "scid-coverage".into(),
+            context_id: "cov-webvh".into(),
+            portable: false,
+            log_entry_count: 1,
+            pre_rotation_count: 0,
+            next_fragment_id: 1,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        crate::webvh_store::store_did(&state.webvh_ks, &record)
+            .await
+            .expect("seed the webvh record");
+
+        ok(&state, t::TASK_WEBVH_DIDS_LIST_1_0, json!({})).await;
+
+        // `agent-name/*` is deliberately NOT covered here, and the reason is
+        // not obvious: the names are local records, but every one of those
+        // tasks refuses a **serverless** DID ("agent names require a hosted
+        // DID"). A seeded record is serverless unless a hosting server is
+        // registered, so covering them means standing up the stub host — which
+        // is where the rest of the webvh write paths already live.
+        let _ = did;
+    }
+
     /// The DID-template family: the operator surface that every
     /// provision-integration flow renders from.
     #[tokio::test]


### PR DESCRIPTION
Coverage **58 → 62 of 109 (53% → 57%)**. Also fixes a mis-signalled
retryability the coverage work surfaced.

## The fix: `retryable: true` on a condition retrying cannot fix

`agent-name/*` refuses a serverless DID with `UpdateDidWebvhError::Publish`,
which renders as `internalError` with **`retryable: true`**. That tells the
producer to send the identical request again — and it will fail identically
every time. A serverless DID does not become hosted by waiting; the caller has
to register it with a server, which is an action, not a delay.

Now `InvalidDocument`, which is non-retryable. `Publish` is for a transient
failure talking to a host, and this never reaches one.

No test asserted on the old code, which is why it survived: nothing exercised
the path, and the string reads plausibly either way.

## What is covered

| family | tasks |
|---|---|
| `vta/services/*` | `list`, `get`, `drain/list` |
| `vta/webvh/*` | `dids/list` |

`drain/list` is covered deliberately while empty: an empty collection is the
response shape most likely to be got wrong — `[]` against absent — and it is
exactly what `null`-for-absent defects look like.

`dids/list` runs against a **seeded** record rather than an empty store, so it
answers with content. An empty array exercises far less of the shape.

## The boundary is not where it looks

Only read paths, and the write/read line is not the one that matters here:

- `services/{enable,update,disable,rollback}` publish a WebVH LogEntry and run
  a **live DIDComm handshake** against the running service;
- every `webvh/servers/*` and `dids/{create,delete,register-with-server,rotate-keys}`
  task reaches a remote host;
- and — least obviously — **every `agent-name/*` task requires a *hosted* DID.**
  The names themselves are local records, so they look like cheap reads. They
  are not: a seeded record is serverless unless a hosting server is registered,
  and all of them refuse it. That is what turned up the retryability bug above.

Those belong with the stub-host tests, which is where the rest of the webvh
write paths already live. The comment in the test says so, so the next person
does not repeat the same twenty minutes.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **62/109**
- `cargo fmt --all --check`

Refs #1059
