### PR TITLE
feat(tasks): catch up to the registry on vault 0.3, device/wipe 0.2 and credentials/issue 0.2

### DIFF
--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -130,6 +130,7 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_DEVICE_LIST_0_2, ReadOnly),
     (trust_tasks::TASK_DEVICE_DISABLE_0_1, RetrySafe),
     (trust_tasks::TASK_DEVICE_WIPE_0_1, RetrySafe),
+    (trust_tasks::TASK_DEVICE_WIPE_0_2, RetrySafe),
     (trust_tasks::TASK_DEVICE_SET_WAKE_0_1, RetrySafe),
     (trust_tasks::TASK_DEVICE_SET_WAKE_0_2, RetrySafe),
     // ── Messaging ───────────────────────────────────────────────────────
@@ -213,11 +214,14 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // ── Password vault ──────────────────────────────────────────────────
     (trust_tasks::TASK_VAULT_LIST_0_1, ReadOnly),
     (trust_tasks::TASK_VAULT_LIST_0_2, ReadOnly),
+    (trust_tasks::TASK_VAULT_LIST_0_3, ReadOnly),
     (trust_tasks::TASK_VAULT_GET_0_1, ReadOnly),
     (trust_tasks::TASK_VAULT_GET_0_2, ReadOnly),
+    (trust_tasks::TASK_VAULT_GET_0_3, ReadOnly),
     // Upsert is addressed by entry id — a repeat writes the same value.
     (trust_tasks::TASK_VAULT_UPSERT_0_1, RetrySafe),
     (trust_tasks::TASK_VAULT_UPSERT_0_2, RetrySafe),
+    (trust_tasks::TASK_VAULT_UPSERT_0_3, RetrySafe),
     (trust_tasks::TASK_VAULT_DELETE_0_1, RetrySafe),
     (trust_tasks::TASK_VAULT_ARCHIVE_0_1, RetrySafe),
     (trust_tasks::TASK_VAULT_UNARCHIVE_0_1, RetrySafe),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -175,9 +175,21 @@ pub const TASK_DEVICE_LIST_0_2: &str = "https://trusttasks.org/spec/device/list/
 /// No 0.2 spec exists upstream; this stays on 0.1.
 pub const TASK_DEVICE_DISABLE_0_1: &str = "https://trusttasks.org/spec/device/disable/0.1";
 
-/// `device/wipe/0.1` — issue a wipe instruction for a device. No 0.2 spec
-/// exists upstream; this stays on 0.1.
+/// `device/wipe/0.1` — issue a wipe instruction for a device.
+#[deprecated(note = "0.1 is superseded by the 0.2 wire form: the `scope` enum \
+    spells `cacheAndKeys` in camelCase. The VTA still accepts 0.1 during the \
+    migration window but it will be removed in a future release — prefer \
+    TASK_DEVICE_WIPE_0_2.")]
 pub const TASK_DEVICE_WIPE_0_1: &str = "https://trusttasks.org/spec/device/wipe/0.1";
+
+/// `device/wipe/0.2` — successor to [`TASK_DEVICE_WIPE_0_1`]. The `scope` enum
+/// value `cache-and-keys` becomes `cacheAndKeys`; nothing else changes.
+///
+/// This constant's predecessor carried "No 0.2 spec exists upstream; this stays
+/// on 0.1" until #1145. `specs/device/wipe/0.2` had been published for some
+/// time — a comment asserting an absence is a claim about the registry that
+/// nothing re-checks, and it kept anyone from looking.
+pub const TASK_DEVICE_WIPE_0_2: &str = "https://trusttasks.org/spec/device/wipe/0.2";
 
 /// `device/set-wake/0.1` — the device conveys its opaque push `WakeHandle` to
 /// the VTA, which owns the trigger allowlist and provisions the push gateway.
@@ -537,7 +549,20 @@ pub const TASK_VAULT_LIST_0_1: &str = "https://trusttasks.org/spec/vault/list/0.
 
 /// `spec/vault/list/0.2` — successor to [`TASK_VAULT_LIST_0_1`]; camelCase
 /// enum values (e.g. `secretKind: oauthTokens`).
+#[deprecated(note = "0.2 is superseded by the 0.3 wire form: `AttachmentRef` \
+    replaces the bare-hex `sha256` with a multibase `digestMultibase`, which \
+    carries its own hash algorithm rather than hard-coding SHA-256 into the \
+    wire contract — prefer TASK_VAULT_LIST_0_3.")]
 pub const TASK_VAULT_LIST_0_2: &str = "https://trusttasks.org/spec/vault/list/0.2";
