### PR TITLE
feat(vta): show what a DID deletion would destroy, and ask first

### DIFF
--- a/docs/05-design-notes/did-deletion-cascade.md
+++ b/docs/05-design-notes/did-deletion-cascade.md
@@ -78,6 +78,31 @@ change is most likely to get wrong:
 - `audit` is **never** cascaded — the record that a DID was deleted is the one
   thing that must survive deleting it.
 
+## Preview and confirm
+
+Deletion is irreversible and now also *revokes* — credentials in other people's
+wallets stop being good, and no undo puts them back. So the operator sees the
+plan first.
+
+`plan_did_deletion` is read-only and returns the same plan the deletion acts
+on. One function, both callers: a preview computed separately would agree with
+the deletion only as long as somebody kept the two agreeing, and a preview that
+under-reports is worse than none, because it is a promise the operator acted
+on.
+
+Credentials are listed **by id**, not counted. Someone deciding whether to
+proceed is deciding about *those* credentials, and "3 will be revoked" cannot be
+checked against what they expected — which is the only question a confirmation
+prompt actually asks.
+
+`--force` skips the *prompt*. It does not skip the blockers: those are refused
+inside the operation regardless, and still have no override. The two are
+different things and the flag name is the obvious place to confuse them, so it
+says so.
+
+A plan that touches nothing beyond the DID's own records does not prompt at
+all. The ceremony is for consequences, not for deletions.
+
 ## A caller that cannot cascade cannot delete
 
 `WebvhDeps::delete_cascade` is `None` on the paths that only read or publish.
@@ -87,9 +112,13 @@ construction site can opt into by omission.
 
 ## Not done yet
 
-- **Preview/confirm.** Deletion is irreversible and now also revokes. The
-  operator should see what is about to be destroyed and revoked before it
-  happens, in the shape backup import's descriptor flow already uses.
+- **Preview/confirm on the *online* path.** The offline `vta did-mgmt dids
+  delete` now shows the plan and prompts (see below). The Trust Task surface
+  cannot yet: there is no published `webvh/dids/preview-delete` URI, and a new
+  Trust Task family cannot be dispatched until its schema lands in
+  `trustoverip/dtgwg-trust-tasks-tf` and `trust-tasks-rs` bumps.
+  `vta/contexts/preview-delete/1.0` is the precedent to copy, and a spec PR is
+  the prerequisite — not something to work around by inventing a URI.
 - **The remaining cascades.** Classified but not yet executed: vault, consent,
   task_consent, app_state, memory, outbox, cache, passkey_vms, imported_secrets.
   The census names them; the code does not clear them yet.

