### PR TITLE
feat(vta): mint the consent ceremony's correlator instead of deriving it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,15 +351,31 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached here any more.
+          #
+          # It was, keyed on `hashFiles('**/Cargo.lock')` with a prefix
+          # `restore-keys` fallback — and every crate in this workspace is a
+          # **path** dependency, so changing one member's source does not move
+          # `Cargo.lock` and therefore does not move the key. A PR that edits
+          # `vta-policy` and nothing else restores `main`'s `target/`
+          # byte-for-byte, and `cargo check` reuses the stale `vta-policy`
+          # artifact: the build then fails on the *new* code with
+          # `no field ... on type ...`, naming a field that is right there in
+          # the source.
+          #
+          # That is a false red on a green tree, and it is the worst kind: it
+          # points at the author's own diff. It failed #1133 exactly this way,
+          # which a clean-room checkout of the same commit compiled without
+          # complaint.
+          #
+          # The registry and git caches stay: they are content-addressed by
+          # package version, so a stale entry is impossible by construction.
+          # `cargo check` on a warm registry is under two minutes, which is not
+          # worth a class of failure that costs an afternoon to disbelieve.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-msrv-${{ steps.msrv.outputs.msrv }}-${{ hashFiles('**/Cargo.lock') }}
-          # Deliberately NO `${{ runner.os }}-cargo-` fallback. This job runs a
-          # different toolchain, so another job's `target/` is unusable to it —
-          # the shared key only ever restored gigabytes it could not link
-          # against, onto a disk that then had to hold this job's own build too.
           restore-keys: |
             ${{ runner.os }}-cargo-msrv-${{ steps.msrv.outputs.msrv }}-
 

