### PR TITLE
feat(vta)!: stop error messages from being a probing oracle

### DIFF
--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -113,15 +113,34 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Trus
                 details: None,
             }
         }
-        // Hand the framework the *cause*, not the rendered error. Both
-        // `AppError::Internal` and `RejectReason::InternalError` render as
-        // "internal error: {…}", so passing the outer `Display` in put the
-        // prefix on twice and the operator dialog read "internal error:
-        // internal error: log entry has no update_keys". Every other arm above
-        // pairs a differently-worded reason with its variant, so only this one
-        // stutters — and only this one is fixed here.
-        AppError::Internal(cause) => RejectReason::InternalError { reason: cause },
-        _ => RejectReason::InternalError { reason: message },
+        // Framework 0.5.0, *What a `message` May Not Say*: a `message` MUST NOT
+        // reveal consumer-internal state. That rule is now normative for every
+        // code, and `internalError` is where this service leaked hardest — the
+        // cause went out verbatim, so a caller learned things like "ATM not
+        // configured — server cannot pack DIDComm envelopes" or "log entry has
+        // no update_keys": the deployment's shape, its configuration, and which
+        // internal invariant just broke.
+        //
+        // The producer needs one fact from an `internalError`: the failure was
+        // not its doing, so re-sending an identical document may work. The
+        // cause is what the *operator* needs, and it goes to the log where the
+        // operator is.
+        //
+        // Every other arm above is safe to pass through: they describe the
+        // caller's own request back to it (`not found`, `malformed`,
+        // `permission denied`), which is not consumer-internal state.
+        AppError::Internal(cause) => {
+            tracing::error!(cause = %cause, "trust task failed with an internal error");
+            RejectReason::InternalError {
+                reason: OPAQUE_INTERNAL_ERROR.to_string(),
+            }
+        }
+        other => {
+            tracing::error!(cause = %other, "trust task failed with an internal error");
+            RejectReason::InternalError {
+                reason: OPAQUE_INTERNAL_ERROR.to_string(),
+            }
+        }
     };
     reject_with(doc, reason)
 }
@@ -129,6 +148,15 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Trus
 /// Build a routed rejection document for the given reason and wrap it
 /// in an HTTP response. The framework computes the status code from
 /// the reject's standard code.
