### PR TITLE
fix(sdk)!: give every authenticated client its identity, and adopt provision/integration 0.3

### DIFF
--- a/cnm-cli/src/auth.rs
+++ b/cnm-cli/src/auth.rs
@@ -112,6 +112,19 @@ pub async fn ensure_authenticated(
     store().ensure_authenticated(base_url, keyring_key).await
 }
 
+/// An authenticated client that can also *sign* what it sends.
+///
+/// [`ensure_authenticated`] returns a bearer token, which authenticates the
+/// connection and nothing else. SPEC §7.2 item 7a makes a per-document proof
+/// mandatory for most tasks, so a client built from the token alone has every
+/// call refused. This carries the session's DID and key across too.
+pub async fn authenticated_client(
+    base_url: &str,
+    keyring_key: &str,
+) -> Result<vta_sdk::client::VtaClient, Box<dyn std::error::Error>> {
+    store().rest_client(base_url, keyring_key).await
+}
+
 /// Connect to the VTA using the preferred transport (DIDComm or REST).
 ///
 /// If `url_override` is provided, always uses REST.

--- a/cnm-cli/src/setup.rs
+++ b/cnm-cli/src/setup.rs
@@ -165,9 +165,8 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
             let context_name = format!("CNM - {community_name}");
 
             // Authenticate personal VTA client
-            let personal_client = VtaClient::new(&personal_url);
-            let token = auth::ensure_authenticated(&personal_url, PERSONAL_KEYRING_KEY).await?;
-            personal_client.set_token(token);
+            let personal_client =
+                auth::authenticated_client(&personal_url, PERSONAL_KEYRING_KEY).await?;
 
             // Create context in personal VTA
             eprintln!("\nCreating context '{context_name}' in personal VTA...");
