### PR TITLE
feat(sdk)!: any DID that names a key may sign a Trust Task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9843,6 +9843,7 @@ dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
+ "affinidi-secrets-resolver",
  "affinidi-tdk",
  "async-trait",
  "axum",

--- a/docs/05-design-notes/trust-task-envelope-conformance.md
+++ b/docs/05-design-notes/trust-task-envelope-conformance.md
@@ -1,9 +1,10 @@
 # `proofRequired` on `pnm contexts create` — the envelope-conformance gap
 
-**Status:** root cause identified and already fixed for the affected
-constructors (#1184, released in `vta-sdk` 0.31.1); this note records the
-diagnosis, the operator-visible remedy, and the instances of the same root cause
-that are **still live on `main`**.
+**Status:** root cause identified and fixed. The transport constructors were
+fixed in #1184 (released in `vta-sdk` 0.31.1); the deeper restriction — that
+only a `did:key` holder could sign a Trust Task at all — is lifted in the
+follow-up recorded below. This note carries the diagnosis, the operator-visible
+remedy, and the rule that replaced the restriction.
 
 ## The report
 
@@ -86,23 +87,62 @@ Remedies, in order of preference:
 Three instances remain. None is a regression from #1184; all are the same shape
 — *a client that cannot produce a conforming envelope*.
 
-### 1. `did:webvh` bundle holders cannot sign at all
+### 1. `did:webvh` bundle holders cannot sign at all — **fixed**
 
-`VtaClient::connect_didcomm_bundle` and `connect_didcomm_bundle_on` pass
-`identity: None` **deliberately**: the holder is the bundle's `did:webvh`, and
-`trust_task_sign` refuses any holder that is not a `did:key`, because both
-services verify with a `did:key`-only resolver
-(`vti_common::auth::di_proof`).
+`VtaClient::connect_didcomm_bundle` and `connect_didcomm_bundle_on` passed
+`identity: None` deliberately: the holder is the bundle's `did:webvh`, and
+`trust_task_sign` refused any holder that was not a `did:key`, because both
+services verified with a `did:key`-only resolver.
 
-The consequence is not a missing member but a missing capability: **a provisioned
-integration cannot dispatch any of the 210 proof-requiring Trust Tasks**, over
-any transport. This is reachable through the documented
-`AgentConnect` ladder (`ConnectMode::DidWebvhBundle`), i.e. every mediator,
-did-hosting daemon and app provisioned through `provision-integration`.
+The consequence was not a missing member but a missing capability: **a
+provisioned integration could not dispatch any of the 210 proof-requiring Trust
+Tasks**, over any transport — every mediator, did-hosting daemon and app
+provisioned through `provision-integration`.
 
-Fixing it is a design decision, not a patch: either the DI verifier learns to
-resolve `did:webvh`, or provisioned integrations are issued a `did:key` signing
-identity alongside their `did:webvh`. Deliberately not decided here.
+**The rule is: any DID that can name a key may sign.** The DID method is not
+the authorization; resolving the verification method and checking the signature
+is. `did:key:z6Mk…#z6Mk…`, `did:webvh:<scid>:example.com:glenn#key-0` and
+`did:web:example.com#key-1` are all ordinary holders.
+
+The restriction was never a policy anyone chose. It was the shape of two
+helpers:
+
+- **The signer** took `(holder_did, private_key)` and *derived* the
+  verification method as `<did>#<multibase>`. That derivation only exists for
+  `did:key`, whose key is its identifier. A `did:webvh` document decides what
+  its keys are called, so nothing can guess `#key-0` — and a signer that takes
+  only a DID therefore cannot serve any method but one.
+  `HolderKey` now carries the verification method explicitly;
+  `HolderKey::from_did_key` keeps the derivation for the one method that has
+  one.
+- **The verifier** used `DidKeyResolver`, which refuses everything else.
+  `TrustTaskVmResolver` resolves `did:key` locally and every other method
+  through the configured DID cache.
+
+`ClientIdentity` gained `verification_method`, and the bundle constructors now
+build one from the bundle's own Ed25519 `SecretEntry` — whose `key_id` *is* the
+verification method the DID document publishes, so nothing has to be guessed.
+
+#### What this costs, and why it is still right
+
+`did:key` resolves with no I/O. Every other method needs a DID document, which
+means network resolution — on the login routes, before the caller is anybody.
+That widening is real and is bounded rather than dismissed:
+
+- the `did:key` fast path is checked first, so the common case never touches
+  the network;
+- resolution goes through the shared `DIDCacheClient`, which caches and carries
+  its own timeouts, so a flood of repeats costs one resolution;
+- the unauthenticated routes that verify proofs are already behind the
+  per-source-IP rate limiter;
+- a resolver is optional — `TrustTaskVmResolver::did_key_only()` is exactly the
+  previous behaviour, and `verify_trust_task_proof` still means that, so a
+  deployment that wants no outbound resolution on an unauthenticated route
+  configures it and a caller that wants it says so.
+
+The alternative is that no `did:webvh` holder can ever authenticate, which is
+not a security property — it is the absence of a feature the rest of the stack
+already assumes.
 
 ### 2. `VtaClient::new(url)` + `set_token_async(token)` carries no identity
 

--- a/vta-sdk/src/client/auto_connect.rs
+++ b/vta-sdk/src/client/auto_connect.rs
@@ -110,6 +110,7 @@ impl VtaClient {
                         client_did: input.credential_did.to_string(),
                         private_key_multibase: input.private_key_multibase.to_string(),
                         vta_did: input.vta_did.to_string(),
+                        verification_method: None,
                     },
                     token.access_token.clone(),
                 )

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -36,26 +36,74 @@ pub(super) struct RestAuth {
 /// SPEC §7.2 turns two of these into hard requirements, and this SDK carried
 /// neither until the VTA started enforcing them:
 ///
-/// * **item 5b** — every one of the 109 tasks this SDK dispatches declares
+/// * **item 5b** — 343 of the 344 published request payloads declare
 ///   `recipient` REQUIRED, so a document with no in-band recipient is
 ///   `malformedRequest`. `build_task_document` used to emit exactly that.
-/// * **item 7a** — 72 of them declare `proof` REQUIRED. A bearer token
+/// * **item 7a** — 210 of them declare `proof` REQUIRED. A bearer token
 ///   authenticates the *connection*; it says nothing about the document, and
 ///   §7.2 item 7 admits no transport substitute.
 ///
 /// Held together because they are not independent: attaching a proof without an
 /// in-band recipient trips item 8 (audience binding) on any non-bearer spec, so
 /// a client that can sign must also know who it is signing *to*.
+///
+/// # Any DID may be the producer
+///
+/// `client_did` is not restricted to `did:key`. A `did:webvh` holder — which is
+/// what every integration this workspace provisions actually has — signs by
+/// naming its key in [`verification_method`](Self::verification_method);
+/// see [`HolderKey`](crate::trust_task_sign::HolderKey).
 #[derive(Clone, Debug)]
 pub struct ClientIdentity {
-    /// The producer's `did:key`. Becomes the document's `issuer`, and must
-    /// match the identity the transport authenticates as — item 6 rejects a
-    /// document whose in-band issuer disagrees with it.
+    /// The producer's DID. Becomes the document's `issuer`, and must match the
+    /// identity the transport authenticates as — item 6 rejects a document
+    /// whose in-band issuer disagrees with it.
     pub client_did: String,
-    /// Multibase-encoded Ed25519 seed for `client_did`.
+    /// Multibase-encoded Ed25519 seed for the signing key.
     pub private_key_multibase: String,
     /// The VTA's DID. Becomes the document's `recipient`.
     pub vta_did: String,
+    /// The verification method the proof names, when `client_did` does not
+    /// determine it.
+    ///
+    /// `None` means "derive it", which is only possible for a `did:key`, whose
+    /// key *is* its identifier. Every other method must name one —
+    /// `did:webvh:<scid>:example.com:glenn#key-0` — because a DID document
+    /// decides what its keys are called and no amount of string manipulation
+    /// can guess it.
+    pub verification_method: Option<String>,
+}
+
+impl ClientIdentity {
+    /// A `did:key` producer, whose verification method is derivable.
+    pub fn did_key(
+        client_did: impl Into<String>,
+        private_key_multibase: impl Into<String>,
+        vta_did: impl Into<String>,
+    ) -> Self {
+        Self {
+            client_did: client_did.into(),
+            private_key_multibase: private_key_multibase.into(),
+            vta_did: vta_did.into(),
+            verification_method: None,
+        }
+    }
+
+    /// The signing key this identity produces proofs with.
+    ///
+    /// Fails only when the identity cannot name a key at all: no
+    /// `verification_method` and a `client_did` that is not a `did:key`.
+    pub fn holder_key(
+        &self,
+    ) -> Result<crate::trust_task_sign::HolderKey, crate::trust_task_sign::TrustTaskSignError> {
+        match &self.verification_method {
+            Some(vm) => crate::trust_task_sign::HolderKey::new(vm, &self.private_key_multibase),
+            None => crate::trust_task_sign::HolderKey::from_did_key(
+                &self.client_did,
+                &self.private_key_multibase,
+            ),
+        }
+    }
 }
 
 /// Cloneable transport layer.
@@ -416,6 +464,7 @@ impl VtaClient {
             client_did: cred.did.clone(),
             private_key_multibase: cred.private_key_multibase.clone(),
             vta_did: cred.vta_did.clone(),
+            verification_method: None,
         };
 
         Ok(Self {
@@ -497,6 +546,7 @@ impl VtaClient {
                 client_did: client_did.to_string(),
                 private_key_multibase: private_key_multibase.to_string(),
                 vta_did: vta_did.to_string(),
+                verification_method: None,
             }),
         ))
     }
