### PR TITLE
fix(sdk): point session_store's stubs at the binding the SDK actually calls

### DIFF
--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -13,6 +13,14 @@
 //!   3. **Network paths** — `login` / `ensure_authenticated` /
 //!      `rotate_key` against a `wiremock` server, using `did:key` DIDs
 //!      so TDK's resolver doesn't need outbound DNS.
+//!
+//! The layer-3 stubs serve `POST /trust-tasks` — the Trust-Task HTTPS binding —
+//! and answer with a `#response` document whose `payload` is what the client
+//! returns. They used to serve bespoke REST routes (`GET /config`,
+//! `GET|POST|DELETE /acl…`), which the SDK no longer calls. Nothing caught the
+//! drift because nothing compiled this file: it is gated on `session` +
+//! `test-support`, and no CI step built that pair until one was added for
+//! exactly this class of rot.
 
 #![cfg(all(feature = "session", feature = "test-support"))]
 
@@ -437,26 +445,15 @@ async fn ensure_authenticated_runs_full_rotation_flow() {
     let (temp_did, temp_pk) = did_key_from_seed(0x10);
     let (vta_did, _) = did_key_from_seed(0x20);
 
-    // GET /acl/{temp_did} — return the entry the admin granted.
-    Mock::given(method("GET"))
-        .and(path(format!("/acl/{temp_did}")))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "did": temp_did,
-            "role": "admin",
-            "label": "ops",
-            "allowed_contexts": ["primary"],
-            "created_at": 1_700_000_000_u64,
-            "created_by": "did:web:vta",
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    // POST /acl — create entry for new DID. We don't know the new DID
-    // ahead of time (it's randomly generated), so don't assert path
-    // beyond /acl + method.
+    // `POST /acl/swap` — one atomic operation, and the reason this stub is a
+    // single mock where it used to be three. Rotation was read-the-entry,
+    // create-under-the-new-DID, delete-the-temp; `acl/swap-key` moves the
+    // entry's role and contexts onto the new DID in one step, so there is no
+    // window in which both DIDs are privileged. The new DID is minted inside
+    // `rotate_key` and unknown here, which is exactly why the swap carries a
+    // VP-JWT proving control of it rather than the caller naming it.
     Mock::given(method("POST"))
-        .and(path("/acl"))
+        .and(path("/acl/swap"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "did": "did:key:zNew",
             "role": "admin",
@@ -465,14 +462,6 @@ async fn ensure_authenticated_runs_full_rotation_flow() {
             "created_at": 1_700_000_000_u64,
             "created_by": "did:web:vta",
         })))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    // DELETE /acl/{temp_did} — best-effort cleanup of the temp DID.
-    Mock::given(method("DELETE"))
-        .and(path(format!("/acl/{temp_did}")))
-        .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&server)
         .await;
@@ -491,10 +480,15 @@ async fn ensure_authenticated_runs_full_rotation_flow() {
 }
 
 #[tokio::test]
-async fn ensure_authenticated_rotation_fails_when_acl_read_fails() {
-    // If the GET /acl/{temp_did} call fails, the rotation must bail
-    // BEFORE deleting the temp ACL entry — so the temp DID stays
-    // authoritative and the caller can retry.
+async fn ensure_authenticated_rotation_leaves_the_temp_did_authoritative_on_failure() {
+    // This used to assert that a failed `GET /acl/{temp_did}` bailed *before*
+    // the delete, so the temp entry survived. That hazard is gone: rotation is
+    // one atomic `acl/swap-key`, not read-create-delete, so there is no
+    // half-applied state to protect against.
+    //
+    // What still matters is the caller-visible half — a refused swap must leave
+    // the stored session on the temp DID, so the operator can fix the ACL and
+    // retry with the credential they still hold.
     let server = MockServer::start().await;
     mount_challenge(&server).await;
     let future = now_secs() + 3600;
@@ -503,15 +497,11 @@ async fn ensure_authenticated_rotation_fails_when_acl_read_fails() {
     let (temp_did, temp_pk) = did_key_from_seed(0x10);
     let (vta_did, _) = did_key_from_seed(0x20);
 
-    Mock::given(method("GET"))
-        .and(path(format!("/acl/{temp_did}")))
-        .respond_with(ResponseTemplate::new(404).set_body_string("no entry yet"))
+    Mock::given(method("POST"))
+        .and(path("/acl/swap"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("no entry for the temp DID"))
         .mount(&server)
         .await;
-
-    // Important: NO /acl POST mock — if rotation tries to create a new
-    // entry without a successful read, the test fails on the unmatched
-    // request.
 
     let s = store();
     s.store_pending_rotation("k", &temp_did, &temp_pk, &vta_did)
@@ -523,11 +513,15 @@ async fn ensure_authenticated_rotation_fails_when_acl_read_fails() {
         .unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("temp DID's ACL"),
-        "expected ACL-read failure guidance, got: {msg}"
+        msg.contains("acl/swap-key failed"),
+        "the error must name the operation that refused, got: {msg}"
+    );
+    assert!(
+        msg.contains("import-did"),
+        "and the remedy an operator can act on, got: {msg}"
     );
 
-    // Session is still the temp DID after a failed rotation.
+    // The session is still the temp DID, so the retry has a credential to use.
     let info = s.loaded_session("k").unwrap();
     assert_eq!(info.client_did, temp_did);
 }
@@ -560,14 +554,22 @@ async fn connect_with_url_override_uses_rest_and_attaches_token() {
         .await;
     // Authenticated request after connect() returns: should carry the
     // token established during the auth round-trip.
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    // `get_config()` dispatches `config/show/0.1`; the bearer assertion is the
+    // point of the call, so it stays on the binding endpoint.
+    Mock::given(method("POST"))
+        .and(path("/trust-tasks"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "type": "https://trusttasks.org/spec/config/show/0.1"
+        })))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer connect-token",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "vta_did": null, "vta_name": null, "public_url": null
+            "id": "urn:uuid:stub-response",
+            "type": "https://trusttasks.org/spec/config/show/0.1#response",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            "payload": { "fields": [] },
         })))
         .expect(1)
         .mount(&server)
