### PR TITLE
fix(trust-tasks)!: verify the proofs we require, and cover the canonical device lifecycle

### DIFF
--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -950,6 +950,56 @@ async fn dispatch_trust_task_validated(
         return reject_with(&doc, reason);
     }
 
+    // SPEC §7.2 item 7, *first* clause: "If the document carries a `proof`
+    // member, verify it per §4.7 against the in-band `issuer` and reject the
+    // document with `proofInvalid` on verification failure."
+    //
+    // The second clause — reject a *missing* proof where the spec requires one
+    // — is `enforce_spec_policy` above. Only that half was implemented, which
+    // is the worse way round to have it: a caller attaches a proof *because*
+    // the task demands one, and until now any bytes in the member satisfied the
+    // demand. A document signed by a key its issuer does not control reached
+    // the handler.
+    //
+    // Verified here rather than per-handler for the reason the schema check is:
+    // it must happen before anything reads the payload, and a slice that forgets
+    // it is a slice with no proof checking at all. `step_up` and `task_consent`
+    // keep their own calls — they bind the signer to a *specific* party (the
+    // approver), which is a stronger claim than "the issuer signed this".
+    if doc.proof.is_some() {
+        match vti_common::auth::di_proof::verify_trust_task_proof(&doc).await {
+            Ok(signer) => {
+                // A valid proof by some *other* DID is not a proof by the
+                // issuer; without this the signature would establish only that
+                // somebody signed something.
+                if doc.issuer.as_deref() != Some(signer.as_str()) {
+                    tracing::warn!(
+                        type_uri,
+                        issuer = ?doc.issuer,
+                        signer = %signer,
+                        "document proof verifies, but not as its issuer"
+                    );
+                    return reject_with(
+                        &doc,
+                        RejectReason::ProofInvalid {
+                            reason: "the proof verifies as a DID other than the document's issuer"
+                                .to_string(),
+                        },
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::info!(type_uri, error = %e, "document proof failed verification");
+                return reject_with(
+                    &doc,
+                    RejectReason::ProofInvalid {
+                        reason: e.to_string(),
+                    },
+                );
+            }
+        }
+    }
+
     // Idempotency claim. Only bites when the document carries an
     // `idempotencyKey` *and* the task is one where a second execution leaves a
     // second durable artefact (`vta_sdk::retry_safety`) — everything else
@@ -2803,6 +2853,109 @@ mod response_coverage {
         .await;
         ok(&state, t::TASK_DEVICE_HEARTBEAT_0_2, json!({})).await;
         ok(&state, t::TASK_DEVICE_SET_WAKE_0_2, json!({})).await;
+    }
+
+    /// SPEC §7.2 item 7, first clause: "If the document carries a `proof`
+    /// member, verify it per §4.7 against the in-band `issuer` and reject the
+    /// document with `proofInvalid` on verification failure."
+    #[tokio::test]
+    async fn a_proof_that_does_not_verify_is_refused() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let vta_did = state.config.read().await.vta_did.clone().expect("vta_did");
+
+        // Signed by a *different* identity than the one it claims as issuer.
+        let mut doc: TrustTask<Value> = serde_json::from_value(json!({
+            "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            "type": t::TASK_AUTH_WHOAMI_0_1,
+            "issuer": crate::test_support::test_admin_did().0,
+            "recipient": vta_did,
+            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            "payload": {},
+        }))
+        .expect("envelope");
+        crate::test_support::sign_as(0xEE, &mut doc);
+
+        let outcome = super::dispatch_trust_task_core(
+            &state,
+            &crate::test_support::super_admin_claims(),
+            &serde_json::to_vec(&doc).expect("bytes"),
+            transport::TransportConfidentiality::HopByHop,
+        )
+        .await;
+        let v: Value = serde_json::from_slice(&outcome.body).expect("a response");
+        assert_eq!(
+            v["payload"]["code"], "proofInvalid",
+            "a proof from a key the issuer does not control must be refused: {v}"
+        );
+    }
+
+    /// The same family at its **canonical** 0.1 URIs, plus the two ends of the
+    /// lifecycle that have no 0.2 form.
+    ///
+    /// Not a duplicate of the 0.2 walk above. A 0.2 request is down-converted
+    /// to the 0.1 handler and its response up-converted back, so driving 0.2
+    /// never produces a `…/0.1#response` and never exercises the branch that
+    /// answers a caller who asked in the canonical form. Those are two
+    /// different paths through the spine, and only one of them was tested.
+    ///
+    /// Its own `AppState` because `device/register` refuses a second binding
+    /// for the same DID, and both walks register as the super-admin.
+    // Names the deprecated 0.1 URIs on purpose: they are what this test exists
+    // to cover, and they are still dispatched.
+    #[allow(deprecated)]
+    #[tokio::test]
+    async fn device_lifecycle_canonical() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let claims = crate::test_support::super_admin_claims();
+        crate::test_support::seed_acl_entry(
+            &state.acl_ks,
+            &claims.did,
+            crate::acl::Role::Admin,
+            vec![],
+        )
+        .await;
+
+        let registered = ok(
+            &state,
+            t::TASK_DEVICE_REGISTER_0_1,
+            json!({
+                // `formFactor`, not `form-factor`: the 0.1 → 0.2 difference is
+                // in the enum *values*, never the member names, and the edge
+                // transform only ever rewrites values at declared enum paths.
+                "consumerKind": { "kind": "companion", "formFactor": "mobile" },
+                "displayName": "Coverage Phone (canonical)",
+            }),
+        )
+        .await;
+        // The id the rest of the lifecycle is addressed by. Read from the
+        // response rather than minted here: the VTA assigns it, and a test that
+        // guesses would pass against a VTA that had stopped returning one.
+        let device_id = registered["binding"]["deviceId"]
+            .as_str()
+            .expect("register returns the binding's deviceId")
+            .to_string();
+
+        ok(&state, t::TASK_DEVICE_HEARTBEAT_0_1, json!({})).await;
+        ok(&state, t::TASK_DEVICE_SET_WAKE_0_1, json!({})).await;
+
+        // Wipe before disable: a wipe instruction is issued *to* a device, and
+        // a disabled one has nothing to collect it. The operator's order.
+        ok(
+            &state,
+            t::TASK_DEVICE_WIPE_0_1,
+            json!({
+                "deviceId": device_id,
+                "scope": "cache-and-keys",
+                "reason": "coverage",
+            }),
+        )
+        .await;
+        ok(
+            &state,
+            t::TASK_DEVICE_DISABLE_0_1,
+            json!({ "deviceId": device_id, "reason": "coverage" }),
+        )
+        .await;
     }
 
     /// The runtime service-management read paths.

