### PR TITLE
fix(vti-common): gate the keyspace name on the feature that reads it

### DIFF
--- a/vti-common/src/store/mod.rs
+++ b/vti-common/src/store/mod.rs
@@ -435,6 +435,14 @@ pub struct LocalKeyspaceHandle {
     /// Keyspace name, bound into the AES-GCM associated data so a value
     /// cannot be relocated to another keyspace (which shares the storage
     /// key) and still authenticate. See [`encryption`].
+    ///
+    /// Gated with the feature it serves, like `encryption_key` below: every
+    /// read of it is an AAD construction, so a build without `encryption` has
+    /// nothing to read it and the compiler says so (`field is never read`,
+    /// which is what `pnm-cli` and every other default-feature consumer sees).
+    /// Carrying it regardless would leave a security-relevant field looking
+    /// like it might be doing something in builds where it cannot.
+    #[cfg(feature = "encryption")]
     name: String,
     /// The owning database, kept so the handle can fsync the shared
     /// journal ([`LocalKeyspaceHandle::persist`]) — fjall only exposes
@@ -478,6 +486,7 @@ impl LocalStore {
             .clone();
         Ok(LocalKeyspaceHandle {
             keyspace,
+            #[cfg(feature = "encryption")]
             name: name.to_string(),
             db: self.db.clone(),
             write_lock,


### PR DESCRIPTION
## The warning

`cargo build --release -p pnm-cli` — and every other default-feature consumer of `vti-common` — has been emitting:

```
warning: field `name` is never read
   --> vti-common/src/store/mod.rs:438:5
    |
433 | pub struct LocalKeyspaceHandle {
    |            ------------------- field in this struct
...
438 |     name: String,
```

## It is not unused code

`LocalKeyspaceHandle::name` is the keyspace name bound into the AES-GCM **associated data**, so a value cannot be relocated to another keyspace — which shares the storage key — and still authenticate.

But every read of it constructs an AAD, and all of them are behind `#[cfg(feature = "encryption")]`: the five `let name = self.name.clone()` bindings feeding `encryption::maybe_decrypt_bytes`, and `maybe_encrypt`'s `encryption::encrypt_value(key, &self.name, …)`. `encryption` is not a default feature, so in a `pnm-cli` build there is genuinely nothing left to read the field, and the compiler is right.

## The fix

Gate the field with the feature it serves — exactly as the sibling `encryption_key` field on the same struct already is — and cfg its one construction site in `LocalStore::keyspace`.

The alternative, carrying it unconditionally under an `allow(dead_code)`, would leave a security-relevant field looking like it might be doing something in builds where it cannot. The doc comment now says why the gate is there, so the next reader does not "restore" it.

No behaviour change in either configuration: with `encryption` on, the field and its readers are untouched; with it off, nothing referenced the field.

## Verification

- `cargo build --release -p pnm-cli` — warning-free (defaults, and with `--features config-session`, the set the build script uses)
- `cargo check -p vti-common --all-features --all-targets` — clean, so the encryption path and the test targets still compile
- `cargo test -p vti-common --all-features` — 476 passing
- `cargo fmt --check`, `cargo clippy -p vti-common --all-targets` — clean

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — n/a
- [x] No lock held across a network await (R1.3) — n/a
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — n/a
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — n/a, no wire types touched
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — n/a
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations; compile-time only
- [x] Deviations from this guide flagged explicitly with rule numbers — none
```
