### PR TITLE
fix(services): let enable reconcile a config the document does not match

### DIFF
--- a/vta-service/src/operations/protocol/enable_rest.rs
+++ b/vta-service/src/operations/protocol/enable_rest.rs
@@ -204,14 +204,35 @@ mod tests {
         }
     }
 
+    /// "Already enabled" means enabled in **both** the live config and the
+    /// published document — not in either.
+    ///
+    /// This fixture is the disagreement case: the config says the service is
+    /// on, the document advertises nothing. It used to be refused, which left
+    /// it unmanageable — `update` requires the service on in both places, so
+    /// neither operation would touch it and the only way out was to edit the
+    /// config by hand. It is reachable by re-pointing `vta_did` at a freshly
+    /// minted DID, or by restoring a config without its log.
+    ///
+    /// Reconciling that is what enable is *for*, so it no longer stops here.
+    ///
+    /// It stops at the *next* precondition instead — this fixture seeds no
+    /// webvh record — and that is the whole assertion: reaching
+    /// `VtaDidRecordMissing` proves the config check no longer short-circuits
+    /// ahead of the document. Asserting success would need a fixture that
+    /// models a fully published VTA, which the round-trip in
+    /// `tests/mock_vta.rs` does against the stub host.
     #[tokio::test]
-    async fn preconditions_reject_when_already_enabled() {
+    async fn preconditions_no_longer_stop_at_the_config_alone() {
         let fx = build_fixture(true);
         let err =
             check_enable_preconditions::<RestService, EnableRestError>(&fx.config, &fx.webvh_ks())
                 .await
                 .unwrap_err();
-        assert!(matches!(err, EnableRestError::ServiceAlreadyEnabled));
+        assert!(
+            matches!(err, EnableRestError::VtaDidRecordMissing(_)),
+            "expected the document check to be reached, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/vta-service/src/operations/protocol/enable_tsp.rs
+++ b/vta-service/src/operations/protocol/enable_tsp.rs
@@ -209,14 +209,35 @@ mod tests {
         }
     }
 
+    /// "Already enabled" means enabled in **both** the live config and the
+    /// published document — not in either.
+    ///
+    /// This fixture is the disagreement case: the config says the service is
+    /// on, the document advertises nothing. It used to be refused, which left
+    /// it unmanageable — `update` requires the service on in both places, so
+    /// neither operation would touch it and the only way out was to edit the
+    /// config by hand. It is reachable by re-pointing `vta_did` at a freshly
+    /// minted DID, or by restoring a config without its log.
+    ///
+    /// Reconciling that is what enable is *for*, so it no longer stops here.
+    ///
+    /// It stops at the *next* precondition instead — this fixture seeds no
+    /// webvh record — and that is the whole assertion: reaching
+    /// `VtaDidRecordMissing` proves the config check no longer short-circuits
+    /// ahead of the document. Asserting success would need a fixture that
+    /// models a fully published VTA, which the round-trip in
+    /// `tests/mock_vta.rs` does against the stub host.
     #[tokio::test]
-    async fn preconditions_reject_when_already_enabled() {
+    async fn preconditions_no_longer_stop_at_the_config_alone() {
         let fx = build_fixture(true);
         let err =
             check_enable_preconditions::<TspService, EnableTspError>(&fx.config, &fx.webvh_ks())
                 .await
                 .unwrap_err();
-        assert!(matches!(err, EnableTspError::ServiceAlreadyEnabled));
+        assert!(
+            matches!(err, EnableTspError::VtaDidRecordMissing(_)),
+            "expected the document check to be reached, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/vta-service/src/operations/protocol/service_lifecycle.rs
+++ b/vta-service/src/operations/protocol/service_lifecycle.rs
@@ -188,15 +188,25 @@ where
     S: ServiceLifecycle,
     E: EnableMutationError,
 {
-    {
+    // "Already enabled" means enabled in **both** places, not in either.
+    //
+    // Refusing on the config alone made one reachable state unmanageable.
+    // `update` requires the service ON in the config *and* advertised in the
+    // document; this refused whenever the config said ON. So config-ON with the
+    // document silent — which is exactly what re-pointing `vta_did` at a freshly
+    // minted DID produces, and what restoring a config without its log produces
+    // — could be neither enabled nor updated. The operator's only route out was
+    // to edit the config by hand.
+    //
+    // Enable's job is to make both true. Where they disagree there is work to
+    // do, and this is the operation that does it.
+    let cfg_on = {
         let cfg = config.read().await;
-        if S::config_enabled(&cfg) {
-            return Err(E::already_enabled());
-        }
-    }
+        S::config_enabled(&cfg)
+    };
     let state =
         crate::operations::protocol::preconditions::load_vta_doc_state(config, webvh_ks).await?;
-    if S::current_service_url(&state.current_doc).is_some() {
+    if cfg_on && S::current_service_url(&state.current_doc).is_some() {
         return Err(E::already_enabled());
     }
     Ok(state)

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -972,3 +972,113 @@ async fn consent_family_response_shapes() {
 
     mock.shutdown().await;
 }
+
+/// The `services/*` write paths, against a VTA whose own DID is hosted.
+///
+/// These were the last uncovered block with a shared cause. `services/enable`
+/// and its siblings publish a new WebVH LogEntry for the VTA's *own* DID, so
+/// `load_vta_doc_state` needs a record and a log for it — and the ordinary test
+/// fixture's `vta_did` is a self-resolving `did:key`, which has neither. No
+/// amount of test-writing reaches them from there; the fixture is the blocker.
+///
+/// Minting one against the stub host and pointing `vta_did` at it is what
+/// unlocks the whole family, which is why this is one test rather than five.
+#[tokio::test]
+async fn services_write_paths_against_a_hosted_vta_did() {
+    use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
+    use vta_sdk::protocols::did_management::create::WebvhPathMode;
+
+    let mock = MockVta::start_with_webvh_host().await;
+    let client: VtaClient = mock.signing_client(0x40, "admin", vec![]).await;
+
+    // A real hosted DID, with the record and log the preconditions read.
+    let minted = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.into()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            add_tsp_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("mint a hosted DID for the VTA itself");
+    let did = minted.did.clone();
+
+    // Point the VTA at it. `services/*` mutate *this* DID's document, so the
+    // one under test has to be the one the VTA calls its own.
+    {
+        let mut cfg = mock.ctx.config.write().await;
+        cfg.vta_did = Some(did.clone());
+    }
+
+    // And re-address the client. The VTA's identity just changed, and a
+    // document's `recipient` has to name the consumer it is sent to — SPEC §7.2
+    // item 5 rejects one that does not. Reusing the old client would fail on
+    // `wrongRecipient` before reaching anything this test is about.
+    let (identity, token) = mock
+        .ctx
+        .mint_signing_identity(0x40, "admin", vec![], &did)
+        .await;
+    let client = VtaClient::new(mock.base_url()).with_identity(identity);
+    client.set_token_async(token).await;
+
+    // REST throughout: it is the transport with no live handshake, so these
+    // exercise the publish path rather than a service-liveness probe.
+    //
+    // `enable` first, and it is doing real work: the freshly minted DID's
+    // document advertises no REST service, while the fixture's config says REST
+    // is on. Reconciling that disagreement is what enable is for — and until
+    // this change it refused to, leaving the state unmanageable.
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_SERVICES_ENABLE_1_0,
+            serde_json::json!({ "service": "rest", "config": { "url": "https://vta.test" } }),
+            30,
+        )
+        .await
+        .expect("services/enable");
+
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_SERVICES_UPDATE_1_0,
+            serde_json::json!({ "service": "rest", "config": { "url": "https://vta.test/moved" } }),
+            30,
+        )
+        .await
+        .expect("services/update");
+
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_SERVICES_DISABLE_1_0,
+            serde_json::json!({ "service": "rest" }),
+            30,
+        )
+        .await
+        .expect("services/disable");
+
+    client
+        .dispatch_trust_task(
+            vta_sdk::trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
+            serde_json::json!({ "service": "rest" }),
+            30,
+        )
+        .await
+        .expect("services/rollback");
+
+    mock.shutdown().await;
+}


### PR DESCRIPTION
Coverage **93 → 97 of 109 (89%)** — the `services/{enable,update,disable,rollback}` write paths — and a state they could not get out of.

## The deadlock

`enable` refused when the service was on in the live config **or** advertised in the published document. `update` requires it on in **both**.

So **config-on with a silent document was unmanageable**: neither operation would touch it, and the operator's only route out was editing the config by hand.

| config | document | `enable` | `update` |
|---|---|---|---|
| on | on | refuses (correct — nothing to do) | works |
| off | off | works | refuses (correct) |
| on | **off** | refused | refused | ← **stuck** |
| off | on | refused | refused | ← stuck |

That state is reachable, and not exotically: re-point `vta_did` at a freshly minted DID and you have it — the new document advertises nothing while the config still says REST is on. Restoring a config without its log does the same.

## The rule

"Already enabled" now means enabled in **both** places, which is the only reading under which there is genuinely nothing to do. Where the two disagree there is work, and this is the operation that does it. Both disagreement directions become recoverable; the no-op case is still refused.

## The coverage is what found it

These four were the last block with a shared cause. They publish a new WebVH LogEntry for the VTA's **own** DID, so `load_vta_doc_state` needs a record and a log for it — and the ordinary fixture's `vta_did` is a self-resolving `did:key`, which has neither. No amount of test-writing reaches them from there; the fixture was the blocker.

Minting one against the stub host and pointing `vta_did` at it is the unlock, which is why this is one test rather than four.

The client is rebuilt after the flip. A document's `recipient` must name the consumer it is sent to, and the VTA's identity just changed — reusing the old client fails on `wrongRecipient` before reaching anything under test.

## The two unit tests that encoded the old rule

They now assert the new one, and assert it **precisely**: the fixture seeds no webvh record, so reaching `VtaDidRecordMissing` is what proves the config check no longer short-circuits ahead of the document. Asserting success would need a fixture modelling a fully published VTA — which is what the stub-host round-trip is for.

## Verification

- `vta-service --all-features`: **0 failed**, zero response-conformance violations
- `cargo clippy --workspace --all-features --all-targets`: exit 0
- `cargo fmt --all --check`: exit 0
- `TRUST-TASK RESPONSE COVERAGE 97/109 (89%)`