### PR TITLE
fix(vta): say which fact refused a retire-orphan, and cover the slot paths

### DIFF
--- a/vta-service/src/operations/did_webvh/servers.rs
+++ b/vta-service/src/operations/did_webvh/servers.rs
@@ -587,10 +587,28 @@ impl RetireOrphanRefusal {
 
     pub fn message(&self) -> String {
         match self {
-            Self::NotOrphaned { slot_id, .. } => format!(
-                "slot `{slot_id}` has a record in this VTA, so it is not an orphan. \
+            // Two different facts reach this variant, and they want opposite
+            // next actions. `did: Some` means the VTA still controls the slot —
+            // delete it properly. `did: None` means the slot is not in the
+            // host's own listing at all, so there is nothing to retire and the
+            // caller's report was about some other server or is long stale.
+            //
+            // The message used to assert the first for both, telling an
+            // operator "slot X has a record in this VTA" about a slot the VTA
+            // has never heard of — and pointing them at `dids/delete` for a DID
+            // that does not exist.
+            Self::NotOrphaned {
+                slot_id,
+                did: Some(did),
+            } => format!(
+                "slot `{slot_id}` still serves {did} in this VTA, so it is not an orphan. \
                  retire-orphan applies only to slots this VTA has no record of — \
                  use `webvh/dids/delete` for one it still controls."
+            ),
+            Self::NotOrphaned { slot_id, did: None } => format!(
+                "slot `{slot_id}` is not in this server's listing, so there is nothing \
+                 to retire. Re-run reconcile: the report naming it was for another \
+                 server, or the slot has since been released."
             ),
             Self::DidMismatch {
                 slot_id, actual, ..

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1320,17 +1320,25 @@ impl StubWebvhHost {
             // for one owner. `servers/{reconcile,retire-orphan}` both read it
             // to compare the host's list against the VTA's records.
             //
-            // Answers with an empty list. That is the interesting case rather
-            // than a lazy one: reconcile's whole job is to report the
-            // difference between two sets, and "the host holds nothing while
-            // the VTA holds records" is the shape that exercises the
-            // *missing-on-host* arm. A stub echoing the VTA's own records back
-            // would only ever prove the empty-difference path.
+            // Answers with one slot the VTA has **no** record of. Reconcile's
+            // job is to report the difference between two sets, so this makes
+            // both arms non-empty at once: the slot below is `host_only`, and
+            // the DID the test mints is `agent_only`. An empty list would prove
+            // only one arm, and a list echoing the VTA's own records would
+            // prove neither.
+            //
+            // It is also what makes `servers/retire-orphan` reachable — a slot
+            // is retireable precisely when it is host-only.
             .route(
                 "/api/dids",
                 axum::routing::get(|headers: axum::http::HeaderMap| async move {
                     require_bearer(&headers)?;
-                    Ok::<_, axum::http::StatusCode>(axum::Json(json!([])))
+                    Ok::<_, axum::http::StatusCode>(axum::Json(json!([{
+                        "mnemonic": "cov-orphan-slot",
+                        "domain": "webvh-host.test",
+                        "disabled": false,
+                        "updatedAt": 1_767_225_600u64,
+                    }])))
                 }),
             )
             // The caller-scoped domain listing. A real `did-hosting-control`

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -806,6 +806,30 @@ async fn webvh_family_response_shapes() {
     // enrolled VM to remove. Both want the soft-authenticator harness the
     // `admin_passkeys` suites stand up on the VTC side.
 
+    // ── server slot maintenance ───────────────────────────────────────────
+    // A slot the host holds with no local record behind it. `reconcile` above
+    // reports these; `retire-orphan` is how an operator clears one, so covering
+    // them together follows the operator's actual sequence.
+    client
+        .retire_orphan_slot(
+            &vta_sdk::protocols::did_management::servers::RetireOrphanSlotBody {
+                server_id: MockVta::WEBVH_SERVER_ID.into(),
+                // A slot this VTA has no record of — which is what "orphan"
+                // means. The minted DID's own slot is deliberately not used:
+                // the task refuses it, and correctly, pointing the caller at
+                // `webvh/dids/delete` for a slot it still controls.
+                slot_id: "cov-orphan-slot".into(),
+                // `None`: this stub reports no host-only slots, so there is no
+                // DID the caller "believes the slot serves". The member exists
+                // to turn a stale reconcile report into a refusal rather than a
+                // surprise, which needs a report to have been stale.
+                expected_did: None,
+                reason: Some("coverage".into()),
+            },
+        )
+        .await
+        .expect("servers/retire-orphan");
+
     // ── the DID itself ────────────────────────────────────────────────────
     // Rotate before delete: a rotation on a deleted DID has nothing to rotate,
     // and delete is terminal.
@@ -814,6 +838,13 @@ async fn webvh_family_response_shapes() {
         .await
         .expect("dids/rotate-keys");
     client.delete_did_webvh(&did).await.expect("dids/delete");
+
+    // Last: removing the server registration invalidates every path above it,
+    // so an operator does this once nothing depends on it.
+    client
+        .remove_webvh_server(MockVta::WEBVH_SERVER_ID)
+        .await
+        .expect("servers/remove");
 
     mock.shutdown().await;
 }


### PR DESCRIPTION
Coverage **79 → 81 of 109**, and a misleading refusal message fixed — found,
again, by trying to make a task succeed.

## A refusal that asserted the opposite of the truth

`servers/retire-orphan` refuses a slot it cannot confirm is orphaned. Two very
different facts reach the same `NotOrphaned` variant, and its message asserted
one of them for both:

```
slot `X` has a record in this VTA, so it is not an orphan.
use `webvh/dids/delete` for one it still controls.
```

The variant already carries `did: Option<String>`, which distinguishes them:

- **`Some`** — the VTA still controls the slot. The message is right, and
  `dids/delete` is the correct next action.
- **`None`** — the slot is not in the host's listing at all. The VTA has never
  heard of it, so the message told the operator "slot X has a record in this
  VTA" about a slot it has no record of, and pointed them at `dids/delete` for a
  DID that does not exist.

Both now say what actually happened, and name different next actions: delete it,
or re-run reconcile because the report was for another server or has gone stale.

The `did: Option` was there the whole time; only the message ignored it.

## The stub host now reports a host-only slot

Previously it answered `GET /api/dids` with an empty list, deliberately, to
exercise reconcile's *missing-on-host* arm. It now answers with **one slot the
VTA has no record of**, which is strictly better:

- `host_only` — that slot;
- `agent_only` — the DID the test mints.

Both arms non-empty in one call, where an empty list proved one and a list
echoing the VTA's own records would prove neither.

It is also what makes `retire-orphan` reachable at all: **a slot is retireable
precisely when it is host-only**, so there was no way to cover the success path
while the host claimed to hold nothing.

## Newly covered

`vta/webvh/servers/{retire-orphan,remove}`.

`remove` runs last, after `dids/delete` — removing the server registration
invalidates every path above it, so the test follows the order an operator
actually uses rather than a convenient one.

## Gates

- `cargo clippy --workspace --all-targets --features vta-service/test-support -- -D warnings` — **exit 0**
- `./scripts/trust-task-coverage.sh` — 28 suites, **0 violations**, coverage **81/109**
- `cargo test -p vtc-service --no-fail-fast` — exit 0
- `cargo fmt --all --check` — exit 0

Refs #1059
