### PR TITLE
chore(deps): update dependencies and drop the legacy rustls tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ dependencies = [
  "highway",
  "moka",
  "rand 0.10.2",
- "rustls 0.23.43",
+ "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde-wasm-bindgen",
@@ -213,7 +213,7 @@ dependencies = [
  "sha1 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tracing",
  "url",
  "wasm-bindgen",
@@ -389,7 +389,7 @@ dependencies = [
  "http 1.5.0",
  "humantime",
  "itertools",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "metrics",
  "metrics-exporter-prometheus",
  "num-format",
@@ -398,7 +398,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
- "rustls 0.23.43",
+ "rustls",
  "semver",
  "serde",
  "serde_json",
@@ -426,7 +426,7 @@ checksum = "2972b94ba1f4236c8739ad5660ec1ffe92e0b6a55c64b4ed13ad0c029cf4f283"
 dependencies = [
  "aes-gcm",
  "ahash",
- "argon2",
+ "argon2 0.5.3",
  "async-trait",
  "axum",
  "base64 0.23.1",
@@ -493,7 +493,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "reqwest",
- "rustls 0.23.43",
+ "rustls",
  "serde",
  "serde_json",
  "sha256",
@@ -519,9 +519,9 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "async-trait",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "ring",
- "rustls 0.23.43",
+ "rustls",
  "serde_json",
  "sha256",
  "thiserror 2.0.20",
@@ -701,7 +701,7 @@ dependencies = [
  "affinidi-tdk-common",
  "affinidi-tsp",
  "clap",
- "rustls 0.23.43",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -727,7 +727,7 @@ dependencies = [
  "keyring-core",
  "moka",
  "reqwest",
- "rustls 0.23.43",
+ "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -747,7 +747,7 @@ dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "blake2",
+ "blake2 0.10.6",
  "chacha20poly1305 0.10.1",
  "ed25519-dalek",
  "hex",
@@ -939,9 +939,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
- "blake2",
+ "blake2 0.10.6",
  "cpufeatures 0.2.17",
- "password-hash",
+ "password-hash 0.5.0",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
+dependencies = [
+ "base64ct",
+ "blake2 0.11.0",
+ "cpufeatures 0.3.1",
+ "password-hash 0.6.1",
 ]
 
 [[package]]
@@ -1490,23 +1502,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.19",
- "http 0.2.12",
+ "h2",
  "http 1.5.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.11.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -1677,7 +1683,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1752,13 +1758,13 @@ dependencies = [
  "fs-err 3.3.1",
  "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2035,6 +2041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,13 +2287,13 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -2302,7 +2317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead 0.6.1",
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "cipher 0.5.2",
  "poly1305 0.9.1",
 ]
@@ -2616,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -2791,7 +2806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -2952,7 +2967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3954,23 +3969,23 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54aab44c16b8463ae11b165a87c3d484780231f157bb1ed65843d591beb5abd"
+checksum = "ff461519b1a948200f163574be072753bcfb462a323f0eb426629d89872dd685"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
- "chrono",
  "google-cloud-gax",
  "hex",
  "hmac 0.13.0",
  "http 1.5.0",
- "jsonwebtoken",
+ "jiff",
+ "jsonwebtoken 11.0.0",
  "reqwest",
  "rustc_version",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3983,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a46dd0fd026bbc4a5d84e6ab0c941cee6e3b057976a0bb107fdb5238ce598f"
+checksum = "c5615cff28ee59cfe52fbb4c11b8b1e77f650296e2ea4f4c2b7757ac6b19e752"
 dependencies = [
  "bytes",
  "futures",
@@ -3998,13 +4013,14 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb04c54317ace06d489213f761797240b3046142a9b7ce6b9a82a9d134e193d1"
+checksum = "d2766757d877a7a8ac23da9884cb0e3f10ed9b75a0ce59801ce6b19bf9d5819e"
 dependencies = [
  "bytes",
  "futures",
@@ -4013,7 +4029,7 @@ dependencies = [
  "google-cloud-rpc",
  "http 1.5.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "lazy_static",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -4033,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-iam-v1"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cdf5acc7ef946ee2db7a7f62bd436d8395a6543b4beef110cdc061fcf578bb"
+checksum = "5f962b40234b1531e6ef73f7558871c96e117231e962086c98804323fb8d2c82"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4081,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-secretmanager-v1"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c698b2c961dd595c5f4daacdedb23321089ca8d85353f505ad53a54caa7d63e"
+checksum = "c598f57330c712f077cf2406eb1a481b1cacba85ea896d5ab94b428889c505c0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4171,25 +4187,6 @@ dependencies = [
  "ff 0.14.0",
  "rand_core 0.10.1",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -4482,30 +4479,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
@@ -4514,7 +4487,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.19",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -4528,33 +4501,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.5.0",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -4564,7 +4522,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4583,12 +4541,12 @@ dependencies = [
  "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
- "hyper 1.11.0",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5008,7 +4966,7 @@ dependencies = [
  "referencing",
  "regex",
  "reqwest",
- "rustls 0.23.43",
+ "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -5039,6 +4997,22 @@ dependencies = [
  "serde_json",
  "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
  "zeroize",
 ]
 
@@ -5087,7 +5061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -5133,8 +5107,8 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jiff",
@@ -5142,7 +5116,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rustls 0.23.43",
+ "rustls",
  "secrecy",
  "serde",
  "serde_json",
@@ -5218,9 +5192,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -5282,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5402,15 +5376,15 @@ dependencies = [
  "base64 0.22.1",
  "evmap",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "indexmap 2.14.0",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "rustls 0.23.43",
+ "rustls",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6032,6 +6006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+dependencies = [
+ "getrandom 0.4.3",
+ "phc",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6114,6 +6098,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
+]
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -6284,7 +6279,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "universal-hash 0.6.1",
 ]
 
@@ -6424,8 +6419,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.43",
- "socket2 0.5.10",
+ "rustls",
+ "socket2",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6446,7 +6441,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.20",
@@ -6464,7 +6459,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6523,7 +6518,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -6756,13 +6751,13 @@ dependencies = [
  "num-bigint 0.5.1",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "ryu",
  "sha1_smol",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "url",
  "xxhash-rust",
@@ -6915,12 +6910,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.19",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -6928,7 +6923,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -6936,7 +6931,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http 0.6.11",
@@ -7082,18 +7077,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -7102,7 +7085,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.15",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7140,10 +7123,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.15",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7155,16 +7138,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -7282,16 +7255,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7599,7 +7562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -7627,7 +7590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -7816,16 +7779,6 @@ name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -8251,7 +8204,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8269,21 +8222,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.43",
+ "rustls",
  "tokio",
 ]
 
@@ -8296,6 +8239,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -8318,11 +8262,11 @@ checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.43",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite 0.30.0",
  "webpki-roots 0.26.11",
 ]
@@ -8413,20 +8357,20 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.19",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.5",
+ "socket2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -8617,9 +8561,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353aaf722fe973429964b5f7f73e83587dcd4f7339fd823563f60116a6452eab"
+checksum = "fd89e31d13896e945f95674dd36fa7f40607be72434967cfa1fc5954dcc6f5b1"
 dependencies = [
  "chrono",
  "serde",
@@ -8631,9 +8575,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1974962777655ed96b6d11fd2576fa86d9b2746244dc08e30839a035f3915e24"
+checksum = "69b72951b407ef3d30fed0572f108ad72ea9ab969c90b0dc269c46e1e44c5738"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -8647,13 +8591,13 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f9307dd3d05da704e079ce7c5f5b8e37cf1a9a809accb0bd924b0c579d1776"
+checksum = "4e675e8e84f98701f2c5afb28bf20edc5576fa516bb60c5c38080b1cda48f6a0"
 dependencies = [
  "axum",
  "chrono",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -8666,9 +8610,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6180c087ad44a2907720e9d999dd6d21cfc055213a6384d8d931b67c266d187e"
+checksum = "7395dec266796624f255530d5820dd5e1418edf886885f6c9581dc1e634e7bf6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8731,7 +8675,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.10.2",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.11.0",
  "thiserror 2.0.20",
@@ -8750,9 +8694,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "typenum"
@@ -9107,9 +9051,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -9205,7 +9149,7 @@ name = "vta-backup"
 version = "0.2.0"
 dependencies = [
  "aes-gcm",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -9434,7 +9378,7 @@ dependencies = [
  "nitro_attest",
  "reqwest",
  "ring",
- "rustls 0.23.43",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9479,7 +9423,7 @@ dependencies = [
  "affinidi-tdk",
  "affinidi-tdk-common",
  "agent-names",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "aws-lc-rs",
  "axum",
@@ -9499,7 +9443,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "http-body-util",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "keyring-core",
  "libc",
  "metrics",
@@ -9717,7 +9661,7 @@ dependencies = [
  "affinidi-status-list",
  "affinidi-tdk",
  "affinidi-vc",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "axum",
  "axum-extra",
@@ -9740,7 +9684,7 @@ dependencies = [
  "http-body-util",
  "include_dir",
  "jsonschema",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "keyring-core",
  "mime_guess",
  "multibase",
@@ -9804,7 +9748,7 @@ dependencies = [
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "http-body-util",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "libc",
  "multibase",
  "rand 0.10.2",
@@ -10435,7 +10379,7 @@ dependencies = [
  "futures",
  "http 1.5.0",
  "http-body-util",
- "hyper 1.11.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -45,7 +45,7 @@ sha2 = { workspace = true }
 subtle = { workspace = true }
 zeroize = { version = "1", features = ["derive"] }
 aes-gcm = { workspace = true }
-argon2 = "0.5"
+argon2 = "0.6"
 async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/vta-backup/src/ops/mod.rs
+++ b/vta-backup/src/ops/mod.rs
@@ -998,6 +998,40 @@ mod tests {
     use vti_common::config::StoreConfig as VtiStoreConfig;
     use vti_common::store::Store;
 
+    /// The Argon2id key derivation, pinned to a frozen vector.
+    ///
+    /// A backup envelope stores the salt and the KDF parameters, not the key.
+    /// Decryption re-derives it, so this function's output *is* the format:
+    /// change a byte of it and every backup ever written becomes
+    /// undecryptable, with nothing to say so but an AES-GCM tag failure.
+    ///
+    /// The encrypt/decrypt round-trip tests cannot catch that — they derive
+    /// the key twice with the same linked version, so both sides move
+    /// together. This vector was produced by argon2 0.5 and re-checked
+    /// against 0.6 during that upgrade; it does not move.
+    ///
+    /// If this fails, do not regenerate it. It means the linked crate changed
+    /// its derivation, and the change needs a versioned KDF marker in the
+    /// envelope plus a path that reads the old one.
+    #[test]
+    fn argon2id_derivation_matches_the_frozen_vector() {
+        let argon2 = Argon2::new(
+            argon2::Algorithm::Argon2id,
+            argon2::Version::V0x13,
+            argon2::Params::new(ARGON2_M_COST, ARGON2_T_COST, ARGON2_P_COST, Some(32)).unwrap(),
+        );
+        let mut key = [0u8; 32];
+        argon2
+            .hash_password_into(b"backup-password", b"0123456789abcdef", &mut key)
+            .unwrap();
+        assert_eq!(
+            key.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            "3558837960e818d4ae946a900d505053894bf02a6ac9e046f0781fe09a616bf9",
+            "the backup KDF changed — every existing envelope is now \
+             undecryptable"
+        );
+    }
+
     /// Pre-existing daemon REST auth-cache records must be wiped by
     /// the restore path. Otherwise a backup imported on a different
     /// VTA (or a fresh install before re-onboarding the daemons)

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -335,7 +335,7 @@ tower_governor = "0.8"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.18", default-features = false }
 aes-gcm = { workspace = true }
-argon2 = "0.5"
+argon2 = "0.6"
 hmac = "0.13"
 # RSA-OAEP / constant-time crypto (aws-lc-rs, AWS's BoringSSL-based lib).
 # The KMS bootstrap that used it moved to `vta-tee`; this remains for the

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -277,7 +277,7 @@ bip39 = "2"
 # Argon2id for hashing admin-invite claim secrets (the out-of-band
 # code the invitee types alongside the install URL). Same pin as
 # `vta-service`'s backup-password KDF.
-argon2 = "0.5"
+argon2 = "0.6"
 # AES-256-GCM for the encrypted backup/restore payload (P3.9). Same
 # workspace pin as `vta-service`'s backup feature.
 aes-gcm = { workspace = true }

--- a/vtc-service/src/install/claim_secret.rs
+++ b/vtc-service/src/install/claim_secret.rs
@@ -20,8 +20,8 @@
 //! to brute-force.
 
 use argon2::Argon2;
-use argon2::password_hash::rand_core::OsRng as PhcOsRng;
-use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use argon2::password_hash::phc::PasswordHash;
+use argon2::password_hash::{PasswordHasher, PasswordVerifier};
 use rand::RngExt;
 use vti_common::error::AppError;
 
@@ -53,9 +53,12 @@ pub fn generate() -> String {
 /// hashing cost is paid once at invite-mint and once at claim
 /// time; well below operator-perceivable latency.
 pub fn hash(secret: &str) -> Result<String, AppError> {
-    let salt = SaltString::generate(&mut PhcOsRng);
+    // `password-hash` 0.6 generates the salt itself (`getrandom`, on by
+    // default) rather than taking one. The 0.5 call passed an explicitly
+    // generated `SaltString`; dropping it is not a weakening — the library
+    // draws a large random salt from the same OS source.
     Argon2::default()
-        .hash_password(secret.as_bytes(), &salt)
+        .hash_password(secret.as_bytes())
         .map(|h| h.to_string())
         .map_err(|e| AppError::Internal(format!("claim secret hash failed: {e}")))
 }
@@ -69,7 +72,7 @@ pub fn verify(secret: &str, stored_hash: &str) -> Result<bool, AppError> {
         .map_err(|e| AppError::Internal(format!("malformed claim secret hash: {e}")))?;
     match Argon2::default().verify_password(secret.as_bytes(), &parsed) {
         Ok(()) => Ok(true),
-        Err(argon2::password_hash::Error::Password) => Ok(false),
+        Err(argon2::password_hash::Error::PasswordInvalid) => Ok(false),
         Err(e) => Err(AppError::Internal(format!(
             "claim secret verify failed: {e}"
         ))),
@@ -125,6 +128,32 @@ mod tests {
             format!("{err}").contains("malformed claim secret hash"),
             "expected malformed-hash error, got: {err}"
         );
+    }
+
+    /// A PHC string written by **argon2 0.5**, verified by whatever version
+    /// is linked now.
+    ///
+    /// Claim-secret hashes are persisted at invite-mint and read back at claim
+    /// time, so they outlive any upgrade of the hashing crate. Every other test
+    /// here hashes and verifies with the same linked version, which cannot fail
+    /// on a format or parameter change — both sides move together. This one
+    /// cannot move: the string is frozen, generated against 0.5 before the 0.6
+    /// bump, so it fails if a future upgrade stops reading what we already
+    /// wrote to disk.
+    ///
+    /// Regenerate only when deliberately migrating stored hashes, and then only
+    /// alongside a migration for the rows already out there.
+    #[test]
+    fn verifies_a_hash_written_by_the_previous_argon2() {
+        const WRITTEN_BY_0_5: &str = "$argon2id$v=19$m=19456,t=2,p=1$\
+                                      rYUqQxBXAxmC08nsOcap4Q$\
+                                      FO7Xh+ZqT32UeAoqfQtwb7dRcygZ8xxYYBS63AXGqkk";
+        assert!(
+            verify("CLAIM-SECRET-05", WRITTEN_BY_0_5).unwrap(),
+            "a hash written by argon2 0.5 no longer verifies — every claim \
+             secret minted before the upgrade is unusable"
+        );
+        assert!(!verify("WRONG-SECRET", WRITTEN_BY_0_5).unwrap());
     }
 
     #[test]

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -62,9 +62,23 @@ multibase = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 
 # AWS Secrets Manager backend (aws-secrets feature).
-aws-sdk-secretsmanager = { version = "1", optional = true }
-aws-config = { version = "1", features = [
+#
+# `default-features = false` + an explicit `default-https-client`, matching
+# `vta-tee`. The SDK's own default feature set still turns on the deprecated
+# `rustls` feature, which resolves to `aws-smithy-http-client`'s
+# `legacy-rustls-ring` and pulls **rustls 0.21** — and with it
+# `rustls-webpki` 0.101, which carries three open advisories (one high: a
+# DoS panic on a malformed CRL BIT STRING) and has no fixed release in the
+# 0.101 line. `default-https-client` selects the modern `rustls-aws-lc`
+# path instead, so the legacy tree is never built.
+aws-sdk-secretsmanager = { version = "1", default-features = false, features = [
+  "default-https-client",
+  "rt-tokio",
+], optional = true }
+aws-config = { version = "1", default-features = false, features = [
   "behavior-version-latest",
+  "default-https-client",
+  "rt-tokio",
 ], optional = true }
 # GCP Secret Manager backend (gcp-secrets feature).
 google-cloud-secretmanager-v1 = { version = "1", optional = true }


### PR DESCRIPTION
Three parts.

### Lockfile refresh

`cargo update` moves 20 crates, including `trust-tasks-*` 0.17.0 → 0.17.1 and the `google-cloud-*` set.

### argon2 0.5 → 0.6

The only workspace requirement behind latest (`cargo outdated --root-deps-only` reports nothing else). `password_hash` 0.6 reworks what `claim_secret` used: `PasswordHash` moved to `password_hash::phc`, `SaltString` is gone because `hash_password` now draws its own salt from `getrandom`, and `Error::Password` is `Error::PasswordInvalid`.

Two upgrade risks the existing tests could not see, because every one of them hashes and verifies with the **same linked version** — both sides move together, so a format or derivation change passes silently:

| | why it survives an upgrade blind | now pinned by |
|---|---|---|
| Claim-secret PHC strings | persisted at invite-mint, read at claim time | a hash generated against 0.5, verified under 0.6 |
| Backup envelope KDF | envelope stores salt + params, not the key — so `hash_password_into`'s output *is* the format | a frozen vector, confirmed byte-identical across 0.5 and 0.6 |

A changed byte in the second would make every existing backup undecryptable, reported only as an AES-GCM tag failure. Both are verified, not assumed — the 0.5 fixtures were generated by building against 0.5 and comparing.

### The rustls-webpki advisories

All three open dependabot alerts (one **high**: DoS panic on a malformed CRL BIT STRING) are `rustls-webpki` 0.101, which has no fixed release in that line — the patched versions are 0.102.9+ / 0.103.

It arrived because `vti-secrets` took the AWS SDK's default features:

```
aws-sdk-secretsmanager feature "rustls"
  └── aws-smithy-runtime feature "tls-rustls"
      └── aws-smithy-http-client feature "legacy-rustls-ring"
          └── rustls 0.21 → rustls-webpki 0.101
```

`vta-tee` already pinned `default-https-client` explicitly; `vti-secrets` now does the same. That drops `h2`, `hyper` 0.14, `hyper-rustls` 0.24, `rustls` 0.21, `rustls-webpki` 0.101, `sct` and `tokio-rustls` 0.24 from the lockfile entirely. Nothing in the tree was using them — under default features it was lockfile-only, and under `--all-features` it was compiled but unused.

### Verification

- `cargo clippy --workspace --all-features --tests` — 0
- `cargo test --workspace --all-features --exclude vtc-service` — green
- `cargo test -p vtc-service` — green

Note: `cargo test -p vtc-service --all-features` fails 8 `keys::seed_store` tests, and does so on `main` as well — they assert the cloud secret backends are *not* compiled ("did the feature leak on?"), which `--all-features` necessarily breaks. Pre-existing and out of scope here, but worth a follow-up to gate them.