### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6314,7 +6314,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9242,7 +9242,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "tokio",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9284,7 +9284,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9309,7 +9309,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9342,7 +9342,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9375,7 +9375,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "vti-common",
 ]
@@ -9426,7 +9426,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "multibase",
@@ -9446,7 +9446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.31.1"
+version = "0.32.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9510,7 +9510,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -9613,7 +9613,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -9633,7 +9633,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9649,7 +9649,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes 0.9.2",
  "aes-gcm 0.11.1",
@@ -9683,7 +9683,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9717,7 +9717,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9738,7 +9738,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "reqwest",
@@ -9837,7 +9837,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -9912,7 +9912,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.0...cnm-cli-v0.13.1) — 2026-08-29
+
+
 ## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.12.2...cnm-cli-v0.13.0) — 2026-08-28
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.12", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }
@@ -26,7 +26,7 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 # SLIP-0010 key derivation (`vti_common::slip10`) — the harness re-derives the
 # same keys the VTA does, from the same seed and paths.
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 
 [lints]
 workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.0...pnm-cli-v0.14.1) — 2026-08-29
+
+
 ## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.13.2...pnm-cli-v0.14.0) — 2026-08-28
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.0...vta-audit-v0.3.1) — 2026-08-29
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.2.0...vta-audit-v0.3.0) — 2026-08-28
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,8 +20,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15" }
-vta-sdk = { path = "../vta-sdk", version = "0.31" }
+vti-common = { path = "../vti-common", version = "0.16" }
+vta-sdk = { path = "../vta-sdk", version = "0.32" }
 async-trait = "0.1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.0...vta-backup-v0.3.1) — 2026-08-29
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.2.0...vta-backup-v0.3.0) — 2026-08-28
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,12 +27,12 @@ webvh = ["vta-keyspaces/webvh"]
 tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 # Nonce and bundle-id generation. Was reached through `aes_gcm::aead::OsRng`,
 # a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
 # own and was borrowing one from its cipher.
 rand = { workspace = true }
