### PR TITLE
chore(deps): azure_identity 1.0, with the Key Vault bump it requires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.35.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9966f75417a6779ea221531960d9d46fe630879606501aa5277312ad4ae38587"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.8.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1834,9 +1834,9 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "0.35.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385e4426c01965149a002a72c54c43d6f1b9d2244179e70647df48e3b28f8c32"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1852,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c1feb5088b6865b7681e0012e71ae3d14b456a45b7ef0de85ca94a58633746"
+checksum = "a344d7c923ea305fa36bdad4d36c54e7c6fb806077430efcafb19ee40ed7b786"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -8814,9 +8814,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typespec"
-version = "0.14.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247afbeabe0c383f630d0fdcb4fb92818c31cd3fe5d293335daff8cac79d4e0f"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8828,9 +8828,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.14.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714a935f6aa74724775f07291390e8f07df0a1804544cd4106ac3b75c0478d2"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8853,9 +8853,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.13.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17153fde258b3c862cecffad95e185c0eb83e619e76542c4b3ed9828af840f0"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,8 +335,8 @@ tokio-vsock = "0.7"
 libc = "0.2"
 
 # Azure secret-store deps shared across SDK + both services.
-azure_security_keyvault_secrets = "0.14"
-azure_identity = "0.35"
+azure_security_keyvault_secrets = "1.0"
+azure_identity = "1.0"
 
 # Kubernetes secret-store backend (feature `k8s-secrets`, off by default) for
 # both services. The seed/key material is stored as a hex string inside a


### PR DESCRIPTION
Replaces Dependabot's #1169, which bumped `azure_identity` alone and failed with:

```
error[E0277]: the trait bound `DeveloperToolsCredential:
             azure_core::credentials::TokenCredential` is not satisfied
note: there are multiple different versions of crate `azure_core` in the dependency graph
```

That second line is the whole story, and it's easy to read past. **Nothing about `DeveloperToolsCredential` changed.**

| crate | azure_core |
|---|---|
| `azure_identity` 1.0 | 1.1 |
| `azure_security_keyvault_secrets` 0.14 | 0.35 |

The credential implements 1.1's `TokenCredential`; `SecretClient::new` wants 0.35's. Same trait by name, a different trait to the compiler.

This is the **same shape as #1166** (k8s-openapi / kube): Dependabot bumped one half of a coupled pair, and the resulting error names a type rather than the version skew that produced it. So `azure_security_keyvault_secrets` goes 0.14 → 1.0 alongside, and the lockfile is back to exactly one `azure_core`.

**No source changes.** `SecretClient::new(vault_url, credential, None)` and the `DeveloperToolsCredential::new` call are identical across both majors.

- `cargo check --workspace --all-features` clean
- `cargo clippy --workspace --all-features --all-targets` → 0
- `cargo test -p vti-secrets --features azure-secrets` passes

Closes #1169.