### PR TITLE
fix(vtc): an admin with no passkeys has an empty list, not a missing one

### DIFF
--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -646,7 +646,7 @@
         "operationId": "adminPasskeyList",
         "responses": {
           "200": {
-            "description": "Registered admin passkeys",
+            "description": "Registered admin passkeys; empty when the                                       caller has enrolled none",
             "content": {
               "application/json": {
                 "schema": {
@@ -660,9 +660,6 @@
           },
           "403": {
             "description": "Caller is not an admin"
-          },
-          "404": {
-            "description": "No admin entry for caller"
           }
         },
         "security": [

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -5095,7 +5095,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Registered admin passkeys */
+            /** @description Registered admin passkeys; empty when the                                       caller has enrolled none */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -5113,13 +5113,6 @@ export interface operations {
             };
             /** @description Caller is not an admin */
             403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description No admin entry for caller */
-            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/vtc-service/admin-ui/src/plugins/myPasskeys.tsx
+++ b/vtc-service/admin-ui/src/plugins/myPasskeys.tsx
@@ -167,6 +167,10 @@ export function MyPasskeys() {
     queryFn: fetchPasskeys,
   });
 
+  // `register/start` challenges an existing credential before issuing a new
+  // one, so the button is only meaningful once at least one is enrolled.
+  const canRegister = (query.data?.credentials.length ?? 0) > 0;
+
   const registerMutation = useMutation({
     mutationFn: registerPasskey,
     onSuccess: () => {
@@ -203,6 +207,12 @@ export function MyPasskeys() {
         </section>
       )}
 
+      {/* Registering steps up against a passkey you already hold, so it
+          cannot mint the first one — the bootstrap path is the install URL.
+          Offering the button with none enrolled sent operators at a ceremony
+          that answers 404 from `register/start`, on the page whose whole
+          purpose is to tell them how to get one. */}
+      {canRegister && (
       <section className="card">
         <div className="toolbar">
           <div className="spacer" />
@@ -223,6 +233,7 @@ export function MyPasskeys() {
           </button>
         </div>
       </section>
+      )}
 
       {showRegister && (
         <section className="card">
@@ -303,7 +314,13 @@ export function MyPasskeys() {
                       <KeyRound />
                     </span>
                     <h4>No passkeys registered</h4>
-                    <p>Claim the install URL or register a new passkey.</p>
+                    <p>
+                      Your session is authenticated another way — by your VTA
+                      wallet — so there is no passkey here to add a second
+                      device against. Registering one starts from an install
+                      URL, which an operator mints on the host with{" "}
+                      <code>vtc admin invite --did &lt;your-did&gt;</code>.
+                    </p>
                   </div>
                 </td>
               </tr>

--- a/vtc-service/src/routes/admin/passkeys.rs
+++ b/vtc-service/src/routes/admin/passkeys.rs
@@ -234,21 +234,35 @@ fn revoke_target_key(revocation_id: &str) -> Vec<u8> {
     operation_id = "adminPasskeyList", tag = "admin",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "Registered admin passkeys", body = ListResponse),
+        (status = 200, description = "Registered admin passkeys; empty when the                                       caller has enrolled none", body = ListResponse),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
-        (status = 404, description = "No admin entry for caller"),
     ),
 )]
 pub async fn list(
     admin: AdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<ListResponse>, AppError> {
-    let entry = get_admin_entry(&state.passkey_ks, &admin.0.did)
-        .await?
-        .ok_or_else(|| AppError::NotFound("no admin entry for caller".into()))?;
+    // No `AdminEntry` means the caller has enrolled no passkeys — an empty
+    // collection, not a missing one, so it answers 200 with an empty list.
+    //
+    // It returned 404 until an operator hit it: an admin who signs in with
+    // their VTA wallet (SIOP, `/auth/admin-session`) holds an ACL entry and no
+    // passkey enrolment, which is a perfectly ordinary state and the *first*
+    // thing such an operator sees on this page. The console rendered the 404 as
+    // "FAILED TO LOAD PASSKEYS" directly above its own, correct, "No passkeys
+    // registered" empty state — the page contradicting itself about whether
+    // anything had gone wrong.
+    //
+    // 404 is right for `revoke`, which names a credential that must exist.
+    // It was never right here.
+    let entry = get_admin_entry(&state.passkey_ks, &admin.0.did).await?;
     Ok(Json(ListResponse {
-        credentials: entry.passkeys.iter().map(Into::into).collect(),
+        credentials: entry
+            .iter()
+            .flat_map(|e| e.passkeys.iter())
+            .map(Into::into)
+            .collect(),
     }))
 }
 

--- a/vtc-service/tests/admin_passkeys.rs
+++ b/vtc-service/tests/admin_passkeys.rs
@@ -281,6 +281,84 @@ async fn list_returns_bootstrap_passkey() {
     assert_eq!(arr[0]["deviceLabel"], "install");
 }
 
+/// An admin who has enrolled no passkeys gets an empty list, not a 404.
+///
+/// This is an entirely ordinary state, not an error: an operator who signs in
+/// with their VTA wallet (SIOP, `/auth/admin-session`) holds an ACL entry and
+/// no passkey enrolment, and this page is the first place they land. Answering
+/// 404 made the console render "FAILED TO LOAD PASSKEYS" directly above its
+/// own, correct, "No passkeys registered" empty state — one page disagreeing
+/// with itself about whether anything was wrong.
+///
+/// Nothing pinned the old behaviour, which is how it survived to an operator
+/// report. `revoke` keeps its 404: that one names a credential which must exist.
+#[tokio::test]
+async fn list_is_empty_for_an_admin_with_no_passkeys() {
+    let fix = build_fixture(true).await;
+
+    // Same fixture, minus the enrolment: a DID with the admin ACL role and no
+    // `AdminEntry`, which is exactly what wallet sign-in produces.
+    let did = format!("did:key:z6Mk{}", Uuid::new_v4().simple());
+    store_acl_entry(
+        &fix.state.acl_ks,
+        &AclEntry::new(did.clone(), Role::Admin, "did:key:vtc-wallet"),
+    )
+    .await
+    .unwrap();
+    assert!(
+        get_admin_entry(&fix.state.passkey_ks, &did)
+            .await
+            .unwrap()
+            .is_none(),
+        "the premise of this test is an admin with no enrolment"
+    );
+
+    let session_id = format!("sess-{}", Uuid::new_v4());
+    store_session(
+        &fix.state.sessions_ks,
+        &Session {
+            session_id: session_id.clone(),
+            did: did.clone(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now_epoch(),
+            last_seen: now_epoch(),
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+            amr: Vec::new(),
+            acr: String::new(),
+            acr_expires_at: None,
+            token_id: None,
+            session_pubkey_b58btc: None,
+        },
+    )
+    .await
+    .unwrap();
+    let claims = fix
+        .jwt_keys
+        .new_claims(did, session_id, "admin".to_string(), vec![], 900, false);
+    let token = fix.jwt_keys.encode(&claims).unwrap();
+
+    let (status, body) = request(
+        &fix.router,
+        "GET",
+        "/v1/admin/passkeys",
+        Some(LIST_TASK),
+        Some(&token),
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "an empty collection is not a 404");
+    assert_eq!(
+        body["credentials"].as_array().map(Vec::len),
+        Some(0),
+        "the member must be present and empty, not absent: the console reads \
+         `credentials.length`, and an absent member is a different failure"
+    );
+}
+
 #[tokio::test]
 async fn list_requires_admin_role() {
     let fix = build_fixture(true).await;


### PR DESCRIPTION
Reported from the console: **"My passkeys"** showed a red *FAILED TO LOAD PASSKEYS — not found: no admin entry for caller*, directly above its own, correct, *"No passkeys registered"* empty state. One page disagreeing with itself about whether anything had gone wrong.

Nothing had. `AdminEntry` lives in `passkey_ks` keyed by DID and records a passkey **enrolment** — it is not the ACL entry. An operator who signs in with their VTA wallet (SIOP, `/auth/admin-session`) holds an admin ACL role and no enrolment. That is an entirely ordinary state, and this page is the first place such an operator lands.

`GET /admin/passkeys` now answers `200 {"credentials": []}`. An empty collection is not a missing resource. `revoke` keeps its 404 — that one names a credential which must exist.

## The button was worse than the error

`register/start` challenges an existing credential for a step-up UV before issuing a new one, so it **cannot mint the first passkey** — it answers 404 as well. The only path that creates a `PasskeyUser` from nothing is the install-URL claim (`install.rs:313`).

So the page offered *"Register new passkey"* to precisely the operators for whom it could not work, on the page whose entire purpose is to tell them how to get one. The button is now hidden until at least one passkey exists, and the empty state names the real next step:

> **No passkeys registered**
> Your session is authenticated another way — by your VTA wallet — so there is no passkey here to add a second device against. Registering one starts from an install URL, which an operator mints on the host with `vtc admin invite --did <your-did>`.

**Deliberately not fixed** by letting `register/start` skip the UV when the caller has none. That would make any admin session sufficient to mint a passkey with no second factor, putting wallet DID-auth and passkey auth on equal footing for enrolment. Keeping *"adding a credential requires holding one"* is worth an out-of-band step. Raised as an explicit choice rather than assumed.

## Coverage

`list_is_empty_for_an_admin_with_no_passkeys` builds the wallet-sign-in shape directly — an ACL admin with no `AdminEntry` — and asserts 200 with a **present, empty** `credentials` (the console reads `.length`, so an absent member is a different failure). Checked against the old handler: it fails there with `left: 404, right: 200`.

Nothing pinned the 404, which is how it reached an operator. The three existing `list` tests covered the enrolled admin, the wrong role, and no token — the state an *unenrolled* admin is actually in was the one case missing.

## Regenerated artefacts

The response annotation lost its 404, so `admin-ui/openapi.json` and `src/lib/wire.ts` are regenerated. #1188's snapshot gate caught the staleness before this commit existed — the chain working on its first real change after landing, which is the evidence I wanted for it.

## Gates

`cargo test -p vtc-service` (all green), `cargo clippy --workspace --all-targets`, `cargo fmt --all --check`, `npm run lint` + `npm run build` in `admin-ui`.

Refs #1188