-vta-sdk = { path = "../vta-sdk", version = "0.31" }
+vta-sdk = { path = "../vta-sdk", version = "0.32" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.4" }
 vta-config = { path = "../vta-config", version = "0.4" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.0...vta-cli-common-v0.12.1) — 2026-08-29
+
+
 ## [0.12.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.11.5...vta-cli-common-v0.12.0) — 2026-08-28
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,13 +18,13 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.0...vta-config-v0.4.1) — 2026-08-29
+
+
 ## [0.4.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.3.13...vta-config-v0.4.0) — 2026-08-28
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,11 +26,11 @@ default = []
 tee = []
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.31", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.32", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,8 +34,8 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.22", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.15", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.23", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build
 # links no overlay code.

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.0...vta-keys-v0.4.1) — 2026-08-29
+
+
 ## [0.4.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.3.0...vta-keys-v0.4.0) — 2026-08-28
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -36,9 +36,9 @@ tee = ["vti-secrets/tee"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4" }
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.2...vta-keyspaces-v0.2.3) — 2026-08-29
+
+
 ## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.1...vta-keyspaces-v0.2.2) — 2026-08-28
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,4 +26,4 @@ webvh = []
 
 [dependencies]
 # For `KeyspaceHandle` in the shared `Keyspaces` handle bundle.
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.0...vta-policy-v0.3.1) — 2026-08-29
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.2.12...vta-policy-v0.3.0) — 2026-08-28
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,12 +20,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 vta-config = { path = "../vta-config", version = "0.4" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.31", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.32", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,162 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.32.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.31.1...vta-sdk-v0.32.0) — 2026-08-29
+
+
+### Added
+
+- **sdk**: Any DID that names a key may sign a Trust Task ([#1193](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1193))
+
+A Trust Task proof could only be made by a `did:key`. That was never a policy
+  anyone chose — it was the shape of two helpers, and it meant a provisioned
+  integration could not dispatch any of the 210 proof-requiring Trust Tasks, over
+  any transport, because every DID this workspace provisions is a `did:webvh`.
+
+  The rule is now the obvious one: **any DID that can name a key may sign**. The
+  DID method is not the authorization; resolving the verification method and
+  checking the signature is. `did:key:z6Mk…#z6Mk…`,
+  `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are
+  all ordinary holders.
+
+  What actually stood in the way:
+
+  The signer took `(holder_did, private_key)` and *derived* the verification
+  method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose
+  key is its identifier — a `did:webvh` document decides what its keys are
+  called, so nothing can guess `#key-0`. A signer that takes only a DID
+  structurally cannot serve any other method. `HolderKey` now carries the
+  verification method; `HolderKey::from_did_key` keeps the derivation for the one
+  method that has one, and refuses to invent one for the others.
+
+  The verifier used `DidKeyResolver`, which refuses everything else.
+  `TrustTaskVmResolver` resolves `did:key` locally and any other method through
+  the configured DID cache, matching a proof's absolute `verificationMethod`
+  against a document that may name it relatively. It is hoisted from the
+  equivalent the VTC already had for credential verification.
+
+  `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}`
+  build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id`
+  *is* the verification method the DID document publishes, so nothing is guessed.
+  Those constructors passed `identity: None` deliberately; that reason is gone.
+
+  Every verifying call site now takes a resolver: the VTA's dispatch spine, REST
+  login, step-up and consent; the VTC's dispatch, REST login and relationships.
+  Threading it is the half that makes the signer change real.
+
+- **device**: Let a device correct its display name on the heartbeat ([#1191](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1191))
+
+`displayName` was written exactly once, at registration, and nothing in the
+  device family could change it. `device/register` is intentionally not
+  idempotent — a binding hangs off the caller's ACL entry, one per DID, and a
+  second claim is refused with `device/register:alreadyRegistered` — so a
+  renamed machine, or an install moved to another profile, kept announcing a
+  name that no longer identified it. The spec is explicit that `displayName`
+  exists "to help a human pick their own laptop out of a list", which is the
+  thing that degrades.
+
+  Heartbeat is where the spec already puts metadata drift: `platform` is
+  defined there as "updated platform descriptor if it changed since
+  registration". `ext` is the slot it provides for the rest, so a device now
+  sends `org.openvtc.device-name: { displayName }` and the VTA applies it.
+
+  Nothing about the register refusal moves. The binding, its `deviceId` and
+  its `registeredAt` are untouched, no new binding can be claimed this way,
+  and the entry `version` does not bump: a rename is metadata, and the spec
+  forbids `displayName` being used as a security input by anything that
+  renders it, so no policy decision can turn on it. The entry is fetched by
+  `auth.did`, so a device can only correct the binding it authenticated as.
+
+  A malformed extension is **ignored, not rejected**. A heartbeat's real job
+  is refreshing `lastSeenAt`, and failing the call over a bad name would make
+  a device with a client-side bug look offline — the more expensive error,
+  because it is the one that sends an operator after a machine that is running
+  fine. The 1..=128 bound the untyped `ext` slot cannot inherit from the
+  register schema is enforced here instead.
+
+  The extension key is defined once, in the SDK that produces it, and imported
+  by the service that honours it — the two sides otherwise agree by string,
+  and a typo on either would be a rename that silently never happens.
+
+  `device_heartbeat_named` is a new method rather than a wider
+  `device_heartbeat`: this crate is consumed across repositories, and
+  widening a public signature would spend a breaking release on a diagnostic
+  field. The new `ext` member on `DeviceHeartbeatBody` is still a public-field
+  addition, so this is a **minor** for `vta-sdk`, not a patch — nothing in the
+  workspace or in OpenVTC constructs that struct, but the semver report will
+  name it and the release should follow it.
+
+  A VTA that does not understand the extension ignores it (SPEC §4.5.1): the
+  heartbeat still refreshes liveness and the name stays as it was.
+
+
+
+### Fixed
+
+- **sdk**: Stop rewriting the envelope a Trust Task proof covers ([#1192](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1192))
+
+An operator running `pnm contexts create` against a production VTA got:
+
+      Protocol error: trust task failed [proofRequired]: proof required but
+      not present
+
+  That is `SpecPolicy::enforce` on the VTA's dispatch spine refusing a document
+  whose specification declares `proof` REQUIRED (SPEC §7.2 item 7a).
+
+  The cause is the one #1184 fixed: `didcomm_transport` and `tsp_transport` built
+  every client with `identity: None`, so `build_task_document` set no `issuer` or
+  `recipient` and `signed_task_document` attached no proof. What is new here is
+  why it reported itself as `proofRequired` rather than the `malformedRequest:
+  … no in-band recipient` #1184's changelog describes. `address_trust_task`
+  back-fills both members on the TSP paths, which satisfies item 5b — so a TSP
+  document sails past the recipient check and lands on the proof check instead.
+  Same defect, two names, depending on transport.
+
+  It is released in vta-sdk 0.31.1; pnm-cli 0.14.0 was cut against 0.31.0 and has
+  not been re-released, so an installed binary still carries it. Rebuilding, or
+  `--transport rest`, is the operator's way out.
+
+  Three things this changes.
+
+  `address_trust_task` no longer assigns `issuer` and `recipient`
+  unconditionally. A Data-Integrity proof covers every member but `proof`, so
+  writing either one *after* signing turns a valid signature into `proofInvalid`
+  at the far end — a failure that names the proof and says nothing about the
+  rewrite that caused it. The values come from the same triple the identity was
+  built from, so the assignment was a no-op; "it happens to be equal" is not
+  something the next constructor has to keep true, and nothing was checking. It
+  now fills only an absent member and refuses a disagreement, since neither
+  answer is safe: honouring the transport breaks the proof, honouring the
+  document sends it somewhere the caller did not ask for.
+
+  A new test builds the document the SDK actually sends and runs it through
+  `schema_index::spec_policy_for(uri).enforce(..)` — the same call the VTA makes.
+  The existing tests checked `issuer`, `recipient` and `proof` by name and
+  passed, because they were written from the same understanding as the code.
+  Asserting against the registry means a new flag starts being checked without
+  the test being edited. It covers a mutation and a read deliberately: the proof
+  flag falls almost exactly along that line, so a client that only ever listed
+  saw nothing wrong.
+
+  The rationale on `signed_task_document` said "72 of the 109" specs require a
+  proof. It is 210 of 344 in trust-tasks-rs 0.17 — and the number that actually
+  justifies the hard error is `recipient`, which 343 of 344 require.
+
+  `docs/05-design-notes/trust-task-envelope-conformance.md` records the
+  diagnosis and the two instances of the same root cause still live on main: a
+  `did:webvh` bundle holder cannot sign at all, because `trust_task_sign` refuses
+  a non-`did:key` holder — so a provisioned integration cannot dispatch any of
+  the 210 proof-requiring tasks; and `VtaClient::new` + `set_token_async` carries
+  no identity, which is the documented `url + token` rung of the `AgentConnect`
+  ladder. Neither is fixed here: the first needs a decision about how a
+  `did:webvh` integration signs.
+
+  Verified with `cargo fmt --all --check`, `cargo check --workspace
+  --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, and
+  `cargo test -p vta-sdk` (298 passing).
+
+
+
 ## [0.31.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.31.0...vta-sdk-v0.31.1) — 2026-08-28
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.31.1"
+version = "0.32.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,96 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.23.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.22.0...vta-service-v0.23.0) — 2026-08-29
+
+
+### Added
+
+- **sdk**: Any DID that names a key may sign a Trust Task ([#1193](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1193))
+
+A Trust Task proof could only be made by a `did:key`. That was never a policy
+  anyone chose — it was the shape of two helpers, and it meant a provisioned
+  integration could not dispatch any of the 210 proof-requiring Trust Tasks, over
+  any transport, because every DID this workspace provisions is a `did:webvh`.
+
+  The rule is now the obvious one: **any DID that can name a key may sign**. The
+  DID method is not the authorization; resolving the verification method and
+  checking the signature is. `did:key:z6Mk…#z6Mk…`,
+  `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are
+  all ordinary holders.
+
+  What actually stood in the way:
+
+  The signer took `(holder_did, private_key)` and *derived* the verification
+  method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose
+  key is its identifier — a `did:webvh` document decides what its keys are
+  called, so nothing can guess `#key-0`. A signer that takes only a DID
+  structurally cannot serve any other method. `HolderKey` now carries the
+  verification method; `HolderKey::from_did_key` keeps the derivation for the one
+  method that has one, and refuses to invent one for the others.
+
+  The verifier used `DidKeyResolver`, which refuses everything else.
+  `TrustTaskVmResolver` resolves `did:key` locally and any other method through
+  the configured DID cache, matching a proof's absolute `verificationMethod`
+  against a document that may name it relatively. It is hoisted from the
+  equivalent the VTC already had for credential verification.
+
+  `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}`
+  build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id`
+  *is* the verification method the DID document publishes, so nothing is guessed.
+  Those constructors passed `identity: None` deliberately; that reason is gone.
+
+  Every verifying call site now takes a resolver: the VTA's dispatch spine, REST
+  login, step-up and consent; the VTC's dispatch, REST login and relationships.
+  Threading it is the half that makes the signer change real.
+
+- **device**: Let a device correct its display name on the heartbeat ([#1191](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1191))
+
+`displayName` was written exactly once, at registration, and nothing in the
+  device family could change it. `device/register` is intentionally not
+  idempotent — a binding hangs off the caller's ACL entry, one per DID, and a
+  second claim is refused with `device/register:alreadyRegistered` — so a
+  renamed machine, or an install moved to another profile, kept announcing a
+  name that no longer identified it. The spec is explicit that `displayName`
+  exists "to help a human pick their own laptop out of a list", which is the
+  thing that degrades.
+
+  Heartbeat is where the spec already puts metadata drift: `platform` is
+  defined there as "updated platform descriptor if it changed since
+  registration". `ext` is the slot it provides for the rest, so a device now
+  sends `org.openvtc.device-name: { displayName }` and the VTA applies it.
+
+  Nothing about the register refusal moves. The binding, its `deviceId` and
+  its `registeredAt` are untouched, no new binding can be claimed this way,
+  and the entry `version` does not bump: a rename is metadata, and the spec
+  forbids `displayName` being used as a security input by anything that
+  renders it, so no policy decision can turn on it. The entry is fetched by
+  `auth.did`, so a device can only correct the binding it authenticated as.
+
+  A malformed extension is **ignored, not rejected**. A heartbeat's real job
+  is refreshing `lastSeenAt`, and failing the call over a bad name would make
+  a device with a client-side bug look offline — the more expensive error,
+  because it is the one that sends an operator after a machine that is running
+  fine. The 1..=128 bound the untyped `ext` slot cannot inherit from the
+  register schema is enforced here instead.
+
+  The extension key is defined once, in the SDK that produces it, and imported
+  by the service that honours it — the two sides otherwise agree by string,
+  and a typo on either would be a rename that silently never happens.
+
+  `device_heartbeat_named` is a new method rather than a wider
+  `device_heartbeat`: this crate is consumed across repositories, and
+  widening a public signature would spend a breaking release on a diagnostic
+  field. The new `ext` member on `DeviceHeartbeatBody` is still a public-field
+  addition, so this is a **minor** for `vta-sdk`, not a patch — nothing in the
+  workspace or in OpenVTC constructs that struct, but the semver report will
+  name it and the release should follow it.
+
+  A VTA that does not understand the extension ignores it (SPEC §4.5.1): the
+  heartbeat still refreshes liveness and the name stays as it was.
+
+
+
 ## [0.22.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.21.0...vta-service-v0.22.0) — 2026-08-28
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -139,7 +139,7 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.16", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
@@ -179,7 +179,7 @@ vta-policy = { path = "../vta-policy", version = "0.3" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.2", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -375,7 +375,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.0...vta-support-v0.3.1) — 2026-08-29
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.2.12...vta-support-v0.3.0) — 2026-08-28
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -29,8 +29,8 @@ vta-config = { path = "../vta-config", version = "0.4" }
 # verifies each crate in isolation, where nothing enables it, so the method
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
-vti-common = { path = "../vti-common", version = "0.15", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.1...vta-sweepers-v0.3.2) — 2026-08-29
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.0...vta-sweepers-v0.3.1) — 2026-08-28
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 vta-audit = { path = "../vta-audit", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-vault = { path = "../vta-vault", version = "0.5" }

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.0...vta-tee-v0.2.1) — 2026-08-29
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.1.10...vta-tee-v0.2.0) — 2026-08-28
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,7 +27,7 @@ repository.workspace = true
 tenant-overlay = ["dep:tokio-vsock"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15", features = ["encryption", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.16", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4", features = ["tee"] }
 vta-keys = { path = "../vta-keys", version = "0.4" }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.0...vta-vault-v0.5.1) — 2026-08-29
+
+
 ## [0.5.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.4.0...vta-vault-v0.5.0) — 2026-08-28
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -33,8 +33,8 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.15", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["didcomm", "sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.0...vta-webvh-v0.2.1) — 2026-08-29
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.1.14...vta-webvh-v0.2.0) — 2026-08-28
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,8 +21,8 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.15" }
-vta-sdk = { path = "../vta-sdk", version = "0.31" }
+vti-common = { path = "../vti-common", version = "0.16" }
+vta-sdk = { path = "../vta-sdk", version = "0.32" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.0...vtc-client-v0.5.1) — 2026-08-29
+
+
 ## [0.5.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.4.0...vtc-client-v0.5.0) — 2026-08-28
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -14,7 +14,7 @@ repository.workspace = true
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session"] }
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -117,7 +117,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15", features = [
+vti-common = { path = "../vti-common", version = "0.16", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
@@ -134,7 +134,7 @@ vti-common = { path = "../vti-common", version = "0.15", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,77 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.15.0...vti-common-v0.16.0) — 2026-08-29
+
+
+### Added
+
+- **sdk**: Any DID that names a key may sign a Trust Task ([#1193](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1193))
+
+A Trust Task proof could only be made by a `did:key`. That was never a policy
+  anyone chose — it was the shape of two helpers, and it meant a provisioned
+  integration could not dispatch any of the 210 proof-requiring Trust Tasks, over
+  any transport, because every DID this workspace provisions is a `did:webvh`.
+
+  The rule is now the obvious one: **any DID that can name a key may sign**. The
+  DID method is not the authorization; resolving the verification method and
+  checking the signature is. `did:key:z6Mk…#z6Mk…`,
+  `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are
+  all ordinary holders.
+
+  What actually stood in the way:
+
+  The signer took `(holder_did, private_key)` and *derived* the verification
+  method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose
+  key is its identifier — a `did:webvh` document decides what its keys are
+  called, so nothing can guess `#key-0`. A signer that takes only a DID
+  structurally cannot serve any other method. `HolderKey` now carries the
+  verification method; `HolderKey::from_did_key` keeps the derivation for the one
+  method that has one, and refuses to invent one for the others.
+
+  The verifier used `DidKeyResolver`, which refuses everything else.
+  `TrustTaskVmResolver` resolves `did:key` locally and any other method through
+  the configured DID cache, matching a proof's absolute `verificationMethod`
+  against a document that may name it relatively. It is hoisted from the
+  equivalent the VTC already had for credential verification.
+
+  `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}`
+  build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id`
+  *is* the verification method the DID document publishes, so nothing is guessed.
+  Those constructors passed `identity: None` deliberately; that reason is gone.
+
+  Every verifying call site now takes a resolver: the VTA's dispatch spine, REST
+  login, step-up and consent; the VTC's dispatch, REST login and relationships.
+  Threading it is the half that makes the signer change real.
+
+
+
+### Fixed
+
+- **vti-common**: Gate the keyspace name on the feature that reads it ([#1190](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1190))
+
+`cargo build -p pnm-cli` (and every other default-feature consumer) warned
+  `field `name` is never read` on `LocalKeyspaceHandle`. The field is not
+  unused — it is the keyspace name bound into the AES-GCM associated data, so
+  a value cannot be relocated to another keyspace that shares the storage key
+  and still authenticate. But every read of it builds an AAD, and all of them
+  sit behind `#[cfg(feature = "encryption")]`, which is off by default. With
+  the feature off there is genuinely nothing to read it.
+
+  So it is now gated with the feature it serves, exactly as the sibling
+  `encryption_key` field already is, and cfg'd at its one construction site.
+  The alternative — carrying it unconditionally under an `allow(dead_code)` —
+  would leave a security-relevant field looking like it might be doing
+  something in builds where it cannot.
+
+  No behaviour change in either configuration: with `encryption` on the field
+  and its readers are unchanged; with it off nothing referenced the field.
+  Verified warning-free on `cargo build --release -p pnm-cli` (defaults and
+  `config-session`), `cargo check -p vti-common --all-features --all-targets`,
+  and `cargo test -p vti-common --all-features` (476 passing).
+
+
+
 ## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.14.0...vti-common-v0.15.0) — 2026-08-28
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.31", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.32", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.0...vti-secrets-v0.3.1) — 2026-08-29
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.2.2...vti-secrets-v0.3.0) — 2026-08-28
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,14 +47,14 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.15" }
+vti-common = { path = "../vti-common", version = "0.16" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.31", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.31.1 -> 0.32.0 (✓ API compatible changes)
* `vti-common`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `cnm-cli`: 0.13.0 -> 0.13.1
* `pnm-cli`: 0.14.0 -> 0.14.1
* `vta-service`: 0.22.0 -> 0.23.0 (✓ API compatible changes)
* `vta-cli-common`: 0.12.0 -> 0.12.1
* `vta-audit`: 0.3.0 -> 0.3.1
* `vti-secrets`: 0.3.0 -> 0.3.1
* `vta-config`: 0.4.0 -> 0.4.1
* `vta-keyspaces`: 0.2.2 -> 0.2.3
* `vta-keys`: 0.4.0 -> 0.4.1
* `vta-support`: 0.3.0 -> 0.3.1
* `vta-backup`: 0.3.0 -> 0.3.1
* `vta-policy`: 0.3.0 -> 0.3.1
* `vta-vault`: 0.5.0 -> 0.5.1
* `vta-sweepers`: 0.3.1 -> 0.3.2
* `vta-tee`: 0.2.0 -> 0.2.1
* `vta-webvh`: 0.2.0 -> 0.2.1
* `vtc-client`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.32.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.31.1...vta-sdk-v0.32.0) — 2026-08-29

### Added

- **sdk**: Any DID that names a key may sign a Trust Task ([#1193](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1193))

A Trust Task proof could only be made by a `did:key`. That was never a policy
  anyone chose — it was the shape of two helpers, and it meant a provisioned
  integration could not dispatch any of the 210 proof-requiring Trust Tasks, over
  any transport, because every DID this workspace provisions is a `did:webvh`.

  The rule is now the obvious one: **any DID that can name a key may sign**. The
  DID method is not the authorization; resolving the verification method and
  checking the signature is. `did:key:z6Mk…#z6Mk…`,
  `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are
  all ordinary holders.

  What actually stood in the way:

  The signer took `(holder_did, private_key)` and *derived* the verification
  method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose
  key is its identifier — a `did:webvh` document decides what its keys are
  called, so nothing can guess `#key-0`. A signer that takes only a DID
  structurally cannot serve any other method. `HolderKey` now carries the
  verification method; `HolderKey::from_did_key` keeps the derivation for the one
  method that has one, and refuses to invent one for the others.

  The verifier used `DidKeyResolver`, which refuses everything else.
  `TrustTaskVmResolver` resolves `did:key` locally and any other method through
  the configured DID cache, matching a proof's absolute `verificationMethod`
  against a document that may name it relatively. It is hoisted from the
  equivalent the VTC already had for credential verification.

  `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}`
  build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id`
  *is* the verification method the DID document publishes, so nothing is guessed.
  Those constructors passed `identity: None` deliberately; that reason is gone.

  Every verifying call site now takes a resolver: the VTA's dispatch spine, REST
  login, step-up and consent; the VTC's dispatch, REST login and relationships.
  Threading it is the half that makes the signer change real.

- **device**: Let a device correct its display name on the heartbeat ([#1191](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1191))

`displayName` was written exactly once, at registration, and nothing in the
  device family could change it. `device/register` is intentionally not
  idempotent — a binding hangs off the caller's ACL entry, one per DID, and a
  second claim is refused with `device/register:alreadyRegistered` — so a
  renamed machine, or an install moved to another profile, kept announcing a
  name that no longer identified it. The spec is explicit that `displayName`
  exists "to help a human pick their own laptop out of a list", which is the
  thing that degrades.

  Heartbeat is where the spec already puts metadata drift: `platform` is
  defined there as "updated platform descriptor if it changed since
  registration". `ext` is the slot it provides for the rest, so a device now
  sends `org.openvtc.device-name: { displayName }` and the VTA applies it.

  Nothing about the register refusal moves. The binding, its `deviceId` and
  its `registeredAt` are untouched, no new binding can be claimed this way,
  and the entry `version` does not bump: a rename is metadata, and the spec
  forbids `displayName` being used as a security input by anything that
  renders it, so no policy decision can turn on it. The entry is fetched by
  `auth.did`, so a device can only correct the binding it authenticated as.

  A malformed extension is **ignored, not rejected**. A heartbeat's real job
  is refreshing `lastSeenAt`, and failing the call over a bad name would make
  a device with a client-side bug look offline — the more expensive error,
  because it is the one that sends an operator after a machine that is running
  fine. The 1..=128 bound the untyped `ext` slot cannot inherit from the
  register schema is enforced here instead.

  The extension key is defined once, in the SDK that produces it, and imported
  by the service that honours it — the two sides otherwise agree by string,
  and a typo on either would be a rename that silently never happens.

  `device_heartbeat_named` is a new method rather than a wider
  `device_heartbeat`: this crate is consumed across repositories, and
  widening a public signature would spend a breaking release on a diagnostic
  field. The new `ext` member on `DeviceHeartbeatBody` is still a public-field
  addition, so this is a **minor** for `vta-sdk`, not a patch — nothing in the
  workspace or in OpenVTC constructs that struct, but the semver report will
  name it and the release should follow it.

  A VTA that does not understand the extension ignores it (SPEC §4.5.1): the
  heartbeat still refreshes liveness and the name stays as it was.



### Fixed

- **sdk**: Stop rewriting the envelope a Trust Task proof covers ([#1192](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1192))

An operator running `pnm contexts create` against a production VTA got:

      Protocol error: trust task failed [proofRequired]: proof required but
      not present

  That is `SpecPolicy::enforce` on the VTA's dispatch spine refusing a document
  whose specification declares `proof` REQUIRED (SPEC §7.2 item 7a).

  The cause is the one #1184 fixed: `didcomm_transport` and `tsp_transport` built
  every client with `identity: None`, so `build_task_document` set no `issuer` or
  `recipient` and `signed_task_document` attached no proof. What is new here is
  why it reported itself as `proofRequired` rather than the `malformedRequest:
  … no in-band recipient` #1184's changelog describes. `address_trust_task`
  back-fills both members on the TSP paths, which satisfies item 5b — so a TSP
  document sails past the recipient check and lands on the proof check instead.
  Same defect, two names, depending on transport.

  It is released in vta-sdk 0.31.1; pnm-cli 0.14.0 was cut against 0.31.0 and has
  not been re-released, so an installed binary still carries it. Rebuilding, or
  `--transport rest`, is the operator's way out.

  Three things this changes.

  `address_trust_task` no longer assigns `issuer` and `recipient`
  unconditionally. A Data-Integrity proof covers every member but `proof`, so
  writing either one *after* signing turns a valid signature into `proofInvalid`
  at the far end — a failure that names the proof and says nothing about the
  rewrite that caused it. The values come from the same triple the identity was
  built from, so the assignment was a no-op; "it happens to be equal" is not
  something the next constructor has to keep true, and nothing was checking. It
  now fills only an absent member and refuses a disagreement, since neither
  answer is safe: honouring the transport breaks the proof, honouring the
  document sends it somewhere the caller did not ask for.

  A new test builds the document the SDK actually sends and runs it through
  `schema_index::spec_policy_for(uri).enforce(..)` — the same call the VTA makes.
  The existing tests checked `issuer`, `recipient` and `proof` by name and
  passed, because they were written from the same understanding as the code.
  Asserting against the registry means a new flag starts being checked without
  the test being edited. It covers a mutation and a read deliberately: the proof
  flag falls almost exactly along that line, so a client that only ever listed
  saw nothing wrong.

  The rationale on `signed_task_document` said "72 of the 109" specs require a
  proof. It is 210 of 344 in trust-tasks-rs 0.17 — and the number that actually
  justifies the hard error is `recipient`, which 343 of 344 require.

  `docs/05-design-notes/trust-task-envelope-conformance.md` records the
  diagnosis and the two instances of the same root cause still live on main: a
  `did:webvh` bundle holder cannot sign at all, because `trust_task_sign` refuses
  a non-`did:key` holder — so a provisioned integration cannot dispatch any of
  the 210 proof-requiring tasks; and `VtaClient::new` + `set_token_async` carries
  no identity, which is the documented `url + token` rung of the `AgentConnect`
  ladder. Neither is fixed here: the first needs a decision about how a
  `did:webvh` integration signs.

  Verified with `cargo fmt --all --check`, `cargo check --workspace
  --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, and
  `cargo test -p vta-sdk` (298 passing).
</blockquote>

## `vti-common`

<blockquote>

## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.15.0...vti-common-v0.16.0) — 2026-08-29

### Added

- **sdk**: Any DID that names a key may sign a Trust Task ([#1193](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1193))

A Trust Task proof could only be made by a `did:key`. That was never a policy
  anyone chose — it was the shape of two helpers, and it meant a provisioned
  integration could not dispatch any of the 210 proof-requiring Trust Tasks, over
  any transport, because every DID this workspace provisions is a `did:webvh`.

  The rule is now the obvious one: **any DID that can name a key may sign**. The
  DID method is not the authorization; resolving the verification method and
  checking the signature is. `did:key:z6Mk…#z6Mk…`,
  `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are
  all ordinary holders.

  What actually stood in the way:

  The signer took `(holder_did, private_key)` and *derived* the verification
  method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose
  key is its identifier — a `did:webvh` document decides what its keys are
  called, so nothing can guess `#key-0`. A signer that takes only a DID
  structurally cannot serve any other method. `HolderKey` now carries the
  verification method; `HolderKey::from_did_key` keeps the derivation for the one
  method that has one, and refuses to invent one for the others.

  The verifier used `DidKeyResolver`, which refuses everything else.
  `TrustTaskVmResolver` resolves `did:key` locally and any other method through
  the configured DID cache, matching a proof's absolute `verificationMethod`
  against a document that may name it relatively. It is hoisted from the
  equivalent the VTC already had for credential verification.

  `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}`
  build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id`
  *is* the verification method the DID document publishes, so nothing is guessed.
  Those constructors passed `identity: None` deliberately; that reason is gone.

  Every verifying call site now takes a resolver: the VTA's dispatch spine, REST
  login, step-up and consent; the VTC's dispatch, REST login and relationships.
  Threading it is the half that makes the signer change real.



### Fixed

- **vti-common**: Gate the keyspace name on the feature that reads it ([#1190](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1190))

`cargo build -p pnm-cli` (and every other default-feature consumer) warned
  `field `name` is never read` on `LocalKeyspaceHandle`. The field is not
  unused — it is the keyspace name bound into the AES-GCM associated data, so
  a value cannot be relocated to another keyspace that shares the storage key
  and still authenticate. But every read of it builds an AAD, and all of them
  sit behind `#[cfg(feature = "encryption")]`, which is off by default. With
  the feature off there is genuinely nothing to read it.

  So it is now gated with the feature it serves, exactly as the sibling
  `encryption_key` field already is, and cfg'd at its one construction site.
  The alternative — carrying it unconditionally under an `allow(dead_code)` —
  would leave a security-relevant field looking like it might be doing
  something in builds where it cannot.

  No behaviour change in either configuration: with `encryption` on the field
  and its readers are unchanged; with it off nothing referenced the field.
  Verified warning-free on `cargo build --release -p pnm-cli` (defaults and
  `config-session`), `cargo check -p vti-common --all-features --all-targets`,
  and `cargo test -p vti-common --all-features` (476 passing).
</blockquote>



## `vta-service`

<blockquote>

## [0.23.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.22.0...vta-service-v0.23.0) — 2026-08-29

### Added

- **sdk**: Any DID that names a key may sign a Trust Task ([#1193](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1193))

A Trust Task proof could only be made by a `did:key`. That was never a policy
  anyone chose — it was the shape of two helpers, and it meant a provisioned
  integration could not dispatch any of the 210 proof-requiring Trust Tasks, over
  any transport, because every DID this workspace provisions is a `did:webvh`.

  The rule is now the obvious one: **any DID that can name a key may sign**. The
  DID method is not the authorization; resolving the verification method and
  checking the signature is. `did:key:z6Mk…#z6Mk…`,
  `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are
  all ordinary holders.

  What actually stood in the way:

  The signer took `(holder_did, private_key)` and *derived* the verification
  method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose
  key is its identifier — a `did:webvh` document decides what its keys are
  called, so nothing can guess `#key-0`. A signer that takes only a DID
  structurally cannot serve any other method. `HolderKey` now carries the
  verification method; `HolderKey::from_did_key` keeps the derivation for the one
  method that has one, and refuses to invent one for the others.

  The verifier used `DidKeyResolver`, which refuses everything else.
  `TrustTaskVmResolver` resolves `did:key` locally and any other method through
  the configured DID cache, matching a proof's absolute `verificationMethod`
  against a document that may name it relatively. It is hoisted from the
  equivalent the VTC already had for credential verification.

  `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}`
  build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id`
  *is* the verification method the DID document publishes, so nothing is guessed.
  Those constructors passed `identity: None` deliberately; that reason is gone.

  Every verifying call site now takes a resolver: the VTA's dispatch spine, REST
  login, step-up and consent; the VTC's dispatch, REST login and relationships.
  Threading it is the half that makes the signer change real.

- **device**: Let a device correct its display name on the heartbeat ([#1191](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1191))

`displayName` was written exactly once, at registration, and nothing in the
  device family could change it. `device/register` is intentionally not
  idempotent — a binding hangs off the caller's ACL entry, one per DID, and a
  second claim is refused with `device/register:alreadyRegistered` — so a
  renamed machine, or an install moved to another profile, kept announcing a
  name that no longer identified it. The spec is explicit that `displayName`
  exists "to help a human pick their own laptop out of a list", which is the
  thing that degrades.

  Heartbeat is where the spec already puts metadata drift: `platform` is
  defined there as "updated platform descriptor if it changed since
  registration". `ext` is the slot it provides for the rest, so a device now
  sends `org.openvtc.device-name: { displayName }` and the VTA applies it.

  Nothing about the register refusal moves. The binding, its `deviceId` and
  its `registeredAt` are untouched, no new binding can be claimed this way,
  and the entry `version` does not bump: a rename is metadata, and the spec
  forbids `displayName` being used as a security input by anything that
  renders it, so no policy decision can turn on it. The entry is fetched by
  `auth.did`, so a device can only correct the binding it authenticated as.

  A malformed extension is **ignored, not rejected**. A heartbeat's real job
  is refreshing `lastSeenAt`, and failing the call over a bad name would make
  a device with a client-side bug look offline — the more expensive error,
  because it is the one that sends an operator after a machine that is running
  fine. The 1..=128 bound the untyped `ext` slot cannot inherit from the
  register schema is enforced here instead.

  The extension key is defined once, in the SDK that produces it, and imported
  by the service that honours it — the two sides otherwise agree by string,
  and a typo on either would be a rename that silently never happens.

  `device_heartbeat_named` is a new method rather than a wider
  `device_heartbeat`: this crate is consumed across repositories, and
  widening a public signature would spend a breaking release on a diagnostic
  field. The new `ext` member on `DeviceHeartbeatBody` is still a public-field
  addition, so this is a **minor** for `vta-sdk`, not a patch — nothing in the
  workspace or in OpenVTC constructs that struct, but the semver report will
  name it and the release should follow it.

  A VTA that does not understand the extension ignores it (SPEC §4.5.1): the
  heartbeat still refreshes liveness and the name stays as it was.
</blockquote>
















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).