### PR TITLE
feat(vtc-service)!: enforce Trust Task Context Binding on presented credentials

### DIFF
--- a/vtc-service/src/ceremony/assemble.rs
+++ b/vtc-service/src/ceremony/assemble.rs
@@ -33,6 +33,14 @@ pub struct FactsInputs {
     pub subject_did: String,
     pub subject_member: Option<MemberState>,
     pub evidence: Evidence,
+    /// The trust task exchange this ceremony runs in, when it has one. `None`
+    /// for the synchronous REST ceremonies (leave, role-change, directory, and
+    /// the raw-VP join submit), which are not threaded.
+    ///
+    /// Required rather than defaulted so adding a threaded ceremony has to
+    /// answer the question: an omitted thread silently unbinds every credential
+    /// in the exchange, and it does it without failing anything.
+    pub thread_id: Option<String>,
 }
 
 /// Build a [`Facts`] from the uniform community context plus the per-purpose
@@ -57,6 +65,7 @@ pub async fn assemble_facts(state: &AppState, inputs: FactsInputs) -> Result<Fac
             community_did,
             channel: "rest".to_string(),
             member_count: state.member_count(),
+            thread_id: inputs.thread_id,
         },
         evidence: inputs.evidence,
         state: FactsState {

--- a/vtc-service/src/ceremony/effects.rs
+++ b/vtc-service/src/ceremony/effects.rs
@@ -187,6 +187,7 @@ mod tests {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 10,
+                thread_id: None,
             },
             evidence: Evidence::default(),
             state: State {

--- a/vtc-service/src/ceremony/evaluate.rs
+++ b/vtc-service/src/ceremony/evaluate.rs
@@ -132,6 +132,7 @@ cred_trusted(t) if {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 10,
+                thread_id: None,
             },
             evidence: Evidence {
                 invitation: None,
@@ -147,6 +148,7 @@ cred_trusted(t) if {
                         claims: json!({}),
                         valid_until: None,
                         witness_binding: None,
+                        task_context: None,
                     }],
                 }),
                 request: Some(json!({ "agreements": {} })),

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -41,6 +41,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+use crate::credentials::task_context::TaskContextBinding;
 use crate::credentials::witness::WitnessBinding;
 
 /// Which ceremony this evaluation is deciding.
@@ -180,6 +181,21 @@ pub struct Context {
     /// Current member count — feeds size-sensitive policy (e.g. a
     /// quorum threshold or a first-member bootstrap branch).
     pub member_count: u64,
+    /// The trust task exchange this ceremony *is* — the `threadId` the
+    /// evidence arrived on. Present for a threaded ceremony (the
+    /// credential-exchange join, whose thread keys the single-use
+    /// presentation challenge); absent for a synchronous REST
+    /// submission, which has no thread.
+    ///
+    /// This is what makes each credential's
+    /// [`Credential::task_context`] verdict mean something: without
+    /// naming the exchange in the facts, "the credential says it came
+    /// from thread X" is unanswerable, and a credential from another
+    /// exchange satisfies a policy rule as readily as one from this
+    /// one (DTG Credentials Security Considerations 5, context
+    /// collapse).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
 }
 
 /// Everything the actor presented, grouped by kind. Each slot is
@@ -300,6 +316,25 @@ pub struct Credential {
     /// cryptography.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub witness_binding: Option<WitnessBinding>,
+    /// Host verdict: which trust task exchange this credential's own
+    /// `taskContext` names, relative to
+    /// [`Context::thread_id`] — the exchange it is being presented in.
+    ///
+    /// `None` where the path never looked (the raw-VP submit path
+    /// verifies nothing about an embedded VC, so it cannot report on
+    /// this either). Present and
+    /// [`TaskContextBinding::ForeignExchange`] is a different fact
+    /// from absent: it says the credential was issued in some *other*
+    /// exchange, which is ordinary for a witness and disqualifying for
+    /// anything offered as evidence that *this* ceremony reached its
+    /// terminal state (DTG Credentials Security Considerations 5).
+    ///
+    /// A policy asserting a ceremony outcome should require
+    /// `task_context.state == "sameExchange"`; one merely weighing
+    /// background evidence should not, or it refuses every honest
+    /// witness.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_context: Option<TaskContextBinding>,
 }
 
 /// Resolved credential status. The host computes this from the
@@ -369,6 +404,7 @@ mod tests {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 1421,
+                thread_id: None,
             },
             evidence: Evidence {
                 invitation: None,
@@ -384,6 +420,7 @@ mod tests {
                         claims: json!({ "kind": "proximity" }),
                         valid_until: None,
                         witness_binding: None,
+                        task_context: None,
                     }],
                 }),
                 request: Some(json!({ "agreements": {} })),
@@ -438,6 +475,7 @@ mod tests {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 1421,
+                thread_id: None,
             },
             evidence: Evidence {
                 invitation: None,
@@ -479,6 +517,83 @@ mod tests {
             let parsed: Purpose = serde_json::from_value(json!(wire)).unwrap();
             assert_eq!(parsed, purpose);
         }
+    }
+
+    /// The task-context binding reaches the policy under the keys a rule is
+    /// written against — `context.thread_id` names the exchange, and each
+    /// credential's `task_context.state` says where *it* came from. The pair is
+    /// what makes "a credential from another exchange" expressible at all; a
+    /// rule reading either key by a different name matches nothing, and
+    /// matching nothing is indistinguishable from finding no foreign
+    /// credential.
+    #[test]
+    fn the_task_context_binding_reaches_the_policy_input() {
+        let mut facts = Facts {
+            purpose: Purpose::Join,
+            now: "2026-05-30T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:z6MkHuman".into(),
+                role: None,
+                authenticated: true,
+            },
+            subject: Subject {
+                did: "did:key:z6MkHuman".into(),
+            },
+            context: Context {
+                community_did: "did:webvh:acme.example".into(),
+                channel: "didcomm".into(),
+                member_count: 1,
+                thread_id: Some("urn:uuid:this-exchange".into()),
+            },
+            evidence: Evidence {
+                invitation: None,
+                presentation: Some(Presentation {
+                    verified: true,
+                    holder: "did:key:z6MkHuman".into(),
+                    credentials: vec![Credential {
+                        credential_type: "WitnessCredential".into(),
+                        issuer: "did:webvh:notary.example".into(),
+                        issuer_trusted: true,
+                        status: CredentialStatus::Valid,
+                        holder_bound: true,
+                        claims: json!({}),
+                        valid_until: None,
+                        witness_binding: None,
+                        task_context: Some(TaskContextBinding::ForeignExchange {
+                            thread_id: "urn:uuid:some-other-exchange".into(),
+                        }),
+                    }],
+                }),
+                request: None,
+            },
+            state: State {
+                subject_member: None,
+            },
+        };
+
+        let wire = serde_json::to_value(&facts).unwrap();
+        assert_eq!(wire["context"]["thread_id"], "urn:uuid:this-exchange");
+        let cred = &wire["evidence"]["presentation"]["credentials"][0];
+        assert_eq!(cred["task_context"]["state"], "foreignExchange");
+        assert_eq!(
+            cred["task_context"]["thread_id"],
+            "urn:uuid:some-other-exchange"
+        );
+        let parsed: Facts = serde_json::from_value(wire).unwrap();
+        assert_eq!(parsed, facts);
+
+        // Unthreaded ceremonies and unexamined credentials omit the keys rather
+        // than sending `null`, matching every other optional slot — a Rego rule
+        // sees `undefined` either way, and the design examples carry neither.
+        facts.context.thread_id = None;
+        facts.evidence.presentation.as_mut().unwrap().credentials[0].task_context = None;
+        let wire = serde_json::to_value(&facts).unwrap();
+        assert!(wire["context"].get("thread_id").is_none());
+        assert!(
+            wire["evidence"]["presentation"]["credentials"][0]
+                .get("task_context")
+                .is_none()
+        );
     }
 
     #[test]