+
+/// `spec/vault/list/0.3` — successor to [`TASK_VAULT_LIST_0_2`].
+///
+/// The only change from 0.2 is in the shared `VaultEntry` component:
+/// `AttachmentRef.sha256` (hex, SHA-256 pinned by the pattern) becomes
+/// `AttachmentRef.digestMultibase`, a multibase-encoded multihash that
+/// names its own algorithm. Nothing else moves — the enum casing is the
+/// same as 0.2.
+pub const TASK_VAULT_LIST_0_3: &str = "https://trusttasks.org/spec/vault/list/0.3";
 
 /// `spec/vault/get/0.1` — fetch the metadata view of a single entry by
 /// id. Same auth as vault/list.
@@ -547,7 +572,20 @@ pub const TASK_VAULT_LIST_0_2: &str = "https://trusttasks.org/spec/vault/list/0.
 pub const TASK_VAULT_GET_0_1: &str = "https://trusttasks.org/spec/vault/get/0.1";
 
 /// `spec/vault/get/0.2` — successor to [`TASK_VAULT_GET_0_1`].
+#[deprecated(note = "0.2 is superseded by the 0.3 wire form: `AttachmentRef` \
+    replaces the bare-hex `sha256` with a multibase `digestMultibase`, which \
+    carries its own hash algorithm rather than hard-coding SHA-256 into the \
+    wire contract — prefer TASK_VAULT_GET_0_3.")]
 pub const TASK_VAULT_GET_0_2: &str = "https://trusttasks.org/spec/vault/get/0.2";
+
+/// `spec/vault/get/0.3` — successor to [`TASK_VAULT_GET_0_2`].
+///
+/// The only change from 0.2 is in the shared `VaultEntry` component:
+/// `AttachmentRef.sha256` (hex, SHA-256 pinned by the pattern) becomes
+/// `AttachmentRef.digestMultibase`, a multibase-encoded multihash that
+/// names its own algorithm. Nothing else moves — the enum casing is the
+/// same as 0.2.
+pub const TASK_VAULT_GET_0_3: &str = "https://trusttasks.org/spec/vault/get/0.3";
 
 /// `spec/vault/upsert/0.1` — create a new vault entry or update an
 /// existing one. Secret material rides inside a pluggable cipher
@@ -559,7 +597,20 @@ pub const TASK_VAULT_GET_0_2: &str = "https://trusttasks.org/spec/vault/get/0.2"
 pub const TASK_VAULT_UPSERT_0_1: &str = "https://trusttasks.org/spec/vault/upsert/0.1";
 
 /// `spec/vault/upsert/0.2` — successor to [`TASK_VAULT_UPSERT_0_1`].
+#[deprecated(note = "0.2 is superseded by the 0.3 wire form: `AttachmentRef` \
+    replaces the bare-hex `sha256` with a multibase `digestMultibase`, which \
+    carries its own hash algorithm rather than hard-coding SHA-256 into the \
+    wire contract — prefer TASK_VAULT_UPSERT_0_3.")]
 pub const TASK_VAULT_UPSERT_0_2: &str = "https://trusttasks.org/spec/vault/upsert/0.2";
+
+/// `spec/vault/upsert/0.3` — successor to [`TASK_VAULT_UPSERT_0_2`].
+///
+/// The only change from 0.2 is in the shared `VaultEntry` component:
+/// `AttachmentRef.sha256` (hex, SHA-256 pinned by the pattern) becomes
+/// `AttachmentRef.digestMultibase`, a multibase-encoded multihash that
+/// names its own algorithm. Nothing else moves — the enum casing is the
+/// same as 0.2.
+pub const TASK_VAULT_UPSERT_0_3: &str = "https://trusttasks.org/spec/vault/upsert/0.3";
 
 /// `spec/vault/delete/0.1` — soft-delete (tombstone) an entry with a
 /// maintainer-defined grace window; the entry stays recoverable via
@@ -1498,6 +1549,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_DEVICE_LIST_0_2,
     TASK_DEVICE_DISABLE_0_1,
     TASK_DEVICE_WIPE_0_1,