@@ -585,6 +635,7 @@ impl VtaClient {
                 client_did: client_did.to_string(),
                 private_key_multibase: private_key_multibase.to_string(),
                 vta_did: vta_did.to_string(),
+                verification_method: None,
             }),
         ))
     }
@@ -628,12 +679,11 @@ impl VtaClient {
         .await
         .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
 
-        // No `ClientIdentity`: the holder here is `bundle.did` — a
-        // `did:webvh` — and `trust_task_sign` signs for `did:key` holders
-        // only. Carrying an unsignable identity would buy an in-band
-        // `recipient` and then fail at the proof, so the gap is left visible
-        // to `signed_task_document` instead.
-        Ok(Self::didcomm_transport(session, rest_url, None))
+        Ok(Self::didcomm_transport(
+            session,
+            rest_url,
+            bundle_identity(bundle, vta_did),
+        ))
     }
 
     /// Connect from a hosted-DID secrets bundle as one identity **on a shared
@@ -663,12 +713,11 @@ impl VtaClient {
         .await
         .map_err(|e| VtaError::DidcommTransport(e.to_string()))?;
 
-        // No `ClientIdentity`: the holder here is `bundle.did` — a
-        // `did:webvh` — and `trust_task_sign` signs for `did:key` holders
-        // only. Carrying an unsignable identity would buy an in-band
-        // `recipient` and then fail at the proof, so the gap is left visible
-        // to `signed_task_document` instead.
-        Ok(Self::didcomm_transport(session, rest_url, None))
+        Ok(Self::didcomm_transport(
+            session,
+            rest_url,
+            bundle_identity(bundle, vta_did),
+        ))
     }
 
     /// Connect via **TSP** through a mediator — the transport-agnostic
@@ -731,6 +780,7 @@ impl VtaClient {
                 client_did: client_did.to_string(),
                 private_key_multibase: private_key_multibase.to_string(),
                 vta_did: vta_did.to_string(),
+                verification_method: None,
             }),
         ))
     }
@@ -770,6 +820,7 @@ impl VtaClient {
                 client_did: client_did.to_string(),
                 private_key_multibase: private_key_multibase.to_string(),
                 vta_did: vta_did.to_string(),
+                verification_method: None,
             }),
         ))
     }
@@ -2682,6 +2733,30 @@ mod tests {
     }
 }
 
+/// The [`ClientIdentity`] a hosted-DID secrets bundle can sign as.
+///
+/// The holder is the bundle's `did:webvh`, which names its keys in its own DID
+/// document — so the identity carries the verification method verbatim from the
+/// bundle rather than deriving one, which is only possible for a `did:key`.
+///
+/// `None` when the bundle has no Ed25519 key to sign with. That is the honest
+/// answer rather than a placeholder identity: `signed_task_document` then
+/// refuses locally and names the missing piece, instead of building a document
+/// that fails at the far end.
+#[cfg(feature = "session")]
+fn bundle_identity(
+    bundle: &crate::did_secrets::DidSecretsBundle,
+    vta_did: &str,
+) -> Option<ClientIdentity> {
+    let entry = bundle.trust_task_signing_key()?;
+    Some(ClientIdentity {
+        client_did: bundle.did.clone(),
+        private_key_multibase: entry.private_key_multibase.clone(),
+        vta_did: vta_did.to_string(),
+        verification_method: Some(entry.key_id.clone()),
+    })
+}
+
 /// Build the Trust Task document a dispatch sends.
 ///
 /// Split out of [`VtaClient::dispatch_trust_task`] so the one interesting thing
@@ -2748,13 +2823,14 @@ impl VtaClient {
             .map_err(|e| {
             VtaError::Protocol(format!("could not build a Trust Task document: {e}"))
         })?;
-        crate::trust_task_sign::sign_in_place(
-            &mut typed,
-            &identity.client_did,
-            &identity.private_key_multibase,
-        )
-        .await
-        .map_err(|e| VtaError::Protocol(format!("could not sign the Trust Task document: {e}")))?;
+        let key = identity
+            .holder_key()
+            .map_err(|e| VtaError::Protocol(format!("this client cannot sign: {e}")))?;
+        crate::trust_task_sign::sign_in_place_with(&mut typed, &key)
+            .await
+            .map_err(|e| {
+                VtaError::Protocol(format!("could not sign the Trust Task document: {e}"))
+            })?;
         serde_json::to_value(&typed)
             .map_err(|e| VtaError::Protocol(format!("could not serialise the document: {e}")))
     }
@@ -2898,6 +2974,7 @@ mod client_identity_tests {
             client_did,
             private_key_multibase,
             vta_did: "did:key:z6MkVta".to_string(),
+            verification_method: None,
         }
     }
 

--- a/vta-sdk/src/did_secrets.rs
+++ b/vta-sdk/src/did_secrets.rs
@@ -53,6 +53,25 @@ pub struct SecretEntry {
     pub private_key_multibase: String,
 }
 