--- a/vtc-service/src/ceremony/invariant.rs
+++ b/vtc-service/src/ceremony/invariant.rs
@@ -156,6 +156,7 @@ mod tests {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 10,
+                thread_id: None,
             },
             evidence: Evidence {
                 invitation: None,

--- a/vtc-service/src/ceremony/mod.rs
+++ b/vtc-service/src/ceremony/mod.rs
@@ -139,6 +139,7 @@ mod tests {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 10,
+                thread_id: None,
             },
             evidence: Evidence::default(),
             state: State::default(),

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -157,6 +157,10 @@ async fn assemble_role_change_facts(
                 presentation: None,
                 request: Some(json!({ "target_role": target_role, "step_up": step_up })),
             },
+            // A role change is a synchronous admin action, not a trust task
+            // exchange, and presents no credentials — there is nothing to bind
+            // and no thread to bind it to.
+            thread_id: None,
         },
     )
     .await
@@ -476,6 +480,9 @@ async fn assemble_leave_facts(
                 presentation: None,
                 request,
             },
+            // Unthreaded, and presents no credentials — see the role-change
+            // spine above.
+            thread_id: None,
         },
     )
     .await

--- a/vtc-service/src/ceremony/verify.rs
+++ b/vtc-service/src/ceremony/verify.rs
@@ -173,6 +173,7 @@ mod tests {
                 community_did: "did:webvh:acme.example".into(),
                 channel: "rest".into(),
                 member_count: 10,
+                thread_id: None,
             },
             evidence: Evidence::default(),
             state: State::default(),
@@ -192,6 +193,7 @@ mod tests {
                 claims: json!({}),
                 valid_until: None,
                 witness_binding: None,
+                task_context: None,
             }],
         }
     }

--- a/vtc-service/src/credentials/exchange/verify.rs
+++ b/vtc-service/src/credentials/exchange/verify.rs
@@ -82,6 +82,31 @@ pub struct VerifiedPresentation {
     /// from [`Self::claims`] because the DI path stores only `credentialSubject`
     /// in `claims`, while `credentialStatus` is a sibling top-level VC field.
     pub credential_status: Option<Value>,
+    /// The credential's `taskContext` — the `threadId` of the trust task
+    /// exchange it was issued in (DTG Credentials §Trust Task Context Binding),
+    /// or `None` when it asserts none.
+    ///
+    /// Captured here for the same reason [`Self::credential_status`] is: it is a
+    /// **top-level** credential property, and the DI and bbs paths keep only
+    /// `credentialSubject` in [`Self::claims`], so a `taskContext` read from
+    /// `claims` downstream would be unconditionally `None` on those paths — a
+    /// verifier that could never see the binding it is required to enforce.
+    /// Resolved into a verdict by [`crate::credentials::task_context`].
+    pub task_context: Option<String>,
+}
+
+/// Read a credential's top-level `taskContext`.
+///
+/// `source` is the whole credential — the SD-JWT-VC payload, or the DI / bbs VC
+/// object — never `credentialSubject`. DTG Credentials places `taskContext`
+/// beside `issuer`, not inside the subject, so looking for it in the subject as
+/// well would accept a shape the issuing catalog cannot produce and the
+/// signature-covered position would stop being the one that counts.
+fn extract_task_context(source: &Value) -> Option<String> {
+    source
+        .get("taskContext")
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// Extract a credential's status entry from a verified SD-JWT-VC payload or a DI
@@ -252,6 +277,7 @@ pub async fn verify_presentation(
         .and_then(Value::as_str)
         .map(str::to_string);
     let credential_status = extract_credential_status(&result.claims);
+    let task_context = extract_task_context(&result.claims);
     Ok(VerifiedPresentation {
         issuer_did,
         holder_did,
@@ -261,6 +287,7 @@ pub async fn verify_presentation(
         holder_bound: true,
         claims: result.claims,
         credential_status,
+        task_context,
     })
 }
 
@@ -491,6 +518,10 @@ async fn verify_di_vp(
         // The W3C `credentialStatus` is a top-level VC field (sibling of
         // `credentialSubject`); capture it from the full VC, not the subject.
         let credential_status = extract_credential_status(vc);
+        // Same reasoning as `credentialStatus` directly above: a top-level VC
+        // field, so it has to be taken from the full credential before `claims`
+        // narrows to `credentialSubject`.
+        let task_context = extract_task_context(vc);
         out.push(VerifiedPresentation {
             issuer_did,
             holder_did: holder_did.clone(),
@@ -500,6 +531,7 @@ async fn verify_di_vp(
             holder_bound: true,
             claims: vc.get("credentialSubject").cloned().unwrap_or(Value::Null),
             credential_status,
+            task_context,
         });
     }
     Ok(out)
@@ -700,6 +732,12 @@ async fn verify_bbs_presentation(
         _ => None,
     });
     let credential_status = extract_credential_status(vc);
+    // A derived proof reveals only what the issuer made mandatory-disclosed plus
+    // what the holder chose to disclose. An issuer that leaves `taskContext`
+    // selectively disclosable therefore mints a VWC that a verifier is *unable*
+    // to bind to its exchange, and the receipt gate refuses it — correctly, and
+    // the fix belongs on the issuing side.
+    let task_context = extract_task_context(vc);
 
     Ok(VerifiedPresentation {
         issuer_did,
@@ -710,5 +748,6 @@ async fn verify_bbs_presentation(
         holder_bound,
         claims: vc.get("credentialSubject").cloned().unwrap_or(Value::Null),
         credential_status,
+        task_context,
     })
 }

--- a/vtc-service/src/credentials/ingress.rs
+++ b/vtc-service/src/credentials/ingress.rs
@@ -35,6 +35,18 @@
 //! EndorsementCredential" instead of `recognition::verify`'s "VEC validUntil …
 //! is in the past".
 //!
+//! ## Trust Task Context Binding
+//!
+//! [`classify_dtg`] also refuses a `WitnessCredential` carrying no
+//! `taskContext`. That *is* classification, not validity: DTG Credentials marks
+//! the property REQUIRED on that subtype, and the catalog's own
+//! `TryFrom<DTGCommon>` rejects a witness without one at exactly this point. So
+//! it belongs inside the filter rather than beside it — a document that cannot
+//! be built as a VWC is not a VWC being skipped for the wrong reason. Without
+//! it, a witness made in one exchange reads identically to one made in the
+//! exchange it is presented in (Security Considerations 5, context collapse);
+//! see [`crate::credentials::task_context`].
+//!
 //! For the same reason the VIC and recognition paths are **left alone**. Both
 //! already implement `validFrom <= now < validUntil` with the same boundary
 //! this module uses, and each carries semantics the shared check does not:
@@ -94,9 +106,20 @@ pub fn classify_dtg(doc: &JsonValue) -> Result<DTGCredentialType, AppError> {
         }
     }
 
-    DTGCredentialType::try_from(types.as_slice()).map_err(|_| {
+    let subtype = DTGCredentialType::try_from(types.as_slice()).map_err(|_| {
         AppError::Validation("credential `type` names no DTG credential subtype".into())
-    })
+    })?;
+
+    // §Trust Task Context Binding makes `taskContext` REQUIRED on the VWC, and
+    // the catalog's own `TryFrom<DTGCommon>` refuses a witness without one at
+    // exactly this point — classification, not validity. Enforced here so the
+    // rule holds at every JSON-LD ingress rather than only where someone
+    // remembered it: the missing binding is what lets a witness from one
+    // exchange be read as evidence in another (Security Considerations 5).
+    if matches!(subtype, DTGCredentialType::Witness) && doc.get("taskContext").is_none() {
+        return Err(crate::credentials::task_context::missing());
+    }
+    Ok(subtype)
 }
 
 /// Check the common structure, require one specific subtype, and require the