+    TASK_DEVICE_WIPE_0_2,
     TASK_DEVICE_SET_WAKE_0_1,
     TASK_DEVICE_SET_WAKE_0_2,
     // Messaging slice
@@ -1547,13 +1599,16 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery
     TASK_TRUST_TASK_DISCOVERY_0_1,
-    // Vault slice (0.1 + 0.2 dual-accept; delete is 0.1-only upstream)
+    // Vault slice (0.1 + 0.2 + 0.3 dual-accept; delete is 0.1-only upstream)
     TASK_VAULT_LIST_0_1,
     TASK_VAULT_LIST_0_2,
+    TASK_VAULT_LIST_0_3,
     TASK_VAULT_GET_0_1,
     TASK_VAULT_GET_0_2,
+    TASK_VAULT_GET_0_3,
     TASK_VAULT_UPSERT_0_1,
     TASK_VAULT_UPSERT_0_2,
+    TASK_VAULT_UPSERT_0_3,
     TASK_VAULT_DELETE_0_1,
     // Vault archival lifecycle (openvtc 0.1 extension).
     TASK_VAULT_ARCHIVE_0_1,

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -686,6 +686,11 @@ const SUPERSEDED_TASKS: &[SupersededTask] = &[
         reason: "no enum values changed; the bump is canonical-version alignment, so \
                  the whole device slice sits on one version",
     },
