### PR TITLE
feat(vta)!: close the CI cache class, map the 0.5.0 lifecycle, cover more tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,19 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached. Every crate in this
+          # workspace is a **path** dependency, so a source-only change does not
+          # move `Cargo.lock` and therefore does not move this key: the job
+          # restores a `target/` built from *other* source and reuses stale
+          # artifacts. The failure names a field that is plainly there in the
+          # diff, so it reads as the author's bug — see #1133, where a
+          # clean-room checkout of the same commit compiled fine.
+          #
+          # The registry and git caches stay: content-addressed by package
+          # version, so a stale entry is impossible by construction.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-check-
@@ -185,10 +194,19 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached. Every crate in this
+          # workspace is a **path** dependency, so a source-only change does not
+          # move `Cargo.lock` and therefore does not move this key: the job
+          # restores a `target/` built from *other* source and reuses stale
+          # artifacts. The failure names a field that is plainly there in the
+          # diff, so it reads as the author's bug — see #1133, where a
+          # clean-room checkout of the same commit compiled fine.
+          #
+          # The registry and git caches stay: content-addressed by package
+          # version, so a stale entry is impossible by construction.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
@@ -253,10 +271,19 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached. Every crate in this
+          # workspace is a **path** dependency, so a source-only change does not
+          # move `Cargo.lock` and therefore does not move this key: the job
+          # restores a `target/` built from *other* source and reuses stale
+          # artifacts. The failure names a field that is plainly there in the
+          # diff, so it reads as the author's bug — see #1133, where a
+          # clean-room checkout of the same commit compiled fine.
+          #
+          # The registry and git caches stay: content-addressed by package
+          # version, so a stale entry is impossible by construction.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
@@ -660,10 +687,19 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached. Every crate in this
+          # workspace is a **path** dependency, so a source-only change does not
+          # move `Cargo.lock` and therefore does not move this key: the job
+          # restores a `target/` built from *other* source and reuses stale
+          # artifacts. The failure names a field that is plainly there in the
+          # diff, so it reads as the author's bug — see #1133, where a
+          # clean-room checkout of the same commit compiled fine.
+          #
+          # The registry and git caches stay: content-addressed by package
+          # version, so a stale entry is impossible by construction.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-features-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-features-
@@ -825,10 +861,19 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached. Every crate in this
+          # workspace is a **path** dependency, so a source-only change does not
+          # move `Cargo.lock` and therefore does not move this key: the job
+          # restores a `target/` built from *other* source and reuses stale
+          # artifacts. The failure names a field that is plainly there in the
+          # diff, so it reads as the author's bug — see #1133, where a
+          # clean-room checkout of the same commit compiled fine.
+          #
+          # The registry and git caches stay: content-addressed by package
+          # version, so a stale entry is impossible by construction.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-enclave-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-enclave-
@@ -864,10 +909,19 @@ jobs:
 
       - uses: actions/cache@v5
         with:
+          # `target/` is deliberately NOT cached. Every crate in this
+          # workspace is a **path** dependency, so a source-only change does not
+          # move `Cargo.lock` and therefore does not move this key: the job
+          # restores a `target/` built from *other* source and reuses stale
+          # artifacts. The failure names a field that is plainly there in the
+          # diff, so it reads as the author's bug — see #1133, where a
+          # clean-room checkout of the same commit compiled fine.
+          #
+          # The registry and git caches stay: content-addressed by package
+          # version, so a stale entry is impossible by construction.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-mobile-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-mobile-

--- a/vta-sdk/src/protocols/auth.rs
+++ b/vta-sdk/src/protocols/auth.rs
@@ -44,7 +44,22 @@ pub struct ChallengeRequest {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RevokeSessionRequest {
     /// Identifier of the session to revoke.
-    pub session_id: String,
+    ///
+    /// Optional because `auth/revoke-session/0.1` is `sessionId` **XOR**
+    /// `all` — a `oneOf` that refuses both and neither. It was a required
+    /// `String` here, so a conforming client sending `{"all": true}` got
+    /// `malformedRequest`: the wrong answer for a legal document, and one that
+    /// tells the client its *shape* is wrong when the shape was fine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Revoke every session the caller may revoke.
+    ///
+    /// Accepted so the document parses, and then **refused explicitly**: this
+    /// VTA revokes exactly the one named session. See the handler — an
+    /// unimplemented option deserves to be named as unimplemented, not
+    /// reported as a malformed request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub all: Option<bool>,
 }
 
 /// Trust-task payload for `spec/auth/revoke-session/0.1#response`.
@@ -204,12 +219,18 @@ mod tests {
     #[test]
     fn revoke_session_request_round_trips() {
         let req = RevokeSessionRequest {
-            session_id: "sess-abc-123".to_string(),
+            session_id: Some("sess-abc-123".to_string()),
+            all: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"sessionId\":\"sess-abc-123\""), "{json}");
+        // `all` is absent, not `null`: the schema types it `boolean`, and the
+        // `oneOf` reads "both present" as malformed — so emitting `null` would
+        // turn a valid request into an invalid one.
+        assert!(!json.contains("all"), "{json}");
         let parsed: RevokeSessionRequest = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.session_id, "sess-abc-123");
+        assert_eq!(parsed.session_id.as_deref(), Some("sess-abc-123"));
+        assert_eq!(parsed.all, None);
     }
 
     #[test]

