### PR TITLE
fix(sdk): compile the one test file nothing in CI ever compiled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -737,6 +737,28 @@ jobs:
       - name: vta-sdk client + sealed-transfer + provision-integration
         run: cargo check -p vta-sdk --features client,sealed-transfer,provision-integration
 
+      # The *maximal* combination. Every step above narrows the feature set;
+      # nothing built the top end, and `clippy`/`check` elsewhere in this
+      # workflow run `--all-targets` without `--all-features`. So a target
+      # gated on two non-default features was never compiled by anything:
+      # `vta-sdk/tests/provision_client_e2e.rs` (`provision-client` +
+      # `test-support`) sat uncompilable for as long as it took
+      # `ProvisionIntegrationRequest.request` to become a `serde_json::Value`.
+      #
+      # Compiling it is not enough — the same file's auth mock still handed out
+      # a 14-char challenge against a `minLength: 16` payload, a *runtime*
+      # failure that the identical fixture in `runner_rest.rs`'s unit tests had
+      # already been fixed for. So this runs the tests too.
+      - name: workspace all-features (lint)
+        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+      # `-p vta-sdk`, not the workspace: `vtc-service`'s
+      # `*_without_feature_is_config_error` tests assert the error you get when
+      # a secrets backend is *not* compiled in, so `--all-features` is the one
+      # build where they cannot pass. That is the tests being right about the
+      # feature, not a combination worth fixing.
+      - name: vta-sdk all-features (test)
+        run: cargo test -p vta-sdk --all-features
+
       # Every step above only *compiles*. The setup wizard's scripted-prompt
       # tests are the one place where a feature flag changes behaviour rather
       # than just what compiles: each secrets backend adds an option to the

--- a/vta-sdk/tests/provision_client_e2e.rs
+++ b/vta-sdk/tests/provision_client_e2e.rs
@@ -57,6 +57,22 @@ struct SealResponder {
     producer_did: String,
 }
 
