### PR TITLE
fix(deps): declare the spec families this VTA validates against

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,18 @@ aws-lc-rs = "1.16"
 # than fail quietly — but it would fail as "you are serving unspecced URIs",
 # which reads as an implementation fault instead of a stale dependency. The
 # pin makes the resolver say the true thing instead.
-trust-tasks-rs = { version = "0.17", default-features = false, features = ["validate"] }
+# `all-specs` is declared, not inherited. This workspace asked for
+# `default-features = false` and got every spec family anyway, because
+# `affinidi-messaging-sdk` -> `affinidi-tdk` happens to enable the default
+# feature and cargo unions them. That is the entire schema index arriving by
+# luck: if any crate in that chain ever set `default-features = false`,
+# `schema_index::schema_for` would answer `None` for every URI, `validate_payload`
+# would stop validating with one `debug!` line to say so, and `spec_policy_for`
+# would stop enforcing SPEC §7.2 the same way. Both fail *open*.
+trust-tasks-rs = { version = "0.17", default-features = false, features = [
+  "validate",
+  "all-specs",
+] }
 trust-tasks-capability-client = "0.17"
 trust-tasks-https = { version = "0.17", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1721,6 +1721,47 @@ mod tests {
     /// the operation is served by a dedicated REST route rather than the
     /// dispatcher, it belongs in `deprecation::SUPERSEDED` — the route table —
     /// not here.
+    /// The schema index must be a declared dependency, not an inherited one.
+    ///
+    /// This workspace asks `trust-tasks-rs` for `default-features = false`. It
+    /// received every spec family regardless, because a transitive dependency
+    /// enables the default feature and cargo unions them — so the index that
+    /// `validate_payload` and `spec_policy_for` both read arrived by luck.
+    ///
+    /// Both of those fail *open* when a spec is unknown: `validate_payload`
+    /// dispatches unvalidated unless `require_payload_schema` is set, and
+    /// `spec_policy_for` returning `None` skips SPEC §7.2 entirely. So the day
+    /// that chain changed, this VTA would have quietly stopped checking
+    /// payloads and stopped enforcing proof-REQUIRED, with one `debug!` line
+    /// between it and nobody noticing.
+    ///
+    /// What this test does and does not prove, precisely: it fails when the
+    /// index is empty, which is the outcome that matters. It cannot fail when
+    /// the *declaration* is removed but the transitive path still supplies the
+    /// families — cargo unions features, so the two are indistinguishable from
+    /// inside the build. That is the right coverage anyway: an index populated
+    /// by either route is a working VTA, and this fires on the day neither
+    /// route supplies it.
+    #[test]
+    fn the_spec_index_is_populated() {
+        for uri in [
+            "https://trusttasks.org/spec/acl/grant/0.1",
+            "https://trusttasks.org/spec/auth/authenticate/0.1",
+            "https://trusttasks.org/spec/vault/list/0.3",
+        ] {
+            assert!(
+                trust_tasks_rs::schema_index::schema_for(uri).is_some(),
+                "no schema for `{uri}` — this build's `trust-tasks-rs` carries no spec \
+                 families, so payload validation and SPEC §7.2 enforcement are both off"
+            );
+            assert!(
+                trust_tasks_rs::schema_index::spec_policy_for(uri).is_some(),
+                "no spec policy for `{uri}` — §7.2's recipient/proof/issuedAt checks \
+                 cannot fire for it"
+            );
+        }
+    }
+
     #[test]
     fn superseded_tasks_are_dispatched() {
         let dispatched = dispatched_uris();


### PR DESCRIPTION
The workspace asks `trust-tasks-rs` for `default-features = false, features = ["validate"]` — and receives **every spec family** regardless, because `affinidi-messaging-sdk` → `affinidi-tdk` enables the default feature and cargo unions them.

So the entire schema index arrives by luck rather than by request. That index is what `validate_payload` checks payloads against, and what `spec_policy_for` reads SPEC §7.2's constants from.

## Both fail open

- `validate_payload` dispatches **unvalidated** when it knows no schema (unless `policy.require_payload_schema` is set)
- `spec_policy_for` returning `None` skips the recipient / proof / issuedAt checks **entirely**

The day any crate in that chain set `default-features = false`, this VTA would have stopped validating payloads and stopped enforcing §7.2 — with a single `debug!` line between that and nobody noticing.

## The fix

`all-specs` is declared. **No behaviour change today** — the features were already resolving on — which is exactly the point: the resolved set is unchanged, and the reason it resolves is no longer somebody else's business.

## What the test proves, precisely

It asserts the index is populated for three URIs across three families. Being exact: it fails when the index is empty, which is the outcome that matters. It **cannot** fail when the declaration is removed while the transitive path still supplies the families — cargo unions features, so from inside the build the two are indistinguishable. I checked, and it does not.

That is the right coverage anyway. An index populated by either route is a working VTA; this fires on the day neither route supplies it.

## Verification

- `vta-service --all-features`: 0 failed
- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo fmt --all --check`: exit 0