### PR TITLE
fix(scripts): run the coverage suite with --all-features

### DIFF
--- a/scripts/trust-task-coverage.sh
+++ b/scripts/trust-task-coverage.sh
@@ -25,9 +25,23 @@ mkdir -p "$OBSERVED"
 export TRUST_TASK_OBSERVED_DIR="$OBSERVED"
 
 echo "==> running the vta-service suite (observations -> $OBSERVED/<pid>.tasks)"
+# `--all-features` because half the answer is behind feature gates. Without it
+# every `#![cfg(feature = ...)]` test binary is silently skipped — the
+# `transport-harness` one alone carries `vault/{release,proxy-login,
+# sign-trust-task}` — and those tasks are then reported as uncovered even
+# though a `cargo test --all-features` run exercises them. The failure is
+# invisible in exactly the wrong direction: nothing errors, the number is
+# simply too low, and the missing tasks look like harness gaps to go and
+# write tests for that already exist.
+#
+# It matters on the report line below too, not just the capture: the
+# denominator comes from the dispatch table, which is itself feature-gated,
+# so building the two with different feature sets compares a numerator and a
+# denominator that do not describe the same service.
+#
 # `--no-fail-fast` so a failing binary still contributes what it exercised:
 # coverage of a partial run is a floor, and a floor beats no number.
-cargo test -p vta-service --no-fail-fast "$@" || true
+cargo test -p vta-service --all-features --no-fail-fast "$@" || true
 
 echo "==> coverage"
-cargo test -p vta-service --lib -- --ignored --nocapture report_task_coverage
+cargo test -p vta-service --all-features --lib -- --ignored --nocapture report_task_coverage


### PR DESCRIPTION
`scripts/trust-task-coverage.sh` builds the suite with the **default** feature set, so every `#![cfg(feature = ...)]` test binary is silently skipped. Neither `webvh` nor `transport-harness` is in `default`:

```
vta-service/tests/delegated_consent_e2e.rs:28:#![cfg(feature = "webvh")]
vta-service/tests/vault_release_didcomm.rs:14:#![cfg(feature = "transport-harness")]
```

so both binaries never run — the latter carrying `vault/{release,proxy-login,sign-trust-task}` — along with every `webvh`-gated test inside the binaries that do run.

The failure is invisible in the wrong direction. Nothing errors; the number is just too low, and the missing tasks read as harness gaps to go and write tests for that already exist. It cost a real afternoon: a `cargo test --all-features` run recorded the vault three, the script reported them uncovered, and the recorder looked at fault.

It matters on the report line too, not only the capture — the denominator comes from the dispatch table, which is itself feature-gated, so building the two halves with different feature sets compares a numerator and a denominator that don't describe the same service.

With this, and with #1154 and #1155 in front of it:

```
TRUST-TASK RESPONSE COVERAGE  109/109          (100%) — 0 never exercised
```

Stacked on #1155.