### PR TITLE
chore(deps): trust-tasks-rs 0.17.2, and drop the permissive-type waiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7425,7 +7425,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -8735,9 +8735,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53926c6d164f8c7662171c513f05631590e87a1523ba21063ad105742c671b94"
+checksum = "1f532daea6f7b98859b06254aa61d0972bb2da85780ea52743eeb4fe3913e3d8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2702,27 +2702,6 @@ fn every_published_dispatched_uri_has_a_witness() {
 
 /// Correctness: every witness's request parses as the generated `Payload`
 /// and its response as the generated `Response` — and the check has teeth:
-/// Generated types that do **not** reject an unknown member, with the reason.
-///
-/// Not a waiver for loose validation on the wire: the *schema* is strict in
-/// every case here, so `validate_payload` still rejects the member. What is
-/// missing is the type-level guard, which means the drifted-witness check
-/// below would pass vacuously and prove nothing — so it is skipped rather
-/// than allowed to give false assurance.
-///
-/// Each entry is a bug somewhere else, not a decision. Delete the entry when
-/// the upstream fix lands; the check then re-arms on its own.
-const PERMISSIVE_GENERATED_TYPE: &[(&str, &str, &str)] = &[(
-    "https://trusttasks.org/spec/vta/credentials/issue/0.2",
-    "response",
-    "0.2 closes its response with `unevaluatedProperties: false` (it has to — \
-     `additionalProperties` is evaluated per-subschema and would reject the \
-     `allOf`-supplied members). trust-tasks-codegen maps only \
-     `additionalProperties: false` onto `deny_unknown_fields`, so the \
-     generated struct is permissive where 0.1's was strict. Fix belongs in \
-     the codegen, not here.",
-)];
-
 /// a drifted (unknown-member) form of each MUST be rejected, so a witness
 /// cannot pass vacuously against a schema that accepts anything.
 #[test]
@@ -2765,20 +2744,16 @@ fn every_witnessed_task_round_trips_through_its_generated_types() {
         });
 
         // Teeth: an unknown member must be rejected on both sides. The
-        // generated types carry `deny_unknown_fields` wherever the spec is
-        // `additionalProperties: false`, which is all but one published task.
-        // A URI for which this stops holding needs an entry in
-        // `PERMISSIVE_GENERATED_TYPE` stating why, not a silent pass.
+        // generated types carry `deny_unknown_fields` wherever the spec closes
+        // the object — `additionalProperties: false`, or `unevaluatedProperties`
+        // on a composed one, which trust-tasks-rs 0.17.2 also honours. A URI for
+        // which this stops holding needs a KnownDrift-style review, not a silent
+        // pass: the check below injects an unknown member, so a type that
+        // accepts it makes the whole witness pass vacuously.
         for (side, value, parse) in [
             ("request", &w.request, w.parse_request),
             ("response", &w.response, w.parse_response),
         ] {
-            if PERMISSIVE_GENERATED_TYPE
-                .iter()
-                .any(|(u, s, _)| *u == uri && *s == side)
-            {
-                continue;
-            }
             let mut drifted = value.clone();
             drifted
                 .as_object_mut()


### PR DESCRIPTION
0.17.2 carries the codegen fix from [dtgwg-trust-tasks-tf#327](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/327): a schema that closes a *composed* object with `unevaluatedProperties: false` — the only way a composition can be closed — now generates `deny_unknown_fields`, where before only `additionalProperties: false` did.

That was the whole reason #1159 had to record `vta/credentials/issue/0.2` in `PERMISSIVE_GENERATED_TYPE` and skip the drifted-witness check for it. The schema was always strict, so **the wire was never affected**; what was missing was the type-level guard, and its absence made that witness pass vacuously.

With the fix in, the entry comes out and the check is unconditional again.

**No manifest change** — `trust-tasks-rs = "0.17"` already admits 0.17.2, so this is a lockfile move only.

I verified the strictness actually landed rather than assuming it: the generated `issue/v0_2.rs` in 0.17.2 carries `deny_unknown_fields`, and the conformance sweep passes with nothing waived. `cargo clippy -p vta-service --all-features --all-targets` → 0.

This is the last thing standing between #1119 and shipping with the check armed.