@@ -310,6 +333,28 @@ mod tests {
                 "{label} classified as {got}"
             );
         }
+    }
+
+    /// A VWC the catalog itself would refuse to build must not classify as one
+    /// here either. `taskContext` is REQUIRED on this subtype, and a witness
+    /// without it is the credential that cannot be tied to any exchange — the
+    /// one the context-collapse attack needs.
+    #[test]
+    fn refuses_a_witness_credential_with_no_task_context() {
+        let mut witness = vmc();
+        witness["type"] =
+            serde_json::json!(["VerifiableCredential", "DTGCredential", "WitnessCredential"]);
+
+        let err = classify_dtg(&witness).expect_err("a VWC without taskContext must be refused");
+        assert!(format!("{err:?}").contains("taskContext"), "{err:?}");
+
+        // The same document with the binding present classifies normally, so
+        // the refusal is about the missing property and not about the subtype.
+        witness["taskContext"] = serde_json::json!("urn:uuid:some-exchange");
+        assert_eq!(
+            std::mem::discriminant(&classify_dtg(&witness).expect("a bound VWC classifies")),
+            std::mem::discriminant(&DTGCredentialType::Witness)
+        );
     }
 
     #[test]

--- a/vtc-service/src/credentials/mod.rs
+++ b/vtc-service/src/credentials/mod.rs
@@ -54,6 +54,7 @@ pub mod invitation_registry;
 pub mod invitation_verify;
 pub mod present_challenge;
 pub mod signer;
+pub mod task_context;
 pub mod vec;
 pub mod vm_resolver;
 pub mod vmc;

