### PR TITLE
fix(vtc): gate the fail-closed backend tests on the feature being absent

### DIFF
--- a/vtc-service/src/keys/seed_store/mod.rs
+++ b/vtc-service/src/keys/seed_store/mod.rs
@@ -273,6 +273,19 @@ mod tests {
     // The default test build compiles only `keyring` (see Cargo.toml
     // `default`), so the cloud/config backends are all "not compiled" here —
     // exactly the set-but-uncompiled case P0.8 must fail closed on.
+    //
+    // Each of those tests carries `#[cfg(not(feature = ...))]` for its own
+    // backend, because the assertion is *about* the backend being absent. Left
+    // ungated they were not merely redundant under `--all-features`, they were
+    // guaranteed to fail: with the feature compiled, `create_secret_store`
+    // correctly returns a store, and the test reads that as
+    // "did the feature leak on?". Eight of them failed on every
+    // `cargo test -p vtc-service --all-features` run, which is the sort of
+    // standing red that teaches people to skip the feature matrix.
+    //
+    // The gate is per-backend, not one blanket `not(any(...))`: under
+    // `--features aws-secrets` only the aws case is unaskable, and the other
+    // five still have something to prove.
 
     // `Box<dyn SecretStore>` is not `Debug`, so `expect_err` won't compile;
     // pattern-match the result instead.
@@ -289,6 +302,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "aws-secrets"))]
     #[test]
     fn aws_set_without_feature_is_config_error() {
         let mut config = base_config();
@@ -296,6 +310,7 @@ mod tests {
         assert_config_err_mentions(&config, "aws-secrets");
     }
 
+    #[cfg(not(feature = "gcp-secrets"))]
     #[test]
     fn gcp_set_without_feature_is_config_error() {
         let mut config = base_config();
@@ -303,6 +318,7 @@ mod tests {
         assert_config_err_mentions(&config, "gcp-secrets");
     }
 
+    #[cfg(not(feature = "azure-secrets"))]
     #[test]
     fn azure_set_without_feature_is_config_error() {
         let mut config = base_config();
@@ -310,6 +326,7 @@ mod tests {
         assert_config_err_mentions(&config, "azure-secrets");
     }
 
+    #[cfg(not(feature = "config-secret"))]
     #[test]
     fn config_secret_set_without_feature_is_config_error() {
         let mut config = base_config();
@@ -317,6 +334,7 @@ mod tests {
         assert_config_err_mentions(&config, "config-secret");
     }
 
+    #[cfg(not(feature = "k8s-secrets"))]
     #[test]
     fn k8s_set_without_feature_is_config_error() {
         let mut config = base_config();
@@ -324,6 +342,7 @@ mod tests {
         assert_config_err_mentions(&config, "k8s-secrets");
     }
 
+    #[cfg(not(feature = "vault-secrets"))]
     #[test]
     fn vault_set_without_feature_is_config_error() {
         let mut config = base_config();
@@ -343,6 +362,7 @@ mod tests {
 
     use crate::config::SecretBackend;
 
+    #[cfg(not(feature = "vault-secrets"))]
     #[test]
     fn explicit_backend_uncompiled_is_config_error() {
         // `backend = "vault"` on the keyring-only default test build fails
@@ -352,6 +372,7 @@ mod tests {
         assert_config_err_mentions(&config, "vault-secrets");
     }
 
+    #[cfg(not(feature = "aws-secrets"))]
     #[test]
     fn explicit_aws_uncompiled_is_config_error() {
         let mut config = base_config();


### PR DESCRIPTION
`cargo test -p vtc-service --all-features` has been eight-red on every run, including on `main`:

```
failures:
    keys::seed_store::tests::aws_set_without_feature_is_config_error
    keys::seed_store::tests::azure_set_without_feature_is_config_error
    keys::seed_store::tests::config_secret_set_without_feature_is_config_error
    keys::seed_store::tests::explicit_aws_uncompiled_is_config_error
    keys::seed_store::tests::explicit_backend_uncompiled_is_config_error
    keys::seed_store::tests::gcp_set_without_feature_is_config_error
    keys::seed_store::tests::k8s_set_without_feature_is_config_error
    keys::seed_store::tests::vault_set_without_feature_is_config_error
```

Each asserts that a secret backend which is **not compiled** fails closed when its config field is set. Ungated they weren't merely redundant under `--all-features` — they were *guaranteed* to fail: with the feature compiled, `create_secret_store` correctly returns a store, and the test reads that as `expected a Config error, got a store (did the feature leak on?)`.

That's the sort of standing red that teaches people to skip the feature matrix — and the matrix is exactly where a fail-closed guard needs checking.

Each test now carries `#[cfg(not(feature = ...))]` for its own backend, matching the `#[cfg(feature = "vault-secrets")]` already on the compiled-side counterpart a few lines below. The gate is **per-backend** rather than one blanket `not(any(...))`: under `--features aws-secrets` only the aws case becomes unaskable, and the other five still have something to prove.

| build | before | after |
|---|---|---|
| default features | 13 pass | 12 pass |
| `--all-features` | 5 pass, **8 fail** | 5 pass |

`cargo test -p vtc-service --all-features` now reports no failures, and clippy is 0.