### PR TITLE
chore(vta)!: release vta-service 0.22.0 for the added ProvisionIntegrationOutput field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9401,7 +9401,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aes-gcm",
  "affinidi-bbs",

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,7 +34,7 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.21", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.22", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.14", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.


### PR DESCRIPTION
The `semver report` is red on `main` again, with a different crate this time:

```
--- failure constructible_struct_adds_field ---
  field ProvisionIntegrationOutput.digest_multibase
    in vta-service/src/operations/provision_integration/mod.rs:178
Summary: semver requires new major version: 1 major and 0 minor checks failed
```

`ProvisionIntegrationOutput` gained `digest_multibase` with the provision/integration 0.3 cut-over while the crate stayed at 0.21.0. The struct is exhaustively constructible through the public API, so an existing literal no longer compiles.

Found because #1160 (which touches **no Rust at all** — it only adds `.github/dependabot.yml`) came back red on semver. A PR that changes no code failing a code check is how you know the finding is `main`'s, not the branch's.

This is the third of the same shape:

| PR | crate | cause |
|---|---|---|
| #1156 | `vta-sdk` 0.29 → 0.30 | `CreateKeyBody.key_id` added |
| #1159 | `vta-sdk` 0.30 → 0.31 | `IssueCredentialResponse.issued_at` added, `TASK_VTA_CREDENTIALS_ISSUE_0_1` renamed |
| this  | `vta-service` 0.21 → 0.22 | `ProvisionIntegrationOutput.digest_multibase` added |

That's the pattern, not a coincidence: the spec cut-overs add members and nothing bumps the crate carrying them. The semver report catches each one and is the only thing that does — worth remembering next time someone reads it as a broken check rather than a working one.

Bumps the crate and the single intra-workspace requirement that pins it (`vta-enclave`). `cargo check --workspace --all-features` is clean.