--- a/vta-policy/src/consent.rs
+++ b/vta-policy/src/consent.rs
@@ -150,6 +150,26 @@ pub struct PendingTaskConsent {
     pub exclude_requester: bool,
     /// Nonce the approver echoes + signs, binding the decision to this request.
     pub challenge: String,
+    /// Freshly-minted correlator for this ceremony, used as the `threadId` on
+    /// the documents it produces.
+    ///
+    /// Framework 0.5.0 (*Identifier correlation and linkability*) requires
+    /// `id`, `threadId` and `ceremony.enactment` to be "freshly minted and
+    /// unguessable" and **MUST NOT** be derived from subject data. The granted
+    /// notice used to thread on [`wire_digest`], which is derived from the task
+    /// payload — salted, so not recoverable, but still a function of the
+    /// content and the same string the documents carry as `payloadDigest`.
+    ///
+    /// A mediator sees `threadId` as routing metadata. With the digest there it
+    /// could link the refusal, the approval pushes and the notice into one
+    /// ceremony *and* tie them to the payload digest it forwards, which is the
+    /// linkage the rule exists to remove.
+    ///
+    /// `#[serde(default)]` so a pending written before this field existed still
+    /// loads; such a record correlates on an empty string, which is no worse
+    /// than the notice being unthreaded.
+    #[serde(default)]
+    pub correlator: String,
     /// Distinct approver DIDs who have approved so far.
     pub approvals: Vec<String>,
     /// The prior state the effects shown to the approver were computed against.
@@ -527,6 +547,7 @@ mod tests {
         PendingTaskConsent {
             digest: digest.into(),
             wire_digest: format!("wire-{digest}"),
+            correlator: "urn:uuid:test-correlator".into(),
             state_pin: None,
             guards: Default::default(),
             type_uri: "https://…/dids/update/1.0".into(),

--- a/vta-service/src/trust_tasks/consent_request.rs
+++ b/vta-service/src/trust_tasks/consent_request.rs
@@ -307,6 +307,10 @@ pub(super) async fn push_granted(
     state: &AppState,
     #[cfg_attr(not(feature = "didcomm"), allow(unused))] requester: &str,
     #[cfg_attr(not(feature = "didcomm"), allow(unused))] wire_digest: &str,
+    // The ceremony's minted correlator, used as the notice's `threadId`.
+    // Deliberately separate from `wire_digest`, which stays the payload digest
+    // the notice carries in its body — see `PendingTaskConsent::correlator`.
+    #[cfg_attr(not(feature = "didcomm"), allow(unused))] correlator: &str,
     #[cfg_attr(not(feature = "didcomm"), allow(unused))] type_uri: &str,
 ) {
     let mediator_did = {
@@ -338,7 +342,7 @@ pub(super) async fn push_granted(
         let mut body = serde_json::json!({
             "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
             "type": TASK_CONSENT_GRANTED_0_1,
-            "threadId": wire_digest,
+            "threadId": correlator,
             "recipient": requester,
             "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "payload": {
@@ -369,7 +373,7 @@ pub(super) async fn push_granted(
                 message_type: TRUST_TASK_ENVELOPE_TYPE.to_string(),
                 recipient_did: requester.to_string(),
                 body: body.clone(),
-                thread_id: Some(wire_digest.to_string()),
+                thread_id: Some(correlator.to_string()),
             };
             if let Err(e) = state
                 .mediator_registry
@@ -446,6 +450,7 @@ mod tests {
             &state,
             REQUESTER,
             "digest-abc",
+            "urn:uuid:correlator-abc",
             "https://example.org/task/1.0",
         )
         .await;
@@ -467,6 +472,69 @@ mod tests {
         assert_eq!(
             pushed[0].body["payload"]["payloadDigest"].as_str(),
             Some("digest-abc")
+        );
+    }
+
+    /// The notice's `threadId` is the minted correlator, never the digest.
+    ///
+    /// Framework 0.5.0 (*Identifier correlation and linkability*) requires a
+    /// `threadId` to be freshly minted and forbids deriving one from subject
+    /// data. This notice used to thread on `wire_digest` — salted, so not
+    /// recoverable, but still a function of the payload and the *same string*
+    /// the document carries as `payloadDigest`.
+    ///
+    /// A mediator sees `threadId` as routing metadata. With the digest there it
+    /// could tie the routing it performs to the digest it forwards and link
+    /// every counterparty in the ceremony, which is the linkage the rule exists
+    /// to remove. The body still carries `payloadDigest`, so a requester that
+    /// matches on the digest is unaffected.
+    #[tokio::test]
+    async fn the_notice_threads_on_the_correlator_not_the_digest() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        state
+            .mediator_registry
+            .record_activate(MediatorBinding {
+                mediator_did: MEDIATOR.into(),
+                endpoint: "https://mediator.test".into(),
+            })
+            .await;
+        {
+            let mut cfg = state.config.write().await;
+            cfg.messaging = Some(vti_common::config::MessagingConfig {
+                mediator_url: String::new(),
+                mediator_did: MEDIATOR.into(),
+                mediator_host: None,
+                setup_acl: false,
+                drain_inbox_on_start: false,
+            });
+        }
+
+        super::push_granted(
+            &state,
+            REQUESTER,
+            "digest-abc",
+            "urn:uuid:correlator-abc",
+            "https://example.org/task/1.0",
+        )
+        .await;
+
+        let pushed = state.mediator_registry.take_outbound(MEDIATOR).await;
+        let one = pushed.first().expect("a notice was pushed");
+        assert_eq!(
+            one.thread_id.as_deref(),
+            Some("urn:uuid:correlator-abc"),
+            "the envelope must thread on the minted correlator"
+        );
+        assert_eq!(
+            one.body["threadId"], "urn:uuid:correlator-abc",
+            "and so must the document: {}",
+            one.body
+        );
+        assert_eq!(
+            one.body["payload"]["payloadDigest"], "digest-abc",
+            "the body still carries the digest, so a requester matching on it \
+             is unaffected: {}",
+            one.body
         );
     }
 }

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -627,6 +627,10 @@ async fn consent_gate(
             // The salted digest: what the approver signs, and what the two
             // screens compare. The internal one never leaves this process.
             "payloadDigest": pending.wire_digest,
+            // What the granted notice will be threaded on. The requester needs
+            // it to correlate, and it is deliberately *not* the digest: see
+            // `PendingTaskConsent::correlator`.
+            "correlator": pending.correlator,
             "challenge": pending.challenge,
             "approverSet": require.approver_set,
             "minApprovals": min_approvals,
@@ -725,6 +729,11 @@ async fn mint_pending(
     let pending = consent::PendingTaskConsent {
         digest,
         wire_digest,
+        // A correlator of its own, not the digest. Framework 0.5.0 requires a
+        // `threadId` to be freshly minted; deriving one from the payload hands
+        // a mediator the link between the routing metadata it sees and the
+        // digest it forwards.
+        correlator: format!("urn:uuid:{}", Uuid::new_v4()),
         type_uri: type_uri.to_string(),
         requester_did: auth.did.clone(),
         approver_set: require.approver_set.clone(),

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -354,6 +354,7 @@ pub(super) async fn handle_decision(
             state,
             &updated.requester_did,
             &updated.wire_digest,
+            &updated.correlator,
             &updated.type_uri,
         )
         .await;
@@ -460,6 +461,7 @@ mod tests {
             &consent::PendingTaskConsent {
                 digest: digest.clone(),
                 wire_digest: wire_digest.clone(),
+                correlator: "urn:uuid:test-correlator".into(),
                 type_uri: TYPE_URI.into(),
                 requester_did: REQUESTER.into(),
                 approver_set: "webvh-approvers".into(),
@@ -547,6 +549,7 @@ mod tests {
         consent::PendingTaskConsent {
             digest: "d".into(),
             wire_digest: "w".into(),
+            correlator: "urn:uuid:test-correlator".into(),
             type_uri: "https://…/dids/update/1.0".into(),
             requester_did: "did:key:zAgent".into(),
             approver_set: "openvtc-admins".into(),


### PR DESCRIPTION
Framework **0.5.0**, *Identifier correlation and linkability* — the last
VTI-side item of the 0.5.0 set that is not upstream work.

`id`, `threadId` and `ceremony.enactment` are correlators. 0.5.0 makes them
normative: each **MUST** be freshly minted and unguessable, and **MUST NOT** be
derived from subject data, an account number, a session identifier or a
counter.

## What was wrong

The `task-consent/granted` notice threaded on `wire_digest`:

```rust
"threadId": wire_digest,
…
thread_id: Some(wire_digest.to_string()),
```

`wire_digest` is `SHA-256(type_uri ‖ JCS(payload) ‖ challenge)` — a function of
the task payload, and **the same string the document carries as
`payloadDigest`**.

## Why it matters, and why it is not merely cosmetic

I checked whether this was a real exposure before changing a consent ceremony.
The challenge is 256 bits of randomness, so the digest is *not* guessable from
the payload — it is not the "UUIDv5 over a subject identifier" case 0.5.0 names.

**The mediator is the exposure.** `threadId` is routing metadata: the mediator
reads it to route, and it forwards documents whose body carries `payloadDigest`.
With the same value in both, it can tie the routing it performs to the digest it
carries and link the refusal, the approval pushes and the notice into one
ceremony with named counterparties — which is exactly the linkage the rule
exists to remove.

## The change

`PendingTaskConsent` gains a minted `correlator` (a fresh UUID), created
alongside the challenge and stored with the pending request. The notice threads
on it; **the body still carries `payloadDigest` unchanged**, so a requester that
matches on the digest is unaffected.

The requester is told the correlator in the `auth:consent_required` refusal,
beside the digest it already receives, so it can still correlate the notice.

`#[serde(default)]` on the new field: a pending record written before this
change still loads, and correlates on an empty string — no worse than an
unthreaded notice, and it drains within the consent expiry.

## Scope checked before changing it

- The **request** push to approvers already threaded on the request document's
  own `id` — a fresh UUID per approver. Only the requester-facing notice was
  derived, so this is a smaller change than it first looked.
- The granted notice is **produced but never consumed in this workspace**, and
  is explicitly non-load-bearing: "the grant check at re-submit is the real
  gate". So the blast radius is an external client that filters on the envelope
  `threadId` — and the body member it would more naturally match on is
  unchanged.

## Test

`the_notice_threads_on_the_correlator_not_the_digest` asserts all three
properties together: the envelope threads on the correlator, the document's
`threadId` agrees, and `payload.payloadDigest` still carries the digest.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings`
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**
- `cargo fmt --all --check`

Refs #1059
