### PR TITLE
fix(consent): stop dropping the approver's label, and make revoke idempotent

### DIFF
--- a/vta-sdk/src/client/consent.rs
+++ b/vta-sdk/src/client/consent.rs
@@ -27,21 +27,15 @@ impl VtaClient {
     /// agent. Default-deny: if no live grant exists, a pending consent is minted
     /// for an approver. `scope` is `"receive"` or `"converse"`. `challenge` (≥128
     /// bits) is echoed by the matching decision.
-    pub async fn consent_request(
-        &self,
-        subject: Value,
-        scope: &str,
-        challenge: &str,
-        display_hint: Option<&str>,
-        context_hint: Option<&str>,
-    ) -> Result<Value, VtaError> {
-        let payload = serde_json::to_value(ConsentRequestBody {
-            subject,
-            scope: scope.to_string(),
-            challenge: challenge.to_string(),
-            display_hint: display_hint.map(str::to_string),
-            context_hint: context_hint.map(str::to_string),
-        })?;
+    ///
+    /// Takes the body rather than positional arguments. The schema declares
+    /// three optional members and two of them are hints, so the positional form
+    /// was four `Option<&str>` in a row with `displayHint` and `contextHint`
+    /// adjacent and interchangeable to the compiler — and it had to break every
+    /// time the schema grew another optional member. Named fields cost the
+    /// caller one `..Default::default()` and settle both.
+    pub async fn consent_request(&self, body: &ConsentRequestBody) -> Result<Value, VtaError> {
+        let payload = serde_json::to_value(body)?;
         self.dispatch_trust_task(
             trust_tasks::TASK_CONSENT_REQUEST_1_0,
             payload,

--- a/vta-sdk/src/protocols/consent_management.rs
+++ b/vta-sdk/src/protocols/consent_management.rs
@@ -19,7 +19,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// `consent/request/1.0` — ask whether an inbound conversation may reach an agent.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Default` is for the three optional members: `subject`, `scope` and
+/// `challenge` are required by the schema, so a defaulted value of this struct
+/// is not a valid payload — build it as `ConsentRequestBody { subject, scope,
+/// challenge, ..Default::default() }`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsentRequestBody {
     pub subject: Value,
@@ -27,8 +32,14 @@ pub struct ConsentRequestBody {
     pub scope: String,
     /// base64url nonce, `minLength` 16 — echoed by the matching decision.
     pub challenge: String,
+    /// Operator-facing label for the approval prompt (e.g. `Signal group
+    /// 'Family'`). MUST NOT carry a raw platform address.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_hint: Option<String>,
+    /// Multibase multihash over the JCS canonicalization of the held first
+    /// message, binding the request to concrete content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_message_digest: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_hint: Option<String>,
 }
@@ -115,8 +126,8 @@ mod tests {
         );
     }
 
-    /// A request with neither hint carries neither member — the shape
-    /// `consent_request(subject, scope, challenge, None, None)` emits.
+    /// A request with no optional member set carries none of them — the
+    /// required trio and nothing else.
     #[test]
     fn an_unset_hint_is_absent_from_a_request() {
         let body = ConsentRequestBody {
@@ -128,13 +139,37 @@ mod tests {
             }),
             scope: "converse".into(),
             challenge: "Y2hhbGxlbmdlLW5vbmNlLTEyOA".into(),
-            display_hint: None,
-            context_hint: None,
+            ..Default::default()
         };
         let v = serde_json::to_value(&body).expect("serialises");
         assert!(v.get("displayHint").is_none());
+        assert!(v.get("firstMessageDigest").is_none());
         assert!(v.get("contextHint").is_none());
         assert_eq!(v.as_object().expect("object").len(), 3);
+    }
+
+    /// …and every optional member reaches the wire under its camelCase name
+    /// when set. `firstMessageDigest` is the one this was added for: the VTA
+    /// dropped it and the SDK could not send it, so nothing in the stack named
+    /// it and nothing failed.
+    #[test]
+    fn a_request_carries_every_optional_member_when_set() {
+        let body = ConsentRequestBody {
+            subject: serde_json::json!({"platform": "signal"}),
+            scope: "converse".into(),
+            challenge: "Y2hhbGxlbmdlLW5vbmNlLTEyOA".into(),
+            display_hint: Some("Signal group 'Family'".into()),
+            first_message_digest: Some("zQmSK9pGKFnmc77pqyNAPJyPKt8rMqctngfg3vwuMArwGYZ".into()),
+            context_hint: Some("ctx-a".into()),
+        };
+        let v = serde_json::to_value(&body).expect("serialises");
+        assert_eq!(v["displayHint"], "Signal group 'Family'");
+        assert_eq!(
+            v["firstMessageDigest"],
+            "zQmSK9pGKFnmc77pqyNAPJyPKt8rMqctngfg3vwuMArwGYZ"
+        );
+        assert_eq!(v["contextHint"], "ctx-a");
+        assert_eq!(v.as_object().expect("object").len(), 6);
     }
 
     /// Set members reach the wire under their canonical camelCase names — the

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -606,15 +606,19 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::consent::request::v1_0::Payload,
                 specs::consent::request::v1_0::Response,
-                // Neither hint set — the shape
-                // `consent_request(subject, scope, challenge, None, None)`
-                // emits, and the one that leaves both optionals to the skip.
+                // Every optional member set. The witness used to leave both
+                // hints `None`, which serialized them away — so the fixture
+                // proved the required trio and nothing about the optional
+                // members' encoding. `firstMessageDigest` in particular is a
+                // `DigestMultibase`, and an omitted member cannot fail its
+                // pattern.
                 to_v(ConsentRequestBody {
                     subject: consent_subject_json(),
                     scope: "converse".into(),
                     challenge: "chal-0123456789abcdef".into(),
-                    display_hint: None,
-                    context_hint: None,
+                    display_hint: Some("Slack DM".into()),
+                    first_message_digest: Some(DIGEST_MULTIBASE.into()),
+                    context_hint: Some("ctx-a".into()),
                 }),
                 json!({ "status": "accepted", "requestId": "chal-1" })
             ),

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -78,6 +78,18 @@ struct RequestPayload {
     subject: WireSubject,
     scope: ConsentScope,
     challenge: String,
+    /// Operator-facing label for the approval prompt ("Signal group 'Family'").
+    /// The bridge sends it precisely because `conversationRef` is an opaque
+    /// handle by design — without this the approver is asked to decide about
+    /// `sig-1a2b3c4d`.
+    #[serde(default)]
+    display_hint: Option<String>,
+    /// Multibase multihash over the JCS canonicalization of the held first
+    /// message. The VTA never sees the message, so it cannot check the digest;
+    /// carrying it is the whole job — it binds the prompt the approver answered
+    /// to concrete content, for the bridge to check and the audit trail to keep.
+    #[serde(default)]
+    first_message_digest: Option<String>,
     #[serde(default)]
     context_hint: Option<String>,
 }
@@ -293,6 +305,8 @@ pub(super) async fn handle_request(
 
     // Snapshot the prompt subject (camelCase) before `subject` is moved.
     let wire_subject = serde_json::to_value(WireSubject::from(&subject)).unwrap_or_default();
+    let display_hint = payload.display_hint.clone();
+    let first_message_digest = payload.first_message_digest.clone();
 
     let pending = new_pending_consent(
         subject,
@@ -316,6 +330,8 @@ pub(super) async fn handle_request(
             wire_subject,
             payload.scope,
             &payload.challenge,
+            display_hint.as_deref(),
+            first_message_digest.as_deref(),
         )
         .await;
     }
@@ -342,12 +358,15 @@ const CONSENT_APPROVE_REQUEST_TYPE: &str =
 /// and ring the push-gateway doorbell. Best-effort; mirrors the step-up wake
 /// path (`maybe_push_step_up` + `trigger_gateway_wake`).
 #[cfg(feature = "didcomm")]
+#[allow(clippy::too_many_arguments)]
 async fn maybe_wake_consent_approver(
     state: &AppState,
     approver: &str,
     subject: Value,
     scope: ConsentScope,
     challenge: &str,
+    display_hint: Option<&str>,
+    first_message_digest: Option<&str>,
 ) {
     let mediator_did = {
         let cfg = state.config.read().await;
@@ -375,11 +394,25 @@ async fn maybe_wake_consent_approver(
     // already relies on.
     #[cfg(feature = "webvh")]
     {
+        // Built member-by-member so an unset hint is *absent*, not `null`.
+        // `json!` with an `Option` writes the null, and the approver's renderer
+        // has to tell "no label supplied" from "the label is null" — only the
+        // first is a thing that can happen.
+        let mut prompt_payload = serde_json::Map::new();
+        prompt_payload.insert("subject".into(), subject);
+        prompt_payload.insert("scope".into(), serde_json::json!(scope));
+        prompt_payload.insert("challenge".into(), serde_json::json!(challenge));
+        if let Some(h) = display_hint {
+            prompt_payload.insert("displayHint".into(), serde_json::json!(h));
+        }
+        if let Some(d) = first_message_digest {
+            prompt_payload.insert("firstMessageDigest".into(), serde_json::json!(d));
+        }
         let approve_request = serde_json::json!({
             "id": format!("urn:uuid:{}", Uuid::new_v4()),
             "type": CONSENT_APPROVE_REQUEST_TYPE,
             "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": { "subject": subject, "scope": scope, "challenge": challenge },
+            "payload": prompt_payload,
         });
         let pending = crate::messaging::registry::PendingResponse {
             recipient_did: approver.to_string(),
@@ -413,18 +446,27 @@ async fn maybe_wake_consent_approver(
         }
     }
     #[cfg(not(feature = "webvh"))]
-    let _ = (&subject, &scope, challenge);
+    let _ = (
+        &subject,
+        &scope,
+        challenge,
+        display_hint,
+        first_message_digest,
+    );
 
     super::step_up::trigger_gateway_wake(state, approver, &mediator_did).await;
 }
 
 #[cfg(not(feature = "didcomm"))]
+#[allow(clippy::too_many_arguments)]
 async fn maybe_wake_consent_approver(
     _state: &AppState,
     _approver: &str,
     _subject: Value,
     _scope: ConsentScope,
     _challenge: &str,
+    _display_hint: Option<&str>,
+    _first_message_digest: Option<&str>,
 ) {
 }
 
@@ -556,12 +598,29 @@ pub(super) async fn handle_revoke(
     };
     let _ = &payload.reason;
     let subject: ConsentSubject = payload.subject.into();
+    // No grant → `notFound` as a *status*, not a reject. The published response
+    // schema declares the value ("`revoked` = the grant was deleted.
+    // `notFound` = no grant existed for the subject."), so a conforming
+    // producer is already written to receive it, and rejecting instead means
+    // the VTA can never emit a value its own schema promises.
+    //
+    // It is also the answer the caller wants. Revoke's post-condition is
+    // "no grant for this subject", and with none stored that already holds:
+    // the conversation is at default-deny either way. An operator revoking
+    // twice, or racing another operator to the same grant, would otherwise get
+    // an error for the outcome they asked for. The `consent/revoke:notFound`
+    // error code stays declared upstream for a consumer that cannot answer at
+    // all; it is not this case.
     match get_consent_grant(&state.consent_ks, &subject).await {
         Ok(Some(_)) => {}
         Ok(None) => {
-            return app_error_to_reject(
+            return success_response(
                 &doc,
-                AppError::NotFound("consent/revoke: no grant for subject".into()),
+                AckResponse {
+                    status: "notFound",
+                    request_id: None,
+                    grant_id: None,
+                },
             );
         }
         Err(e) => return app_error_to_reject(&doc, e),
@@ -812,6 +871,8 @@ mod envelope_push_tests {
             subject,
             ConsentScope::Converse,
             "challenge-xyz",
+            Some("Signal group 'Family'"),
+            None,
         )
         .await;
 
@@ -832,6 +893,19 @@ mod envelope_push_tests {
             pushed[0].body["payload"]["challenge"].as_str(),
             Some("challenge-xyz"),
             "the challenge the approver signs against must survive the re-wrap"
+        );
+        assert_eq!(
+            pushed[0].body["payload"]["displayHint"].as_str(),
+            Some("Signal group 'Family'"),
+            "the operator-facing label is the point of the prompt: without it \
+             the approver is asked to decide about an opaque conversationRef"
+        );
+        assert!(
+            !pushed[0].body["payload"]
+                .as_object()
+                .expect("prompt payload is an object")
+                .contains_key("firstMessageDigest"),
+            "an unset hint is absent, not null"
         );
     }
 }

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -819,10 +819,11 @@ async fn webvh_family_response_shapes() {
                 // the task refuses it, and correctly, pointing the caller at
                 // `webvh/dids/delete` for a slot it still controls.
                 slot_id: "cov-orphan-slot".into(),
-                // `None`: this stub reports no host-only slots, so there is no
-                // DID the caller "believes the slot serves". The member exists
-                // to turn a stale reconcile report into a refusal rather than a
-                // surprise, which needs a report to have been stale.
+                // `None`: the caller retires the slot on the strength of the
+                // reconcile report alone. Setting it asserts "I believe this
+                // slot serves <did>", which turns a stale report into a
+                // refusal rather than a surprise — a guard worth its own test,
+                // not worth spending the happy path on.
                 expected_did: None,
                 reason: Some("coverage".into()),
             },
@@ -845,6 +846,142 @@ async fn webvh_family_response_shapes() {
         .remove_webvh_server(MockVta::WEBVH_SERVER_ID)
         .await
         .expect("servers/remove");
+
+    mock.shutdown().await;
+}
+
+/// The `consent/*` family, driven as the ceremony it is: bind an approver, ask,
+/// decide, read back, withdraw.
+///
+/// The order is the point. `consent/request` is default-deny and resolves an
+/// approver for the (platform, context) before it will mint anything, so
+/// `approver-set` is not setup for this test — it is the step that makes the
+/// rest of the family reachable at all. Running the six in isolation would
+/// prove six shapes; running them in sequence proves the gate.
+#[tokio::test]
+async fn consent_family_response_shapes() {
+    use vta_sdk::client::VtaClient;
+    use vta_sdk::protocols::consent_management::ConsentRequestBody;
+
+    const PLATFORM: &str = "signal";
+    const CONTEXT: &str = "ctx1";
+    const OPERATOR: &str = "did:key:z6MkConsentOperator";
+    // base64url, ≥128 bits per the schema's `minLength` 16.
+    const CHALLENGE: &str = "Y29uc2VudC1jb3ZlcmFnZS0xMjhi";
+
+    let mock = MockVta::start().await;
+    // One context, not the unrestricted admin: `consent/request` falls back to
+    // `default_context()` when the caller sends no `contextHint`, and that
+    // returns `Some` only for a caller with *exactly* one allowed context. An
+    // admin minted with `vec![]` has unrestricted access and no default, so the
+    // fallback this test exercises would be dead.
+    let token = mock
+        .ctx
+        .mint_token(OPERATOR, "admin", vec![CONTEXT.to_string()])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    let subject = serde_json::json!({
+        "platform": PLATFORM,
+        "conversationRef": "sig-cov-1a2b3c4d",
+        "kind": "group",
+        "agent": "did:key:z6MkConsentAgent",
+    });
+
+    // ── the approver must exist before anything can be asked ──────────────
+    client
+        .consent_approver_set(PLATFORM, CONTEXT, OPERATOR, Some("bridge-relay"), None)
+        .await
+        .expect("consent/approver-set");
+    let listed = client
+        .consent_approver_list(Some(PLATFORM), Some(CONTEXT))
+        .await
+        .expect("consent/approver-list");
+    assert_eq!(
+        listed["approvers"].as_array().map(Vec::len),
+        Some(1),
+        "the binding just written must come back through the filter that names it"
+    );
+
+    // ── ask ───────────────────────────────────────────────────────────────
+    // No `contextHint`: the approver resolves through `default_context()`.
+    let asked = client
+        .consent_request(&ConsentRequestBody {
+            subject: subject.clone(),
+            scope: "converse".into(),
+            challenge: CHALLENGE.into(),
+            display_hint: Some("Signal group 'Coverage'".into()),
+            first_message_digest: None,
+            context_hint: None,
+        })
+        .await
+        .expect("consent/request");
+    assert_eq!(asked["status"], "accepted");
+    assert_eq!(
+        asked["requestId"], CHALLENGE,
+        "the request id a bridge correlates on is the challenge it sent"
+    );
+
+    // ── decide ────────────────────────────────────────────────────────────
+    let decided = client
+        .consent_decision(
+            subject.clone(),
+            "allow",
+            Some("converse"),
+            Some(CHALLENGE),
+            None,
+        )
+        .await
+        .expect("consent/decision");
+    assert_eq!(decided["status"], "recorded");
+
+    // Asking again now short-circuits on the live grant rather than minting a
+    // second pending consent — the branch that stops a bridge re-prompting an
+    // operator who has already answered.
+    let again = client
+        .consent_request(&ConsentRequestBody {
+            subject: subject.clone(),
+            scope: "converse".into(),
+            challenge: "Y29uc2VudC1jb3ZlcmFnZS1hZ2Fpbg".into(),
+            display_hint: None,
+            first_message_digest: None,
+            context_hint: None,
+        })
+        .await
+        .expect("consent/request (already decided)");
+    assert_eq!(again["requestId"], "existing-grant");
+
+    // ── read back ─────────────────────────────────────────────────────────
+    let grants = client
+        .consent_list(None, Some(PLATFORM), None)
+        .await
+        .expect("consent/list");
+    assert_eq!(grants["grants"].as_array().map(Vec::len), Some(1));
+
+    // ── withdraw, and prove it took ───────────────────────────────────────
+    client
+        .consent_revoke(subject.clone(), Some("coverage"))
+        .await
+        .expect("consent/revoke");
+    let after = client
+        .consent_list(None, Some(PLATFORM), None)
+        .await
+        .expect("consent/list after revoke");
+    assert_eq!(
+        after["grants"].as_array().map(Vec::len),
+        Some(0),
+        "revoke must return the subject to default-deny, not merely report success"
+    );
+
+    // Revoking again is `notFound` as a *status*, not a reject: the published
+    // response schema declares the value, and the post-condition the caller
+    // asked for already holds.
+    let twice = client
+        .consent_revoke(subject, None)
+        .await
+        .expect("consent/revoke is idempotent");
+    assert_eq!(twice["status"], "notFound");
 
     mock.shutdown().await;
 }

--- a/vta-service/tests/producer_payload_conformance.rs
+++ b/vta-service/tests/producer_payload_conformance.rs
@@ -208,8 +208,23 @@ async fn every_optional_argument_unset_still_builds_a_conforming_payload() {
     assert_conforms(
         &captured(|c| async move {
             drop(
-                c.consent_request(s, "converse", CHALLENGE, None, None)
-                    .await,
+                c.consent_request(
+                    &vta_sdk::protocols::consent_management::ConsentRequestBody {
+                        subject: s,
+                        scope: "converse".into(),
+                        challenge: CHALLENGE.into(),
+                        // Every optional member set: this suite checks what the
+                        // producer *emits*, and a member left `None` is skipped
+                        // before it reaches the schema. Populated, it is the only
+                        // place `firstMessageDigest` gets its encoding checked.
+                        display_hint: Some("Signal group 'Family'".into()),
+                        first_message_digest: Some(
+                            "zQmSK9pGKFnmc77pqyNAPJyPKt8rMqctngfg3vwuMArwGYZ".into(),
+                        ),
+                        context_hint: Some("ctx-a".into()),
+                    },
+                )
+                .await,
             )
         })
         .await,


### PR DESCRIPTION
Coverage **81 → 87 of 109 (74% → 80%)** — the whole `consent/*` family — and three divergences from the published schemas that covering it turned up.

## The approval prompt lost its label

`consent/request/1.0` declares `displayHint`: the operator-facing name for the conversation (`"Signal group 'Family'"`), sent precisely because `conversationRef` is an opaque handle *by design* — the spec says it "MUST NOT contain a raw platform address".

The SDK sent it. The VTA's `RequestPayload` had no field for it, so serde dropped it on the floor, and the wake prompt built for the approver carried `{subject, scope, challenge}`. An approver was being asked to allow or deny `sig-1a2b3c4d`.

Nothing failed. That is why it lasted: the member was optional, the payload had no `deny_unknown_fields`, and the response gate only ever sees responses.

## `firstMessageDigest` existed only in the schema

Declared on the same payload, absent from `ConsentRequestBody` and from the VTA's `RequestPayload` — no part of the stack could send it, store it, or name it. It binds the prompt the approver answered to concrete content.

The VTA never sees the message, so carrying it *is* the implementation: the bridge computes and checks the digest, the VTA records what the approver was shown.

## `consent/revoke` could never emit a status its own schema promises

The published response schema declares:

```json
"status": { "enum": ["revoked", "notFound"],
  "description": "`revoked` = the grant was deleted. `notFound` = no grant existed for the subject." }
```

The VTA returned `AppError::NotFound` — a reject — so a conforming producer written to receive `notFound` never could.

It is also the answer the caller wants. Revoke's post-condition is *"no grant for this subject"*, and with none stored that already holds: the conversation is at default-deny either way. An operator revoking twice, or racing another operator to the same grant, got an error for the outcome they asked for.

The spec declares `notFound` **both** ways — as a response status and as an error code. They are not equivalent, and the status is the coherent reading. The `consent/revoke:notFound` error code stays declared upstream for a consumer that cannot answer at all; it is not this case. No upstream change needed — this is the VTA catching up to what is already published.

## `consent_request` takes its body

The schema declares three optional members and two of them are hints, so the positional form was four `Option<&str>` in a row with `displayHint` and `contextHint` adjacent and interchangeable to the compiler. It also had to break every time the schema grew an optional member — as it just did. One caller.

## Witnesses now set every optional member

Both conformance fixtures for the request left the hints `None`, which serializes them away — so they proved the required trio and nothing about the optional members' encoding. `firstMessageDigest` is a `DigestMultibase` with a real pattern, and an omitted member cannot fail it.

## The test is a ceremony, not six shapes

`approver-set` is not setup for this test — `consent/request` is default-deny and resolves an approver for the (platform, context) before it mints anything, so it is the step that makes the rest of the family reachable. Running the six in sequence proves the gate; running them in isolation would prove six shapes.

The caller is minted with **exactly one** context on purpose: the no-`contextHint` path falls back to `default_context()`, which answers `Some` only for a caller with exactly one allowed context. An admin minted with `vec![]` has unrestricted access and no default, which would leave that fallback dead.

Revoke is then called twice — once to prove the grant is gone from `consent/list` (not merely that the call reported success), once to prove the second is `notFound` rather than an error.

## Also here

- A stale comment from #1138: the retire-orphan block said "this stub reports no host-only slots" after that same PR changed the stub to report exactly one.

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `TRUST-TASK RESPONSE COVERAGE 87/109 (80%)` — 22 never exercised, down from 28
- `cargo clippy --workspace --all-targets` (CI's combination): exit 0
- `cargo fmt --all --check`: exit 0
- `vtc-service`: unchanged by this PR, green

## Unrelated, found while verifying

`cargo clippy -p vta-sdk --all-features --all-targets` fails on `main` with 5 errors in `tests/provision_client_e2e.rs` — `ProvisionIntegrationRequest.request` became `serde_json::Value` (correctly: holding it typed re-rendered a document the holder had signed, with this crate's casing) and that test was never updated. It is gated on `provision-client` + `test-support`, neither default, and CI runs `--all-targets` without `--all-features`, so nothing compiles it. Follow-up PR.

Refs #1059
