### PR TITLE
test(vta): cover the webvh family by extending the stub host

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1217,7 +1217,7 @@ pub struct StubWebvhHost {
 impl StubWebvhHost {
     /// Start the stub host on a random loopback port and return once bound.
     pub async fn start() -> StubWebvhHost {
-        use axum::routing::{post, put};
+        use axum::routing::post;
         use serde_json::json;
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1281,6 +1281,89 @@ impl StubWebvhHost {
             )
             .route("/api/auth/", post(tokens))
             .route("/api/auth/refresh", post(tokens))
+            // Agent names live on the *host*, not in the VTA — which is why
+            // every `agent-name/*` task refuses a serverless DID. The host
+            // takes one `update` verb carrying the target state (`bound`,
+            // `parked`, …) rather than a verb per operation, so set / remove /
+            // disable / enable all land here.
+            .route(
+                "/api/agent-names/update",
+                post(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!({ "record": {} })))
+                }),
+            )
+            // `remove` is its own verb, not an `update` state: releasing a name
+            // returns it to the pool, which is a different act from parking it.
+            .route(
+                "/api/agent-names/remove",
+                post(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!({ "record": {} })))
+                }),
+            )
+            .route(
+                "/api/agent-names/check",
+                post(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    // Available and unreserved: the arm a caller checks before
+                    // claiming, and the one whose shape the VTA relays.
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!({
+                        "name": "coverage-agent",
+                        "domain": "webvh-host.test",
+                        "available": true,
+                        "reserved": false,
+                    })))
+                }),
+            )
+            // `GET /api/dids?owner=…` — the host's view of the DIDs it holds
+            // for one owner. `servers/{reconcile,retire-orphan}` both read it
+            // to compare the host's list against the VTA's records.
+            //
+            // Answers with an empty list. That is the interesting case rather
+            // than a lazy one: reconcile's whole job is to report the
+            // difference between two sets, and "the host holds nothing while
+            // the VTA holds records" is the shape that exercises the
+            // *missing-on-host* arm. A stub echoing the VTA's own records back
+            // would only ever prove the empty-difference path.
+            .route(
+                "/api/dids",
+                axum::routing::get(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!([])))
+                }),
+            )
+            // The caller-scoped domain listing. A real `did-hosting-control`
+            // serves this so an operator can discover which tenant domains
+            // their credential may mint into; the VTA proxies it for
+            // `vta/webvh/servers/domains/0.1`. One domain is enough to exercise
+            // the response shape, and `default: true` makes it the one a mint
+            // with no explicit `--domain` resolves to.
+            .route(
+                "/api/me/domains",
+                axum::routing::get(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(
+                        // `name` / `defaultDomain` / `status` / `createdAt`,
+                        // matching `vta_webvh::MyDomainEntry`. Two details a
+                        // stub gets wrong by guessing: `createdAt` is **Unix
+                        // seconds**, not RFC 3339 — the VTA converts when it
+                        // relays into the canonical `DomainEntry`, which does
+                        // want a string — and the canonical shape *requires*
+                        // it, so omitting it fails the relayed schema rather
+                        // than the decode.
+                        json!({
+                            "domains": [{
+                                "name": "webvh-host.test",
+                                "defaultDomain": true,
+                                "status": "active",
+                                "createdAt": 1_767_225_600u64,
+                            }],
+                            "default": "webvh-host.test",
+                        }),
+                    ))
+                }),
+            )
             .route(
                 "/api/dids",
                 post(|headers: axum::http::HeaderMap| async move {
@@ -1319,8 +1402,22 @@ impl StubWebvhHost {
                 }),
             )
             .route(
+                // `GET` answers the DID's record, whose `agentNames` array is
+                // what `agent-name/list` reads. `createdAt` is Unix seconds
+                // here as it is on the domain listing — the wire type has a
+                // custom deserializer for it, which is the tell.
                 "/api/dids/{mnemonic}",
-                put({
+                axum::routing::get(|headers: axum::http::HeaderMap| async move {
+                    require_bearer(&headers)?;
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!({
+                        "agentNames": [{
+                            "name": "coverage-agent",
+                            "enabled": true,
+                            "createdAt": 1_767_225_600u64,
+                        }],
+                    })))
+                })
+                .put({
                     let fail_puts = fail_puts.clone();
                     move |headers: axum::http::HeaderMap| {
                         let fail_puts = fail_puts.clone();

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2565,6 +2565,31 @@ mod response_coverage {
         // asserted in `revoke_all_is_refused_as_unsupported_not_malformed`.
     }
 
+    /// The credential issuance path.
+    ///
+    /// `vta/passkey-vms/*` is deliberately not here: those tasks require a
+    /// **VTA-managed** DID ("DID not found or not VTA-managed"), and this
+    /// fixture's `did:key` signing identity is not one — the same constraint
+    /// that puts `agent-name/*` in the stub-host test. There is also no
+    /// `VtaClient` method for them, so covering them means dispatching raw
+    /// against a minted DID.
+    #[tokio::test]
+    async fn credentials_issue() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        // Needs the VTA's `#key-0`, which this fixture provisions — that is
+        // what `build_signing_test_app_state` is for.
+        ok(
+            &state,
+            t::TASK_VTA_CREDENTIALS_ISSUE_0_1,
+            json!({
+                "holder": "did:key:z6MkCoverageHolder",
+                "claims": { "role": "coverage" },
+                "validitySeconds": 3600,
+            }),
+        )
+        .await;
+    }
+
     /// The runtime service-management read paths.
     ///
     /// Only the reads: `enable`/`update`/`disable`/`rollback` publish a new

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -676,3 +676,128 @@ async fn a_superseded_signing_key_is_recovered_from_the_seed() {
 
     mock.shutdown().await;
 }
+
+/// Response-conformance coverage for the webvh family, against the stub host.
+///
+/// These tasks are not covered by the lib-level `response_coverage` module for
+/// a reason worth stating: **every one of them either reaches a hosting server
+/// or requires a DID that is already hosted.** `agent-name/*` looks local — the
+/// names are local records — but each refuses a serverless DID ("agent names
+/// require a hosted DID"), and a DID seeded straight into the keyspace *is*
+/// serverless. So the whole family needs a real mint against a host, which is
+/// exactly what `MockVta::start_with_webvh_host` provides.
+///
+/// The assertions here are deliberately thin. The response-conformance layer
+/// validates every response these provoke against its published schema, so a
+/// drift shows up as a `500` and fails the call, not as a weak assertion here.
+#[cfg(feature = "webvh")]
+#[tokio::test]
+async fn webvh_family_response_shapes() {
+    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+
+    let mock = MockVta::start_with_webvh_host().await;
+    let token = mock
+        .ctx
+        .mint_token("did:key:z6MkWebvhCoverage", "admin", vec![])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    // A real mint: everything below needs a *hosted* DID, not a seeded record.
+    let minted = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.into()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            add_tsp_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("mint against the stub host");
+    let did = minted.did;
+
+    // ── server surface ────────────────────────────────────────────────────
+    client.list_webvh_servers().await.expect("servers/list");
+    client
+        .list_webvh_server_domains(MockVta::WEBVH_SERVER_ID)
+        .await
+        .expect("servers/domains");
+    client
+        .reconcile_webvh_server_dids(MockVta::WEBVH_SERVER_ID)
+        .await
+        .expect("servers/reconcile");
+
+    // ── agent names ───────────────────────────────────────────────────────
+    // Ordered as an operator would: claim, read back, disable, re-enable, drop.
+    client
+        .set_agent_name(&did, "coverage-agent")
+        .await
+        .expect("agent-name/set");
+    client
+        .check_agent_name(&did, "coverage-agent")
+        .await
+        .expect("agent-name/check");
+    client
+        .list_agent_names(&did)
+        .await
+        .expect("agent-name/list");
+    client
+        .disable_agent_name(&did, "coverage-agent")
+        .await
+        .expect("agent-name/disable");
+    client
+        .enable_agent_name(&did, "coverage-agent")
+        .await
+        .expect("agent-name/enable");
+    client
+        .remove_agent_name(&did, "coverage-agent")
+        .await
+        .expect("agent-name/remove");
+
+    // ── passkey verification methods ──────────────────────────────────────
+    // Same constraint as agent names, for a different reason: these refuse a
+    // DID that is not **VTA-managed**, so the fixture's own `did:key` signing
+    // identity does not qualify and a minted one does. Dispatched raw because
+    // `VtaClient` exposes no method for this family.
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
+            serde_json::json!({ "did": did }),
+            30,
+        )
+        .await
+        .expect("passkey-vms/list");
+    // `enroll-challenge` / `enroll-submit` / `revoke` are not covered: they
+    // answer `unavailable` here because this fixture configures no WebAuthn
+    // relying party, and a challenge with no RP to bind to is not a thing the
+    // service will mint. Covering them means standing up a WebAuthn config and
+    // a soft authenticator, which is what the `admin_passkeys` suites already
+    // do for the VTC side.
+
+    // ── the DID itself ────────────────────────────────────────────────────
+    // Rotate before delete: a rotation on a deleted DID has nothing to rotate,
+    // and delete is terminal.
+    client
+        .rotate_did_webvh_keys_by_did(&did, Default::default())
+        .await
+        .expect("dids/rotate-keys");
+    client.delete_did_webvh(&did).await.expect("dids/delete");
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
Coverage **64 → 76 of 109 (59% → 70%)**. Twelve tasks, almost all of the webvh
family, by extending the stub host rather than by writing more assertions.

## Why these were the hard ones

They were left until last because they looked like they needed a live hosting
server. Most did — and the stub host that already exists
(`MockVta::start_with_webvh_host`) was three endpoints short of covering them.

The non-obvious part is **which** tasks need a host:

- `webvh/servers/*` and the `dids` write paths — obviously.
- **`agent-name/*`** — not obviously. The names are *local* records, so they
  read like cheap local reads. Every one of them refuses a **serverless** DID
  ("agent names require a hosted DID"), and a DID seeded straight into the
  keyspace is serverless. Only a real mint against a host qualifies.
- **`passkey-vms/*`** — same shape, different reason: they refuse a DID that is
  not **VTA-managed**, so the fixture's own `did:key` signing identity does not
  qualify either.

That is why this batch is one test against a minted DID rather than a dozen
small ones.

## Three endpoints added to the stub host

Each was found by running the real client against it and reading what it asked
for. Two of the three had a shape that could not be guessed:

| endpoint | the detail that bites |
|---|---|
| `GET /api/me/domains` | `createdAt` is **Unix seconds**, not RFC 3339 — the VTA converts when relaying into the canonical `DomainEntry`, which does want a string. A string here fails the decode with "error decoding response body". |
| `GET /api/dids` | answers **empty** on purpose: reconcile's job is to report the difference between two sets, so an empty host list exercises the *missing-on-host* arm. A stub echoing the VTA's own records back would only ever prove the empty-difference path. The run logs `host_only=0 agent_only=1`, which is the arm under test. |
| `POST /api/agent-names/{update,remove,check}` | `remove` is its own verb, not an `update` state — releasing a name returns it to the pool, which is a different act from parking it. |

## A note on debugging this after #1130

Every one of these failures arrived as `internalError: the consumer could not
complete this task` — because #1130 stopped `internalError` from carrying its
cause to the wire, which is exactly what Framework 0.5.0 requires.

That is the sanitisation working, and it has a cost: the cause is in the
operator's log, so debugging these meant attaching a subscriber rather than
reading the response. Worth knowing before someone concludes the errors became
useless. They did not move — they moved *audience*.

## Coverage boundaries recorded, not left implicit

Three families stay uncovered with the reason written into the test, so the
next person does not re-derive it:

- `passkey-vms/{enroll-challenge,enroll-submit,revoke}` — answer `unavailable`
  because this fixture configures no WebAuthn relying party. Covering them
  needs an RP and a soft authenticator, which the `admin_passkeys` suites
  already stand up on the VTC side.
- `device/*` — `device/register` refuses a DID not already in the ACL, so the
  family needs a provisioned integration.
- `services/{enable,update,disable,rollback}` — publish a WebVH LogEntry *and*
  run a live DIDComm handshake against the running service.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings` — **exit 0**
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **76/109**
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, 0 failures
- `cargo fmt --all --check` — exit 0

Refs #1059
