### PR TITLE
chore(deps): trust-tasks 0.17.3, and retire the consent-prompt debt entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8669,9 +8669,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd89e31d13896e945f95674dd36fa7f40607be72434967cfa1fc5954dcc6f5b1"
+checksum = "8b98bc63ee0c95b3d0778aa03264da922cb23cd098326fb7406c8b1bd0fa5550"
 dependencies = [
  "chrono",
  "serde",
@@ -8683,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b72951b407ef3d30fed0572f108ad72ea9ab969c90b0dc269c46e1e44c5738"
+checksum = "b20a9db1b7be64041806c7b17e8be51c9c26122dacd9c5cbd132c5a742e8f0ab"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -8699,9 +8699,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e675e8e84f98701f2c5afb28bf20edc5576fa516bb60c5c38080b1cda48f6a0"
+checksum = "941b8f7370e736e8981f2b67d0f4a47ff0bdd5dad4de0af358cb413710dd78ed"
 dependencies = [
  "axum",
  "chrono",
@@ -8718,9 +8718,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7395dec266796624f255530d5820dd5e1418edf886885f6c9581dc1e634e7bf6"
+checksum = "158491d91a627ff16875f15851c4b9ff08eb38e21427485a838faefe333dc7ba"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8735,9 +8735,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f532daea6f7b98859b06254aa61d0972bb2da85780ea52743eeb4fe3913e3d8"
+checksum = "41d841bf16638473fed22f94ce446cadcc932afc60ca3f623eef184d546d945b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -1008,5 +1008,19 @@ mod envelope_push_tests {
             "SPEC §7.2 item 5b: recipient is REQUIRED, and it is what stops \
              this prompt being replayed at a different approver"
         );
+
+        // And the payload matches the schema we published for it.
+        //
+        // Nothing on this side would otherwise catch a divergence: the prompt
+        // is *produced*, never served, so it never reaches the dispatcher's
+        // `validate_payload`. The party that validates it is the approver's
+        // device — which means a mismatch surfaces as a refused prompt on
+        // someone's phone rather than as a failing build here. That is the
+        // shape of both shipped payload defects this workspace has had
+        // (#895, #919): found by a person, from a rejected request.
+        let schema = trust_tasks_rs::schema_index::schema_for(super::CONSENT_APPROVE_REQUEST_TYPE)
+            .expect("consent/approve-request/0.1 is published");
+        trust_tasks_rs::validate::against_schema(schema, &pushed[0].body["payload"])
+            .expect("the prompt we send validates against the schema we published");
     }
 }

--- a/vta-service/src/trust_tasks/produced_census.rs
+++ b/vta-service/src/trust_tasks/produced_census.rs
@@ -54,15 +54,6 @@ use std::path::{Path, PathBuf};
 /// the only thing this file can buy.
 const PRODUCED_UNPUBLISHED: &[(&str, &str)] = &[
     (
-        "https://trusttasks.org/spec/consent/approve-request/0.1",
-        "The consent prompt pushed to a `wake`-routed approver's device. Now \
-         signed (#1180), so a verifier has something to check; publishing it \
-         with `proof` REQUIRED is what makes that normative rather than this \
-         implementation's local convention. Tracked in #1177 — no fold \
-         target: `consent/request/1.0` is the requester-side task and \
-         `auth/step-up/approve-request/0.2` is a different ceremony.",
-    ),
-    (
         "https://trusttasks.org/spec/vta/attestation/status/1.0",
         "Found by this census on the day it was written, which is the case \
          for having it: REST-routed rather than dispatched, so the served-URI \


### PR DESCRIPTION
**Yes — and VTI was further behind than just the one crate.** Four of the five were two releases back:

| crate | was | now |
|---|---|---|
| `trust-tasks-rs` | 0.17.2 | **0.17.3** |
| `trust-tasks-capability-client` | 0.17.1 | **0.17.3** |
| `trust-tasks-didcomm` | 0.17.1 | **0.17.3** |
| `trust-tasks-https` | 0.17.1 | **0.17.2** |
| `trust-tasks-proof` | 0.17.1 | **0.17.2** |

**No manifest change.** Every requirement is already `"0.17"`, which admits all of these — the drift was purely a stale lockfile, the kind nothing reports until something asks.

### The guard fired, as designed

0.17.3 carries `consent/approve-request/0.1`, published upstream in [dtgwg-trust-tasks-tf#331](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/331). That makes the `PRODUCED_UNPUBLISHED` entry from #1181 stale, and its shrink-only guard said so on the first run after `cargo update`:

```
these have a published spec now and must be removed from PRODUCED_UNPUBLISHED:
  https://trusttasks.org/spec/consent/approve-request/0.1
```

Publishing a spec cannot silently leave debt recorded claiming otherwise. Entry removed; the full cycle — add entry, publish spec, guard fails, remove entry — has now run end to end.

### A new obligation, and a test for it

Publishing the schema creates something that did not exist while there was none: **what we send must match what we published.**

Nothing on this side would catch a divergence. The prompt is *produced*, never served, so it never reaches the dispatcher's `validate_payload` — the party that validates it is the approver's device. A mismatch would therefore surface as a refused prompt on someone's phone, not a failing build. That is precisely the shape of both shipped payload defects this workspace has had (#895, #919): found by a person, from a rejected request in production.

So the wake test now validates the document it builds against the published schema. I confirmed it has teeth by adding a member the schema forbids and watching it fail, rather than trusting that it would.

Closes the last VTI-side item on #1177. `cargo clippy --workspace --all-features --all-targets` → 0; full workspace suite passes.