--- a/vtc-service/src/credentials/task_context.rs
+++ b/vtc-service/src/credentials/task_context.rs
@@ -1,0 +1,273 @@
+//! Trust Task Context Binding — which exchange a credential came out of.
+//!
+//! DTG Credentials gives every credential an optional `taskContext`: the
+//! `threadId` of the trust task exchange it was issued in. On the VWC it is
+//! REQUIRED, because a witness attestation only means anything under the
+//! conditions it was made under, and those live in the exchange.
+//!
+//! Security Considerations 5 names the attack this exists to stop —
+//! **context collapse**: "A credential presented outside the trust task
+//! exchange in which it was issued may be misinterpreted as evidence of a
+//! completed ceremony." The credential is genuinely signed, correctly typed,
+//! unrevoked and in date. What is false is only the *exchange* it is offered
+//! against. Nothing else in a credential says which exchange that was, so
+//! without reading `taskContext` a verifier has no way to tell the difference
+//! and every ceremony that reasons over presented credentials is exposed.
+//!
+//! ## Absence is refused; a different thread is reported
+//!
+//! Those are two different failures and they get two different answers.
+//!
+//! A VWC with no `taskContext` is **malformed** — the specification marks the
+//! property REQUIRED on that type, and `dtg_credentials` refuses to build one
+//! without it. So does [`resolve`], and it refuses rather than substituting the
+//! current thread: defaulting would manufacture the exact binding the verifier
+//! is supposed to be checking, and would do it most eagerly for the credential
+//! least entitled to it.
+//!
+//! A credential naming a *different* thread is refused by nobody, because it is
+//! the ordinary case. A VWC's `taskContext` names the exchange the **witnessing**
+//! happened in, which is not the join exchange it is later presented in; every
+//! honest witness presented at a join is a [`TaskContextBinding::ForeignExchange`].
+//! Rejecting on mismatch would refuse all of them. What the verifier must not do
+//! is read such a credential as evidence that *this* ceremony completed, which is
+//! the specification's own note: a verifier "MUST NOT interpret a
+//! `taskContext`-bearing credential as proof that the associated trust task
+//! completed unless the matching trust task outcome evidence is also present and
+//! verified". So the verdict is surfaced into the ceremony facts and the policy
+//! decides what it is allowed to satisfy — the same division of labour as
+//! [`crate::credentials::witness`]: the host settles the question, the policy
+//! branches on the answer.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+
+/// Whether DTG Credentials marks `taskContext` REQUIRED on the credential being
+/// resolved.
+///
+/// Passed in rather than derived here because the two receipt paths classify a
+/// credential differently — `credentials::ingress` reads the JSON-LD `type`
+/// array, the presentation path reads an SD-JWT-VC `vct` — and neither should
+/// have to agree with the other about how to spell a credential type in order
+/// for the requirement to be enforced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Requirement {
+    /// The VWC. Absence is a rejection.
+    Required,
+    /// Every other DTG credential type: `taskContext` is OPTIONAL, and a
+    /// credential without one "MUST be interpretable standing alone,
+    /// independent of any exchange".
+    Optional,
+}
+
+/// The host's verdict on where a credential's `taskContext` points, relative to
+/// the exchange it was presented in. Resolved before policy runs.
+///
+/// The variants are kept apart because a policy that collapses them loses the
+/// only distinction that matters here — between a credential issued *inside*
+/// this exchange, which may speak to its outcome, and one issued elsewhere,
+/// which may not.
+///
+/// Serialized exactly like [`crate::credentials::witness::WitnessBinding`]
+/// beside it: internally tagged on `state`, camelCase variant names,
+/// `snake_case` payload members. The camelCase in this feature is the
+/// specification's `taskContext`, read *off the credential*; what is written
+/// *into* the facts document follows that document's own contract, which is
+/// `snake_case` (see the module doc of [`crate::ceremony::facts`] — the
+/// compiled Rego reads those keys literally).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "state")]
+pub enum TaskContextBinding {
+    /// The credential names this exchange. The only variant that can support a
+    /// claim about *this* ceremony's outcome.
+    SameExchange,
+    /// The credential names a different exchange, carried here so an operator
+    /// reading an audit record can find it. Not an accusation: a witness
+    /// attesting an earlier exchange is exactly this, and honest.
+    ForeignExchange { thread_id: String },
+    /// The credential asserts no `taskContext`. Reachable only where the
+    /// property is OPTIONAL — [`Requirement::Required`] turns this into an
+    /// error instead.
+    Absent,
+    /// The credential names an exchange but this ceremony has none to compare
+    /// against (a synchronous REST submission, which is not threaded). Distinct
+    /// from [`Self::ForeignExchange`]: we are not saying the credential belongs
+    /// elsewhere, we are saying there is nothing here for it to belong to.
+    Unthreaded,
+}
+
+impl TaskContextBinding {
+    /// Whether the credential was issued inside the exchange it is being
+    /// presented in. The one predicate a policy needs to refuse a credential as
+    /// evidence of *this* ceremony's outcome.
+    pub fn is_same_exchange(&self) -> bool {
+        matches!(self, Self::SameExchange)
+    }
+}
+
+/// Resolve a presented credential's task-context binding, refusing the absence
+/// the specification does not permit.
+///
+/// `asserted` is the credential's own `taskContext`; `exchange_thread` is the
+/// thread of the exchange it arrived on, or `None` for an unthreaded ceremony.
+///
+/// The two identifiers are compared **verbatim**. DTG Credentials defines
+/// `taskContext` as *the* `threadId` and specifies no canonicalization, so
+/// there is no sanctioned way to decide that `urn:uuid:x` and `x` are the same
+/// thread. Guessing one would be a verifier inventing the equality it is
+/// supposed to be testing, and it would fail open — the mistake shows up as a
+/// foreign credential accepted as local. Comparing verbatim fails the other
+/// way: a peer that spells the thread differently is reported as
+/// [`TaskContextBinding::ForeignExchange`] and its credential simply cannot
+/// speak to this ceremony's outcome. If a normalization is ever needed it
+/// belongs in the specification first.
+pub fn resolve(
+    requirement: Requirement,
+    asserted: Option<&str>,
+    exchange_thread: Option<&str>,
+) -> Result<TaskContextBinding, AppError> {
+    let Some(asserted) = asserted else {
+        // Checked before anything about the exchange: a VWC without a
+        // `taskContext` is malformed on its own terms, whatever it was
+        // presented against.
+        return match requirement {
+            Requirement::Required => Err(missing()),
+            Requirement::Optional => Ok(TaskContextBinding::Absent),
+        };
+    };
+    Ok(match exchange_thread {
+        Some(thread) if thread == asserted => TaskContextBinding::SameExchange,
+        Some(_) => TaskContextBinding::ForeignExchange {
+            thread_id: asserted.to_string(),
+        },
+        None => TaskContextBinding::Unthreaded,
+    })
+}
+
+/// The rejection for a credential that must carry a `taskContext` and does not.
+///
+/// `Validation`, not `Forbidden`: nothing about the credential's cryptography
+/// failed. It is structurally not the credential it claims to be, which is the
+/// same answer `credentials::ingress` gives a document whose `type` array is
+/// wrong.
+pub fn missing() -> AppError {
+    AppError::Validation(
+        "WitnessCredential is missing the required `taskContext`; DTG Credentials \
+         marks it REQUIRED on this type and a verifier cannot bind the credential \
+         to the exchange it was issued in without it"
+            .into(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const THREAD: &str = "urn:uuid:0b3f2a8e-1f8c-4a3d-9c1a-6d2f5e7b8c90";
+
+    #[test]
+    fn a_credential_naming_this_exchange_is_bound_to_it() {
+        assert_eq!(
+            resolve(Requirement::Optional, Some(THREAD), Some(THREAD)).unwrap(),
+            TaskContextBinding::SameExchange
+        );
+        assert!(
+            resolve(Requirement::Required, Some(THREAD), Some(THREAD))
+                .unwrap()
+                .is_same_exchange()
+        );
+    }
+
+    /// The context-collapse case: a genuinely-signed credential from another
+    /// exchange. It resolves, and it resolves to something a policy can tell
+    /// apart from the local one.
+    #[test]
+    fn a_credential_from_another_exchange_is_foreign_not_bound() {
+        let binding = resolve(Requirement::Optional, Some("urn:uuid:other"), Some(THREAD)).unwrap();
+        assert_eq!(
+            binding,
+            TaskContextBinding::ForeignExchange {
+                thread_id: "urn:uuid:other".into()
+            }
+        );
+        assert!(!binding.is_same_exchange());
+    }
+
+    /// The whole point of the module: absence is refused, never filled in with
+    /// the current thread. An implementation that defaulted would hand back
+    /// `SameExchange` here — the strongest possible verdict, awarded to the
+    /// credential that earned it least.
+    #[test]
+    fn a_witness_without_a_task_context_is_refused_not_defaulted() {
+        let err = resolve(Requirement::Required, None, Some(THREAD)).unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("taskContext")),
+            "{err:?}"
+        );
+    }
+
+    /// Refused on its own terms — an unthreaded ceremony does not excuse a
+    /// missing REQUIRED property, and neither does having nothing to compare
+    /// against.
+    #[test]
+    fn a_witness_without_a_task_context_is_refused_even_unthreaded() {
+        assert!(resolve(Requirement::Required, None, None).is_err());
+    }
+
+    #[test]
+    fn absence_is_fine_where_the_specification_makes_it_optional() {
+        assert_eq!(
+            resolve(Requirement::Optional, None, Some(THREAD)).unwrap(),
+            TaskContextBinding::Absent
+        );
+    }
+
+    /// An unthreaded ceremony cannot bind anything, and says so rather than
+    /// claiming the credential is foreign — there is no local thread for it to
+    /// be foreign *to*.
+    #[test]
+    fn an_unthreaded_ceremony_binds_nothing() {
+        assert_eq!(
+            resolve(Requirement::Optional, Some(THREAD), None).unwrap(),
+            TaskContextBinding::Unthreaded
+        );
+    }
+
+    /// Verbatim comparison, asserted deliberately: the two spellings of one
+    /// UUID are *not* silently the same thread. This test is the record of that
+    /// decision, so a later reader adding normalization has to change it on
+    /// purpose.
+    #[test]
+    fn thread_ids_are_compared_verbatim() {
+        let bare = "0b3f2a8e-1f8c-4a3d-9c1a-6d2f5e7b8c90";
+        assert!(
+            !resolve(Requirement::Required, Some(bare), Some(THREAD))
+                .unwrap()
+                .is_same_exchange()
+        );
+    }
+
+    /// The verdict rides into the policy `input` document, so its wire shape is
+    /// part of the facts contract: tagged on `state`, camelCase variant names
+    /// and a `snake_case` payload member, exactly like `WitnessBinding`. A
+    /// policy is written against these literals, so drift here breaks rules
+    /// that no longer match anything — silently, and in the allow direction for
+    /// a rule phrased as a denial.
+    #[test]
+    fn the_wire_shape_matches_the_facts_contract() {
+        assert_eq!(
+            serde_json::to_value(TaskContextBinding::SameExchange).unwrap(),
+            serde_json::json!({ "state": "sameExchange" })
+        );
+        assert_eq!(
+            serde_json::to_value(TaskContextBinding::ForeignExchange {
+                thread_id: "urn:uuid:other".into()
+            })
+            .unwrap(),
+            serde_json::json!({ "state": "foreignExchange", "thread_id": "urn:uuid:other" })
+        );
+        let parsed: TaskContextBinding =
+            serde_json::from_value(serde_json::json!({ "state": "absent" })).unwrap();
+        assert_eq!(parsed, TaskContextBinding::Absent);
+    }
+}

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -214,7 +214,10 @@ pub async fn submit_inner(
     // 5. Decide: assemble verified Facts (the route-layer holder-binding
     // makes this presentation `verified`) and run the active join policy.
     let presentation = presentation_from_vp(&applicant_did, &vp);
-    let verdict = decide_join(state, &applicant_did, presentation, invitation).await?;
+    // No thread: this is a synchronous REST submission, not a trust task
+    // exchange. Nothing here can be `sameExchange`, which is the honest answer
+    // — there is no exchange to be the same as.
+    let verdict = decide_join(state, &applicant_did, presentation, invitation, None).await?;
 
     // 6. Realize the verdict (store + audit + auto-admit on allow). On an
     // invitation-driven admit the VIC is burned in the single-use ledger.
@@ -237,13 +240,20 @@ pub async fn submit_inner(
 /// it has already established as `verified` (route-layer holder-binding for the
 /// VP path; cryptographic `vp_token` verification for the credential-exchange
 /// path).
+///
+/// `thread_id` is the trust task exchange the evidence arrived on, or `None` on
+/// the unthreaded REST path. It is what each credential's `taskContext` verdict
+/// is resolved against, so passing `None` where a thread exists would not error
+/// — it would quietly make every credential unbindable.
 pub async fn decide_join(
     state: &AppState,
     applicant_did: &str,
     presentation: Presentation,
     invitation: Option<Invitation>,
+    thread_id: Option<&str>,
 ) -> Result<Verdict, AppError> {
-    let facts = assemble_join_facts(state, applicant_did, presentation, invitation).await?;
+    let facts =
+        assemble_join_facts(state, applicant_did, presentation, invitation, thread_id).await?;
     let verified = VerifiedFacts::assemble(facts)?;
     let policy = load_active_compiled(
         &state.active_policies_ks,
@@ -457,6 +467,7 @@ async fn assemble_join_facts(
     applicant_did: &str,
     presentation: Presentation,
     invitation: Option<Invitation>,
+    thread_id: Option<&str>,
 ) -> Result<Facts, AppError> {
     // The applicant proved holder-binding (route-layer for the VP path,
     // cryptographic kb-jwt for the credential-exchange path) but is not (yet) a
@@ -476,6 +487,7 @@ async fn assemble_join_facts(
                 presentation: Some(presentation),
                 request: None,
             },
+            thread_id: thread_id.map(str::to_string),
         },
     )
     .await
@@ -564,6 +576,11 @@ fn credential_from_vc(vc: &JsonValue) -> Option<Credential> {
         // "we did not check" as "the digest names no edge we hold", which is
         // the fail-safe direction here only by accident.
         witness_binding: None,
+        // Likewise absent rather than `Absent`: this path reads no credential
+        // property under a verified signature, so it has nothing to say about
+        // where the credential came from. `Absent` would assert that the
+        // credential carries no `taskContext`, which we did not check.
+        task_context: None,
     })
 }
 

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -1313,6 +1313,9 @@ async fn credential_present_handler(msg: &Message, state: &AppState) -> Option<R
         &body.vp_token,
         &challenge.aud,
         &challenge.nonce,
+        // The same thread the challenge was keyed by: the exchange every
+        // presented credential's `taskContext` is resolved against.
+        &thread_id,
         JoinTransport::DIDComm,
         now,
     )

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -187,6 +187,9 @@ async fn assemble_directory_facts(
                 presentation: None,
                 request,
             },