@@ -666,10 +668,16 @@ async fn connect_url_override_falls_back_to_rest() {
     s.store_direct("k", &did, &pk, &vta_did).unwrap();
 
     // Round-trip an authenticated call to prove the client is wired.
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    Mock::given(method("POST"))
+        .and(path("/trust-tasks"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "type": "https://trusttasks.org/spec/config/show/0.1"
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "vta_did": null, "vta_name": null, "public_url": null
+            "id": "urn:uuid:stub-response",
+            "type": "https://trusttasks.org/spec/config/show/0.1#response",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            "payload": { "fields": [] },
         })))
         .expect(1)
         .mount(&server)
@@ -710,14 +718,20 @@ async fn connect_auto_rest_authenticates_and_returns_token() {
     let future = now_secs() + 3600;
     mount_authenticate(&server, future).await;
     // An authenticated call must carry the token established at connect.
-    Mock::given(method("GET"))
-        .and(path("/config"))
+    Mock::given(method("POST"))
+        .and(path("/trust-tasks"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "type": "https://trusttasks.org/spec/config/show/0.1"
+        })))
         .and(wiremock::matchers::header(
             "authorization",
             "Bearer access-jwt",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "vta_did": null, "vta_name": null, "public_url": null
+            "id": "urn:uuid:stub-response",
+            "type": "https://trusttasks.org/spec/config/show/0.1#response",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            "payload": { "fields": [] },
         })))
         .expect(1)
         .mount(&server)


### PR DESCRIPTION
Five tests in `vta-sdk/tests/session_store.rs` fail on `main`. They stub bespoke REST routes the SDK stopped calling:

| stub | what the SDK does now |
|---|---|
| `GET /config` | `get_config()` dispatches `config/show/0.1` over `POST /trust-tasks` |
| `GET /acl/{did}` + `POST /acl` + `DELETE /acl/{did}` | rotation is a single atomic `POST /acl/swap` |

Every one 404s on an unmatched stub.

## Why now

Nothing compiled the file. It is gated on `session` + `test-support`, neither default, and no CI step built that pair until #1140 added `cargo test -p vta-sdk --all-features` — for exactly this class of rot. That step could not *run* until #1142 got the same job's clippy green, so it surfaces today rather than two days ago.

## The rotation stubs collapse three mocks into one

That is the change, not tidying. Rotation used to read the temp entry, create one under the new DID, then delete the temp — a window in which **both DIDs were privileged**. `acl/swap-key` moves the entry's role and contexts across atomically, so the window does not exist. The new DID is minted inside `rotate_key` and unknown to the caller, which is why the swap carries a VP-JWT proving control of it rather than naming it.

## One test lost its premise

`ensure_authenticated_rotation_fails_when_acl_read_fails` asserted that window's safety property — that a failed read bailed *before* the delete. There is no delete to bail before any more.

It now asserts what is still true and still matters: a refused swap leaves the stored session on the temp DID, so an operator can fix the ACL and retry with the credential they still hold. Renamed to `ensure_authenticated_rotation_leaves_the_temp_did_authoritative_on_failure`, and it checks the error names both the operation that refused and the remedy.

## Verification

- `cargo test -p vta-sdk --all-features --test session_store`: **24 passed, 0 failed** (was 19/5)
- `cargo test -p vta-sdk --all-features`: 0 failed
- `cargo clippy -p vta-sdk --all-features --all-targets`: exit 0
- `cargo fmt --all --check`: exit 0