### PR TITLE
test(vta): cover webvh/dids/register-with-server

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -2380,3 +2380,156 @@ impl SoftAuthenticator {
         }
     }
 }
+
+// ── Held credentials ─────────────────────────────────────────────────────────
+
+/// Mint an SD-JWT-VC and receive it into the vault, as a holder would.
+///
+/// `credential-exchange/pending/approve` answers a deferred presentation, so it
+/// needs a credential that actually satisfies the deferred query — it refuses
+/// with "no held credential satisfies the deferred query" otherwise, which is
+/// why that task sat uncovered. Seeding a stored row directly would skip the
+/// receive path that decides how a credential is indexed, and the DCQL match
+/// runs off that index; so this mints and receives rather than writing a row.
+///
+/// Returns the stored credential's id.
+/// `subject_did` must be a holder key this VTA manages: presenting the
+/// credential means signing as the holder, and the operation refuses a subject
+/// whose key it does not hold. The VTA's own DID is the one a test fixture has.
+pub async fn seed_held_credential(
+    vault_ks: &KeyspaceHandle,
+    vct: &str,
+    disclosable_claim: &str,
+    subject_did: &str,
+) -> String {
+    use affinidi_sd_jwt::error::SdJwtError;
+    use affinidi_sd_jwt::signer::JwtSigner;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use ed25519_dalek::{Signer, SigningKey};
+    use vta_vault::mint::{MintRequest, mint_sd_jwt_vc};
+
+    /// The issuer. A `did:key`, so the receive path can resolve it without a
+    /// network or a resolver fixture.
+    struct EddsaSigner {
+        key: SigningKey,
+        kid: String,
+    }
+    impl JwtSigner for EddsaSigner {
+        fn algorithm(&self) -> &str {
+            "EdDSA"
+        }
+        fn key_id(&self) -> Option<&str> {
+            Some(&self.kid)
+        }
+        fn sign_jwt(
+            &self,
+            header: &serde_json::Value,
+            payload: &serde_json::Value,
+        ) -> Result<String, SdJwtError> {
+            let h = URL_SAFE_NO_PAD.encode(serde_json::to_string(header)?.as_bytes());
+            let p = URL_SAFE_NO_PAD.encode(serde_json::to_string(payload)?.as_bytes());
+            let input = format!("{h}.{p}");
+            let sig = self.key.sign(input.as_bytes());
+            Ok(format!(
+                "{input}.{}",
+                URL_SAFE_NO_PAD.encode(sig.to_bytes())
+            ))
+        }
+    }
+
+    let issuer_key = SigningKey::from_bytes(&[0x71; 32]);
+    let issuer_did =
+        affinidi_crypto::did_key::ed25519_pub_to_did_key(issuer_key.verifying_key().as_bytes());
+    let signer = EddsaSigner {
+        key: issuer_key,
+        kid: format!("{issuer_did}#key-0"),
+    };
+
+    let compact = mint_sd_jwt_vc(
+        &MintRequest {
+            vct,
+            issuer_did: &issuer_did,
+            subject_did,
+            claims: &serde_json::json!({ disclosable_claim: "Alice" }),
+            disclosable: &[disclosable_claim],
+            iat: 1_700_000_000,
+            exp: Some(1_900_000_000),
+        },
+        &signer,
+    )
+    .expect("mint the SD-JWT-VC");
+
+    // Nested under `credential_response`, which is where the issue message
+    // carries it — a bare `credential` member is refused as "no credential".
+    let body = serde_json::from_value(
+        serde_json::json!({ "credential_response": { "credential": compact } }),
+    )
+    .expect("issue body deserialises");
+    let cred = crate::operations::credential_exchange::receive_issued_credential(
+        vault_ks,
+        &body,
+        None,
+        None,
+        chrono::Utc::now(),
+    )
+    .await
+    .expect("receive the issued credential");
+    cred.id
+}
+
+/// Seed a **holder** key this VTA manages, and return its `did:key`.
+///
+/// Distinct from the VTA's own signing identity, which is not a holder key:
+/// presenting a credential means signing *as the subject*, and
+/// `resolve_holder_keys` looks the subject up in the keys keyspace under
+/// `{did:key}#{multibase}`. A test that uses `vta_did` as the subject is
+/// refused with "holder key … is not managed by this VTA", correctly.
+///
+/// Derived from the app state's own seed at `derivation_path`, so the record
+/// and the key material agree — a record whose public half did not match the
+/// seed would resolve and then fail to sign.
+pub async fn seed_holder_key(
+    state: &crate::server::AppState,
+    derivation_path: &str,
+    context_id: Option<&str>,
+) -> String {
+    use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
+    use vti_common::slip10::{DerivationPath, ExtendedSigningKey};
+
+    let seed = state
+        .seed_store
+        .get()
+        .await
+        .expect("read the seed")
+        .expect("an active seed");
+    let bip32 = ExtendedSigningKey::from_seed(&seed).expect("seed is a valid BIP-32 root");
+    let derived = bip32
+        .derive(&derivation_path.parse::<DerivationPath>().expect("a path"))
+        .expect("derive");
+    let did = affinidi_crypto::did_key::ed25519_pub_to_did_key(
+        derived.signing_key.verifying_key().as_bytes(),
+    );
+    let multibase = did.strip_prefix("did:key:").expect("a did:key");
+    let key_id = format!("{did}#{multibase}");
+
+    let record = KeyRecord {
+        key_id: key_id.clone(),
+        derivation_path: derivation_path.to_string(),
+        key_type: KeyType::Ed25519,
+        status: KeyStatus::Active,
+        public_key: multibase.to_string(),
+        label: None,
+        context_id: context_id.map(str::to_string),
+        seed_id: None,
+        origin: KeyOrigin::Derived,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    state
+        .keys_ks
+        .insert(crate::keys::store_key(&key_id), &record)
+        .await
+        .expect("store the holder key record");
+    did
+}

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -3187,6 +3187,83 @@ mod response_coverage {
         .await;
     }
 
+    /// `credential-exchange/pending/approve` — answer a deferral the holder can
+    /// satisfy.
+    ///
+    /// The refusal path (nothing held matches the query) is covered in
+    /// `tests/pending_presentation_trust_task.rs`. This is the other side, and
+    /// it needs two things that fixture cannot give it: a credential the DCQL
+    /// query matches, and a holder key this VTA manages — presenting means
+    /// signing as the holder.
+    ///
+    /// The credential is minted and received rather than written straight into
+    /// storage. The DCQL match runs off the index the receive path builds, so a
+    /// hand-written row would exercise a different lookup than production does.
+    #[tokio::test]
+    async fn pending_approve_presents_a_held_credential() {
+        use crate::operations::credential_exchange::pending::{
+            PendingPresentation, put as put_pending,
+        };
+
+        const VCT: &str = "https://openvtc.org/credentials/MembershipCredential";
+
+        let (state, _dir) = build_signing_test_app_state().await;
+
+        // A holder key, not the VTA's signing identity: presenting means
+        // signing *as the subject*, and `resolve_holder_keys` looks the subject
+        // up in the keys keyspace. Using `vta_did` here is refused with
+        // "holder key … is not managed by this VTA", correctly.
+        let holder = crate::test_support::seed_holder_key(&state, "m/26'/2'/0'/0'", None).await;
+        let credential_id =
+            crate::test_support::seed_held_credential(&state.vault_ks, VCT, "givenName", &holder)
+                .await;
+
+        let record: PendingPresentation = serde_json::from_value(json!({
+            "id": "cov-pending-1",
+            "verifier_did": "did:web:stranger.example",
+            // The *real* stored id, not a placeholder. The consent is built by
+            // mapping the requested claims onto the matched credential, so an
+            // id that matches nothing yields an empty reveal set — which the
+            // operation refuses as authorizing nothing.
+            "requested": [{
+                "credential_query_id": "membership",
+                "credential_id": credential_id,
+                "claims": ["givenName"]
+            }],
+            "purpose": "coverage",
+            "query": {
+                "dcql_query": {
+                    "credentials": [{
+                        "id": "membership",
+                        "format": "dc+sd-jwt",
+                        "meta": { "vct_values": [VCT] },
+                        // The reveal set comes from the *query's* claim paths,
+                        // not from `requested` — a query that names no claims
+                        // discloses nothing, and the operation refuses an empty
+                        // reveal set as authorizing nothing.
+                        "claims": [{ "path": ["givenName"] }]
+                    }]
+                },
+                "nonce": "n-1",
+                "purpose": "coverage"
+            },
+            "status": "pending",
+            "created_at": "2026-06-12T00:00:00Z",
+            "expires_at": "2126-06-12T00:00:00Z"
+        }))
+        .expect("pending record deserialises");
+        put_pending(&state.vault_ks, &record)
+            .await
+            .expect("seed the deferral");
+
+        ok(
+            &state,
+            vta_sdk::protocols::credential_exchange::PENDING_APPROVE,
+            json!({ "id": "cov-pending-1" }),
+        )
+        .await;
+    }
+
     /// The runtime service-management read paths.
     ///
     /// Only the reads: `enable`/`update`/`disable`/`rollback` publish a new

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -862,6 +862,45 @@ async fn webvh_family_response_shapes() {
         .await
         .expect("servers/retire-orphan");
 
+    // ── promoting a serverless DID ────────────────────────────────────────
+    // `dids/register-with-server` is the one webvh path that cannot be reached
+    // from the DID above: it refuses anything already server-managed, so it
+    // needs a *second* DID minted the other way — `url` set, `server_id`
+    // unset, which is what puts `"serverless"` on the record. That mint also
+    // writes the local `did.jsonl` the register pushes; a hand-seeded record
+    // would satisfy the serverless check and then fail at `LogMissing`, which
+    // is the reject arm, not the shape this is here for.
+    let serverless = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".into(),
+            server_id: None,
+            url: Some(vta_service::test_support::STUB_WEBVH_DID_URL.into()),
+            path: None,
+            path_mode: None,
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            add_tsp_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("mint a serverless DID");
+    let promoted = client
+        .register_did_with_server(&serverless.did, MockVta::WEBVH_SERVER_ID, false, None)
+        .await
+        .expect("dids/register-with-server");
+    assert_eq!(promoted.server_id, MockVta::WEBVH_SERVER_ID);
+
     // ── the DID itself ────────────────────────────────────────────────────
     // Rotate before delete: a rotation on a deleted DID has nothing to rotate,
     // and delete is terminal.


### PR DESCRIPTION
The last task in the `webvh` family with no observed success response.

It cannot be reached from the DID `webvh_family_response_shapes` already mints — `register-with-server` refuses anything already server-managed — so it needs a second DID minted the other way: `url` set, `server_id` unset, which is what puts `"serverless"` on the record.

That mint is also what writes the local `did.jsonl` the register pushes. A hand-seeded record would pass the serverless check and then fail at `LogMissing`, which is the reject arm rather than the shape this is for.

The stub host already serves `/api/dids/register`, so the promotion completes against it; the test asserts the flipped `server_id` on the response.

Stacked on #1154. This is the last harness in the series.