--- a/vta-service/tests/idempotency_trust_task.rs
+++ b/vta-service/tests/idempotency_trust_task.rs
@@ -37,7 +37,15 @@ const CALLER_SEED: u8 = 0x40;
 fn caller() -> String {
     vta_service::test_support::did_for_seed(CALLER_SEED).0
 }
-const OTHER_CALLER: &str = "did:key:z6MkSomeoneElseEntirely";
+/// A second caller, seeded like the first. It used to be a hand-written DID
+/// with no key behind it, which worked while nothing verified proofs — the
+/// document claimed that issuer and was signed by the first caller, and the VTA
+/// took its word for it. It cannot now.
+const OTHER_SEED: u8 = 0x41;
+
+fn other_caller() -> String {
+    vta_service::test_support::did_for_seed(OTHER_SEED).0
+}
 const CONTEXT: &str = "test";
 
 /// A live app with the `test` context in place and an unrestricted admin token
@@ -61,7 +69,7 @@ async fn app_with_second_caller() -> (axum::Router, String, String) {
         .await
         .expect("context");
     let mine = ctx.mint_token(caller().as_str(), "admin", vec![]).await;
-    let theirs = ctx.mint_token(OTHER_CALLER, "admin", vec![]).await;
+    let theirs = ctx.mint_token(&other_caller(), "admin", vec![]).await;
     (router, mine, theirs)
 }
 