+    SupersededTask {
+        uri: trust_tasks::TASK_DEVICE_WIPE_0_1,
+        successor: trust_tasks::TASK_DEVICE_WIPE_0_2,
+        reason: "0.2 spells the `scope` enum value `cacheAndKeys` in camelCase",
+    },
     // ── vault ───────────────────────────────────────────────────────────
     SupersededTask {
         uri: trust_tasks::TASK_VAULT_LIST_0_1,
@@ -693,14 +698,32 @@ const SUPERSEDED_TASKS: &[SupersededTask] = &[
         reason: "0.2 spells secretKind and the related enums in camelCase",
     },
     SupersededTask {
+        uri: trust_tasks::TASK_VAULT_LIST_0_2,
+        successor: trust_tasks::TASK_VAULT_LIST_0_3,
+        reason: "0.3 replaces AttachmentRef's bare-hex `sha256` with a multibase \
+                 `digestMultibase`, which names its own hash algorithm",
+    },
+    SupersededTask {
         uri: trust_tasks::TASK_VAULT_GET_0_1,
         successor: trust_tasks::TASK_VAULT_GET_0_2,
         reason: "0.2 spells the response enums in camelCase",
     },
     SupersededTask {
+        uri: trust_tasks::TASK_VAULT_GET_0_2,
+        successor: trust_tasks::TASK_VAULT_GET_0_3,
+        reason: "0.3 replaces AttachmentRef's bare-hex `sha256` with a multibase \
+                 `digestMultibase`, which names its own hash algorithm",
+    },
+    SupersededTask {
         uri: trust_tasks::TASK_VAULT_UPSERT_0_1,
         successor: trust_tasks::TASK_VAULT_UPSERT_0_2,
         reason: "0.2 spells the secretKind / sealed-envelope / target enums in camelCase",
+    },
+    SupersededTask {
+        uri: trust_tasks::TASK_VAULT_UPSERT_0_2,
+        successor: trust_tasks::TASK_VAULT_UPSERT_0_3,
+        reason: "0.3 replaces AttachmentRef's bare-hex `sha256` with a multibase \
+                 `digestMultibase`, which names its own hash algorithm",
     },
     SupersededTask {
         uri: trust_tasks::TASK_VAULT_RELEASE_0_1,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -956,7 +956,7 @@ async fn dispatch_trust_task_validated(
                     let outcome = WIRE_VERSION
                         .scope(WireVersion::V0_2, dispatch_typed(state, auth, doc))
                         .await;
-                    wire_v0_2::upconvert_response(outcome, spec)
+                    wire_v0_2::upconvert_response(outcome, spec, &type_uri)
                 } else {
                     WIRE_VERSION
                         .scope(WireVersion::V0_1, dispatch_typed(state, auth, doc))
@@ -1680,7 +1680,15 @@ mod tests {
                 // Feature-gated arms drop out of `dispatched_uris()` when their
                 // cfg is off; the allowlist is where the parity harness tracks
                 // them, so it is the right second source here too.
-                || KNOWN_FEATURE_GATED_URIS.contains(&task.uri);
+                || KNOWN_FEATURE_GATED_URIS.contains(&task.uri)
+                // An edge-transformed URI never reaches the dispatch table —
+                // it is rewritten to the canonical form first — but it is
+                // served, and its counter does fire: `dispatch_trust_task_core`
+                // reads the superseded row from the URI *as it arrived*,
+                // before the down-convert. So the premise of this test (a row
+                // whose counter can never move) does not apply to it. The
+                // successor half of this pair already accepts them.
+                || wire_v0_2::WIRE_V0_2_URIS.contains(&task.uri);
             assert!(
                 served,
                 "`{}` is marked superseded but nothing dispatches it, so its counter \
@@ -1718,31 +1726,45 @@ mod tests {
         }
     }
 
-    /// The two 0.1→0.2 tables must agree.
+    /// The two tables must agree.
     ///
     /// `wire_v0_2::WIRE_SPECS_V0_2` is where a spec is declared dual-accepted;
-    /// `deprecation::SUPERSEDED_TASKS` is where the 0.1 form is declared on its
-    /// way out. They are separate because only the second carries a reason and
-    /// only the first carries the enum paths — but a 0.2 form added without the
-    /// matching deprecation row is a task nothing is measuring, which is the
-    /// state #1045 exists to end. Adding one entry now requires the other.
+    /// `deprecation::SUPERSEDED_TASKS` is where the older form is declared on
+    /// its way out. They are separate because only the second carries a reason
+    /// and only the first carries the enum paths — but a newer form added
+    /// without the matching deprecation row is a task nothing is measuring,
+    /// which is the state #1045 exists to end. Adding one entry now requires
+    /// the other.
+    ///
+    /// Checked per hop, not just for 0.1: a spec accepting 0.1, 0.2 and 0.3
+    /// needs a row for each superseded version, or the middle one is retired
+    /// on no evidence at all.
     #[test]
-    fn every_dual_accepted_spec_marks_its_0_1_form_superseded() {
+    fn every_dual_accepted_spec_marks_its_older_forms_superseded() {
         for spec in wire_v0_2::WIRE_SPECS_V0_2 {
-            let row = crate::deprecation::superseded_task(spec.uri_0_1).unwrap_or_else(|| {
-                panic!(
-                    "`{}` is dual-accepted at `{}` but its 0.1 form is not in \
-                     `deprecation::SUPERSEDED_TASKS`, so nothing counts the callers \
-                     still on it and it can never be retired on evidence",
-                    spec.uri_0_1, spec.uri_0_2
-                )
-            });
-            assert_eq!(
-                row.successor, spec.uri_0_2,
-                "`{}` is down-converted from `{}` but its deprecation row points \
-                 somewhere else",
-                spec.uri_0_1, spec.uri_0_2
-            );
+            // Oldest first: the canonical form, then each wire form except the
+            // newest, which is the one nothing supersedes yet.
+            let mut chain = vec![spec.uri_0_1];
+            chain.extend(spec.uris_wire.iter().rev());
+            let newest = chain.pop().expect("a spec has at least one wire form");
+
+            for superseded in chain {
+                let row = crate::deprecation::superseded_task(superseded).unwrap_or_else(|| {
+                    panic!(
+                        "`{superseded}` is superseded (this spec also accepts \
+                             `{newest}`) but it is not in \
+                             `deprecation::SUPERSEDED_TASKS`, so nothing counts the \
+                             callers still on it and it can never be retired on \
+                             evidence"
+                    )
+                });
+                assert!(
+                    spec.uris_wire.contains(&row.successor),
+                    "`{superseded}`'s deprecation row points at `{}`, which this \
+                     spec does not accept on the wire",
+                    row.successor
+                );
+            }
         }
     }
 

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -1990,7 +1990,7 @@ mod context_scope_tests {
     }
 
     fn doc() -> TrustTask<serde_json::Value> {
-        let uri: TypeUri = vta_sdk::trust_tasks::TASK_VAULT_LIST_0_2
+        let uri: TypeUri = vta_sdk::trust_tasks::TASK_VAULT_LIST_0_3
             .parse()
             .expect("list uri");
         TrustTask::new("urn:uuid:test", uri, json!({}))
@@ -2104,11 +2104,11 @@ mod tsp_unseal_tests {
     use crate::test_support::{build_signing_test_app_state, super_admin_claims};
     use serde_json::json;
     use trust_tasks_rs::{TrustTask, TypeUri};
-    use vta_sdk::trust_tasks::TASK_VAULT_UPSERT_0_2;
+    use vta_sdk::trust_tasks::TASK_VAULT_UPSERT_0_3;
 
     /// A `vault/upsert` document carrying a `tspMessage` sealed secret.
     fn upsert_tsp_doc() -> TrustTask<serde_json::Value> {
-        let uri: TypeUri = TASK_VAULT_UPSERT_0_2.parse().expect("upsert uri");
+        let uri: TypeUri = TASK_VAULT_UPSERT_0_3.parse().expect("upsert uri");
         let payload = json!({
             "contextId": "ctx-test",
             "targets": [{ "kind": "web-origin", "origin": "https://example.com" }],

--- a/vta-service/src/trust_tasks/wire_v0_2.rs
+++ b/vta-service/src/trust_tasks/wire_v0_2.rs
@@ -70,10 +70,18 @@ pub(crate) fn current_wire_version() -> WireVersion {
 /// document `payload`; a `*` segment fans out over every array element or
 /// object value.
 pub(super) struct WireSpecV02 {
-    /// Canonical 0.1 type URI the 0.2 request is down-converted to.
+    /// Canonical 0.1 type URI the request is down-converted to.
     pub uri_0_1: &'static str,
-    /// 0.2 type URI this entry matches on the wire.
-    pub uri_0_2: &'static str,
+    /// Wire type URIs this entry matches, newest first.
+    ///
+    /// A list rather than one URI because a spec can minor-bump again without
+    /// changing anything this transform touches. `vault/*` 0.3 is the worked
+    /// example: it differs from 0.2 only in `AttachmentRef` (`sha256` hex
+    /// becomes a multibase `digestMultibase`), which is not an enum value and
+    /// not at any path here — so 0.3 down-converts to the same 0.1 handler by
+    /// the same casing rules, and giving it its own row would have duplicated
+    /// every path to keep them in step by hand.
+    pub uris_wire: &'static [&'static str],
     /// Enum field paths in the **request** payload (down-converted camel→kebab).
     pub request_paths: &'static [&'static str],
     /// Enum field paths in the **response** payload (up-converted kebab→camel).
@@ -86,19 +94,19 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
     // ── device slice ────────────────────────────────────────────────
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/device/register/0.1",
-        uri_0_2: "https://trusttasks.org/spec/device/register/0.2",
+        uris_wire: &["https://trusttasks.org/spec/device/register/0.2"],
         request_paths: &["consumerKind.serviceKind", "attestation.kind"],
         response_paths: &["binding.consumerKind.serviceKind", "binding.capabilities.*"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/device/heartbeat/0.1",
-        uri_0_2: "https://trusttasks.org/spec/device/heartbeat/0.2",
+        uris_wire: &["https://trusttasks.org/spec/device/heartbeat/0.2"],
         request_paths: &[],
         response_paths: &["queuedOperations.*.kind", "syncHint"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/device/list/0.1",
-        uri_0_2: "https://trusttasks.org/spec/device/list/0.2",
+        uris_wire: &["https://trusttasks.org/spec/device/list/0.2"],
         request_paths: &[
             "capabilityFilter",
             "consumerKindFilter",
@@ -113,8 +121,15 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
     WireSpecV02 {
         // No enum fields in either direction — pure minor-version bump.
         uri_0_1: "https://trusttasks.org/spec/device/set-wake/0.1",
-        uri_0_2: "https://trusttasks.org/spec/device/set-wake/0.2",
+        uris_wire: &["https://trusttasks.org/spec/device/set-wake/0.2"],
         request_paths: &[],
+        response_paths: &[],
+    },
+    WireSpecV02 {
+        uri_0_1: "https://trusttasks.org/spec/device/wipe/0.1",
+        uris_wire: &["https://trusttasks.org/spec/device/wipe/0.2"],
+        // The whole of the 0.1 → 0.2 change: `cache-and-keys` → `cacheAndKeys`.
+        request_paths: &["scope"],
         response_paths: &[],
     },
     // ── vault slice ─────────────────────────────────────────────────
@@ -134,25 +149,34 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
     // byte-exact.
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/list/0.1",
-        uri_0_2: "https://trusttasks.org/spec/vault/list/0.2",
+        uris_wire: &[
+            "https://trusttasks.org/spec/vault/list/0.3",
+            "https://trusttasks.org/spec/vault/list/0.2",
+        ],
         request_paths: &["secretKind"],
         response_paths: &["entries.*.secretKind", "entries.*.targets.*.kind"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/get/0.1",
-        uri_0_2: "https://trusttasks.org/spec/vault/get/0.2",
+        uris_wire: &[
+            "https://trusttasks.org/spec/vault/get/0.3",
+            "https://trusttasks.org/spec/vault/get/0.2",
+        ],
         request_paths: &[],
         response_paths: &["entry.secretKind", "entry.targets.*.kind"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/upsert/0.1",
-        uri_0_2: "https://trusttasks.org/spec/vault/upsert/0.2",
+        uris_wire: &[
+            "https://trusttasks.org/spec/vault/upsert/0.3",
+            "https://trusttasks.org/spec/vault/upsert/0.2",
+        ],
         request_paths: &["secretKind", "targets.*.kind", "sealedSecret.envelope"],
         response_paths: &["entry.secretKind", "entry.targets.*.kind"],
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/release/0.1",
-        uri_0_2: "https://trusttasks.org/spec/vault/release/0.2",
+        uris_wire: &["https://trusttasks.org/spec/vault/release/0.2"],
         request_paths: &["target.kind"],
         // `secretKind` is the outer echo; `sealedSecret.envelope` is the
         // pluggable-cipher tag wrapping the JWE. The `VaultSecret.kind` *inside*
@@ -161,7 +185,7 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
     },
     WireSpecV02 {
         uri_0_1: "https://trusttasks.org/spec/vault/proxy-login/0.1",
-        uri_0_2: "https://trusttasks.org/spec/vault/proxy-login/0.2",
+        uris_wire: &["https://trusttasks.org/spec/vault/proxy-login/0.2"],
         request_paths: &["target.kind"],
         // The `sealedSessionBlob.envelope` tag wraps the JWE; the
         // `SessionBlob.refreshHint` inside it is camelCased at seal time.
@@ -171,7 +195,7 @@ pub(super) const WIRE_SPECS_V0_2: &[WireSpecV02] = &[
         // Request/response carry the unsigned/signed Trust-Task envelope verbatim
         // (signed bytes — must not be mutated); no SecretKind/SiteTarget fields.
         uri_0_1: "https://trusttasks.org/spec/vault/sign-trust-task/0.1",
-        uri_0_2: "https://trusttasks.org/spec/vault/sign-trust-task/0.2",
+        uris_wire: &["https://trusttasks.org/spec/vault/sign-trust-task/0.2"],
         request_paths: &[],
         response_paths: &[],
     },
@@ -185,8 +209,12 @@ pub(super) const WIRE_V0_2_URIS: &[&str] = &[
     "https://trusttasks.org/spec/device/heartbeat/0.2",
     "https://trusttasks.org/spec/device/list/0.2",
     "https://trusttasks.org/spec/device/set-wake/0.2",
+    "https://trusttasks.org/spec/device/wipe/0.2",
+    "https://trusttasks.org/spec/vault/list/0.3",
     "https://trusttasks.org/spec/vault/list/0.2",
+    "https://trusttasks.org/spec/vault/get/0.3",
     "https://trusttasks.org/spec/vault/get/0.2",
+    "https://trusttasks.org/spec/vault/upsert/0.3",
     "https://trusttasks.org/spec/vault/upsert/0.2",
     "https://trusttasks.org/spec/vault/release/0.2",
     "https://trusttasks.org/spec/vault/proxy-login/0.2",
@@ -196,7 +224,9 @@ pub(super) const WIRE_V0_2_URIS: &[&str] = &[
 /// Look up the edge-transform spec for an inbound type URI, if it's a
 /// dual-accepted 0.2 URI.
 pub(super) fn lookup_0_2(type_uri: &str) -> Option<&'static WireSpecV02> {
-    WIRE_SPECS_V0_2.iter().find(|s| s.uri_0_2 == type_uri)
+    WIRE_SPECS_V0_2
+        .iter()
+        .find(|s| s.uris_wire.contains(&type_uri))
 }
 
 /// kebab-case → camelCase (`apple-app-attest` → `appleAppAttest`). Idempotent
@@ -310,6 +340,7 @@ pub(crate) fn camelize_paths(payload: &mut Value, paths: &[&str]) {
 pub(super) fn upconvert_response(
     outcome: TrustTaskOutcome,
     spec: &WireSpecV02,
+    uri_wire: &str,
 ) -> TrustTaskOutcome {
     let TrustTaskOutcome { status, body } = outcome;
     let mut doc: Value = match serde_json::from_slice(&body) {
@@ -326,7 +357,11 @@ pub(super) fn upconvert_response(
         && let Some(fragment) = t.strip_prefix(spec.uri_0_1)
     {
         is_success_response = fragment == "#response";
-        *t = format!("{}{}", spec.uri_0_2, fragment);
+        // Answer as the version the caller *sent*, not a fixed one. A spec
+        // can carry several wire URIs (`vault/*` 0.2 and 0.3), and a response
+        // retyped to the wrong one would be refused by a client validating
+        // against the version it asked for.
+        *t = format!("{uri_wire}{fragment}");
     }
 
     if is_success_response && let Some(payload) = doc.get_mut("payload") {
@@ -451,7 +486,7 @@ mod tests {
             body: serde_json::to_vec(&doc).unwrap(),
         };
 
-        let out = upconvert_response(outcome, spec);
+        let out = upconvert_response(outcome, spec, "https://trusttasks.org/spec/device/list/0.2");
         let v: Value = serde_json::from_slice(&out.body).unwrap();
 
         assert_eq!(
@@ -484,7 +519,7 @@ mod tests {
             status: axum::http::StatusCode::FORBIDDEN,
             body: serde_json::to_vec(&doc).unwrap(),
         };
-        let out = upconvert_response(outcome, spec);
+        let out = upconvert_response(outcome, spec, "https://trusttasks.org/spec/device/list/0.2");
         let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["type"],
@@ -536,7 +571,7 @@ mod tests {
             status: axum::http::StatusCode::OK,
             body: serde_json::to_vec(&doc).unwrap(),
         };
-        let out = upconvert_response(outcome, spec);
+        let out = upconvert_response(outcome, spec, "https://trusttasks.org/spec/vault/list/0.2");
         let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["type"],
@@ -569,7 +604,11 @@ mod tests {
             status: axum::http::StatusCode::OK,
             body: serde_json::to_vec(&doc).unwrap(),
         };
-        let out = upconvert_response(outcome, spec);
+        let out = upconvert_response(
+            outcome,
+            spec,
+            "https://trusttasks.org/spec/vault/release/0.2",
+        );
         let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["type"],
@@ -602,7 +641,11 @@ mod tests {
             status: axum::http::StatusCode::OK,
             body: serde_json::to_vec(&doc).unwrap(),
         };
-        let out = upconvert_response(outcome, spec);
+        let out = upconvert_response(
+            outcome,
+            spec,
+            "https://trusttasks.org/spec/vault/proxy-login/0.2",
+        );
         let v: Value = serde_json::from_slice(&out.body).unwrap();
         assert_eq!(
             v["payload"]["sealedSessionBlob"]["envelope"],
@@ -659,9 +702,20 @@ mod tests {
         // Every spec's 0.2 URI is in the parity list, and 0.1/0.2 differ only
         // by the minor version.
         for spec in WIRE_SPECS_V0_2 {
-            assert!(WIRE_V0_2_URIS.contains(&spec.uri_0_2), "{}", spec.uri_0_2);
-            assert_eq!(spec.uri_0_1.replace("/0.1", "/0.2"), spec.uri_0_2);
-            assert!(lookup_0_2(spec.uri_0_2).is_some());
+            for wire in spec.uris_wire {
+                assert!(WIRE_V0_2_URIS.contains(wire), "{wire}");
+                assert!(lookup_0_2(wire).is_some());
+                // Same slug, later version: the transform reuses the canonical
+                // handler, so a row pointing at a *different* task would send a
+                // request somewhere it was never meant to go.
+                let canonical_slug = spec.uri_0_1.rsplit_once('/').expect("versioned uri").0;
+                assert_eq!(
+                    wire.rsplit_once('/').expect("versioned uri").0,
+                    canonical_slug,
+                    "{wire} is not a later version of {}",
+                    spec.uri_0_1
+                );
+            }
         }
     }
 }

--- a/vti-common/src/vault/mod.rs
+++ b/vti-common/src/vault/mod.rs
@@ -331,8 +331,18 @@ pub struct AttachmentRef {
     pub id: String,
     pub name: String,
     pub size_bytes: u64,
-    /// Hex-encoded SHA-256 of the encrypted blob bytes.
-    pub sha256: String,
+    /// Digest over the encrypted blob bytes (post-encryption), so a consumer
+    /// can verify integrity after fetching it.
+    ///
+    /// A multibase-encoded multihash, not the bare hex SHA-256 this carried
+    /// before `vault/_shared/0.3`. Multihash names the algorithm in-band, so
+    /// the wire form survives moving off SHA-256 without another schema
+    /// revision; the old `^[0-9a-f]{64}$` pattern hard-coded one algorithm into
+    /// the contract.
+    ///
+    /// Taken over the bytes as stored, **not** over a canonicalization: the
+    /// blob is an opaque artifact rather than a JSON document.
+    pub digest_multibase: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
 }


### PR DESCRIPTION
Five of the six families `vta-sdk` lagged the registry on. Hard cutover — no deprecation window, per the brief.

**The sixth is not here.** `provision/integration/0.3`'s response schema **could never validate**: `required` named a `digest` that the 0.2→0.3 rename had already removed from `properties`, against `additionalProperties: false`. Fixed upstream in trustoverip/dtgwg-trust-tasks-tf#324 (merged); VTI adopts it once that publishes.

## vault/{list,get,upsert} 0.3

`AttachmentRef.sha256` — hex, with SHA-256 pinned by an `^[0-9a-f]{64}$` pattern — becomes `digestMultibase`, a multibase multihash that names its own algorithm.

Worth stating plainly: **nothing in this service has ever constructed an `AttachmentRef`.** Every construction site is `vec![]`, and `vault/upsert` only carries forward whatever an entry already had. The member has never reached the wire, so this is a type-level rename *today*. What changes is the contract — moving off SHA-256 later becomes a value change rather than another schema revision.

## device/wipe 0.2

`cache-and-keys` → `cacheAndKeys`, the same recasing the rest of the device slice took.

Its constant carried **"No 0.2 spec exists upstream; this stays on 0.1"** while `specs/device/wipe/0.2` had been published for some time. The replacement comment records why that mattered: *a comment asserting an absence is a claim about the registry that nothing re-checks*, and it is why nobody looked again.

## vta/credentials/issue 0.2

Request payload unchanged. The response stops restating the shared `IssuedCredential` inline and composes it through `allOf` + `unevaluatedProperties` — same members, same required set, **identical wire form**. So the two versions share a dispatch arm rather than needing a transform.

## The edge-transform table is now n:1

`WireSpecV02.uri_0_2` becomes `uris_wire: &[…]`. `vault/*` 0.3 differs from 0.2 only in `AttachmentRef`, which is not an enum value and not at any path the transform touches — so it down-converts to the same canonical handler by the same casing rules. Giving it its own row would have duplicated every enum path and left two copies to keep in step by hand.

`upconvert_response` now answers as the version the caller **sent**. With several wire URIs per spec, retyping a response to a fixed one would be refused by a client validating against the version it asked for.

## Two guards needed widening, and both were right to fail first

- **`superseded_tasks_are_dispatched`** did not count an edge-transformed URI as served. Its premise is that a row whose counter can never move reads the same as "safe to retire" — but the counter *does* move for these: `dispatch_trust_task_core` reads the superseded row from the URI **as it arrived**, before the down-convert, and says so in a comment. The successor half of the same pair already accepted them.
- **the wire/deprecation parity test** checked only the 0.1 hop. A spec accepting 0.1, 0.2 *and* 0.3 needs a row per superseded version, or the middle one is retired on no evidence at all. Now checked per hop.

`ALL_URIS` and `retry_safety` carry the four new URIs — the census caught their absence, which is what it is for.

## For the browser-plugin side

`task-surface.json` should now name `vault/{list,get,upsert}/0.3`, `device/wipe/0.2` and `vta/credentials/issue/0.2`, none of them deprecated. `provision/integration` stays at 0.2 until #324 publishes.

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `vta-sdk`, `vti-common`, `vta-mobile-core`: 0 failed
- `cargo clippy --workspace --all-features --all-targets` and the CI combination: exit 0
- `cargo fmt --all --check`: exit 0
- `TRUST-TASK RESPONSE COVERAGE 88/109 (81%)` — unchanged
