### PR TITLE
fix(vtc): refuse an ACL revoke that would orphan a member row

### DIFF
--- a/vtc-service/src/routes/acl.rs
+++ b/vtc-service/src/routes/acl.rs
@@ -13,6 +13,7 @@ use crate::acl::{
 };
 use crate::auth::{AdminAuth, AuthClaims, ManageAuth, session::now_epoch};
 use crate::error::AppError;
+use crate::members::get_member;
 use crate::server::AppState;
 use vti_common::audit::{AclChangeData, AclRevokedData, AuditEvent};
 use vti_common::pagination::{Cursor, MAX_LIMIT};
@@ -680,6 +681,39 @@ pub async fn delete_acl(
             "ACL scopes reduced",
         );
         return Ok(StatusCode::NO_CONTENT);
+    }
+
+    // Revoking the ACL of a **member** would orphan their member row.
+    //
+    // Two surfaces own the ACL row and only one of them knows membership
+    // exists. The leave ceremony (`DELETE /v1/members/{did}` →
+    // `ceremony::execute::depart`) deletes the ACL, tombstones the member row,
+    // *and* flips the revocation bit on their VMC + VEC. This route deletes the
+    // ACL and stops — so a revoke aimed at a member left a live member row with
+    // no authorization and, worse, credentials that still verify for anyone
+    // holding them.
+    //
+    // The reader already believed this could not happen: `members::read` calls
+    // a live member row with no ACL entry "genuine out-of-band corruption (e.g.
+    // an interrupted purge)" and warns on every list. It was not corruption. It
+    // was this handler, doing exactly what it was asked, on a DID it could see
+    // was a member — the audit row it writes even records `priorRole: "member"`.
+    //
+    // Refused rather than quietly routed to `depart`: removal runs the removal
+    // policy, resolves a disposition, and revokes credentials. An operator who
+    // asked to revoke an ACL entry should not get all of that without saying
+    // so. So this names the command that does. (Scope *reduction* is untouched
+    // — it leaves the entry in place and orphans nothing, which is why this
+    // guard sits after that branch has already returned.)
+    if let Some(member) = get_member(&state.members_ks, &did).await?
+        && !member.is_removed()
+    {
+        return Err(AppError::Conflict(format!(
+            "{did} is a member of this community — revoking their ACL entry would leave the \
+             member row with no authorization and their membership credentials unrevoked. \
+             To remove them from the community, use the leave ceremony instead:\n    \
+             DELETE /v1/members/{did}"
+        )));
     }
 
     delete_acl_entry(&acl, &did).await?;

--- a/vtc-service/tests/acl_canonical.rs
+++ b/vtc-service/tests/acl_canonical.rs
@@ -374,3 +374,115 @@ async fn list_filters_and_paginates() {
         "a cursor must not carry across a filter change: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Revoking a *member's* ACL entry would orphan their member row.
+//
+// Two surfaces own the ACL row and only one knows membership exists. The leave
+// ceremony deletes the ACL, tombstones the member row, and revokes the
+// credentials; this route deleted the ACL and stopped — leaving a live member
+// row with no authorization and a VMC that still verified for anyone holding
+// it. `members::read` called the result "genuine out-of-band corruption (e.g.
+// an interrupted purge)" and warned on every list; it was not corruption, it
+// was this route doing what it was asked.
+// ---------------------------------------------------------------------------
+
+/// Store a live member row for `did` — what admission leaves behind.
+async fn make_member(fix: &Fixture, did: &str) {
+    vtc_service::members::store_member(
+        &fix.vtc.state.members_ks,
+        &vtc_service::members::Member::fresh(did),
+    )
+    .await
+    .expect("store member row");
+}
+
+#[tokio::test]
+async fn revoking_a_members_acl_is_refused_and_names_the_removal_command() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    const DID: &str = "did:key:z6MkHurdle";
+    grant(&fix, &token, DID, "member", json!(["ctx-a"])).await;
+    make_member(&fix, DID).await;
+
+    let (status, body) = call(
+        &fix,
+        "DELETE",
+        &format!("/v1/acl/{DID}"),
+        REVOKE,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+
+    // "Operator errors should suggest the fix" — the message must carry the
+    // command that actually removes a member, not just refuse.
+    let msg = body.to_string();
+    assert!(
+        msg.contains("/v1/members/"),
+        "the refusal must name the leave ceremony: {msg}"
+    );
+
+    // And the entry must survive: a refusal that already deleted the row would
+    // be the same bug wearing a 409.
+    let (status, body) = call(&fix, "GET", &format!("/v1/acl/{DID}"), SHOW, &token, None).await;
+    assert_eq!(status, StatusCode::OK, "entry must be untouched: {body}");
+}
+
+/// A *departed* member row does not block the revoke. Tombstone and historical
+/// departures keep the row as a "who was a member" record, and cleaning up a
+/// stray ACL entry beside one is a legitimate admin action — the guard is about
+/// orphaning a live membership, not about the row existing.
+#[tokio::test]
+async fn revoking_the_acl_of_a_departed_member_is_allowed() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    const DID: &str = "did:key:z6MkDeparted";
+    grant(&fix, &token, DID, "member", json!(["ctx-a"])).await;
+
+    let mut member = vtc_service::members::Member::fresh(DID);
+    member.tombstone();
+    vtc_service::members::store_member(&fix.vtc.state.members_ks, &member)
+        .await
+        .expect("store tombstoned member");
+
+    let (status, body) = call(
+        &fix,
+        "DELETE",
+        &format!("/v1/acl/{DID}"),
+        REVOKE,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "{body}");
+}
+
+/// Scope *reduction* orphans nothing — the entry survives, minus those scopes —
+/// so the guard must sit after that branch has returned. Putting it earlier
+/// would block an ordinary privilege reduction on every member in the
+/// community.
+#[tokio::test]
+async fn reducing_a_members_scopes_is_still_allowed() {
+    let fix = build().await;
+    let token = admin_token(&fix).await;
+    const DID: &str = "did:key:z6MkScoped";
+    grant(&fix, &token, DID, "member", json!(["ctx-a", "ctx-b"])).await;
+    make_member(&fix, DID).await;
+
+    let (status, body) = call(
+        &fix,
+        "DELETE",
+        &format!("/v1/acl/{DID}?scopes=ctx-a"),
+        REVOKE,
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "{body}");
+
+    let (status, body) = call(&fix, "GET", &format!("/v1/acl/{DID}"), SHOW, &token, None).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["entry"]["scopes"], json!(["ctx-b"]));
+}


