### PR TITLE
fix(sdk): stop rewriting the envelope a Trust Task proof covers

### DIFF
--- a/docs/05-design-notes/trust-task-envelope-conformance.md
+++ b/docs/05-design-notes/trust-task-envelope-conformance.md
@@ -1,0 +1,139 @@
+# `proofRequired` on `pnm contexts create` — the envelope-conformance gap
+
+**Status:** root cause identified and already fixed for the affected
+constructors (#1184, released in `vta-sdk` 0.31.1); this note records the
+diagnosis, the operator-visible remedy, and the instances of the same root cause
+that are **still live on `main`**.
+
+## The report
+
+Against a production VTA, with `pnm` 0.14.0:
+
+```
+$ pnm contexts create --id openvtc-gt1 --name "OpenVTC" \
+    --admin-did did:key:z6Mko3iZZCNn6LprU7iTEe86LbXfKFqaGigs4e8T9PJYGPAQ \
+    --admin-expires 1h
+X Protocol error: trust task failed [proofRequired]: proof required but not present
+```
+
+The code and message come from the VTA, not the client: it is
+`RejectReason::ProofRequired`, raised by `SpecPolicy::enforce` on the dispatch
+spine (`vta-service/src/trust_tasks/mod.rs`), rendered by the SDK's
+`trust_task_error`.
+
+## Root cause
+
+SPEC §7.2 shipped in two halves that were never checked against each other.
+
+- **The consumer half** (#1146) taught the VTA to enforce the flags a
+  specification declares: `recipient` REQUIRED (item 5b), `proof` REQUIRED
+  (item 7a), `issuedAt` REQUIRED (§7.3 item 17), and audience binding (item 8).
+- **The producer half** (also #1146) taught `VtaClient` to address and sign the
+  documents it sends — but only where the client carried a `ClientIdentity`.
+  `didcomm_transport` and `tsp_transport` built every client with
+  `identity: None`, so `build_task_document` set neither `issuer` nor
+  `recipient`, and `signed_task_document` attached no proof.
+
+The guard meant to catch this was gated on `has_token()`, which is false by
+construction for DIDComm and TSP — it covered the one transport whose
+constructor was already correct.
+
+### Why the message differs by transport
+
+The same defect reports itself under two names, which is why it was diagnosed
+twice:
+
+| Transport | Document as sent | First check it fails | Operator sees |
+|---|---|---|---|
+| DIDComm | no `issuer`, no `recipient`, no `proof` | item 5b | `malformedRequest: … no in-band recipient` |
+| TSP | `issuer`/`recipient` back-filled, no `proof` | item 7a | **`proofRequired: proof required but not present`** |
+
+The difference is `address_trust_task`, which the TSP paths call on the
+already-built document to set `issuer` and `recipient` from the transport. That
+back-fill satisfies item 5b, so a TSP document sails past the recipient check
+and lands on the proof check instead. #1184's changelog describes only the
+DIDComm spelling; this is the TSP one, and it is the same bug.
+
+### Why it was not caught earlier — and why reads kept working
+
+The proof flag falls almost exactly along read-versus-mutate. In
+`trust-tasks-rs` 0.17, of the 344 request payloads:
+
+- **210 declare `proof` REQUIRED** — `vta/contexts/create/1.0` among them.
+- **343 declare `recipient` REQUIRED** — `vta/contexts/list/1.0` among those.
+
+So on an affected build the failure is transport-dependent *and*
+operation-dependent: over TSP, reads succeed and mutations fail; over DIDComm,
+essentially everything fails. A session that listed contexts before creating one
+saw a working client right up to the moment it mattered.
+
+## The fix, and what an operator should do now
+
+#1184 makes the identity a required argument of both transport constructors and
+turns the guard into an unconditional local error. It is released in **`vta-sdk`
+0.31.1** (2026-08-28).
+
+`pnm-cli` 0.14.0 was cut on 2026-08-28 against `vta-sdk` 0.31.0 and **has not
+been re-released**, so an installed 0.14.0 binary still carries the defect.
+Remedies, in order of preference:
+
+1. Rebuild / reinstall `pnm` against `vta-sdk` ≥ 0.31.1.
+2. `pnm --transport rest …` as a stop-gap: `SessionStore::rest_client` builds
+   through `VtaClient::authenticated`, which has always carried an identity.
+
+## Same root cause, still live on `main`
+
+Three instances remain. None is a regression from #1184; all are the same shape
+— *a client that cannot produce a conforming envelope*.
+
+### 1. `did:webvh` bundle holders cannot sign at all
+
+`VtaClient::connect_didcomm_bundle` and `connect_didcomm_bundle_on` pass
+`identity: None` **deliberately**: the holder is the bundle's `did:webvh`, and
+`trust_task_sign` refuses any holder that is not a `did:key`, because both
+services verify with a `did:key`-only resolver
+(`vti_common::auth::di_proof`).
+
+The consequence is not a missing member but a missing capability: **a provisioned
+integration cannot dispatch any of the 210 proof-requiring Trust Tasks**, over
+any transport. This is reachable through the documented
+`AgentConnect` ladder (`ConnectMode::DidWebvhBundle`), i.e. every mediator,
+did-hosting daemon and app provisioned through `provision-integration`.
+
+Fixing it is a design decision, not a patch: either the DI verifier learns to
+resolve `did:webvh`, or provisioned integrations are issued a `did:key` signing
+identity alongside their `did:webvh`. Deliberately not decided here.
+
+### 2. `VtaClient::new(url)` + `set_token_async(token)` carries no identity
+
+`set_token_async` sets the bearer token and nothing else, so the classic
+"REST client with a token" has `identity: None` and now fails every Trust Task
+locally. This is reachable through `AgentConnect`'s `ConnectMode::Token` — the
+documented `url + token` rung. `from_credential` and `authenticated` are the
+only REST constructors that set an identity.
+
+The local error names the missing piece, so this fails loudly rather than
+silently; it is listed because the ladder still advertises the rung.
+
+### 3. `address_trust_task` used to rewrite what the proof covers
+
+Fixed in this change. It assigned `issuer` and `recipient` unconditionally,
+after signing. A Data-Integrity proof covers every member but `proof`, so a
+disagreement between the document and the transport would have converted a valid
+signature into `proofInvalid` at the far end — a failure that names the proof and
+says nothing about the rewrite that caused it. The values came from the same
+triple, so it was a no-op in practice; "it happens to be equal" was not
+something the next constructor had to keep true, and nothing was checking. It
+now fills only an absent member and refuses a disagreement.
+
+## The guard
+
+`client_identity_tests::the_built_document_satisfies_its_own_specification`
+builds the document the SDK actually sends and runs it through
+`schema_index::spec_policy_for(uri).enforce(..)` — the same `SpecPolicy::enforce`
+the VTA's dispatch spine calls.
+
+Asserting against the registry rather than a list of member names is the point:
+the previous tests checked `issuer`, `recipient` and `proof` by name and passed,
+because they were written from the same understanding as the code. When a
+specification adds a flag, this test starts checking it without being edited.

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1788,18 +1788,44 @@ impl VtaClient {
     /// Address a trust-task document for a **mediator** transport and serialize
     /// it.
     ///
-    /// `issuer`/`recipient` are set here rather than at document construction
-    /// because only a mediator transport knows both DIDs — the REST leg posts to
-    /// an already-addressed endpoint. Shared by every TSP path so the wire shape
-    /// cannot drift between them.
+    /// Both members are already set by [`build_task_document`] from the client's
+    /// [`ClientIdentity`]; this only fills them in for a document that somehow
+    /// arrived without them, and otherwise checks that the transport agrees with
+    /// what was signed.
+    ///
+    /// It used to assign both unconditionally, which is the shape of a bug this
+    /// path has already produced once in the other direction. A Data-Integrity
+    /// proof covers every member but `proof`, so writing `issuer` or `recipient`
+    /// *after* signing changes the bytes the signature was computed over: the
+    /// document leaves looking correctly addressed and is refused at the far end
+    /// as `proofInvalid`, which reads like a key problem rather than a
+    /// client-side rewrite. Today the values come from the same triple the
+    /// identity was built from, so the assignment was a no-op — but "it happens
+    /// to be equal" is not something the next constructor has to keep true, and
+    /// nothing was checking.
+    ///
+    /// A disagreement is refused rather than resolved, because neither answer is
+    /// safe: honouring the transport breaks the proof, and honouring the
+    /// document sends it somewhere the caller did not ask for.
     #[cfg(feature = "tsp")]
     fn address_trust_task(
         mut doc: serde_json::Value,
         issuer: &str,
         recipient: &str,
     ) -> Result<Vec<u8>, VtaError> {
-        doc["issuer"] = serde_json::Value::String(issuer.to_string());
-        doc["recipient"] = serde_json::Value::String(recipient.to_string());
+        for (member, from_transport) in [("issuer", issuer), ("recipient", recipient)] {
+            match doc.get(member).and_then(serde_json::Value::as_str) {
+                Some(signed) if signed == from_transport => {}
+                Some(signed) => {
+                    return Err(VtaError::Protocol(format!(
+                        "trust-task `{member}` is `{signed}` in the document but `{from_transport}`                          on the transport; rewriting it would invalidate the proof that covers it"
+                    )));
+                }
+                None => {
+                    doc[member] = serde_json::Value::String(from_transport.to_string());
+                }
+            }
+        }
         serde_json::to_vec(&doc).map_err(|e| VtaError::Protocol(format!("trust-task encode: {e}")))
     }
 
@@ -2676,9 +2702,18 @@ impl VtaClient {
     /// Build the document this client puts on the wire, signed when it can be.
     ///
     /// Signing is unconditional rather than keyed on whether *this* spec
-    /// declares `proof` REQUIRED: 72 of the 109 do, the flag lives in the
-    /// registry rather than here, and a proof on a task that merely RECOMMENDs
-    /// one is legal and strictly more attributable. The one thing it must not
+    /// declares `proof` REQUIRED: 210 of the 344 request payloads in
+    /// `trust-tasks-rs` 0.17 do, the flag lives in the registry rather than
+    /// here, and a proof on a task that merely RECOMMENDs one is legal and
+    /// strictly more attributable.
+    ///
+    /// `recipient` is the sharper number, and the reason the guard below is a
+    /// hard error rather than a warning: **343 of those 344** declare it
+    /// REQUIRED, so an identity-less client cannot dispatch essentially
+    /// anything to a consumer that enforces SPEC §7.2. The proof split falls
+    /// almost exactly along read-versus-mutate — `contexts/list` needs none,
+    /// `contexts/create` does — which is what let the gap survive: the reads a
+    /// client makes first all worked. The one thing it must not
     /// do is attach a proof with no in-band `recipient` — §7.2 item 8 refuses
     /// that on a non-bearer spec — and `build_task_document` sets both from the
     /// same [`ClientIdentity`], so the two cannot come apart.
@@ -2909,6 +2944,100 @@ mod client_identity_tests {
         assert!(
             doc.get("proof").is_some(),
             "a signable identity must yield a proof (item 7a)"
+        );
+    }
+
+    /// The check the hand-written assertions above cannot make: run the
+    /// document the SDK actually builds through **its own specification's**
+    /// policy, the same `SpecPolicy::enforce` the VTA's dispatch spine calls.
+    ///
+    /// This is the test that was missing. Both halves of SPEC §7.2 shipped —
+    /// the VTA began enforcing the flags, and the client began signing — but
+    /// nothing compared one against the other, so a constructor that carried no
+    /// identity produced a document no test rejected and every VTA did. Which
+    /// member it was refused for depended on the transport, which is why the
+    /// same defect was reported twice under two different names: over DIDComm
+    /// the document reaches item 5b first and comes back `malformedRequest: …
+    /// no in-band recipient`, while over TSP `address_trust_task` had already
+    /// filled `recipient` in, so it sailed past 5b and landed on item 7a —
+    /// `proofRequired: proof required but not present`.
+    ///
+    /// Asserting against the registry rather than a list of member names is the
+    /// point: when a spec adds a flag, this test starts checking it without
+    /// being edited.
+    #[tokio::test]
+    async fn the_built_document_satisfies_its_own_specification() {
+        // A mutation and a read. The pair matters: the proof flag falls almost
+        // exactly along that line — `contexts/create` requires one and
+        // `contexts/list` does not — which is why the gap survived long enough
+        // to reach an operator. A client that only ever listed saw nothing
+        // wrong.
+        const URIS: [&str; 3] = [
+            trust_tasks::TASK_CONTEXTS_CREATE_1_0,
+            trust_tasks::TASK_ACL_GRANT_0_1,
+            trust_tasks::TASK_CONTEXTS_LIST_1_0,
+        ];
+
+        let id = identity();
+        let client = VtaClient::new("http://vta.invalid").with_identity(id.clone());
+        let mut saw_proof_required = false;
+
+        for uri in URIS {
+            let policy = trust_tasks_rs::schema_index::spec_policy_for(uri).unwrap_or_else(|| {
+                panic!("{uri} has no published policy — the registry moved under this test")
+            });
+            saw_proof_required |= policy.is_proof_required;
+
+            let doc = client
+                .signed_task_document(uri, serde_json::json!({}))
+                .await
+                .unwrap_or_else(|e| panic!("{uri}: building the document failed: {e}"));
+            let typed: trust_tasks_rs::TrustTask<serde_json::Value> =
+                serde_json::from_value(doc).expect("the built document is a TrustTask");
+
+            policy
+                .enforce(&typed)
+                .unwrap_or_else(|r| panic!("{uri}: the VTA would refuse this document: {r:?}"));
+        }
+
+        // Without this the set could drift to reads only, and the test would
+        // pass while checking nothing about the member that actually broke.
+        assert!(
+            saw_proof_required,
+            "no URI under test requires a proof — this has stopped covering its own case"
+        );
+    }
+
+    /// A signed document must not be re-addressed on its way onto the wire.
+    ///
+    /// `address_trust_task` assigned `issuer` and `recipient` unconditionally,
+    /// after signing. The proof covers both, so any disagreement between the
+    /// document and the transport silently turned a valid signature into
+    /// `proofInvalid` at the far end — a failure that names the proof and says
+    /// nothing about the rewrite that caused it.
+    #[cfg(feature = "tsp")]
+    #[test]
+    fn addressing_refuses_to_rewrite_what_the_proof_covers() {
+        let doc = serde_json::json!({
+            "id": "urn:uuid:1", "type": TYPE,
+            "issuer": "did:key:zIssuer", "recipient": "did:key:zVta",
+            "payload": {}, "proof": { "type": "DataIntegrityProof" },
+        });
+
+        // Agreement is the ordinary case and passes through untouched.
+        let bytes = VtaClient::address_trust_task(doc.clone(), "did:key:zIssuer", "did:key:zVta")
+            .expect("matching addressing is accepted");
+        let out: serde_json::Value = serde_json::from_slice(&bytes).expect("valid JSON");
+        assert_eq!(out["issuer"], "did:key:zIssuer");
+        assert_eq!(out["recipient"], "did:key:zVta");
+
+        // Disagreement is refused, not silently resolved either way.
+        let err = VtaClient::address_trust_task(doc, "did:key:zSomeoneElse", "did:key:zVta")
+            .expect_err("a differing issuer must not be written over a signed document");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("issuer") && msg.contains("proof"),
+            "the error must name the member and why it matters, got: {msg}"
         );
     }
 


### PR DESCRIPTION
Investigation of a `proofRequired` failure reported from a production VTA, plus the hardening and the guard that would have caught it.

## What was reported

```
$ pnm contexts create --id openvtc-gt1 --name "OpenVTC" \
    --admin-did did:key:z6Mko3iZ… --admin-expires 1h
X Protocol error: trust task failed [proofRequired]: proof required but not present
```

That code comes from the VTA, not the client: `SpecPolicy::enforce` on the dispatch spine refusing a document whose specification declares `proof` REQUIRED (SPEC §7.2 item 7a).

## Root cause

The one #1184 fixed: `didcomm_transport` and `tsp_transport` built every client with `identity: None`, so `build_task_document` set neither `issuer` nor `recipient` and `signed_task_document` attached no proof. The guard meant to catch it was gated on `has_token()` — false by construction for DIDComm and TSP, so it covered the one transport whose constructor was already correct.

**What is new here is why it said `proofRequired`** rather than the `malformedRequest: … no in-band recipient` #1184's changelog describes:

| Transport | Document as sent | First check it fails | Operator sees |
|---|---|---|---|
| DIDComm | no `issuer`/`recipient`/`proof` | item 5b | `malformedRequest: … no in-band recipient` |
| TSP | `issuer`/`recipient` back-filled, no `proof` | item 7a | **`proofRequired`** |

`address_trust_task` back-fills both members on the TSP paths, which satisfies item 5b — so a TSP document sails past the recipient check and lands on the proof check. Same defect, two names.

It is released in `vta-sdk` 0.31.1. **`pnm-cli` 0.14.0 was cut against 0.31.0 and has not been re-released**, so an installed binary still carries it. Rebuild against ≥ 0.31.1, or use `--transport rest` (whose `rest_client` goes through `VtaClient::authenticated`, which has always carried an identity).

## Why it survived to production

The proof flag falls almost exactly along read-versus-mutate. Of the 344 request payloads in `trust-tasks-rs` 0.17, **210 require a proof** and **343 require a recipient**. So on an affected build the failure is both transport- and operation-dependent: over TSP reads succeed and mutations fail; over DIDComm essentially everything fails. A session that listed contexts before creating one saw a working client right up to the moment it mattered.

## What this changes

**`address_trust_task` no longer rewrites what the proof covers.** It assigned `issuer` and `recipient` unconditionally, after signing. A Data-Integrity proof covers every member but `proof`, so writing either one afterwards turns a valid signature into `proofInvalid` at the far end — a failure that names the proof and says nothing about the rewrite. Today the values come from the same triple, so it was a no-op; "it happens to be equal" is not something the next constructor has to keep true, and nothing was checking. It now fills only an absent member and refuses a disagreement, because neither resolution is safe.

**A guard that asserts against the registry, not against member names.** `the_built_document_satisfies_its_own_specification` builds the document the SDK actually sends and runs it through `spec_policy_for(uri).enforce(..)` — the same call the VTA makes. The existing tests checked `issuer`/`recipient`/`proof` by name and passed, because they were written from the same understanding as the code. It covers a mutation and a read deliberately, and fails if the URI set ever drifts to reads only.

**A corrected count.** The rationale on `signed_task_document` said "72 of the 109" specs require a proof. It is 210 of 344 — and the number that justifies the hard error is `recipient`, at 343 of 344. (My first draft of this claimed 413 of 413; the new test rejected it, which is a fair advertisement for asserting against the registry.)

## Same root cause, still live on `main` — reported, not fixed

Recorded in `docs/05-design-notes/trust-task-envelope-conformance.md`:

1. **A `did:webvh` bundle holder cannot sign at all.** `connect_didcomm_bundle{,_on}` pass `identity: None` deliberately, because `trust_task_sign` refuses a non-`did:key` holder — both services verify with a `did:key`-only resolver. So a provisioned integration (mediator, did-hosting daemon, app) cannot dispatch **any** of the 210 proof-requiring Trust Tasks, over any transport. Reachable through `AgentConnect::DidWebvhBundle`. Fixing it is a decision — teach the DI verifier `did:webvh`, or issue integrations a `did:key` signing identity alongside — not a patch, so it is not made here.
2. **`VtaClient::new(url)` + `set_token_async(token)` carries no identity**, so the documented `url + token` rung of the `AgentConnect` ladder fails every Trust Task. It fails loudly and locally, so it is listed rather than urgent.

## Testing

`cargo fmt --all --check`, `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p vta-sdk` (298 passing).

No version edit — release-plz assigns those.