### PR TITLE
fix(vta)!: refuse a swap-key without linkProof by name, not as malformed

### DIFF
--- a/vta-sdk/src/protocols/acl_management/swap.rs
+++ b/vta-sdk/src/protocols/acl_management/swap.rs
@@ -46,9 +46,20 @@ pub struct SwapKeyBody {
     /// The VID being swapped in — MUST equal the `iss` of `link_proof`.
     pub new_subject: String,
     /// Compact Ed25519 JWS (VP-JWT) signed by `new_subject` proving consent
-    /// to take over `current_subject`'s ACL entry. The spec marks this
-    /// optional at the framework level, but the FPN deployment policy requires it.
-    pub link_proof: String,
+    /// to take over `current_subject`'s ACL entry.
+    ///
+    /// Optional on the wire, required by this deployment's policy — which is
+    /// exactly the split `acl/swap-key/0.1` describes: "required by some
+    /// maintainers … Producers omit this when the consumer's policy doesn't
+    /// require it."
+    ///
+    /// It was a bare `String` here, so a conforming producer that omitted it
+    /// got `malformedRequest` — "your document is the wrong shape" — when the
+    /// shape was right and the *policy* wanted more. The handler now refuses it
+    /// by name instead. The security posture is unchanged: a swap without a
+    /// proof of possession is still refused.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link_proof: Option<String>,
     /// Optional human-readable rationale recorded in the audit log.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -690,8 +690,16 @@ pub async fn handle_swap_acl(
                 body.current_subject, auth.did
             )));
         }
+        // Same policy as the Trust Task path: optional at the framework level,
+        // required here, and refused by name rather than as a parse failure.
+        let Some(link_proof) = body.link_proof else {
+            return Err(handler_err(
+                "acl:link_proof_required — this maintainer requires a `linkProof` proving \
+                 the new subject consents to the takeover",
+            ));
+        };
         (
-            body.link_proof,
+            link_proof,
             Some(body.new_subject),
             Some(body.current_subject),
         )

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -237,6 +237,22 @@ pub(super) async fn handle_swap_key(
         Err(resp) => return resp,
     };
 
+    // `linkProof` is optional at the framework level and required by this
+    // deployment. Refused by name rather than as a parse failure: the document
+    // is well-formed, and telling a producer its shape is wrong sends it to
+    // re-read the schema, which will agree with the producer.
+    let Some(link_proof) = req.link_proof.clone() else {
+        return reject_with(
+            &doc,
+            RejectReason::TaskFailed {
+                reason: "acl:link_proof_required — this maintainer requires a `linkProof` \
+                         proving the new subject consents to the takeover"
+                    .to_string(),
+                details: None,
+            },
+        );
+    };
+
     // The authenticated caller must equal the declared currentSubject — stops a
     // sender from claiming to rotate someone else's entry.
     if req.current_subject != auth.did {
@@ -282,7 +298,7 @@ pub(super) async fn handle_swap_key(
         &state.acl_ks,
         &state.audit_sink,
         auth,
-        &req.link_proof,
+        &link_proof,
         did_resolver,
         &vta_did,
         TRANSPORT_TRUST_TASK,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -827,7 +827,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(SwapKeyBody {
                     current_subject: SUBJECT.into(),
                     new_subject: "did:key:z6MkNewSubject".into(),
-                    link_proof: "eyJhbGciOiJFZERTQSJ9.e30.c2ln".into(),
+                    link_proof: Some("eyJhbGciOiJFZERTQSJ9.e30.c2ln".into()),
                     reason: Some("wallet rotation".into()),
                 }),
                 to_v(SwapKeyResultBody {

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -2565,6 +2565,96 @@ mod response_coverage {
         // asserted in `revoke_all_is_refused_as_unsupported_not_malformed`.
     }
 
+    /// Issue then revoke, chained: revoke needs an id only an issue produces.
+    #[tokio::test]
+    async fn credentials_issue_then_revoke() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let issued = ok(
+            &state,
+            t::TASK_VTA_CREDENTIALS_ISSUE_0_1,
+            json!({
+                "holder": "did:key:z6MkCoverageHolder",
+                "claims": { "role": "coverage" },
+                "validitySeconds": 3600,
+            }),
+        )
+        .await;
+        let id = issued["credentialId"]
+            .as_str()
+            .or_else(|| issued["credential"]["id"].as_str())
+            .unwrap_or_else(|| panic!("issue must name the credential: {issued}"))
+            .to_owned();
+        ok(
+            &state,
+            t::TASK_VTA_CREDENTIALS_REVOKE_0_1,
+            json!({ "credentialId": id, "reason": "coverage" }),
+        )
+        .await;
+    }
+
+    /// A context's DID can be repointed after creation.
+    #[tokio::test]
+    async fn contexts_update_did() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        a_context(&state, "cov-update-did").await;
+        ok(
+            &state,
+            t::TASK_CONTEXTS_UPDATE_DID_1_0,
+            json!({ "id": "cov-update-did", "did": "did:key:z6MkCovContextDid" }),
+        )
+        .await;
+    }
+
+    /// A swap with no `linkProof` names the policy, rather than calling a
+    /// well-formed document malformed.
+    ///
+    /// `acl/swap-key/0.1` makes `linkProof` optional — "required by some
+    /// maintainers … Producers omit this when the consumer's policy doesn't
+    /// require it." This deployment requires it, which is exactly the split the
+    /// specification describes; what was wrong was the answer. A producer that
+    /// omitted it got `malformedRequest`, sending it to re-read a schema that
+    /// would agree with it.
+    ///
+    /// The success path is not covered: it needs a real VP-JWT signed by the
+    /// new subject, and `currentSubject` must equal the authenticated caller,
+    /// so it wants a second keypair and a signing ceremony.
+    #[tokio::test]
+    async fn swap_key_without_a_link_proof_names_the_policy() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let claims = crate::test_support::super_admin_claims();
+        let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
+        let body = serde_json::to_vec(&json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": t::TASK_ACL_SWAP_KEY_0_1,
+            "issuer": "did:key:zTestAdmin",
+            "recipient": vta_did,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": {
+                "currentSubject": claims.did,
+                "newSubject": "did:key:z6MkCovNewSubject",
+            },
+        }))
+        .expect("envelope");
+        let outcome = super::dispatch_trust_task_core(
+            &state,
+            &claims,
+            &body,
+            transport::TransportConfidentiality::HopByHop,
+        )
+        .await;
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("a response document");
+        assert_eq!(
+            doc["payload"]["code"], "taskFailed",
+            "a document the schema accepts must not be called malformed: {doc}"
+        );
+        assert!(
+            doc["payload"]["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("link_proof_required")),
+            "the refusal must name what this maintainer wants: {doc}"
+        );
+    }
+
     /// The device family.
     ///
     /// `device/register` refuses a DID that holds no ACL entry
