### PR TITLE
fix(auth): stop revoke-session telling a stranger the session exists

### DIFF
--- a/vta-service/src/trust_tasks/auth.rs
+++ b/vta-service/src/trust_tasks/auth.rs
@@ -21,13 +21,34 @@ use super::helpers::{app_error_to_reject, reject_with, success_response};
 
 /// Handler for `spec/vta/auth/revoke-session/1.0`.
 ///
-/// Parses the request payload, looks up the session, authorises the
-/// caller (session owner OR `Role::Admin`), deletes the session, and
-/// returns a `#response`-typed success document with an empty body.
+/// Parses the request payload, looks up the session, authorises the caller
+/// (session owner OR `Role::Admin`), deletes the session, and answers with
+/// `revokedCount` — the number of sessions this call invalidated.
 ///
-/// Mirrors `routes::auth::revoke_session` (the legacy
-/// `DELETE /auth/sessions/{session_id}` REST handler) — same audit
-/// event key (`session.revoke`), same authorisation rule.
+/// **`revokedCount: 0` is a success, and it is deliberately ambiguous.** The
+/// spec asks for both things at once. The response schema says "Zero is a valid
+/// outcome (e.g. the named sessionId was already revoked)" and the prose adds
+/// that producers "SHOULD treat zero as 'the post-state is what you asked for',
+/// not as an error" — so a retry of a revoke that already happened must
+/// succeed. `vta-sdk`'s own `retry_safety` table agrees: this task is
+/// `RetrySafe`. Separately, the `notOwner` error code carries "The auth service
+/// MUST NOT reveal whether the session exists at all when the producer is not
+/// its owner."
+///
+/// Those two only hold together if a session the caller may not touch and a
+/// session that is not there answer identically. So both return zero, and this
+/// handler never emits `notOwner`: emitting it *only* when the session exists
+/// is exactly the disclosure the code's own definition forbids. The count stays
+/// literally true either way — zero sessions were invalidated by this call. The
+/// refusal is still recorded in the audit trail, which is not the caller's to
+/// read.
+///
+/// This diverges from `routes::auth::revoke_session` (the legacy
+/// `DELETE /auth/sessions/{session_id}` REST handler), which 404s on a missing
+/// session. That is the conventional REST answer for a missing resource and is
+/// in its published OpenAPI responses; it is not governed by this task's
+/// `revokedCount` schema. Same audit event key (`session.revoke`), same
+/// authorisation rule.
 pub(super) async fn handle_revoke_session(
     state: &AppState,
     auth: &AuthClaims,
@@ -74,16 +95,7 @@ pub(super) async fn handle_revoke_session(
     };
 
     let session = match get_session(&state.sessions_ks, &session_id).await {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            return reject_with(
-                &doc,
-                RejectReason::TaskFailed {
-                    reason: format!("session not found: {session_id}"),
-                    details: None,
-                },
-            );
-        }
+        Ok(s) => s,
         Err(e) => {
             tracing::error!(error = %e, "session lookup failed in revoke-session");
             return reject_with(
@@ -95,21 +107,29 @@ pub(super) async fn handle_revoke_session(
         }
     };
 
-    // 3. Authorise: caller owns the session OR has Role::Admin. Same
-    //    rule as the legacy REST handler.
-    if session.did != auth.did && auth.role != Role::Admin {
+    // 3. Authorise: caller owns the session OR has Role::Admin. Same rule as
+    //    the legacy REST handler. A session that is not the caller's and a
+    //    session that does not exist take the same arm, so the caller cannot
+    //    tell them apart — see this function's doc comment.
+    if session
+        .filter(|s| s.did == auth.did || auth.role == Role::Admin)
+        .is_none()
+    {
+        // Warn, not reject. The operator reading logs is entitled to know a
+        // caller reached for a session; the caller is not entitled to know
+        // whether it was there.
         tracing::warn!(
             caller = %auth.did,
-            session_did = %session.did,
             session_id = %session_id,
-            "revoke-session rejected: caller is not owner or admin"
+            "revoke-session: no session revoked (absent, or not the caller's)"
         );
-        return reject_with(
-            &doc,
-            RejectReason::PermissionDenied {
-                reason: "cannot revoke another user's session".to_string(),
-            },
+        audit!(
+            "session.revoke",
+            actor = &auth.did,
+            resource = &session_id,
+            outcome = "no-op"
         );
+        return success_response(&doc, RevokeSessionResponse { revoked_count: 0 });
     }
 
     // 4. Delete.
@@ -136,8 +156,8 @@ pub(super) async fn handle_revoke_session(
         "session revoked via trust-task"
     );
 
-    // 6. Build the success response document. Canonical `revokedCount` is 1:
-    // this handler revokes exactly the one named session.
+    // 6. Build the success response document. `revokedCount` is 1: this handler
+    // revokes exactly the one named session.
     success_response(&doc, RevokeSessionResponse { revoked_count: 1 })
 }
 

--- a/vta-service/tests/revoke_session_trust_task.rs
+++ b/vta-service/tests/revoke_session_trust_task.rs
@@ -1,0 +1,209 @@
+//! Integration test for `auth/revoke-session/0.1` — signing a session out over
+//! the trust-task dispatcher (bearer-authed).
+//!
+//! The interesting behaviour is not the happy path; it is what the caller is
+//! told when nothing is revoked. The spec pulls in two directions at once:
+//! `revokedCount: 0` is a documented success ("the named sessionId was already
+//! revoked", and producers "SHOULD treat zero as 'the post-state is what you
+//! asked for', not as an error"), while the `notOwner` error code carries "The
+//! auth service MUST NOT reveal whether the session exists at all when the
+//! producer is not its owner."
+//!
+//! Both hold only if a session that is not there and a session that is not
+//! yours answer identically. These tests pin that: same status, same payload,
+//! byte for byte.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use vta_service::test_support::{TestAppContext, build_test_app};
+use vti_common::auth::session::{Session, SessionState, get_session, now_epoch, store_session};
+
+const CALLER: &str = "did:key:z6MkRevokeCaller";
+const STRANGER: &str = "did:key:z6MkRevokeStranger";
+
+async fn seed_session(ctx: &TestAppContext, session_id: &str, did: &str) {
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        last_seen: now_epoch(),
+        refresh_token: Some(format!("rt-{session_id}")),
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into()],
+        acr: "aal1".into(),
+        acr_expires_at: None,
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+}
+
+/// Dispatch a `revoke-session` for `target`, authenticated as `CALLER` on
+/// `caller_session` with `role`. Returns `(status, response document)`.
+async fn revoke(
+    router: &axum::Router,
+    ctx: &TestAppContext,
+    caller_session: &str,
+    role: &str,
+    target: &str,
+    doc_id: &str,
+) -> (StatusCode, Value) {
+    let claims = ctx.jwt_keys.new_claims(
+        CALLER.into(),
+        caller_session.into(),
+        role.into(),
+        vec![],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+    let doc = json!({
+        "id": format!("urn:uuid:{doc_id}"),
+        "type": "https://trusttasks.org/spec/auth/revoke-session/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "issuer": CALLER,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": { "sessionId": target },
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// The happy path, and then the retry of it.
+#[tokio::test]
+async fn revoking_own_session_counts_one_then_zero() {
+    let (router, ctx) = build_test_app().await;
+    seed_session(&ctx, "sess-here", CALLER).await;
+    seed_session(&ctx, "sess-other-device", CALLER).await;
+
+    let (status, v) = revoke(
+        &router,
+        &ctx,
+        "sess-here",
+        "reader",
+        "sess-other-device",
+        "revoke-1",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["payload"]["revokedCount"], 1, "{v}");
+    assert!(
+        get_session(&ctx.sessions_ks, "sess-other-device")
+            .await
+            .unwrap()
+            .is_none(),
+        "the session must actually be gone, not merely reported gone"
+    );
+
+    // The retry. `vta-sdk`'s `retry_safety` table calls this task `RetrySafe`,
+    // and the response schema names this exact case — "Zero is a valid outcome
+    // (e.g. the named sessionId was already revoked)". It used to reject.
+    let (status, v) = revoke(
+        &router,
+        &ctx,
+        "sess-here",
+        "reader",
+        "sess-other-device",
+        "revoke-2",
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a retried revoke is not an error: {v}"
+    );
+    assert_eq!(v["payload"]["revokedCount"], 0, "{v}");
+}
+
+/// The disclosure rule, which is the whole reason zero is ambiguous: a session
+/// belonging to someone else must be indistinguishable from one that was never
+/// there.
+#[tokio::test]
+async fn a_stranger_session_and_a_missing_one_answer_identically() {
+    let (router, ctx) = build_test_app().await;
+    seed_session(&ctx, "sess-here", CALLER).await;
+    seed_session(&ctx, "sess-not-yours", STRANGER).await;
+
+    let (exists_status, exists) = revoke(
+        &router,
+        &ctx,
+        "sess-here",
+        "reader",
+        "sess-not-yours",
+        "revoke-3",
+    )
+    .await;
+    let (absent_status, absent) = revoke(
+        &router,
+        &ctx,
+        "sess-here",
+        "reader",
+        "sess-never-existed",
+        "revoke-4",
+    )
+    .await;
+
+    assert_eq!(exists_status, absent_status, "status must not disclose");
+    assert_eq!(
+        exists["payload"], absent["payload"],
+        "payload must not disclose: a caller who is not the owner learns \
+         nothing about whether the session exists"
+    );
+    assert_eq!(exists["payload"]["revokedCount"], 0, "{exists}");
+
+    // And the stranger's session is untouched — non-disclosure is not a licence
+    // to revoke it.
+    assert!(
+        get_session(&ctx.sessions_ks, "sess-not-yours")
+            .await
+            .unwrap()
+            .is_some(),
+        "answering zero must not have deleted a session the caller cannot touch"
+    );
+}
+
+/// An admin does reach another subject's session — the authorisation rule is
+/// unchanged, only what a *refusal* discloses.
+#[tokio::test]
+async fn an_admin_revokes_another_subjects_session() {
+    let (router, ctx) = build_test_app().await;
+    seed_session(&ctx, "sess-here", CALLER).await;
+    seed_session(&ctx, "sess-not-yours", STRANGER).await;
+
+    let (status, v) = revoke(
+        &router,
+        &ctx,
+        "sess-here",
+        "admin",
+        "sess-not-yours",
+        "revoke-5",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+    assert_eq!(v["payload"]["revokedCount"], 1, "{v}");
+    assert!(
+        get_session(&ctx.sessions_ks, "sess-not-yours")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}


### PR DESCRIPTION
Coverage **87 → 88 of 109 (81%)**, and a disclosure the spec forbids in as many words.

## Three answers where there should be one

`auth/revoke-session/0.1` distinguished, to any bearer-token holder:

| target | old answer |
|---|---|
| your own session | `revokedCount: 1` |
| **someone else's session** | reject — `PermissionDenied` |
| **no such session** | reject — `TaskFailed "session not found: {id}"` |

The bottom two are different, so session ids were enumerable: send a revoke, and which refusal comes back tells you whether the session exists.

The `notOwner` error code says so in its own definition:

> The named `sessionId` exists but belongs to a different subject than the producer. **The auth service MUST NOT reveal whether the session exists at all when the producer is not its owner.**

## And it wasn't retry-safe, though this repo said it was

Three sources agree that zero is a success:

- the response schema — *"Number of sessions invalidated by this call. Zero is a valid outcome (e.g. the named sessionId was already revoked)."*
- the prose — *"Producers SHOULD treat zero as 'the post-state is what you asked for', not as an error."*
- `vta-sdk/src/retry_safety.rs` — `(TASK_AUTH_REVOKE_SESSION_0_1, RetrySafe)`

The handler rejected. So the SDK's own retry table promised something the VTA made false: retry a revoke that already landed and you got `TaskFailed`.

## One answer

Both rules hold together only if "not yours" and "not there" answer identically. Both now return `revokedCount: 0`, which is literally true either way — zero sessions were invalidated by this call.

This handler therefore never emits `notOwner`. Emitting it *only* when the session exists is exactly the disclosure the code's own definition forbids, and an error code is a registry entry, not an obligation.

**Non-disclosure is not a licence to act.** A session the caller cannot touch is left alone — the test asserts it is still there afterwards. The refusal is recorded in the audit trail (`outcome = "no-op"`) and a `warn!` line, neither of which the caller can read. The authorisation rule is unchanged: owner or admin, and an admin still reaches another subject's session.

## What is deliberately *not* changed

`routes::auth::revoke_session` — the legacy `DELETE /auth/sessions/{session_id}` REST handler — keeps its 404. That is the conventional answer for a missing resource, it is in the route's published OpenAPI `responses`, and it is not governed by this task's `revokedCount` schema. The trust-task handler's doc comment now says why the two differ.

## Tests

New `vta-service/tests/revoke_session_trust_task.rs`, three cases:

- **`revoking_own_session_counts_one_then_zero`** — happy path, and the retry. Also asserts the session is *actually* gone, not merely reported gone.
- **`a_stranger_session_and_a_missing_one_answer_identically`** — the disclosure rule: same status, same payload. And the stranger's session survives.
- **`an_admin_revokes_another_subjects_session`** — the authorisation rule still works; only what a *refusal* discloses has changed.

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `TRUST-TASK RESPONSE COVERAGE 88/109 (81%)`
- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo fmt --all --check`: exit 0

Refs #1059