+            // A directory read is synchronous and unthreaded, and presents no
+            // credentials to bind.
+            thread_id: None,
         },
     )
     .await

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -12,10 +12,20 @@
 //! Unlike the VP submit path (whose `presentation.verified` rests on a
 //! route-layer hex signature), here `verified` rests on the holder `kb-jwt` /
 //! DI holder proof binding the verifier's `nonce` + audience — real VP
-//! cryptography. [`present_and_decide_join`] takes the expected audience + nonce
-//! as parameters so it is transport-agnostic; the DIDComm
+//! cryptography. [`present_and_decide_join`] takes the expected audience, nonce
+//! and exchange thread as parameters so it is transport-agnostic; the DIDComm
 //! `credential-exchange/present` handler (`messaging.rs`) sources them from the
-//! single-use presentation challenge it consumes.
+//! single-use presentation challenge it consumes and the `thid` that keyed it.
+//!
+//! ## Trust Task Context Binding
+//!
+//! The thread is not only a correlation handle. It is the identity of the
+//! exchange, and every presented credential is resolved against it: a VWC
+//! without the `taskContext` DTG Credentials marks REQUIRED is refused outright,
+//! and one naming a different exchange is surfaced to the policy as such
+//! ([`crate::credentials::task_context`]). Without that, a credential issued
+//! during some other exchange is indistinguishable from one issued during this
+//! one — Security Considerations 5, context collapse.
 //!
 //! This module also hosts the **query send side** ([`prepare_join_query`] +
 //! [`send_query`]): the VTC issues the challenge and builds the DCQL query (from
@@ -38,6 +48,7 @@ use vti_common::error::AppError;
 
 use crate::ceremony::{Credential, CredentialStatus, Presentation};
 use crate::credentials::present_challenge::{self, DEFAULT_CHALLENGE_TTL};
+use crate::credentials::task_context::{self, TaskContextBinding};
 use crate::credentials::witness::{self, WitnessBinding};
 use crate::credentials::{VerifiedPresentation, VerifiedPresentationSet, verify_vp_token};
 use affinidi_data_integrity::VerificationMethodResolver;
@@ -55,14 +66,19 @@ use crate::join::{JoinSubmitOutcome, decide_join, realize_join_verdict};
 ///
 /// `expected_aud` is this VTC's identity (the `domain`/`aud` the holder bound
 /// into the kb-jwt); `expected_nonce` is the single-use freshness value the VTC
