### PR TITLE
fix(vtc): remove a member whose ACL entry is already gone

### DIFF
--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -21,7 +21,7 @@ use super::{
     Evidence, FactsInputs, Purpose, Verdict, VerifiedFacts, assemble_facts, decide,
     effects::EffectPlan, load_actor_role, member_state,
 };
-use crate::acl::get_acl_entry;
+use crate::acl::{VtcRole, get_acl_entry};
 use crate::members::{Disposition, get_member};
 use crate::policy::{PolicyPurpose, load_active_compiled};
 use crate::server::AppState;
@@ -294,11 +294,35 @@ pub async fn remove_inner(
         .as_ref()
         .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
 
-    let target_acl = get_acl_entry(&state.acl_ks, target_did)
-        .await?
-        .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
-
+    let target_acl = get_acl_entry(&state.acl_ks, target_did).await?;
     let target_member = get_member(&state.members_ks, target_did).await?;
+
+    // Removal needs *a* subject, not specifically an ACL entry.
+    //
+    // This used to require the ACL row and 404 `member not found` without one,
+    // which closed the only door out of the exact state an `acl/revoke` aimed
+    // at a member left behind: a live member row, no authorization, and
+    // credentials still unrevoked (#1194 stops new ones being created; this
+    // is how the existing ones get cleaned up). The operator was told the
+    // member did not exist while `members list` was warning about that very
+    // row — two surfaces disagreeing about whether somebody is here.
+    //
+    // Only genuinely-absent is still `not found`: neither row.
+    if target_acl.is_none() && target_member.is_none() {
+        return Err(AppError::NotFound(format!(
+            "member not found: {target_did}"
+        )));
+    }
+
+    // The subject's role, for the removal policy and the audit row. With no
+    // ACL entry there is no role to read, and `member` is the honest answer
+    // rather than a cautious one: role *is* the ACL entry, so a subject
+    // without one holds no authority — they cannot be the admin the policy
+    // protects, and `depart`'s no-last-admin invariant reads the same absent
+    // row and reaches the same conclusion.
+    let subject_role = target_acl
+        .as_ref()
+        .map_or_else(|| VtcRole::Member.to_string(), |a| a.role.to_string());
 
     // Decide. Assemble verified leave Facts and run the active removal-purpose
     // decision policy. The no-last-admin invariant + the credential revocation
@@ -307,7 +331,7 @@ pub async fn remove_inner(
         state,
         actor_did,
         target_did,
-        &target_acl.role.to_string(),
+        &subject_role,
         target_member.as_ref(),
         disposition,
         &reason,
@@ -374,7 +398,7 @@ pub async fn remove_inner(
             AuditEvent::MemberRemoved(MemberRemovedData {
                 disposition: disposition_str.into(),
                 reason: reason.clone(),
-                prior_role: Some(target_acl.role.to_string()),
+                prior_role: target_acl.as_ref().map(|a| a.role.to_string()),
             }),
         )
         .await?;

--- a/vtc-service/tests/members_crud.rs
+++ b/vtc-service/tests/members_crud.rs
@@ -668,3 +668,56 @@ async fn promoting_an_existing_admin_is_an_idempotent_no_op() {
         .unwrap();
     assert_eq!(entry.role, VtcRole::Admin);
 }
+
+/// Removal must work on a member whose ACL entry is already gone.
+///
+/// `remove_inner` used to read the ACL entry first and 404 `member not found`
+/// without one — which closed the only exit from the exact state an
+/// `acl/revoke` aimed at a member leaves behind: a live member row, no
+/// authorization, credentials unrevoked. The operator was told the member did
+/// not exist while `members list` was warning about that very row, which is two
+/// surfaces disagreeing about whether somebody is here.
+#[tokio::test]
+async fn removing_a_member_whose_acl_is_already_gone_succeeds() {
+    let fix = build_fixture().await;
+    // A live member row with no ACL entry — what an `acl/revoke` leaves.
+    store_member(&fix.members_ks, &Member::fresh("did:key:zOrphan"))
+        .await
+        .unwrap();
+
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/did:key:zOrphan",
+        "https://trusttasks.org/spec/vtc/members/admin-remove/0.1",
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "clearing an orphaned member row" })),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a member row with no ACL entry is still a member to remove: {body}"
+    );
+    assert!(
+        status.is_success(),
+        "removal should succeed: {status} {body}"
+    );
+}
+
+/// A DID with neither row is still genuinely absent — the guard must not turn
+/// "not found" into "removed nothing, successfully".
+#[tokio::test]
+async fn removing_a_did_with_no_rows_at_all_is_still_not_found() {
+    let fix = build_fixture().await;
+    let (status, _) = send(
+        &fix.router,
+        "DELETE",
+        "/v1/members/did:key:zNeverExisted",
+        "https://trusttasks.org/spec/vtc/members/admin-remove/0.1",
+        Some(&fix.admin_token),
+        Some(json!({ "reason": "clearing an orphaned member row" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Follow-up to #1194, which flagged this and deliberately did not fold it in.

## The problem

`remove_inner` read the ACL entry first and 404'd `member not found` without one:

```rust
let target_acl = get_acl_entry(&state.acl_ks, target_did)
    .await?
    .ok_or_else(|| AppError::NotFound(format!("member not found: {target_did}")))?;
```

That closed the only exit from the exact state an `acl/revoke` aimed at a member leaves behind — a live member row, no authorization, credentials still unrevoked. The operator was told the member did not exist while `members list` was warning about that very row on every call. Two surfaces disagreeing about whether somebody is here.

#1194 stops new instances of that state being created. This is how the existing ones get cleaned up — and it matters which tool does it, because the leave ceremony tombstones the row **and** flips the revocation bit on the member's VMC and VEC, where `purge` (the only thing that previously worked) does neither.

## The change

Removal needs *a subject*, not specifically an ACL entry. Only genuinely absent — neither row — is still `not found`.

Two details that could have gone the other way:

**The subject's role defaults to `member` with no entry.** Role *is* the ACL entry, so a subject without one holds no authority: they cannot be the admin the removal policy protects, and `depart`'s no-last-admin invariant reads the same absent row and reaches the same conclusion. Nothing is assumed in the permissive direction.

**The audit row records `prior_role: None`, not `member`.** There was no role. Writing one in would assert an authority the community had already taken away — into the tamper-evident log, which is the last place for a convenient fiction.

## Tests

Two, and the second is the one that keeps this honest: removing a member whose ACL is gone succeeds; a DID with *neither* row is still `404`, so the guard cannot quietly turn "not found" into "removed nothing, successfully".

`cargo test -p vtc-service --test members_crud` 20/20, `cargo fmt --all --check` and `cargo clippy -p vtc-service --all-targets -- -D warnings` clean.