### PR TITLE
fix(vtc-admin-ui): read the response shapes the daemon actually sends

### DIFF
--- a/vtc-service/admin-ui/src/App.tsx
+++ b/vtc-service/admin-ui/src/App.tsx
@@ -156,7 +156,7 @@ export default function App() {
   // Scope-filtered plugins surface server errors as 403s anyway, but
   // hiding them from the nav keeps the UX coherent.
   const isSuperAdmin =
-    probe.data.role === "admin" && probe.data.allowedContexts.length === 0;
+    probe.data.roles.includes("admin") && probe.data.scopes.length === 0;
   const plugins = allPlugins.filter((p) => {
     if (!p.scopes || p.scopes.length === 0) return true;
     if (p.scopes.includes("super-admin")) return isSuperAdmin;
@@ -281,9 +281,9 @@ function SessionBadge({ whoami }: { whoami: WhoamiResponse }) {
 
   return (
     <div className="session-badge">
-      <div className="session-did" title={whoami.did}>
+      <div className="session-did" title={whoami.session.subject}>
         <span className="session-label">Signed in as</span>
-        <code>{shortenDid(whoami.did)}</code>
+        <code>{shortenDid(whoami.session.subject)}</code>
       </div>
       <button
         type="button"

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -243,13 +243,33 @@ export const fetchDiagnostics = (): Promise<DiagnosticsResponse> =>
     trustTask: DIAGNOSTICS_TASK,
   });
 
+/**
+ * The canonical `Session` shape, as published by the `auth/whoami/0.1`
+ * component. Nested under `session` — #1112 moved the whole payload here
+ * from the flat `{did, role, sessionId, accessExpiresAt, allowedContexts}`
+ * this console used to read.
+ */
+export interface SessionView {
+  id: string;
+  /** The DID this session authenticates — was the top-level `did`. */
+  subject: string;
+  /** RFC3339. The JWT's `iat`. */
+  issuedAt: string;
+  /** RFC3339. Was the epoch-seconds `accessExpiresAt`. */
+  expiresAt: string;
+  /** Authentication methods per RFC 8176. Omitted when the token records none. */
+  amr?: string[];
+  /** Authentication context class per OIDC Core §2. Omitted when unrecorded. */
+  acr?: string;
+}
+
 /** Shape returned by `GET /v1/auth/whoami`. */
 export interface WhoamiResponse {
-  did: string;
-  role: string;
-  sessionId: string;
-  accessExpiresAt: number;
-  allowedContexts: string[];
+  session: SessionView;
+  /** The caller's roles. A single role is one entry — was the scalar `role`. */
+  roles: string[];
+  /** The contexts this session may act in — was `allowedContexts`. */
+  scopes: string[];
 }
 
 const WHOAMI_TASK = "https://trusttasks.org/spec/auth/whoami/0.1";

--- a/vtc-service/admin-ui/src/pages/Login.tsx
+++ b/vtc-service/admin-ui/src/pages/Login.tsx
@@ -68,15 +68,18 @@ export function Login() {
   const signIn = async () => {
     setPhase({ kind: "running" });
     try {
+      // `login/start/0.2` sends the *inner* WebAuthn options — the value that
+      // goes in `navigator.credentials.get({ publicKey: … })` — not
+      // webauthn-rs's `{publicKey: …}` wrapper. #1112 dropped the wrapper.
       const start = await postJson<{
         authId: string;
-        options: { publicKey: JsonPublicKeyOptions };
+        options: JsonPublicKeyOptions;
       }>("/v1/auth/passkey-login/start", undefined, {
         trustTask: TRUST_TASK_START,
       });
 
       const publicKey = decodePublicKeyOptions(
-        start.options.publicKey,
+        start.options,
       ) as PublicKeyCredentialRequestOptions;
 
       const credential = (await navigator.credentials.get({

--- a/vtc-service/admin-ui/src/plugins/acl.tsx
+++ b/vtc-service/admin-ui/src/plugins/acl.tsx
@@ -74,8 +74,17 @@ async function fetchAcl(scope: string | null): Promise<AclListResponse> {
   });
 }
 
+// `acl/grant` answers with `{entry: …}` — the envelope the task publishes,
+// added in #1109. Unwrapped at the seam so callers see a flat entry.
+interface AclEntryEnvelope {
+  entry: AclEntry;
+}
+
 async function createAcl(req: CreateAclRequest): Promise<AclEntry> {
-  return postJson<AclEntry>("/v1/acl", req, { trustTask: TRUST_TASK_GRANT });
+  const body = await postJson<AclEntryEnvelope>("/v1/acl", req, {
+    trustTask: TRUST_TASK_GRANT,
+  });
+  return body.entry;
 }
 
 async function deleteAcl(subject: string): Promise<void> {
@@ -91,7 +100,7 @@ async function patchAclLabel(args: {
   entry: AclEntry;
   label: string;
 }): Promise<AclEntry> {
-  return postJson<AclEntry>(
+  const body = await postJson<AclEntryEnvelope>(
     "/v1/acl",
     {
       entry: {
@@ -105,6 +114,7 @@ async function patchAclLabel(args: {
     },
     { trustTask: TRUST_TASK_GRANT },
   );
+  return body.entry;
 }
 
 // ── Admin invites ────────────────────────────────────────────

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -63,7 +63,7 @@ const QUEUE_LINKS: Record<string, { label: string; to: string }> = {
 
 interface JoinRequestsPage {
   items: unknown[];
-  total_estimate?: number;
+  totalEstimate?: number;
 }
 
 async function fetchPendingCount(): Promise<number> {
@@ -71,7 +71,7 @@ async function fetchPendingCount(): Promise<number> {
     "/v1/join-requests?status=pending&limit=50",
     { trustTask: TRUST_TASK_JOIN_REQUESTS },
   );
-  return page.total_estimate ?? page.items.length;
+  return page.totalEstimate ?? page.items.length;
 }
 
 type Effect = "allow" | "deny" | "refer" | "request_more";

--- a/vtc-service/admin-ui/src/plugins/joinRequests.tsx
+++ b/vtc-service/admin-ui/src/plugins/joinRequests.tsx
@@ -44,12 +44,15 @@ interface JoinRequestRow {
 interface JoinRequestsPage {
   items: JoinRequestRow[];
   nextCursor: string | null;
-  total_estimate?: number;
+  totalEstimate?: number;
 }
 
+// What `join-requests/decide/0.1` actually answers with: the decided
+// request's id and its new status, plus the credentials an approval issued.
+// It does not echo the row back.
 interface DecideResponse {
-  request: JoinRequestRow;
-  member?: unknown;
+  requestId: string;
+  status: JoinStatus;
   vmc?: unknown;
   roleVec?: unknown;
 }
@@ -71,10 +74,18 @@ async function fetchJoinRequests(params: {
   });
 }
 
+// `join-requests/show/0.1` publishes `{request: …}`; the row was returned
+// bare until #1093. Unwrapped here so the detail view reads a flat row.
+interface JoinRequestEnvelope {
+  request: JoinRequestRow;
+}
+
 async function fetchJoinRequest(id: string): Promise<JoinRequestRow> {
-  return getJson<JoinRequestRow>(`/v1/join-requests/${id}`, {
-    trustTask: TRUST_TASK_SHOW,
-  });
+  const body = await getJson<JoinRequestEnvelope>(
+    `/v1/join-requests/${id}`,
+    { trustTask: TRUST_TASK_SHOW },
+  );
+  return body.request;
 }
 
 // One decision endpoint (`decide/0.1`) carries both outcomes as

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -82,7 +82,7 @@ interface MemberRow {
 interface MembersPage {
   items: MemberRow[];
   nextCursor: string | null;
-  total_estimate?: number;
+  totalEstimate?: number;
 }
 
 async function fetchMembers(params: {
@@ -99,10 +99,18 @@ async function fetchMembers(params: {
   });
 }
 
+// `members/show/0.1` publishes `{member: …}`; the row was returned bare until
+// #1093. Unwrapped here so the detail view keeps reading a flat `MemberRow`.
+interface MemberEnvelope {
+  member: MemberRow;
+}
+
 async function fetchMember(did: string): Promise<MemberRow> {
-  return getJson<MemberRow>(`/v1/members/${encodeURIComponent(did)}`, {
-    trustTask: TRUST_TASK_SHOW,
-  });
+  const body = await getJson<MemberEnvelope>(
+    `/v1/members/${encodeURIComponent(did)}`,
+    { trustTask: TRUST_TASK_SHOW },
+  );
+  return body.member;
 }
 
 interface RequestVmcResponse {
@@ -122,9 +130,11 @@ async function requestMemberVmc(did: string): Promise<RequestVmcResponse> {
   );
 }
 
+// As on the sign-in path: `login/start/0.2` sends the inner WebAuthn options,
+// not webauthn-rs's `{publicKey: …}` wrapper (#1112).
 interface StepUpStartResponse {
   authId: string;
-  options: { publicKey: JsonPublicKeyOptions };
+  options: JsonPublicKeyOptions;
 }
 
 /** Elevate this session with a passkey user-verification gesture.
@@ -140,7 +150,7 @@ async function stepUpSession(): Promise<void> {
   );
 
   const publicKey = decodePublicKeyOptions(
-    start.options.publicKey,
+    start.options,
   ) as PublicKeyCredentialRequestOptions;
   const credential = (await navigator.credentials.get({
     publicKey,
@@ -194,10 +204,17 @@ interface RemovedMemberRow {
   status: string;
 }
 
+// `members/removed/0.1` publishes `{removed: […]}`; the handler returned a
+// top-level array until #1082.
+interface RemovedMembersResponse {
+  removed: RemovedMemberRow[];
+}
+
 async function fetchRemovedMembers(): Promise<RemovedMemberRow[]> {
-  return getJson<RemovedMemberRow[]>("/v1/members/removed", {
+  const body = await getJson<RemovedMembersResponse>("/v1/members/removed", {
     trustTask: TRUST_TASK_REMOVED,
   });
+  return body.removed;
 }
 
 async function purgeMember(did: string): Promise<void> {
@@ -443,9 +460,9 @@ function MembersList() {
           >
             Next page <ArrowRight size={12} aria-hidden="true" />
           </button>
-          {query.data?.total_estimate !== undefined && (
+          {query.data?.totalEstimate !== undefined && (
             <span className="muted">
-              ~{query.data.total_estimate} total
+              ~{query.data.totalEstimate} total
             </span>
           )}
         </div>

--- a/vtc-service/admin-ui/src/plugins/sessions.tsx
+++ b/vtc-service/admin-ui/src/plugins/sessions.tsx
@@ -115,8 +115,8 @@ export function Sessions() {
   });
 
   const allSessions = sessionsQuery.data ?? [];
-  const myDid = whoami?.did;
-  const mySessionId = whoami?.sessionId;
+  const myDid = whoami?.session.subject;
+  const mySessionId = whoami?.session.id;
 
   // Filter on substring match against either identifier, then sort.
   // useMemo so revoke-button clicks (which mutate React Query


### PR DESCRIPTION
The console was reading five endpoints at shapes the daemon stopped sending. Reported as a crash on load — `Cannot read properties of undefined (reading 'startsWith')`, which is `shortenDid(whoami.did)` on a `did` that moved. Sweeping the ~35 endpoints the SPA calls against their Rust response types found five more of the same defect, from three earlier PRs in the same conformance programme.

**Two of them were the console's only two ways in.**

| Endpoint | Moved in | Symptom |
|---|---|---|
| `auth/whoami` | #1112 | shell crashes on load (the reported bug) |
| `auth/passkey/login/start/0.2` | #1112 | **passkey sign-in dead** (`Login.tsx`) |
| ″ | ″ | **admin promotion dead** — step-up throws (`members.tsx`) |
| `members/removed` | #1082 | Members page crashes, `rows.map is not a function` |
| `members/show` | #1093 | detail view renders every field blank |
| `join-requests/show` | #1093 | detail blank, **Approve/Reject never appear** |
| `acl/grant` | #1109 | toast reads "Created ACL entry for undefined" |

## Detail

- **`auth/whoami`** went flat → `{session:{id,subject,…},roles,scopes}`. `App.tsx:159` reads `role === "admin"`, which short-circuits to `false` on `undefined` and so hides the failure until `shortenDid` dereferences the DID two components later.
- **`auth/passkey/login/start/0.2`** dropped webauthn-rs's `{publicKey: …}` wrapper for the inner options. `myPasskeys.tsx` moved with it in #1112; `Login.tsx` and `members.tsx` did not, so both `decodePublicKeyOptions` call sites throw.
- **`members/removed`** array → `{removed: […]}`. `RemovedMembers` does `query.data ?? []` then `rows.map`, so the page dies rather than rendering an empty section.
- **`members/show`** / **`join-requests/show`** bare row → `{member: …}` / `{request: …}`. The join-request Approve/Reject block is gated on `status === "pending"`, false on `undefined`.
- **`acl/grant`** → `{entry: …}`.

Each envelope is unwrapped at the fetch seam, leaving the rendering code reading a flat row — the shape `profile.tsx` already uses, which is the one consumer that moved correctly (#1094). Every changed interface carries a comment naming the PR that moved the wire.

Two stale types with no runtime effect are corrected in passing: `DecideResponse` described `{request, member, vmc, roleVec}` where `decide/0.1` answers `{requestId, status, vmc?, roleVec?}` (the call sites only invalidate, so nothing read it), and three `total_estimate` fields left snake_case after #1078 recased the pagination wrapper to `totalEstimate`.

## Swept and clean

So the next reader need not repeat it: audit, ACL list, admin invites, admin passkeys, community profile, members list, join-requests list, policies (list/active/upsert/test), diagnostics, invitations, relationships graph, recognition check, ceremonies, the install claim ceremony (`ClaimStartResponse` still types webauthn-rs's `CreationChallengeResponse`, so its `{publicKey: …}` is correct), the wallet SIOP login, `plugins.json` and build-info. Every request body matched too, including the four `deny_unknown_fields` ones — this defect class is response-shaped.

## Why nothing caught it

`tsc` checks the SPA against its own hand-written interfaces, so a stale interface typechecks, builds and ships; the response-conformance witness checks the daemon. Nothing checks the pair, which is how four consecutive breaking response PRs each left the console a little more broken behind entirely green gates.

#1093's own message says "every in-repo consumer moves with them in this PR" — it moved the three diagnostics consumers and left the two `show` routes. That is not carelessness so much as the absence of a signal: there is no way to be told.

Generating these types from the OpenAPI document the service already emits would close it. Until then a `vtc-service` response change wants a grep of `admin-ui/src` for the path. Happy to open a follow-up issue for the codegen if that's wanted.

## Gates

`npx tsc --noEmit`, `npm run lint`, `npm run build` in `vtc-service/admin-ui`. No Rust touched.

Refs #1059
