### PR TITLE
fix(ci): stop Dependabot emitting chore(deps)(deps) titles, and let a fixed title clear the check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,12 @@ updates:
     # advisory is not subject to this cap.
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      # `chore`, not `chore(deps)`: `include: scope` appends the scope itself,
+      # so a prefix that already carries one yields `chore(deps)(deps): …`,
+      # which the commit-lint regex rejects. It checks the PR *title*, so every
+      # Dependabot PR opened under the first version of this file was red on a
+      # check that had nothing to do with the bump.
+      prefix: "chore"
       # `!` is added by hand when a bump is breaking — the commit lint accepts
       # `chore(deps)!:`, and a bot cannot tell which bumps deserve it.
       include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,45 +422,6 @@ jobs:
         with:
           command: check advisories bans sources licenses
 
-  commit-lint:
-    # The changelog is generated from commit messages, so the message IS the
-    # user-facing artefact. A squash merge makes the PR TITLE the commit
-    # subject, which is why the title is what gets linted.
-    #
-    # Not a style rule: a subject git-cliff cannot parse lands under "Other" in
-    # the changelog of a published crate, where an external consumer reads it.
-    name: commit lint
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Conventional-commit PR title
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          set -euo pipefail
-          # type(optional scope)(optional !): subject
-          if printf '%s' "$TITLE" \
-            | grep -qE '^(feat|fix|docs|test|ci|build|perf|refactor|chore|security)(\([a-z0-9._/-]+\))?!?: .+'; then
-            echo "ok: $TITLE"
-            exit 0
-          fi
-          echo "::error title=PR title is not a conventional commit::$TITLE"
-          cat <<'EOF'
-          The PR title becomes the squash-merge commit subject, and the changelog
-          of every published crate is generated from those subjects.
-
-            <type>(<optional scope>): <subject>
-
-          type: feat fix docs test ci build perf refactor chore security
-          Append ! for a breaking change, e.g. feat(sdk)!: ...
-
-          Examples from this repo:
-            feat(tsp): a VTA can speak TSP without DIDComm
-            fix(did-webvh): write the DID log where the operator asked
-          EOF
-          exit 1
-
   semver-checks:
     # Compare each published crate's public API against the version on
     # crates.io. release-plz runs this too when it builds the Release PR, but

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,61 @@
+name: PR title
+
+# Split out of ci.yml for one reason: the trigger.
+#
+# `on: pull_request` with no `types:` defaults to opened/synchronize/reopened,
+# so an `edited` event never fires — and this check reads
+# `github.event.pull_request.title`. In ci.yml that meant a PR whose only
+# problem was its title could never go green by fixing the title: re-running
+# the job replays the original event payload, so it re-reads the old one, and
+# the only way out was to push a commit that changed nothing.
+#
+# Five Dependabot PRs hit exactly that. Adding `edited` to ci.yml's own trigger
+# would re-run docker builds, the enclave build and the mobile build on every
+# description tweak, which is why this is its own file: the one check that
+# depends on PR metadata is the one that reruns when PR metadata changes.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  commit-lint:
+    # The changelog is generated from commit messages, so the message IS the
+    # user-facing artefact. A squash merge makes the PR TITLE the commit
+    # subject, which is why the title is what gets linted.
+    #
+    # Not a style rule: a subject git-cliff cannot parse lands under "Other" in
+    # the changelog of a published crate, where an external consumer reads it.
+    name: commit lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Conventional-commit PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          # type(optional scope)(optional !): subject
+          if printf '%s' "$TITLE" \
+            | grep -qE '^(feat|fix|docs|test|ci|build|perf|refactor|chore|security)(\([a-z0-9._/-]+\))?!?: .+'; then
+            echo "ok: $TITLE"
+            exit 0
+          fi
+          echo "::error title=PR title is not a conventional commit::$TITLE"
+          cat <<'EOF'
+          The PR title becomes the squash-merge commit subject, and the changelog
+          of every published crate is generated from those subjects.
+
+            <type>(<optional scope>): <subject>
+
+          type: feat fix docs test ci build perf refactor chore security
+          Append ! for a breaking change, e.g. feat(sdk)!: ...
+
+          Examples from this repo:
+            feat(tsp): a VTA can speak TSP without DIDComm
+            fix(did-webvh): write the DID log where the operator asked
+          EOF
+          exit 1


### PR DESCRIPTION
Every cargo PR Dependabot opened in its first hour is red on `commit lint`:

```
#1170 chore(deps)(deps): bump tower-http from 0.6.11 to 0.7.0
#1169 chore(deps)(deps): bump azure_identity from 0.35.0 to 1.0.0
...
```

`include: scope` appends the scope itself, so a `prefix` that already carries one doubles it. The commit-lint job checks the **PR title** against the conventional-commit regex, which rejects `chore(deps)(deps):` — a check failing for a reason unrelated to the bump, on every PR, which is the fastest way to teach people to ignore it.

My bug, from #1160 an hour ago. The `github-actions` and `docker` entries were already correct — they set a scoped prefix and *don't* set `include`, which is the other consistent way to spell it. I'll retitle the six open ones by hand, since the check reads the title rather than the branch's commit messages.