+/// Read a required string member out of the raw bootstrap-request JSON.
+///
+/// `ProvisionIntegrationRequest.request` is a `serde_json::Value`, not a typed
+/// `BootstrapRequest`, and deliberately so: a relayer is usually not the holder
+/// — the air-gap flow exists precisely because it isn't — so holding it typed
+/// meant re-rendering, with this crate's casing, a document some other process
+/// signed. This fake reads it the way a real VTA does, out of the bytes that
+/// arrived.
+fn req_str(request: &serde_json::Value, member: &str) -> String {
+    request
+        .get(member)
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("bootstrap request carries a string `{member}`"))
+        .to_string()
+}
+
 impl Respond for SealResponder {
     fn respond(&self, request: &Request) -> ResponseTemplate {
         let req: ProvisionIntegrationRequest =
@@ -66,7 +82,9 @@ impl Respond for SealResponder {
         let nonce: [u8; 16] = {
             use base64::Engine;
             use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
-            let raw = B64URL.decode(&req.request.nonce).expect("nonce b64");
+            let raw = B64URL
+                .decode(req_str(&req.request, "nonce"))
+                .expect("nonce b64");
             raw.try_into().expect("nonce 16 bytes")
         };
 
@@ -166,9 +184,9 @@ impl Respond for SealResponder {
             bundle: armored,
             digest,
             summary: ProvisionSummary {
-                client_did: req.request.holder.clone(),
+                client_did: req_str(&req.request, "holder"),
                 admin_did: self.admin_did.clone(),
-                admin_rolled_over: req.request.holder != self.admin_did,
+                admin_rolled_over: req_str(&req.request, "holder") != self.admin_did,
                 integration_did: Some(self.integration_did.clone()),
                 template_name: Some(self.template_name.clone()),
                 template_kind: Some(self.template_kind.clone()),
@@ -205,11 +223,22 @@ fn x25519_pub_from_setup_seed(seed: &[u8; 32]) -> [u8; 32] {
         .expect("ed25519 → x25519 pubkey conversion")
 }
 
+/// A challenge that satisfies the spec payload's `minLength: 16` — the
+/// canonical handler issues hex-encoded 32 random bytes.
+///
+/// The same 14-char `"test-challenge"` fixture was corrected in
+/// `runner_rest.rs`'s unit tests when the client stopped hand-writing its auth
+/// payload and started building the typed spec type. This file was missed, and
+/// stayed missed because it is gated on `provision-client` + `test-support` —
+/// neither default — and CI runs `--all-targets` without `--all-features`, so
+/// nothing ever compiled it to find out.
+const TEST_CHALLENGE: &str = "test-challenge-0123456789abcdef";
+
 async fn mount_auth_mocks(server: &MockServer) {
     Mock::given(method("POST"))
         .and(path("/auth/challenge"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "challenge": "test-challenge",
+            "challenge": TEST_CHALLENGE,
             "sessionId": "test-session",
             "expiresAt": "2099-12-31T23:59:59Z"
         })))
@@ -363,7 +392,9 @@ impl Respond for AdminRotationResponder {
         let nonce: [u8; 16] = {
             use base64::Engine;
             use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64URL;
-            let raw = B64URL.decode(&req.request.nonce).expect("nonce b64");
+            let raw = B64URL
+                .decode(req_str(&req.request, "nonce"))
+                .expect("nonce b64");
             raw.try_into().expect("nonce 16 bytes")
         };
 
@@ -429,7 +460,7 @@ impl Respond for AdminRotationResponder {
             bundle: armored,
             digest,
             summary: ProvisionSummary {
-                client_did: req.request.holder.clone(),
+                client_did: req_str(&req.request, "holder"),
                 admin_did: self.admin_did.clone(),
                 admin_rolled_over: true,
                 integration_did: None,


### PR DESCRIPTION
`vta-sdk/tests/provision_client_e2e.rs` did not build, and had not for a while.

## Five compile errors

`ProvisionIntegrationRequest.request` became a `serde_json::Value` — correctly, and the field's own doc says why:

> Holding it typed meant serialising this struct re-rendered that document with this crate's casing, and the maintainer verified bytes the holder never signed.

This file still reached through it for `.nonce` and `.holder`. It now reads them out of the JSON that arrived, the way a real VTA does.

## Three runtime failures, hiding behind them

Making it compile is what found the actual bug. Three of its five tests fail:

```
WorkflowFailed("… invalid auth payload: challenge: shorter than 16 characters")
```

The auth mock hands out `"test-challenge"` — 14 characters — against a payload whose spec type enforces `minLength: 16`. That exact fixture was **already corrected** in `runner_rest.rs`'s unit tests when the client stopped hand-writing its auth payload JSON and started building the typed spec type; there's a comment there saying so. This file was missed, and stayed missed.

## Why it stayed missed

Nothing compiles it.

- the file is gated on `provision-client` + `test-support`, neither default
- the `clippy` job runs `--all-targets` **without** `--all-features`
- the `features` job runs a dozen combinations — every one of them a *narrowing* (`--no-default-features --features …`)

Nothing built the top end, so a target needing two non-default features sat outside every gate in the workflow.

## The gate

Two steps in the `features` job, not one — linting the maximal combination would have caught the five compile errors, but only running the tests catches the challenge:

```yaml
- name: workspace all-features (lint)
  run: cargo clippy --workspace --all-features --all-targets -- -D warnings
- name: vta-sdk all-features (test)
  run: cargo test -p vta-sdk --all-features
```

`-p vta-sdk` for the test step rather than the workspace, deliberately: `vtc-service`'s `*_without_feature_is_config_error` tests assert the error you get when a secrets backend is *not* compiled in, so `--all-features` is the one build where they cannot pass. That is the tests being right about the feature, not a combination worth fixing.

## Verification

- `cargo test -p vta-sdk --all-features --test provision_client_e2e`: **5 passed, 0 failed** (was 2 passed, 3 failed, and before that: did not compile)
- `cargo test -p vta-sdk --all-features`: 0 failed
- `cargo clippy --workspace --all-features --all-targets`: exit 0 — the new gate passes on the tree it gates
- `cargo fmt --all --check`: exit 0

Found while verifying #1139; unrelated to it.
