### PR TITLE
feat(vta): cascade, refuse and revoke when a DID is deleted

### DIFF
--- a/docs/05-design-notes/did-deletion-cascade.md
+++ b/docs/05-design-notes/did-deletion-cascade.md
@@ -1,0 +1,101 @@
+# Deleting a DID: what goes with it
+
+**Status:** classification + census, blockers, revocation and the
+authorization cascade shipped. Preview/confirm and the remaining cascades are
+follow-ups — see *Not done yet*.
+
+## The problem
+
+`dids delete` removed the daemon-side DID, the local `webvh` record and log,
+and the DID's key records. Nothing else. ACL entries, issued credentials,
+sessions, contexts and per-DID state were left behind.
+
+That is the same defect class as the VTC's ACL-revoke orphan (#1194, #1196),
+one level up: **a surface owning part of a multi-part identity and knowing
+nothing about the rest.** The VTC learned it the expensive way — an
+`acl/revoke` aimed at a member left a live member row with no authorization and
+credentials that still verified for anyone holding them, and the members-list
+reader called the result "genuine out-of-band corruption" while the writer
+produced it on request.
+
+## Deleting a DID is four relationships, not one
+
+Treating them alike gets one wrong in a way nobody notices until it matters.
+
+| Relationship | Verb | Examples |
+|---|---|---|
+| The DID **owns** it | Cascade | keys, the webvh log, resolution cache |
+| It **names the DID as a subject of authorization** | Cascade | ACL entry, sessions, passkey VMs, consent, vault |
+| It **depends on the DID to function** | Blocks | a context acting as this DID, an advertised service, a policy or approver set naming it |
+| The VTA **issued** it | Revoke | issued credentials |
+
+The fourth is the one that cannot be "cleaned up" and the one most likely to be
+got wrong, because it looks the most like a cascade. Third parties hold copies
+of what the VTA issued. Deleting our record does not invalidate theirs — it
+destroys the only means of revoking them, leaving every copy in the wild valid
+forever. It is precisely the residue left on the VTC.
+
+## Decisions
+
+Three, settled deliberately:
+
+1. **A deletion revokes what it cannot destroy.** Credentials the VTA issued to
+   the DID are revoked, not deleted.
+2. **A dependency refuses the deletion, and says what to unpick.** Not a
+   cascade — cascading silently breaks a context. The refusal names the
+   corrective command, per the workspace's "operator errors should suggest the
+   fix" convention.
+3. **No `--force`.** Same call as `would_violate_last_service`, for the same
+   reason: the escape hatch is what gets used at 2am.
+
+## Ordering
+
+Revocation runs **first**, before any deletion, remote or local.
+
+If anything later fails, the credentials are already dead and the DID still
+exists — recoverable by re-running. The other order leaves live credentials for
+a DID nobody can revoke through any more. When a partial failure is possible,
+the surviving state should be the *over*-restrictive one.
+
+The preflight is read-only, so a refusal leaves the VTA exactly as it found it.
+
+## Why a census rather than a list in a function
+
+The failure mode is not getting today's answers wrong. It is a keyspace added
+next quarter that nobody classifies, whose rows then quietly outlive the DID
+they belong to — which is how the original gap happened.
+
+`vta_keyspaces::did_delete_effect` classifies every keyspace, and a census test
+fails when one is unclassified. `Unrelated` is a fine answer; it just has to be
+a *chosen* one. This rides the same rail as the existing backup-partition
+census, and turns "we forgot" from an orphan found months later in a log into a
+red test.
+
+Two classifications are pinned explicitly because they are the ones a future
+change is most likely to get wrong:
+
+- `issued_credentials` is **never** `Cascade`.
+- `audit` is **never** cascaded — the record that a DID was deleted is the one
+  thing that must survive deleting it.
+
+## A caller that cannot cascade cannot delete
+
+`WebvhDeps::delete_cascade` is `None` on the paths that only read or publish.
+That does not mean "skip the cascade" — `delete_did_webvh` refuses. Half a
+deletion is the failure this exists to prevent, so it is not something a
+construction site can opt into by omission.
+
+## Not done yet
+
+- **Preview/confirm.** Deletion is irreversible and now also revokes. The
+  operator should see what is about to be destroyed and revoked before it
+  happens, in the shape backup import's descriptor flow already uses.
+- **The remaining cascades.** Classified but not yet executed: vault, consent,
+  task_consent, app_state, memory, outbox, cache, passkey_vms, imported_secrets.
+  The census names them; the code does not clear them yet.
+- **The remaining blockers.** `service_state` / `service_prev_config`, `policy`
+  and `consent_approvers` are classified `Blocks` but only the context and
+  self-DID checks are implemented.
+- **Resumability (R2.1).** The daemon delete still happens before local cleanup
+  with no idempotency key, so a failure between them leaves the daemon-side
+  orphan the code already warns about.