@@ -72,11 +80,18 @@ async fn app_with_second_caller() -> (axum::Router, String, String) {
 /// case. If these tests reused the envelope id they would be exercising the
 /// wrong layer and passing for the wrong reason.
 fn create_doc(envelope_id: &str, label: &str, idempotency_key: Option<&str>) -> Value {
+    create_doc_as(CALLER_SEED, envelope_id, label, idempotency_key)
+}
+
+/// The same document, issued and signed by whichever seeded identity `seed`
+/// names. Split out because a proof only counts as the issuer's when the two
+/// come from the same key.
+fn create_doc_as(seed: u8, envelope_id: &str, label: &str, idempotency_key: Option<&str>) -> Value {
     let mut doc = json!({
         "id": format!("urn:uuid:{envelope_id}"),
         "type": KEYS_CREATE,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "issuer": caller(),
+        "issuer": vta_service::test_support::did_for_seed(seed).0,
         "recipient": "did:key:z6MkTestVTA",
         "payload": {
             "keyType": "ed25519",
@@ -92,7 +107,7 @@ fn create_doc(envelope_id: &str, label: &str, idempotency_key: Option<&str>) -> 
     // it before `idempotencyKey` would sign a document that is not the one sent.
     let mut typed: trust_tasks_rs::TrustTask<Value> =
         serde_json::from_value(doc).expect("envelope deserialises");
-    vta_service::test_support::sign_as(CALLER_SEED, &mut typed);
+    vta_service::test_support::sign_as(seed, &mut typed);
     serde_json::to_value(&typed).expect("envelope serialises")
 }
 
@@ -299,8 +314,7 @@ async fn one_callers_key_does_not_block_another() {
     let (s1, b1) = post(&router, &mine, &create_doc("f1", "mine", shared)).await;
     assert_eq!(s1, StatusCode::OK, "{b1}");
 
-    let mut doc = create_doc("f2", "theirs", shared);
-    doc["issuer"] = json!(OTHER_CALLER);
+    let doc = create_doc_as(OTHER_SEED, "f2", "theirs", shared);
     let (s2, b2) = post(&router, &theirs, &doc).await;
     assert_eq!(
         s2,


### PR DESCRIPTION
## SPEC §7.2 item 7 has two clauses. Only the second was implemented.

> If the document carries a `proof` member, **verify it per §4.7 against the in-band `issuer`** and reject the document with `proofInvalid` on verification failure. Independently, if the specification declares `proof` REQUIRED and no `proof` is present, reject with `proofRequired`.

#1146 added the second. The first was never there — and that is the **worse way round** to have it. A caller attaches a proof *because* the task demands one, and until now any bytes in the member satisfied the demand.

Proven, not inferred. The test added here sends a document signed by an unrelated seed and watches it reach the handler:

```
expected: proofInvalid
got:      taskFailed — "session not found: test-session"
```

A document signed by a key its issuer does not control was executing.

## The verifier already existed

`vti_common::auth::di_proof::verify_trust_task_proof` returns the cryptographically-proven signer DID, and `step_up` and `task_consent` have called it for their own gates all along. **The spine did not**, so every other task took the issuer's word for who signed.

Two checks, because a valid proof is not the same as a valid proof *by the issuer*:

1. the proof verifies, and
2. the DID it verifies as **is** the document's `issuer`

Without the second, a signature establishes only that somebody signed something.

`step_up` and `task_consent` keep their own calls. They bind the signer to a *specific* party — the approver — which is a stronger claim than "the issuer signed this", and not one this can make for them.

## Coverage 88 → 93 of 109

The device family's canonical `0.1` URIs, plus `disable` and `wipe`, which have no `0.2` form.

**Not a duplicate of the existing 0.2 walk.** A 0.2 request is down-converted to the 0.1 handler and its response up-converted back, so driving 0.2 never produces a `…/0.1#response` and never exercises the branch that answers a caller who asked canonically. Two paths through the spine; one was tested.

(Worth noting for anyone writing these: the 0.1 → 0.2 difference is in enum *values*, never member names. `formFactor` stays camelCase in both — the edge transform only rewrites values at declared enum paths.)

## One fixture needed a real second identity

`idempotency_trust_task`'s "other caller" was a hand-written DID with no key behind it. The document claimed that issuer and was signed by the *first* caller, and the VTA took its word for it. It cannot now — which is exactly the point of the change.

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `vta-sdk`, `vti-common`, `vta-mobile-core`: 0 failed
- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo fmt --all --check`: exit 0
- `TRUST-TASK RESPONSE COVERAGE 93/109 (85%)`

## Downstream

A producer whose `proof` does not verify as its `issuer` is now refused. That is the intended behaviour and the whole point, but it will surface any client that was signing with a key other than the DID it claims — which nothing could previously detect.