+impl DidSecretsBundle {
+    /// The bundle's Ed25519 assertion key, as a Trust Task signing key.
+    ///
+    /// A provisioned integration holds a `did:webvh` and the keys under it. Its
+    /// verification method is [`SecretEntry::key_id`] — the DID document
+    /// decided what the key is called, and that name is in the bundle, so
+    /// nothing here has to guess it.
+    ///
+    /// `None` when the bundle carries no Ed25519 entry: X25519 is a key
+    /// agreement key and signs nothing, and P-256 is not what `eddsa-jcs-2022`
+    /// verifies.
+    #[must_use]
+    pub fn trust_task_signing_key(&self) -> Option<&SecretEntry> {
+        self.secrets
+            .iter()
+            .find(|e| matches!(e.key_type, KeyType::Ed25519))
+    }
+}
+
 /// Convert a [`GetKeySecretResponse`](crate::client::GetKeySecretResponse) into a [`SecretEntry`].
 #[cfg(feature = "client")]
 impl From<crate::client::GetKeySecretResponse> for SecretEntry {

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -152,6 +152,7 @@ pub(crate) async fn run_rest_attempt_full_setup(
             client_did: setup_did.clone(),
             private_key_multibase: setup_privkey_mb.clone(),
             vta_did: vta_did.to_string(),
+            verification_method: None,
         },
         token_result.access_token,
     )
@@ -327,6 +328,7 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
             client_did: setup_did.clone(),
             private_key_multibase: setup_privkey_mb.clone(),
             vta_did: vta_did.to_string(),
+            verification_method: None,
         },
         token_result.access_token,
     )

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -659,6 +659,7 @@ impl SessionStore {
                 client_did: session.client_did.clone(),
                 private_key_multibase: session.private_key.clone(),
                 vta_did,
+                verification_method: None,
             },
             token,
         )