--- a/vta-service/src/trust_tasks/auth.rs
+++ b/vta-service/src/trust_tasks/auth.rs
@@ -47,13 +47,39 @@ pub(super) async fn handle_revoke_session(
     };
 
     // 2. Look up the session.
-    let session = match get_session(&state.sessions_ks, &req.session_id).await {
+    // `sessionId` XOR `all`, per the specification's `oneOf`. Both arms are
+    // legal documents; only one of them is a thing this VTA can do.
+    let session_id = match (&req.session_id, req.all.unwrap_or(false)) {
+        (Some(id), false) => id.clone(),
+        (None, true) => {
+            return reject_with(
+                &doc,
+                RejectReason::TaskFailed {
+                    reason: "auth:revoke_all_unsupported — this maintainer revokes one named \
+                             session; resend with `sessionId`"
+                        .to_string(),
+                    details: None,
+                },
+            );
+        }
+        // Both or neither: the `oneOf` refuses it, and so does this.
+        _ => {
+            return reject_with(
+                &doc,
+                RejectReason::MalformedRequest {
+                    reason: "revoke-session takes exactly one of `sessionId` or `all`".to_string(),
+                },
+            );
+        }
+    };
+
+    let session = match get_session(&state.sessions_ks, &session_id).await {
         Ok(Some(s)) => s,
         Ok(None) => {
             return reject_with(
                 &doc,
                 RejectReason::TaskFailed {
-                    reason: format!("session not found: {}", req.session_id),
+                    reason: format!("session not found: {session_id}"),
                     details: None,
                 },
             );
@@ -75,7 +101,7 @@ pub(super) async fn handle_revoke_session(
         tracing::warn!(
             caller = %auth.did,
             session_did = %session.did,
-            session_id = %req.session_id,
+            session_id = %session_id,
             "revoke-session rejected: caller is not owner or admin"
         );
         return reject_with(
@@ -87,8 +113,8 @@ pub(super) async fn handle_revoke_session(
     }
 
     // 4. Delete.
-    if let Err(e) = delete_session(&state.sessions_ks, &req.session_id).await {
-        tracing::error!(error = %e, session_id = %req.session_id, "session delete failed");
+    if let Err(e) = delete_session(&state.sessions_ks, &session_id).await {
+        tracing::error!(error = %e, session_id = %session_id, "session delete failed");
         return reject_with(
             &doc,
             RejectReason::InternalError {
@@ -101,12 +127,12 @@ pub(super) async fn handle_revoke_session(
     audit!(
         "session.revoke",
         actor = &auth.did,
-        resource = &req.session_id,
+        resource = &session_id,
         outcome = "success"
     );
     tracing::info!(
         caller = %auth.did,
-        session_id = %req.session_id,
+        session_id = %session_id,
         "session revoked via trust-task"
     );
 

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -535,7 +535,8 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::auth::revoke_session::v0_1::Payload,
                 specs::auth::revoke_session::v0_1::Response,
                 to_v(RevokeSessionRequest {
-                    session_id: "sess-1".into(),
+                    all: None,
+                    session_id: Some("sess-1".into()),
                 }),
                 to_v(RevokeSessionResponse { revoked_count: 1 })
             ),

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -551,6 +551,60 @@ async fn dispatch_trust_task_inner(
 ///
 /// Split from [`dispatch_trust_task_inner`] so the deprecation signal there
 /// wraps every exit path out of this function, not just the last one.
+/// How this consumer's transports map onto the Framework 0.5.0 document
+/// lifecycle.
+///
+/// 0.5.0 adds a normative state table — `received` → `validated` → `accepted` →
+/// {`executing`, `suspended`} → {`responded`, `errored`, `cancelled`,
+/// `expired`} — and requires that **a transport binding map it onto its own
+/// protocol**. The upstream work does that for the five published binding
+/// crates; it does not reach here, because this workspace uses exactly one item
+/// from them (`trust_tasks_https::status_for_code`) and dispatches through its
+/// own spine. So the mapping is written down here, against the code that
+/// actually implements it.
+///
+/// All three transports converge on [`dispatch_trust_task_core`], so the
+/// state machine is **one** implementation with three renderings:
+///
+/// | state | where it happens | what the producer sees |
+/// |---|---|---|
+/// | `received` | the transport hands bytes to the spine | nothing |
+/// | `validated` | `validate_freshness` → `validate_basic` → payload schema | nothing, or a `trust-task-error` |
+/// | `accepted` | the `ReplayGuard` claim succeeds (`Fresh`) | nothing |
+/// | `executing` | the handler runs | nothing |
+/// | `responded` | `success_response` | `<type>#response` |
+/// | `errored` | `reject_with` | `trust-task-error` |
+/// | `expired` | `validate_freshness` / `validate_basic` refuse | `trust-task-error`, code `expired` |
+///
+/// Two states this service does not implement, named so their absence is a
+/// decision rather than an oversight:
+///
+/// - **`suspended`** — there is no `trust-task-control` surface here, so no
+///   document can suspend one in flight. A task runs to a terminal state or
+///   fails.
+/// - **`cancelled`** — nothing stops a task on the consumer's own initiative
+///   once accepted. The nearest thing is a policy refusal, which happens
+///   *before* acceptance and is therefore `errored`, not `cancelled`.
+///
+/// # Silence signifies no state
+///
+/// 0.5.0 settles four contradictory readings of an absent reply on one rule:
+/// **the absence of a reply distinguishes no two states**, and a producer
+/// **MUST NOT** infer any state from it.
+///
+/// This service has one place where silence is emitted deliberately, and it is
+/// conformant: a duplicate whose first execution recorded no response is
+/// answered with `204` ([`dispatch_trust_task_validated`]). That is the
+/// fire-and-forget disposition of §7.2, not a claim about state — and the
+/// in-flight case is `202` precisely so the two are not conflated.
+///
+/// The producer-side rule binds the **SDK**, not the spine: a client must not
+/// read a timeout as failure and reissue a consequential task. That is what
+/// `VtaClient::idempotent` and the delivery layer are for, and it is why
+/// `receive_next` returns `Ok(None)` on timeout — "nothing arrived", not
+/// "nothing happened".
+mod lifecycle_mapping {}
+
 /// How this consumer bounds a Trust Task document in time, and therefore how
 /// long its duplicate-execution record must be kept.
 ///
@@ -2434,6 +2488,81 @@ mod response_coverage {
             json!({ "id": id, "name": id }),
         )
         .await;
+    }
+
+    // The `device/*` family is deliberately NOT covered here. It looks cheap —
+    // register, heartbeat, set-wake, disable — and it is not: `device/register`
+    // refuses a DID that is not already in the ACL ("complete
+    // provision-integration + acl/swap-key first"), so every path behind it
+    // needs a provisioned integration rather than a seeded row. That belongs
+    // with the provision-integration tests.
+
+    /// `all: true` is a legal document, refused as unsupported — not malformed.
+    ///
+    /// `auth/revoke-session/0.1` is `sessionId` **XOR** `all`. This VTA
+    /// implements only the named-session arm, and its request type used to
+    /// require `sessionId`, so a conforming client sending `{"all": true}` got
+    /// `malformedRequest` — which tells the client its *shape* is wrong when
+    /// the shape was fine. An unimplemented option deserves to be named.
+    #[tokio::test]
+    async fn revoke_all_is_refused_as_unsupported_not_malformed() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
+        let body = serde_json::to_vec(&json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": t::TASK_AUTH_REVOKE_SESSION_0_1,
+            "issuer": "did:key:zTestAdmin",
+            "recipient": vta_did,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": { "all": true },
+        }))
+        .expect("envelope");
+        let outcome = super::dispatch_trust_task_core(
+            &state,
+            &crate::test_support::super_admin_claims(),
+            &body,
+            transport::TransportConfidentiality::HopByHop,
+        )
+        .await;
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("a response document");
+        assert_eq!(
+            doc["payload"]["code"], "taskFailed",
+            "a legal document must not be called malformed: {doc}"
+        );
+        assert!(
+            doc["payload"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("revoke_all_unsupported")),
+            "the refusal must name the option it cannot honour: {doc}"
+        );
+    }
+
+    /// Signing paths that derive a key rather than naming a stored one, plus
+    /// the two liveness/session tasks that need no fixture at all.
+    #[tokio::test]
+    async fn derive_and_sign_ping_and_revoke_session() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"coverage");
+
+        // Derive-and-sign never stores the key: it derives, signs and discards,
+        // so there is no `keys/create` to pair it with.
+        ok(
+            &state,
+            t::TASK_KEYS_DERIVE_AND_SIGN_0_1,
+            json!({
+                "keyType": "ed25519",
+                "derivationPath": "m/26'/2'/0'/7'",
+                "payload": payload,
+                "algorithm": "EdDSA",
+            }),
+        )
+        .await;
+
+        ok(&state, t::TASK_MESSAGING_PING_0_1, json!({})).await;
+        // `auth/revoke-session` is not covered for a success response: it needs
+        // a real session row, and `all: true` is a legal document this VTA
+        // refuses by design (it revokes one named session). The refusal path is
+        // asserted in `revoke_all_is_refused_as_unsupported_not_malformed`.
     }
 
     /// The runtime service-management read paths.


### PR DESCRIPTION
Three things that belong to the same release, taken together: the CI cache
class, the last 0.5.0 item VTI owns, and a coverage batch that found a fourth
request-side divergence.

## 1. The stale-`target/` cache class, closed

#1133 fixed the MSRV job after it failed on a commit a clean-room checkout
compiled without complaint. **Six other jobs had the identical bug**: Check,
Test, Clippy, Feature combos, Enclave build, Mobile build.

Every crate here is a **path** dependency, so a source-only change does not move
`Cargo.lock` and therefore does not move a key built from
`hashFiles('**/Cargo.lock')`. The job restores a `target/` built from *other*
source and reuses stale artifacts. The failure then names a field that is
plainly there in the diff, so it reads as the author's bug.

`target/` is dropped from all six. The registry and git caches stay: they are
content-addressed by package version, so a stale entry is impossible by
construction. Each site carries the reason, because the next person to see a
slow job will otherwise put it back.

The direction of risk is worth stating: this causes **false red, not false
green** — git checkout gives fresh mtimes on changed sources, so a stale
artifact cannot hide a real break. It costs time and trust, not correctness.

## 2. The document lifecycle, mapped onto this consumer's transports

0.5.0 adds a normative state table and requires **a transport binding to map it
onto its own protocol**. Upstream
[#294](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/294) does that
for the five published binding crates — and **does not reach this workspace**,
which uses exactly one item from them (`status_for_code`) and dispatches through
its own spine.

So the mapping is written where the code is. All three transports converge on
`dispatch_trust_task_core`, so it is one state machine with three renderings:
`received` at the transport boundary, `validated` across freshness → recipient →
schema, `accepted` at the `ReplayGuard` claim, `responded`/`errored` at
`success_response`/`reject_with`.

**Two states are named as absent rather than left ambiguous.** `suspended`:
there is no `trust-task-control` surface here, so nothing can suspend a task in
flight. `cancelled`: nothing stops a task on the consumer's own initiative once
accepted — a policy refusal happens *before* acceptance and is therefore
`errored`.

On **silence signifies no state**: this service's one deliberate silence is
conformant. A duplicate whose first execution recorded no response is answered
`204`, which is §7.2's fire-and-forget disposition, and the in-flight case is
`202` precisely so the two are not conflated. The producer-side half of that
rule binds the SDK, not the spine — which is why `receive_next` returns
`Ok(None)` on timeout: "nothing arrived", not "nothing happened".

## 3. Coverage 62 → 64, and a fourth request-side divergence

`auth/revoke-session/0.1` is `sessionId` **XOR** `all`. `RevokeSessionRequest`
required `sessionId`, so a conforming client sending `{"all": true}` got
**`malformedRequest`** — telling the client its *shape* is wrong when the shape
was fine.

This VTA implements only the named-session arm. That is a legitimate limit, but
an unimplemented option deserves to be **named as unimplemented**: `all: true`
now parses and is refused with `auth:revoke_all_unsupported`, and "both or
neither" is still malformed because the `oneOf` says so.

Fourth of this class, after `derivationPath` (#1123), `internal` (#1118) and
`enabled` (#1128). All four share a shape a response gate structurally cannot
see: the request never reaches a handler, so nothing about the *response* is
wrong.

Newly covered: `keys/derive-and-sign`, `messaging/ping`, and the refusal path
above.

### Two families that look cheap and are not

Recorded in the tests so the next person does not spend the same afternoon:

- **`device/*`** — `device/register` refuses a DID that is not already in the
  ACL ("complete provision-integration + acl/swap-key first"), so every path
  behind it needs a provisioned integration, not a seeded row.
- **`auth/revoke-session` success** — needs a real session row, and its other
  arm is one this VTA refuses by design.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings` — **exit 0**
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **64/109**
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, 0 failures
- `cargo test -p vta-sdk` — exit 0
- `cargo fmt --all --check` — exit 0

BREAKING CHANGE: `RevokeSessionRequest::session_id` is `Option<String>` and the
type gains `all`. `auth/revoke-session/0.1` with `all: true` is now accepted as
a document and refused as unsupported, rather than rejected as malformed.

Refs #1059
