### PR TITLE
feat(device): let a device correct its display name on the heartbeat

### DIFF
--- a/vta-sdk/src/client/agent_devices.rs
+++ b/vta-sdk/src/client/agent_devices.rs
@@ -21,7 +21,7 @@ use super::VtaClient;
 use crate::error::VtaError;
 use crate::protocols::device_management::{
     DeviceDisableBody, DeviceHeartbeatBody, DeviceRegisterBody, DeviceSetWakeBody, DeviceWipeBody,
-    WakeHandle,
+    WakeHandle, device_name_ext,
 };
 use crate::trust_tasks;
 
@@ -59,9 +59,35 @@ impl VtaClient {
     /// `device/heartbeat/0.1` — refresh `lastSeenAt` (and `platform` if
     /// supplied). Returns server time + any queued operations for the device.
     pub async fn device_heartbeat(&self, platform: Option<&str>) -> Result<Value, VtaError> {
+        self.device_heartbeat_named(platform, None).await
+    }
+
+    /// `device/heartbeat/0.1` carrying this device's **current** display name.
+    ///
+    /// `displayName` is set once, at registration, and re-registration is
+    /// intentionally refused — so a renamed machine (or an install moved to
+    /// another profile) otherwise keeps announcing a name that no longer picks
+    /// it out of the list the name exists for. Sending it on the heartbeat is
+    /// how a device corrects its own binding; the VTA applies it only when it
+    /// differs, and only to the binding the caller authenticated as.
+    ///
+    /// A separate method rather than a wider `device_heartbeat`: this crate is
+    /// published and consumed across repositories, and changing a public
+    /// signature to add an optional argument would spend a breaking release on a
+    /// diagnostic field.
+    ///
+    /// A VTA that does not understand the extension ignores it (SPEC §4.5.1) —
+    /// the heartbeat still refreshes `lastSeenAt`, and the name simply stays as
+    /// it was.
+    pub async fn device_heartbeat_named(
+        &self,
+        platform: Option<&str>,
+        display_name: Option<&str>,
+    ) -> Result<Value, VtaError> {
         let payload = serde_json::to_value(DeviceHeartbeatBody {
             platform: platform.map(str::to_string),
             vault_seq: None,
+            ext: display_name.map(device_name_ext),
         })?;
         self.dispatch_trust_task(
             trust_tasks::TASK_DEVICE_HEARTBEAT_0_1,

--- a/vta-sdk/src/protocols/device_management.rs
+++ b/vta-sdk/src/protocols/device_management.rs
@@ -56,6 +56,42 @@ pub struct DeviceHeartbeatBody {
     pub platform: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vault_seq: Option<u64>,
+    /// Namespaced extension members (SPEC §4.5.1). Carries
+    /// `org.openvtc.device-name` when the device is correcting its own
+    /// `displayName`, which registration set once and nothing else updates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// Extension member a device uses to correct its own `displayName` on a
+/// heartbeat. Its value is `{ "displayName": "…" }`.
+///
+/// Reverse-DNS namespaced per SPEC §4.5.1, named the way this ecosystem already
+/// names its extensions (`org.openvtc.vault-session`,
+/// `org.openvtc.authorization-context`). **Defined once, here**, and imported by
+/// the VTA that honours it: the two sides otherwise agree by string, and a typo
+/// on either would be a rename that silently never happens.
+///
+/// # Why an extension and not `device/register`
+///
+/// `displayName` exists "to help a human pick their own laptop out of a list"
+/// (dtgwg `device/register/0.2` §Security & Privacy) and is set exactly once, at
+/// registration, because re-registration is **intentionally** refused
+/// (`device/register:alreadyRegistered`). Nothing in the device family updates
+/// it, so a renamed machine keeps announcing a name that no longer identifies
+/// it. Heartbeat is where the spec already puts metadata drift — `platform` is
+/// defined there as "updated platform descriptor if it changed since
+/// registration" — and `ext` is the slot it provides for the rest.
+pub const EXT_DEVICE_NAME: &str = "org.openvtc.device-name";
+
+/// The `ext` member that corrects this device's `displayName` — see
+/// [`EXT_DEVICE_NAME`].
+///
+/// A constructor rather than a literal at the call site, so the key is written
+/// once on this side of the wire.
+#[must_use]
+pub fn device_name_ext(display_name: &str) -> Value {
+    serde_json::json!({ EXT_DEVICE_NAME: { "displayName": display_name } })
 }
 
 /// `device/disable/0.1` — disable a device by id; the record is kept.
@@ -114,6 +150,53 @@ mod tests {
             serde_json::to_value(DeviceHeartbeatBody::default()).expect("serialises"),
             serde_json::json!({})
         );
+    }
+
+    /// The name correction rides in the spec's own extension slot, under the
+    /// key the VTA matches on.
+    #[test]
+    fn a_named_heartbeat_carries_the_device_name_extension() {
+        let body = DeviceHeartbeatBody {
+            platform: None,
+            vault_seq: None,
+            ext: Some(device_name_ext("OpenVTC on new-host (default)")),
+        };
+        assert_eq!(
+            serde_json::to_value(&body).expect("serialises"),
+            serde_json::json!({
+                "ext": {
+                    "org.openvtc.device-name": {
+                        "displayName": "OpenVTC on new-host (default)"
+                    }
+                }
+            })
+        );
+    }
+
+    /// The `ext` key has to satisfy the schema's reverse-DNS pattern
+    /// (`^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$`) or a conforming maintainer rejects
+    /// the whole heartbeat — taking `lastSeenAt` down with it, so a bad key here
+    /// is a liveness bug, not a cosmetic one.
+    #[test]
+    fn the_extension_key_matches_the_schema_pattern() {
+        let segments: Vec<&str> = EXT_DEVICE_NAME.split('.').collect();
+        assert!(segments.len() >= 2, "{EXT_DEVICE_NAME} needs a namespace");
+        assert!(
+            EXT_DEVICE_NAME.starts_with(|c: char| c.is_ascii_lowercase()),
+            "{EXT_DEVICE_NAME} must start with a lowercase letter"
+        );
+        for segment in segments {
+            assert!(
+                !segment.is_empty(),
+                "{EXT_DEVICE_NAME} has an empty segment"
+            );
+            assert!(
+                segment
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "{segment} may only hold [a-z0-9-]"
+            );
+        }
     }
 
     #[test]

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -18,8 +18,50 @@ use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
 
+use trust_tasks_rs::specs::device::heartbeat::v0_1 as heartbeat_spec;
 use trust_tasks_rs::specs::device::list::v0_1 as list_spec;
 use trust_tasks_rs::specs::device::register::v0_1 as register_spec;
+
+// The extension key a device uses to correct its own `displayName`
+// (`org.openvtc.device-name`) is defined by the SDK that produces it, and
+// imported rather than re-spelled: the two sides agree by string, and a typo on
+// either would be a rename that silently never happens. `EXT_DEVICE_NAME` on
+// that constant carries the rationale — in short, `displayName` is set once at
+// registration and re-registration is intentionally refused, so heartbeat's
+// `ext` is the only spec-provided place a correction can travel. Honouring it
+// weakens nothing: the binding, its `deviceId` and its `registeredAt` are
+// untouched, and no new binding can be claimed this way.
+use vta_sdk::protocols::device_management::EXT_DEVICE_NAME;
+
+/// Ceiling on a display name, mirroring the `device/register` schema's
+/// `maxLength: 128`. The `ext` slot is untyped, so a bound the schema would have
+/// enforced has to be enforced here — a heartbeat must not become a way to store
+/// an unbounded string on the maintainer.
+const MAX_DISPLAY_NAME_CHARS: usize = 128;
+
+/// The corrected display name a heartbeat carries, if it carries a usable one.
+///
+/// **Invalid input is ignored, not rejected.** A heartbeat's real job is to
+/// refresh `lastSeenAt`; failing the whole call over a malformed extension would
+/// make a device with a client-side bug look *offline*, which is the more
+/// expensive error — it is the one that sends an operator looking for a machine
+/// that is running fine. A name that does not survive this returns `None` and
+/// the rest of the heartbeat proceeds.
+fn extension_display_name(ext: Option<&heartbeat_spec::Ext>) -> Option<String> {
+    let value = ext?
+        .iter()
+        .find(|(key, _)| key.as_str() == EXT_DEVICE_NAME)
+        .map(|(_, value)| value)?;
+    let name = value.get("displayName")?.as_str()?.trim();
+    if name.is_empty() || name.chars().count() > MAX_DISPLAY_NAME_CHARS {
+        tracing::debug!(
+            len = name.chars().count(),
+            "ignoring a heartbeat display name outside 1..={MAX_DISPLAY_NAME_CHARS} characters"
+        );
+        return None;
+    }
+    Some(name.to_string())
+}
 
 /// Register the caller's device: attach a [`DeviceBinding`] to its existing ACL
 /// entry. The caller (`auth.did`) MUST already be in the ACL (its long-term key,
@@ -92,15 +134,22 @@ pub async fn register_device(
     Ok(json!({ "binding": to_wire_binding(&entry) }))
 }
 
-/// Device heartbeat: refresh the binding's `lastSeenAt` (and `platform` if the
-/// device reports a change), and return the maintainer's server time + any
-/// queued operations. The caller MUST be a registered device (else
-/// `not_registered`).
+/// Device heartbeat: refresh the binding's `lastSeenAt` (and `platform` or
+/// `displayName` if the device reports a change), and return the maintainer's
+/// server time + any queued operations. The caller MUST be a registered device
+/// (else `not_registered`).
+///
+/// A device may only correct **its own** binding: the entry is fetched by
+/// `auth.did`, so the rename reaches the row the caller authenticated as and no
+/// other. See [`EXT_DEVICE_NAME`] for why the correction rides here.
 ///
 /// Does **not** bump the ACL entry `version` — a heartbeat is a metadata
 /// refresh, not a policy change, so it must not collide with concurrent admin
-/// edits guarded by `If-Match`. High-volume, so it is not individually audited
-/// (the spec permits sampling).
+/// edits guarded by `If-Match`. A rename is metadata by the same measure:
+/// `displayName` **MUST NOT** be used as a security input by anything that
+/// renders it (dtgwg `device/register/0.2`), so no policy decision can turn on
+/// it. High-volume, so it is not individually audited (the spec permits
+/// sampling).
 ///
 /// `queuedOperations` is empty until `device/wipe` lands (C3); `syncHint` is
 /// `up-to-date` until vault/sync is wired (the `vaultSeq` hint is accepted but
@@ -109,6 +158,7 @@ pub async fn heartbeat_device(
     acl_ks: &KeyspaceHandle,
     auth: &AuthClaims,
     platform: Option<String>,
+    ext: Option<&heartbeat_spec::Ext>,
 ) -> Result<Value, AppError> {
     let did = auth.did.clone();
     let mut entry = get_acl_entry(acl_ks, &did).await?.ok_or_else(|| {
@@ -126,6 +176,17 @@ pub async fn heartbeat_device(
     binding.last_seen_at = Some(now.clone());
     if platform.is_some() {
         binding.platform = platform;
+    }
+    if let Some(renamed) = extension_display_name(ext)
+        && renamed != binding.display_name
+    {
+        info!(
+            did = %did,
+            from = %binding.display_name,
+            to = %renamed,
+            "device corrected its display name"
+        );
+        binding.display_name = renamed;
     }
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -799,7 +860,7 @@ mod tests {
         .await
         .unwrap();
 
-        let body = heartbeat_device(&acl_ks, &device_auth(did), Some("iOS 19.1".into()))
+        let body = heartbeat_device(&acl_ks, &device_auth(did), Some("iOS 19.1".into()), None)
             .await
             .expect("heartbeat on a registered device succeeds");
         assert_eq!(body["syncHint"], "up-to-date");
@@ -817,6 +878,169 @@ mod tests {
         );
     }
 
+    /// Build the heartbeat `ext` a device sends to correct its own name.
+    fn name_ext(display_name: &str) -> heartbeat_spec::Ext {
+        serde_json::from_value(
+            serde_json::json!({ EXT_DEVICE_NAME: { "displayName": display_name } }),
+        )
+        .expect("the ext key matches the schema's reverse-DNS pattern")
+    }
+
+    /// Enrol a device and give it a binding, returning its DID.
+    async fn registered(
+        acl_ks: &KeyspaceHandle,
+        audit: &vta_audit::SharedAuditSink,
+        did: &str,
+        display_name: &str,
+    ) {
+        store_acl_entry(
+            acl_ks,
+            &AclEntry::new(did, Role::Application, "did:key:zSetup"),
+        )
+        .await
+        .unwrap();
+        register_device(
+            acl_ks,
+            audit,
+            &device_auth(did),
+            mobile_kind(),
+            display_name.into(),
+            None,
+            Some("did:key:zHpke".into()),
+            "test",
+        )
+        .await
+        .unwrap();
+    }
+
+    /// `displayName` is set once at registration and re-registration is refused,
+    /// so without this a renamed machine announces its old name forever — in the
+    /// list the name exists to disambiguate.
+    #[tokio::test]
+    async fn heartbeat_applies_a_corrected_display_name() {
+        let (acl_ks, audit, _dir) = fresh().await;
+        let did = "did:key:zDevice";
+        registered(&acl_ks, &audit, did, "OpenVTC on old-host (default)").await;
+        let before = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+        let claimed = before.device.unwrap();
+
+        heartbeat_device(
+            &acl_ks,
+            &device_auth(did),
+            None,
+            Some(&name_ext("OpenVTC on new-host (default)")),
+        )
+        .await
+        .expect("heartbeat succeeds");
+
+        let entry = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+        let b = entry.device.unwrap();
+        assert_eq!(b.display_name, "OpenVTC on new-host (default)");
+        // The binding is corrected, not re-claimed: identity and enrolment time
+        // are exactly what registration minted, and no policy version moved.
+        assert_eq!(b.device_id, claimed.device_id);
+        assert_eq!(b.registered_at, claimed.registered_at);
+        assert_eq!(
+            entry.version, 1,
+            "a rename is metadata, so it must not bump the entry version"
+        );
+    }
+
+    /// A device can only correct the binding it authenticated as — the entry is
+    /// fetched by `auth.did`, so there is no way to rename someone else's row.
+    #[tokio::test]
+    async fn a_rename_reaches_only_the_callers_own_binding() {
+        let (acl_ks, audit, _dir) = fresh().await;
+        registered(&acl_ks, &audit, "did:key:zMine", "Mine").await;
+        registered(&acl_ks, &audit, "did:key:zTheirs", "Theirs").await;
+
+        heartbeat_device(
+            &acl_ks,
+            &device_auth("did:key:zMine"),
+            None,
+            Some(&name_ext("Renamed")),
+        )
+        .await
+        .unwrap();
+
+        let theirs = get_acl_entry(&acl_ks, "did:key:zTheirs")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(theirs.device.unwrap().display_name, "Theirs");
+    }
+
+    /// A malformed extension must not fail the heartbeat: `lastSeenAt` is the
+    /// call's real job, and a device that looks offline sends an operator
+    /// chasing a machine that is running fine.
+    #[tokio::test]
+    async fn an_unusable_name_is_ignored_and_the_heartbeat_still_lands() {
+        let (acl_ks, audit, _dir) = fresh().await;
+        let did = "did:key:zDevice";
+        registered(&acl_ks, &audit, did, "Original").await;
+
+        for bad in [
+            serde_json::json!({ EXT_DEVICE_NAME: { "displayName": "   " } }),
+            serde_json::json!({ EXT_DEVICE_NAME: { "displayName": "x".repeat(129) } }),
+            serde_json::json!({ EXT_DEVICE_NAME: { "displayName": 42 } }),
+            serde_json::json!({ EXT_DEVICE_NAME: { "somethingElse": "y" } }),
+            serde_json::json!({ "org.example.unrelated": { "displayName": "Hijack" } }),
+        ] {
+            let ext: heartbeat_spec::Ext = serde_json::from_value(bad.clone()).unwrap();
+            heartbeat_device(&acl_ks, &device_auth(did), None, Some(&ext))
+                .await
+                .unwrap_or_else(|e| panic!("heartbeat must survive {bad}: {e:?}"));
+
+            let entry = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+            let b = entry.device.unwrap();
+            assert_eq!(b.display_name, "Original", "{bad} must not rename");
+            assert!(
+                b.last_seen_at.is_some(),
+                "{bad} must still refresh liveness"
+            );
+        }
+    }
+
+    /// A name is trimmed, and one that is already current is a no-op.
+    #[tokio::test]
+    async fn a_name_is_trimmed_and_an_unchanged_one_is_a_no_op() {
+        let (acl_ks, audit, _dir) = fresh().await;
+        let did = "did:key:zDevice";
+        registered(&acl_ks, &audit, did, "Original").await;
+
+        heartbeat_device(
+            &acl_ks,
+            &device_auth(did),
+            None,
+            Some(&name_ext("  Trimmed  ")),
+        )
+        .await
+        .unwrap();
+        let entry = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+        assert_eq!(entry.device.unwrap().display_name, "Trimmed");
+
+        heartbeat_device(&acl_ks, &device_auth(did), None, Some(&name_ext("Trimmed")))
+            .await
+            .unwrap();
+        let entry = get_acl_entry(&acl_ks, did).await.unwrap().unwrap();
+        assert_eq!(entry.device.unwrap().display_name, "Trimmed");
+        assert_eq!(entry.version, 1);
+    }
+
+    /// The boundary the untyped `ext` slot has to enforce itself, since the
+    /// register schema's `maxLength: 128` cannot reach it.
+    #[test]
+    fn the_name_length_bound_matches_the_register_schema() {
+        let at_limit = "x".repeat(MAX_DISPLAY_NAME_CHARS);
+        assert_eq!(
+            extension_display_name(Some(&name_ext(&at_limit))).as_deref(),
+            Some(at_limit.as_str())
+        );
+        let over = "x".repeat(MAX_DISPLAY_NAME_CHARS + 1);
+        assert!(extension_display_name(Some(&name_ext(&over))).is_none());
+        assert!(extension_display_name(None).is_none());
+    }
+
     #[tokio::test]
     async fn heartbeat_rejects_unregistered_device() {
         let (acl_ks, _audit, _dir) = fresh().await;
@@ -827,7 +1051,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let err = heartbeat_device(&acl_ks, &device_auth("did:key:zBare"), None)
+        let err = heartbeat_device(&acl_ks, &device_auth("did:key:zBare"), None, None)
             .await
             .expect_err("heartbeat without a binding must be refused");
         assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");

--- a/vta-service/src/trust_tasks/device.rs
+++ b/vta-service/src/trust_tasks/device.rs
@@ -61,7 +61,8 @@ pub(super) async fn handle_register(
 }
 
 /// `device/heartbeat/0.1` — periodic check-in; refreshes `lastSeenAt` (and
-/// `platform` if changed) and returns server time + queued operations.
+/// `platform` or `displayName` if changed) and returns server time + queued
+/// operations.
 pub(super) async fn handle_heartbeat(
     state: &AppState,
     auth: &AuthClaims,
@@ -71,7 +72,14 @@ pub(super) async fn handle_heartbeat(
         Ok(p) => p,
         Err(resp) => return resp,
     };
-    match operations::device::heartbeat_device(&state.acl_ks, auth, payload.platform).await {
+    match operations::device::heartbeat_device(
+        &state.acl_ks,
+        auth,
+        payload.platform,
+        payload.ext.as_ref(),
+    )
+    .await
+    {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }


### PR DESCRIPTION
## The gap

`displayName` is written exactly once — at registration — and nothing in the `device/*` family can change it. `device/register` is intentionally not idempotent: a binding hangs off the caller's ACL entry, one per DID, and a second claim is refused.

```rust
// Re-registration is intentionally not idempotent (spec): rotate keys + retry.
if entry.device.is_some() {
    return Err(AppError::Conflict("device/register:alreadyRegistered — …"))
}
```

So a renamed machine, or an install moved to another profile, keeps announcing a name that no longer identifies it — in the list the name exists for. The spec is explicit about that purpose: `displayName` exists "to help a human pick their own laptop out of a list" (dtgwg `device/register/0.2` §Security & Privacy).

Surfaced while fixing OpenVTC#261, where an install's own binding was being mistaken for a second instance; the name being frozen is the other half of the same surface.

## Where the correction belongs

Heartbeat, in the `ext` slot — not a relaxed `register`.

The spec already puts metadata drift on the heartbeat: `platform` is defined there as *"updated platform descriptor if it changed since registration"*. `ext` is the namespaced extension slot §4.5.1 provides for the rest, and this workspace already uses it that way (`org.openvtc.vault-session`, `org.openvtc.authorization-context`). A device now sends:

```json
{ "ext": { "org.openvtc.device-name": { "displayName": "OpenVTC on new-host (default)" } } }
```

**Nothing about the register refusal moves.** The binding, its `deviceId` and its `registeredAt` are untouched, and no new binding can be claimed this way.

## Safety properties, each pinned by a test

- **A device can only rename itself.** The entry is fetched by `auth.did`, so the correction reaches the row the caller authenticated as and no other (`a_rename_reaches_only_the_callers_own_binding`).
- **No policy can turn on it.** The entry `version` does not bump — a rename is metadata, and the spec forbids `displayName` being used as a security input by anything that renders it, so nothing guarded by `If-Match` collides with it.
- **A bad name never costs liveness.** A malformed extension is ignored, not rejected: a heartbeat's real job is refreshing `lastSeenAt`, and failing the call over a client-side bug would make a running device look *offline* — the more expensive error (`an_unusable_name_is_ignored_and_the_heartbeat_still_lands`, covering a blank name, an over-long one, a non-string, a wrong member, and someone else's namespace).
- **The untyped slot still has the schema's bound.** `ext` carries arbitrary JSON, so the register schema's `maxLength: 128` is enforced here instead (`the_name_length_bound_matches_the_register_schema`).
- **Names are trimmed, and an unchanged name is a no-op** (`a_name_is_trimmed_and_an_unchanged_one_is_a_no_op`).

The service tests build their `ext` by deserializing into the generated `heartbeat::v0_1::Ext`, so the reverse-DNS `ExtKey` pattern is checked by the schema type itself rather than by hand — a key that could not travel would fail every rename test.

## One definition of the key

`EXT_DEVICE_NAME` lives in `vta-sdk`'s `protocols::device_management` and the service **imports** it. The two sides otherwise agree by string, and a typo on either would be a rename that silently never happens.

## Semver

`device_heartbeat_named` is a new method rather than a wider `device_heartbeat`, so no caller has to move. But the new `ext` member on `DeviceHeartbeatBody` is a public-field addition, which **is** a break for external struct-literal construction:

> **This should be released as a minor for `vta-sdk`, not a patch.** Nothing in this workspace or in OpenVTC constructs `DeviceHeartbeatBody` — only the SDK's own client method and the conformance witness, both via `Default` or an in-crate literal — so the practical blast radius is nil, but the semver report will name it and the release should follow the report rather than the blast radius.

A VTA that does not understand the extension ignores it (SPEC §4.5.1): the heartbeat still refreshes liveness and the name stays as it was.

## Follow-up (gated on a release)

This is the maintainer half. OpenVTC's presence task still calls `device_heartbeat`, so it must move to `device_heartbeat_named(platform, Some(&display_name(profile)))` to actually send the current name — which needs this merged and `vta-sdk` published first.

## Verification

`cargo test -p vta-sdk -p vta-service` (full suites, including the `device_management` producer census and the trust-task conformance witnesses), `cargo fmt`, `cargo clippy -p vta-sdk -p vta-service --all-targets` — all clean.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no new clients; the heartbeat keeps DEVICE_TT_TIMEOUT
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — one store_acl_entry, as before
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — register stays non-idempotent and unretried; this is why the correction rides the heartbeat
- [x] Accept/poll/listen loops survive transient errors (R1.5) — a malformed ext cannot fail the heartbeat
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — the member is the spec's own `ext`, key validated against the generated `ExtKey` pattern; the producer body keeps `skip_serializing_if` so an unset ext stays absent
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — an absent or unusable name changes nothing
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — a rename logs at info with from/to; an ignored name logs at debug with its length
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — the rename is part of the heartbeat's existing single write; a death before it leaves the old name, which is the current behaviour
- [x] Deviations from this guide flagged explicitly with rule numbers — none. The one spec judgement (using `ext` rather than proposing a first-class `displayName` on heartbeat) is stated above and is reversible: if the spec later adds the member, this becomes the compatibility shim
```