@@ -328,9 +327,7 @@ pub async fn bootstrap_community_session(
     let community_url = resolve_vta_url(community_vta_did).await?;
 
     // Authenticate to personal VTA
-    let token = auth::ensure_authenticated(personal_url, PERSONAL_KEYRING_KEY).await?;
-    let personal_client = VtaClient::new(personal_url);
-    personal_client.set_token(token);
+    let personal_client = auth::authenticated_client(personal_url, PERSONAL_KEYRING_KEY).await?;
 
     // Mint a new admin credential locally and register it on the personal
     // VTA via POST /acl. No key material crosses the wire.

--- a/pnm-cli/src/auth.rs
+++ b/pnm-cli/src/auth.rs
@@ -169,6 +169,19 @@ pub async fn ensure_authenticated(
     store().ensure_authenticated(base_url, keyring_key).await
 }
 
+/// An authenticated client that can also *sign* what it sends.
+///
+/// [`ensure_authenticated`] returns a bearer token, which authenticates the
+/// connection and nothing else. SPEC §7.2 item 7a makes a per-document proof
+/// mandatory for most tasks, so a client built from the token alone has every
+/// call refused. This carries the session's DID and key across too.
+pub async fn authenticated_client(
+    base_url: &str,
+    keyring_key: &str,
+) -> Result<vta_sdk::client::VtaClient, Box<dyn std::error::Error>> {
+    store().rest_client(base_url, keyring_key).await
+}
+
 /// Print the current access token (JWT) to stdout. Performs a fresh
 /// authentication if the cached token is missing or expired. Used by
 /// operator tooling that needs to paste the bearer credential into a

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -608,14 +608,34 @@ pub async fn run_provision_integration(
     }
     eprintln!("  Secrets:         {}", resp.summary.secret_count);
     eprintln!("  Outputs:         {}", resp.summary.output_count);
-    eprintln!("  SHA-256 digest:  {}", resp.digest);
-    eprintln!();
-    eprintln!(
-        "Communicate the digest to the integration's operator out-of-band so they can\n  \
-         verify the bundle on first boot:\n  \
-         pnm bootstrap open --bundle <file> --expect-digest {}",
-        resp.digest
-    );
+    // Printed as hex, because that is what `--expect-digest` takes and what an
+    // operator reads out loud. The wire carries a multibase multihash as of
+    // `provision/integration/0.3`; the two are the same digest in two
+    // encodings, and the human-facing one should not change under an operator
+    // mid-migration.
+    let digest_hex = resp
+        .digest_multibase
+        .as_deref()
+        .map(vta_sdk::sealed_transfer::multibase_digest_to_hex)
+        .transpose()
+        .unwrap_or(None);
+    match digest_hex {
+        Some(hex) => {
+            eprintln!("  SHA-256 digest:  {hex}");
+            eprintln!();
+            eprintln!(
+                "Communicate the digest to the integration's operator out-of-band so they can\n  \
+                 verify the bundle on first boot:\n  \
+                 pnm bootstrap open --bundle <file> --expect-digest {hex}",
+            );
+        }
+        // The member is OPTIONAL from 0.3 on. Say so rather than print an empty
+        // line an operator might read as a digest of nothing.
+        None => {
+            eprintln!("  SHA-256 digest:  (not supplied by this VTA)");
+            eprintln!();
+        }
+    }
     Ok(())
 }
 

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -228,9 +228,14 @@ pub(crate) async fn run(
                 // Fallback: query VTA's REST status endpoint for mediator info.
                 if let Some(url) = effective_rest_url.as_deref() {
                     match auth::ensure_authenticated(url, keyring_key).await {
-                        Ok(token) => {
-                            let client = VtaClient::new(url);
-                            client.set_token_async(token).await;
+                        Ok(_token) => {
+                            let client = match auth::authenticated_client(url, keyring_key).await {
+                                Ok(c) => c,
+                                // The outer arm already handled an auth
+                                // failure; this can only be a missing session,
+                                // which the DIDComm probe below reports.
+                                Err(_) => return Ok(()),
+                            };
                             match client.didcomm_status().await {
                                 Ok(status) if status.enabled => {
                                     Ok(status.mediator_did.map(|did| (did, true)))

--- a/vta-sdk/src/client/auto_connect.rs
+++ b/vta-sdk/src/client/auto_connect.rs
@@ -104,8 +104,16 @@ impl VtaClient {
                 .await
                 .map_err(|e| VtaError::Auth(e.to_string()))?;
 
-                let client = VtaClient::new(input.vta_url);
-                client.set_token_async(token.access_token.clone()).await;
+                let client = VtaClient::authenticated(
+                    input.vta_url,
+                    crate::client::ClientIdentity {
+                        client_did: input.credential_did.to_string(),
+                        private_key_multibase: input.private_key_multibase.to_string(),
+                        vta_did: input.vta_did.to_string(),
+                    },
+                    token.access_token.clone(),
+                )
+                .await;
                 Ok(ConnectedVta {
                     client,
                     rest_token: Some(token),

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -407,10 +407,21 @@ impl VtaClient {
             .trim_end_matches('/')
             .to_string();
 
+        // The credential *is* the identity — the same DID and key that just
+        // authenticated, and the VTA DID it authenticated against. Carrying it
+        // in `RestAuth` for refresh but not as the signing identity is the
+        // split that left this constructor's clients unable to produce a
+        // conforming document.
+        let identity = ClientIdentity {
+            client_did: cred.did.clone(),
+            private_key_multibase: cred.private_key_multibase.clone(),
+            vta_did: cred.vta_did.clone(),
+        };
+
         Ok(Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
-            identity: None,
+            identity: Some(std::sync::Arc::new(identity)),
             transport: Transport::Rest {
                 client: http,
                 base_url,
@@ -974,6 +985,20 @@ impl VtaClient {
     }
 
     /// Set the Bearer token (async version).
+    /// A client authenticated as `identity`, carrying both the token and the
+    /// identity it signs with.
+    ///
+    /// Prefer this over `new` + [`with_identity`](Self::with_identity) +
+    /// `set_token_async` wherever all three are known at once, which is every
+    /// post-authentication site: the three-step form is what let five of them
+    /// ship with the identity missing, because nothing about
+    /// `new(url).set_token(t)` looks incomplete.
+    pub async fn authenticated(url: &str, identity: ClientIdentity, token: String) -> Self {
+        let client = Self::new(url).with_identity(identity);
+        client.set_token_async(token).await;
+        client
+    }
+
     /// Give this client the identity it signs and addresses documents with.
     ///
     /// Without one, every dispatched document is missing an in-band `recipient`
@@ -982,6 +1007,19 @@ impl VtaClient {
     pub fn with_identity(mut self, identity: ClientIdentity) -> Self {
         self.identity = Some(std::sync::Arc::new(identity));
         self
+    }
+
+    /// Whether this client is carrying a bearer token.
+    async fn has_token(&self) -> bool {
+        match &self.transport {
+            Transport::Rest { auth, .. } => auth.lock().await.token.is_some(),
+            // The other transports authenticate per-message rather than with a
+            // bearer token, so "has a token" is not the question there.
+            #[cfg(feature = "session")]
+            Transport::DIDComm { .. } => false,
+            #[cfg(feature = "tsp")]
+            Transport::Tsp { .. } => false,
+        }
     }
 
     pub async fn set_token_async(&self, token: String) {
@@ -2619,6 +2657,20 @@ impl VtaClient {
         let identity = self.identity.clone();
         let doc = build_task_document(type_uri, payload, identity.as_deref());
         let Some(identity) = identity else {
+            // Authenticated but identity-less: the document is missing an
+            // in-band `recipient` (SPEC §7.2 item 5b) and a `proof` (item 7a),
+            // and a conforming VTA refuses it. Say so here rather than let the
+            // caller read `malformedRequest: … no in-band recipient` off the
+            // wire and go looking for a payload bug — the fault is in how this
+            // client was built, and this is where that is knowable.
+            if self.has_token().await {
+                return Err(VtaError::Protocol(format!(
+                    "this VtaClient is authenticated but carries no ClientIdentity, so the \
+                     document it would send for `{type_uri}` has no in-band recipient and no \
+                     proof — build it with `VtaClient::authenticated(url, identity, token)` \
+                     or `.with_identity(…)`"
+                )));
+            }
             return Ok(doc);
         };
         let mut typed: trust_tasks_rs::TrustTask<serde_json::Value> = serde_json::from_value(doc)

--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -59,6 +59,20 @@ pub const CANONICAL_PROVISION_INTEGRATION_0_2: &str =
 pub const CANONICAL_PROVISION_INTEGRATION_0_2_RESULT: &str =
     "https://trusttasks.org/spec/provision/integration/0.2#response";
 
+/// Inbound VP + provisioning options — canonical Trust Task URI, v0.3.
+///
+/// The DIDComm surface follows the Trust-Task one onto 0.3, and for the same
+/// reason: the response carries `digestMultibase` where 0.1 and 0.2 carry a
+/// bare-hex `digest`, and both of those close their response with
+/// `additionalProperties: false`. Serving them from one response body would
+/// emit a member their schemas reject.
+pub const CANONICAL_PROVISION_INTEGRATION_0_3: &str =
+    "https://trusttasks.org/spec/provision/integration/0.3";
+
+/// Outbound sealed bundle + summary — canonical Trust Task URI, v0.3.
+pub const CANONICAL_PROVISION_INTEGRATION_0_3_RESULT: &str =
+    "https://trusttasks.org/spec/provision/integration/0.3#response";
+
 /// Match the result URI to whichever request URI the caller used.
 /// Centralised here so the routing decision lives next to the URI
 /// constants — handlers downstream just call this. The 0.2 request URI
@@ -101,6 +115,7 @@ use crate::provision_integration::http::{
 pub enum ProvisionSpecVersion {
     V0_1,
     V0_2,
+    V0_3,
 }
 
 impl ProvisionSpecVersion {
@@ -109,12 +124,20 @@ impl ProvisionSpecVersion {
         match self {
             ProvisionSpecVersion::V0_1 => CANONICAL_PROVISION_INTEGRATION,
             ProvisionSpecVersion::V0_2 => CANONICAL_PROVISION_INTEGRATION_0_2,
+            ProvisionSpecVersion::V0_3 => CANONICAL_PROVISION_INTEGRATION_0_3,
         }
     }
 }
 
+/// Whether `request_uri` is the 0.1 form, whose summary keys are snake_case.
+///
+/// Written as an equality against 0.1, not as "anything that is not 0.2". The
+/// negative form silently classified every *future* version as 0.1: adding 0.3
+/// made it snake_case a camelCase summary, and the only symptom was a response
+/// whose keys no consumer expected. A predicate about one version should name
+/// that version.
 fn is_v0_1(request_uri: &str) -> bool {
-    request_uri != CANONICAL_PROVISION_INTEGRATION_0_2
+    request_uri == CANONICAL_PROVISION_INTEGRATION
 }
 
 /// `fooBarBaz` → `foo_bar_baz`. A single-word key is returned unchanged.
@@ -424,10 +447,10 @@ mod tests {
     }
 
     #[test]
-    fn response_body_v0_1_stays_snake_case_v0_2_camelizes_summary() {
+    fn response_body_v0_1_stays_snake_case_v0_3_camelizes_summary() {
         let resp = ProvisionIntegrationResponse {
             bundle: "armored".into(),
-            digest: "deadbeef".into(),
+            digest_multibase: Some("zQmSK9pGKFnmc77pqyNAPJyPKt8rMqctngfg3vwuMArwGYZ".into()),
             summary: crate::provision_integration::http::ProvisionSummary {
                 client_did: "did:key:zClient".into(),
                 admin_did: "did:key:zAdmin".into(),
@@ -448,8 +471,8 @@ mod tests {
         assert_eq!(v01["summary"]["client_did"], "did:key:zClient");
         assert_eq!(v01["summary"]["bundle_id_hex"], "abc");
         assert!(v01["summary"].get("clientDid").is_none());
-        // 0.2 — summary keys camelized; values and opaque bundle/digest intact.
-        let v02 = response_body_for_version(&resp, CANONICAL_PROVISION_INTEGRATION_0_2).unwrap();
+        // 0.3 — summary keys camelized; values and opaque bundle/digest intact.
+        let v02 = response_body_for_version(&resp, CANONICAL_PROVISION_INTEGRATION_0_3).unwrap();
         assert_eq!(v02["summary"]["clientDid"], "did:key:zClient");
         assert_eq!(v02["summary"]["bundleIdHex"], "abc");
         assert_eq!(v02["summary"]["secretCount"], 2);
@@ -457,6 +480,13 @@ mod tests {
         assert_eq!(v02["summary"]["contextCreated"], true);
         assert!(v02["summary"].get("client_did").is_none());
         assert_eq!(v02["bundle"], "armored");
-        assert_eq!(v02["digest"], "deadbeef");
+        assert_eq!(
+            v02["digestMultibase"],
+            "zQmSK9pGKFnmc77pqyNAPJyPKt8rMqctngfg3vwuMArwGYZ"
+        );
+        assert!(
+            v02.get("digest").is_none(),
+            "0.3 carries `digestMultibase` and nothing else — its response is closed"
+        );
     }
 }

--- a/vta-sdk/src/provision_client/result.rs
+++ b/vta-sdk/src/provision_client/result.rs
@@ -136,7 +136,17 @@ pub fn response_to_result(
     }
 
     let x_secret = crate::sealed_transfer::ed25519_seed_to_x25519_secret(seed);
-    let opened = open_bundle(&x_secret, bundle, Some(&response.digest))?;
+    // Decoded back to hex for the comparison: the pin travels as a multibase
+    // multihash from 0.3 on, but `open_bundle` compares the hex it computes.
+    // `None` is a real answer — the member is OPTIONAL, and a holder that does
+    // not pin the bundle out of band sends no digest to check against.
+    let expected = response
+        .digest_multibase
+        .as_deref()
+        .map(crate::sealed_transfer::multibase_digest_to_hex)
+        .transpose()
+        .map_err(|e| ProvisionError::Armor(e.to_string()))?;
+    let opened = open_bundle(&x_secret, bundle, expected.as_deref())?;
 
     let payload = match opened.payload {
         SealedPayloadV1::TemplateBootstrap(boxed) => *boxed,
@@ -145,7 +155,7 @@ pub fn response_to_result(
 
     Ok(ProvisionResult {
         bundle_id_hex: hex_lower(&opened.bundle_id),
-        digest: response.digest,
+        digest: expected.unwrap_or_default(),
         summary: response.summary,
         payload,
     })
@@ -181,7 +191,17 @@ pub fn admin_rotation_response_to_reply(
     }
 
     let x_secret = crate::sealed_transfer::ed25519_seed_to_x25519_secret(seed);
-    let opened = open_bundle(&x_secret, bundle, Some(&response.digest))?;
+    // Decoded back to hex for the comparison: the pin travels as a multibase
+    // multihash from 0.3 on, but `open_bundle` compares the hex it computes.
+    // `None` is a real answer — the member is OPTIONAL, and a holder that does
+    // not pin the bundle out of band sends no digest to check against.
+    let expected = response
+        .digest_multibase
+        .as_deref()
+        .map(crate::sealed_transfer::multibase_digest_to_hex)
+        .transpose()
+        .map_err(|e| ProvisionError::Armor(e.to_string()))?;
+    let opened = open_bundle(&x_secret, bundle, expected.as_deref())?;
 
     let payload = match opened.payload {
         SealedPayloadV1::AdminRotation(boxed) => *boxed,

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -144,8 +144,18 @@ pub(crate) async fn run_rest_attempt_full_setup(
         }
     };
 
-    let client = VtaClient::new(rest_url);
-    client.set_token_async(token_result.access_token).await;
+    // The setup DID *is* this client's identity: it just authenticated with it,
+    // and the provisioning tasks that follow are proof-REQUIRED like any other.
+    let client = VtaClient::authenticated(
+        rest_url,
+        crate::client::ClientIdentity {
+            client_did: setup_did.clone(),
+            private_key_multibase: setup_privkey_mb.clone(),
+            vta_did: vta_did.to_string(),
+        },
+        token_result.access_token,
+    )
+    .await;
 
     let _ = tx.send(VtaEvent::CheckDone(
         DiagCheck::ListWebvhServers,
@@ -309,8 +319,18 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
         }
     };
 
-    let client = VtaClient::new(rest_url);
-    client.set_token_async(token_result.access_token).await;
+    // The setup DID *is* this client's identity: it just authenticated with it,
+    // and the provisioning tasks that follow are proof-REQUIRED like any other.
+    let client = VtaClient::authenticated(
+        rest_url,
+        crate::client::ClientIdentity {
+            client_did: setup_did.clone(),
+            private_key_multibase: setup_privkey_mb.clone(),
+            vta_did: vta_did.to_string(),
+        },
+        token_result.access_token,
+    )
+    .await;
 
     let _ = tx.send(VtaEvent::CheckDone(
         DiagCheck::ListWebvhServers,

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -110,14 +110,26 @@ pub enum AssertionMode {
 /// Response body. Used by both transports — REST handlers serialize
 /// and the DIDComm provision-integration client (`vta-sdk`)
 /// deserializes the result message body.
+/// `rename_all` is on the struct rather than on the one field that needs it.
+/// Every member was a single word until `digestMultibase`, so nothing here had
+/// ever exercised the casing — and the first multi-word field went out as
+/// `digest_multibase`, which `additionalProperties: false` rejects. Naming the
+/// rule once means the next multi-word member cannot repeat that.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ProvisionIntegrationResponse {
     /// Armored sealed bundle.
     pub bundle: String,
-    /// SHA-256 digest of the sealed ciphertext (lowercase hex).
-    pub digest: String,
+    /// Digest over the armored ciphertext, for a holder that pins the bundle
+    /// out-of-band.
+    ///
+    /// A multibase multihash as of `provision/integration/0.3`, where it
+    /// replaced the bare-hex `digest`: multihash names its own algorithm, so
+    /// moving off SHA-256 is a change of value rather than of schema. OPTIONAL
+    /// — a holder that does not pin does not need it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest_multibase: Option<String>,
     pub summary: ProvisionSummary,
 }
 
@@ -346,9 +358,9 @@ mod tests {
         use chrono::Duration;
 
         let schema = trust_tasks_rs::schema_index::schema_for(
-            crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+            crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_3,
         )
-        .expect("the 0.2 schema is published and indexed");
+        .expect("the 0.3 schema is published and indexed");
 
         let (seed, pub_bytes) = crate::sealed_transfer::generate_ed25519_keypair();
         let client_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&pub_bytes);

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -313,7 +313,7 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // Mints a DID, keys, an ACL grant and an authorization VC, and returns them
     // HPKE-sealed. Non-convergent in every one of those, and the response is the
     // secret bundle. Remediation-plan F3.
-    (trust_tasks::TASK_PROVISION_INTEGRATION_0_2, KeyedSecret),
+    (trust_tasks::TASK_PROVISION_INTEGRATION_0_3, KeyedSecret),
     // ── WebVH servers ───────────────────────────────────────────────────
     (trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0, ReadOnly),
     (trust_tasks::TASK_WEBVH_SERVERS_REGISTER_1_0, Keyed),
@@ -532,7 +532,7 @@ mod tests {
             );
         }
         assert_eq!(
-            retry_safety(trust_tasks::TASK_PROVISION_INTEGRATION_0_2),
+            retry_safety(trust_tasks::TASK_PROVISION_INTEGRATION_0_3),
             Some(RetrySafety::KeyedSecret)
         );
     }

--- a/vta-sdk/src/sealed_transfer/mod.rs
+++ b/vta-sdk/src/sealed_transfer/mod.rs
@@ -87,6 +87,48 @@ pub fn bundle_digest(bundle: &SealedBundle) -> String {
     crate::hex::lower(hasher.finalize().as_slice())
 }
 
+/// The same digest as [`bundle_digest`], in the form the wire now carries.
+///
+/// A multibase-encoded multihash — `0x12 0x20` (sha2-256, 32 bytes) followed by
+/// the digest, base58btc with the `z` prefix. `provision/integration/0.3`
+/// replaced the bare-hex `digest` with this, so that moving off SHA-256 later
+/// is a change of value rather than another schema revision: multihash names
+/// the algorithm in-band, where `^[0-9a-f]{64}$` hard-coded it into the
+/// contract.
+///
+/// [`bundle_digest`] stays, and stays hex: it is what the open path compares
+/// against and what operators read off a terminal, and neither of those is a
+/// wire contract.
+pub fn bundle_digest_multibase(bundle: &SealedBundle) -> String {
+    let mut chunks: Vec<&ArmoredChunk> = bundle.chunks.iter().collect();
+    chunks.sort_by_key(|c| c.chunk_index);
+    let mut hasher = Sha256::new();
+    for c in chunks {
+        hasher.update(&c.sealed_bytes);
+    }
+    let mut mh = vec![0x12, 0x20];
+    mh.extend_from_slice(hasher.finalize().as_slice());
+    multibase::encode(multibase::Base::Base58Btc, mh)
+}
+
+/// Decode a wire `digestMultibase` back to the lowercase hex the open path
+/// compares against.
+///
+/// Rejects anything that is not a sha2-256 multihash (`0x12 0x20` + 32 bytes):
+/// the digest is an integrity pin, and silently accepting an algorithm this
+/// build cannot compute would turn a mismatch into a pass.
+pub fn multibase_digest_to_hex(value: &str) -> Result<String, SealedTransferError> {
+    let (_base, bytes) = multibase::decode(value).map_err(|e| {
+        SealedTransferError::Armor(format!("digestMultibase is not multibase: {e}"))
+    })?;
+    match bytes.split_at_checked(2) {
+        Some(([0x12, 0x20], digest)) if digest.len() == 32 => Ok(crate::hex::lower(digest)),
+        _ => Err(SealedTransferError::Armor(
+            "digestMultibase is not a sha2-256 multihash — this build cannot verify it".into(),
+        )),
+    }
+}
+
 /// Seal a [`SealedPayloadV1`] for delivery to `recipient_pubkey`.
 ///
 /// `bundle_id` should be the consumer's request nonce. The producer's

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -633,29 +633,36 @@ impl SessionStore {
     ///
     /// An authenticated REST client carrying the identity it signs with.
     ///
+    /// Public because every caller that authenticates against a VTA needs this
+    /// exact triple — token, client DID, key — and assembling it by hand is how
+    /// five call sites shipped without the identity. `pnm`, `cnm` and the
+    /// provisioning runners all go through here.
+    ///
     /// The session is re-loaded *after* `ensure_authenticated` on purpose: a
     /// session that needed rotation now holds a different `client_did` and key,
     /// and signing with the pre-rotation pair would produce documents whose
     /// `issuer` no longer matches the identity the bearer token authenticates —
     /// which SPEC §7.2 item 6 rejects.
-    async fn rest_client(
+    pub async fn rest_client(
         &self,
         url: &str,
         key: &str,
-        vta_did: &str,
     ) -> Result<crate::client::VtaClient, Box<dyn std::error::Error>> {
         let token = self.ensure_authenticated(url, key).await?;
         let session = self
             .load_session(key)
             .ok_or_else(|| format!("session `{key}` vanished during authentication"))?;
-        let client =
-            crate::client::VtaClient::new(url).with_identity(crate::client::ClientIdentity {
+        let vta_did = require_vta_did(&session)?.to_string();
+        Ok(crate::client::VtaClient::authenticated(
+            url,
+            crate::client::ClientIdentity {
                 client_did: session.client_did.clone(),
                 private_key_multibase: session.private_key.clone(),
-                vta_did: vta_did.to_string(),
-            });
-        client.set_token(token);
-        Ok(client)
+                vta_did,
+            },
+            token,
+        )
+        .await)
     }
 
     pub async fn connect(
@@ -730,7 +737,7 @@ impl SessionStore {
                     .ok_or_else(|| no_rest_endpoint_error(&session_vta_did))?,
             };
             debug!(url = %url, "connecting via REST (forced --transport rest)");
-            let client = self.rest_client(&url, key, &session_vta_did).await?;
+            let client = self.rest_client(&url, key).await?;
             return Ok(client);
         }
 
@@ -893,7 +900,7 @@ impl SessionStore {
                 }
                 if let Some(url) = rest_url {
                     debug!(url = %url, "connecting via REST (fallback from TSP)");
-                    let client = self.rest_client(&url, key, &session_vta_did).await?;
+                    let client = self.rest_client(&url, key).await?;
                     return Ok(client);
                 }
                 // TSP-only VTA whose TSP is down: there is nothing to fall back
@@ -930,7 +937,7 @@ impl SessionStore {
                     return Err(no_didcomm_endpoint_error(&session_vta_did, false, true));
                 }
                 debug!(url = %url, "connecting via REST (from DID doc)");
-                let client = self.rest_client(&url, key, &session_vta_did).await?;
+                let client = self.rest_client(&url, key).await?;
                 return Ok(client);
             }
             Err(e) => {
@@ -962,9 +969,12 @@ impl SessionStore {
         // token we just obtained. Prefer DIDComm if available, otherwise keep
         // the REST client we already built.
         if let Some(url) = url_override {
-            let token = self.ensure_authenticated(url, key).await?;
-            let rest_client = crate::client::VtaClient::new(url);
-            rest_client.set_token(token);
+            // Via `rest_client` so the identity travels with the token: this
+            // client is used for the authenticated status probe *and* kept as
+            // the fallback when DIDComm is not available, so a bare
+            // `VtaClient::new` here would hand the caller a client that cannot
+            // produce a conforming document.
+            let rest_client = self.rest_client(url, key).await?;
 
             // Priority 3: DIDComm discovery via the authenticated status endpoint.
             if let Some(mediator_did) = discover_mediator_via_status(&rest_client).await {

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -549,10 +549,6 @@ pub const TASK_VAULT_LIST_0_1: &str = "https://trusttasks.org/spec/vault/list/0.
 
 /// `spec/vault/list/0.2` — successor to [`TASK_VAULT_LIST_0_1`]; camelCase
 /// enum values (e.g. `secretKind: oauthTokens`).
-#[deprecated(note = "0.2 is superseded by the 0.3 wire form: `AttachmentRef` \
-    replaces the bare-hex `sha256` with a multibase `digestMultibase`, which \
-    carries its own hash algorithm rather than hard-coding SHA-256 into the \
-    wire contract — prefer TASK_VAULT_LIST_0_3.")]
 pub const TASK_VAULT_LIST_0_2: &str = "https://trusttasks.org/spec/vault/list/0.2";
 
 /// `spec/vault/list/0.3` — successor to [`TASK_VAULT_LIST_0_2`].
@@ -572,10 +568,6 @@ pub const TASK_VAULT_LIST_0_3: &str = "https://trusttasks.org/spec/vault/list/0.
 pub const TASK_VAULT_GET_0_1: &str = "https://trusttasks.org/spec/vault/get/0.1";
 
 /// `spec/vault/get/0.2` — successor to [`TASK_VAULT_GET_0_1`].
-#[deprecated(note = "0.2 is superseded by the 0.3 wire form: `AttachmentRef` \
-    replaces the bare-hex `sha256` with a multibase `digestMultibase`, which \
-    carries its own hash algorithm rather than hard-coding SHA-256 into the \
-    wire contract — prefer TASK_VAULT_GET_0_3.")]
 pub const TASK_VAULT_GET_0_2: &str = "https://trusttasks.org/spec/vault/get/0.2";
 
 /// `spec/vault/get/0.3` — successor to [`TASK_VAULT_GET_0_2`].
@@ -597,10 +589,6 @@ pub const TASK_VAULT_GET_0_3: &str = "https://trusttasks.org/spec/vault/get/0.3"
 pub const TASK_VAULT_UPSERT_0_1: &str = "https://trusttasks.org/spec/vault/upsert/0.1";
 
 /// `spec/vault/upsert/0.2` — successor to [`TASK_VAULT_UPSERT_0_1`].
-#[deprecated(note = "0.2 is superseded by the 0.3 wire form: `AttachmentRef` \
-    replaces the bare-hex `sha256` with a multibase `digestMultibase`, which \
-    carries its own hash algorithm rather than hard-coding SHA-256 into the \
-    wire contract — prefer TASK_VAULT_UPSERT_0_3.")]
 pub const TASK_VAULT_UPSERT_0_2: &str = "https://trusttasks.org/spec/vault/upsert/0.2";
 
 /// `spec/vault/upsert/0.3` — successor to [`TASK_VAULT_UPSERT_0_2`].
@@ -1076,14 +1064,32 @@ pub const TASK_PASSKEY_VMS_REVOKE_0_1: &str =
 // carries the same request/response shapes the SDK already exports
 // under `vta_sdk::provision_integration::http`.
 
-/// `provision/integration/0.2` — submit a VP-framed
-/// `BootstrapRequest` plus provisioning options to the VTA; receive a
-/// sealed `TemplateBootstrap` bundle back. Payload:
+/// `provision/integration/0.3` — submit a VP-framed `BootstrapRequest` plus
+/// provisioning options to the VTA; receive a sealed `TemplateBootstrap` bundle
+/// back. Payload:
 /// [`crate::provision_integration::http::ProvisionIntegrationRequest`].
 /// Auth: Admin role on the target context (super-admin to use
 /// `create_context: true`).
-pub const TASK_PROVISION_INTEGRATION_0_2: &str =
-    "https://trusttasks.org/spec/provision/integration/0.2";
+///
+/// **0.2 is gone rather than deprecated.** It required a bare-hex `digest` and
+/// forbade `digestMultibase`; 0.3 is the reverse, and both close their response
+/// with `additionalProperties: false` — so no single response satisfies the
+/// two. Dual-accepting them would have meant a version-aware response shape for
+/// one renamed member.
+///
+/// The bundle digest is the whole change: the bare-hex `digest` (SHA-256 pinned
+/// by an `^[0-9a-f]{64}$` pattern) becomes an OPTIONAL `digestMultibase`, a
+/// multibase multihash that names its own algorithm. Taken over the armored
+/// bytes exactly as carried in `bundle`, not over a canonicalization — the
+/// armor is the artifact, and re-armoring the same ciphertext need not
+/// reproduce the same bytes.
+///
+/// 0.3's response schema was unsatisfiable until
+/// trustoverip/dtgwg-trust-tasks-tf#324: `required` still named the `digest`
+/// the rename had removed, against `additionalProperties: false`. This VTA
+/// could not have served it before that landed.
+pub const TASK_PROVISION_INTEGRATION_0_3: &str =
+    "https://trusttasks.org/spec/provision/integration/0.3";
 
 // ─── WebVH-DID-lifecycle slice (spec/vta/webvh/*) ────────────────────────
 //
@@ -1657,7 +1663,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_PASSKEY_VMS_LIST_0_1,
     TASK_PASSKEY_VMS_REVOKE_0_1,
     // Provision-integration (feature-gated: webvh)
-    TASK_PROVISION_INTEGRATION_0_2,
+    TASK_PROVISION_INTEGRATION_0_3,
     // WebVH-DID-lifecycle slice (feature-gated: webvh)
     TASK_WEBVH_SERVERS_LIST_1_0,
     TASK_WEBVH_SERVERS_REGISTER_1_0,

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -69,10 +69,34 @@ fn no_payload_key(key: &'static str) -> impl Fn(&wiremock::Request) -> bool {
 
 const TOKEN: &str = "test-token";
 
+/// A client with both a token and the identity it signs with.
+///
+/// The identity is not decoration here. An authenticated client with none
+/// refuses to dispatch — it would otherwise emit a document with no in-band
+/// `recipient` and no `proof`, which a conforming VTA rejects (SPEC §7.2 items
+/// 5b and 7a). The stubs in this file do not check the signature, but the
+/// client will not produce a request without one.
+/// A real `did:key` and its seed, so the proof this client attaches is one a
+/// verifier could actually check.
+fn test_identity() -> vta_sdk::client::ClientIdentity {
+    let sk = ed25519_dalek::SigningKey::from_bytes(&[0xC1; 32]);
+    let mut mc = vec![0xed, 0x01];
+    mc.extend_from_slice(sk.verifying_key().as_bytes());
+    vta_sdk::client::ClientIdentity {
+        client_did: format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, mc)
+        ),
+        private_key_multibase: multibase::encode(
+            multibase::Base::Base58Btc,
+            sk.to_bytes().as_slice(),
+        ),
+        vta_did: "did:key:z6MkTestVta".into(),
+    }
+}
+
 async fn client(server: &MockServer) -> VtaClient {
-    let c = VtaClient::new(&server.uri());
-    c.set_token_async(TOKEN.into()).await;
-    c
+    VtaClient::authenticated(&server.uri(), test_identity(), TOKEN.into()).await
 }
 
 fn err_body(msg: &str) -> Value {
@@ -2023,8 +2047,9 @@ async fn oversized_error_body_is_truncated() {
 async fn network_error_when_server_unreachable() {
     // Port 1 is reserved (TCPMUX) and effectively never listens on
     // dev/CI machines — connection refused → reqwest::Error → Network.
-    let c = VtaClient::new("http://127.0.0.1:1");
-    c.set_token_async(TOKEN.into()).await;
+    // With an identity, so the failure under test is the *connection* and not
+    // this client refusing to build a non-conforming document.
+    let c = VtaClient::authenticated("http://127.0.0.1:1", test_identity(), TOKEN.into()).await;
     let err = c.get_config().await.unwrap_err();
     assert!(err.is_network(), "got {err:?}");
 }

--- a/vta-sdk/tests/provision_client_e2e.rs
+++ b/vta-sdk/tests/provision_client_e2e.rs
@@ -35,8 +35,7 @@ use vta_sdk::provision_integration::payload::{
     VtaTrustBundle,
 };
 use vta_sdk::sealed_transfer::{
-    AssertionProof, InMemoryNonceStore, ProducerAssertion, SealedPayloadV1, armor, bundle_digest,
-    seal_payload,
+    AssertionProof, InMemoryNonceStore, ProducerAssertion, SealedPayloadV1, armor, seal_payload,
 };
 
 /// Fake VTA bootstrap responder. On every POST, decodes the request VP
@@ -178,11 +177,11 @@ impl Respond for SealResponder {
         .expect("seal payload");
 
         let armored = armor::encode(&bundle);
-        let digest = bundle_digest(&bundle);
+        let digest_multibase = vta_sdk::sealed_transfer::bundle_digest_multibase(&bundle);
 
         let response = ProvisionIntegrationResponse {
             bundle: armored,
-            digest,
+            digest_multibase: Some(digest_multibase),
             summary: ProvisionSummary {
                 client_did: req_str(&req.request, "holder"),
                 admin_did: self.admin_did.clone(),
@@ -454,11 +453,11 @@ impl Respond for AdminRotationResponder {
         .expect("seal AdminRotation payload");
 
         let armored = armor::encode(&bundle);
-        let digest = bundle_digest(&bundle);
+        let digest_multibase = vta_sdk::sealed_transfer::bundle_digest_multibase(&bundle);
 
         let response = ProvisionIntegrationResponse {
             bundle: armored,
-            digest,
+            digest_multibase: Some(digest_multibase),
             summary: ProvisionSummary {
                 client_did: req_str(&req.request, "holder"),
                 admin_did: self.admin_did.clone(),
@@ -697,7 +696,7 @@ async fn admin_rotated_didcomm_response_decoder_extracts_rotated_credentials() {
 
     let response = ProvisionIntegrationResponse {
         bundle: armor::encode(&bundle),
-        digest: bundle_digest(&bundle),
+        digest_multibase: Some(vta_sdk::sealed_transfer::bundle_digest_multibase(&bundle)),
         summary: ProvisionSummary {
             client_did: key.did.clone(),
             admin_did: rotated_admin_did.clone(),

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1505,7 +1505,7 @@ pub async fn handle_provision_integration(
 
     let result = vta_sdk::provision_integration::http::ProvisionIntegrationResponse {
         bundle: output.armored,
-        digest: output.digest,
+        digest_multibase: Some(output.digest_multibase),
         summary: vta_sdk::provision_integration::http::ProvisionSummary {
             client_did: output.summary.client_did,
             admin_did: output.summary.admin_did,

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -542,9 +542,10 @@ pub async fn dispatch(
     // ── Provision-integration (webvh) ────────────────────────────────
     #[cfg(feature = "webvh")]
     {
-        if t == provision_integration_management::CANONICAL_PROVISION_INTEGRATION
-            || t == provision_integration_management::CANONICAL_PROVISION_INTEGRATION_0_2
-        {
+        // 0.3 only, matching the Trust-Task dispatcher: the response carries
+        // `digestMultibase`, which 0.1's and 0.2's closed response schemas
+        // reject.
+        if t == provision_integration_management::CANONICAL_PROVISION_INTEGRATION_0_3 {
             return finish(
                 handlers::handle_provision_integration(ctx, msg, Extension(vta_state)).await,
             );

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -172,7 +172,10 @@ pub struct ProvisionIntegrationParams {
 /// operator, plus a small summary for CLI display / HTTP response.
 pub struct ProvisionIntegrationOutput {
     pub armored: String,
+    /// Lowercase hex — what an operator reads and what `--expect-digest` takes.
     pub digest: String,
+    /// Multibase multihash — what `provision/integration/0.3` puts on the wire.
+    pub digest_multibase: String,
     pub summary: ProvisionSummary,
 }
 
@@ -755,7 +758,11 @@ pub async fn provision_integration(
     };
 
     // ── 8. Seal ─────────────────────────────────────────────────────
-    let seal::SealedProvisionBundle { armored, digest } = seal::seal_provision_payload(
+    let seal::SealedProvisionBundle {
+        armored,
+        digest,
+        digest_multibase,
+    } = seal::seal_provision_payload(
         state,
         &vta_did,
         assertion_mode,
@@ -784,6 +791,7 @@ pub async fn provision_integration(
     Ok(ProvisionIntegrationOutput {
         armored,
         digest,
+        digest_multibase,
         summary: ProvisionSummary {
             client_did,
             admin_did,
@@ -980,7 +988,11 @@ async fn provision_admin_rotation(
     };
 
     // ── 7. Seal ─────────────────────────────────────────────────────
-    let seal::SealedProvisionBundle { armored, digest } = seal::seal_provision_payload(
+    let seal::SealedProvisionBundle {
+        armored,
+        digest,
+        digest_multibase,
+    } = seal::seal_provision_payload(
         state,
         &vta_did,
         assertion_mode,
@@ -1003,6 +1015,7 @@ async fn provision_admin_rotation(
     Ok(ProvisionIntegrationOutput {
         armored,
         digest,
+        digest_multibase,
         summary: ProvisionSummary {
             client_did: client_did.to_string(),
             admin_did,

--- a/vta-service/src/operations/provision_integration/seal.rs
+++ b/vta-service/src/operations/provision_integration/seal.rs
@@ -31,7 +31,15 @@ pub(super) struct SealedProvisionBundle {
     pub armored: String,
     /// Lowercase-hex SHA-256 of the bundle, communicated out-of-band so
     /// the consumer can pin integrity before opening.
+    ///
+    /// Kept in hex for the operator-facing surfaces (`pnm bootstrap open
+    /// --expect-digest`, the CLI printouts). The *wire* form is
+    /// [`digest_multibase`](Self::digest_multibase).
     pub digest: String,
+    /// The same digest as a multibase multihash — the form
+    /// `provision/integration/0.3` puts on the wire, where it replaced the
+    /// bare-hex `digest` so the algorithm travels with the value.
+    pub digest_multibase: String,
 }
 
 /// Seal a `SealedPayloadV1` for the consumer's HPKE pubkey, choosing
@@ -80,5 +88,6 @@ pub(super) async fn seal_provision_payload(
     Ok(SealedProvisionBundle {
         armored: armor::encode(&bundle),
         digest: bundle_digest(&bundle),
+        digest_multibase: vta_sdk::sealed_transfer::bundle_digest_multibase(&bundle),
     })
 }

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -697,8 +697,18 @@ mod provision {
     pub struct ProvisionIntegrationResponseBody {
         /// Armored sealed bundle (PGP-style BEGIN/END blocks).
         pub bundle: String,
-        /// SHA-256 digest of the sealed ciphertext (lowercase hex).
-        pub digest: String,
+        /// Digest over the sealed ciphertext, as a multibase multihash.
+        ///
+        /// Renamed from the bare-hex `digest` with
+        /// `provision/integration/0.3`. This body is a second declaration of
+        /// the same wire shape `vta_sdk`'s `ProvisionIntegrationResponse`
+        /// defines, and the SDK decodes it with `deny_unknown_fields` — so the
+        /// two are not merely conventionally aligned, they must match or the
+        /// client cannot read the response at all. It did not, and that is what
+        /// `url_direct_admin_rotation_round_trips_against_rest_only_mock`
+        /// caught.
+        #[serde(rename = "digestMultibase")]
+        pub digest_multibase: String,
         /// Operator-readable summary.
         pub summary: ProvisionSummaryWire,
     }
@@ -805,7 +815,7 @@ mod provision {
 
         Ok(Json(ProvisionIntegrationResponseBody {
             bundle: output.armored,
-            digest: output.digest,
+            digest_multibase: output.digest_multibase,
             summary: ProvisionSummaryWire {
                 client_did: output.summary.client_did,
                 admin_did: output.summary.admin_did,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2094,7 +2094,10 @@ fn table() -> Vec<(&'static str, Conformance)> {
         });
         let response = to_v(prov::ProvisionIntegrationResponse {
             bundle: "-----BEGIN VTA SEALED BUNDLE-----".into(),
-            digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            // A real `DigestMultibase`, not a placeholder: 0.3 constrains the
+            // encoding, and a fixture that cannot satisfy the pattern proves
+            // nothing about what this producer emits.
+            digest_multibase: Some(DIGEST_MULTIBASE.into()),
             summary: prov::ProvisionSummary {
                 client_did: "did:key:z6MkAgentSetup".into(),
                 admin_did: "did:key:z6MkAdmin".into(),
@@ -2115,10 +2118,10 @@ fn table() -> Vec<(&'static str, Conformance)> {
         serde_json::from_value::<prov::ProvisionIntegrationRequest>(request.clone())
             .expect("canonical provision request parses into ProvisionIntegrationRequest");
         t.push((
-            uris::TASK_PROVISION_INTEGRATION_0_2,
+            uris::TASK_PROVISION_INTEGRATION_0_3,
             checked!(
-                specs::provision::integration::v0_2::Payload,
-                specs::provision::integration::v0_2::Response,
+                specs::provision::integration::v0_3::Payload,
+                specs::provision::integration::v0_3::Response,
                 request,
                 response
             ),

--- a/vta-service/src/trust_tasks/idempotency.rs
+++ b/vta-service/src/trust_tasks/idempotency.rs
@@ -421,7 +421,7 @@ mod tests {
     #[test]
     fn secret_bearing_tasks_are_never_recorded_with_a_body() {
         assert!(
-            !retry_safety(trust_tasks::TASK_PROVISION_INTEGRATION_0_2)
+            !retry_safety(trust_tasks::TASK_PROVISION_INTEGRATION_0_3)
                 .expect("classified")
                 .response_is_replayable()
         );

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -141,7 +141,11 @@ const REST_ROUTED: &[&str] = vta_sdk::trust_tasks::REST_ROUTED_URIS;
 ///
 /// All entries are unconditional (don't change per cfg). They're
 /// just statements that the dispatcher knows about them.
-#[allow(dead_code)] // consumed by the dispatcher's test-only parity harness
+#[allow(dead_code)]
+// consumed by the dispatcher's test-only parity harness
+// Names deprecated URIs on purpose: this VTA still serves them, and the census
+// is what proves an entry has not outlived its handler.
+#[allow(deprecated)]
 const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     // Passkey-VMs slice — requires `webvh` + `didcomm` features. The
     // `dispatch_table!` entries list the same URIs and are tracked by the
@@ -152,7 +156,7 @@ const KNOWN_FEATURE_GATED_URIS: &[&str] = &[
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_LIST_0_1,
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1,
     // Provision-integration — requires `webvh`.
-    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_3,
     // WebVH-DID-lifecycle slice — requires `webvh`. The `dispatch_table!`
     // entries list the same URIs and are tracked by the parity harness when
     // `webvh` is on; this allowlist covers builds where `webvh` is off.
@@ -1440,8 +1444,13 @@ dispatch_table! {
     vta_sdk::trust_tasks::TASK_PASSKEY_VMS_REVOKE_0_1 => passkey_vms::handle_revoke
         [ Destructive None false ],
     // ─── Provision-integration (feature-gated: webvh) ────────────
+    // 0.3 only. 0.2 required a bare-hex `digest` and forbade
+    // `digestMultibase`; 0.3 is the reverse, and both close their response with
+    // `additionalProperties: false` — so no single response satisfies the two,
+    // and dual-accepting them would mean a version-aware response shape for one
+    // renamed member. Cut over instead.
     #[cfg(feature = "webvh")]
-    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2
+    vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_3
         => provision_integration::handle_request
         [ Mutating Secret false ],
     // ─── WebVH-DID-lifecycle slice (feature-gated: webvh) ────────

--- a/vta-service/src/trust_tasks/provision_integration.rs
+++ b/vta-service/src/trust_tasks/provision_integration.rs
@@ -143,7 +143,7 @@ pub(super) async fn handle_request(
 
     let body = ProvisionIntegrationResponse {
         bundle: output.armored,
-        digest: output.digest,
+        digest_multibase: Some(output.digest_multibase),
         summary: vta_sdk::provision_integration::http::ProvisionSummary {
             client_did: output.summary.client_did,
             admin_did: output.summary.admin_did,

--- a/vta-service/tests/delegated_consent_e2e.rs
+++ b/vta-service/tests/delegated_consent_e2e.rs
@@ -1019,7 +1019,7 @@ async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
 
     // ── 1. Refused, pending a human.
     let doc = envelope(
-        vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+        vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_3,
         &requester,
         &ctx.vta_did,
         payload.clone(),
@@ -1078,7 +1078,7 @@ async fn a_reprovision_is_refused_pending_consent_and_executes_once_approved() {
     //       digest, not the envelope id, and the replay guard would refuse a
     //       reused id outright.
     let resubmit = envelope(
-        vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_2,
+        vta_sdk::trust_tasks::TASK_PROVISION_INTEGRATION_0_3,
         &requester,
         &ctx.vta_did,
         payload,

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -878,8 +878,19 @@ async fn connect_setup_client(
         )
         .await
         .map_err(|e| AppError::Internal(format!("VTA REST authentication failed: {e}")))?;
-        let client = VtaClient::new(rest_url);
-        client.set_token_async(auth.access_token).await;
+        // The setup key is this client's identity — it is what just
+        // authenticated, and the tasks the wizard dispatches are proof-REQUIRED
+        // like any other.
+        let client = VtaClient::authenticated(
+            rest_url,
+            vta_sdk::client::ClientIdentity {
+                client_did: setup_key.did.clone(),
+                private_key_multibase: setup_key.private_key_multibase().to_string(),
+                vta_did: resolved.vta_did.clone(),
+            },
+            auth.access_token,
+        )
+        .await;
         return Ok(client);
     }
 


### PR DESCRIPTION
Two things: the fallout from #1146 that I left behind, and the `provision/integration` 0.3 adoption #1145 deferred.

## #1146 left seven production paths unable to send anything

#1146 made every producer sign. `SessionStore::connect` was fixed; nothing else was, and **no test drives those paths against an enforcing VTA** — so they shipped broken:

| path | |
|---|---|
| `vta-sdk` `from_credential` | carried the DID, key and VTA DID into `RestAuth` for refresh while leaving `identity: None` **beside them** |
| `vta-sdk` `integration/auth` | post-challenge-response client |
| `vta-sdk` `client/auto_connect` | auto-connect |
| `vta-sdk` `session` (URL-override leg) | the REST client kept as the DIDComm fallback |
| `vta-sdk` `provision_client/runner_rest` ×2 | the setup DID it just authenticated with |
| `vtc-service` `setup/wizard` | VTC's own wizard |

Each authenticates, takes the token, and drops the identity. Every task they dispatch is refused for a missing `recipient` and `proof`.

### The fix, and a guard

`VtaClient::authenticated(url, identity, token)` replaces the three-step `new` + `with_identity` + `set_token`. The three-step form is *why* this happened — nothing about `new(url).set_token(t)` looks incomplete.

`SessionStore::rest_client` is public now; `pnm` and `cnm` route through it rather than assembling the triple by hand. One implementation, three callers.

And a guard, because seven sites is not something to fix by inspection twice — dispatch fails at the call site when a client holds a token but no identity:

```
this VtaClient is authenticated but carries no ClientIdentity, so the document it
would send for `…/config/show/0.1` has no in-band recipient and no proof — build
it with `VtaClient::authenticated(url, identity, token)` or `.with_identity(…)`
```

It immediately found three more in `auth_light_rest` and the whole of `client_rest` — **72 tests** building exactly the shape that shipped broken.

## provision/integration 0.3

#1145 deferred this pending the upstream schema fix; that landed as trustoverip/dtgwg-trust-tasks-tf#324 and published in 0.17.1.

The bundle digest moves from a bare-hex `digest` to a multibase `digestMultibase`, so the algorithm travels with the value instead of being hard-coded by an `^[0-9a-f]{64}$` pattern.

**0.2 is removed, not deprecated.** It requires `digest` and forbids `digestMultibase`; 0.3 is the reverse, and both close their response with `additionalProperties: false` — no single response satisfies the two. Dual-accepting would have meant a version-aware response shape for one renamed member. The DIDComm surface follows for the same reason.

`bundle_digest` stays, and stays hex: it is what the open path compares and what an operator reads off a terminal, and neither is a wire contract. `bundle_digest_multibase` is the wire form; `multibase_digest_to_hex` decodes a pin back for the comparison and **rejects anything that is not a sha2-256 multihash**, rather than letting an algorithm this build cannot compute pass as a match.

## Three defects surfaced on the way

- **`ProvisionIntegrationResponse` had no `rename_all`.** Every member had been a single word, so nothing had ever exercised the casing — and the first multi-word field went out as `digest_multibase`, which the closed schema rejects.
- **`routes::bootstrap`'s response body is a second declaration of the same wire shape**, and the SDK decodes it with `deny_unknown_fields`. Updating one and not the other meant the client could not read the response at all. Caught by `url_direct_admin_rotation_round_trips_against_rest_only_mock`.
- **`is_v0_1` was written as "not 0.2"** rather than "is 0.1". Adding 0.3 silently classified it as 0.1 and snake_cased a camelCase summary. A predicate about one version now names that version.

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `vta-sdk`, `vti-common`, `vta-mobile-core`, `vta-vault`, `vta-webvh`, `pnm-cli`, `cnm-cli`: 0 failed
- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo fmt --all --check`: exit 0
- `TRUST-TASK RESPONSE COVERAGE 88/109 (81%)` — unchanged

## Downstream

`provision/integration/0.2` is gone from both the Trust-Task and DIDComm surfaces. Anything still on it must move to 0.3 and read `digestMultibase`.
