### PR TITLE
fix(vta)!: carry ecosystem-local capabilities under ext, not in the closed enum

### DIFF
--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -179,7 +179,7 @@ pub async fn list_devices(
         }
         if let Some(cap) = &payload.capability_filter {
             let want = serde_json::to_value(cap).ok();
-            let have = wire_capabilities(entry);
+            let have = split_capabilities(entry).0;
             if !want.is_some_and(|w| have.contains(&w)) {
                 continue;
             }
@@ -436,6 +436,7 @@ pub fn to_wire_binding(entry: &AclEntry) -> Value {
         .as_ref()
         .expect("to_wire_binding requires entry.device to be Some");
 
+    let (published_caps, local_caps) = split_capabilities(entry);
     let mut out = json!({
         "deviceId": b.device_id,
         "consumerDid": entry.did,
@@ -443,9 +444,18 @@ pub fn to_wire_binding(entry: &AclEntry) -> Value {
         "displayName": b.display_name,
         "registeredAt": b.registered_at,
         "pushCapable": b.push_capable(),
-        "capabilities": wire_capabilities(entry),
+        "capabilities": published_caps,
     });
     let map = out.as_object_mut().expect("json object");
+    if !local_caps.is_empty() {
+        // Reverse-DNS namespaced per SPEC §4.5.1: these are this ecosystem's
+        // capabilities, not the framework's, so they travel in the slot the
+        // framework provides rather than widening its closed enum.
+        map.insert(
+            "ext".into(),
+            json!({ "org.openvtc": { "capabilities": local_caps } }),
+        );
+    }
     if let Some(p) = &b.platform {
         map.insert("platform".into(), json!(p));
     }
@@ -505,20 +515,69 @@ fn kind_to_wire(kind: &ConsumerKind) -> Value {
     }
 }
 
-/// Wire capability list (kebab-case), mirrored from the ACL entry — derived from
-/// the role for legacy entries with no explicit set. Drops the VTA-internal
-/// `sign-trust-task` capability, which is absent from the wire schema's closed
-/// `Capability` enum.
-fn wire_capabilities(entry: &AclEntry) -> Vec<Value> {
+/// Capabilities the published `device/_shared/0.2` `Capability` enum defines.
+///
+/// Listed **positively** so a capability added to this workspace later is
+/// treated as ecosystem-local by default and lands in `ext` rather than
+/// leaking into a closed enum. The previous code filtered out the one local
+/// capability by name; `CredentialWrite` was added afterwards, the filter was
+/// not extended, and it went onto the wire and failed the schema.
+const PUBLISHED_CAPABILITIES: &[Capability] = &[
+    Capability::VaultRead,
+    Capability::VaultWrite,
+    Capability::ProxyLogin,
+    Capability::FillRelease,
+    Capability::PolicyAdmin,
+    Capability::DeviceAdmin,
+    Capability::Sign,
+    Capability::KeyMint,
+];
+
+/// The capabilities an ACL entry confers, split into what the published
+/// `capabilities` member may carry and what belongs under `ext`.
+///
+/// Ecosystem-local capabilities are **carried, not dropped**. SPEC §4.5.1 has
+/// an extension slot for exactly this, and `DeviceBinding` declares one; the
+/// earlier approach silently omitted `sign-trust-task`, which told a reader the
+/// device lacked an authority it actually held. Dropping a capability from a
+/// listing is a safety claim, and it was not a true one.
+fn split_capabilities(entry: &AclEntry) -> (Vec<Value>, Vec<Value>) {
     let caps = if entry.capabilities.is_empty() {
         derived_capabilities_for_role(&entry.role)
     } else {
         entry.capabilities.clone()
     };
-    caps.iter()
-        .filter(|c| !matches!(c, Capability::SignTrustTask))
-        .map(|c| serde_json::to_value(c).expect("Capability serialises"))
-        .collect()
+    let (published, local): (Vec<_>, Vec<_>) = caps
+        .iter()
+        .partition(|c| PUBLISHED_CAPABILITIES.contains(c));
+    let to_value = |c: &Capability| serde_json::to_value(c).expect("Capability serialises");
+    // The published list is re-cased kebab -> camel on the way out by the 0.2
+    // dual-accept layer (`wire_v0_2`), which only knows the members the
+    // specification defines. An `ext` member is invisible to it, so these are
+    // camel-cased here — a document that spelled `deviceAdmin` beside
+    // `sign-trust-task` would be answering in two dialects at once, and
+    // SPEC §4.10 asks for lowerCamelCase either way.
+    let to_camel = |c: &Capability| {
+        let kebab = to_value(c);
+        let s = kebab.as_str().unwrap_or_default();
+        let mut out = String::with_capacity(s.len());
+        let mut upper = false;
+        for ch in s.chars() {
+            match ch {
+                '-' => upper = true,
+                c if upper => {
+                    out.extend(c.to_uppercase());
+                    upper = false;
+                }
+                c => out.push(c),
+            }
+        }
+        Value::String(out)
+    };
+    (
+        published.iter().map(to_value).collect(),
+        local.iter().map(to_camel).collect(),
+    )
 }
 
 #[cfg(test)]
@@ -559,20 +618,26 @@ mod tests {
     }
 
     #[test]
-    fn wire_capabilities_drops_internal_sign_trust_task() {
+    fn local_capabilities_are_split_out_not_dropped() {
         let mut e = entry_with_binding();
         e.capabilities = vec![
             Capability::VaultRead,
             Capability::SignTrustTask,
             Capability::Sign,
         ];
-        let caps = wire_capabilities(&e);
-        let strs: Vec<&str> = caps.iter().map(|c| c.as_str().unwrap()).collect();
-        assert!(strs.contains(&"vault-read"));
-        assert!(strs.contains(&"sign"));
+        let (published, local) = split_capabilities(&e);
+        let p: Vec<&str> = published.iter().map(|c| c.as_str().unwrap()).collect();
+        let l: Vec<&str> = local.iter().map(|c| c.as_str().unwrap()).collect();
+        assert!(p.contains(&"vault-read"), "{p:?}");
+        assert!(p.contains(&"sign"), "{p:?}");
         assert!(
-            !strs.contains(&"sign-trust-task"),
-            "internal-only capability must not leak to the wire: {strs:?}"
+            !p.contains(&"sign-trust-task"),
+            "an ecosystem-local capability must not enter the closed enum: {p:?}"
+        );
+        assert!(
+            l.contains(&"signTrustTask"),
+            "…but it must still be reported, under `ext` — and in lowerCamelCase, \
+             so the document does not answer in two dialects at once: {l:?}"
         );
     }
 

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2565,6 +2565,39 @@ mod response_coverage {
         // asserted in `revoke_all_is_refused_as_unsupported_not_malformed`.
     }
 
+    /// The device family.
+    ///
+    /// `device/register` refuses a DID that holds no ACL entry
+    /// ("noPendingEnrolment — complete provision-integration + acl/swap-key
+    /// first"), which reads as though the whole family needs a provisioned
+    /// integration. It needs one *row*: the entry is the enrolment the device
+    /// is completing, and seeding it is what a swapped-in long-term key leaves
+    /// behind.
+    #[tokio::test]
+    async fn device_lifecycle() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let claims = crate::test_support::super_admin_claims();
+        crate::test_support::seed_acl_entry(
+            &state.acl_ks,
+            &claims.did,
+            crate::acl::Role::Admin,
+            vec![],
+        )
+        .await;
+
+        ok(
+            &state,
+            t::TASK_DEVICE_REGISTER_0_2,
+            json!({
+                "consumerKind": { "kind": "companion", "formFactor": "mobile" },
+                "displayName": "Coverage Phone",
+            }),
+        )
+        .await;
+        ok(&state, t::TASK_DEVICE_HEARTBEAT_0_2, json!({})).await;
+        ok(&state, t::TASK_DEVICE_SET_WAKE_0_2, json!({})).await;
+    }
+
     /// The credential issuance path.
     ///
     /// `vta/passkey-vms/*` is deliberately not here: those tasks require a

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -783,12 +783,28 @@ async fn webvh_family_response_shapes() {
         )
         .await
         .expect("passkey-vms/list");
-    // `enroll-challenge` / `enroll-submit` / `revoke` are not covered: they
-    // answer `unavailable` here because this fixture configures no WebAuthn
-    // relying party, and a challenge with no RP to bind to is not a thing the
-    // service will mint. Covering them means standing up a WebAuthn config and
-    // a soft authenticator, which is what the `admin_passkeys` suites already
-    // do for the VTC side.
+    // `enroll-challenge` needs `public_url`, not a WebAuthn relying party as
+    // first assumed: the RP is *derived* from the VTA's public origin
+    // (`require_public_url` → `build_webauthn`), and this fixture leaves it
+    // unset, so the task answers `unavailable`. Setting the origin is the whole
+    // prerequisite.
+    {
+        let mut cfg = mock.ctx.config.write().await;
+        cfg.public_url = Some("https://vta.test".into());
+    }
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_PASSKEY_VMS_ENROLL_CHALLENGE_0_1,
+            serde_json::json!({ "did": did, "label": "coverage-key" }),
+            30,
+        )
+        .await
+        .expect("passkey-vms/enroll-challenge");
+
+    // `enroll-submit` and `revoke` stay uncovered: submit needs a real
+    // authenticator attestation over the challenge above, and revoke needs an
+    // enrolled VM to remove. Both want the soft-authenticator harness the
+    // `admin_passkeys` suites stand up on the VTC side.
 
     // ── the DID itself ────────────────────────────────────────────────────
     // Rotate before delete: a rotation on a deleted DID has nothing to rotate,


### PR DESCRIPTION
Coverage **76 → 77 of 109**, and a real conformance defect found by covering
the device family — plus two blockers that turned out not to be blockers.

## The defect: an ecosystem-local capability leaked into a closed enum

`device/register/0.2` put `credentialWrite` in the response's `capabilities`
array. The published `Capability` enum does not have it, so the response failed
its own schema.

The interesting part is that **this was already known and half-fixed**. There
was a filter dropping `sign-trust-task` with a comment saying it is "absent from
the wire schema's closed `Capability` enum". `CredentialWrite` was added later
(the vault-credential lifecycle), the filter was not extended, and it went
straight out.

### Fixed by carrying them, not dropping them

Dropping is what the old filter did, and it is lossy in the direction that
matters: omitting a capability from a listing is a **safety claim**, and it was
not a true one — the device held `sign-trust-task` and the response said it did
not.

SPEC §4.5.1 has an extension slot for exactly this, and `DeviceBinding`
declares one. Both local capabilities now travel under
`ext["org.openvtc"].capabilities`, so a reader sees the device's real authority
and the closed enum stays closed.

**No upstream change.** Widening the framework's vocabulary with two
ecosystem-specific concepts would be the wrong fix even if it were cheaper:
that enum is closed on purpose, and `ext` is the mechanism the specification
provides for precisely this.

### The filter is now positive, not negative

`PUBLISHED_CAPABILITIES` lists what the published enum defines, and anything
else is treated as local. A capability added to this workspace tomorrow lands
in `ext` by default rather than leaking — which is the exact failure mode that
produced this bug, one variant at a time.

### Casing

The local values are camel-cased at the source. `wire_v0_2` re-cases enum
values kebab→camel for the 0.2 wire, but only at **declared enum field paths**
— an `ext` member is invisible to it. Without this the response would answer
`deviceAdmin` beside `sign-trust-task`, in two dialects at once.

## Two "blockers" that were not

Both were recorded in earlier PRs as needing heavy fixtures. Both were one line:

- **`passkey-vms/enroll-challenge`** — I recorded this as needing a WebAuthn
  relying party. It needs **`public_url`**: the RP is *derived* from the VTA's
  public origin (`require_public_url` → `build_webauthn`), and the fixture left
  it unset. Setting the origin is the whole prerequisite.
- **`device/*`** — recorded as needing a provisioned integration, because
  `register` refuses a DID with no ACL entry ("complete provision-integration +
  acl/swap-key first"). It needs one **row**: the entry *is* the enrolment the
  device is completing, and seeding it is what a swapped-in long-term key leaves
  behind.

Worth stating plainly because I wrote both of those notes: a refusal message
that names a *procedure* ("complete provision-integration first") reads as
needing the whole procedure, when what it needs is that procedure's residue.

## Newly covered

`device/{register,heartbeat,set-wake}` (on the non-deprecated `0.2` URIs),
`passkey-vms/enroll-challenge`.

Still uncovered, with the reason in the test: `passkey-vms/{enroll-submit,
revoke}` need a real authenticator attestation over the challenge, and the
`services` write paths need a live DIDComm handshake.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings` — **exit 0**
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **77/109**
- `cargo test -p vtc-service --no-fail-fast` — 54 suites, 0 failures
- `cargo fmt --all --check` — exit 0

BREAKING CHANGE: `device/register` and the other device responses carry
`credentialWrite` / `signTrustTask` under `ext["org.openvtc"].capabilities`
instead of omitting them (`signTrustTask`) or emitting them in the closed
`capabilities` enum (`credentialWrite`).

Refs #1059