-/// issued with its query. On success the applicant is the **proven holder** of
-/// the presentation. On `allow` the MembershipCredential is issued inline (the
-/// returned [`JoinSubmitOutcome::admit`]).
+/// issued with its query. `thread_id` is the exchange the holder presented on —
+/// the same thread that keyed the single-use challenge — and is what each
+/// credential's `taskContext` is resolved against, so a credential issued in a
+/// different exchange is visible as such to the policy rather than
+/// indistinguishable from a local one. On success the applicant is the **proven
+/// holder** of the presentation. On `allow` the MembershipCredential is issued
+/// inline (the returned [`JoinSubmitOutcome::admit`]).
 pub async fn present_and_decide_join(
     state: &AppState,
     vp_token: &JsonValue,
     expected_aud: &str,
     expected_nonce: &str,
+    thread_id: &str,
     transport: JoinTransport,
     now: DateTime<Utc>,
 ) -> Result<JoinSubmitOutcome, AppError> {
@@ -80,13 +96,16 @@ pub async fn present_and_decide_join(
     let applicant_did = set.holder.clone();
 
     // 2. Project the verified set into the ceremony evidence shape, resolving
-    //    each issuer's trust via TRQP against the community's recognition graph.
-    let presentation = presentation_from_verified_set(state, &set).await;
+    //    each issuer's trust via TRQP against the community's recognition graph
+    //    and each credential's task-context binding against this exchange. A
+    //    credential the specification requires a `taskContext` on and that does
+    //    not carry one is refused here, before any decision is taken.
+    let presentation = presentation_from_verified_set(state, &set, thread_id).await?;
 
     // 3 + 4. Decide under the active join policy, then realize the verdict. The
     // credential-exchange path carries no VIC (invitations ride the VP-submit
     // path), so no invitation fact and nothing to consume.
-    let verdict = decide_join(state, &applicant_did, presentation, None).await?;
+    let verdict = decide_join(state, &applicant_did, presentation, None, Some(thread_id)).await?;
     let vp_claims = vp_claims_from_set(&set);
     realize_join_verdict(
         state,
@@ -283,10 +302,22 @@ async fn push_credential_query(
 /// ([`issuer_trusted`]) and its lifecycle `status` is resolved live against the
 /// issuer's status list ([`resolve_presented_status`]). The credential `type` is
 /// the SD-JWT-VC `vct`.
+///
+/// `exchange_thread` is the thread the presentation arrived on, against which
+/// each credential's `taskContext` is resolved.
+///
+/// Fallible where the sibling resolutions are not: an unreachable status list or
+/// a flaky registry degrade to a surfaced verdict the policy can weigh, but a
+/// VWC with no `taskContext` is not a credential with a weaker claim — it is not
+/// a well-formed VWC, and the specification marks the property REQUIRED. It is
+/// refused for the whole presentation rather than dropped from it, because
+/// silently discarding one credential turns a malformed submission into a
+/// decision made on less evidence than the holder thinks it supplied.
 async fn presentation_from_verified_set(
     state: &AppState,
     set: &VerifiedPresentationSet,
-) -> Presentation {
+    exchange_thread: &str,
+) -> Result<Presentation, AppError> {
     let own_did = state.config.read().await.vtc_did.clone();
     let registry = state.registry_client.as_deref();
     // A presented credential's revocation is checked against the *issuer's*
@@ -325,7 +356,8 @@ async fn presentation_from_verified_set(
         // whole presentation: one unreadable keyspace must not decide a
         // ceremony, and `Unresolved` is the honest answer — we could not find
         // the edge. The policy still sees an unbound witness.
-        let witness_binding = if is_witness_credential(p) {
+        let is_witness = is_witness_credential(p);
+        let witness_binding = if is_witness {
             Some(
                 witness::resolve_binding(&state.relationships_ks, &p.claims)
                     .await
@@ -338,19 +370,35 @@ async fn presentation_from_verified_set(
         } else {
             None
         };
+        // The receipt half of Trust Task Context Binding. A VWC is the one type
+        // the specification marks `taskContext` REQUIRED on, so its absence is
+        // an error rather than a verdict — and the error is raised instead of
+        // filling the current thread in, which would forge the very binding
+        // being checked. Everything else resolves to a verdict the policy reads.
+        let requirement = if is_witness {
+            task_context::Requirement::Required
+        } else {
+            task_context::Requirement::Optional
+        };
+        let task_context = task_context::resolve(
+            requirement,
+            p.task_context.as_deref(),
+            Some(exchange_thread),
+        )?;
         credentials.push(credential_from_verified(
             p,
             trusted,
             status,
             witness_binding,
+            Some(task_context),
         ));
     }
 
-    Presentation {
+    Ok(Presentation {
         verified: true,
         holder: set.holder.clone(),
         credentials,
-    }
+    })
 }
 
 /// Whether this verified credential is a VWC, and so has a digest binding to
@@ -381,6 +429,7 @@ fn credential_from_verified(
     issuer_trusted: bool,
     status: CredentialStatus,
     witness_binding: Option<WitnessBinding>,
+    task_context: Option<TaskContextBinding>,
 ) -> Credential {
     Credential {
         credential_type: p
@@ -402,6 +451,9 @@ fn credential_from_verified(
         // of the pure projection so it stays unit-testable without storage,
         // for the same reason `issuer_trusted` and `status` are parameters.
         witness_binding,
+        // Also caller-resolved: the comparison needs the exchange's thread,
+        // which is a property of the ceremony rather than of the credential.
+        task_context,
     }
 }
 
@@ -561,6 +613,7 @@ mod tests {
             holder_bound: true,
             claims: json!({ "givenName": "Alice", "exp": 1_900_000_000 }),
             credential_status: None,
+            task_context: None,
         }
     }
 
@@ -592,8 +645,13 @@ mod tests {
 
     #[test]
     fn projects_a_verified_presentation_into_a_ceremony_credential() {
-        let c =
-            credential_from_verified(&sample_presentation(), true, CredentialStatus::Valid, None);
+        let c = credential_from_verified(
+            &sample_presentation(),
+            true,
+            CredentialStatus::Valid,
+            None,
+            None,
+        );
         assert_eq!(
             c.credential_type,
             "https://openvtc.org/credentials/MembershipCredential"
@@ -611,6 +669,7 @@ mod tests {
             &sample_presentation(),
             true,
             CredentialStatus::Revoked,
+            None,
             None,
         );
         assert_eq!(c.status, CredentialStatus::Revoked);
@@ -668,8 +727,13 @@ mod tests {
 
     #[test]
     fn untrusted_issuer_carries_through_to_the_credential() {
-        let c =
-            credential_from_verified(&sample_presentation(), false, CredentialStatus::Valid, None);
+        let c = credential_from_verified(
+            &sample_presentation(),
+            false,
+            CredentialStatus::Valid,
+            None,
+            None,
+        );
         assert!(!c.issuer_trusted);
     }
 

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1032,11 +1032,13 @@ async fn list_requires_authentication() {
 /// `aud` + `nonce`, framed as an OID4VP DCQL `vp_token` map (keyed by
 /// credential-query id) — exactly the shape `vta-service`'s `present_query`
 /// emits. Returns `(holder_did, vp_token)`.
-fn build_membership_vp_token(
+fn build_vp_token(
     holder_seed: u8,
     aud: &str,
     nonce: &str,
     now_ts: i64,
+    vct: &str,
+    extra_claims: &[(&str, Value)],
 ) -> (String, Value) {
     use affinidi_sd_jwt::error::SdJwtError;
     use affinidi_sd_jwt::hasher::Sha256Hasher;
@@ -1091,11 +1093,16 @@ fn build_membership_vp_token(
         ),
     };
 
-    let vct = "https://openvtc.org/credentials/MembershipCredential";
-    let claims = json!({
+    let mut claims = json!({
         "iss": issuer_did, "sub": holder_did, "vct": vct,
         "iat": now_ts, "exp": now_ts + 3600, "givenName": "Alice"
     });
+    // Issuer-protected and always disclosed — `taskContext` rides here, not in
+    // the `_sd` frame, because a selectively-disclosable binding is one the
+    // holder can withhold from the verifier that has to enforce it.
+    for (key, value) in extra_claims {
+        claims[*key] = value.clone();
+    }
     let frame = json!({ "_sd": ["givenName"] });
     let hasher = Sha256Hasher;
     let holder_jwk = json!({
@@ -1116,6 +1123,38 @@ fn build_membership_vp_token(
         holder_did,
         json!({ "membership": presentation.serialize() }),
     )
+}
+
+/// The membership presentation every pre-existing test in this file uses.
+fn build_membership_vp_token(
+    holder_seed: u8,
+    aud: &str,
+    nonce: &str,
+    now_ts: i64,
+) -> (String, Value) {
+    build_vp_token(
+        holder_seed,
+        aud,
+        nonce,
+        now_ts,
+        "https://openvtc.org/credentials/MembershipCredential",
+        &[],
+    )
+}
+
+/// A `WitnessCredential` presentation, optionally carrying the `taskContext`
+/// DTG Credentials marks REQUIRED on that type.
+fn build_witness_vp_token(
+    holder_seed: u8,
+    aud: &str,
+    nonce: &str,
+    now_ts: i64,
+    task_context: Option<&str>,
+) -> (String, Value) {
+    let extra: Vec<(&str, Value)> = task_context
+        .map(|t| vec![("taskContext", json!(t))])
+        .unwrap_or_default();
+    build_vp_token(holder_seed, aud, nonce, now_ts, "WitnessCredential", &extra)
 }
 
 const VTC_AUD: &str = "did:webvh:vtc.example.com:abc";
@@ -1145,6 +1184,7 @@ async fn credential_exchange_present_auto_admits_under_allow_policy() {
         &vp_token,
         VTC_AUD,
         nonce,
+        "query-thread",
         JoinTransport::DIDComm,
         now,
     )
@@ -1188,6 +1228,7 @@ async fn credential_exchange_present_defers_under_default_policy() {
         &vp_token,
         VTC_AUD,
         nonce,
+        "query-thread",
         JoinTransport::DIDComm,
         now,
     )
@@ -1217,6 +1258,7 @@ async fn credential_exchange_present_rejects_a_wrong_nonce() {
             &vp_token,
             VTC_AUD,
             "wrong-nonce",
+            "query-thread",
             JoinTransport::DIDComm,
             now,
         )
@@ -1277,6 +1319,7 @@ async fn credential_exchange_present_over_a_single_use_challenge_closes_the_loop
         &vp_token,
         &challenge.aud,
         &challenge.nonce,
+        thread,
         JoinTransport::DIDComm,
         now,
     )
@@ -1298,6 +1341,153 @@ async fn credential_exchange_present_over_a_single_use_challenge_closes_the_loop
             .await
             .is_err(),
         "a replayed presentation finds no challenge"
+    );
+}
+
+// ── Trust Task Context Binding (#1065) ──────────────────────────────────────
+
+/// A join policy that admits only on a credential issued **inside this
+/// exchange**. This is what the ceremony facts have to make expressible: the
+/// same credential, cryptographically identical, decides differently depending
+/// on which exchange it came out of.
+const SAME_EXCHANGE_ONLY_JOIN_REGO: &str = "package vtc.join\nimport rego.v1\n\n\
+     default decision := {\"effect\": \"deny\", \"with\": {\"code\": \"foreign-exchange\"}}\n\n\
+     decision := {\"effect\": \"allow\", \"with\": {\"role\": \"member\"}} if {\n\
+     \tsome c in input.evidence.presentation.credentials\n\
+     \tc.task_context.state == \"sameExchange\"\n\
+     }\n";
+
+/// DTG Credentials marks `taskContext` REQUIRED on the VWC. A witness presented
+/// without one is refused at receipt — and refused rather than defaulted to the
+/// thread it happened to arrive on, which would manufacture the binding the
+/// verifier exists to check. The `allow`-everything policy is deliberate: if the
+/// refusal were happening in the policy rather than at receipt, this would admit.
+#[tokio::test]
+async fn credential_exchange_present_refuses_a_witness_with_no_task_context() {
+    use vtc_service::join::JoinTransport;
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    activate_join_policy(
+        &fix,
+        "package vtc.join\nimport rego.v1\n\n\
+         default decision := {\"effect\": \"allow\", \"with\": {\"role\": \"member\"}}\n",
+    )
+    .await;
+
+    let now = chrono::Utc::now();
+    let nonce = "n";
+    let (holder_did, vp_token) =
+        build_witness_vp_token(0x51, VTC_AUD, nonce, now.timestamp(), None);
+
+    let err = present_and_decide_join(
+        &fix.state,
+        &vp_token,
+        VTC_AUD,
+        nonce,
+        "urn:uuid:this-exchange",
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .err()
+    .expect("a witness with no taskContext must be refused");
+    assert!(
+        matches!(&err, vti_common::error::AppError::Validation(m) if m.contains("taskContext")),
+        "{err:?}"
+    );
+    assert!(
+        vtc_service::acl::get_acl_entry(&fix.acl_ks, &holder_did)
+            .await
+            .unwrap()
+            .is_none(),
+        "the refusal must land before the decision, so nothing is admitted"
+    );
+}
+
+/// The bound case: a witness naming this exchange satisfies a policy that
+/// requires it.
+#[tokio::test]
+async fn a_witness_from_this_exchange_satisfies_a_same_exchange_policy() {
+    use vtc_service::join::{JoinStatus, JoinTransport};
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    activate_join_policy(&fix, SAME_EXCHANGE_ONLY_JOIN_REGO).await;
+
+    let now = chrono::Utc::now();
+    let nonce = "n";
+    let thread = "urn:uuid:this-exchange";
+    let (holder_did, vp_token) =
+        build_witness_vp_token(0x52, VTC_AUD, nonce, now.timestamp(), Some(thread));
+
+    let outcome = present_and_decide_join(
+        &fix.state,
+        &vp_token,
+        VTC_AUD,
+        nonce,
+        thread,
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .expect("present and decide");
+
+    assert_eq!(outcome.request.status, JoinStatus::Approved);
+    assert!(
+        vtc_service::acl::get_acl_entry(&fix.acl_ks, &holder_did)
+            .await
+            .unwrap()
+            .is_some(),
+        "a witness bound to this exchange admits under the same-exchange policy"
+    );
+}
+
+/// Context collapse, and the whole point of #1065: the *same* well-formed,
+/// signed, in-date witness — differing only in the exchange its `taskContext`
+/// names — cannot satisfy the rule it satisfies above. Without the binding in
+/// the facts these two presentations are indistinguishable to the policy.
+#[tokio::test]
+async fn a_witness_from_another_exchange_cannot_satisfy_this_one() {
+    use vtc_service::join::{JoinStatus, JoinTransport};
+    use vtc_service::routes::join_requests::present::present_and_decide_join;
+
+    let fix = build_fixture().await;
+    activate_join_policy(&fix, SAME_EXCHANGE_ONLY_JOIN_REGO).await;
+
+    let now = chrono::Utc::now();
+    let nonce = "n";
+    let (holder_did, vp_token) = build_witness_vp_token(
+        0x53,
+        VTC_AUD,
+        nonce,
+        now.timestamp(),
+        Some("urn:uuid:some-other-exchange"),
+    );
+
+    let outcome = present_and_decide_join(
+        &fix.state,
+        &vp_token,
+        VTC_AUD,
+        nonce,
+        "urn:uuid:this-exchange",
+        JoinTransport::DIDComm,
+        now,
+    )
+    .await
+    .expect("a foreign taskContext is not a rejection at receipt — the policy decides");
+
+    assert_eq!(
+        outcome.request.status,
+        JoinStatus::Rejected,
+        "a witness from another exchange must not satisfy a same-exchange rule"
+    );
+    assert!(
+        vtc_service::acl::get_acl_entry(&fix.acl_ks, &holder_did)
+            .await
+            .unwrap()
+            .is_none(),
+        "and must not admit"
     );
 }
 


### PR DESCRIPTION
Closes #1065.

`taskContext` had zero occurrences in `vtc-service`. DTG Credentials marks it
REQUIRED on the VWC and defines Trust Task Context Binding as the mechanism that
keeps a credential from escaping the exchange that produced it. Security
Considerations 5 names what its absence permits — **context collapse**: a
credential that is genuinely signed, correctly typed, unrevoked and in date,
presented as evidence that *this* ceremony reached its terminal state when it was
issued during some other exchange entirely.

The ceremony pipeline was exposed to precisely that. It evaluates credentials as
facts and decides on them, and nothing in a fact said which exchange a credential
came from.

## What this does

Follows the division of labour `credentials::witness` (#1161) established — the
host settles what needs storage or keys, the policy branches on a settled state.

**Captured.** `VerifiedPresentation` gains `task_context`, read at verify time
from the credential's top level. It had to be captured *there* for the same
reason `credential_status` is: the DI and bbs paths keep only
`credentialSubject` in `claims`, so a `taskContext` read downstream would have
been unconditionally absent on those paths — a verifier structurally unable to
see the binding it is required to enforce.

**Enforced on receipt.** A VWC with no `taskContext` is refused, at both ingress
points: `credentials::ingress::classify_dtg` for JSON-LD arrivals (where the
catalog's own `TryFrom<DTGCommon>` puts the identical check) and the
credential-exchange present path for SD-JWT-VC / DI / bbs arrivals. Refused
rather than defaulted to the current thread — defaulting would manufacture the
binding being checked, and would award the strongest possible verdict to the
credential least entitled to it.

**Asserted in the evidence.** `Context.thread_id` names the exchange the ceremony
*is*; `Credential.task_context` names where each credential came from, as a
resolved `TaskContextBinding` (`sameExchange` / `foreignExchange` / `absent` /
`unthreaded`). A policy asserting an outcome can now require `sameExchange`.
Without the pair, "a credential from another exchange" is not expressible at all.

The end-to-end tests are the argument: the *same* well-formed, signed, in-date
witness admits or is rejected under one policy depending only on the exchange its
`taskContext` names.

## Decisions a reviewer should check

1. **A mismatch is reported, not refused.** A VWC's `taskContext` names the
   exchange the *witnessing* happened in — never the join exchange it is later
   presented in — so rejecting on mismatch would refuse every honest witness. The
   specification draws the same line: a verifier "MUST NOT interpret a
   `taskContext`-bearing credential as proof that the associated trust task
   completed unless the matching trust task outcome evidence is also present and
   verified". So absence (a malformed VWC) is an error; a foreign exchange is a
   fact the policy weighs.
2. **No shipped policy was tightened.** For the reason above: the default join
   and personhood policies read a VWC as background evidence of personhood, not
   as terminal-state evidence, and requiring `sameExchange` there would deny every
   legitimate witness.
3. **Thread ids are compared verbatim.** DTG Credentials specifies no
   canonicalization for `taskContext`, so there is no sanctioned way to decide
   that `urn:uuid:x` and `x` are one thread. Guessing fails open (a foreign
   credential accepted as local); comparing verbatim fails the other way. Pinned
   by a test so a later normalization has to be a deliberate change.
4. **Facts keys stay `snake_case`.** `context.thread_id` and
   `task_context.thread_id` follow the Rego facts contract (`facts.rs` documents
   `snake_case` keys as load-bearing — compiled policies read the literals), and
   match `witness_binding.relationship_id` beside them. The camelCase in this
   feature is `taskContext`, read *off the credential*, where the DTG spec
   dictates it.
5. **`presentation_from_verified_set` became fallible**, and refuses the whole
   presentation rather than dropping the offending credential — silently
   discarding one turns a malformed submission into a decision taken on less
   evidence than the holder believes it supplied.

## Deliberately not included

**Issuance (the issue's part 1).** Nothing in this workspace mints a VWC —
`dtg_credentials::DTGCredential::new_vwc` has no caller anywhere in VTI — so there
is no issuance flow to carry `taskContext` through, and adding one would be
inventing a feature rather than closing this gap. The catalog constructor already
takes `task_context: String` as a required parameter, so the first issuance path
cannot omit it. `taskContext` is OPTIONAL on every other DTG type, so it was not
added to the VMC / VEC / VIC the VTC does mint — that would change the wire shape
of every credential this service issues for no requirement, and the spec's own
note warns against reading such a credential as proof a task completed.

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --all-features --all-targets` — 0 warnings
- `cargo test -p vtc-service --all-features` — pass
- `cargo test -p vta-service --all-features` — pass (rebased onto #1176)

Rebased on current `main` (`42cb978f`). The `semver report` check going red is
expected — no version was edited.