+/// What an `internalError` says on the wire.
+///
+/// Fixed text on purpose. Framework 0.5.0 forbids revealing consumer-internal
+/// state in a `message`, and an internal failure's cause is nothing but that.
+/// It tells the producer the one thing it can act on — the failure was not its
+/// document's fault — and nothing an unauthenticated caller could probe with.
+pub(super) const OPAQUE_INTERNAL_ERROR: &str =
+    "the consumer could not complete this task; the request itself was accepted";
+
 pub(super) fn reject_with(doc: &TrustTask<Value>, reason: RejectReason) -> TrustTaskOutcome {
     let routed = doc.reject_with(format!("urn:uuid:{}", Uuid::new_v4()), reason);
     error_response(routed)
@@ -277,21 +305,54 @@ mod tests {
             .to_string()
     }
 
-    /// The framework already says "internal error"; so does `AppError::Internal`.
-    /// Rendering the outer error into the reason put the prefix on twice, and the
-    /// operator's dialog read "internal error: internal error: log entry has no
-    /// update_keys". The cause is what the framework wants, not the rendering.
+    /// An `internalError` says nothing about the consumer's internals.
+    ///
+    /// Framework 0.5.0, *What a `message` May Not Say*: a `message` MUST NOT
+    /// reveal consumer-internal state, now normative for every code. This
+    /// service used to pass the cause through verbatim, so a caller — on the
+    /// unauthenticated routes, not yet anybody — learned the deployment's
+    /// shape from its failures.
+    ///
+    /// The earlier version of this test asserted the opposite, that the cause
+    /// *was* on the wire; its subject was a doubled "internal error:" prefix,
+    /// which the fixed text also settles.
     #[test]
-    fn an_internal_error_does_not_say_internal_error_twice() {
+    fn an_internal_error_reveals_no_internal_state() {
+        let secret = "log entry has no update_keys";
         let message = message_of(app_error_to_reject(
             &doc(),
-            AppError::Internal("log entry has no update_keys".into()),
+            AppError::Internal(secret.into()),
         ));
-        assert_eq!(message, "internal error: log entry has no update_keys");
+        assert!(
+            !message.contains(secret),
+            "the cause must reach the operator's log, never the wire: {message}"
+        );
+        assert!(
+            message.contains(OPAQUE_INTERNAL_ERROR),
+            "the producer still needs to be told the failure was not its \
+             document's doing: {message}"
+        );
         assert!(
             !message.contains("internal error: internal error"),
             "{message}"
         );
+    }
+
+    /// Every `AppError` that is not a caller-facing class lands on the same
+    /// opaque text, not just `Internal`.
+    ///
+    /// The catch-all arm was the quieter leak: it rendered whatever `Display`
+    /// the error happened to have, so a variant added later would start
+    /// publishing itself without anyone choosing to.
+    #[test]
+    fn the_catch_all_arm_is_opaque_too() {
+        let message = message_of(app_error_to_reject(
+            &doc(),
+            AppError::SecretStore("vault backend at 10.0.0.7 refused the token".into()),
+        ));
+        assert!(!message.contains("10.0.0.7"), "{message}");
+        assert!(!message.contains("vault backend"), "{message}");
+        assert!(message.contains(OPAQUE_INTERNAL_ERROR), "{message}");
     }
 
     /// The unrouted body-parse error must claim the same document type as a

--- a/vti-common/src/auth/di_proof.rs
+++ b/vti-common/src/auth/di_proof.rs
@@ -38,13 +38,41 @@ pub enum DiProofError {
     VerifyFailed(String),
 }
 
+impl DiProofError {
+    /// The underlying verifier detail, for the operator's log only.
+    ///
+    /// Deliberately not reachable through [`Display`]: that rendering goes on
+    /// the wire, and this is exactly what Framework 0.5.0 forbids putting
+    /// there. Log it beside the rejection; never return it.
+    #[must_use]
+    pub fn cause(&self) -> Option<&str> {
+        match self {
+            Self::VerifyFailed(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Display for DiProofError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NoProof => write!(f, "document has no proof"),
             Self::NotDataIntegrity => write!(f, "proof is not a Data Integrity proof"),
             Self::NoDid => write!(f, "proof verificationMethod carries no DID"),
-            Self::VerifyFailed(e) => write!(f, "proof verification failed: {e}"),
+            // Framework 0.5.0, *What a `message` May Not Say*: a `message`
+            // MUST NOT reveal "resolver, verifier, or key-status internals",
+            // normative for every code rather than for `identityMismatch`
+            // alone. This `Display` reaches the wire through
+            // `PermissionDenied { reason }`, so interpolating the underlying
+            // verifier error published which cryptosuite ran, whether the key
+            // resolved, and how it failed — to a party that is, on the
+            // unauthenticated routes, not yet anybody.
+            //
+            // The producer needs to know its proof did not verify and that
+            // retrying unchanged will not help. It does not need to know why,
+            // and every additional word is an oracle. The cause is available
+            // to the operator through [`Self::cause`].
+            Self::VerifyFailed(_) => write!(f, "proof verification failed"),
         }
     }
 }


### PR DESCRIPTION
Framework **0.5.0**'s error-model hardening, taken as current per the maintainer.

0.5.0 makes the message-sanitization rule **normative for every code**, where it
was normative for `identityMismatch` alone and a SHOULD in an informative
section for everything else. The reasoning is the part that matters:

> every rejection is emitted on the same path, to the same possibly-
> unauthenticated party, generally before any authorization decision has been
> reached … Otherwise each error response is an identity- and
> reachability-probing oracle that the *consumer* pays for and operates on the
> sender's behalf.

A `message` **MUST NOT** reveal consumer-internal state, the contested value of
a mismatched party, or resolver, verifier, or key-status internals. This service
violated two of the three.

## 1. `internalError` published the cause verbatim

`app_error_to_reject` passed `AppError::Internal`'s cause straight into
`RejectReason::InternalError { reason }`, which is surfaced as `message`. So a
caller learned things like:

- `ATM not configured — server cannot pack DIDComm envelopes`
- `log entry has no update_keys`

— the deployment's shape, its configuration, and which internal invariant just
broke. On the unauthenticated routes that caller is not yet anybody.

The producer needs exactly one fact from an `internalError`: the failure was not
its document's doing, so resending an identical document may work. The cause is
what the **operator** needs, and it now goes to the log where the operator is.

**The catch-all arm was the quieter half.** It rendered whatever `Display` the
error happened to have, so any `AppError` variant added later would begin
publishing itself with nobody choosing to. Both arms now land on one fixed
string.

Every other arm passes through unchanged, and deliberately: `notFound`,
`malformedRequest` and `permissionDenied` describe the caller's *own request*
back to it, which is not consumer-internal state. Blanket-opaquing those would
make the service unusable and buys nothing.

## 2. `DiProofError` published verifier internals

`Display` rendered `proof verification failed: {underlying}`, and that reaches
the wire through `PermissionDenied { reason }`. A caller could read which
cryptosuite ran, whether the key resolved, and how verification failed —
`signature invalid for cryptosuite EddsaJcs2022` is a real example from the
suite.

Now `proof verification failed`, full stop. The underlying detail moves to a
new `DiProofError::cause()`, which is deliberately **not** reachable through
`Display` — the whole defect was that the wire rendering and the operator
rendering were the same function.

## The test that asserted the bug

`an_internal_error_does_not_say_internal_error_twice` asserted the cause **was**
on the wire (`assert_eq!(message, "internal error: log entry has no
update_keys")`). Its actual subject was a doubled prefix, which the fixed string
also settles. It is now `an_internal_error_reveals_no_internal_state`, plus
`the_catch_all_arm_is_opaque_too` for the quieter half — that one feeds a
`SecretStore` error naming a host and a token and asserts neither reaches the
wire.

## Not in this PR

The rest of 0.5.0, each its own subject: the Document Lifecycle state table (a
transport binding MUST map it, and this service has three); **silence signifies
no state**; `details` size bounds; the `cancelled` `effects` shape. `identifier
correlation` needs an audit of `id`/`threadId` minting that is worth doing
properly rather than alongside this.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage 62/109
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, 0 failures
- `cargo fmt --all --check`

BREAKING CHANGE: an `internalError` response now carries a fixed message
instead of the underlying cause, and a failed Data-Integrity proof reports
`proof verification failed` without the verifier's reason. Both causes are
logged for the operator.

Refs #1059