### PR DESCRIPTION
## What was seen

A production VTC logging this on every members-list call:

```
WARN vtc_service::routes::members::read: member row has no matching ACL entry;
     skipping in list response did=did:webvh:…:hurdle-surface
```

The audit trail for that DID settles it — six events, and the gap is the story:

| When | Event |
|---|---|
| 16 Aug 22:08:50 | `JoinRequestSubmitted` |
| 16 Aug 22:09:13 | `JoinRequestApproved`, `MemberAdded`, `VmcIssued`, `VecIssued` |
| 29 Aug 01:14:33 | **`AclRevoked`** — `priorRole: "member"` |

No `MemberRemoved`, ever. The member row from 16 Aug is still live; someone revoked the ACL 13 days later and that is the entire cause.

## Why one revoke orphans a member

`DELETE /v1/acl/{did}` has five guards — self-deletion, entry exists, visibility, admin-target scoping, scope-reduction mode — and **not one reads the members keyspace**. After them it does one thing:

```rust
delete_acl_entry(&acl, &did).await?;
```

The leave ceremony (`DELETE /v1/members/{did}` → `ceremony::execute::depart`) deletes the ACL, tombstones the member row, **and** flips the revocation bit on the member's VMC and VEC. This route did the first of the three. So the member row survives with no authorization, and — the part that is not just log noise — **their membership credentials are still valid to any third party verifying them.**

Two surfaces own the ACL row; only one knows membership exists.

## Why this is a defect and not an operator mistake

`members::read` calls the resulting state *"genuine out-of-band corruption (e.g. an interrupted purge)"*. So the reader believes it is unreachable while the writer produces it on request — on a DID it could see was a member, since the audit row it writes records `priorRole: "member"`. A writer that produces a state its own reader calls impossible is the bug.

## The fix

Refuse, and name the command that actually removes a member — the workspace's "operator errors should suggest the fix" convention, same shape as `pnm contexts create` → `pnm acl create`:

```
did:…:hurdle-surface is a member of this community — revoking their ACL entry
would leave the member row with no authorization and their membership
credentials unrevoked. To remove them from the community, use the leave
ceremony instead:
    DELETE /v1/members/did:…:hurdle-surface
```

**Refused rather than quietly routed into `depart`**: removal runs the removal policy, resolves a disposition, and revokes credentials. An operator who asked to revoke an ACL entry should not get all of that without saying so.

**Placement is load-bearing.** The guard sits *after* the scope-reduction branch has returned. Reduction leaves the entry in place and orphans nothing, so guarding earlier would block an ordinary privilege reduction on every member in the community. A departed (tombstoned / historical) row does not block either — clearing a stray ACL entry beside one is legitimate cleanup.

## Verified the 409 actually reaches the operator

Given the admin UI's history as an untested consumer: `AppError::Conflict` serialises as `{"error": "conflict: …"}` and the admin UI's `request()` helper reads `body.error` and throws an `ApiError` carrying it. The suggested command surfaces, rather than degrading to "409 Conflict".

## Not fixed here

**An already-orphaned row cannot be cleared through the leave ceremony.** `remove_inner` (`ceremony/orchestrate.rs:297`) looks the ACL entry up first and returns `404 member not found` without one — the state the revoke created is the state the removal path refuses. `DELETE /v1/members/{did}/purge` is the way out: `purge_member` only refuses when *neither* row exists. It will not retroactively revoke credentials already issued.

Whether `remove_inner` should tolerate a missing ACL entry is a separate question, and arguably yes — but it changes the meaning of "member not found" on a route that is otherwise correct, so it is not folded in.

## Tests

Three cases in `vtc-service/tests/acl_canonical.rs`, one per branch of the guard: a live member's revoke is refused *and the entry survives* (a refusal that had already deleted the row would be the same bug wearing a 409); a departed member's revoke is allowed; a member's scope reduction is untouched. Suite is 12/12.

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean; full `cargo test --workspace` was still running when this was opened, so CI is the authority on it.