@@ -2596,31 +2686,6 @@ mod response_coverage {
         .await;
         ok(&state, t::TASK_DEVICE_HEARTBEAT_0_2, json!({})).await;
         ok(&state, t::TASK_DEVICE_SET_WAKE_0_2, json!({})).await;
-    }
-
-    /// The credential issuance path.
-    ///
-    /// `vta/passkey-vms/*` is deliberately not here: those tasks require a
-    /// **VTA-managed** DID ("DID not found or not VTA-managed"), and this
-    /// fixture's `did:key` signing identity is not one — the same constraint
-    /// that puts `agent-name/*` in the stub-host test. There is also no
-    /// `VtaClient` method for them, so covering them means dispatching raw
-    /// against a minted DID.
-    #[tokio::test]
-    async fn credentials_issue() {
-        let (state, _dir) = build_signing_test_app_state().await;
-        // Needs the VTA's `#key-0`, which this fixture provisions — that is
-        // what `build_signing_test_app_state` is for.
-        ok(
-            &state,
-            t::TASK_VTA_CREDENTIALS_ISSUE_0_1,
-            json!({
-                "holder": "did:key:z6MkCoverageHolder",
-                "claims": { "role": "coverage" },
-                "validitySeconds": 3600,
-            }),
-        )
-        .await;
     }
 
     /// The runtime service-management read paths.


### PR DESCRIPTION
Coverage **77 → 79 of 109**, and a **fifth** request-side divergence — the same
shape as the four before it, and the second one that turned out to be a *good
policy reported with the wrong code*.

## `acl/swap-key`: right policy, wrong answer

`SwapKeyBody::link_proof` was a bare `String`, so a producer that omitted it got
`malformedRequest`.

The schema makes it optional, and says why:

> Cryptographic evidence — **required by some maintainers** — that the new VID
> consents to taking over. … Producers omit this when the consumer's policy
> doesn't require it.

So this deployment requiring it is **exactly the split the specification
describes**, and the existing comment already said so: "The spec marks this
optional at the framework level, but the FPN deployment policy requires it."

What was wrong is the *answer*. `malformedRequest` tells a producer its document
is the wrong shape, sending it to re-read a schema that will agree with the
producer. It now parses and is refused with `acl:link_proof_required`, naming
what this maintainer wants.

**The security posture is unchanged** — a swap with no proof of possession is
still refused, on both the Trust Task and DIDComm paths.

That is the second of these (after `auth/revoke-session`'s `all` in #1134) where
the service's behaviour was right and only the reporting was wrong. Worth
separating from the other three (`derivationPath`, `internal`, `enabled`), which
were plain bugs.

## Also covered

- `vta/credentials/{issue,revoke}` — chained, because revoke needs an id only an
  issue produces.
- `vta/contexts/update-did`.

## What is asserted, and what is not

`swap_key_without_a_link_proof_names_the_policy` covers the **refusal**, not the
success. The success path needs a real VP-JWT signed by the new subject *and*
`currentSubject` equal to the authenticated caller — a second keypair and a
signing ceremony. Recorded in the test so it is a known cost rather than an
oversight.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings` — **exit 0**
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **79/109**
- `cargo test -p vtc-service --no-fail-fast` — exit 0
- `cargo fmt --all --check` — exit 0

BREAKING CHANGE: `SwapKeyBody::link_proof` is `Option<String>`. An
`acl/swap-key` request without one is refused as `taskFailed` /
`acl:link_proof_required` instead of `malformedRequest`; it is still refused.

Refs #1059