--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -288,3 +288,159 @@ mod tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// What a DID deletion means for each keyspace
+// ---------------------------------------------------------------------------
+
+/// What happens to a keyspace's DID-keyed contents when that DID is deleted.
+///
+/// Deleting a DID is not one cleanup. It is four different relationships, and
+/// treating them alike gets one of them wrong in a way nobody notices until it
+/// matters:
+///
+/// * things the DID **owns** go with it;
+/// * things that **name it as a subject of authorization** must go with it, or
+///   they become authority for an identity that no longer resolves;
+/// * things that **depend on it to function** must *stop* the deletion, because
+///   cascading would silently break them;
+/// * credentials the VTA **issued** cannot be deleted at all — copies exist
+///   elsewhere — so the only honest action is revocation.
+///
+/// # Why this is an enum and not a list in a function
+///
+/// The failure mode is not getting today's answers wrong. It is a keyspace
+/// added next quarter that nobody classifies, whose rows then quietly outlive
+/// the DID they belong to. [`ALL`] is already pinned by a census test for the
+/// backup partition, for exactly the same reason; this rides the same rail, so
+/// "we forgot" is a red test rather than an orphan found months later in a log.
+///
+/// The classifications below are judgements and several are arguable. That is
+/// fine — the point of the census is to force the question to be asked, not to
+/// claim these answers are the last word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DidDeleteEffect {
+    /// Rows belonging to the DID are removed with it.
+    Cascade,
+    /// A row referencing the DID **blocks** the deletion: something still in
+    /// use would break. Refused, never forced — the operator is told what to
+    /// unpick first.
+    Blocks,
+    /// Rows cannot be removed, because the VTA is not the only holder. They
+    /// are revoked instead.
+    Revoke,
+    /// Nothing here is keyed to a DID.
+    Unrelated,
+}
+
+/// The effect a DID deletion has on `keyspace`, or `None` if the name is not a
+/// keyspace this build knows.
+///
+/// Every entry in [`ALL`] is classified — see `did_delete_census` in this
+/// module's tests.
+#[must_use]
+pub const fn did_delete_effect(keyspace: &str) -> Option<DidDeleteEffect> {
+    use DidDeleteEffect::*;
+    // `const fn` cannot match on `&str`, so this is a byte-slice match.
+    Some(match keyspace.as_bytes() {
+        // ---- Owned by the DID -------------------------------------------
+        // Key material derived under it, its own log, its advertised name.
+        b"keys" | b"internal_keys" | b"imported_secrets" | b"webvh" => Cascade,
+        // Resolution + protocol caches keyed by DID: stale the moment it goes.
+        b"cache" | b"outbox" => Cascade,
+
+        // ---- Names the DID as a subject of authorization -----------------
+        // An ACL entry outliving its DID is the worst of the orphans: live
+        // authority for an identity that can no longer be resolved or rotated.
+        // The VTC learned this the expensive way (#1194, #1196).
+        b"acl" | b"sessions" | b"passkey_vms" => Cascade,
+        // Consent state and the vault are held *for* a holder; with the holder
+        // gone they are unreachable by anyone.
+        b"consent" | b"task_consent" | b"vault" => Cascade,
+        // Per-DID application state the VTA stores on a holder's behalf.
+        b"app_state" | b"memory" => Cascade,
+
+        // ---- Depends on the DID to function ------------------------------
+        // A context whose `did` is this one, a DID named in an advertised
+        // service entry (or its rollback snapshot), a policy or approver set
+        // that names it. Cascading any of these breaks something that is still
+        // in use; refusing tells the operator what to unpick.
+        b"contexts" | b"service_state" | b"service_prev_config" => Blocks,
+        b"policy" | b"consent_approvers" => Blocks,
+
+        // ---- Cannot be deleted, only revoked -----------------------------
+        // Third parties hold copies. Deleting our record achieves nothing but
+        // losing our ability to revoke it.
+        b"issued_credentials" => Revoke,
+
+        // ---- Not keyed to a DID ------------------------------------------
+        // The audit log is deliberately here: it is append-only, and the record
+        // that a DID was deleted is the one thing that must survive deleting it.
+        b"audit" => Unrelated,
+        b"did_templates" | b"sealed_nonces" | b"backup_bundles" => Unrelated,
+        b"drains" | b"bootstrap" | b"idempotency" => Unrelated,
+
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod did_delete_tests {
+    use super::*;
+
+    /// Every keyspace must have an answer to "what happens to this when a DID
+    /// is deleted".
+    ///
+    /// This is the whole point of the classification. Adding a keyspace is
+    /// easy; remembering that its rows might outlive the DID they belong to is
+    /// not, and nothing about adding one prompts the question. This test asks
+    /// it, once, at the only moment anyone is looking.
+    ///
+    /// A new keyspace fails here until it is classified. `Unrelated` is a
+    /// perfectly good answer — but it has to be a chosen one.
+    #[test]
+    fn every_keyspace_is_classified_for_did_deletion() {
+        let unclassified: Vec<&str> = ALL
+            .iter()
+            .copied()
+            .filter(|ks| did_delete_effect(ks).is_none())
+            .collect();
+        assert!(
+            unclassified.is_empty(),
+            "these keyspaces have no DID-deletion effect declared: {unclassified:?}\n\
+             Add them to `did_delete_effect`. `Unrelated` is a fine answer if \
+             nothing in the keyspace is keyed to a DID — but it must be chosen, \
+             not defaulted."
+        );
+    }
+
+    /// An unknown name is not silently `Unrelated`. The distinction matters:
+    /// `None` means "this build does not know that keyspace", and answering
+    /// `Unrelated` to it would let a typo read as "nothing to clean up".
+    #[test]
+    fn an_unknown_keyspace_has_no_effect_rather_than_a_harmless_one() {
+        assert_eq!(did_delete_effect("not_a_keyspace"), None);
+        assert_eq!(did_delete_effect(""), None);
+    }
+
+    /// The credential keyspace must never be classified `Cascade`.
+    ///
+    /// Pinned explicitly because it is the one that looks most like a cascade
+    /// and is not: the VTA is not the only holder of what it issued, so
+    /// deleting our record destroys the ability to revoke it while leaving
+    /// every copy in the wild valid forever. That is the exact residue an ACL
+    /// revoke left behind on the VTC.
+    #[test]
+    fn issued_credentials_are_revoked_never_deleted() {
+        assert_eq!(
+            did_delete_effect(ISSUED_CREDENTIALS),
+            Some(DidDeleteEffect::Revoke)
+        );
+    }
+
+    /// The audit log must survive the deletion it records.
+    #[test]
+    fn the_audit_log_is_never_cascaded() {
+        assert_eq!(did_delete_effect(AUDIT), Some(DidDeleteEffect::Unrelated));
+    }
+}

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -88,6 +88,9 @@ pub struct VtaState {
     pub service_state_ks: KeyspaceHandle,
     #[cfg(feature = "webvh")]
     pub webvh_ks: KeyspaceHandle,
+    /// Credentials the VTA issued — needed so a DID deletion over this
+    /// transport can revoke them rather than orphan them.
+    pub issued_credentials_ks: KeyspaceHandle,
     /// Anti-replay log for sealed-bootstrap `bundle_id`s — required by
     /// the DIDComm provision-integration handler so it can drive the
     /// same shared library function the REST handler does.
@@ -199,6 +202,7 @@ impl From<&AppState> for VtaState {
             service_state_ks: state.service_state_ks.clone(),
             #[cfg(feature = "webvh")]
             webvh_ks: state.webvh_ks.clone(),
+            issued_credentials_ks: state.issued_credentials_ks.clone(),
             sealed_nonces_ks: state.sealed_nonces_ks.clone(),
             #[cfg(feature = "webvh")]
             drains_ks: state.drains_ks.clone(),

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -95,11 +95,38 @@ use vti_common::slip10::{DerivationPath, ExtendedSigningKey};
 /// being operated on, the WebVH server target) stays a separate argument — it
 /// varies per call and isn't ambient state. `contexts_ks` is read only by
 /// `rotate_did_webvh_keys`; the other ops ignore it.
+/// The keyspaces a DID deletion has to reach beyond the DID's own records.
+///
+/// Bundled rather than three loose fields because they are needed together or
+/// not at all: a caller that can reach the ACL but not the issued credentials
+/// can still only perform half a deletion, and half is the shape that leaves
+/// live authority and unrevokable credentials behind.
+pub struct DeleteCascadeDeps<'a> {
+    /// Authorization keyed by DID. An ACL entry outliving its subject is live
+    /// authority for an identity that can no longer be resolved or rotated.
+    pub acl_ks: &'a KeyspaceHandle,
+    /// Sessions are authority already issued; they go the same way.
+    pub sessions_ks: &'a KeyspaceHandle,
+    /// Credentials the VTA issued. Revoked, never deleted — third parties hold
+    /// copies, so removing our record would destroy the only means of revoking
+    /// them. See [`vta_keyspaces::DidDeleteEffect`].
+    pub issued_credentials_ks: &'a KeyspaceHandle,
+}
+
 pub struct WebvhDeps<'a> {
     pub keys_ks: &'a KeyspaceHandle,
     pub imported_ks: &'a KeyspaceHandle,
     pub contexts_ks: &'a KeyspaceHandle,
     pub webvh_ks: &'a KeyspaceHandle,
+    /// The state a *deletion* must reach, absent on callers that only read or
+    /// publish.
+    ///
+    /// `None` does not mean "skip the cascade" — it means this caller cannot
+    /// perform one, and [`delete_did_webvh`] refuses rather than deleting a DID
+    /// while leaving its authorization and credentials behind. A partial
+    /// deletion is the failure mode this whole change exists to prevent, so it
+    /// is not something a construction site gets to opt into by omission.
+    pub delete_cascade: Option<DeleteCascadeDeps<'a>>,
     pub audit: &'a vta_audit::SharedAuditSink,
     pub seed_store: &'a dyn SeedStore,
     pub did_resolver: &'a DIDCacheClient,
@@ -126,6 +153,11 @@ impl<'a> WebvhDeps<'a> {
             imported_ks: &s.imported_ks,
             contexts_ks: &s.contexts_ks,
             webvh_ks: &s.webvh_ks,
+            delete_cascade: Some(DeleteCascadeDeps {
+                acl_ks: &s.acl_ks,
+                sessions_ks: &s.sessions_ks,
+                issued_credentials_ks: &s.issued_credentials_ks,
+            }),
             audit: &s.audit_sink,
             seed_store: &*s.seed_store,
             did_resolver,
@@ -149,6 +181,11 @@ impl<'a> WebvhDeps<'a> {
             imported_ks: &s.imported_ks,
             contexts_ks: &s.contexts_ks,
             webvh_ks: &s.webvh_ks,
+            delete_cascade: Some(DeleteCascadeDeps {
+                acl_ks: &s.acl_ks,
+                sessions_ks: &s.sessions_ks,
+                issued_credentials_ks: &s.issued_credentials_ks,
+            }),
             audit: &s.audit_sink,
             seed_store: &*s.seed_store,
             did_resolver,
@@ -1470,6 +1507,57 @@ pub async fn delete_did_webvh(
     // VTA.
     auth.require_context(&record.context_id)?;
 
+    // ---- Refuse before destroying anything --------------------------------
+    //
+    // A DID something still depends on must not be deleted out from under it.
+    // Cascading here would silently break a context or an advertised service;
+    // refusing tells the operator exactly what to unpick, per the workspace's
+    // "operator errors should suggest the fix" convention. There is no
+    // `--force`: the same call as `would_violate_last_service`, for the same
+    // reason — the escape hatch is what gets used at 2am.
+    let blockers = delete_blockers(deps, auth, did, vta_did).await?;
+    if !blockers.is_empty() {
+        return Err(AppError::Conflict(format!(
+            "{did} cannot be deleted — {} still depend{} on it:\n{}",
+            blockers.len(),
+            if blockers.len() == 1 { "s" } else { "" },
+            blockers
+                .iter()
+                .map(|b| format!("  - {b}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )));
+    }
+
+    // A caller that cannot reach the state a deletion must take with the DID
+    // cannot delete it. Half a deletion — the DID gone, its authorization and
+    // credentials left behind — is the failure this whole path exists to
+    // prevent, so it is refused rather than attempted.
+    let cascade = deps.delete_cascade.as_ref().ok_or_else(|| {
+        AppError::Internal(
+            "this code path cannot delete a DID: it has no access to the ACL, session and \
+             issued-credential keyspaces that must be cleaned up with it"
+                .into(),
+        )
+    })?;
+
+    // ---- Revoke before deleting -------------------------------------------
+    //
+    // Credentials the VTA issued naming this DID cannot be cleaned up: third
+    // parties hold copies, and deleting our record would destroy the only
+    // means of revoking them while leaving every copy in the wild valid
+    // forever. That is exactly the residue an ACL revoke left behind on the
+    // VTC, found in production.
+    //
+    // Revocation runs *first*, and deliberately: if anything later fails, the
+    // credentials are already dead and the DID still exists, which is
+    // recoverable by re-running. The other order leaves live credentials for a
+    // DID nobody can revoke through any more.
+    let revoked = revoke_credentials_for_did(cascade.issued_credentials_ks, did).await?;
+    if revoked > 0 {
+        info!(channel, did = %did, revoked, "revoked credentials issued to a DID being deleted");
+    }
+
     // Resolve server for remote deletion. Track the outcome so the
     // operator can act on a daemon-side orphan rather than seeing
     // local cleanup succeed silently. (Spec / audit H4: surface the
@@ -1527,12 +1615,120 @@ pub async fn delete_did_webvh(
         let _ = deps.keys_ks.remove(store_key).await;
     }
 
-    info!(channel, did = %did, "webvh DID deleted");
+    // ---- Cascade the authorization that named it --------------------------
+    //
+    // An ACL entry outliving its subject is live authority for an identity
+    // that can no longer be resolved or rotated — strictly worse than an
+    // orphaned record, because it still grants. Sessions are authority already
+    // issued and go the same way.
+    vti_common::acl::delete_acl_entry(cascade.acl_ks, did).await?;
+    let sessions_revoked = revoke_sessions_for_did(cascade.sessions_ks, did).await?;
+
+    info!(
+        channel,
+        did = %did,
+        credentials_revoked = revoked,
+        sessions_revoked,
+        "webvh DID deleted"
+    );
     Ok(DeleteDidWebvhResultBody {
         did: did.to_string(),
         deleted: true,
         daemon_cleanup_error,
     })
+}
+
+/// Everything that still depends on `did`, as operator-facing lines naming the
+/// command that unpicks each one.
+///
+/// Read-only: this runs before any write, so a refusal leaves the VTA exactly
+/// as it found it.
+async fn delete_blockers(
+    deps: &WebvhDeps<'_>,
+    auth: &AuthClaims,
+    did: &str,
+    vta_did_value: Option<&str>,
+) -> Result<Vec<String>, AppError> {
+    let mut blockers = Vec::new();
+
+    // The VTA's own DID. Deleting it does not decommission the VTA; it strands
+    // it — unable to authenticate to its mediator, unable to publish, and
+    // unable to be found by anyone holding its credentials.
+    if vta_did_value == Some(did) {
+        blockers.push(format!(
+            "this VTA's own DID ({did}) — deleting it would strand the VTA rather than              decommission it; change `vta_did` first if that is really the intent"
+        ));
+    }
+
+    // A context whose identity this DID is.
+    for ctx in crate::contexts::list_contexts(deps.contexts_ks).await? {
+        if ctx.did.as_deref() == Some(did) {
+            let id = &ctx.id;
+            blockers.push(format!(
+                "context `{id}` acts as this DID — reassign it first:                  `pnm contexts update {id} --did <new-did>`"
+            ));
+        }
+    }
+
+    let _ = auth;
+    Ok(blockers)
+}
+
+/// Revoke every credential the VTA issued to `did`, returning how many moved.
+///
+/// Already-revoked records are left alone: revocation is a tombstone, and
+/// re-revoking would rewrite the timestamp that says when the credential
+/// actually stopped being good.
+async fn revoke_credentials_for_did(
+    issued_credentials_ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<usize, AppError> {
+    use crate::operations::credentials::IssuedCredentialRecord;
+
+    let mut revoked = 0usize;
+    for (key, raw) in issued_credentials_ks
+        .prefix_iter_raw(b"cred:".to_vec())
+        .await?
+    {
+        // A record this build cannot parse is left alone rather than skipped
+        // silently-and-forgotten: it is not ours to rewrite, and failing the
+        // whole deletion over one unreadable row would be worse than leaving
+        // it for the operator to look at.
+        let Ok(mut record) = serde_json::from_slice::<IssuedCredentialRecord>(&raw) else {
+            tracing::warn!(
+                "unparseable issued-credential record skipped during DID deletion; \
+                 it may name the deleted DID and will not have been revoked"
+            );
+            continue;
+        };
+        if record.holder != did || record.revoked_at.is_some() {
+            continue;
+        }
+        record.revoked_at = Some(chrono::Utc::now().to_rfc3339());
+        record.revocation_reason = Some("holder DID deleted".to_string());
+        let bytes = serde_json::to_vec(&record)
+            .map_err(|e| AppError::Internal(format!("re-encode credential record: {e}")))?;
+        issued_credentials_ks.insert_raw(key, bytes).await?;
+        revoked += 1;
+    }
+    Ok(revoked)
+}
+
+/// Delete every live session held by `did`.
+async fn revoke_sessions_for_did(
+    sessions_ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<usize, AppError> {
+    use vti_common::auth::session::{delete_session, list_sessions};
+
+    let mut revoked = 0usize;
+    for session in list_sessions(sessions_ks).await? {
+        if session.did == did {
+            delete_session(sessions_ks, &session.session_id).await?;
+            revoked += 1;
+        }
+    }
+    Ok(revoked)
 }
 
 // ---------------------------------------------------------------------------
@@ -2160,6 +2356,134 @@ mod tests {
         assert!(
             after.cache_hit,
             "after a failed refresh the prior cache entry must be preserved (still a cache hit)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod delete_cascade_tests {
+    use super::*;
+    use crate::operations::credentials::IssuedCredentialRecord;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn credential_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open store");
+        let ks = store
+            .keyspace(crate::keyspaces::ISSUED_CREDENTIALS)
+            .expect("issued_credentials ks");
+        (ks, dir)
+    }
+
+    async fn seed(ks: &KeyspaceHandle, id: &str, holder: &str, revoked: Option<&str>) {
+        let record = IssuedCredentialRecord {
+            id: id.to_string(),
+            holder: holder.to_string(),
+            credential: serde_json::json!({ "id": id }),
+            issued_at: "2026-01-01T00:00:00Z".to_string(),
+            expires_at: "2027-01-01T00:00:00Z".to_string(),
+            revoked_at: revoked.map(str::to_string),
+            revocation_reason: None,
+        };
+        ks.insert_raw(
+            format!("cred:{id}").into_bytes(),
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn load(ks: &KeyspaceHandle, id: &str) -> IssuedCredentialRecord {
+        let raw = ks
+            .get_raw(format!("cred:{id}").into_bytes())
+            .await
+            .unwrap()
+            .expect("record present");
+        serde_json::from_slice(&raw).unwrap()
+    }
+
+    /// Credentials issued to the deleted DID are revoked — and *only* those.
+    ///
+    /// The blast radius matters as much as the effect: this runs during a
+    /// deletion, over every issued credential the VTA holds, and a `holder`
+    /// comparison that was slightly too loose would revoke other people's
+    /// credentials as a side effect of deleting one DID.
+    #[tokio::test]
+    async fn only_the_deleted_dids_credentials_are_revoked() {
+        let (ks, _dir) = credential_ks();
+        seed(&ks, "a", "did:key:zGone", None).await;
+        seed(&ks, "b", "did:key:zGone", None).await;
+        seed(&ks, "c", "did:key:zStays", None).await;
+
+        let revoked = revoke_credentials_for_did(&ks, "did:key:zGone")
+            .await
+            .expect("revoke");
+        assert_eq!(revoked, 2);
+
+        assert!(load(&ks, "a").await.revoked_at.is_some());
+        assert!(load(&ks, "b").await.revoked_at.is_some());
+        assert!(
+            load(&ks, "c").await.revoked_at.is_none(),
+            "another holder's credential must be untouched"
+        );
+    }
+
+    /// The record is revoked, never removed. Deleting it would destroy the only
+    /// evidence that the credential in somebody else's wallet is no longer good
+    /// — which is the whole reason this path revokes rather than cascades.
+    #[tokio::test]
+    async fn revocation_is_a_tombstone_not_a_deletion() {
+        let (ks, _dir) = credential_ks();
+        seed(&ks, "a", "did:key:zGone", None).await;
+
+        revoke_credentials_for_did(&ks, "did:key:zGone")
+            .await
+            .expect("revoke");
+
+        let record = load(&ks, "a").await;
+        assert!(record.revoked_at.is_some());
+        assert_eq!(
+            record.revocation_reason.as_deref(),
+            Some("holder DID deleted")
+        );
+        // The credential itself survives, so a verifier asking about it still
+        // gets an answer.
+        assert_eq!(record.credential["id"], "a");
+    }
+
+    /// An already-revoked credential keeps its original timestamp. Re-revoking
+    /// would rewrite when the credential actually stopped being good, which is
+    /// the one fact the record exists to carry.
+    #[tokio::test]
+    async fn an_already_revoked_credential_keeps_its_original_timestamp() {
+        let (ks, _dir) = credential_ks();
+        seed(&ks, "a", "did:key:zGone", Some("2026-02-02T00:00:00Z")).await;
+
+        let revoked = revoke_credentials_for_did(&ks, "did:key:zGone")
+            .await
+            .expect("revoke");
+        assert_eq!(revoked, 0, "already-revoked records are not counted again");
+        assert_eq!(
+            load(&ks, "a").await.revoked_at.as_deref(),
+            Some("2026-02-02T00:00:00Z")
+        );
+    }
+
+    /// Nothing to revoke is a successful no-op, not an error — a DID may
+    /// legitimately have been issued nothing.
+    #[tokio::test]
+    async fn a_did_with_no_credentials_revokes_none() {
+        let (ks, _dir) = credential_ks();
+        seed(&ks, "c", "did:key:zStays", None).await;
+        assert_eq!(
+            revoke_credentials_for_did(&ks, "did:key:zNothing")
+                .await
+                .expect("revoke"),
+            0
         );
     }
 }

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -402,6 +402,8 @@ mod tests {
         locks: &'a super::super::WebvhAuthLocks,
     ) -> super::super::WebvhDeps<'a> {
         super::super::WebvhDeps {
+            // Registering a DID with a server never deletes one.
+            delete_cascade: None,
             keys_ks: webvh_ks,
             imported_ks: webvh_ks,
             contexts_ks: webvh_ks,

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -652,6 +652,8 @@ mod pre_rotation_e2e_tests {
         locks: &'a crate::operations::did_webvh::WebvhAuthLocks,
     ) -> crate::operations::did_webvh::WebvhDeps<'a> {
         crate::operations::did_webvh::WebvhDeps {
+            // The update path publishes a log entry; it deletes nothing.
+            delete_cascade: None,
             keys_ks: &ts.keys_ks,
             imported_ks: &ts.imported_ks,
             contexts_ks: &ts.contexts_ks,

--- a/vta-service/src/operations/protocol/mod.rs
+++ b/vta-service/src/operations/protocol/mod.rs
@@ -277,6 +277,8 @@ impl<'a> ServiceOpDeps<'a> {
             imported_ks: self.imported_ks,
             contexts_ks: self.contexts_ks,
             webvh_ks: self.webvh_ks,
+            // This bundle serves the protocol ops, none of which delete a DID.
+            delete_cascade: None,
             audit: self.audit,
             seed_store: self.seed_store,
             did_resolver: self.did_resolver,

--- a/vta-service/src/operations/protocol/passkey_vm_cleanup.rs
+++ b/vta-service/src/operations/protocol/passkey_vm_cleanup.rs
@@ -128,6 +128,8 @@ pub async fn strip_all_passkey_vms(
             imported_ks,
             contexts_ks,
             webvh_ks,
+            // Publishing a service change never deletes a DID.
+            delete_cascade: None,
             audit,
             seed_store,
             did_resolver,

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -294,6 +294,12 @@ pub async fn run_delete_did(
     let audit: vta_audit::SharedAuditSink =
         std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
     let webvh_ks = cs.keyspace(crate::keyspaces::WEBVH)?;
+    // The offline delete cascades exactly as the online one does. An operator
+    // reaching for the break-glass CLI is the *last* person who should be left
+    // with a half-deleted DID.
+    let acl_ks = cs.keyspace(crate::keyspaces::ACL)?;
+    let sessions_ks = cs.keyspace(crate::keyspaces::SESSIONS)?;
+    let issued_credentials_ks = cs.keyspace(crate::keyspaces::ISSUED_CREDENTIALS)?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);
 
@@ -302,6 +308,11 @@ pub async fn run_delete_did(
     let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
     let deps = operations::did_webvh::WebvhDeps {
+        delete_cascade: Some(crate::operations::did_webvh::DeleteCascadeDeps {
+            acl_ks: &acl_ks,
+            sessions_ks: &sessions_ks,
+            issued_credentials_ks: &issued_credentials_ks,
+        }),
         keys_ks: &keys_ks,
         imported_ks: &imported_ks,
         contexts_ks: &contexts_ks,
@@ -490,6 +501,8 @@ pub async fn run_edit_did(
     let vta_did = config.vta_did.clone();
     let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
     let deps = crate::operations::did_webvh::WebvhDeps {
+        // `update` publishes a new log entry; it deletes nothing.
+        delete_cascade: None,
         keys_ks: &keys_ks,
         imported_ks: &imported_ks,
         contexts_ks: &contexts_ks,
@@ -578,6 +591,8 @@ pub async fn run_register_did(
 
     let auth = cli_super_admin();
     let deps = operations::did_webvh::WebvhDeps {
+        // This surface publishes; it deletes nothing.
+        delete_cascade: None,
         keys_ks: &keys_ks,
         imported_ks: &imported_ks,
         contexts_ks: &contexts_ks,


### PR DESCRIPTION
Implements the model agreed for "when I delete a DID, what happens to everything tied to it". Design note: `docs/05-design-notes/did-deletion-cascade.md`.

## The gap

`dids delete` removed the daemon-side DID, the local webvh record and log, and the DID's keys. **Nothing else.** ACL entries, issued credentials, sessions and per-DID state were left behind.

That is the VTC's ACL-revoke orphan (#1194, #1196) one level up — a surface owning part of a multi-part identity and knowing nothing about the rest. There it produced a live member row with no authorization and credentials that still verified for anyone holding them, found in production. The VTA had the same shape; nobody had asked it the question yet.

## Deleting a DID is four relationships, not one

| Relationship | Verb | Examples |
|---|---|---|
| The DID **owns** it | Cascade | keys, the webvh log, resolution cache |
| It **names the DID as a subject of authorization** | Cascade | ACL entry, sessions, passkey VMs, consent, vault |
| It **depends on the DID to function** | Blocks | a context acting as this DID, an advertised service, a policy naming it |
| The VTA **issued** it | Revoke | issued credentials |

The fourth is the one most likely to be got wrong, because it looks most like a cascade. Third parties hold copies of what the VTA issued: deleting our record does not invalidate theirs, it destroys the only means of revoking them.

## The three decisions, implemented

**1. It revokes what it cannot destroy** — and revocation runs *first*, before any deletion. If a later step fails, the credentials are already dead and the DID still exists, which is recoverable by re-running. The other order leaves live credentials for a DID nobody can revoke through any more. When a partial failure is possible, the surviving state should be the over-restrictive one.

**2. A dependency refuses, and says what to unpick.** Read-only preflight, so a refusal leaves the VTA exactly as it found it:

```
did:webvh:… cannot be deleted — 1 still depends on it:
  - context `openvtc-test` acts as this DID — reassign it first:
    `pnm contexts update openvtc-test --did <new-did>`
```

Also refuses on the VTA's own DID: deleting that strands the VTA rather than decommissioning it.

**3. No `--force`.** Same call as `would_violate_last_service`, for the same reason — the escape hatch is what gets used at 2am.

## Why a census rather than a list in a function

The failure mode was never getting today's answers wrong. It is a keyspace added next quarter that nobody classifies, whose rows then quietly outlive the DID they belong to — which is exactly how the original gap happened.

`vta_keyspaces::did_delete_effect` classifies all 27 keyspaces, and a census test fails when one is unclassified. `Unrelated` is a fine answer; it has to be a *chosen* one. Same rail the backup partition already rides.

Two pinned explicitly, being the ones a future change is most likely to get wrong: `issued_credentials` is never `Cascade`, and `audit` is never cascaded — the record that a DID was deleted is the one thing that must survive deleting it.

## A caller that cannot cascade cannot delete

`WebvhDeps::delete_cascade` is `None` on paths that only read or publish. That does not mean "skip the cascade" — the delete refuses and names what it cannot reach. Half a deletion is the failure this exists to prevent, so a construction site cannot opt into it by omission. The offline break-glass CLI gets a *real* cascade, deliberately: an operator reaching for that is the last person who should be left with a half-deleted DID.

## Tests

Four on the revocation, which is the riskiest new logic since it rewrites credential records in place — and the blast radius matters as much as the effect, because it runs over every issued credential the VTA holds:

- only the deleted DID's credentials are revoked, and another holder's is untouched;
- revocation is a tombstone, not a deletion — the credential survives so a verifier still gets an answer;
- an already-revoked credential keeps its original timestamp, since re-revoking would rewrite the one fact the record exists to carry;
- a DID with no credentials is a successful no-op.

Plus four census tests in `vta-keyspaces`.

## Deliberately not done

Recorded in the design note rather than dropped:

- **Preview/confirm** before an irreversible delete that now also revokes. I'd do this next.
- **Cascades classified but not yet executed**: vault, consent, task_consent, app_state, memory, outbox, cache, passkey_vms, imported_secrets. The census names them; the code does not clear them yet.
- **Blockers classified but not yet checked**: `service_state` / `service_prev_config`, `policy`, `consent_approvers`. Only the context and self-DID checks are implemented.
- **Resumability (R2.1)**: the daemon delete still precedes local cleanup with no idempotency key.

So this closes the two relationships actively causing harm — unrevoked credentials and orphaned authorization — and turns the rest from an unknown into a visible, tested to-do.

`fmt` and `clippy --workspace --all-targets -D warnings` clean; full `cargo test --workspace` was re-running when this was opened (155 suites green on the commit before the tests were added) — CI is the authority.