### PR TITLE
chore(deps)!: aes-gcm 0.11, and stop the nonce conversions panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,23 @@ dependencies = [
  "aead 0.5.2",
  "aes 0.8.4",
  "cipher 0.4.4",
- "ctr",
- "ghash",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
  "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.2",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ctutils",
+ "ghash 0.6.0",
 ]
 
 [[package]]
@@ -264,7 +278,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a923616197dc73661b1b57ad8dfaef7d9297c51c137062c9435b6edd6c98a3"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "ciborium",
  "ciborium-io",
  "coset 0.3.8",
@@ -424,7 +438,7 @@ version = "0.15.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2972b94ba1f4236c8739ad5660ec1ffe92e0b6a55c64b4ed13ad0c029cf4f283"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "ahash",
  "argon2 0.5.3",
  "async-trait",
@@ -2790,6 +2804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,7 +3958,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.3",
 ]
 
 [[package]]
@@ -6293,6 +6325,17 @@ dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.1",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -9148,12 +9191,13 @@ dependencies = [
 name = "vta-backup"
 version = "0.2.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "argon2 0.6.0",
  "async-trait",
  "base64 0.22.1",
  "chrono",
  "hex",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9177,7 +9221,7 @@ dependencies = [
 name = "vta-cli-common"
 version = "0.11.5"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "affinidi-crypto",
  "base64 0.22.1",
  "chrono",
@@ -9235,7 +9279,7 @@ dependencies = [
 name = "vta-keys"
 version = "0.3.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "affinidi-crypto",
  "affinidi-tdk",
  "base64 0.22.1",
@@ -9403,7 +9447,7 @@ dependencies = [
 name = "vta-service"
 version = "0.21.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9543,7 +9587,7 @@ name = "vta-tee"
 version = "0.1.10"
 dependencies = [
  "aes 0.9.2",
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "aws-config",
  "aws-lc-rs",
  "aws-sdk-dynamodb",
@@ -9645,7 +9689,7 @@ dependencies = [
 name = "vtc-service"
 version = "0.11.58"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "affinidi-bbs",
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9730,7 +9774,7 @@ dependencies = [
 name = "vti-common"
 version = "0.14.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.1",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,7 +320,7 @@ dirs = "6"
 hex = "0.4"
 
 # Symmetric crypto helpers used by sealed-transfer + storage encryption.
-aes-gcm = "0.10"
+aes-gcm = "0.11"
 hkdf = "0.13"
 
 # HMAC-SHA256 for vti-common's audit-log actor/target identifier

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -28,6 +28,10 @@ tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.14" }
+# Nonce and bundle-id generation. Was reached through `aes_gcm::aead::OsRng`,
+# a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
+# own and was borrowing one from its cipher.
+rand = { workspace = true }
 vta-sdk = { path = "../vta-sdk", version = "0.30" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.3" }

--- a/vta-backup/src/backup_bundle_store.rs
+++ b/vta-backup/src/backup_bundle_store.rs
@@ -13,10 +13,9 @@
 
 use std::path::PathBuf;
 
-use aes_gcm::aead::OsRng;
-use aes_gcm::aead::rand_core::RngCore;
 use base64::Engine;
 use chrono::{DateTime, Utc};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
@@ -193,7 +192,7 @@ pub fn mint_token() -> Result<(BundleToken, [u8; 32]), AppError> {
     // `keys::imported` for KEK salts). Stays inside the
     // `aes_gcm::aead` re-export so the workspace pins one
     // rand-core version transitively.
-    OsRng.fill_bytes(&mut raw);
+    rand::rng().fill_bytes(&mut raw);
     let token_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
     let hash = hash_token(&token_b64);
     Ok((BundleToken(token_b64), hash))
@@ -346,7 +345,7 @@ mod tests {
             a.as_str(),
             b.as_str(),
             "two mint_token calls must produce different tokens \
-             (OsRng output collision is effectively impossible)"
+             (CSPRNG output collision is effectively impossible)"
         );
     }
 

--- a/vta-backup/src/ops/mod.rs
+++ b/vta-backup/src/ops/mod.rs
@@ -828,8 +828,8 @@ fn encrypt_payload(
     let plaintext =
         serde_json::to_vec(payload).map_err(|e| AppError::Internal(format!("serialize: {e}")))?;
 
-    use aes_gcm::aead::rand_core::RngCore;
-    let mut rng = aes_gcm::aead::OsRng;
+    use rand::Rng;
+    let mut rng = rand::rng();
     let mut salt = [0u8; SALT_LEN];
     rng.fill_bytes(&mut salt);
     let mut nonce_bytes = [0u8; NONCE_LEN];
@@ -850,7 +850,7 @@ fn encrypt_payload(
     // Encrypt with AES-256-GCM
     let cipher =
         Aes256Gcm::new_from_slice(&key).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce = (&nonce_bytes).into();
     let ciphertext = cipher
         .encrypt(nonce, plaintext.as_ref())
         .map_err(|e| AppError::Internal(format!("aes encrypt: {e}")))?;
@@ -937,10 +937,13 @@ pub fn decrypt_backup(
     let nonce_bytes = BASE64
         .decode(&envelope.encryption.nonce)
         .map_err(|e| AppError::Validation(format!("invalid nonce: {e}")))?;
-    // Hard length check before `Nonce::from_slice` — the
-    // `aes-gcm` impl of that constructor panics on the wrong length,
-    // which a crafted backup envelope would otherwise weaponise into
-    // a process-killing DoS on `/backup/import`.
+    // Length check before the nonce is built. This used to be the *only*
+    // thing standing between a crafted backup envelope and a process-killing
+    // DoS on `/backup/import`, because `Nonce::from_slice` panicked on the
+    // wrong length. The conversion below is now `TryFrom`, so the panic is
+    // gone by construction and this check is no longer load-bearing for
+    // safety — it stays because it produces the better error: "invalid nonce
+    // length: 11 (expected 12)" rather than a bare conversion failure.
     if nonce_bytes.len() != NONCE_LEN {
         return Err(AppError::Validation(format!(
             "invalid nonce length: {} (expected {NONCE_LEN})",
@@ -971,9 +974,10 @@ pub fn decrypt_backup(
     // Decrypt with AES-256-GCM
     let cipher =
         Aes256Gcm::new_from_slice(&key).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce = Nonce::try_from(nonce_bytes.as_slice())
+        .map_err(|_| AppError::Validation(format!("nonce must be {NONCE_LEN} bytes")))?;
     let plaintext = cipher
-        .decrypt(nonce, ciphertext.as_ref())
+        .decrypt(&nonce, ciphertext.as_ref())
         .map_err(|_| AppError::Authentication("incorrect backup password".into()))?;
 
     serde_json::from_slice(&plaintext)
@@ -1688,10 +1692,13 @@ mod tests {
 
     // ── Salt / nonce length validation on import ───────────────────
     //
-    // Regression tests for the DoS where a crafted envelope's
-    // wrong-length nonce would panic `Nonce::from_slice`, taking the
-    // import handler (super-admin only, but reachable over REST) down
-    // with it. The length checks fire before `from_slice` is reached.
+    // Regression tests for the DoS where a crafted envelope's wrong-length
+    // nonce would panic `Nonce::from_slice`, taking the import handler
+    // (super-admin only, but reachable over REST) down with it.
+    //
+    // The panic is now impossible by construction — the conversion is
+    // `TryFrom` — but these stay: they assert the *rejection*, not the
+    // absence of a panic, and that is still the behaviour callers depend on.
 
     #[test]
     fn nonce_wrong_length_rejected_without_panic() {

--- a/vta-keys/src/imported.rs
+++ b/vta-keys/src/imported.rs
@@ -43,9 +43,9 @@ pub async fn get_or_create_salt(keys_ks: &KeyspaceHandle) -> Result<Vec<u8>, App
         return Ok(existing);
     }
     // Generate a new random salt and try to claim the slot.
-    use aes_gcm::aead::rand_core::RngCore;
+    use rand::Rng;
     let mut salt = vec![0u8; 32];
-    aes_gcm::aead::OsRng.fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut salt);
     if keys_ks
         .insert_raw_if_absent(KEK_SALT_KEY, salt.clone())
         .await?
@@ -85,10 +85,10 @@ pub async fn store_secret(
         Aes256Gcm::new_from_slice(&kek).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
 
     // Random nonce
-    use aes_gcm::aead::rand_core::RngCore;
+    use rand::Rng;
     let mut nonce_bytes = [0u8; NONCE_LEN];
-    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    rand::rng().fill_bytes(&mut nonce_bytes);
+    let nonce = (&nonce_bytes).into();
 
     let aad = build_aad(key_id, key_type);
     let ciphertext = cipher
@@ -137,11 +137,17 @@ pub async fn load_secret(
     let cipher =
         Aes256Gcm::new_from_slice(&kek).map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
 
-    let nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+    // `try_from` rather than the deprecated `from_slice`: the latter *panics* on a
+    // wrong length, and this parses a stored blob. The bounds check above already
+    // guarantees the slice is exactly NONCE_LEN, so this cannot fail — but a
+    // panicking conversion on a decrypt path is one refactor away from being
+    // reachable, and the fallible form costs nothing.
+    let nonce = Nonce::try_from(&blob[..NONCE_LEN])
+        .map_err(|_| AppError::Internal("stored nonce is not NONCE_LEN bytes".into()))?;
     let aad = build_aad(key_id, key_type);
     let mut plaintext = cipher
         .decrypt(
-            nonce,
+            &nonce,
             aes_gcm::aead::Payload {
                 msg: &blob[NONCE_LEN..],
                 aad: &aad,
@@ -205,13 +211,18 @@ pub async fn reencrypt_all(
             continue;
         }
 
-        let old_nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+        let Ok(old_nonce) = Nonce::try_from(&blob[..NONCE_LEN]) else {
+            // Unreachable given the length check above. `continue` rather than
+            // abort: this is a rewrap loop over every stored key, and one
+            // unreadable blob must not strand the rest mid-rotation.
+            continue;
+        };
         let aad = build_aad(key_id, key_type);
 
         // Decrypt with old KEK
         let mut plaintext = old_cipher
             .decrypt(
-                old_nonce,
+                &old_nonce,
                 aes_gcm::aead::Payload {
                     msg: &blob[NONCE_LEN..],
                     aad: &aad,
@@ -224,10 +235,10 @@ pub async fn reencrypt_all(
             })?;
 
         // Re-encrypt with new KEK
-        use aes_gcm::aead::rand_core::RngCore;
+        use rand::Rng;
         let mut new_nonce_bytes = [0u8; NONCE_LEN];
-        aes_gcm::aead::OsRng.fill_bytes(&mut new_nonce_bytes);
-        let new_nonce = Nonce::from_slice(&new_nonce_bytes);
+        rand::rng().fill_bytes(&mut new_nonce_bytes);
+        let new_nonce = (&new_nonce_bytes).into();
 
         let new_ciphertext = new_cipher
             .encrypt(

--- a/vta-keys/src/internal.rs
+++ b/vta-keys/src/internal.rs
@@ -32,8 +32,8 @@
 //! Internal keys raise the bar against *export*; they do not by themselves make
 //! a non-TEE VTA tamper-proof.
 
-use aes_gcm::aead::{OsRng, rand_core::RngCore};
 use p256::elliptic_curve::sec1::ToSec1Point;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use vta_sdk::keys::KeyType;
 use vti_common::error::AppError;
@@ -84,7 +84,7 @@ pub async fn generate(
     let (mut secret, public) = match key_type {
         KeyType::Ed25519 => {
             let mut seed = [0u8; 32];
-            OsRng.fill_bytes(&mut seed);
+            rand::rng().fill_bytes(&mut seed);
             let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
             seed.zeroize();
             let public = signing.verifying_key().to_bytes().to_vec();
@@ -92,7 +92,7 @@ pub async fn generate(
         }
         KeyType::P256 => {
             let mut raw = [0u8; 32];
-            OsRng.fill_bytes(&mut raw);
+            rand::rng().fill_bytes(&mut raw);
             let secret = p256::SecretKey::from_slice(&raw)
                 .map_err(|e| AppError::Internal(format!("internal P-256 keygen: {e}")))?;
             raw.zeroize();

--- a/vta-keys/src/seeds.rs
+++ b/vta-keys/src/seeds.rs
@@ -78,10 +78,10 @@ fn encrypt_archived_seed(
     let cipher = Aes256Gcm::new_from_slice(&kek)
         .map_err(|e| AppError::Internal(format!("archive aes key: {e}")))?;
 
-    use aes_gcm::aead::rand_core::RngCore;
+    use rand::Rng;
     let mut nonce_bytes = [0u8; NONCE_LEN];
-    aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    rand::rng().fill_bytes(&mut nonce_bytes);
+    let nonce = (&nonce_bytes).into();
 
     let aad = archive_aad(seed_id);
     let ciphertext = cipher
@@ -115,11 +115,11 @@ fn decrypt_archived_seed(
     }
     let mut kek = derive_archive_kek(active_seed, salt);
     let cipher = Aes256Gcm::new_from_slice(&kek).ok()?;
-    let nonce = Nonce::from_slice(&blob[..NONCE_LEN]);
+    let nonce = Nonce::try_from(&blob[..NONCE_LEN]).ok()?;
     let aad = archive_aad(seed_id);
     let pt = cipher
         .decrypt(
-            nonce,
+            &nonce,
             aes_gcm::aead::Payload {
                 msg: &blob[NONCE_LEN..],
                 aad: &aad,

--- a/vta-keys/src/wrapping.rs
+++ b/vta-keys/src/wrapping.rs
@@ -154,8 +154,13 @@ impl WrappingKeyCache {
         // Decrypt
         let cipher = Aes256Gcm::new_from_slice(&aes_key)
             .map_err(|e| AppError::Internal(format!("aes key: {e}")))?;
-        let nonce = Nonce::from_slice(&nonce_bytes);
-        let mut plaintext = cipher.decrypt(nonce, ciphertext.as_ref()).map_err(|_| {
+        // Genuinely fallible, unlike the fixed-array sites: `nonce_bytes` is
+        // decoded from the wire, so its length is attacker-controlled. The
+        // deprecated `from_slice` panicked here.
+        let nonce = Nonce::try_from(nonce_bytes.as_slice()).map_err(|_| {
+            AppError::Validation(format!("wrapped-key nonce must be {NONCE_LEN} bytes"))
+        })?;
+        let mut plaintext = cipher.decrypt(&nonce, ciphertext.as_ref()).map_err(|_| {
             AppError::Authentication("failed to unwrap key (ECDH mismatch or tampering)".into())
         })?;
 
@@ -283,10 +288,10 @@ mod tests {
             .unwrap();
 
         let cipher = Aes256Gcm::new_from_slice(&aes_key).unwrap();
-        use aes_gcm::aead::rand_core::RngCore;
+        use rand::Rng;
         let mut nonce_bytes = [0u8; NONCE_LEN];
-        aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
-        let nonce = Nonce::from_slice(&nonce_bytes);
+        rand::rng().fill_bytes(&mut nonce_bytes);
+        let nonce: &Nonce<_> = (&nonce_bytes).into();
         let ciphertext = cipher.encrypt(nonce, plaintext).unwrap();
 
         format!(

--- a/vta-service/src/hardened_bootstrap.rs
+++ b/vta-service/src/hardened_bootstrap.rs
@@ -153,9 +153,13 @@ pub fn legacy_aes_gcm_open(key: &[u8; 32], blob: &[u8]) -> Option<Vec<u8>> {
     if blob.len() < 13 {
         return None;
     }
-    let nonce = aes_gcm::Nonce::from_slice(&blob[..12]);
+    // `try_from` rather than the deprecated `from_slice`, which panics on a
+    // wrong length. The bounds check above makes the slice exactly 12, so this
+    // cannot fail — but a panicking conversion on a decrypt path is one
+    // refactor away from being reachable.
+    let nonce = aes_gcm::Nonce::try_from(&blob[..12]).ok()?;
     let cipher = Aes256Gcm::new_from_slice(key).ok()?;
-    cipher.decrypt(nonce, &blob[12..]).ok()
+    cipher.decrypt(&nonce, &blob[12..]).ok()
 }
 
 /// Error variants for [`load_or_generate_jwt_key`].
@@ -485,11 +489,11 @@ mod tests {
     /// AES-GCM seal in the retired format, so the legacy-import test can build
     /// a fixture. Nothing in the crate writes this any more.
     fn legacy_aes_gcm_seal(key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
-        use aes_gcm::aead::rand_core::RngCore;
+        use rand::Rng;
         let cipher = Aes256Gcm::new_from_slice(key).expect("32-byte key");
         let mut nonce_bytes = [0u8; 12];
-        aes_gcm::aead::OsRng.fill_bytes(&mut nonce_bytes);
-        let nonce = aes_gcm::Nonce::from_slice(&nonce_bytes);
+        rand::rng().fill_bytes(&mut nonce_bytes);
+        let nonce: &aes_gcm::Nonce<_> = (&nonce_bytes).into();
         let mut ct = cipher.encrypt(nonce, plaintext).expect("AES-GCM encrypt");
         let mut out = Vec::with_capacity(12 + ct.len());
         out.extend_from_slice(&nonce_bytes);

--- a/vta-tee/src/kms_bootstrap.rs
+++ b/vta-tee/src/kms_bootstrap.rs
@@ -665,13 +665,12 @@ async fn kms_generate_data_key_direct(
 
 /// AES-256-GCM encrypt, returning `[nonce: 12 bytes][ciphertext]`.
 fn aes_gcm_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, AppError> {
-    use aes_gcm::aead::generic_array::GenericArray;
     use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
 
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
+    let cipher = Aes256Gcm::new(key.into());
     let mut nonce_bytes = [0u8; 12];
     rand::fill(&mut nonce_bytes);
-    let nonce = GenericArray::from_slice(&nonce_bytes);
+    let nonce = (&nonce_bytes).into();
     let ciphertext = cipher
         .encrypt(nonce, plaintext)
         .map_err(|e| tee_attestation_error(format!("AES-GCM encryption failed: {e}")))?;
@@ -684,8 +683,7 @@ fn aes_gcm_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, AppError
 
 /// AES-256-GCM decrypt a `[nonce: 12 bytes][ciphertext]` blob.
 fn aes_gcm_decrypt(key: &[u8], blob: &[u8]) -> Result<Vec<u8>, AppError> {
-    use aes_gcm::aead::generic_array::GenericArray;
-    use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
 
     if key.len() != 32 {
         return Err(tee_attestation_error(format!(
@@ -697,11 +695,17 @@ fn aes_gcm_decrypt(key: &[u8], blob: &[u8]) -> Result<Vec<u8>, AppError> {
         return Err(tee_attestation_error("AES-GCM blob too short"));
     }
 
-    let nonce = GenericArray::from_slice(&blob[..12]);
+    // `key` is a runtime slice whose length was checked above, so this cannot
+    // fail; the nonce slice is fixed at 12 by the same guard.
+    let nonce = Nonce::try_from(&blob[..12])
+        .map_err(|_| tee_attestation_error("AES-GCM nonce is not 12 bytes"))?;
     let ciphertext = &blob[12..];
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
+    let key: &aes_gcm::Key<Aes256Gcm> = key
+        .try_into()
+        .map_err(|_| tee_attestation_error("data key is not 32 bytes"))?;
+    let cipher = Aes256Gcm::new(key);
     cipher
-        .decrypt(nonce, ciphertext)
+        .decrypt(&nonce, ciphertext)
         .map_err(|e| tee_attestation_error(format!("AES-GCM decryption failed: {e}")))
 }
 
@@ -803,30 +807,39 @@ fn decrypt_cms_envelope(cms_bytes: &[u8], private_key_pkcs8: &[u8]) -> Result<Ve
         plaintext.to_vec()
     } else if fields.content_encryption_oid == aes_256_gcm_oid {
         // AES-256-GCM
-        use aes_gcm::aead::generic_array::GenericArray;
-        use aes_gcm::{AesGcm, KeyInit, aead::Aead};
+        use aes_gcm::{Aes256Gcm, AesGcm, KeyInit, aead::Aead};
+
+        // The CEK and IV are both runtime-sized, so both conversions are
+        // fallible and neither may be unwrapped: a malformed envelope is an
+        // input, not a bug.
+        let cek_arr: &aes_gcm::Key<Aes256Gcm> = cek
+            .as_slice()
+            .try_into()
+            .map_err(|_| tee_attestation_error("CMS content-encryption key is not 32 bytes"))?;
 
         match fields.iv.len() {
             12 => {
-                let cipher = AesGcm::<aes_gcm::aes::Aes256, aes_gcm::aead::consts::U12>::new(
-                    GenericArray::from_slice(&cek),
-                );
+                let cipher =
+                    AesGcm::<aes_gcm::aes::Aes256, aes_gcm::aead::consts::U12>::new(cek_arr);
+                let iv: &aes_gcm::Nonce<aes_gcm::aead::consts::U12> = fields
+                    .iv
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| tee_attestation_error("CMS GCM IV is not 12 bytes"))?;
                 cipher
-                    .decrypt(
-                        GenericArray::from_slice(&fields.iv),
-                        fields.ciphertext.as_ref(),
-                    )
+                    .decrypt(iv, fields.ciphertext.as_ref())
                     .map_err(|e| tee_attestation_error(format!("AES-GCM decryption failed: {e}")))?
             }
             16 => {
-                let cipher = AesGcm::<aes_gcm::aes::Aes256, aes_gcm::aead::consts::U16>::new(
-                    GenericArray::from_slice(&cek),
-                );
+                let cipher =
+                    AesGcm::<aes_gcm::aes::Aes256, aes_gcm::aead::consts::U16>::new(cek_arr);
+                let iv: &aes_gcm::Nonce<aes_gcm::aead::consts::U16> = fields
+                    .iv
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| tee_attestation_error("CMS GCM IV is not 16 bytes"))?;
                 cipher
-                    .decrypt(
-                        GenericArray::from_slice(&fields.iv),
-                        fields.ciphertext.as_ref(),
-                    )
+                    .decrypt(iv, fields.ciphertext.as_ref())
                     .map_err(|e| tee_attestation_error(format!("AES-GCM decryption failed: {e}")))?
             }
             n => {
@@ -1428,7 +1441,6 @@ mod tests {
     /// decrypt_cms_envelope round-trip without needing real KMS or NSM.
     #[test]
     fn test_cms_envelope_roundtrip() {
-        use aes_gcm::aead::generic_array::GenericArray;
         use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
         use aws_lc_rs::rsa::{
             KeySize, OAEP_SHA256_MGF1SHA256, OaepPublicEncryptingKey, PrivateDecryptingKey,
@@ -1447,8 +1459,8 @@ mod tests {
         rand::fill(&mut nonce_bytes);
 
         // AES-GCM encrypt the plaintext
-        let cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));
-        let nonce = GenericArray::from_slice(&nonce_bytes);
+        let cipher = Aes256Gcm::new((&cek).into());
+        let nonce: &aes_gcm::Nonce<aes_gcm::aead::consts::U12> = (&nonce_bytes).into();
         let aes_ciphertext = cipher.encrypt(nonce, original_plaintext.as_ref()).unwrap();
 
         // RSA-OAEP-SHA256 encrypt the CEK using the public key — mirrors
@@ -1645,7 +1657,6 @@ mod tests {
     /// private key, then return both. Tests then mutate one or the
     /// other to test specific tamper classes.
     fn cms_fixture() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        use aes_gcm::aead::generic_array::GenericArray;
         use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
         use aws_lc_rs::encoding::AsDer;
         use aws_lc_rs::rsa::{
@@ -1659,9 +1670,9 @@ mod tests {
         let mut nonce_bytes = [0u8; 12];
         rand::fill(&mut nonce_bytes);
 
-        let cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));
+        let cipher = Aes256Gcm::new((&cek).into());
         let aes_ct = cipher
-            .encrypt(GenericArray::from_slice(&nonce_bytes), plaintext.as_ref())
+            .encrypt((&nonce_bytes).into(), plaintext.as_ref())
             .unwrap();
 
         let oaep_pub = OaepPublicEncryptingKey::new(private_key.public_key().clone()).unwrap();
@@ -1732,7 +1743,6 @@ mod tests {
         // AES-GCM's auth tag must catch this regardless of where the
         // bit flip lands inside the ciphertext. Without the tag check,
         // tampered key material would be loaded silently — fatal.
-        use aes_gcm::aead::generic_array::GenericArray;
         use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
         use aws_lc_rs::encoding::AsDer;
         use aws_lc_rs::rsa::{
@@ -1745,9 +1755,9 @@ mod tests {
         rand::fill(&mut cek);
         let mut nonce_bytes = [0u8; 12];
         rand::fill(&mut nonce_bytes);
-        let cipher = Aes256Gcm::new(GenericArray::from_slice(&cek));
+        let cipher = Aes256Gcm::new((&cek).into());
         let mut aes_ct = cipher
-            .encrypt(GenericArray::from_slice(&nonce_bytes), plaintext.as_ref())
+            .encrypt((&nonce_bytes).into(), plaintext.as_ref())
             .unwrap();
         // Flip a bit inside the AES-GCM ciphertext (before the auth tag).
         aes_ct[0] ^= 0x01;

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -13,13 +13,13 @@
 
 use std::collections::BTreeMap;
 
-use aes_gcm::aead::rand_core::RngCore;
-use aes_gcm::aead::{Aead, OsRng};
+use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use argon2::Argon2;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use chrono::{DateTime, Utc};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use vti_common::error::AppError;
@@ -443,15 +443,15 @@ fn encrypt_payload_inner(
         .map_err(|e| AppError::Internal(format!("backup serialize: {e}")))?;
 
     let mut salt = [0u8; SALT_LEN];
-    OsRng.fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut salt);
     let mut nonce_bytes = [0u8; NONCE_LEN];
-    OsRng.fill_bytes(&mut nonce_bytes);
+    rand::rng().fill_bytes(&mut nonce_bytes);
 
     let key = derive_key(password, &salt, ARGON2_M_COST, ARGON2_T_COST, ARGON2_P_COST)?;
     let cipher = Aes256Gcm::new_from_slice(&key)
         .map_err(|e| AppError::Internal(format!("backup aes key: {e}")))?;
     let ciphertext = cipher
-        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_ref())
+        .encrypt((&nonce_bytes).into(), plaintext.as_ref())
         .map_err(|e| AppError::Internal(format!("backup encrypt: {e}")))?;
 
     Ok(BackupEnvelope {
@@ -554,8 +554,14 @@ pub fn decrypt_backup(
     )?;
     let cipher = Aes256Gcm::new_from_slice(&key)
         .map_err(|e| AppError::Internal(format!("backup aes key: {e}")))?;
+    // `try_from`, not the deprecated `from_slice`, which panicked on a wrong
+    // length. The check at the top of this function already rejects that, so
+    // this cannot fail — the point is that it can no longer panic if that
+    // check is ever moved or removed.
+    let nonce = Nonce::try_from(nonce_bytes.as_slice())
+        .map_err(|_| AppError::Validation(format!("nonce must be {NONCE_LEN} bytes")))?;
     let plaintext = cipher
-        .decrypt(Nonce::from_slice(&nonce_bytes), ciphertext.as_ref())
+        .decrypt(&nonce, ciphertext.as_ref())
         .map_err(|_| AppError::Authentication("incorrect backup password".into()))?;
 
     serde_json::from_slice(&plaintext)

--- a/vti-common/src/store/encryption.rs
+++ b/vti-common/src/store/encryption.rs
@@ -65,7 +65,7 @@ pub fn encrypt_value(
 
     let mut nonce_bytes = [0u8; NONCE_LEN];
     rand::fill(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce: &Nonce<_> = (&nonce_bytes).into();
 
     let aad = build_aad(keyspace, store_key);
     let ciphertext = cipher
@@ -123,13 +123,14 @@ fn decrypt_value(
     let cipher = Aes256Gcm::new_from_slice(enc_key)
         .map_err(|e| AppError::Internal(format!("AES key error: {e}")))?;
 
-    let nonce = Nonce::from_slice(&body[..NONCE_LEN]);
+    let nonce = Nonce::try_from(&body[..NONCE_LEN])
+        .map_err(|_| AppError::Internal("stored nonce is not NONCE_LEN bytes".into()))?;
     let ciphertext = &body[NONCE_LEN..];
     let aad = build_aad(keyspace, store_key);
 
     cipher
         .decrypt(
-            nonce,
+            &nonce,
             Payload {
                 msg: ciphertext,
                 aad: &aad,


### PR DESCRIPTION
Replaces Dependabot's #1167, which was red on **ten** checks. 0.11 removes two things this workspace was reaching through the cipher rather than depending on directly.

### `aead::OsRng` is gone

Nine sites across five crates generated nonces and salts through `aes_gcm::aead::OsRng` — a re-export, borrowing whatever CSPRNG the cipher happened to vendor. They now use `rand::rng()`, which is what the rest of the workspace already uses for exactly this. `vta-backup` gains a direct `rand` dependency it always needed and was getting by accident.

### `aead::generic_array` became `hybrid_array`

The `GenericArray::from_slice` calls in `vta-tee`'s KMS bootstrap move to the public `Key` / `Nonce` aliases — infallible `.into()` where the source is a fixed-size array, `try_from` where it's a runtime slice out of a CMS envelope.

### The part worth reading

Not required by the bump. `Nonce::from_slice` is deprecated in favour of `TryFrom`, and CI runs clippy with `-D warnings`, so all nineteen call sites had to move. **They were not equivalent.**

`from_slice` **panics** on a wrong length, and every one of those sites parses a stored or transmitted blob. `vta-backup` already knew:

```rust
// Hard length check before `Nonce::from_slice` — the `aes-gcm` impl of that
// constructor panics on the wrong length, which a crafted backup envelope
// would otherwise weaponise into a process-killing DoS on `/backup/import`.
```

…with regression tests for it. That hand-written guard was the only thing between the parser and the panic, and it had to be remembered at every new call site.

With `TryFrom` the panic is gone **by construction**. The length checks stay, because they produce the better error — `invalid nonce length: 11 (expected 12)` rather than a bare conversion failure — but they're no longer load-bearing for safety, and the comments now say so. The DoS regression tests stay too: they assert the *rejection*, which is still the contract.

One site was genuinely reachable rather than defence-in-depth: `vta-keys::wrapping` unwrapping a wire-supplied nonce, where the length is attacker-controlled and nothing checked it first.

### Verification

- clippy **0** across the workspace, all features, all targets
- the crypto crates' **146 tests** pass — including the CMS envelope round-trip and the wrong-length-nonce DoS regressions
- `vtc-service` 866 pass; full `cargo test --workspace --all-features` clean

Closes #1167.