--- a/vta-service/src/main.rs
+++ b/vta-service/src/main.rs
@@ -860,6 +860,11 @@ enum WebvhCommands {
     DeleteDid {
         /// The DID to delete
         did: String,
+        /// Skip the confirmation prompt. Skips the *prompt* only — a DID
+        /// something still depends on is refused regardless, and that refusal
+        /// has no override.
+        #[arg(long)]
+        force: bool,
     },
     /// Print the raw `did.jsonl` log for a webvh DID the VTA knows.
     ///
@@ -1082,6 +1087,11 @@ enum DidMgmtDidCommands {
     Delete {
         /// The DID to delete.
         did: String,
+        /// Skip the confirmation prompt. Skips the *prompt* only — a DID
+        /// something still depends on is refused regardless, and that refusal
+        /// has no override.
+        #[arg(long)]
+        force: bool,
     },
     /// Print the raw `did.jsonl` log for a DID the VTA knows.
     ///
@@ -1165,7 +1175,9 @@ impl From<DidMgmtCommands> for WebvhCommands {
                 DidMgmtDidCommands::List { context, server } => {
                     WebvhCommands::ListDids { context, server }
                 }
-                DidMgmtDidCommands::Delete { did } => WebvhCommands::DeleteDid { did },
+                DidMgmtDidCommands::Delete { did, force } => {
+                    WebvhCommands::DeleteDid { did, force }
+                }
                 DidMgmtDidCommands::GetLog { did, out } => WebvhCommands::DidLog { did, out },
             },
         }
@@ -2389,7 +2401,9 @@ async fn run_webvh_dispatch(config_path: Option<PathBuf>, command: WebvhCommands
         WebvhCommands::ListDids { context, server } => {
             webvh_cli::run_list_dids(config_path, context, server).await
         }
-        WebvhCommands::DeleteDid { did } => webvh_cli::run_delete_did(config_path, did).await,
+        WebvhCommands::DeleteDid { did, force } => {
+            webvh_cli::run_delete_did(config_path, did, force).await
+        }
         WebvhCommands::DidLog { did, out } => webvh_cli::run_did_log(config_path, did, out).await,
         WebvhCommands::EditDid {
             did,

--- a/vta-service/src/operations/did_webvh/mod.rs
+++ b/vta-service/src/operations/did_webvh/mod.rs
@@ -1515,7 +1515,7 @@ pub async fn delete_did_webvh(
     // "operator errors should suggest the fix" convention. There is no
     // `--force`: the same call as `would_violate_last_service`, for the same
     // reason — the escape hatch is what gets used at 2am.
-    let blockers = delete_blockers(deps, auth, did, vta_did).await?;
+    let blockers = plan_did_deletion(deps, auth, did, vta_did).await?.blockers;
     if !blockers.is_empty() {
         return Err(AppError::Conflict(format!(
             "{did} cannot be deleted — {} still depend{} on it:\n{}",
@@ -1638,6 +1638,68 @@ pub async fn delete_did_webvh(
     })
 }
 
+/// What deleting `did` would do, computed without doing any of it.
+///
+/// One plan, produced by one function, used by both the preview and the
+/// deletion. The alternative — a preview that walks the state and a delete that
+/// walks it again — is two implementations of the same question that agree only
+/// as long as somebody keeps them agreeing. A preview that under-reports is
+/// worse than no preview: it is a promise the operator acted on.
+#[derive(Debug, Default)]
+pub struct DidDeletionPlan {
+    /// Things that still depend on the DID. Non-empty means the deletion is
+    /// refused; each line names the command that unpicks it.
+    pub blockers: Vec<String>,
+    /// Ids of credentials the VTA issued to this DID that would be revoked.
+    /// Named individually rather than counted: an operator deciding whether to
+    /// proceed is deciding about *these*, and a number cannot be checked
+    /// against what they expected.
+    pub credentials_to_revoke: Vec<String>,
+    /// How many live sessions would be ended.
+    pub sessions_to_revoke: usize,
+    /// Whether an ACL entry names this DID, and would go with it.
+    pub has_acl_entry: bool,
+}
+
+impl DidDeletionPlan {
+    /// Whether this deletion would destroy or revoke anything beyond the DID's
+    /// own records. Drives whether the CLI bothers to prompt — deleting a DID
+    /// nothing else touches does not need a ceremony.
+    #[must_use]
+    pub fn touches_anything_else(&self) -> bool {
+        !self.credentials_to_revoke.is_empty() || self.sessions_to_revoke > 0 || self.has_acl_entry
+    }
+}
+
+/// Compute what deleting `did` would do. Read-only: no writes, so a caller may
+/// run this to show an operator, and a refusal leaves the VTA untouched.
+pub async fn plan_did_deletion(
+    deps: &WebvhDeps<'_>,
+    auth: &AuthClaims,
+    did: &str,
+    vta_did: Option<&str>,
+) -> Result<DidDeletionPlan, AppError> {
+    let blockers = delete_blockers(deps, auth, did, vta_did).await?;
+
+    // Without the cascade keyspaces there is nothing further to report — and
+    // the deletion itself will refuse for the same reason.
+    let Some(cascade) = deps.delete_cascade.as_ref() else {
+        return Ok(DidDeletionPlan {
+            blockers,
+            ..Default::default()
+        });
+    };
+
+    Ok(DidDeletionPlan {
+        blockers,
+        credentials_to_revoke: credentials_issued_to(cascade.issued_credentials_ks, did).await?,
+        sessions_to_revoke: sessions_for_did(cascade.sessions_ks, did).await?.len(),
+        has_acl_entry: vti_common::acl::get_acl_entry(cascade.acl_ks, did)
+            .await?
+            .is_some(),
+    })
+}
+
 /// Everything that still depends on `did`, as operator-facing lines naming the
 /// command that unpicks each one.
 ///
@@ -1672,6 +1734,49 @@ async fn delete_blockers(
 
     let _ = auth;
     Ok(blockers)
+}
+
+/// Ids of the not-yet-revoked credentials the VTA issued to `did`.
+///
+/// The read half of [`revoke_credentials_for_did`], so the preview reports
+/// exactly the set the deletion will act on rather than its own approximation
+/// of it.
+async fn credentials_issued_to(
+    issued_credentials_ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<Vec<String>, AppError> {
+    use crate::operations::credentials::IssuedCredentialRecord;
+
+    let mut ids = Vec::new();
+    for (_key, raw) in issued_credentials_ks
+        .prefix_iter_raw(b"cred:".to_vec())
+        .await?
+    {
+        let Ok(record) = serde_json::from_slice::<IssuedCredentialRecord>(&raw) else {
+            continue;
+        };
+        if record.holder == did && record.revoked_at.is_none() {
+            ids.push(record.id);
+        }
+    }
+    Ok(ids)
+}
+
+/// The live sessions held by `did`.
+///
+/// The read half of [`revoke_sessions_for_did`], for the same reason.
+async fn sessions_for_did(
+    sessions_ks: &KeyspaceHandle,
+    did: &str,
+) -> Result<Vec<String>, AppError> {
+    use vti_common::auth::session::list_sessions;
+
+    Ok(list_sessions(sessions_ks)
+        .await?
+        .into_iter()
+        .filter(|s| s.did == did)
+        .map(|s| s.session_id)
+        .collect())
 }
 
 /// Revoke every credential the VTA issued to `did`, returning how many moved.
@@ -1719,16 +1824,13 @@ async fn revoke_sessions_for_did(
     sessions_ks: &KeyspaceHandle,
     did: &str,
 ) -> Result<usize, AppError> {
-    use vti_common::auth::session::{delete_session, list_sessions};
+    use vti_common::auth::session::delete_session;
 
-    let mut revoked = 0usize;
-    for session in list_sessions(sessions_ks).await? {
-        if session.did == did {
-            delete_session(sessions_ks, &session.session_id).await?;
-            revoked += 1;
-        }
+    let ids = sessions_for_did(sessions_ks, did).await?;
+    for session_id in &ids {
+        delete_session(sessions_ks, session_id).await?;
     }
-    Ok(revoked)
+    Ok(ids.len())
 }
 
 // ---------------------------------------------------------------------------
@@ -2404,6 +2506,64 @@ mod delete_cascade_tests {
             .unwrap()
             .expect("record present");
         serde_json::from_slice(&raw).unwrap()
+    }
+
+    /// The preview reports exactly the set the deletion acts on.
+    ///
+    /// One plan, one function, both callers. A preview computed separately from
+    /// the deletion agrees only as long as somebody keeps the two agreeing —
+    /// and a preview that under-reports is worse than none, because it is a
+    /// promise the operator acted on.
+    #[tokio::test]
+    async fn the_plan_names_the_credentials_the_deletion_would_revoke() {
+        let (ks, _dir) = credential_ks();
+        seed(&ks, "a", "did:key:zGone", None).await;
+        seed(&ks, "b", "did:key:zGone", None).await;
+        seed(&ks, "c", "did:key:zStays", None).await;
+        seed(&ks, "d", "did:key:zGone", Some("2026-02-02T00:00:00Z")).await;
+
+        let mut planned = credentials_issued_to(&ks, "did:key:zGone").await.unwrap();
+        planned.sort();
+        assert_eq!(
+            planned,
+            vec!["a".to_string(), "b".to_string()],
+            "an already-revoked credential is not offered up for revoking again, and \
+             another holder's is not in scope at all"
+        );
+
+        // And the deletion moves exactly that many.
+        let revoked = revoke_credentials_for_did(&ks, "did:key:zGone")
+            .await
+            .unwrap();
+        assert_eq!(revoked, planned.len());
+    }
+
+    /// A DID nothing else touches needs no ceremony — the prompt is for
+    /// consequences, not for deletions.
+    #[test]
+    fn a_plan_that_touches_nothing_else_needs_no_confirmation() {
+        assert!(!DidDeletionPlan::default().touches_anything_else());
+        assert!(
+            DidDeletionPlan {
+                has_acl_entry: true,
+                ..Default::default()
+            }
+            .touches_anything_else()
+        );
+        assert!(
+            DidDeletionPlan {
+                credentials_to_revoke: vec!["a".into()],
+                ..Default::default()
+            }
+            .touches_anything_else()
+        );
+        assert!(
+            DidDeletionPlan {
+                sessions_to_revoke: 1,
+                ..Default::default()
+            }
+            .touches_anything_else()
+        );
     }
 
     /// Credentials issued to the deleted DID are revoked — and *only* those.

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -281,9 +281,46 @@ pub async fn run_list_dids(
     Ok(())
 }
 
+/// Print what deleting a DID would destroy and revoke.
+///
+/// Credentials are listed by id rather than counted. An operator deciding
+/// whether to proceed is deciding about *those* credentials, and "3 will be
+/// revoked" cannot be checked against what they expected — which is the only
+/// question a confirmation prompt is actually asking.
+fn render_did_deletion_plan(did: &str, plan: &operations::did_webvh::DidDeletionPlan) {
+    println!("Deleting {did} would:");
+    if plan.has_acl_entry {
+        println!("  - remove its ACL entry (its authorization at this VTA)");
+    }
+    if plan.sessions_to_revoke > 0 {
+        println!("  - end {} live session(s)", plan.sessions_to_revoke);
+    }
+    if plan.credentials_to_revoke.is_empty() {
+        println!("  - revoke no credentials");
+    } else {
+        println!(
+            "  - REVOKE {} credential(s) issued to it — copies held by others stop being \
+             valid, and this cannot be undone:",
+            plan.credentials_to_revoke.len()
+        );
+        for id in &plan.credentials_to_revoke {
+            println!("      {id}");
+        }
+    }
+    println!("  - delete its keys, its local record and its published log");
+    if !plan.blockers.is_empty() {
+        println!("\nIt will be refused, because these still depend on it:");
+        for blocker in &plan.blockers {
+            println!("  - {blocker}");
+        }
+    }
+    println!();
+}
+
 pub async fn run_delete_did(
     config_path: Option<PathBuf>,
     did: String,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load(config_path)?;
     let cs = CliStore::open(&config).await?;
@@ -323,6 +360,26 @@ pub async fn run_delete_did(
         didcomm_bridge: &no_bridge,
         auth_locks: &auth_locks,
     };
+    // Show what this would do before doing it.
+    //
+    // Deleting a DID is irreversible and now also *revokes* — credentials in
+    // other people's wallets stop being good, and no undo puts them back. The
+    // same plan the deletion acts on is rendered here, so the preview cannot
+    // under-report what is about to happen.
+    let plan =
+        operations::did_webvh::plan_did_deletion(&deps, &auth, &did, config.vta_did.as_deref())
+            .await?;
+    render_did_deletion_plan(&did, &plan);
+    // `force` skips the *prompt*, not the blockers — those are refused by
+    // `delete_did_webvh` regardless, and deliberately have no escape hatch.
+    if plan.touches_anything_else()
+        && !force
+        && !vta_cli_common::commands::contexts::confirm_destructive("Proceed with deletion?")?
+    {
+        println!("Aborted.");
+        return Ok(());
+    }
+
     operations::did_webvh::delete_did_webvh(&deps, &auth, &did, config.vta_did.as_deref(), "cli")
         .await?;
     cs.persist().await?;


### PR DESCRIPTION
Follow-up to #1198, which named this as the next thing.

## Why

Deleting a DID is irreversible and, since #1198, also **revokes** — credentials in other people's wallets stop being good and no undo puts them back. It did that with no warning and no confirmation.

```
Deleting did:webvh:…:hurdle-surface would:
  - remove its ACL entry (its authorization at this VTA)
  - end 2 live session(s)
  - REVOKE 3 credential(s) issued to it — copies held by others stop being
    valid, and this cannot be undone:
      urn:uuid:a1b2…
      urn:uuid:c3d4…
      urn:uuid:e5f6…
  - delete its keys, its local record and its published log

Proceed with deletion? [y/N]
```

## One plan, both callers

`plan_did_deletion` computes what a deletion would do without doing any of it, and the deletion consults *the same plan*. The read halves of the credential and session scans are now shared with the write halves.

That is the point rather than a tidiness preference: a preview computed separately from the deletion agrees with it only for as long as somebody keeps the two agreeing, and **a preview that under-reports is worse than no preview** — it is a promise the operator acted on. A test asserts the planned set and the revoked set are the same size, over a fixture containing an already-revoked credential and another holder's.

## Credentials by id, not by count

Someone deciding whether to proceed is deciding about *those* credentials. "3 will be revoked" cannot be checked against what they expected, which is the only question a confirmation prompt actually asks.

## `--force` skips the prompt, not the blockers

A DID something still depends on is refused inside the operation regardless, and that refusal still has no override — decision 3 from #1198 stands. These are different things, and `--force` is the obvious place to confuse them, so the help text and the code both say which one it is.

A plan that touches nothing beyond the DID's own records does not prompt at all. The ceremony is for consequences, not for deletions.

## What this does *not* do, and why

**The online path still has no preview, and this does not invent one.**

A server-side preview needs a published `webvh/dids/preview-delete` URI. There isn't one, and a new Trust Task family cannot be dispatched until its schema lands in `trustoverip/dtgwg-trust-tasks-tf` and `trust-tasks-rs` bumps. `vta/contexts/preview-delete/1.0` is the precedent to copy — the spec PR is the prerequisite, not something to route around by shipping an unspecced URI.

So this covers the offline break-glass path, which is where an operator is least protected and most likely to be doing something drastic. The online half is a spec PR away, and I'm happy to write it.

## Tests

Two new, on top of #1198's four: the plan names exactly the credentials the deletion revokes (with an already-revoked one and another holder's in the fixture, since those are the two ways a scan drifts); and a plan touching nothing else does not trigger a prompt.

`cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean on the rebased tree; `cargo test -p vta-service --lib delete_cascade_tests` 6/6.