### PR TITLE
feat(compliance)!: enforce SPEC §7.2's flag-driven checks, and sign what we send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,7 +2952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4588,7 +4588,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6425,7 +6425,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6464,7 +6464,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -8683,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b1d714ac143f1e887030a7a21a8b9eac72dfe2535e47869240982c2c55fab1"
+checksum = "53926c6d164f8c7662171c513f05631590e87a1523ba21063ad105742c671b94"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-sdk/src/client/loopback.rs
+++ b/vta-sdk/src/client/loopback.rs
@@ -110,6 +110,9 @@ impl super::VtaClient {
     #[must_use]
     pub fn loopback(sink: Arc<dyn LoopbackSink>) -> Self {
         Self {
+            // A loopback client never reaches a conforming consumer — the sink
+            // answers ahead of the transport — so there is nothing to sign for.
+            identity: None,
             transport: super::Transport::Rest {
                 client: crate::http::rest_client(),
                 base_url: "http://loopback.invalid".to_string(),

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -31,6 +31,33 @@ pub(super) struct RestAuth {
     pub(super) credential: Option<AuthCredential>,
 }
 
+/// What a conforming *producer* needs to put on the wire, beyond the payload.
+///
+/// SPEC §7.2 turns two of these into hard requirements, and this SDK carried
+/// neither until the VTA started enforcing them:
+///
+/// * **item 5b** — every one of the 109 tasks this SDK dispatches declares
+///   `recipient` REQUIRED, so a document with no in-band recipient is
+///   `malformedRequest`. `build_task_document` used to emit exactly that.
+/// * **item 7a** — 72 of them declare `proof` REQUIRED. A bearer token
+///   authenticates the *connection*; it says nothing about the document, and
+///   §7.2 item 7 admits no transport substitute.
+///
+/// Held together because they are not independent: attaching a proof without an
+/// in-band recipient trips item 8 (audience binding) on any non-bearer spec, so
+/// a client that can sign must also know who it is signing *to*.
+#[derive(Clone, Debug)]
+pub struct ClientIdentity {
+    /// The producer's `did:key`. Becomes the document's `issuer`, and must
+    /// match the identity the transport authenticates as — item 6 rejects a
+    /// document whose in-band issuer disagrees with it.
+    pub client_did: String,
+    /// Multibase-encoded Ed25519 seed for `client_did`.
+    pub private_key_multibase: String,
+    /// The VTA's DID. Becomes the document's `recipient`.
+    pub vta_did: String,
+}
+
 /// Cloneable transport layer.
 ///
 /// Auth state is wrapped in `Arc<Mutex>` so cloned clients share tokens
@@ -178,6 +205,12 @@ pub struct VtaClient {
     /// the transports that really exist.
     #[cfg(feature = "test-loopback")]
     pub(super) loopback: Option<std::sync::Arc<dyn loopback::LoopbackSink>>,
+    /// Set when this client can produce conforming documents — see
+    /// [`ClientIdentity`]. `None` emits the pre-§7.2 shape, which a conforming
+    /// consumer refuses; it is kept only so a caller that has not been given an
+    /// identity yet fails at the VTA with a message naming the missing member,
+    /// rather than at construction with one that does not.
+    pub(super) identity: Option<std::sync::Arc<ClientIdentity>>,
 }
 
 // ── Protocol response aliases ──────────────────────────────────────
@@ -343,6 +376,7 @@ impl VtaClient {
         Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            identity: None,
             transport: Transport::Rest {
                 client: crate::http::rest_client(),
                 base_url: base_url.trim_end_matches('/').to_string(),
@@ -376,6 +410,7 @@ impl VtaClient {
         Ok(Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            identity: None,
             transport: Transport::Rest {
                 client: http,
                 base_url,
@@ -459,6 +494,7 @@ impl VtaClient {
         Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            identity: None,
             transport: Transport::DIDComm {
                 session,
                 rest_client,
@@ -697,6 +733,7 @@ impl VtaClient {
         Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            identity: None,
             transport: Transport::Tsp {
                 session: std::sync::Arc::new(session),
                 vta_did: vta_did.to_string(),
@@ -937,6 +974,16 @@ impl VtaClient {
     }
 
     /// Set the Bearer token (async version).
+    /// Give this client the identity it signs and addresses documents with.
+    ///
+    /// Without one, every dispatched document is missing an in-band `recipient`
+    /// (SPEC §7.2 item 5b, required by all 109 dispatched specs) and a `proof`
+    /// (item 7a, required by 72 of them), and a conforming VTA refuses it.
+    pub fn with_identity(mut self, identity: ClientIdentity) -> Self {
+        self.identity = Some(std::sync::Arc::new(identity));
+        self
+    }
+
     pub async fn set_token_async(&self, token: String) {
         match &self.transport {
             Transport::Rest { auth, .. } => {
@@ -1534,7 +1581,7 @@ impl VtaClient {
             return sink.dispatch(type_uri, &payload);
         }
 
-        let doc = build_task_document(type_uri, payload);
+        let doc = self.signed_task_document(type_uri, payload).await?;
         match &self.transport {
             Transport::Rest {
                 client,
@@ -2554,13 +2601,64 @@ mod tests {
 /// `TrustTask::extra`, and a Data-Integrity proof covers every member but
 /// `proof` — so a signed document's key cannot be rewritten in transit to split
 /// one operation into two.
-fn build_task_document(type_uri: &str, payload: serde_json::Value) -> serde_json::Value {
+impl VtaClient {
+    /// Build the document this client puts on the wire, signed when it can be.
+    ///
+    /// Signing is unconditional rather than keyed on whether *this* spec
+    /// declares `proof` REQUIRED: 72 of the 109 do, the flag lives in the
+    /// registry rather than here, and a proof on a task that merely RECOMMENDs
+    /// one is legal and strictly more attributable. The one thing it must not
+    /// do is attach a proof with no in-band `recipient` — §7.2 item 8 refuses
+    /// that on a non-bearer spec — and `build_task_document` sets both from the
+    /// same [`ClientIdentity`], so the two cannot come apart.
+    async fn signed_task_document(
+        &self,
+        type_uri: &str,
+        payload: serde_json::Value,
+    ) -> Result<serde_json::Value, VtaError> {
+        let identity = self.identity.clone();
+        let doc = build_task_document(type_uri, payload, identity.as_deref());
+        let Some(identity) = identity else {
+            return Ok(doc);
+        };
+        let mut typed: trust_tasks_rs::TrustTask<serde_json::Value> = serde_json::from_value(doc)
+            .map_err(|e| {
+            VtaError::Protocol(format!("could not build a Trust Task document: {e}"))
+        })?;
+        crate::trust_task_sign::sign_in_place(
+            &mut typed,
+            &identity.client_did,
+            &identity.private_key_multibase,
+        )
+        .await
+        .map_err(|e| VtaError::Protocol(format!("could not sign the Trust Task document: {e}")))?;
+        serde_json::to_value(&typed)
+            .map_err(|e| VtaError::Protocol(format!("could not serialise the document: {e}")))
+    }
+}
+
+fn build_task_document(
+    type_uri: &str,
+    payload: serde_json::Value,
+    identity: Option<&ClientIdentity>,
+) -> serde_json::Value {
     let mut doc = serde_json::json!({
         "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
         "type": type_uri,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "payload": payload,
     });
+    // `issuer` and `recipient` are envelope members every dispatched spec
+    // declares REQUIRED (SPEC §7.2 item 5b). They are set here rather than at
+    // each of the ~200 call sites for the same reason `issuedAt` is: a member
+    // the framework requires of every document belongs to the one function that
+    // builds every document.
+    if let Some(id) = identity
+        && let Some(obj) = doc.as_object_mut()
+    {
+        obj.insert("issuer".to_string(), serde_json::json!(id.client_did));
+        obj.insert("recipient".to_string(), serde_json::json!(id.vta_did));
+    }
     if let Some(key) = crate::idempotency::current_key()
         && crate::retry_safety::retry_safety(type_uri).is_some_and(|s| s.needs_key())
         && let Some(obj) = doc.as_object_mut()
@@ -2587,6 +2685,7 @@ mod idempotency_document_tests {
                 let doc = build_task_document(
                     trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
                     serde_json::json!({}),
+                    None,
                 );
                 assert_eq!(key_in(&doc).as_deref(), Some("urn:uuid:k"));
             })
@@ -2602,6 +2701,7 @@ mod idempotency_document_tests {
                 let doc = build_task_document(
                     trust_tasks::TASK_WEBVH_DIDS_LIST_1_0,
                     serde_json::json!({}),
+                    None,
                 );
                 assert_eq!(key_in(&doc), None);
             })
@@ -2613,6 +2713,7 @@ mod idempotency_document_tests {
         let doc = build_task_document(
             trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
             serde_json::json!({}),
+            None,
         );
         assert_eq!(key_in(&doc), None);
     }
@@ -2624,10 +2725,16 @@ mod idempotency_document_tests {
     async fn two_attempts_in_one_scope_share_a_key_but_not_an_envelope_id() {
         IDEMPOTENCY_KEY
             .scope("urn:uuid:k".to_string(), async {
-                let a =
-                    build_task_document(trust_tasks::TASK_KEYS_CREATE_0_1, serde_json::json!({}));
-                let b =
-                    build_task_document(trust_tasks::TASK_KEYS_CREATE_0_1, serde_json::json!({}));
+                let a = build_task_document(
+                    trust_tasks::TASK_KEYS_CREATE_0_1,
+                    serde_json::json!({}),
+                    None,
+                );
+                let b = build_task_document(
+                    trust_tasks::TASK_KEYS_CREATE_0_1,
+                    serde_json::json!({}),
+                    None,
+                );
                 assert_eq!(key_in(&a), key_in(&b), "the retry must reuse the key");
                 assert_ne!(
                     a.get("id"),

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -630,6 +630,34 @@ impl SessionStore {
     /// regardless of what the DID document advertises, use
     /// [`connect_with_transport`](Self::connect_with_transport) with
     /// [`TransportChoice::Rest`].
+    ///
+    /// An authenticated REST client carrying the identity it signs with.
+    ///
+    /// The session is re-loaded *after* `ensure_authenticated` on purpose: a
+    /// session that needed rotation now holds a different `client_did` and key,
+    /// and signing with the pre-rotation pair would produce documents whose
+    /// `issuer` no longer matches the identity the bearer token authenticates —
+    /// which SPEC §7.2 item 6 rejects.
+    async fn rest_client(
+        &self,
+        url: &str,
+        key: &str,
+        vta_did: &str,
+    ) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
+        let token = self.ensure_authenticated(url, key).await?;
+        let session = self
+            .load_session(key)
+            .ok_or_else(|| format!("session `{key}` vanished during authentication"))?;
+        let client =
+            crate::client::VtaClient::new(url).with_identity(crate::client::ClientIdentity {
+                client_did: session.client_did.clone(),
+                private_key_multibase: session.private_key.clone(),
+                vta_did: vta_did.to_string(),
+            });
+        client.set_token(token);
+        Ok(client)
+    }
+
     pub async fn connect(
         &self,
         key: &str,
@@ -702,9 +730,7 @@ impl SessionStore {
                     .ok_or_else(|| no_rest_endpoint_error(&session_vta_did))?,
             };
             debug!(url = %url, "connecting via REST (forced --transport rest)");
-            let token = self.ensure_authenticated(&url, key).await?;
-            let client = crate::client::VtaClient::new(&url);
-            client.set_token(token);
+            let client = self.rest_client(&url, key, &session_vta_did).await?;
             return Ok(client);
         }
 
@@ -867,9 +893,7 @@ impl SessionStore {
                 }
                 if let Some(url) = rest_url {
                     debug!(url = %url, "connecting via REST (fallback from TSP)");
-                    let token = self.ensure_authenticated(&url, key).await?;
-                    let client = crate::client::VtaClient::new(&url);
-                    client.set_token(token);
+                    let client = self.rest_client(&url, key, &session_vta_did).await?;
                     return Ok(client);
                 }
                 // TSP-only VTA whose TSP is down: there is nothing to fall back
@@ -906,9 +930,7 @@ impl SessionStore {
                     return Err(no_didcomm_endpoint_error(&session_vta_did, false, true));
                 }
                 debug!(url = %url, "connecting via REST (from DID doc)");
-                let token = self.ensure_authenticated(&url, key).await?;
-                let client = crate::client::VtaClient::new(&url);
-                client.set_token(token);
+                let client = self.rest_client(&url, key, &session_vta_did).await?;
                 return Ok(client);
             }
             Err(e) => {

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -180,9 +180,94 @@ pub fn test_deps(ts: &TestStore) -> ProvisionIntegrationDeps {
 
 /// Synthesise a super-admin `AuthClaims` for tests that bypass the
 /// normal session/JWT gate.
+/// The test super-admin's identity — a **real** `did:key`, derived from a fixed
+/// seed so it is stable across runs and reproducible from this constant alone.
+///
+/// It used to be the literal `"did:key:zTestAdmin"`, which is not a `did:key`
+/// at all: nothing resolves it, and no document issued by it can carry a
+/// verifiable proof. That was fine while the dispatcher accepted proofless
+/// documents. It stopped being fine when the spine started enforcing SPEC §7.2
+/// item 7 — 72 of the 109 dispatched specs declare `proof` REQUIRED, and a test
+/// that cannot sign cannot exercise any of them.
+pub const TEST_ADMIN_SEED: [u8; 32] = [0x7A; 32];
+
+/// The test super-admin's `did:key`, and the verification method inside it.
+///
+/// `did:key` encodes the public key in the identifier, so the DID document is
+/// derivable from the string — no network, no resolver cache, and the VTA
+/// verifies a proof from it without any test-only resolution path.
+pub fn test_admin_did() -> (String, String) {
+    did_for_seed(TEST_ADMIN_SEED[0])
+}
+
+/// The `did:key` and verification method for a one-byte test seed.
+///
+/// One byte, not 32, because a test only ever needs identities to be *distinct*
+/// and *reproducible*; naming them by a single number keeps a two-caller test
+/// from having to invent two DID strings and keep them in step with two tokens.
+pub fn did_for_seed(seed: u8) -> (String, String) {
+    use ed25519_dalek::SigningKey;
+    let sk = SigningKey::from_bytes(&[seed; 32]);
+    let mut mc = vec![0xed, 0x01];
+    mc.extend_from_slice(sk.verifying_key().as_bytes());
+    let mb = multibase::encode(multibase::Base::Base58Btc, mc);
+    let did = format!("did:key:{mb}");
+    let vm = format!("{did}#{mb}");
+    (did, vm)
+}
+
+/// Attach an `eddsa-jcs-2022` Data Integrity proof from the test super-admin.
+///
+/// Mirrors the producer side: the proof is taken over the document with any
+/// existing `proof` removed, which is what `prepare_sign_input` expects and
+/// what the VTA re-derives when it verifies.
+pub fn sign_as_test_admin(doc: &mut trust_tasks_rs::TrustTask<serde_json::Value>) {
+    sign_as(TEST_ADMIN_SEED[0], doc)
+}
+
+/// Attach an `eddsa-jcs-2022` proof from the identity `seed` names.
+///
+/// The document's `issuer` must be [`did_for_seed`] of the same seed: SPEC §7.2
+/// item 6 rejects a document whose in-band issuer disagrees with the
+/// transport-authenticated identity, so a test that mints a token for one DID
+/// and signs with another is refused for that rather than for whatever it meant
+/// to check.
+pub fn sign_as(seed: u8, doc: &mut trust_tasks_rs::TrustTask<serde_json::Value>) {
+    use affinidi_data_integrity::DataIntegrityProof;
+    use affinidi_data_integrity::crypto_suites::CryptoSuite;
+    use affinidi_data_integrity::prepare_sign_input;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    let (_did, vm) = did_for_seed(seed);
+    let sk = SigningKey::from_bytes(&[seed; 32]);
+    let mut di = DataIntegrityProof::new(
+        CryptoSuite::EddsaJcs2022,
+        vm,
+        "assertionMethod".to_string(),
+        None,
+        Some(
+            chrono::Utc::now()
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+                .to_string(),
+        ),
+        None,
+    );
+    doc.proof = None;
+    let input = prepare_sign_input(&*doc, &di, CryptoSuite::EddsaJcs2022)
+        .expect("the test document prepares for signing");
+    di.proof_value = Some(multibase::encode(
+        multibase::Base::Base58Btc,
+        sk.sign(&input).to_bytes(),
+    ));
+    doc.proof = Some(
+        serde_json::from_value(serde_json::to_value(&di).expect("proof serialises"))
+            .expect("proof round-trips into the framework type"),
+    );
+}
+
 pub fn super_admin_claims() -> AuthClaims {
     AuthClaims {
-        did: "did:key:zTestAdmin".into(),
+        did: test_admin_did().0,
         role: Role::Admin,
         allowed_contexts: Vec::new(),
         session_id: "test-session".into(),
@@ -613,6 +698,48 @@ pub struct TestAppContext {
 }
 
 impl TestAppContext {
+    /// Mint a signing identity **and** a matching token, for a test that drives
+    /// the VTA through `vta_sdk::VtaClient`.
+    ///
+    /// [`mint_token`](Self::mint_token) alone is no longer enough for those.
+    /// The spine enforces SPEC §7.2, so a document needs an in-band `recipient`
+    /// (item 5b, every dispatched spec) and a `proof` from the same identity
+    /// the token authenticates (items 6 and 7a, 72 of them). A token names a
+    /// DID; signing needs the key behind it, and `did:key` is the method where
+    /// the two are derivable from one seed.
+    ///
+    /// `seed` selects the identity, so a test that wants two callers asks for
+    /// two seeds rather than two unrelated strings.
+    pub async fn mint_signing_identity(
+        &self,
+        seed: u8,
+        role: &str,
+        contexts: Vec<String>,
+        vta_did: &str,
+    ) -> (vta_sdk::client::ClientIdentity, String) {
+        use ed25519_dalek::SigningKey;
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(sk.verifying_key().as_bytes());
+        let did = format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, mc)
+        );
+        let token = self.mint_token(&did, role, contexts).await;
+        // The private key travels as the multibase-encoded *seed*, which is what
+        // `trust_task_sign::sign_in_place` decodes.
+        let private_key_multibase =
+            multibase::encode(multibase::Base::Base58Btc, sk.to_bytes().as_slice());
+        (
+            vta_sdk::client::ClientIdentity {
+                client_did: did,
+                private_key_multibase,
+                vta_did: vta_did.to_string(),
+            },
+            token,
+        )
+    }
+
     /// Mint an access token for `did` with `role` + `contexts`, bypassing the
     /// live challenge-response handshake. The SDK's `challenge_response` packs a
     /// DIDComm envelope the server unpacks via ATM; a REST-only [`MockVta`] has
@@ -1875,6 +2002,30 @@ impl MockVta {
     /// [`base_url`](Self::base_url) to a URL-direct provision entry point.
     pub fn vta_did(&self) -> &str {
         &self.ctx.vta_did
+    }
+
+    /// A `VtaClient` that can produce documents this VTA accepts.
+    ///
+    /// `mint_token` alone stopped being enough once the spine enforced SPEC
+    /// §7.2: every dispatched spec declares `recipient` REQUIRED (item 5b) and
+    /// 72 of the 109 declare `proof` REQUIRED (item 7a), so a client needs the
+    /// key behind the DID its token names. `seed` selects the identity, so a
+    /// test wanting two callers asks for two seeds rather than two unrelated
+    /// DID strings.
+    pub async fn signing_client(
+        &self,
+        seed: u8,
+        role: &str,
+        contexts: Vec<String>,
+    ) -> vta_sdk::client::VtaClient {
+        let vta_did = self.vta_did().to_string();
+        let (identity, token) = self
+            .ctx
+            .mint_signing_identity(seed, role, contexts, &vta_did)
+            .await;
+        let client = vta_sdk::client::VtaClient::new(self.base_url()).with_identity(identity);
+        client.set_token_async(token).await;
+        client
     }
 
     /// Fail the stub host's next `n` publishes with a 500 — simulate a

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -905,6 +905,47 @@ async fn dispatch_trust_task_validated(
         return reject;
     }
 
+    // SPEC §7.2's *flag-driven* checks — the ones a specification declares
+    // rather than a consumer chooses:
+    //
+    // * item 5b  — `recipient` REQUIRED
+    // * item 7a  — `proof` REQUIRED
+    // * item 8   — audience binding (proof present, no in-band recipient, on a
+    //              non-bearer spec)
+    // * §7.3 17  — `issuedAt` REQUIRED for a consequential task
+    //
+    // None of these were enforced. `enforce_spec_policy` reads them off the
+    // typed payload's codegen-emitted constants, and this spine holds a
+    // `TrustTask<Value>` — so the check sat behind a `P` nothing here has. The
+    // comment further up still claimed "each slice's typed handler runs it
+    // after `parse_payload`"; no handler did, and that comment was the only
+    // occurrence of the name in this repo.
+    //
+    // `spec_policy_for` (trust-tasks-rs 0.17.1, trustoverip/dtgwg-trust-tasks-tf#321)
+    // keys the same constants by URI, which is what a URI-dispatching consumer
+    // can actually use. `SpecPolicy::enforce` is the same code path the typed
+    // method takes, so the two cannot drift as new flag-driven rules land.
+    //
+    // Runs after schema validation, for the same reason schema validation runs
+    // before the policy gate: a document that is not the shape it claims should
+    // be refused for *that*, with the schema's own message, rather than for a
+    // missing member the reader would then have to interpret.
+    //
+    // `None` means this build knows no spec for the URI — the unspecced-task
+    // case `validate_payload` has already decided about, per
+    // `policy.require_payload_schema`. Deciding it a second time here, with a
+    // different default, would make one of the two answers unreachable.
+    if let Some(policy) = trust_tasks_rs::schema_index::spec_policy_for(&type_uri)
+        && let Err(reason) = policy.enforce(&doc)
+    {
+        tracing::info!(
+            type_uri,
+            ?reason,
+            "document refused by its specification's policy"
+        );
+        return reject_with(&doc, reason);
+    }
+
     // Idempotency claim. Only bites when the document carries an
     // `idempotencyKey` *and* the task is one where a second execution leaves a
     // second durable artefact (`vta_sdk::retry_safety`) — everything else
@@ -2452,21 +2493,33 @@ mod response_coverage {
 
     use crate::test_support::build_signing_test_app_state;
 
+    /// Serialise a signed super-admin document, ready for
+    /// `dispatch_trust_task_core`.
+    ///
+    /// Every test here needs the same three things the spine now enforces — an
+    /// in-band `recipient`, an `issuedAt`, and a `proof` from the same identity
+    /// the claims carry — so they are built in one place rather than seven.
+    pub(super) fn signed_body(uri: &str, vta_did: &str, payload: Value) -> Vec<u8> {
+        let mut doc: TrustTask<Value> = serde_json::from_value(json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": uri,
+            "issuer": crate::test_support::test_admin_did().0,
+            "recipient": vta_did,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": payload,
+        }))
+        .expect("envelope deserialises");
+        crate::test_support::sign_as_test_admin(&mut doc);
+        serde_json::to_vec(&doc).expect("envelope serialises")
+    }
+
     /// Dispatch as a super-admin and require a success document back.
     ///
     /// Returns the response `payload` so a test can chain (e.g. take a key id
     /// out of `keys/create` and sign with it).
     async fn ok(state: &crate::server::AppState, uri: &str, payload: Value) -> Value {
         let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
-        let body = serde_json::to_vec(&json!({
-            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-            "type": uri,
-            "issuer": "did:key:zTestAdmin",
-            "recipient": vta_did,
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": payload,
-        }))
-        .expect("envelope serialises");
+        let body = signed_body(uri, &vta_did, payload);
 
         let outcome = super::dispatch_trust_task_core(
             state,
@@ -2530,15 +2583,11 @@ mod response_coverage {
     async fn revoke_all_is_refused_as_unsupported_not_malformed() {
         let (state, _dir) = build_signing_test_app_state().await;
         let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
-        let body = serde_json::to_vec(&json!({
-            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-            "type": t::TASK_AUTH_REVOKE_SESSION_0_1,
-            "issuer": "did:key:zTestAdmin",
-            "recipient": vta_did,
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": { "all": true },
-        }))
-        .expect("envelope");
+        let body = signed_body(
+            t::TASK_AUTH_REVOKE_SESSION_0_1,
+            &vta_did,
+            json!({ "all": true }),
+        );
         let outcome = super::dispatch_trust_task_core(
             &state,
             &crate::test_support::super_admin_claims(),
@@ -2645,18 +2694,14 @@ mod response_coverage {
         let (state, _dir) = build_signing_test_app_state().await;
         let claims = crate::test_support::super_admin_claims();
         let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
-        let body = serde_json::to_vec(&json!({
-            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-            "type": t::TASK_ACL_SWAP_KEY_0_1,
-            "issuer": "did:key:zTestAdmin",
-            "recipient": vta_did,
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": {
+        let body = signed_body(
+            t::TASK_ACL_SWAP_KEY_0_1,
+            &vta_did,
+            json!({
                 "currentSubject": claims.did,
                 "newSubject": "did:key:z6MkCovNewSubject",
-            },
-        }))
-        .expect("envelope");
+            }),
+        );
         let outcome = super::dispatch_trust_task_core(
             &state,
             &claims,

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -322,6 +322,33 @@ fn delete_auth(uri: &str, token: &str) -> Request<Body> {
 /// This was `capabilities_requires_auth`, pointed at the retired task (#1043).
 /// The property is the spine's, not that task's, so it is asserted through the
 /// discovery task that replaced it rather than deleted with its subject.
+/// A hand-built Trust Task document that a conforming VTA will accept.
+///
+/// The spine enforces SPEC §7.2, so a document needs an in-band `recipient`
+/// (item 5b — every dispatched spec declares it REQUIRED) and, for 72 of the
+/// 109, a `proof` from the same identity the token authenticates (items 6, 7a).
+/// Tests that hand-roll an envelope have to carry both or they are refused
+/// before they reach the behaviour they mean to check.
+fn signed_doc(
+    ctx: &TestContext,
+    id: &str,
+    type_uri: &str,
+    payload: serde_json::Value,
+) -> serde_json::Value {
+    let (did, _vm) = vta_service::test_support::test_admin_did();
+    let mut doc: trust_tasks_rs::TrustTask<serde_json::Value> = serde_json::from_value(json!({
+        "id": id,
+        "type": type_uri,
+        "issuer": did,
+        "recipient": ctx.inner.vta_did,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "payload": payload,
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as_test_admin(&mut doc);
+    serde_json::to_value(&doc).expect("envelope serialises")
+}
+
 #[tokio::test]
 async fn trust_tasks_require_auth() {
     let (app, _ctx) = TestApp::new().await;
@@ -355,12 +382,12 @@ async fn trust_task_discovery_reports_dispatched_tasks() {
         .request(post_auth(
             "/api/trust-tasks",
             &token,
-            json!({
-                "id": "urn:uuid:4c3d5e6f-7081-4293-a4b5-c6d7e8f90123",
-                "type": "https://trusttasks.org/spec/trust-task-discovery/0.1",
-                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                "payload": { "patterns": ["acl/*"] },
-            }),
+            signed_doc(
+                &ctx,
+                "urn:uuid:4c3d5e6f-7081-4293-a4b5-c6d7e8f90123",
+                "https://trusttasks.org/spec/trust-task-discovery/0.1",
+                json!({ "patterns": ["acl/*"] }),
+            ),
         ))
         .await;
     assert_eq!(status, StatusCode::OK, "body: {body}");
@@ -393,12 +420,12 @@ async fn trust_task_discovery_defaults_to_everything() {
         .request(post_auth(
             "/api/trust-tasks",
             &token,
-            json!({
-                "id": "urn:uuid:5d4e6f70-8192-43a4-b5c6-d7e8f9012345",
-                "type": "https://trusttasks.org/spec/trust-task-discovery/0.1",
-                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                "payload": {},
-            }),
+            signed_doc(
+                &ctx,
+                "urn:uuid:5d4e6f70-8192-43a4-b5c6-d7e8f9012345",
+                "https://trusttasks.org/spec/trust-task-discovery/0.1",
+                json!({}),
+            ),
         ))
         .await;
     assert_eq!(status, StatusCode::OK, "body: {body}");
@@ -2204,15 +2231,15 @@ async fn keys_import_trust_task_refuses_cleartext_over_rest() {
         .request(post_auth(
             "/api/trust-tasks",
             &token,
-            json!({
-                "id": "urn:uuid:6f1b2c3d-4e5f-4061-8293-a4b5c6d7e8f9",
-                "type": "https://trusttasks.org/spec/keys/import/0.1",
-                "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                "payload": {
+            signed_doc(
+                &ctx,
+                "urn:uuid:6f1b2c3d-4e5f-4061-8293-a4b5c6d7e8f9",
+                "https://trusttasks.org/spec/keys/import/0.1",
+                json!({
                     "keyType": "ed25519",
                     "privateKeyMultibase": "z6MkDeadbeefDeadbeefDeadbeef",
-                },
-            }),
+                }),
+            ),
         ))
         .await;
 

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -44,13 +44,7 @@ use vta_sdk::client::{CreateAclRequest, UpdateAclRequest, VtaClient};
 
 /// A client authenticated as an unrestricted admin against a live mock VTA.
 async fn admin_client(mock: &MockVta) -> VtaClient {
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkRoundTripAdmin", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
-    client
+    mock.signing_client(0x30, "admin", vec![]).await
 }
 
 // ── ACL ─────────────────────────────────────────────────────────────
@@ -465,8 +459,7 @@ async fn webvh_get_did_round_trips_after_the_get_log_fold() {
         .ctx
         .mint_token("did:key:z6MkRoundTripAdmin", "admin", vec![])
         .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token.clone()).await;
+    let client = mock.signing_client(0x30, "admin", vec![]).await;
 
     let did = "did:webvh:example.com:round-trip";
     let record = WebvhDidRecord {

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -92,6 +92,11 @@ fn approver(seed: u8) -> Approver {
 /// takes the approver's identity from it, never from the bearer session.
 fn sign_as(who: &Approver, doc_json: Value) -> Value {
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
+    // Any existing proof comes off first. `prepare_sign_input` hashes the
+    // document as given, so signing over one that already carries a proof
+    // produces a signature covering bytes the verifier never reconstructs — it
+    // fails as `proofInvalid`, which reads like a key problem and is not one.
+    doc.proof = None;
     let mut di = DataIntegrityProof::new(
         CryptoSuite::EddsaJcs2022,
         who.vm.clone(),
@@ -109,16 +114,31 @@ fn sign_as(who: &Approver, doc_json: Value) -> Value {
     serde_json::to_value(&doc).unwrap()
 }
 
-fn envelope(type_uri: &str, issuer: &str, recipient: &str, payload: Value) -> Value {
-    json!({
-        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
-        "type": type_uri,
-        "issuer": issuer,
-        "recipient": recipient,
-        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "payload": payload,
-    })
+/// A signed envelope from `issuer`.
+///
+/// Signing is not optional any more: SPEC §7.2 item 7a is enforced, and most of
+/// the tasks these tests drive declare `proof` REQUIRED. Taking an `&Approver`
+/// rather than a DID string is what makes that possible — a hand-written DID
+/// has no key behind it, so a document issued by one can never be signed, and
+/// the compiler now says so at the call site instead of the VTA saying it at
+/// run time.
+fn envelope(type_uri: &str, issuer: &Approver, recipient: &str, payload: Value) -> Value {
+    sign_as(
+        issuer,
+        json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": type_uri,
+            "issuer": issuer.did,
+            "recipient": recipient,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": payload,
+        }),
+    )
 }
+
+/// The requester identity these tests act as. Seeded so the DID and the signing
+/// key come from one place.
+const REQUESTER_SEED: u8 = 0x51;
 
 /// The update keys actually in force on `did`, read from the committed log.
 ///
@@ -158,8 +178,8 @@ async fn a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_
         ..Default::default()
     })
     .await;
-    let requester = "did:key:z6MkTestRequester";
-    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let requester = approver(REQUESTER_SEED);
+    let token = ctx.mint_token(&requester.did, "admin", vec![]).await;
     let ops = approver(7);
 
     // A real DID, minted over the wire by the VTA that holds its key.
@@ -191,7 +211,7 @@ async fn a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_
     });
     let update = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         json!({ "did": did, "document": new_doc }),
     );
@@ -270,18 +290,15 @@ async fn a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_
 
     // ── 4. The human approves. The proof is the authorization; the bearer token
     //       belongs to the *requester* and says nothing about who agreed.
-    let decision = sign_as(
+    let decision = envelope(
+        TASK_CONSENT_DECISION,
         &ops,
-        envelope(
-            TASK_CONSENT_DECISION,
-            &ops.did,
-            &ctx.vta_did,
-            json!({
-                "challenge": challenge,
-                "payloadDigest": payload_digest,
-                "decision": "approve"
-            }),
-        ),
+        &ctx.vta_did,
+        json!({
+            "challenge": challenge,
+            "payloadDigest": payload_digest,
+            "decision": "approve"
+        }),
     );
     let (status, granted) = post(&router, &token, &decision).await;
     assert_eq!(
@@ -297,7 +314,7 @@ async fn a_did_update_is_approved_by_a_human_and_the_keys_they_saw_are_the_keys_
     //       re-proposes the approved task in a new envelope, exactly as here.
     let resubmit = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         update["payload"].clone(),
     );
@@ -330,8 +347,8 @@ async fn an_approval_authorizes_exactly_one_execution() {
         ..Default::default()
     })
     .await;
-    let requester = "did:key:z6MkTestRequester";
-    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let requester = approver(REQUESTER_SEED);
+    let token = ctx.mint_token(&requester.did, "admin", vec![]).await;
     let ops = approver(9);
 
     let (did, _scid) = create_did(&router, &ctx, &token).await;
@@ -348,22 +365,19 @@ async fn an_approval_authorizes_exactly_one_execution() {
         "did": did,
         "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did, "alsoKnownAs": ["did:example:x"] }
     });
-    let update = envelope(WEBVH_UPDATE, requester, &ctx.vta_did, payload);
+    let update = envelope(WEBVH_UPDATE, &requester, &ctx.vta_did, payload);
 
     let (_, rejected) = post(&router, &token, &update).await;
     let d = &rejected["payload"]["details"];
-    let decision = sign_as(
+    let decision = envelope(
+        TASK_CONSENT_DECISION,
         &ops,
-        envelope(
-            TASK_CONSENT_DECISION,
-            &ops.did,
-            &ctx.vta_did,
-            json!({
-                "challenge": d["challenge"],
-                "payloadDigest": d["payloadDigest"],
-                "decision": "approve"
-            }),
-        ),
+        &ctx.vta_did,
+        json!({
+            "challenge": d["challenge"],
+            "payloadDigest": d["payloadDigest"],
+            "decision": "approve"
+        }),
     );
     let (status, _) = post(&router, &token, &decision).await;
     assert_eq!(status, StatusCode::OK);
@@ -371,7 +385,7 @@ async fn an_approval_authorizes_exactly_one_execution() {
     // First re-submit (fresh envelope, same payload) executes.
     let first = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         update["payload"].clone(),
     );
@@ -382,7 +396,7 @@ async fn an_approval_authorizes_exactly_one_execution() {
     // grant was consumed; what comes back is a fresh demand for consent.
     let second = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         update["payload"].clone(),
     );
@@ -429,7 +443,7 @@ async fn the_requester_cannot_approve_its_own_task() {
 
     let update = envelope(
         WEBVH_UPDATE,
-        &requester.did,
+        &requester,
         &ctx.vta_did,
         json!({ "did": did, "document": { "@context": ["https://www.w3.org/ns/did/v1"], "id": did } }),
     );
@@ -444,18 +458,15 @@ async fn the_requester_cannot_approve_its_own_task() {
     );
 
     // And if they sign one anyway, the executor refuses it.
-    let decision = sign_as(
+    let decision = envelope(
+        TASK_CONSENT_DECISION,
         &requester,
-        envelope(
-            TASK_CONSENT_DECISION,
-            &requester.did,
-            &ctx.vta_did,
-            json!({
-                "challenge": d["challenge"],
-                "payloadDigest": d["payloadDigest"],
-                "decision": "approve"
-            }),
-        ),
+        &ctx.vta_did,
+        json!({
+            "challenge": d["challenge"],
+            "payloadDigest": d["payloadDigest"],
+            "decision": "approve"
+        }),
     );
     let (status, refused) = post(&router, &token, &decision).await;
     assert_ne!(
@@ -483,16 +494,16 @@ async fn a_context_admin_approval_lets_a_cross_context_requester_execute() {
     // Setup: mint the DID in context `default` using a super-admin (the
     // provisioning identity a deployment already trusts).
     let admin_token = ctx
-        .mint_token("did:key:z6MkTestRequester", "admin", vec![])
+        .mint_token(&approver(REQUESTER_SEED).did, "admin", vec![])
         .await;
     let (did, _scid) = create_did(&router, &ctx, &admin_token).await;
     let keys_before = update_keys_in_force(&ctx, &did).await;
 
     // The requester is an admin — but of `other-ctx`, NOT `default`. On its own
     // token it cannot touch this DID.
-    let requester = "did:key:z6MkCrossCtxAgent";
+    let requester = approver(0x52);
     let deleg_token = ctx
-        .mint_token(requester, "admin", vec!["other-ctx".into()])
+        .mint_token(&requester.did, "admin", vec!["other-ctx".into()])
         .await;
 
     // The approver is an admin of `default` in the ACL — the authority a
@@ -520,7 +531,7 @@ async fn a_context_admin_approval_lets_a_cross_context_requester_execute() {
     //    approver can be shown the effects.
     let update = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         json!({
             "did": did,
@@ -543,14 +554,11 @@ async fn a_context_admin_approval_lets_a_cross_context_requester_execute() {
     );
 
     // 2. The context admin approves.
-    let decision = sign_as(
+    let decision = envelope(
+        TASK_CONSENT_DECISION,
         &ops,
-        envelope(
-            TASK_CONSENT_DECISION,
-            &ops.did,
-            &ctx.vta_did,
-            json!({ "challenge": challenge, "payloadDigest": payload_digest, "decision": "approve" }),
-        ),
+        &ctx.vta_did,
+        json!({ "challenge": challenge, "payloadDigest": payload_digest, "decision": "approve" }),
     );
     let (status, granted) = post(&router, &deleg_token, &decision).await;
     assert_eq!(status, StatusCode::OK, "decision accepted: {granted}");
@@ -560,7 +568,7 @@ async fn a_context_admin_approval_lets_a_cross_context_requester_execute() {
     //    context authority the approval conferred for this one task.
     let resubmit = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         update["payload"].clone(),
     );
@@ -601,14 +609,14 @@ async fn an_unsatisfiable_elevation_is_refused_before_any_consent_ceremony() {
     .await;
 
     let admin_token = ctx
-        .mint_token("did:key:z6MkTestRequester", "admin", vec![])
+        .mint_token(&approver(REQUESTER_SEED).did, "admin", vec![])
         .await;
     let (did, _scid) = create_did(&router, &ctx, &admin_token).await;
     let keys_before = update_keys_in_force(&ctx, &did).await;
 
-    let requester = "did:key:z6MkCrossCtxAgent";
+    let requester = approver(0x52);
     let deleg_token = ctx
-        .mint_token(requester, "admin", vec!["other-ctx".into()])
+        .mint_token(&requester.did, "admin", vec!["other-ctx".into()])
         .await;
 
     // The approver administers a DIFFERENT context, not `default`.
@@ -632,7 +640,7 @@ async fn an_unsatisfiable_elevation_is_refused_before_any_consent_ceremony() {
 
     let update = envelope(
         WEBVH_UPDATE,
-        requester,
+        &requester,
         &ctx.vta_did,
         json!({
             "did": did,
@@ -715,7 +723,7 @@ async fn create_did(router: &axum::Router, ctx: &TestAppContext, token: &str) ->
 
     let doc = envelope(
         vta_sdk::trust_tasks::TASK_WEBVH_DIDS_CREATE_1_0,
-        "did:key:z6MkTestRequester",
+        &approver(REQUESTER_SEED),
         &ctx.vta_did,
         json!({ "contextId": "default", "url": "https://example.com/acme" }),
     );
@@ -747,8 +755,8 @@ async fn rest_and_trust_task_reach_the_same_consent_decision() {
         ..Default::default()
     })
     .await;
-    let requester = "did:key:z6MkTestRequester";
-    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let requester = approver(REQUESTER_SEED);
+    let token = ctx.mint_token(&requester.did, "admin", vec![]).await;
     let ops = approver(11);
 
     vta_service::contexts::create_context(&ctx.contexts_ks, "default", "Default")
@@ -780,7 +788,7 @@ async fn rest_and_trust_task_reach_the_same_consent_decision() {
     // ── Trust-task path: refused, as it always was.
     let doc = envelope(
         vta_sdk::trust_tasks::TASK_ACL_GRANT_0_1,
-        requester,
+        &requester,
         &ctx.vta_did,
         grant.clone(),
     );
@@ -850,8 +858,8 @@ async fn the_webvh_rest_route_is_gated_like_its_trust_task() {
         ..Default::default()
     })
     .await;
-    let requester = "did:key:z6MkTestRequester";
-    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let requester = approver(REQUESTER_SEED);
+    let token = ctx.mint_token(&requester.did, "admin", vec![]).await;
     let ops = approver(13);
 
     let (did, scid) = create_did(&router, &ctx, &token).await;
@@ -984,8 +992,8 @@ async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
         ..Default::default()
     })
     .await;
-    let requester = "did:key:z6MkTestRequester";
-    let token = ctx.mint_token(requester, "admin", vec![]).await;
+    let requester = approver(REQUESTER_SEED);
+    let token = ctx.mint_token(&requester.did, "admin", vec![]).await;
     let ops = approver(23);
 
     vta_service::contexts::create_context(&ctx.contexts_ks, "default", "Default")
@@ -1012,7 +1020,7 @@ async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
     // ── 1. Refused, pending a human.
     let doc = envelope(
         vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
-        requester,
+        &requester,
         &ctx.vta_did,
         payload.clone(),
     );
@@ -1048,18 +1056,15 @@ async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
     //       decision (#907) — `ops` holds no ACL entry, which is exactly the
     //       property that lets a recovery approver be a device rather than an
     //       administrator.
-    let decision = sign_as(
+    let decision = envelope(
+        TASK_CONSENT_DECISION,
         &ops,
-        envelope(
-            TASK_CONSENT_DECISION,
-            &ops.did,
-            &ctx.vta_did,
-            json!({
-                "challenge": challenge,
-                "payloadDigest": payload_digest,
-                "decision": "approve"
-            }),
-        ),
+        &ctx.vta_did,
+        json!({
+            "challenge": challenge,
+            "payloadDigest": payload_digest,
+            "decision": "approve"
+        }),
     );
     let (status, granted) = post(&router, &token, &decision).await;
     assert_eq!(
@@ -1074,7 +1079,7 @@ async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
     //       reused id outright.
     let resubmit = envelope(
         vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
-        requester,
+        &requester,
         &ctx.vta_did,
         payload,
     );

--- a/vta-service/tests/idempotency_trust_task.rs
+++ b/vta-service/tests/idempotency_trust_task.rs
@@ -28,12 +28,20 @@ use vta_service::test_support::build_test_app;
 
 const KEYS_CREATE: &str = "https://trusttasks.org/spec/keys/create/0.1";
 const KEYS_LIST: &str = "https://trusttasks.org/spec/keys/list/0.1";
-const CALLER: &str = "did:key:z6MkIdempotencyCaller";
+/// The caller's signing seed. A `did:key` derived from it, rather than a
+/// hand-written DID, because SPEC §7.2 item 7a wants a proof on `keys/create`
+/// and item 6 wants the in-band issuer to be the identity the token
+/// authenticates — so the DID and the key have to come from one place.
+const CALLER_SEED: u8 = 0x40;
+
+fn caller() -> String {
+    vta_service::test_support::did_for_seed(CALLER_SEED).0
+}
 const OTHER_CALLER: &str = "did:key:z6MkSomeoneElseEntirely";
 const CONTEXT: &str = "test";
 
 /// A live app with the `test` context in place and an unrestricted admin token
-/// for [`CALLER`].
+/// for [`caller().as_str()`].
 ///
 /// `keys/create` needs a real context to derive under, so every test that
 /// counts keys has to create one first.
@@ -42,7 +50,7 @@ async fn app() -> (axum::Router, String) {
     vta_service::contexts::create_context(&ctx.contexts_ks, CONTEXT, "Idempotency tests")
         .await
         .expect("context");
-    let token = ctx.mint_token(CALLER, "admin", vec![]).await;
+    let token = ctx.mint_token(caller().as_str(), "admin", vec![]).await;
     (router, token)
 }
 
@@ -52,7 +60,7 @@ async fn app_with_second_caller() -> (axum::Router, String, String) {
     vta_service::contexts::create_context(&ctx.contexts_ks, CONTEXT, "Idempotency tests")
         .await
         .expect("context");
-    let mine = ctx.mint_token(CALLER, "admin", vec![]).await;
+    let mine = ctx.mint_token(caller().as_str(), "admin", vec![]).await;
     let theirs = ctx.mint_token(OTHER_CALLER, "admin", vec![]).await;
     (router, mine, theirs)
 }
@@ -68,7 +76,7 @@ fn create_doc(envelope_id: &str, label: &str, idempotency_key: Option<&str>) -> 
         "id": format!("urn:uuid:{envelope_id}"),
         "type": KEYS_CREATE,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": CALLER,
+        "issuer": caller(),
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
             "keyType": "ed25519",
@@ -80,7 +88,12 @@ fn create_doc(envelope_id: &str, label: &str, idempotency_key: Option<&str>) -> 
     if let Some(k) = idempotency_key {
         doc["idempotencyKey"] = json!(k);
     }
-    doc
+    // Signed last: the proof is taken over the finished document, so attaching
+    // it before `idempotencyKey` would sign a document that is not the one sent.
+    let mut typed: trust_tasks_rs::TrustTask<Value> =
+        serde_json::from_value(doc).expect("envelope deserialises");
+    vta_service::test_support::sign_as(CALLER_SEED, &mut typed);
+    serde_json::to_value(&typed).expect("envelope serialises")
 }
 
 async fn post(router: &axum::Router, token: &str, doc: &Value) -> (StatusCode, Value) {
@@ -107,7 +120,7 @@ async fn key_count(router: &axum::Router, token: &str) -> usize {
         "id": format!("urn:uuid:{}", uuid_ish()),
         "type": KEYS_LIST,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": CALLER,
+        "issuer": caller(),
         "recipient": "did:key:z6MkTestVTA",
         "payload": { "contextId": CONTEXT },
     });
@@ -268,7 +281,7 @@ async fn the_same_key_on_a_different_task_is_refused() {
         "id": "urn:uuid:e2",
         "type": "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": CALLER,
+        "issuer": caller(),
         "recipient": "did:key:z6MkTestVTA",
         "idempotencyKey": "urn:uuid:idem-cross",
         "payload": { "contextId": CONTEXT, "portable": true },
@@ -306,7 +319,7 @@ async fn a_key_on_a_retry_safe_task_is_ignored_not_rejected() {
         "id": "urn:uuid:g1",
         "type": KEYS_LIST,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": CALLER,
+        "issuer": caller(),
         "recipient": "did:key:z6MkTestVTA",
         "idempotencyKey": "urn:uuid:idem-on-a-read",
         "payload": { "contextId": CONTEXT },

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -4,6 +4,7 @@
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
+use vta_sdk::client::VtaClient;
 use vta_service::test_support::MockVta;
 
 /// Minimal HTTP/1.1 GET over a fresh TCP connection; returns the raw response.
@@ -20,6 +21,24 @@ async fn http_get(addr: &str, path: &str) -> String {
         .await
         .expect("read response");
     String::from_utf8_lossy(&response).into_owned()
+}
+
+/// A client that can produce documents a conforming VTA accepts.
+///
+/// `mint_token` alone stopped being enough when the spine started enforcing
+/// SPEC §7.2: every dispatched spec declares `recipient` REQUIRED (item 5b) and
+/// 72 of them declare `proof` REQUIRED (item 7a), so a client needs the key
+/// behind the DID its token names — not just the token. `seed` picks the
+/// identity, so a test wanting two callers asks for two seeds.
+async fn signing_client(mock: &MockVta, seed: u8, role: &str, contexts: Vec<String>) -> VtaClient {
+    let vta_did = mock.vta_did().to_string();
+    let (identity, token) = mock
+        .ctx
+        .mint_signing_identity(seed, role, contexts, &vta_did)
+        .await;
+    let client = VtaClient::new(mock.base_url()).with_identity(identity);
+    client.set_token_async(token).await;
+    client
 }
 
 #[tokio::test]
@@ -98,12 +117,7 @@ async fn seeded_webvh_server_is_listed_over_http() {
     mock.seed_webvh_server("prod", "did:webvh:host.example.com")
         .await;
 
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkTestAdmin", "admin", vec![])
-        .await;
-    let client = vta_sdk::client::VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x10, "admin", vec![]).await;
 
     let result = client
         .list_webvh_servers()
@@ -176,18 +190,13 @@ async fn url_direct_admin_rotation_round_trips_against_rest_only_mock() {
 /// for the persona-mint layer.
 #[tokio::test]
 async fn create_did_webvh_round_trips_against_stub_host() {
-    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::client::CreateDidWebvhRequest;
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
     let mock = MockVta::start_with_webvh_host().await;
 
     // Authenticate as a super-admin (mint-token shortcut — no live handshake).
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x11, "admin", vec![]).await;
 
     let req = CreateDidWebvhRequest {
         context_id: "ctx1".into(),
@@ -248,17 +257,12 @@ async fn create_did_webvh_round_trips_against_stub_host() {
 #[tokio::test]
 #[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
 async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() {
-    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::client::CreateDidWebvhRequest;
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
     use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
 
     let mock = MockVta::start_with_webvh_host().await;
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x11, "admin", vec![]).await;
 
     let create = client
         .create_did_webvh(CreateDidWebvhRequest {
@@ -376,17 +380,12 @@ async fn a_failed_publish_does_not_wedge_the_did_and_the_next_update_recovers() 
 #[tokio::test]
 #[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
 async fn a_caller_pinned_to_the_host_version_recovers_a_failed_publish() {
-    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::client::CreateDidWebvhRequest;
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
     use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
 
     let mock = MockVta::start_with_webvh_host().await;
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x11, "admin", vec![]).await;
 
     let create = client
         .create_did_webvh(CreateDidWebvhRequest {
@@ -490,17 +489,12 @@ async fn a_caller_pinned_to_the_host_version_recovers_a_failed_publish() {
 #[tokio::test]
 #[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
 async fn a_stale_caller_still_conflicts() {
-    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::client::CreateDidWebvhRequest;
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
     use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
 
     let mock = MockVta::start_with_webvh_host().await;
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x11, "admin", vec![]).await;
 
     let create = client
         .create_did_webvh(CreateDidWebvhRequest {
@@ -598,17 +592,12 @@ async fn a_stale_caller_still_conflicts() {
 #[tokio::test]
 #[allow(deprecated)] // pins the legacy (context_id, scid) route until it is removed
 async fn a_superseded_signing_key_is_recovered_from_the_seed() {
-    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::client::CreateDidWebvhRequest;
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
     use vta_sdk::protocols::did_management::update::UpdateDidWebvhBody;
 
     let mock = MockVta::start_with_webvh_host().await;
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkWebvhAdmin", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x11, "admin", vec![]).await;
 
     let create = client
         .create_did_webvh(CreateDidWebvhRequest {
@@ -693,16 +682,11 @@ async fn a_superseded_signing_key_is_recovered_from_the_seed() {
 #[cfg(feature = "webvh")]
 #[tokio::test]
 async fn webvh_family_response_shapes() {
-    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::client::CreateDidWebvhRequest;
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
     let mock = MockVta::start_with_webvh_host().await;
-    let token = mock
-        .ctx
-        .mint_token("did:key:z6MkWebvhCoverage", "admin", vec![])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+    let client = signing_client(&mock, 0x12, "admin", vec![]).await;
 
     // A real mint: everything below needs a *hosted* DID, not a seeded record.
     let minted = client
@@ -860,12 +844,10 @@ async fn webvh_family_response_shapes() {
 /// prove six shapes; running them in sequence proves the gate.
 #[tokio::test]
 async fn consent_family_response_shapes() {
-    use vta_sdk::client::VtaClient;
     use vta_sdk::protocols::consent_management::ConsentRequestBody;
 
     const PLATFORM: &str = "signal";
     const CONTEXT: &str = "ctx1";
-    const OPERATOR: &str = "did:key:z6MkConsentOperator";
     // base64url, ≥128 bits per the schema's `minLength` 16.
     const CHALLENGE: &str = "Y29uc2VudC1jb3ZlcmFnZS0xMjhi";
 
@@ -875,12 +857,17 @@ async fn consent_family_response_shapes() {
     // returns `Some` only for a caller with *exactly* one allowed context. An
     // admin minted with `vec![]` has unrestricted access and no default, so the
     // fallback this test exercises would be dead.
-    let token = mock
+    let client = signing_client(&mock, 0x20, "admin", vec![CONTEXT.to_string()]).await;
+    // The operator is the caller: `consent/decision` treats the requester and
+    // the approver as one when they are the same DID (bridge-attested), and the
+    // caller's DID is now derived from its signing seed rather than named.
+    let operator = mock
         .ctx
-        .mint_token(OPERATOR, "admin", vec![CONTEXT.to_string()])
-        .await;
-    let client = VtaClient::new(mock.base_url());
-    client.set_token_async(token).await;
+        .mint_signing_identity(0x20, "admin", vec![CONTEXT.to_string()], mock.vta_did())
+        .await
+        .0
+        .client_did;
+    let operator = operator.as_str();
 
     let subject = serde_json::json!({
         "platform": PLATFORM,
@@ -891,7 +878,7 @@ async fn consent_family_response_shapes() {
 
     // ── the approver must exist before anything can be asked ──────────────
     client
-        .consent_approver_set(PLATFORM, CONTEXT, OPERATOR, Some("bridge-relay"), None)
+        .consent_approver_set(PLATFORM, CONTEXT, operator, Some("bridge-relay"), None)
         .await
         .expect("consent/approver-set");
     let listed = client

--- a/vta-service/tests/pending_presentation_trust_task.rs
+++ b/vta-service/tests/pending_presentation_trust_task.rs
@@ -100,15 +100,28 @@ async fn put_pending(ctx: &TestAppContext, id: &str) {
         .expect("seed pending record");
 }
 
+/// The admin's signing seed. The DID is derived from it rather than written
+/// out, because SPEC §7.2 item 7a is enforced and `credential-exchange/*`
+/// declares `proof` REQUIRED — so the DID in `issuer` and the key that signs
+/// have to come from one place, and item 6 rejects them if they disagree.
+const ADMIN_SEED: u8 = 0x60;
+
+fn admin_did() -> String {
+    vta_service::test_support::did_for_seed(ADMIN_SEED).0
+}
+
 fn tt(id: &str, type_uri: &str, issuer: &str, payload: Value) -> Value {
-    json!({
+    let mut doc: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": id,
         "type": type_uri,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": issuer,
         "recipient": "did:key:z6MkTestVTA",
         "payload": payload,
-    })
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(ADMIN_SEED, &mut doc);
+    serde_json::to_value(&doc).expect("envelope serialises")
 }
 
 async fn post_tt(router: &axum::Router, token: Option<&str>, doc: &Value) -> (StatusCode, Value) {
@@ -132,7 +145,8 @@ async fn post_tt(router: &axum::Router, token: Option<&str>, doc: &Value) -> (St
 #[tokio::test]
 async fn list_then_deny_over_the_wire_deletes_the_record() {
     let (router, ctx) = build_test_app().await;
-    let did = "did:key:z6MkPendingAdmin";
+    let did = admin_did();
+    let did = did.as_str();
     let token = seed_admin_and_token(&ctx, did, "sess-pending-1", vec![]).await;
     put_pending(&ctx, "req-wire-1").await;
 

--- a/vta-service/tests/revoke_session_trust_task.rs
+++ b/vta-service/tests/revoke_session_trust_task.rs
@@ -22,7 +22,15 @@ use tower::ServiceExt;
 use vta_service::test_support::{TestAppContext, build_test_app};
 use vti_common::auth::session::{Session, SessionState, get_session, now_epoch, store_session};
 
-const CALLER: &str = "did:key:z6MkRevokeCaller";
+/// The caller's signing seed. `auth/revoke-session/0.1` declares `proof`
+/// REQUIRED, so the DID and the key behind it have to come from one place —
+/// item 6 rejects a document whose issuer disagrees with the identity its token
+/// authenticates.
+const CALLER_SEED: u8 = 0x70;
+
+fn caller() -> String {
+    vta_service::test_support::did_for_seed(CALLER_SEED).0
+}
 const STRANGER: &str = "did:key:z6MkRevokeStranger";
 
 async fn seed_session(ctx: &TestAppContext, session_id: &str, did: &str) {
@@ -45,7 +53,7 @@ async fn seed_session(ctx: &TestAppContext, session_id: &str, did: &str) {
     store_session(&ctx.sessions_ks, &session).await.unwrap();
 }
 
-/// Dispatch a `revoke-session` for `target`, authenticated as `CALLER` on
+/// Dispatch a `revoke-session` for `target`, authenticated as `caller().as_str()` on
 /// `caller_session` with `role`. Returns `(status, response document)`.
 async fn revoke(
     router: &axum::Router,
@@ -56,7 +64,7 @@ async fn revoke(
     doc_id: &str,
 ) -> (StatusCode, Value) {
     let claims = ctx.jwt_keys.new_claims(
-        CALLER.into(),
+        caller(),
         caller_session.into(),
         role.into(),
         vec![],
@@ -64,14 +72,17 @@ async fn revoke(
         false,
     );
     let token = ctx.jwt_keys.encode(&claims).unwrap();
-    let doc = json!({
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": format!("urn:uuid:{doc_id}"),
         "type": "https://trusttasks.org/spec/auth/revoke-session/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": CALLER,
+        "issuer": &caller(),
         "recipient": "did:key:z6MkTestVTA",
         "payload": { "sessionId": target },
-    });
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(CALLER_SEED, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")
@@ -92,8 +103,8 @@ async fn revoke(
 #[tokio::test]
 async fn revoking_own_session_counts_one_then_zero() {
     let (router, ctx) = build_test_app().await;
-    seed_session(&ctx, "sess-here", CALLER).await;
-    seed_session(&ctx, "sess-other-device", CALLER).await;
+    seed_session(&ctx, "sess-here", &caller()).await;
+    seed_session(&ctx, "sess-other-device", caller().as_str()).await;
 
     let (status, v) = revoke(
         &router,
@@ -140,7 +151,7 @@ async fn revoking_own_session_counts_one_then_zero() {
 #[tokio::test]
 async fn a_stranger_session_and_a_missing_one_answer_identically() {
     let (router, ctx) = build_test_app().await;
-    seed_session(&ctx, "sess-here", CALLER).await;
+    seed_session(&ctx, "sess-here", &caller()).await;
     seed_session(&ctx, "sess-not-yours", STRANGER).await;
 
     let (exists_status, exists) = revoke(
@@ -186,7 +197,7 @@ async fn a_stranger_session_and_a_missing_one_answer_identically() {
 #[tokio::test]
 async fn an_admin_revokes_another_subjects_session() {
     let (router, ctx) = build_test_app().await;
-    seed_session(&ctx, "sess-here", CALLER).await;
+    seed_session(&ctx, "sess-here", &caller()).await;
     seed_session(&ctx, "sess-not-yours", STRANGER).await;
 
     let (status, v) = revoke(

--- a/vta-service/tests/session_jti_pin.rs
+++ b/vta-service/tests/session_jti_pin.rs
@@ -63,21 +63,29 @@ async fn whoami_status(
         )
         .with_jti(jti);
     let token = ctx.jwt_keys.encode(&claims).unwrap();
-    let doc = serde_json::json!({
-        // A fresh id per call. These are distinct requests, not replays, and
-        // SPEC §7.2 item 11 keys the duplicate-execution record on the document
-        // `id` **alone** — "transport request identifiers, transport message
-        // identifiers, and execution handles MUST NOT substitute". Reusing one
-        // literal across calls worked only while this service keyed on
-        // `(actor, id)`, which is the deviation the `ReplayGuard` adoption
-        // closed; a real producer mints a fresh id per request anyway.
-        "id": format!("urn:uuid:jti-pin-itest-{}", uuid::Uuid::new_v4()),
-        "type": "https://trusttasks.org/spec/auth/whoami/0.1",
-        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
-        "payload": {},
-    });
+    // `auth/whoami/0.1` declares `proof` REQUIRED, and the seed is what ties the
+    // `issuer` to a key that can produce one — item 6 rejects a document whose
+    // issuer disagrees with the identity its token authenticates.
+    let seed = seed_for(did);
+    let mut typed: trust_tasks_rs::TrustTask<serde_json::Value> =
+        serde_json::from_value(serde_json::json!({
+            // A fresh id per call. These are distinct requests, not replays, and
+            // SPEC §7.2 item 11 keys the duplicate-execution record on the document
+            // `id` **alone** — "transport request identifiers, transport message
+            // identifiers, and execution handles MUST NOT substitute". Reusing one
+            // literal across calls worked only while this service keyed on
+            // `(actor, id)`, which is the deviation the `ReplayGuard` adoption
+            // closed; a real producer mints a fresh id per request anyway.
+            "id": format!("urn:uuid:jti-pin-itest-{}", uuid::Uuid::new_v4()),
+            "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "issuer": did,
+            "recipient": "did:key:z6MkTestVTA",
+            "payload": {},
+        }))
+        .expect("envelope deserialises");
+    vta_service::test_support::sign_as(seed, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")
@@ -88,10 +96,24 @@ async fn whoami_status(
     router.clone().oneshot(req).await.unwrap().status()
 }
 
+/// The signing seed behind a test DID.
+///
+/// These tests use two identities and care which one a token names, so the map
+/// is explicit rather than derived — a wrong answer here signs as the wrong
+/// party and is refused for that instead of for the jti pin under test.
+fn seed_for(did: &str) -> u8 {
+    for seed in [0x80u8, 0x81] {
+        if vta_service::test_support::did_for_seed(seed).0 == did {
+            return seed;
+        }
+    }
+    panic!("no signing seed for {did}");
+}
+
 #[tokio::test]
 async fn matching_jti_authenticates_but_superseded_jti_is_rejected() {
     let (router, ctx) = build_test_app().await;
-    let did = "did:key:z6MkPinned";
+    let did = &vta_service::test_support::did_for_seed(0x80).0;
     seed_admin_acl(&ctx, did).await;
     seed_session(&ctx, "sess-pin", did, Some("jti-A")).await;
 
@@ -115,7 +137,7 @@ async fn matching_jti_authenticates_but_superseded_jti_is_rejected() {
 #[tokio::test]
 async fn unpinned_session_accepts_any_jti() {
     let (router, ctx) = build_test_app().await;
-    let did = "did:key:z6MkLegacy";
+    let did = &vta_service::test_support::did_for_seed(0x81).0;
     seed_admin_acl(&ctx, did).await;
     // token_id: None — a legacy / intrinsic-sender session; the pin is skipped.
     seed_session(&ctx, "sess-legacy", did, None).await;

--- a/vta-service/tests/sessions_list_trust_task.rs
+++ b/vta-service/tests/sessions_list_trust_task.rs
@@ -45,7 +45,9 @@ async fn seed_session(
 #[tokio::test]
 async fn sessions_list_returns_only_callers_active_sessions() {
     let (router, ctx) = build_test_app().await;
-    let did = "did:key:z6MkMultiDevice";
+    const CALLER_SEED: u8 = 0x90;
+    let caller = vta_service::test_support::did_for_seed(CALLER_SEED).0;
+    let did = caller.as_str();
     let other = "did:key:z6MkSomeoneElse";
     let now = now_epoch();
 
@@ -100,14 +102,20 @@ async fn sessions_list_returns_only_callers_active_sessions() {
     );
     let token = ctx.jwt_keys.encode(&claims).unwrap();
 
-    let doc = json!({
+    // `auth/sessions/list/0.1` declares `proof` REQUIRED. The caller's DID is
+    // derived from the signing seed so the issuer and the key agree — item 6
+    // refuses them otherwise.
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": "urn:uuid:sessions-list-itest-1",
         "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},
-    });
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(CALLER_SEED, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -360,7 +360,10 @@ async fn trust_task_acl_mutation_requires_step_up() {
     // are the only trigger now.
     require_step_up_for_everything(&ctx).await;
 
-    let did = "did:key:z6MkAal1Admin".to_string();
+    // Seeded so the issuer has a key: `acl/grant/0.1` declares `proof` REQUIRED,
+    // and the step-up gate this test is about fires *after* that check.
+    const AAL1_SEED: u8 = 0xA1;
+    let did = vta_service::test_support::did_for_seed(AAL1_SEED).0;
     let session_id = "sess-stepup-tt-1".to_string();
 
     // An AAL1 admin session + bearer token: role passes, assurance level does not.
@@ -393,7 +396,7 @@ async fn trust_task_acl_mutation_requires_step_up() {
 
     // A well-formed acl/create addressed to the test VTA. The step-up gate fires
     // before payload parsing, so the body need only route + pass the role check.
-    let doc = json!({
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": "acl-create-itest-1",
         "type": "https://trusttasks.org/spec/acl/grant/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -406,7 +409,10 @@ async fn trust_task_acl_mutation_requires_step_up() {
                 "scopes": ["ctx1"]
             }
         },
-    });
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(AAL1_SEED, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")
@@ -507,7 +513,10 @@ async fn v0_2_minted_request_completes_with_a_0_1_flavored_response() {
 
     // 1. An AAL2-gated trust-task mutation → rejected with the minted
     //    approve-request in `details`.
-    let gated = json!({
+    // Signed with the same seed the DID is derived from (57): `acl/grant/0.1`
+    // declares `proof` REQUIRED, and the step-up gate this test exercises runs
+    // after that check.
+    let mut gated_doc: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": "acl-create-roundtrip-1",
         "type": "https://trusttasks.org/spec/acl/grant/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -520,7 +529,10 @@ async fn v0_2_minted_request_completes_with_a_0_1_flavored_response() {
                 "scopes": ["ctx1"]
             }
         },
-    });
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(57, &mut gated_doc);
+    let gated = serde_json::to_value(&gated_doc).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")

--- a/vta-service/tests/vault_trust_task.rs
+++ b/vta-service/tests/vault_trust_task.rs
@@ -122,14 +122,21 @@ async fn post_vault(
     uri: &str,
     payload: Value,
 ) -> (StatusCode, String) {
-    let doc = json!({
+    // Signed with the holder's own seed (7) — `holder_did()` derives the DID
+    // from it, so the issuer and the key agree, which item 6 requires. The vault
+    // specs declare `proof` REQUIRED, so an unsigned document never reaches the
+    // capability checks these tests are about.
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": format!("tt-{}", uuid::Uuid::new_v4()),
         "type": uri,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": holder_did(),
         "recipient": "did:key:z6MkTestVTA",
         "payload": payload,
-    });
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(7, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")

--- a/vta-service/tests/whoami_trust_task.rs
+++ b/vta-service/tests/whoami_trust_task.rs
@@ -28,7 +28,11 @@ async fn seed_admin_acl(ctx: &TestAppContext, did: &str, contexts: Vec<String>) 
 #[tokio::test]
 async fn whoami_reports_live_session_acr_not_stale_token() {
     let (router, ctx) = build_test_app().await;
-    let did = "did:key:z6MkWhoamiSubject";
+    // Seeded: `auth/whoami/0.1` declares `proof` REQUIRED, so the subject needs
+    // a key, and item 6 needs it to be the same identity the token names.
+    const SUBJECT_SEED: u8 = 0xB0;
+    let did = vta_service::test_support::did_for_seed(SUBJECT_SEED).0;
+    let did = did.as_str();
     let session_id = "sess-whoami-1";
     seed_admin_acl(&ctx, did, vec!["ctx1".into()]).await;
 
@@ -63,14 +67,17 @@ async fn whoami_reports_live_session_acr_not_stale_token() {
     );
     let token = ctx.jwt_keys.encode(&claims).unwrap();
 
-    let doc = json!({
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
         "id": "urn:uuid:whoami-itest-1",
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {},
-    });
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(SUBJECT_SEED, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
     let req = Request::builder()
         .method("POST")
         .uri("/api/trust-tasks")


### PR DESCRIPTION
The VTA enforced **none** of the four checks a *Trust Task specification* declares for itself. It now enforces all of them, and the SDK produces documents that satisfy them.

| SPEC §7.2 | check | dispatched specs declaring it |
|---|---|---|
| item 5b | `recipient` REQUIRED | **109 / 109** |
| item 7a | `proof` REQUIRED | **72 / 109** |
| item 8 | audience binding | non-bearer specs |
| §7.3 item 17 | `issuedAt` REQUIRED | **70 / 109** |

## Why it was unreachable

`TrustTask::enforce_spec_policy` reads those constants off `P`. The dispatch spine holds a `TrustTask<Value>` and routes on a URI string, so it had no `P` to read them from.

`spec_policy_for` — added upstream in trustoverip/dtgwg-trust-tasks-tf#321, authored for this — keys the same constants by Type URI. The alternative was a **109-entry URI→type table** in this repo, duplicating what the codegen already emits, and going stale the first time a spec was added.

The spine's own comment claimed *"each slice's typed handler runs it after `parse_payload`"*. No handler did: that comment was the **only** occurrence of `enforce_audience_binding` in the repository.

## This is an auth-model change, not a wire-format one

A bearer token authenticates the *connection*. §7.2 item 7 admits no transport substitute, so every producer must now sign every document.

`vta-sdk` gains `ClientIdentity` (client DID, its key, the VTA's DID) and signs in `dispatch_trust_task`. `SessionStore::connect` supplies it from the stored session — re-read **after** `ensure_authenticated`, because a session that needed rotation now holds a different DID and key, and signing with the pre-rotation pair produces a document whose `issuer` no longer matches the identity its token authenticates (item 6).

`issuer` and `recipient` are set in `build_task_document` rather than at ~200 call sites, for the same reason `issuedAt` already was: a member the framework requires of *every* document belongs to the one function that builds every document.

Signing is unconditional rather than keyed on the flag — a proof on a task that merely RECOMMENDs one is legal and strictly more attributable. What it must never do is attach a proof with **no** in-band recipient (item 8 refuses that on a non-bearer spec), and both come from the same `ClientIdentity`, so they cannot come apart.

## Test identities are derived from seeds now

`did:key:zTestAdmin` was not a `did:key`. Nothing resolves it, and no document issued by it can carry a verifiable proof. Fine while proofless documents were accepted; fatal once 72 specs demand one.

`did_for_seed(u8)` / `sign_as(u8, doc)` give a DID and the key behind it from one place — which is what item 6 needs, since a test that mints a token for one DID and signs with another is refused for *that* rather than for whatever it meant to check.

## A real bug in the fixtures

`delegated_consent_e2e`'s `sign_as` did not clear an existing proof before signing. `prepare_sign_input` hashes the document as given, so signing over one that already carries a proof yields a signature covering bytes no verifier reconstructs — it fails as `proofInvalid`, which reads like a key problem and is not one.

## Also here

- pins `trust-tasks-rs` 0.17.1 (carries `spec_policy_for` and the `provision/integration/0.3` schema fix from #324)

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations — including the 12 `mock_vta` tests that drive a fully-enforcing VTA through the real `VtaClient` over HTTP
- `vta-sdk`, `vti-common`, `vta-mobile-core`, `vta-vault`, `vta-webvh`: 0 failed
- `cargo clippy --workspace --all-features --all-targets` and the CI combination: exit 0
- `cargo fmt --all --check`: exit 0
- `TRUST-TASK RESPONSE COVERAGE 88/109 (81%)` — unchanged

## Downstream

Any client dispatching Trust Tasks must now carry a `ClientIdentity`. `SessionStore::connect` does it automatically; a caller constructing `VtaClient::new(url)` directly needs `.with_identity(…)`. That includes **pnm, the browser plugin, and mobile-core's REST paths**.
