### PR TITLE
chore(deps)!: move VTI to trust-tasks-rs 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88693f20c94894621230e2742661d76a3181455354677f2b2caaf7f7c02b2a50"
+checksum = "0090bf4aaf7ac6febbf1c294bfc4d6e7eb2def11e610d6fb816048f39adc2189"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17acd47901b288ce519bc9bd57775babfb9514c359cb337037c855c2a383aaa4"
+checksum = "72f32712a19146d4a5353a98a60b676b572976a85abf318a412863389cc8f064"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd634567ac99feceede0a4e6953e5a7ed530b0771ae5911538ae3a8106546e9b"
+checksum = "3858685de0deba7be2b6b7481c2eb0823b7b64dbe6852b474fed4c23360a019f"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f857f43d084f1dc5066d73ce6a1702d3ab0d223371ee12e39ddd6406beb92c"
+checksum = "715c365fa19276fb50332e10b922822b25d52d6119721f28abb6cac02029a365"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8617,9 +8617,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.11.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c5a7c3159de3999884eb2bd6e823225042fbfe6138262002a0c8ab690a4e"
+checksum = "353aaf722fe973429964b5f7f73e83587dcd4f7339fd823563f60116a6452eab"
 dependencies = [
  "chrono",
  "serde",
@@ -8631,12 +8631,13 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4289204b6f77d2037e5371cc9e25008ce54d8e1b8dc12183c64d986c3776c659"
+checksum = "1974962777655ed96b6d11fd2576fa86d9b2746244dc08e30839a035f3915e24"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
+ "chrono",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -8646,9 +8647,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8646a37ec55dcf5e1da713f25800f127e2ec0063ed6f9bcf0e5ae66b5fd8f859"
+checksum = "17f9307dd3d05da704e079ce7c5f5b8e37cf1a9a809accb0bd924b0c579d1776"
 dependencies = [
  "axum",
  "chrono",
@@ -8665,9 +8666,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.11.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d77c7462d3e8cdb6e5797af79a7b37c655d87e96fd0738f80f910bdaa2b965"
+checksum = "6180c087ad44a2907720e9d999dd6d21cfc055213a6384d8d931b67c266d187e"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8682,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.12.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0564661c0874c7a972aec1f3bef1290898f7ba4933be9a9204caabbc80332c"
+checksum = "84b1d714ac143f1e887030a7a21a8b9eac72dfe2535e47869240982c2c55fab1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ uniffi = "0.28"
 # `unpack` rejects plaintext / anoncrypt / forged-`from` envelopes by default.
 # `0.8` would let a fresh resolve on a clean checkout land on a pre-fix 0.8.x,
 # silently moving sender authentication back out of the library. Do not relax it.
-affinidi-tdk = "0.9"
+affinidi-tdk = "0.10"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -244,9 +244,9 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.12", default-features = false, features = ["validate"] }
-trust-tasks-capability-client = "0.11"
-trust-tasks-https = { version = "0.12", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-rs = { version = "0.17", default-features = false, features = ["validate"] }
+trust-tasks-capability-client = "0.17"
+trust-tasks-https = { version = "0.17", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -257,8 +257,8 @@ trust-tasks-https = { version = "0.12", default-features = false, features = ["s
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.12", default-features = false }
-trust-tasks-proof = { version = "0.11", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.17", default-features = false }
+trust-tasks-proof = { version = "0.17", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -19,7 +19,7 @@ autobins = false
 
 [dev-dependencies]
 # Embedded mediator fixture from affinidi-tdk-rs.
-affinidi-messaging-test-mediator = { version = "0.3", features = ["tsp"] }
+affinidi-messaging-test-mediator = { version = "0.4", features = ["tsp"] }
 
 # VTA: enable the `test-support` feature so we can stand up complete VTA
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
@@ -31,7 +31,7 @@ vti-common = { path = "../../vti-common" }
 affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
-affinidi-messaging-sdk = "0.20"
+affinidi-messaging-sdk = "0.21"
 affinidi-messaging-didcomm = "0.15"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/vta-mobile-core/src/consent.rs
+++ b/vta-mobile-core/src/consent.rs
@@ -316,19 +316,25 @@ fn assemble_decision(
         })?
         .with_timezone(&chrono::Utc);
 
-    let payload = decision::Payload {
-        challenge: decision::PayloadChallenge::try_from(draft.challenge.clone()).map_err(conv)?,
-        decision: d,
+    let payload: decision::Payload = decision::Payload::builder()
+        .challenge(decision::PayloadChallenge::try_from(draft.challenge.clone()).map_err(conv)?)
+        .decision(d)
         // `payloadDigest` moved to the shared `DigestMultibase` type — a
         // multibase-encoded multihash, not the bare hex it used to be. Parse
         // rather than assume: a draft carrying a stale hex digest must fail
         // here, at the device that would otherwise sign a decision the VTA
         // could never match.
-        payload_digest: decision::DigestMultibase::try_from(draft.payload_digest.clone())
-            .map_err(conv)?,
-        reason,
-        ext: None,
-    };
+        .payload_digest(
+            decision::DigestMultibase::try_from(draft.payload_digest.clone()).map_err(conv)?,
+        )
+        .reason(
+            reason
+                .map(decision::PayloadReason::try_from)
+                .transpose()
+                .map_err(conv)?,
+        )
+        .try_into()
+        .map_err(conv)?;
 
     let mut doc = TrustTask::for_payload(draft.id.clone(), payload);
     doc.issuer = Some(draft.issuer_did.clone());

--- a/vta-mobile-core/src/push.rs
+++ b/vta-mobile-core/src/push.rs
@@ -124,12 +124,13 @@ pub fn build_push_register(
     registration: PushRegistration,
     controller_vta_did: String,
 ) -> Result<String, FfiError> {
-    let payload = register::Payload {
-        registration: to_wire_registration(registration)?,
-        controller_vta_did: register::PayloadControllerVtaDid::try_from(controller_vta_did)
-            .map_err(conv)?,
-        ext: None,
-    };
+    let payload: register::Payload = register::Payload::builder()
+        .registration(to_wire_registration(registration)?)
+        .controller_vta_did(
+            register::PayloadControllerVtaDid::try_from(controller_vta_did).map_err(conv)?,
+        )
+        .try_into()
+        .map_err(conv)?;
     serialize(&envelope_doc(&env, payload)?)
 }
 
@@ -162,10 +163,11 @@ pub fn build_device_set_wake(
 ) -> Result<String, FfiError> {
     let wake_handle = wake_handle
         .map(|h| -> Result<set_wake::WakeHandle, FfiError> {
-            Ok(set_wake::WakeHandle {
-                gateway: set_wake::WakeHandleGateway::try_from(h.gateway).map_err(conv)?,
-                handle: set_wake::WakeHandleHandle::try_from(h.handle).map_err(conv)?,
-            })
+            set_wake::WakeHandle::builder()
+                .gateway(set_wake::WakeHandleGateway::try_from(h.gateway).map_err(conv)?)
+                .handle(set_wake::WakeHandleHandle::try_from(h.handle).map_err(conv)?)
+                .try_into()
+                .map_err(conv)
         })
         .transpose()?;
     let push_platform = push_platform.map(|p| match p {
@@ -185,12 +187,12 @@ pub fn build_device_set_wake(
                 .map_err(conv)?,
         )
     };
-    let payload = set_wake::Payload {
-        wake_handle,
-        push_platform,
-        suggested_triggers,
-        ext: None,
-    };
+    let payload: set_wake::Payload = set_wake::Payload::builder()
+        .wake_handle(wake_handle)
+        .push_platform(push_platform)
+        .suggested_triggers(suggested_triggers)
+        .try_into()
+        .map_err(conv)?;
     let mut doc = envelope_doc(&env, payload)?;
     attach_did_signed_proof(&mut doc, &*signer, &env.issued_at)?;
     serialize(&doc)
@@ -234,10 +236,11 @@ fn to_wire_registration(reg: PushRegistration) -> Result<register::PushRegistrat
             auth,
         } => register::PushRegistration::Webpush {
             endpoint,
-            keys: register::PushRegistrationKeys {
-                auth: register::PushRegistrationKeysAuth::try_from(auth).map_err(conv)?,
-                p256dh: register::PushRegistrationKeysP256dh::try_from(p256dh).map_err(conv)?,
-            },
+            keys: register::PushRegistrationKeys::builder()
+                .auth(register::PushRegistrationKeysAuth::try_from(auth).map_err(conv)?)
+                .p256dh(register::PushRegistrationKeysP256dh::try_from(p256dh).map_err(conv)?)
+                .try_into()
+                .map_err(conv)?,
         },
     })
 }

--- a/vta-mobile-core/src/session.rs
+++ b/vta-mobile-core/src/session.rs
@@ -125,17 +125,21 @@ pub fn build_auth_challenge(
     subject: Option<String>,
     purpose: Option<String>,
 ) -> Result<String, FfiError> {
-    let payload = challenge::Payload {
-        subject: subject
-            .map(challenge::PayloadSubject::try_from)
-            .transpose()
-            .map_err(conv)?,
-        purpose: purpose
-            .map(challenge::PayloadPurpose::try_from)
-            .transpose()
-            .map_err(conv)?,
-        ext: None,
-    };
+    let payload: challenge::Payload = challenge::Payload::builder()
+        .subject(
+            subject
+                .map(challenge::PayloadSubject::try_from)
+                .transpose()
+                .map_err(conv)?,
+        )
+        .purpose(
+            purpose
+                .map(challenge::PayloadPurpose::try_from)
+                .transpose()
+                .map_err(conv)?,
+        )
+        .try_into()
+        .map_err(conv)?;
     serialize(&envelope_doc(&env, payload)?)
 }
 
@@ -161,16 +165,18 @@ pub fn build_authenticate(
     scope: Vec<String>,
     signer: Box<dyn Signer>,
 ) -> Result<String, FfiError> {
-    let payload = authenticate::Payload {
-        challenge: authenticate::PayloadChallenge::try_from(challenge).map_err(conv)?,
-        session_id: authenticate::PayloadSessionId::try_from(session_id).map_err(conv)?,
-        scope: scope
-            .into_iter()
-            .map(authenticate::PayloadScopeItem::try_from)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(conv)?,
-        ext: None,
-    };
+    let payload: authenticate::Payload = authenticate::Payload::builder()
+        .challenge(authenticate::PayloadChallenge::try_from(challenge).map_err(conv)?)
+        .session_id(authenticate::PayloadSessionId::try_from(session_id).map_err(conv)?)
+        .scope(
+            scope
+                .into_iter()
+                .map(authenticate::PayloadScopeItem::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(conv)?,
+        )
+        .try_into()
+        .map_err(conv)?;
     let mut doc = envelope_doc(&env, payload)?;
     attach_did_signed_proof(&mut doc, &*signer, &env.issued_at)?;
     serialize(&doc)
@@ -204,15 +210,17 @@ pub fn build_refresh(
     refresh_token: String,
     scope: Vec<String>,
 ) -> Result<String, FfiError> {
-    let payload = refresh::Payload {
-        refresh_token: refresh::PayloadRefreshToken::try_from(refresh_token).map_err(conv)?,
-        scope: scope
-            .into_iter()
-            .map(refresh::PayloadScopeItem::try_from)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(conv)?,
-        ext: None,
-    };
+    let payload: refresh::Payload = refresh::Payload::builder()
+        .refresh_token(refresh::PayloadRefreshToken::try_from(refresh_token).map_err(conv)?)
+        .scope(
+            scope
+                .into_iter()
+                .map(refresh::PayloadScopeItem::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(conv)?,
+        )
+        .try_into()
+        .map_err(conv)?;
     serialize(&envelope_doc(&env, payload)?)
 }
 
@@ -282,7 +290,13 @@ pub fn build_revoke_session(
 ) -> Result<String, FfiError> {
     let payload = revoke_session::Payload::Variant0 {
         session_id: revoke_session::PayloadVariant0SessionId::try_from(session_id).map_err(conv)?,
-        reason,
+        // `reason` is a bounded newtype as of the 0.17 registry, not a bare
+        // `String`. Parsing it here fails on the device that would otherwise
+        // sign a document the auth service must reject.
+        reason: reason
+            .map(revoke_session::PayloadVariant0Reason::try_from)
+            .transpose()
+            .map_err(conv)?,
         ext: None,
     };
     let mut doc = envelope_doc(&env, payload)?;
@@ -302,7 +316,10 @@ pub fn build_revoke_all_sessions(
 ) -> Result<String, FfiError> {
     let payload = revoke_session::Payload::Variant1 {
         all: true,
-        reason,
+        reason: reason
+            .map(revoke_session::PayloadVariant1Reason::try_from)
+            .transpose()
+            .map_err(conv)?,
         ext: None,
     };
     let mut doc = envelope_doc(&env, payload)?;

--- a/vta-mobile-core/src/stepup.rs
+++ b/vta-mobile-core/src/stepup.rs
@@ -62,19 +62,26 @@ pub fn build_approve_response_webauthn(
     draft: ApproveResponseDraft,
     assertion: WebAuthnAssertion,
 ) -> Result<String, FfiError> {
-    let evidence = approve_response::Evidence::Webauthn(approve_response::AssertionResponse {
-        id: assertion.credential_id.clone(),
-        raw_id: assertion.credential_id,
-        type_: serde_json::Value::String("public-key".to_string()),
-        response: approve_response::AssertionResponseResponse {
-            authenticator_data: assertion.authenticator_data,
-            client_data_json: assertion.client_data_json,
-            signature: assertion.signature,
-            user_handle: assertion.user_handle,
-        },
-        authenticator_attachment: None,
-        client_extension_results: serde_json::Map::new(),
-    });
+    let response: approve_response::AssertionResponseResponse =
+        approve_response::AssertionResponseResponse::builder()
+            .authenticator_data(assertion.authenticator_data)
+            .client_data_json(assertion.client_data_json)
+            .signature(assertion.signature)
+            .user_handle(assertion.user_handle)
+            .try_into()
+            .map_err(conv)?;
+    // `authenticatorAttachment` is left unset rather than sent as null: the
+    // platform did not report one.
+    let assertion_response: approve_response::AssertionResponse =
+        approve_response::AssertionResponse::builder()
+            .id(assertion.credential_id.clone())
+            .raw_id(assertion.credential_id)
+            .type_(serde_json::Value::String("public-key".to_string()))
+            .response(response)
+            .client_extension_results(serde_json::Map::new())
+            .try_into()
+            .map_err(conv)?;
+    let evidence = approve_response::Evidence::Webauthn(assertion_response);
     let doc = assemble_doc(
         &draft,
         evidence,
@@ -139,18 +146,26 @@ fn assemble_doc(
         })?
         .with_timezone(&chrono::Utc);
 
-    let payload = approve_response::Payload {
-        subject: approve_response::PayloadSubject::try_from(draft.subject.clone()).map_err(conv)?,
-        session_id: approve_response::PayloadSessionId::try_from(draft.session_id.clone())
-            .map_err(conv)?,
-        challenge: approve_response::PayloadChallenge::try_from(draft.challenge.clone())
-            .map_err(conv)?,
-        decision,
-        denied_reason,
-        granted_acr: draft.granted_acr.clone(),
-        evidence: Some(evidence),
-        ext: None,
-    };
+    let payload: approve_response::Payload = approve_response::Payload::builder()
+        .subject(approve_response::PayloadSubject::try_from(draft.subject.clone()).map_err(conv)?)
+        .session_id(
+            approve_response::PayloadSessionId::try_from(draft.session_id.clone()).map_err(conv)?,
+        )
+        .challenge(
+            approve_response::PayloadChallenge::try_from(draft.challenge.clone()).map_err(conv)?,
+        )
+        .decision(decision)
+        // Bounded newtype as of the 0.17 registry, not a bare `String`.
+        .denied_reason(
+            denied_reason
+                .map(approve_response::PayloadDeniedReason::try_from)
+                .transpose()
+                .map_err(conv)?,
+        )
+        .granted_acr(draft.granted_acr.clone())
+        .evidence(Some(evidence))
+        .try_into()
+        .map_err(conv)?;
 
     let mut doc = TrustTask::for_payload(draft.id.clone(), payload);
     doc.issuer = Some(draft.issuer_did.clone());

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -244,7 +244,7 @@ futures-util = { workspace = true, optional = true }
 # `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to
 # one instance, the one `affinidi_tdk::messaging` re-exports) so the `tsp`
 # feature can turn its `tsp` on — mirrors what `vta-service` does.
-affinidi-messaging-sdk = { version = "0.20", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.21", optional = true, default-features = false }
 reqwest = { workspace = true, optional = true }
 # Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
 rustls = { workspace = true, optional = true }

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -179,17 +179,21 @@ async fn set_client_acl_internal(
 /// access-list mode is set to ExplicitDeny (denylist semantics), allowing all
 /// except explicitly denied entries.
 fn build_allow_all_acl() -> account::update::v0_1::MediatorAcl {
-    account::update::v0_1::MediatorAcl {
-        blocked: Some(false),
-        local: Some(true),
-        send_messages: Some(true),
-        receive_messages: Some(true),
-        send_forwarded: Some(true),
-        receive_forwarded: Some(true),
-        create_invites: Some(true),
-        anon_receive: Some(true),
-        access_list_mode: Some(account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny),
-        // Don't set self-manage flags — let the mediator's defaults apply
-        ..Default::default()
-    }
+    // The self-manage flags are deliberately left unset so the mediator's
+    // defaults apply — which is what the builder does with a member never
+    // named, exactly as `..Default::default()` did.
+    account::update::v0_1::MediatorAcl::builder()
+        .blocked(Some(false))
+        .local(Some(true))
+        .send_messages(Some(true))
+        .receive_messages(Some(true))
+        .send_forwarded(Some(true))
+        .receive_forwarded(Some(true))
+        .create_invites(Some(true))
+        .anon_receive(Some(true))
+        .access_list_mode(Some(
+            account::update::v0_1::MediatorAclAccessListMode::ExplicitDeny,
+        ))
+        .try_into()
+        .expect("MediatorAcl has no required member")
 }

--- a/vta-sdk/src/auth_di.rs
+++ b/vta-sdk/src/auth_di.rs
@@ -92,14 +92,18 @@ pub async fn sign_authenticate_doc(
     challenge: &str,
     session_id: &str,
 ) -> Result<String, AuthDiError> {
-    let payload = authenticate::Payload {
-        challenge: authenticate::PayloadChallenge::try_from(challenge.to_string())
-            .map_err(|e| AuthDiError::Payload(format!("challenge: {e}")))?,
-        session_id: authenticate::PayloadSessionId::try_from(session_id.to_string())
-            .map_err(|e| AuthDiError::Payload(format!("sessionId: {e}")))?,
-        scope: Vec::new(),
-        ext: None,
-    };
+    let payload: authenticate::Payload = authenticate::Payload::builder()
+        .challenge(
+            authenticate::PayloadChallenge::try_from(challenge.to_string())
+                .map_err(|e| AuthDiError::Payload(format!("challenge: {e}")))?,
+        )
+        .session_id(
+            authenticate::PayloadSessionId::try_from(session_id.to_string())
+                .map_err(|e| AuthDiError::Payload(format!("sessionId: {e}")))?,
+        )
+        .scope(Vec::new())
+        .try_into()
+        .map_err(|e| AuthDiError::Payload(format!("authenticate payload: {e}")))?;
     Ok(trust_task_sign::build_signed(
         TASK_AUTH_AUTHENTICATE_0_1,
         serde_json::to_value(&payload).map_err(|e| AuthDiError::Payload(e.to_string()))?,
@@ -126,12 +130,14 @@ pub fn build_refresh_doc(
     vta_did: &str,
     refresh_token: &str,
 ) -> Result<String, AuthDiError> {
-    let payload = refresh::Payload {
-        refresh_token: refresh::PayloadRefreshToken::try_from(refresh_token.to_string())
-            .map_err(|e| AuthDiError::Payload(format!("refreshToken: {e}")))?,
-        scope: Vec::new(),
-        ext: None,
-    };
+    let payload: refresh::Payload = refresh::Payload::builder()
+        .refresh_token(
+            refresh::PayloadRefreshToken::try_from(refresh_token.to_string())
+                .map_err(|e| AuthDiError::Payload(format!("refreshToken: {e}")))?,
+        )
+        .scope(Vec::new())
+        .try_into()
+        .map_err(|e| AuthDiError::Payload(format!("refresh payload: {e}")))?;
     let doc = trust_task_sign::build_unsigned(
         TASK_AUTH_REFRESH_0_1,
         serde_json::to_value(&payload).map_err(|e| AuthDiError::Payload(e.to_string()))?,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -250,7 +250,7 @@ futures-util = "0.3"
 # crate's `tsp` feature and are NOT reachable via `affinidi-tdk/tsp`. The crate
 # is already present transitively via `affinidi-tdk` at the same 0.18.x; this
 # entry adds no new code when `tsp` is off (optional + default-features off).
-affinidi-messaging-sdk = { version = "0.20", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.21", optional = true, default-features = false }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"
 affinidi-did-resolver-cache-sdk = { workspace = true }
@@ -323,7 +323,7 @@ tempfile = { version = "3", optional = true }
 # A real dependency rather than a dev-dependency: `test-support` exists to serve
 # *external* consumers, and a dev-dependency would not be available to them.
 # `tsp` so the mediator routes raw-TSP frames, not just DIDComm.
-affinidi-messaging-test-mediator = { version = "0.3", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.4", optional = true, features = [
     "tsp",
 ] }
 libc = { workspace = true, optional = true }

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -473,14 +473,28 @@ pub fn to_wire_binding(entry: &AclEntry) -> Value {
 
 /// Wire `ConsumerKind` (register payload) → internal [`ConsumerKind`].
 /// Explicit because the two types' serde forms differ (see [`to_wire_binding`]).
-pub fn wire_kind_to_internal(w: &register_spec::ConsumerKind) -> ConsumerKind {
+///
+/// Fallible because the generated wire enums are `#[non_exhaustive]`: a caller
+/// on a newer registry can name a device kind, form factor or service kind
+/// added after this binary was built. `device/register` writes an ACL entry
+/// from this value, and the kind is what the VTA's policy keys off — mapping an
+/// unknown one onto `Daemon`, or onto any other arm, would register a device
+/// under a privilege profile nobody asked for. Refusing is the only answer that
+/// cannot silently be wrong.
+pub fn wire_kind_to_internal(w: &register_spec::ConsumerKind) -> Result<ConsumerKind, AppError> {
     use register_spec::{ConsumerKindFormFactor as Wff, ConsumerKindServiceKind as Wsk};
-    match w {
+    let unknown = |what: &str| {
+        AppError::Validation(format!(
+            "device/register: unrecognised {what} — this VTA cannot apply a policy to a              value added to the registry after it was built"
+        ))
+    };
+    Ok(match w {
         register_spec::ConsumerKind::Companion { form_factor } => ConsumerKind::Companion {
             form_factor: match form_factor {
                 Wff::Browser => CompanionFormFactor::Browser,
                 Wff::Mobile => CompanionFormFactor::Mobile,
                 Wff::Desktop => CompanionFormFactor::Desktop,
+                _ => return Err(unknown("companion form factor")),
             },
         },
         register_spec::ConsumerKind::Service { service_kind } => ConsumerKind::Service {
@@ -488,9 +502,11 @@ pub fn wire_kind_to_internal(w: &register_spec::ConsumerKind) -> ConsumerKind {
                 Wsk::Mediator => ServiceKind::Mediator,
                 Wsk::AiAgent => ServiceKind::AiAgent,
                 Wsk::Daemon => ServiceKind::Daemon,
+                _ => return Err(unknown("service kind")),
             },
         },
-    }
+        _ => return Err(unknown("consumer kind")),
+    })
 }
 
 /// Internal [`ConsumerKind`] → wire JSON (camelCase `formFactor`/`serviceKind`).

--- a/vta-service/src/operations/passkey_vms/mod.rs
+++ b/vta-service/src/operations/passkey_vms/mod.rs
@@ -146,6 +146,46 @@ fn user_handle_for_did(did: &str) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
+/// The WebAuthn `user.name` / `user.displayName` for an enrolment.
+///
+/// **Not the DID.** This is the string an authenticator shows in the credential
+/// picker, and WebAuthn L2 §5.4.3 lets an authenticator truncate it to 64
+/// bytes — which the registry's `maxLength: 64` on `userName` /
+/// `userDisplayName` mirrors. A `did:webvh` is routinely longer than that: the
+/// SCID alone is ~46 characters before the host and path. Sending the raw DID
+/// produced a response the 0.17 schema rejects outright, and before that a
+/// picker entry truncated mid-SCID — unreadable, and identical between two DIDs
+/// on the same host.
+///
+/// Nothing is lost by not sending it. `userHandle` is the DID-derived binding
+/// (see [`user_handle_for_did`]) and is unbounded; `user.name` is a label for a
+/// human, so it gets one:
+///
+/// * the operator's `label` when the enrolment supplied one, else
+/// * the DID with its `did:<method>:<scid>:` prefix dropped — the host and path
+///   are the part a person recognises, the SCID is the part they cannot.
+///
+/// Clamped on a `char` boundary so a multi-byte label cannot split.
+fn display_name_for(did: &str, label: Option<&str>) -> String {
+    const MAX: usize = 64;
+    let base = match label {
+        Some(l) if !l.trim().is_empty() => l.trim().to_string(),
+        _ => did
+            .strip_prefix("did:")
+            .and_then(|rest| rest.split_once(':'))
+            .and_then(|(_method, rest)| rest.split_once(':'))
+            .map(|(_scid, tail)| tail.to_string())
+            .unwrap_or_else(|| did.to_string()),
+    };
+    if base.chars().count() <= MAX {
+        return base;
+    }
+    // Keep the tail: for a path-shaped identifier the distinguishing part is at
+    // the end (`…:dids:persona`), not the start.
+    let skip = base.chars().count() - MAX + 1;
+    format!("…{}", base.chars().skip(skip).collect::<String>())
+}
+
 /// VM fragment derivation: `passkey-<base64url(sha256(credential_id))>`.
 fn fragment_for_credential(credential_id: &[u8]) -> String {
     let hash = Sha256::digest(credential_id);
@@ -185,8 +225,9 @@ pub async fn start_enrollment(
     let user_uuid = Uuid::from_slice(&user_handle[..16])
         .map_err(|e| PasskeyVmError::Internal(format!("derive user uuid from handle: {e}")))?;
 
+    let display = display_name_for(did, label.as_deref());
     let (ccr, registration) = webauthn
-        .start_passkey_registration(user_uuid, did, did, None)
+        .start_passkey_registration(user_uuid, &display, &display, None)
         .map_err(|e| PasskeyVmError::Internal(format!("start_passkey_registration: {e}")))?;
 
     // Persist ceremony state. Use a fresh UUID as the ceremony id
@@ -668,5 +709,62 @@ mod tests {
             matches!(err, PasskeyVmError::FragmentNotFound),
             "expected FragmentNotFound, got {err:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod display_name_tests {
+    use super::display_name_for;
+
+    /// The case that broke: a real `did:webvh` is longer than the schema's
+    /// `maxLength: 64`, and the part a person recognises is the tail.
+    #[test]
+    fn a_webvh_did_loses_its_scid_and_fits() {
+        let did =
+            "did:webvh:QmSRTjKQF54iQfv58QjbbcunzZ1GiDzvuFFPERVHwUF4kX:webvh-host.test:dids:persona";
+        assert!(
+            did.chars().count() > 64,
+            "the fixture must be over the bound"
+        );
+        let got = display_name_for(did, None);
+        assert_eq!(got, "webvh-host.test:dids:persona");
+        assert!(got.chars().count() <= 64);
+    }
+
+    /// An operator-supplied label wins — it is the whole reason `label` is on
+    /// the enrolment payload.
+    #[test]
+    fn a_label_is_preferred() {
+        assert_eq!(
+            display_name_for("did:webvh:QmScid:example.com:dids:x", Some("Ops laptop")),
+            "Ops laptop"
+        );
+    }
+
+    /// Whitespace-only is not a label.
+    #[test]
+    fn a_blank_label_falls_back_to_the_did() {
+        assert_eq!(
+            display_name_for("did:webvh:QmScid:example.com:dids:x", Some("   ")),
+            "example.com:dids:x"
+        );
+    }
+
+    /// A DID that is not `did:method:scid:tail` shaped is left alone rather
+    /// than mangled — `did:key` has no SCID to drop.
+    #[test]
+    fn a_short_did_key_is_left_whole() {
+        let did = "did:key:z6MkAgent";
+        assert_eq!(display_name_for(did, None), did);
+    }
+
+    /// Over-long input is clamped on a char boundary, keeping the tail.
+    #[test]
+    fn an_over_long_label_is_clamped_without_splitting_a_char() {
+        let label = "é".repeat(200);
+        let got = display_name_for("did:key:z6Mk", Some(&label));
+        assert_eq!(got.chars().count(), 64, "clamped to the bound");
+        assert!(got.starts_with('…'));
+        assert!(got.is_char_boundary(got.len()));
     }
 }

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -34,7 +34,10 @@ pub(super) async fn handle_register(
         Err(resp) => return resp,
     };
 
-    let consumer_kind = operations::device::wire_kind_to_internal(&payload.consumer_kind);
+    let consumer_kind = match operations::device::wire_kind_to_internal(&payload.consumer_kind) {
+        Ok(k) => k,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
     let display_name = payload.display_name.to_string();
     let hpke_public_key = payload.hpke_public_key.as_ref().map(|k| k.to_string());
     // `attestation` and `keyCustody` are accepted but not yet acted on (spec:

--- a/vta-service/src/trust_tasks/services.rs
+++ b/vta-service/src/trust_tasks/services.rs
@@ -73,14 +73,33 @@ fn state(s: &SdkState) -> spec::list::v1_0::ServiceState {
         } => (K::Didcomm, *enabled, mediator_did.clone(), None),
         SdkState::Webauthn { enabled, url } => (K::Webauthn, *enabled, None, url.clone()),
     };
-    Out {
-        kind,
-        enabled,
-        mediator_did,
-        url,
-        drains_until: None,
-        ext: None,
-    }
+    // `drainsUntil` unset: a state snapshot says nothing about drains, which
+    // `services/drain/list` answers.
+    Out::builder()
+        .kind(kind)
+        .enabled(enabled)
+        .mediator_did(mediator_did)
+        .url(url)
+        .try_into()
+        .expect("every required member of the service state is set above")
+}
+
+/// Finish a generated response/component builder.
+///
+/// The generated types are `#[non_exhaustive]` as of trust-tasks-rs 0.17, so
+/// this crate cannot name their members in a struct literal — that is what lets
+/// the registry add an OPTIONAL member without breaking every consumer. The
+/// builder starts each REQUIRED member as `Err("no value supplied for …")`, so
+/// every call below sets its required members explicitly and lets the optional
+/// ones default.
+fn built<T, B>(builder: B) -> Result<T, AppError>
+where
+    B: TryInto<T>,
+    B::Error: std::fmt::Display,
+{
+    builder
+        .try_into()
+        .map_err(|e| AppError::Internal(format!("couldn't build a services response: {e}")))
 }
 
 fn kind_of(s: &SdkState) -> spec::list::v1_0::ServiceKind {
@@ -119,13 +138,13 @@ pub(super) async fn handle_list(
     match crate::operations::protocol::list::list_services(&state_.config, &state_.webvh_ks, auth)
         .await
     {
-        Ok(body) => success_response(
-            &doc,
-            spec::list::v1_0::Response {
-                services: body.services.iter().map(state).collect(),
-                ext: None,
-            },
-        ),
+        Ok(body) => match built::<spec::list::v1_0::Response, _>(
+            spec::list::v1_0::Response::builder()
+                .services(body.services.iter().map(state).collect::<Vec<_>>()),
+        ) {
+            Ok(r) => success_response(&doc, r),
+            Err(e) => app_error_to_reject(&doc, e),
+        },
         Err(e) => app_error_to_reject(&doc, list_error(e)),
     }
 }
@@ -151,18 +170,35 @@ pub(super) async fn handle_get(
                 spec::get::v1_0::ServiceKind::Rest => spec::list::v1_0::ServiceKind::Rest,
                 spec::get::v1_0::ServiceKind::Tsp => spec::list::v1_0::ServiceKind::Tsp,
                 spec::get::v1_0::ServiceKind::Webauthn => spec::list::v1_0::ServiceKind::Webauthn,
+                // The generated enum is `#[non_exhaustive]`: a caller on a
+                // newer registry can name a transport this build does not
+                // serve. Refuse rather than fall through to one of the four —
+                // `get` exists to distinguish "never configured" from
+                // "configured and disabled", and answering about the wrong
+                // transport would corrupt exactly that distinction.
+                _ => {
+                    return app_error_to_reject(
+                        &doc,
+                        AppError::Validation(
+                            "services/get: unrecognised service kind — this VTA does not serve \
+                             a transport added to the registry after it was built"
+                                .into(),
+                        ),
+                    );
+                }
             };
             match body.services.iter().find(|s| kind_of(s) == want) {
-                Some(found) => success_response(
-                    &doc,
-                    spec::get::v1_0::Response {
-                        state: serde_json::from_value(
+                Some(found) => match built::<spec::get::v1_0::Response, _>(
+                    spec::get::v1_0::Response::builder().state(
+                        serde_json::from_value::<spec::get::v1_0::ServiceState>(
                             serde_json::to_value(state(found)).unwrap_or(Value::Null),
                         )
                         .expect("the two generated ServiceState shapes are identical"),
-                        ext: None,
-                    },
-                ),
+                    ),
+                ) {
+                    Ok(r) => success_response(&doc, r),
+                    Err(e) => app_error_to_reject(&doc, e),
+                },
                 // Absent means never configured — distinct from configured and
                 // disabled, which comes back with `enabled: false`. Answering
                 // an empty success here would erase that distinction, which is
@@ -245,17 +281,22 @@ fn mutation(
     drain_until: Option<chrono::DateTime<chrono::Utc>>,
     draining_mediator: Option<String>,
 ) -> Result<spec::enable::v1_0::ServiceMutationResult, AppError> {
-    Ok(spec::enable::v1_0::ServiceMutationResult {
-        log_entry_version_id: log_entry_version_id
-            .try_into()
-            .map_err(|_| AppError::Internal("operation returned an empty log entry id".into()))?,
-        effective_at: chrono::Utc::now(),
-        drain_until,
-        draining_mediator,
-        vta_did: (!vta_did.is_empty()).then_some(vta_did),
-        serverless,
-        ext: None,
-    })
+    built(
+        spec::enable::v1_0::ServiceMutationResult::builder()
+            .log_entry_version_id(
+                spec::enable::v1_0::ServiceMutationResultLogEntryVersionId::try_from(
+                    log_entry_version_id,
+                )
+                .map_err(|_| {
+                    AppError::Internal("operation returned an empty log entry id".into())
+                })?,
+            )
+            .effective_at(chrono::Utc::now())
+            .drain_until(drain_until)
+            .draining_mediator(draining_mediator)
+            .vta_did((!vta_did.is_empty()).then_some(vta_did))
+            .serverless(serverless),
+    )
 }
 
 /// Re-type an identically-shaped generated value for a sibling family.
@@ -392,9 +433,28 @@ pub(super) async fn handle_enable(
             );
             mutation(r.new_version_id, r.vta_did, r.serverless, None, None)
         }
+        // `#[non_exhaustive]`: a caller on a newer registry can name a
+        // transport this build does not serve. Refusing is the only safe
+        // answer — every arm above mutates the DID document, and picking
+        // one for an unrecognised kind would write the wrong service.
+        _ => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Validation(
+                    "unrecognised service kind — this VTA does not serve a \
+                     transport added to the registry after it was built"
+                        .into(),
+                ),
+            );
+        }
     };
     match result {
-        Ok(result) => success_response(&doc, spec::enable::v1_0::Response { result, ext: None }),
+        Ok(result) => match built::<spec::enable::v1_0::Response, _>(
+            spec::enable::v1_0::Response::builder().result(result),
+        ) {
+            Ok(r) => success_response(&doc, r),
+            Err(e) => app_error_to_reject(&doc, e),
+        },
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
@@ -510,11 +570,32 @@ pub(super) async fn handle_update(
                 Some(r.prior_mediator_did),
             )
         }
+        // `#[non_exhaustive]`: a caller on a newer registry can name a
+        // transport this build does not serve. Refusing is the only safe
+        // answer — every arm above mutates the DID document, and picking
+        // one for an unrecognised kind would write the wrong service.
+        _ => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Validation(
+                    "unrecognised service kind — this VTA does not serve a \
+                     transport added to the registry after it was built"
+                        .into(),
+                ),
+            );
+        }
     };
     match result {
-        Ok(result) => match retype(result) {
+        // Annotated: the target type used to be pinned by the response struct
+        // literal, and the builder's `TryInto` setter no longer pins it.
+        Ok(result) => match retype::<spec::update::v1_0::ServiceMutationResult>(result) {
             Ok(result) => {
-                success_response(&doc, spec::update::v1_0::Response { result, ext: None })
+                match built::<spec::update::v1_0::Response, _>(
+                    spec::update::v1_0::Response::builder().result(result),
+                ) {
+                    Ok(r) => success_response(&doc, r),
+                    Err(e) => app_error_to_reject(&doc, e),
+                }
             }
             Err(e) => app_error_to_reject(&doc, e),
         },
@@ -603,11 +684,30 @@ pub(super) async fn handle_disable(
                 draining,
             )
         }
+        // `#[non_exhaustive]`: a caller on a newer registry can name a
+        // transport this build does not serve. Refusing is the only safe
+        // answer — every arm above mutates the DID document, and picking
+        // one for an unrecognised kind would write the wrong service.
+        _ => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Validation(
+                    "unrecognised service kind — this VTA does not serve a \
+                     transport added to the registry after it was built"
+                        .into(),
+                ),
+            );
+        }
     };
     match result {
-        Ok(result) => match retype(result) {
+        Ok(result) => match retype::<spec::disable::v1_0::ServiceMutationResult>(result) {
             Ok(result) => {
-                success_response(&doc, spec::disable::v1_0::Response { result, ext: None })
+                match built::<spec::disable::v1_0::Response, _>(
+                    spec::disable::v1_0::Response::builder().result(result),
+                ) {
+                    Ok(r) => success_response(&doc, r),
+                    Err(e) => app_error_to_reject(&doc, e),
+                }
             }
             Err(e) => app_error_to_reject(&doc, e),
         },
@@ -650,16 +750,15 @@ fn rollback_result(
     draining_mediator: Option<String>,
 ) -> spec::rollback::v1_0::RollbackResult {
     let wrote_an_entry = new_version_id.is_some();
-    spec::rollback::v1_0::RollbackResult {
-        kind,
-        log_entry_version_id: new_version_id,
-        effective_at: wrote_an_entry.then(chrono::Utc::now),
-        drain_until: None,
-        draining_mediator,
-        vta_did: (!vta_did.is_empty()).then_some(vta_did),
-        serverless,
-        ext: None,
-    }
+    spec::rollback::v1_0::RollbackResult::builder()
+        .kind(kind)
+        .log_entry_version_id(new_version_id)
+        .effective_at(wrote_an_entry.then(chrono::Utc::now))
+        .draining_mediator(draining_mediator)
+        .vta_did((!vta_did.is_empty()).then_some(vta_did))
+        .serverless(serverless)
+        .try_into()
+        .expect("every required member of the rollback result is set above")
 }
 
 pub(super) async fn handle_rollback(
@@ -752,8 +851,27 @@ pub(super) async fn handle_rollback(
                 draining,
             )
         }
+        // `#[non_exhaustive]`: a caller on a newer registry can name a
+        // transport this build does not serve. Refusing is the only safe
+        // answer — every arm above mutates the DID document, and picking
+        // one for an unrecognised kind would write the wrong service.
+        _ => {
+            return app_error_to_reject(
+                &doc,
+                AppError::Validation(
+                    "unrecognised service kind — this VTA does not serve a \
+                     transport added to the registry after it was built"
+                        .into(),
+                ),
+            );
+        }
     };
-    success_response(&doc, spec::rollback::v1_0::Response { result, ext: None })
+    match built::<spec::rollback::v1_0::Response, _>(
+        spec::rollback::v1_0::Response::builder().result(result),
+    ) {
+        Ok(r) => success_response(&doc, r),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
 }
 
 // ── drain ───────────────────────────────────────────────────────────
@@ -776,23 +894,38 @@ pub(super) async fn handle_drain_list(
                 .entries
                 .into_iter()
                 .map(|e| {
-                    Ok(spec::drain::list::v1_0::DrainEntry {
-                        mediator_did: e.mediator_did.try_into().map_err(|_| {
-                            AppError::Internal("drain entry has an empty mediator did".into())
-                        })?,
-                        endpoint: e.endpoint,
-                        drains_until: e.drains_until.parse().map_err(|_| {
-                            AppError::Internal("drain entry has an unparseable deadline".into())
-                        })?,
-                        ext: None,
-                    })
+                    built(
+                        spec::drain::list::v1_0::DrainEntry::builder()
+                            .mediator_did(
+                                spec::drain::list::v1_0::DrainEntryMediatorDid::try_from(
+                                    e.mediator_did,
+                                )
+                                .map_err(|_| {
+                                    AppError::Internal(
+                                        "drain entry has an empty mediator did".into(),
+                                    )
+                                })?,
+                            )
+                            .endpoint(e.endpoint)
+                            .drains_until(
+                                e.drains_until
+                                    .parse::<chrono::DateTime<chrono::Utc>>()
+                                    .map_err(|_| {
+                                        AppError::Internal(
+                                            "drain entry has an unparseable deadline".into(),
+                                        )
+                                    })?,
+                            ),
+                    )
                 })
                 .collect::<Result<Vec<_>, AppError>>();
             match entries {
-                Ok(entries) => success_response(
-                    &doc,
-                    spec::drain::list::v1_0::Response { entries, ext: None },
-                ),
+                Ok(entries) => match built::<spec::drain::list::v1_0::Response, _>(
+                    spec::drain::list::v1_0::Response::builder().entries(entries),
+                ) {
+                    Ok(r) => success_response(&doc, r),
+                    Err(e) => app_error_to_reject(&doc, e),
+                },
                 Err(e) => app_error_to_reject(&doc, e),
             }
         }
@@ -833,13 +966,12 @@ pub(super) async fn handle_drain_cancel(
         // `mediatorDid` is a plain String in this family — no newtype to
         // fall through, so there is nothing to validate here beyond what
         // the operation already guaranteed.
-        Ok(r) => success_response(
-            &doc,
-            spec::drain::cancel::v1_0::Response {
-                mediator_did: r.mediator_did,
-                ext: None,
-            },
-        ),
+        Ok(r) => match built::<spec::drain::cancel::v1_0::Response, _>(
+            spec::drain::cancel::v1_0::Response::builder().mediator_did(r.mediator_did),
+        ) {
+            Ok(resp) => success_response(&doc, resp),
+            Err(e) => app_error_to_reject(&doc, e),
+        },
         Err(e) => app_error_to_reject(&doc, AppError::Conflict(e.to_string())),
     }
 }

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -382,7 +382,10 @@ pub(super) async fn handle_approve_response(
             &doc,
             json!({
                 "status": "rejected",
-                "reason": payload.denied_reason.unwrap_or_else(|| "user declined".to_string()),
+                "reason": payload
+                    .denied_reason
+                    .map(|r| r.to_string())
+                    .unwrap_or_else(|| "user declined".to_string()),
             }),
         );
     }
@@ -402,6 +405,17 @@ pub(super) async fn handle_approve_response(
                 Ok(()) => "passkey",
                 Err(reason) => return reject_with(&doc, reason),
             }
+        }
+        // `#[non_exhaustive]`: the registry can add an evidence kind after this
+        // binary was built. This match *chooses which cryptographic gate to
+        // verify*, so there is no safe fallthrough — landing on the did-signed
+        // arm would check a gate the approver did not present, and report the
+        // step-up as satisfied on evidence this VTA never understood. Refuse.
+        Some(_) => {
+            return reject_with(
+                &doc,
+                step_up_failure("auth/step-up/approve-response:evidenceUnsupported"),
+            );
         }
     };
 
@@ -924,6 +938,18 @@ pub(super) async fn trigger_gateway_wake(
                 Some(push_wake::ResponseStatus::Delivered) => {
                     tracing::info!(gateway = %gateway, approver = %approver, "push/wake delivered by gateway")
                 }
+                // `#[non_exhaustive]`: the registry can add a status after this
+                // binary was built. Named separately from `None` because the two
+                // say different things — `None` is "no status we could read at
+                // all", this is "a status we read but do not know", and only the
+                // second is worth an operator's attention. Either way the
+                // mediator queue and pickup fallback still apply, so wake stays
+                // best-effort rather than failing.
+                Some(other) => tracing::warn!(
+                    gateway = %gateway, approver = %approver, status = ?other,
+                    "push/wake: gateway returned a status this build does not know; \
+                     treating as sent — mediator queue + pickup fallback applies"
+                ),
                 None => tracing::info!(
                     gateway = %gateway, approver = %approver,
                     "push/wake sent to gateway (no recognizable 0.2 response status)"

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -219,7 +219,7 @@ affinidi-messaging-didcomm = "0.15"
 # mediator-side twin of the client-side failure this crate's TSP work is about.
 # Always on (not conditioned on this crate's `tsp`): the harness is test-only,
 # and a mediator that can route TSP is harmless to the DIDComm suite.
-affinidi-messaging-test-mediator = { version = "0.3", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.4", optional = true, features = [
     "tsp",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }


### PR DESCRIPTION
Every `trust-tasks-*` pin to **0.17**, plus the TDK crates that had to publish first — `affinidi-tdk` 0.10, `affinidi-messaging-sdk` 0.21, `affinidi-messaging-test-mediator` 0.4 (affinidi/affinidi-tdk-rs#744). Two `trust-tasks-rs` versions in one graph fail to compile, so the messaging stack had to move before this could.

## What 0.17 changes

The generated payload, response, component structs **and enums** are `#[non_exhaustive]`. Struct literals become builders; matches gain a wildcard. That is what lets the registry add an optional member or an enum variant without breaking every consumer that spelled out the old list.

The cost is worth stating: **"is every required member set?" moves from compile time to the builder's conversion** — the builder starts each required member as `Err("no value supplied for …")`. Every call site here sets its required members explicitly and lets only optional ones default.

## The wildcard arms are decisions, and they went different ways

| site | unknown variant | why |
|---|---|---|
| `step_up` `evidence` | **refuse** | It chooses *which cryptographic gate to verify*. Falling through to the did-signed arm would check a gate the approver never presented, and report the step-up satisfied on evidence this VTA did not understand. |
| `services/{enable,update,disable,rollback,get}` | **refuse** | Every arm mutates the DID document; picking one writes the wrong service. `get` additionally exists to tell "never configured" from "configured and disabled" — answering about another transport destroys exactly that. |
| `device/register` kind / form factor / service kind | **refuse** | Writes an ACL entry, and the kind is what policy keys off. `wire_kind_to_internal` became fallible to say so. |
| `push/wake` reply status | **log and continue** | The only one. Wake is best-effort with a mediator-queue fallback, so an unknown status deserves an operator's attention but not a failure. Named separately from `None` because the two differ: "no status we could read" vs "a status we read but do not know". |

## Bounded newtypes

`reason`, `deniedReason` and siblings are no longer `String`. Parsing them at the producer means an over-long value fails on the device that would otherwise sign a document the consumer must reject.

## The response gate caught a live violation

`passkey-vms/enroll-challenge` put the raw DID into WebAuthn's `userName` / `userDisplayName`, which 0.17 bounds at `maxLength: 64`. A `did:webvh` is ~85 characters, so the response was unconformant:

```
RESPONSE-CONFORMANCE VIOLATION  …/passkey-vms/enroll-challenge/0.1#response:
  "did:webvh:QmSRTjKQF54iQfv58QjbbcunzZ1GiDzvuFFPERVHwUF4kX:webvh-host.test:dids:persona"
  is longer than 64 characters
```

**The schema is self-contradictory here** — `userName`'s description says *"e.g. the DID"* while its constraint makes any `did:webvh` unrepresentable. I fixed it VTI-side rather than upstream because the constraint is the defensible half: WebAuthn L2 §5.4.3 lets an authenticator truncate at 64 bytes, so the raw DID was *already* producing a credential-picker entry cut mid-SCID — unreadable, and identical between two DIDs on the same host.

Nothing is lost. `userHandle` carries the DID-derived binding and is unbounded. `userName` now takes the operator's `label`, or the DID with its `did:<method>:<scid>:` prefix dropped — the host and path are the part a person recognises, the SCID is the part they cannot. Clamped on a `char` boundary, with five unit tests.

## Verification

- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo clippy --workspace --all-targets` (CI's combination): exit 0
- `cargo fmt --all --check`: exit 0
- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `vta-sdk`, `vta-mobile-core`, `vti-common`, `vta-vault`, `vta-webvh`, `vtc-service`: **0 failed**
- `TRUST-TASK RESPONSE COVERAGE 88/109 (81%)` — unchanged

## Follow-up, not in this PR

`enforce_spec_policy` has **zero call sites** in VTI. It is 0.17's single source of truth for the flag-driven §7.2 checks — recipient-REQUIRED (item 5b), proof-REQUIRED (item 7 clause A), audience binding (item 8), and the new issuedAt-REQUIRED (§7.3 item 17).

The dispatch spine's own comment says *"`enforce_audience_binding` needs `P: Payload`, so each slice's typed handler runs it after `parse_payload`"* — that comment is the **only** occurrence of the name in the repo. No handler runs it. Adopting the 0.17 superset is the compliance half of this move and gets its own PR.

(VTI's *producers* are already clean on `issuedAt`: the SDK's single `build_task_document` always stamps it, and I scanned all 233 task-shaped `json!` blocks — every production one sets it.)