--- a/vta-sdk/src/trust_task_sign.rs
+++ b/vta-sdk/src/trust_task_sign.rs
@@ -38,10 +38,16 @@ use crate::did_key::decode_private_key_multibase;
 /// Why building or signing a Trust Task document failed.
 #[derive(Debug)]
 pub enum TrustTaskSignError {
-    /// The holder DID is not a `did:key`. Both services verify the proof with a
-    /// `did:key`-only resolver, so no other method can sign a document they
-    /// will accept — refused here rather than after a round trip.
+    /// [`HolderKey::from_did_key`] was handed something that is not a
+    /// `did:key`. Only that constructor is method-specific, because only
+    /// `did:key` puts the verification method in the identifier; any other DID
+    /// names its key explicitly through [`HolderKey::new`].
     NotDidKey(String),
+    /// A verification method that does not identify a key: not a `did:`, or
+    /// carrying no `#fragment`. A proof names *a key*, not a subject, so
+    /// `did:webvh:<scid>:example.com:glenn` is not one and
+    /// `did:webvh:<scid>:example.com:glenn#key-0` is.
+    NotAVerificationMethod(String),
     /// The holder's private key could not be decoded from its multibase form.
     BadPrivateKey(String),
     /// The Trust Task type URI failed to parse.
@@ -55,7 +61,13 @@ impl std::fmt::Display for TrustTaskSignError {
         match self {
             Self::NotDidKey(did) => write!(
                 f,
-                "signing a Trust Task requires a did:key holder; got {did}"
+                "HolderKey::from_did_key needs a did:key, which carries its own verification \
+                 method; got {did} — use HolderKey::new and name the key"
+            ),
+            Self::NotAVerificationMethod(vm) => write!(
+                f,
+                "`{vm}` does not identify a key: a verification method is a DID with a \
+                 `#fragment`, e.g. did:webvh:<scid>:example.com:glenn#key-0"
             ),
             Self::BadPrivateKey(e) => write!(f, "decode holder private key: {e}"),
             Self::TypeUri(e) => write!(f, "Trust Task type URI parse: {e}"),
@@ -98,19 +110,110 @@ pub fn build_unsigned(
     Ok(doc)
 }
 
-/// Attach the holder's `eddsa-jcs-2022` Data-Integrity proof to `doc` in place.
+/// The key a Trust Task proof is made with: the verification method the proof
+/// will name, and the private key behind it.
 ///
-/// `holder_did` must be a `did:key` whose seed is `private_key_multibase`. The
-/// proof is computed over the document with `proof` removed — see the module
-/// docs for why that matters.
+/// **Any DID that can name a key may sign.** The verifier resolves the
+/// verification method and checks the signature; the DID method is not the
+/// authorization. `did:key:z6Mk…#z6Mk…`,
+/// `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1`
+/// are all ordinary holders.
+///
+/// This type exists because the two cases differ in one way that a bare
+/// `(did, key)` pair cannot express: a `did:key` *contains* its verification
+/// method, and nothing else does. Deriving `#key-0` from a `did:webvh` is not
+/// possible — the document says what the keys are called — so the caller has
+/// to name it, and a signer that takes only a DID silently cannot serve any
+/// method but one. That is the shape the restriction had before this type:
+/// not a policy anyone chose, but a helper that only knew how to build one
+/// kind of identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HolderKey {
+    verification_method: String,
+    private_key_multibase: String,
+}
+
+impl HolderKey {
+    /// A holder that names its own verification method — the general case.
+    ///
+    /// `verification_method` must be a DID with a `#fragment`, e.g.
+    /// `did:webvh:<scid>:example.com:glenn#key-0`. Whether the key is *in* that
+    /// DID document, and whether the DID document is reachable, is the
+    /// verifier's business; this only refuses what cannot identify a key at all.
+    pub fn new(
+        verification_method: impl Into<String>,
+        private_key_multibase: impl Into<String>,
+    ) -> Result<Self, TrustTaskSignError> {
+        let verification_method = verification_method.into();
+        let (did, fragment) = verification_method.split_once('#').ok_or_else(|| {
+            TrustTaskSignError::NotAVerificationMethod(verification_method.clone())
+        })?;
+        if !did.starts_with("did:") || fragment.is_empty() {
+            return Err(TrustTaskSignError::NotAVerificationMethod(
+                verification_method.clone(),
+            ));
+        }
+        Ok(Self {
+            verification_method,
+            private_key_multibase: private_key_multibase.into(),
+        })
+    }
+
+    /// A `did:key` holder, whose verification method is `<did>#<multibase>` and
+    /// so needs no naming.
+    pub fn from_did_key(
+        did: &str,
+        private_key_multibase: impl Into<String>,
+    ) -> Result<Self, TrustTaskSignError> {
+        let vm =
+            did_key_to_vm(did).ok_or_else(|| TrustTaskSignError::NotDidKey(did.to_string()))?;
+        Ok(Self {
+            verification_method: vm,
+            private_key_multibase: private_key_multibase.into(),
+        })
+    }
+
+    /// The verification method the proof will name.
+    #[must_use]
+    pub fn verification_method(&self) -> &str {
+        &self.verification_method
+    }
+
+    /// The holder DID — the verification method without its fragment. This is
+    /// the DID a verifier recovers as the proven signer.
+    #[must_use]
+    pub fn holder_did(&self) -> &str {
+        self.verification_method
+            .split('#')
+            .next()
+            .unwrap_or(&self.verification_method)
+    }
+}
+
+/// Attach the holder's `eddsa-jcs-2022` Data-Integrity proof to `doc` in place,
+/// naming `holder_did`'s `did:key` verification method.
+///
+/// The `did:key` convenience form of [`sign_in_place_with`]; see [`HolderKey`]
+/// for why any other method has to name its key.
 pub async fn sign_in_place(
     doc: &mut TrustTask<Value>,
     holder_did: &str,
     private_key_multibase: &str,
 ) -> Result<(), TrustTaskSignError> {
-    let vm_id = did_key_to_vm(holder_did)
-        .ok_or_else(|| TrustTaskSignError::NotDidKey(holder_did.to_string()))?;
-    let seed = decode_private_key_multibase(private_key_multibase)
+    let key = HolderKey::from_did_key(holder_did, private_key_multibase)?;
+    sign_in_place_with(doc, &key).await
+}
+
+/// Attach the holder's `eddsa-jcs-2022` Data-Integrity proof to `doc` in place.
+///
+/// The proof is computed over the document with `proof` removed — see the
+/// module docs for why that matters.
+pub async fn sign_in_place_with(
+    doc: &mut TrustTask<Value>,
+    key: &HolderKey,
+) -> Result<(), TrustTaskSignError> {
+    let vm_id = key.verification_method.clone();
+    let seed = decode_private_key_multibase(&key.private_key_multibase)
         .map_err(|e| TrustTaskSignError::BadPrivateKey(e.to_string()))?;
     let mut signer = Secret::generate_ed25519(Some(&vm_id), Some(&seed));
     signer.id = vm_id;
@@ -149,8 +252,23 @@ pub async fn build_signed(
     private_key_multibase: &str,
     recipient: &str,
 ) -> Result<String, TrustTaskSignError> {
-    let mut doc = build_unsigned(type_uri, payload, holder_did, recipient)?;
-    sign_in_place(&mut doc, holder_did, private_key_multibase).await?;
+    let key = HolderKey::from_did_key(holder_did, private_key_multibase)?;
+    build_signed_with(type_uri, payload, &key, recipient).await
+}
+
+/// Build a holder-signed Trust Task for a holder of any DID method.
+///
+/// The `issuer` is [`HolderKey::holder_did`] — the verification method's own
+/// DID — so the document's claimed issuer and its proven signer cannot come
+/// apart at the point of construction.
+pub async fn build_signed_with(
+    type_uri: &str,
+    payload: Value,
+    key: &HolderKey,
+    recipient: &str,
+) -> Result<String, TrustTaskSignError> {
+    let mut doc = build_unsigned(type_uri, payload, key.holder_did(), recipient)?;
+    sign_in_place_with(&mut doc, key).await?;
     serde_json::to_string(&doc).map_err(|e| TrustTaskSignError::Sign(e.to_string()))
 }
 
@@ -172,6 +290,76 @@ mod tests {
     }
 
     const TYPE: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.2";
+
+    /// The whole point of [`HolderKey`]: a holder that is not a `did:key`
+    /// signs, and the document it produces is well-formed — `issuer` is the
+    /// holder DID, and the proof names the key the holder was told to use.
+    ///
+    /// A `did:webvh` verification method is not derivable from its DID: the DID
+    /// document decides that `#key-0` is what the key is called. So the only
+    /// thing that ever prevented this was a helper that could build one shape
+    /// of identifier.
+    #[tokio::test]
+    async fn a_did_webvh_holder_signs_and_names_its_key() {
+        const VM: &str = "did:webvh:QmScidExample:example.com:glenn#key-0";
+        let (_did, pk) = did_key_from_seed(0xb2);
+
+        let key = HolderKey::new(VM, &pk).expect("a DID with a fragment is a verification method");
+        assert_eq!(
+            key.holder_did(),
+            "did:webvh:QmScidExample:example.com:glenn"
+        );
+
+        let body = build_signed_with(TYPE, json!({"vp": {}}), &key, "did:key:z6MkVtc")
+            .await
+            .expect("a did:webvh holder can sign");
+        let doc: TrustTask<Value> = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(doc.issuer.as_deref(), Some(key.holder_did()));
+        let proof = doc.proof.as_ref().expect("signed");
+        let di: DataIntegrityProof =
+            serde_json::from_value(serde_json::to_value(proof).unwrap()).unwrap();
+        assert_eq!(
+            di.verification_method, VM,
+            "the proof must name the key the DID document publishes, not a derived one"
+        );
+    }
+
+    /// A verification method identifies a *key*. A bare DID does not, and
+    /// neither does a non-DID string — refused at construction rather than
+    /// producing a proof nothing can resolve.
+    #[test]
+    fn a_verification_method_must_name_a_key() {
+        for bad in [
+            "did:webvh:QmScid:example.com:glenn",
+            "did:webvh:QmScid:example.com:glenn#",
+            "https://example.com/keys#key-0",
+            "no-scheme#key-0",
+        ] {
+            assert!(
+                matches!(
+                    HolderKey::new(bad, "z1234"),
+                    Err(TrustTaskSignError::NotAVerificationMethod(_))
+                ),
+                "`{bad}` must be refused"
+            );
+        }
+    }
+
+    /// `did:key` keeps its convenience: it is the one method whose verification
+    /// method is derivable, because the key is in the identifier.
+    #[test]
+    fn a_did_key_holder_still_derives_its_own_verification_method() {
+        let (did, pk) = did_key_from_seed(0xb3);
+        let key = HolderKey::from_did_key(&did, &pk).expect("did:key derives");
+        assert_eq!(key.verification_method(), format!("{did}#{}", &did[8..]));
+        assert_eq!(key.holder_did(), did);
+
+        assert!(matches!(
+            HolderKey::from_did_key("did:webvh:QmScid:example.com:glenn", &pk),
+            Err(TrustTaskSignError::NotDidKey(_))
+        ));
+    }
 
     /// The signed document verifies under the same `did:key` resolver both
     /// services use, and carries issuer + recipient.
@@ -224,9 +412,16 @@ mod tests {
         );
     }
 
-    /// A non-`did:key` holder is refused locally.
+    /// The `did:key` convenience form refuses a DID it cannot derive a
+    /// verification method from — which is every other method.
+    ///
+    /// This is a limit of *this entry point*, not a rule about who may sign: a
+    /// `did:web` holder signs perfectly well through [`build_signed_with`] by
+    /// naming its key. The refusal is here so the caller finds out at the
+    /// helper rather than by sending a proof whose `verificationMethod` was
+    /// invented.
     #[tokio::test]
-    async fn non_did_key_holder_refused() {
+    async fn the_did_key_helper_refuses_a_did_it_cannot_derive_a_key_from() {
         let (_, pk) = did_key_from_seed(0xa3);
         let err = build_signed(
             TYPE,
@@ -236,8 +431,14 @@ mod tests {
             "did:key:z6MkVtc",
         )
         .await
-        .expect_err("did:web must be refused");
+        .expect_err("the derive-it form cannot serve did:web");
         assert!(matches!(err, TrustTaskSignError::NotDidKey(_)), "{err:?}");
+
+        // The same holder, naming its key, signs.
+        let key = HolderKey::new("did:web:example.com#key-1", &pk).expect("names a key");
+        build_signed_with(TYPE, json!({}), &key, "did:key:z6MkVtc")
+            .await
+            .expect("naming the key is all it took");
     }
 
     /// The unsigned builder always sets `recipient` — a signed document without

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -92,6 +92,7 @@ fn test_identity() -> vta_sdk::client::ClientIdentity {
             sk.to_bytes().as_slice(),
         ),
         vta_did: "did:key:z6MkTestVta".into(),
+        verification_method: None,
     }
 }
 

--- a/vta-service/src/routes/auth.rs
+++ b/vta-service/src/routes/auth.rs
@@ -249,7 +249,7 @@ async fn try_authenticate_trust_task(
     }
 
     // From here the caller's intent is unambiguous; failures are real.
-    let signer_did = verify_authenticate_proof(&doc).await?;
+    let signer_did = verify_authenticate_proof(state, &doc).await?;
     let payload: authenticate::Payload = serde_json::from_value(doc.payload.clone())
         .map_err(|e| AppError::Authentication(format!("invalid authenticate payload: {e}")))?;
     let session_id = payload.session_id.to_string();
@@ -288,9 +288,14 @@ async fn try_authenticate_trust_task(
 /// the subject is *unknown a priori* — it's derived from the proof rather than
 /// checked against an expected value. The signer↔session binding is enforced
 /// downstream by the canonical handler (`signer_did == session.did`).
-/// `did:key` resolution is local (no I/O), matching the mobile holder key.
-async fn verify_authenticate_proof(doc: &TrustTask<Value>) -> Result<String, AppError> {
-    crate::auth::di_proof::verify_trust_task_proof(doc)
+/// Verified against the state's resolver, so a `did:webvh` holder — which is
+/// what every provisioned integration has — can authenticate. `did:key` still
+/// resolves locally, so the mobile holder's login costs no I/O.
+async fn verify_authenticate_proof(
+    state: &AppState,
+    doc: &TrustTask<Value>,
+) -> Result<String, AppError> {
+    crate::auth::di_proof::verify_trust_task_proof_with(doc, &state.trust_task_vm_resolver())
         .await
         .map_err(|e| AppError::Authentication(e.to_string()))
 }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -281,6 +281,18 @@ pub struct AppState {
     pub metrics_handle: Option<crate::metrics::PrometheusHandle>,
 }
 
+impl AppState {
+    /// The resolver Trust Task Data-Integrity proofs are verified with.
+    ///
+    /// Carries the configured DID cache, so a proof by any DID that names a key
+    /// — `did:webvh:<scid>:example.com:glenn#key-0` as much as a `did:key` —
+    /// resolves. With no cache configured this degrades to `did:key` only,
+    /// which is what a deployment with no outbound DID resolution gets.
+    pub fn trust_task_vm_resolver(&self) -> vti_common::auth::TrustTaskVmResolver {
+        vti_common::auth::TrustTaskVmResolver::from_optional(self.did_resolver.clone())
+    }
+}
+
 impl AuthState for AppState {
     fn jwt_keys(&self) -> Option<&Arc<JwtKeys>> {
         self.jwt_keys.as_ref()

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -735,6 +735,7 @@ impl TestAppContext {
                 client_did: did,
                 private_key_multibase,
                 vta_did: vta_did.to_string(),
+                verification_method: None,
             },
             token,
         )

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -969,7 +969,12 @@ async fn dispatch_trust_task_validated(
     // keep their own calls — they bind the signer to a *specific* party (the
     // approver), which is a stronger claim than "the issuer signed this".
     if doc.proof.is_some() {
-        match vti_common::auth::di_proof::verify_trust_task_proof(&doc).await {
+        match vti_common::auth::di_proof::verify_trust_task_proof_with(
+            &doc,
+            &state.trust_task_vm_resolver(),
+        )
+        .await
+        {
             Ok(signer) => {
                 // A valid proof by some *other* DID is not a proof by the
                 // issuer; without this the signature would establish only that

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -120,7 +120,12 @@ pub(super) async fn handle_decision(
     };
 
     // Authority is the proof: verify it and take the *proven* signer DID.
-    let approver = match crate::auth::di_proof::verify_trust_task_proof(&doc).await {
+    let approver = match crate::auth::di_proof::verify_trust_task_proof_with(
+        &doc,
+        &state.trust_task_vm_resolver(),
+    )
+    .await
+    {
         Ok(did) => did,
         Err(e) => {
             // The only decision path that reaches no audit row: every later

--- a/vtc-service/src/routes/auth.rs
+++ b/vtc-service/src/routes/auth.rs
@@ -331,9 +331,12 @@ async fn authenticate_trust_task(
     }
 
     // From here the caller's intent is unambiguous; failures are real.
-    let signer_did = vti_common::auth::di_proof::verify_trust_task_proof(&doc)
-        .await
-        .map_err(|e| AppError::Authentication(e.to_string()))?;
+    let signer_did = vti_common::auth::di_proof::verify_trust_task_proof_with(
+        &doc,
+        &state.trust_task_vm_resolver(),
+    )
+    .await
+    .map_err(|e| AppError::Authentication(e.to_string()))?;
     let payload: authenticate::Payload = serde_json::from_value(doc.payload.clone())
         .map_err(|e| AppError::Authentication(format!("invalid authenticate payload: {e}")))?;
 

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -171,9 +171,12 @@ pub async fn publish(
     //     the key for. Removing them from the community does stop
     //     them immediately, because `is_current_member` reads the
     //     ACL live.
-    let signer_did = vti_common::auth::di_proof::verify_trust_task_proof(&doc)
-        .await
-        .map_err(|e| AppError::Forbidden(format!("document proof: {e}")))?;
+    let signer_did = vti_common::auth::di_proof::verify_trust_task_proof_with(
+        &doc,
+        &state.trust_task_vm_resolver(),
+    )
+    .await
+    .map_err(|e| AppError::Forbidden(format!("document proof: {e}")))?;
 
     // 0c. Per-DID rate limiting, keyed on the HMAC of the signer
     //     rather than the DID itself — the discipline the audit

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -224,6 +224,16 @@ pub(crate) const REMOVAL_NOTICE_DELIVER_BY: std::time::Duration =
     std::time::Duration::from_secs(30 * 24 * 3600);
 
 impl AppState {
+    /// The resolver Trust Task Data-Integrity proofs are verified with.
+    ///
+    /// Carries the configured DID cache, so a proof by any DID that names a key
+    /// — `did:webvh:<scid>:example.com:glenn#key-0` as much as a `did:key` —
+    /// resolves. With no cache configured this degrades to `did:key` only,
+    /// which is what a deployment with no outbound DID resolution gets.
+    pub fn trust_task_vm_resolver(&self) -> vti_common::auth::TrustTaskVmResolver {
+        vti_common::auth::TrustTaskVmResolver::from_optional(self.did_resolver.clone())
+    }
+
     /// Current cached member-row count (equal to
     /// `members::list_members(..).len()`). O(1) — see
     /// [`Self::member_count_cache`].

--- a/vtc-service/src/setup/wizard.rs
+++ b/vtc-service/src/setup/wizard.rs
@@ -887,6 +887,7 @@ async fn connect_setup_client(
                 client_did: setup_key.did.clone(),
                 private_key_multibase: setup_key.private_key_multibase().to_string(),
                 vta_did: resolved.vta_did.clone(),
+                verification_method: None,
             },
             auth.access_token,
         )

--- a/vtc-service/src/trust_tasks/helpers.rs
+++ b/vtc-service/src/trust_tasks/helpers.rs
@@ -27,6 +27,8 @@ use trust_tasks_rs::{ErrorPayload, ErrorResponse, RejectReason, TrustTask, TypeU
 use uuid::Uuid;
 use vti_common::error::AppError;
 
+use crate::server::AppState;
+
 use vta_sdk::protocols::join_requests::VerdictResponse;
 
 /// The transport-neutral result of dispatching a Trust Task: the framework
@@ -234,8 +236,11 @@ pub(crate) fn body_parse_error_response(reason: &str) -> TrustTaskOutcome {
 /// (`eddsa-jcs-2022` canonicalises the proofless document via JCS). The
 /// returned DID is *proven*, not merely claimed — binding it to an expected
 /// identity is the caller's job. `did:key` resolution is local (no network).
-pub(crate) async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<String, AppError> {
-    vti_common::auth::di_proof::verify_trust_task_proof(doc)
+pub(crate) async fn verify_trust_task_proof(
+    state: &AppState,
+    doc: &TrustTask<Value>,
+) -> Result<String, AppError> {
+    vti_common::auth::di_proof::verify_trust_task_proof_with(doc, &state.trust_task_vm_resolver())
         .await
         .map_err(|e| AppError::Unauthorized(format!("Trust Task {e}")))
 }

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -181,12 +181,13 @@ pub(crate) const PERSONHOOD_ASSERT_TYPE: &str = <pa::Payload as trust_tasks_rs::
 /// authcrypt sender; REST → the document proof signer. When the document
 /// carries an `issuer`, it must match the proven identity (anti-spoof).
 async fn resolve_holder(
+    state: &AppState,
     ctx: &JoinAuthCtx,
     doc: &TrustTask<Value>,
 ) -> Result<String, TrustTaskOutcome> {
     let proven = match &ctx.sender_did {
         Some(did) => did.clone(),
-        None => match verify_trust_task_proof(doc).await {
+        None => match verify_trust_task_proof(state, doc).await {
             Ok(did) => did,
             Err(e) => return Err(app_error_to_reject(doc, &e)),
         },
@@ -214,7 +215,7 @@ async fn handle_submit(
     ctx: &JoinAuthCtx,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let applicant_did = match resolve_holder(ctx, &doc).await {
+    let applicant_did = match resolve_holder(state, ctx, &doc).await {
         Ok(did) => did,
         Err(reject) => return reject,
     };
@@ -327,7 +328,7 @@ async fn handle_status(
     ctx: &JoinAuthCtx,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let applicant_did = match resolve_holder(ctx, &doc).await {
+    let applicant_did = match resolve_holder(state, ctx, &doc).await {
         Ok(did) => did,
         Err(reject) => return reject,
     };
@@ -385,7 +386,7 @@ async fn handle_self_remove(
     ctx: &JoinAuthCtx,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let member_did = match resolve_holder(ctx, &doc).await {
+    let member_did = match resolve_holder(state, ctx, &doc).await {
         Ok(did) => did,
         Err(reject) => return reject,
     };
@@ -444,7 +445,7 @@ async fn handle_personhood_challenge(
     ctx: &JoinAuthCtx,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let caller = match resolve_holder(ctx, &doc).await {
+    let caller = match resolve_holder(state, ctx, &doc).await {
         Ok(did) => did,
         Err(reject) => return reject,
     };
@@ -493,7 +494,7 @@ async fn handle_personhood_assert(
     ctx: &JoinAuthCtx,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let caller = match resolve_holder(ctx, &doc).await {
+    let caller = match resolve_holder(state, ctx, &doc).await {
         Ok(did) => did,
         Err(reject) => return reject,
     };
@@ -547,7 +548,7 @@ async fn handle_member_vmc(
     ctx: &JoinAuthCtx,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    let member_did = match resolve_holder(ctx, &doc).await {
+    let member_did = match resolve_holder(state, ctx, &doc).await {
         Ok(did) => did,
         Err(reject) => return reject,
     };

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -79,6 +79,7 @@ bytes = "1"
 # Secrets resolver (for error type)
 affinidi-tdk = { workspace = true }
 affinidi-data-integrity = { workspace = true }
+affinidi-secrets-resolver = { workspace = true }
 trust-tasks-rs = { workspace = true }
 trust-tasks-capability-client = { workspace = true }
 # DID resolution for SIOPv2 id_token verification (auth::siop). The

--- a/vti-common/src/auth/di_proof.rs
+++ b/vti-common/src/auth/di_proof.rs
@@ -16,11 +16,27 @@
 //! same wire shape* — a divergence between them is a divergence in what a
 //! signature means, which is not a thing to let happen twice.
 //!
-//! `did:key` resolution is local (no network I/O) — the mobile holder key is
-//! always a `did:key`, matching the engine's signing side, and it keeps proof
-//! verification off the network on an unauthenticated route.
+//! # Which DIDs may sign
+//!
+//! Any DID that can name a key. A proof's `verificationMethod` is resolved by
+//! [`TrustTaskVmResolver`](super::vm_resolver::TrustTaskVmResolver), which
+//! handles `did:key` locally and every other method through the configured DID
+//! cache — so `did:webvh:<scid>:example.com:glenn#key-0` signs a Trust Task
+//! exactly as a `did:key` does.
+//!
+//! This used to be `did:key` only, on the reasoning that the mobile holder key
+//! is always a `did:key` and it kept proof verification off the network on an
+//! unauthenticated route. The first half was never true of the whole surface:
+//! every DID this workspace provisions for an integration is a `did:webvh`, so
+//! the restriction meant a provisioned integration could not sign a Trust Task
+//! at all. The second half is a real cost and is bounded rather than dismissed
+//! — see the resolver's own module docs, and
+//! [`verify_trust_task_proof`], whose `did:key`-only behaviour is unchanged for
+//! callers that want it.
 
-use affinidi_data_integrity::{DataIntegrityProof, DidKeyResolver, VerifyOptions};
+use affinidi_data_integrity::{DataIntegrityProof, VerifyOptions};
+
+use super::vm_resolver::TrustTaskVmResolver;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 
@@ -77,6 +93,17 @@ impl std::fmt::Display for DiProofError {
     }
 }
 
+/// Verify the proof on `doc` **against `did:key` only**, with no network I/O.
+///
+/// The narrow form, kept for callers whose signer is a `did:key` by
+/// construction and who do not want an unauthenticated request to be able to
+/// trigger DID resolution. Anything that must accept a provisioned
+/// integration's `did:webvh` holder wants
+/// [`verify_trust_task_proof_with`] and a configured resolver.
+pub async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<String, DiProofError> {
+    verify_trust_task_proof_with(doc, &TrustTaskVmResolver::did_key_only()).await
+}
+
 /// Verify the `eddsa-jcs-2022` Data-Integrity proof on `doc` and return the
 /// proven signer DID — the base DID (before `#`) of the proof's
 /// `verificationMethod`.
@@ -84,8 +111,14 @@ impl std::fmt::Display for DiProofError {
 /// The signature is verified over the document with its `proof` block removed
 /// (`eddsa-jcs-2022` canonicalises the proofless document via JCS). The
 /// returned DID is *proven*, not merely claimed; binding it to an expected
-/// identity (session DID, document issuer) is the caller's job.
-pub async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<String, DiProofError> {
+/// identity (session DID, document issuer) is the caller's job — and remains so
+/// however the verification method resolved. A proof by
+/// `did:webvh:…:someone-else#key-0` verifies perfectly well; that it is not the
+/// party you expected is a separate check, and not one this function makes.
+pub async fn verify_trust_task_proof_with(
+    doc: &TrustTask<Value>,
+    resolver: &TrustTaskVmResolver,
+) -> Result<String, DiProofError> {
     let proof = doc.proof.as_ref().ok_or(DiProofError::NoProof)?;
 
     // The framework `Proof` round-trips into a `DataIntegrityProof` (same shape;
@@ -107,7 +140,7 @@ pub async fn verify_trust_task_proof(doc: &TrustTask<Value>) -> Result<String, D
 
     let mut unsigned = doc.clone();
     unsigned.proof = None;
-    di.verify(&unsigned, &DidKeyResolver, VerifyOptions::new())
+    di.verify(&unsigned, resolver, VerifyOptions::new())
         .await
         .map_err(|e| DiProofError::VerifyFailed(e.to_string()))?;
 

--- a/vti-common/src/auth/mod.rs
+++ b/vti-common/src/auth/mod.rs
@@ -9,14 +9,16 @@ pub mod passkey;
 pub mod session;
 pub mod siop;
 pub mod step_up;
+pub mod vm_resolver;
 
 pub use backend::{
     AttestationOutcome, AuthAuditEvent, AuthBackend, AuthError, AuthenticateInput, ChallengeInput,
     RefreshInput, RoleResolution, SessionStore,
 };
-pub use di_proof::{DiProofError, verify_trust_task_proof};
+pub use di_proof::{DiProofError, verify_trust_task_proof, verify_trust_task_proof_with};
 pub use didcomm::{AuthcryptError, bind_authcrypt_sender};
 pub use extractor::{
     AdminAuth, AuthClaims, AuthState, ManageAuth, StepUpAuth, SuperAdminAuth, WriteAuth,
 };
 pub use siop::{SiopError, VerifiedSiopIdToken, parse_unverified_iss, verify_siop_id_token};
+pub use vm_resolver::TrustTaskVmResolver;

--- a/vti-common/src/auth/vm_resolver.rs
+++ b/vti-common/src/auth/vm_resolver.rs
@@ -1,0 +1,233 @@
+//! Verification-method resolution for Trust Task Data-Integrity proofs — the
+//! one place a proof's `verificationMethod` becomes public-key bytes.
+//!
+//! A Trust Task proof may be made by **any DID that can name a key**:
+//! `did:key:z6Mk…#z6Mk…`, `did:webvh:<scid>:example.com:glenn#key-0`,
+//! `did:web:example.com#key-1`. The DID method is not the authorization —
+//! resolving the verification method and checking the signature is.
+//!
+//! Before this existed, both services verified with `DidKeyResolver`, which
+//! refuses everything but `did:key`. That is a smaller rule than it looks:
+//! every DID this workspace provisions for an integration is a `did:webvh`, so
+//! "`did:key` only" meant a provisioned integration could not sign a Trust
+//! Task at all — and 210 of the 344 published request payloads declare a proof
+//! REQUIRED.
+//!
+//! # `did:key` stays local; everything else needs a resolver
+//!
+//! `did:key` is self-describing: the key is *in* the identifier, so it resolves
+//! with no I/O. Every other method requires a DID document, which means the
+//! configured [`DIDCacheClient`] — and therefore network I/O, on a path that on
+//! the login routes is reachable before the caller is anybody.
+//!
+//! That widening is deliberate but not free, so it is bounded rather than
+//! assumed away:
+//!
+//! - The `did:key` fast path is checked **first**, so the common case never
+//!   touches the network however the resolver is configured.
+//! - Resolution goes through the shared [`DIDCacheClient`], which caches and
+//!   carries its own timeouts — a flood of repeats costs one resolution.
+//! - The unauthenticated routes that verify proofs are already behind the
+//!   per-source-IP rate limiter.
+//! - A resolver is **optional**. Construct with `None` and this is exactly the
+//!   old `did:key`-only verifier, which is what a deployment that wants no
+//!   outbound resolution on an unauthenticated route should configure.
+//!
+//! The alternative to accepting that surface is that no `did:webvh` holder can
+//! ever authenticate, which is not a security property — it is the absence of a
+//! feature the rest of the stack already assumes.
+
+use affinidi_data_integrity::did_vm::resolve_did_key;
+use affinidi_data_integrity::{DataIntegrityError, ResolvedKey, VerificationMethodResolver};
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use affinidi_secrets_resolver::secrets::KeyType;
+
+/// Resolves a Trust Task proof's `verificationMethod` to its public key.
+///
+/// `did:key` resolves locally through the upstream multicodec decoder, so every
+/// key type that build supports is covered without listing them here. Any other
+/// method resolves its DID document through the cache and pulls the named
+/// verification method's key with the upstream extractor, which handles
+/// `Multikey`, `Ed25519VerificationKey2020` and `publicKeyJwk` uniformly.
+///
+/// Cheap to clone — [`DIDCacheClient`] is `Arc`-backed.
+#[derive(Clone, Default)]
+pub struct TrustTaskVmResolver {
+    resolver: Option<DIDCacheClient>,
+}
+
+impl std::fmt::Debug for TrustTaskVmResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrustTaskVmResolver")
+            .field("network_resolution", &self.resolver.is_some())
+            .finish()
+    }
+}
+
+impl TrustTaskVmResolver {
+    /// A resolver that can reach DID documents over the network for methods
+    /// that need one. `did:key` still resolves locally.
+    #[must_use]
+    pub fn new(resolver: DIDCacheClient) -> Self {
+        Self {
+            resolver: Some(resolver),
+        }
+    }
+
+    /// A resolver that will only ever resolve `did:key`, with no I/O.
+    ///
+    /// The pre-existing behaviour, kept nameable so a caller that wants it says
+    /// so rather than getting it by omission.
+    #[must_use]
+    pub fn did_key_only() -> Self {
+        Self { resolver: None }
+    }
+
+    /// A resolver from an optional cache client — network resolution when
+    /// `Some`, `did:key`-only when `None`.
+    #[must_use]
+    pub fn from_optional(resolver: Option<DIDCacheClient>) -> Self {
+        Self { resolver }
+    }
+
+    /// Whether this resolver can resolve a method other than `did:key`.
+    #[must_use]
+    pub fn resolves_over_the_network(&self) -> bool {
+        self.resolver.is_some()
+    }
+
+    async fn resolve(&self, vm: &str) -> Result<ResolvedKey, DataIntegrityError> {
+        let base_did = vm.split('#').next().unwrap_or(vm);
+
+        // First, and unconditionally: the key is in the identifier.
+        if base_did.starts_with("did:key:") {
+            return resolve_did_key(vm);
+        }
+
+        let resolver = self.resolver.as_ref().ok_or_else(|| {
+            DataIntegrityError::Resolver(format!(
+                "resolving `{base_did}` needs a DID resolver, but this verifier is configured \
+                 for did:key only"
+            ))
+        })?;
+        let resolved = resolver.resolve(base_did).await.map_err(|e| {
+            DataIntegrityError::Resolver(format!("`{base_did}` did not resolve: {e}"))
+        })?;
+
+        // A DID document may name its verification methods absolutely
+        // (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`); the proof
+        // always names them absolutely. Accept both spellings of the same
+        // method rather than requiring the document to have chosen ours.
+        let relative = vm
+            .split_once('#')
+            .map(|(_, fragment)| format!("#{fragment}"))
+            .unwrap_or_default();
+        let entry = resolved
+            .doc
+            .verification_method
+            .iter()
+            .find(|m| m.id.as_str() == vm || m.id.as_str() == relative)
+            .ok_or_else(|| {
+                DataIntegrityError::Resolver(format!(
+                    "verificationMethod `{vm}` is not in the DID document for `{base_did}`"
+                ))
+            })?;
+
+        let bytes = entry.get_public_key_bytes().map_err(|e| {
+            DataIntegrityError::Resolver(format!(
+                "verificationMethod `{vm}` public key could not be extracted: {e}"
+            ))
+        })?;
+        Ok(ResolvedKey::new(KeyType::Ed25519, bytes))
+    }
+}
+
+#[async_trait::async_trait]
+impl VerificationMethodResolver for TrustTaskVmResolver {
+    async fn resolve_vm(&self, vm: &str) -> Result<ResolvedKey, DataIntegrityError> {
+        self.resolve(vm).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `did:key` never needs the network, so the `did:key`-only resolver and a
+    /// network-capable one must agree on it — and the fast path must come
+    /// first, or a misconfigured resolver would break the common case.
+    #[tokio::test]
+    async fn did_key_resolves_with_no_resolver_configured() {
+        // did:key for the all-0x11 Ed25519 seed.
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[0x11; 32]);
+        let mb = multibase::encode(
+            multibase::Base::Base58Btc,
+            [&[0xed, 0x01][..], &sk.verifying_key().to_bytes()[..]].concat(),
+        );
+        let vm = format!("did:key:{mb}#{mb}");
+
+        let key = TrustTaskVmResolver::did_key_only()
+            .resolve_vm(&vm)
+            .await
+            .expect("did:key resolves with no cache client");
+        assert_eq!(key.public_key_bytes, sk.verifying_key().to_bytes().to_vec());
+    }
+
+    /// The refusal has to say *why* it refused, because "did not resolve" and
+    /// "this verifier will not resolve that method" send an operator to
+    /// completely different places.
+    #[tokio::test]
+    async fn a_did_key_only_resolver_names_its_own_limit() {
+        let err = TrustTaskVmResolver::did_key_only()
+            .resolve_vm("did:webvh:QmScid:example.com:glenn#key-0")
+            .await
+            .expect_err("did:webvh needs a resolver");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did:key only"),
+            "the error must name the configuration, got: {msg}"
+        );
+    }
+
+    /// The resolver is what decides which methods may sign, so a Trust Task
+    /// proof naming a `did:webvh` key must be *refused for that reason* by the
+    /// narrow verifier — not quietly accepted, and not refused as a bad
+    /// signature. Those are three different operator problems.
+    #[tokio::test]
+    async fn a_did_webvh_proof_is_refused_by_the_narrow_verifier_for_the_right_reason() {
+        use trust_tasks_rs::TrustTask;
+
+        let doc: TrustTask<serde_json::Value> = serde_json::from_value(serde_json::json!({
+            "id": "urn:uuid:11111111-1111-4111-8111-111111111111",
+            "type": "https://trusttasks.org/spec/vta/contexts/create/1.0",
+            "issuer": "did:webvh:QmScid:example.com:glenn",
+            "recipient": "did:key:z6MkVta",
+            "payload": {},
+            "proof": {
+                "type": "DataIntegrityProof",
+                "cryptosuite": "eddsa-jcs-2022",
+                "proofPurpose": "assertionMethod",
+                "verificationMethod": "did:webvh:QmScid:example.com:glenn#key-0",
+                "created": "2026-08-29T00:00:00Z",
+                "proofValue": "z2aBcD"
+            }
+        }))
+        .expect("a well-formed Trust Task");
+
+        let err = crate::auth::di_proof::verify_trust_task_proof(&doc)
+            .await
+            .expect_err("did:key-only cannot resolve a did:webvh key");
+        let cause = err.cause().unwrap_or_default();
+        assert!(
+            cause.contains("did:key only"),
+            "the operator-facing cause must name the resolver's configuration, not the \
+             signature, got: {cause}"
+        );
+    }
+
+    #[test]
+    fn the_debug_rendering_says_whether_it_can_reach_the_network() {
+        let s = format!("{:?}", TrustTaskVmResolver::did_key_only());
+        assert!(s.contains("network_resolution: false"), "got {s}");
+    }
+}


### PR DESCRIPTION
Follow-up to #1192, which found this and deferred it. A Trust Task proof could only be made by a `did:key` — so a provisioned integration could not dispatch **any** of the 210 proof-requiring Trust Tasks, over any transport, because every DID this workspace provisions is a `did:webvh`.

## The rule

**Any DID that can name a key may sign.** The DID method is not the authorization; resolving the verification method and checking the signature is. `did:key:z6Mk…#z6Mk…`, `did:webvh:<scid>:example.com:glenn#key-0` and `did:web:example.com#key-1` are all ordinary holders.

## What was actually in the way

Not a policy anyone chose — the shape of two helpers.

**The signer** took `(holder_did, private_key)` and *derived* the verification method as `<did>#<multibase>`. That derivation exists only for `did:key`, whose key is its identifier. A `did:webvh` document decides what its keys are called, so nothing can guess `#key-0` — meaning a signer that takes only a DID structurally cannot serve any other method. The error variant was even named `NotDidKey`, which read as a rule.

`HolderKey` now carries the verification method. `HolderKey::from_did_key` keeps the derivation for the one method that has one, and refuses to invent one for the rest.

**The verifier** used `DidKeyResolver`, which refuses everything else. `TrustTaskVmResolver` resolves `did:key` locally and any other method through the configured DID cache, matching a proof's absolute `verificationMethod` against a document that may name it relatively. It is hoisted from the equivalent `vtc-service` already had for credential verification.

## The rest

- `ClientIdentity` gains `verification_method`, and `connect_didcomm_bundle{,_on}` build an identity from the bundle's own Ed25519 `SecretEntry` — whose `key_id` *is* the verification method the DID document publishes, so nothing is guessed. Those constructors passed `identity: None` deliberately; that reason is gone.
- Every verifying call site takes a resolver: the VTA's dispatch spine, REST login, step-up, consent; the VTC's dispatch, REST login, relationships. Threading it is the half that makes the signer change real.

## What it costs — please read this bit

`did:key` resolves with no I/O. Every other method needs a DID document, so this puts **network resolution on the login routes, before the caller is anybody**. Bounded rather than dismissed:

- the `did:key` fast path is checked first, so the common case never touches the network;
- resolution goes through the caching `DIDCacheClient`, so a flood of repeats costs one resolution;
- those routes are already behind the per-source-IP rate limiter;
- `TrustTaskVmResolver::did_key_only()` is exactly the previous behaviour, and `verify_trust_task_proof` still means it — so a deployment that wants no outbound resolution there configures it, and a caller that wants it says so rather than getting it by omission.

I wired the login routes to the full resolver because otherwise a `did:webvh` integration still cannot authenticate, which defeats the point. **If you'd rather the unauthenticated login routes stay `did:key`-only and only the authenticated surface widen, that is a one-line change per service** — say so and I'll make it.

## Breaking

`ClientIdentity` gains a public `verification_method` field (`ClientIdentity::did_key` builds the previous shape) and `TrustTaskSignError` gains a `NotAVerificationMethod` variant. Commit is marked `feat(sdk)!` with a `BREAKING CHANGE:` trailer; no version edit — release-plz assigns those, and the `semver report` going red is the expected signal, not a defect.

## Testing

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — 155 suites, 0 failures.

New coverage: a `did:webvh` holder signs and the proof names the published key, not a derived one; a verification method must actually name a key (bare DID, empty fragment, non-DID all refused); the `did:key` helper refuses what it cannot derive *and* the same holder signs once it names its key; the resolver's `did:key` path needs no cache client; and a `did:webvh` proof is refused by the narrow verifier **for the right reason** — resolver configuration, not a bad signature, since those send an operator to different places.

**Gap I have not closed:** there is no test proving a `did:webvh` proof verifies end to end, because that needs a resolvable DID document. The resolve-and-verify leg is the same upstream path `vtc-service` already uses for credential verification, but it is not exercised here. A live test against a real `did:webvh` would be the honest confirmation.