### PR TITLE
feat(audit): bound the operator reason an audit row keeps

### DIFF
--- a/vta-audit/src/lib.rs
+++ b/vta-audit/src/lib.rs
@@ -87,6 +87,47 @@ pub async fn record(
     .await
 }
 
+/// How much operator-supplied `detail` an audit row keeps.
+///
+/// Framework 0.5.0 requires every free-text member to carry a bound, on the
+/// reasoning that free text is "where personal data arrives in a task declaring
+/// it ingests none, where a secret arrives pasted by someone asked for a
+/// reason" — and it is unbounded cost. Here the cost is worse than wire bytes:
+/// this row goes into a **hash-chained, append-only** log, so an oversized
+/// `detail` is permanent. It cannot be trimmed later without breaking the
+/// chain that makes the log evidence.
+///
+/// 4096 characters is generous for a `reason` a human typed and small against
+/// the chain.
+pub const DETAIL_MAX_CHARS: usize = 4096;
+
+/// Truncate an over-long `detail`, marking that it was cut.
+///
+/// Truncated rather than rejected, deliberately. This function runs *after* the
+/// operation it records has already happened, so refusing the row would trade
+/// an over-long reason for **no audit record at all** — losing the evidence to
+/// protect its formatting. Truncation keeps the row, the actor, the action and
+/// the outcome, which is what the log is for.
+///
+/// Cut on a character boundary: slicing bytes would panic mid-codepoint on the
+/// first operator who wrote a reason in a language this workspace did not
+/// anticipate.
+fn bound_detail(detail: &str) -> String {
+    if detail.chars().count() <= DETAIL_MAX_CHARS {
+        return detail.to_string();
+    }
+    const MARK: &str = "… [truncated]";
+    let kept: String = detail
+        .chars()
+        .take(DETAIL_MAX_CHARS - MARK.chars().count())
+        .collect();
+    tracing::warn!(
+        original_chars = detail.chars().count(),
+        "audit detail exceeded {DETAIL_MAX_CHARS} characters and was truncated"
+    );
+    format!("{kept}{MARK}")
+}
+
 /// Like [`record`], but also persists an operator-supplied `detail` (e.g. the
 /// `reason` on a `vault.delete`/`vault.archive`). Kept as a separate function
 /// so the existing `record(...)` call sites stay untouched.
@@ -116,7 +157,7 @@ pub async fn record_with_detail(
         outcome: outcome.to_string(),
         channel: channel.map(String::from),
         context_id: context_id.map(String::from),
-        detail: detail.map(String::from),
+        detail: detail.map(bound_detail),
     };
 
     // The storage key is the sink's business — a keyspace derives one, an
@@ -222,4 +263,44 @@ pub async fn cleanup_expired_logs(
     }
 
     Ok(removed)
+}
+
+#[cfg(test)]
+mod detail_bound {
+    use super::*;
+
+    #[test]
+    fn a_short_detail_is_untouched() {
+        assert_eq!(
+            bound_detail("archived on operator request"),
+            "archived on operator request"
+        );
+    }
+
+    #[test]
+    fn an_oversized_detail_is_truncated_and_marked() {
+        let out = bound_detail(&"x".repeat(DETAIL_MAX_CHARS * 2));
+        assert!(
+            out.chars().count() <= DETAIL_MAX_CHARS,
+            "{}",
+            out.chars().count()
+        );
+        assert!(
+            out.ends_with("… [truncated]"),
+            "a silently shortened reason reads as the operator's own words: {out}"
+        );
+    }
+
+    /// Cut on a character boundary, not a byte one.
+    ///
+    /// Slicing bytes panics mid-codepoint, and it would do so on the first
+    /// operator who wrote a reason in a language this workspace did not
+    /// anticipate — an audit path is the worst possible place to learn that.
+    #[test]
+    fn truncation_does_not_split_a_codepoint() {
+        // Four bytes per character, so a byte-slice at any odd offset panics.
+        let out = bound_detail(&"𝄞".repeat(DETAIL_MAX_CHARS * 2));
+        assert!(out.chars().count() <= DETAIL_MAX_CHARS);
+        assert!(out.starts_with('𝄞'));
+    }
 }


### PR DESCRIPTION
Framework **0.5.0** requires every free-text member to carry a bound. Most of
that is upstream schema work — see the note at the end — but one free-text path
is this workspace's own and is bounded by nothing: the operator `reason` that
`record_with_detail` writes into the audit log.

## Why this one is worse than a wire bound

0.5.0 argues free text as unbounded **wire** cost. Here the cost is worse: the
row goes into a **hash-chained, append-only** log. An oversized `detail` is
permanent, and it cannot be trimmed later without breaking the chain that makes
the log evidence in the first place.

`vault.delete`, `vault.archive` and every other operator-reasoned action feed
this path. Nothing checked the length at any point between the CLI and the
chain.

## Truncated, not rejected

4096 characters — generous for a reason a human typed, small against the chain.

The choice of truncation over rejection is the substance. `record_with_detail`
runs **after** the operation it records has already happened, so refusing the
row would trade an over-long reason for **no audit record at all** — losing the
evidence to protect its formatting. Truncation keeps the row, the actor, the
action and the outcome, which is what the log is for.

The cut is marked (`… [truncated]`), because a silently shortened reason reads
as the operator's own words.

## Cut on a character boundary

Byte-slicing panics mid-codepoint, and it would do so on the first operator who
wrote a reason in a language this workspace did not anticipate. An audit path
is the worst place to discover that, so there is a test with a 4-byte-per-char
string.

## Note: the rest of the free-text rule is already in hand upstream

I measured the registry before writing this: **1013 of 1067 free-text string
members carry no `maxLength`.** That is not VTI's to fix, and it is already
being done —
[dtgwg-trust-tasks-tf#296](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/296)
("bound every free-text payload member with a maxLength") is open across 275
files. Once it merges and publishes, the dispatch spine's `validate_payload`
enforces those bounds for free.

Worth stating for anyone sizing 0.5.0 readiness: **taking the latest
`trust-tasks-rs` today would not bound free text** — 0.14.0 predates #296.

Likewise
[#294](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/294) maps the
0.5.0 document lifecycle in the five binding crates. That does **not** reach
this workspace: VTI imports exactly one item from those crates
(`trust_tasks_https::status_for_code`), so a VTI-side lifecycle mapping remains
open and is not duplicated by it.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**
- `cargo test -p vta-audit` — 6 passed
- `cargo fmt --all --check`

Refs #1059
