### PR TITLE
fix(sdk): dispatch provision/integration 0.3 on every transport, not just REST

### DIFF
--- a/vta-sdk/src/client/bootstrap.rs
+++ b/vta-sdk/src/client/bootstrap.rs
@@ -52,7 +52,7 @@ impl VtaClient {
                     req.assertion,
                     req.vc_validity_seconds,
                     req.create_context,
-                    crate::protocols::provision_integration_management::ProvisionSpecVersion::V0_1,
+                    crate::protocols::provision_integration_management::ProvisionSpecVersion::CURRENT,
                 )
                 .await
             }

--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -119,6 +119,23 @@ pub enum ProvisionSpecVersion {
 }
 
 impl ProvisionSpecVersion {
+    /// The version every client in this workspace dispatches under.
+    ///
+    /// Named once, because the per-transport alternative already failed: when
+    /// the VTA cut over to 0.3 (#1147) the REST runner and the server moved,
+    /// and the TSP runner (0.2) and the DIDComm runners (0.1) were left behind
+    /// — each holding its own literal, none of them wrong on its face. The
+    /// server had removed both, so every provisioning attempt over those two
+    /// transports came back `unsupportedType` against a VTA that was working
+    /// perfectly. A dispatch site should ask *which version do we speak*, not
+    /// answer it.
+    ///
+    /// The older variants stay: they still describe the historical wire forms
+    /// that [`request_body_for_version`] and `is_v0_1` case bodies for, and
+    /// they are public API. What they no longer are is something a client
+    /// picks.
+    pub const CURRENT: Self = Self::V0_3;
+
     /// The canonical request URI to address this version at.
     pub fn request_uri(self) -> &'static str {
         match self {

--- a/vta-sdk/src/provision_client/runner_didcomm.rs
+++ b/vta-sdk/src/provision_client/runner_didcomm.rs
@@ -66,7 +66,7 @@ pub async fn provision_via_didcomm(
             None,
             None,
             false,
-            ProvisionSpecVersion::V0_1,
+            ProvisionSpecVersion::CURRENT,
         )
         .await?;
         response_to_result(&seed, nonce, response)
@@ -395,7 +395,7 @@ pub async fn provision_admin_rotation_via_didcomm(
             None,
             None,
             false,
-            ProvisionSpecVersion::V0_1,
+            ProvisionSpecVersion::CURRENT,
         )
         .await?;
         crate::provision_client::result::admin_rotation_response_to_reply(&seed, nonce, response)

--- a/vta-sdk/src/provision_client/runner_tsp.rs
+++ b/vta-sdk/src/provision_client/runner_tsp.rs
@@ -17,17 +17,22 @@
 //!
 //! - `spec/vta/webvh/servers/list/1.0`
 //!   ([`TASK_WEBVH_SERVERS_LIST_1_0`]) — the webvh-host catalogue.
-//! - `spec/provision/integration/0.2`
-//!   ([`TASK_PROVISION_INTEGRATION_0_2`]) — the VP-framed bootstrap
+//! - `spec/provision/integration/0.3`
+//!   ([`TASK_PROVISION_INTEGRATION_0_3`]) — the VP-framed bootstrap
 //!   request and its sealed reply.
 //!
 //! So the request and reply documents are byte-identical to the ones the
 //! other two transports carry, and this module is wiring rather than
-//! protocol design. Note the **0.2** URI: the DIDComm leg addresses
-//! `provision/integration/0.1` as a DIDComm *protocol message* (routed by
-//! `messaging::handlers_protocol`, not by the trust-task spine), and only
-//! 0.2 is on the spine. The signed VP inside is byte-identical either way
-//! — `spec_version` selects the casing of the *options* around it.
+//! protocol design.
+//!
+//! The version is [`ProvisionSpecVersion::CURRENT`] and never a literal
+//! spelled here. TSP and DIDComm once addressed *different* versions of this
+//! operation — the spine carried 0.2, while the DIDComm leg addressed 0.1 as a
+//! protocol message routed by `messaging::handlers_protocol` — so each
+//! transport held its own constant. The 0.3 cut-over collapsed that: both
+//! surfaces now dispatch the same URI, and both moved on the same day the
+//! server dropped the old ones. Keeping the literal here is what made this
+//! module miss that day.
 //!
 //! # What TSP does not share with DIDComm
 //!
@@ -59,7 +64,8 @@
 //! don't pretend the DID document was at fault.
 //!
 //! [`TASK_WEBVH_SERVERS_LIST_1_0`]: crate::trust_tasks::TASK_WEBVH_SERVERS_LIST_1_0
-//! [`TASK_PROVISION_INTEGRATION_0_2`]: crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_2
+//! [`TASK_PROVISION_INTEGRATION_0_3`]: crate::trust_tasks::TASK_PROVISION_INTEGRATION_0_3
+//! [`ProvisionSpecVersion::CURRENT`]: crate::protocols::provision_integration_management::ProvisionSpecVersion::CURRENT
 //! [`VtaClient::dispatch_trust_task`]: crate::client::VtaClient::dispatch_trust_task
 //! [`DiagCheck::AuthenticateTSP`]: super::diagnostics::DiagCheck::AuthenticateTSP
 //! [`DiagCheck::AuthenticateDIDComm`]: super::diagnostics::DiagCheck::AuthenticateDIDComm
@@ -383,7 +389,7 @@ async fn tsp_full_setup(
     }
 }
 
-/// Send the VP-framed bootstrap request as a `provision/integration/0.2`
+/// Send the VP-framed bootstrap request as a `provision/integration`
 /// trust task over `client`'s transport and open the sealed reply.
 ///
 /// The VP is signed with the setup key and the bundle is sealed to it, so
@@ -430,10 +436,11 @@ async fn provision_admin_rotation_over(
     admin_rotation_response_to_reply(&seed, nonce, response)
 }
 
-/// The one place the `provision/integration/0.2` trust task is built and
+/// The one place the `provision/integration` trust task is built and
 /// dispatched, so the two callers above cannot disagree about the wire
-/// shape. `0.2` because that is the version registered on the VTA's shared
-/// trust-task spine — the only surface the TSP inbound dispatcher feeds.
+/// shape — addressed at [`ProvisionSpecVersion::CURRENT`], which is what the
+/// VTA registers on the shared trust-task spine that the TSP inbound
+/// dispatcher feeds.
 #[cfg(feature = "tsp")]
 async fn dispatch_provision_integration(
     client: &crate::client::VtaClient,
@@ -455,7 +462,7 @@ async fn dispatch_provision_integration(
         vc_validity_seconds: None,
         create_context: false,
     };
-    let request_uri = ProvisionSpecVersion::V0_2.request_uri();
+    let request_uri = ProvisionSpecVersion::CURRENT.request_uri();
     let payload = request_body_for_version(&body_struct, request_uri)
         .map_err(ProvisionError::Serialization)?;
 

--- a/vta-sdk/src/provision_integration/didcomm.rs
+++ b/vta-sdk/src/provision_integration/didcomm.rs
@@ -71,11 +71,17 @@ const DEFAULT_TIMEOUT_SECS: u64 = 60;
 /// [`crate::provision_integration::http::ProvisionIntegrationRequest::context`]
 /// for the full inference rules + error semantics.
 ///
-/// `spec_version` selects the Trust Task wire version. [`ProvisionSpecVersion::V0_1`]
-/// emits the legacy snake_case option fields + kebab `assertion` under the
-/// `provision/integration/0.1` URI; [`ProvisionSpecVersion::V0_2`] emits
+/// `spec_version` selects the Trust Task wire version, and a caller in this
+/// workspace passes [`ProvisionSpecVersion::CURRENT`] — the VTA serves exactly
+/// one version of this operation at a time. The older variants remain callable
+/// because they still describe wire forms this crate can *render*, which is
+/// what makes them testable: [`ProvisionSpecVersion::V0_1`] emits the legacy
+/// snake_case option fields + kebab `assertion` under the
+/// `provision/integration/0.1` URI, and [`ProvisionSpecVersion::V0_2`] emits
 /// lowerCamelCase (`vcValiditySeconds` / `createContext` / `didSigned`) under
-/// the `0.2` URI. The signed VP carried in `request` is left byte-identical
+/// the `0.2` URI. Neither is dispatchable against a current VTA — both were
+/// removed rather than deprecated, so they come back `unsupportedType`.
+/// The signed VP carried in `request` is left byte-identical
 /// either way — its casing is the holder's, and the VTA dual-accepts both.
 /// That is why `request` is a raw [`Value`] and not a typed
 /// [`BootstrapRequest`](super::BootstrapRequest): the claim above was

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1995,6 +1995,36 @@ mod tests {
         }
     }
 
+    /// The provisioning clients dispatch the version this service serves.
+    ///
+    /// This is the test that was missing when #1147 cut provision-integration
+    /// over to 0.3. That change moved the server and the REST runner and left
+    /// the TSP runner on 0.2 and the DIDComm runners on 0.1 — versions it had
+    /// just *removed*, because 0.2 requires a bare-hex `digest` and forbids the
+    /// `digestMultibase` 0.3 requires. Nothing failed in CI: each half was
+    /// self-consistent, and the census tests below check that everything this
+    /// service serves is specced, never that a client asks for it. Provisioning
+    /// over TSP and DIDComm was dead from the release until an operator hit
+    /// `unsupportedType` against a VTA that was otherwise healthy.
+    ///
+    /// `ProvisionSpecVersion::CURRENT` is now the single thing every client
+    /// dispatch site reads, so this one assertion covers all of them: move the
+    /// server to 0.4 without moving `CURRENT`, or the reverse, and this fails.
+    #[test]
+    fn provision_clients_dispatch_the_version_this_service_serves() {
+        use vta_sdk::protocols::provision_integration_management::ProvisionSpecVersion;
+
+        let uri = ProvisionSpecVersion::CURRENT.request_uri();
+        let dispatched = dispatched_uris();
+        assert!(
+            dispatched.contains(&uri) || KNOWN_FEATURE_GATED_URIS.contains(&uri),
+            "vta-sdk's provisioning clients dispatch `{uri}` \
+             (`ProvisionSpecVersion::CURRENT`), but this service does not serve \
+             it. A provision-integration version cut-over has to move both \
+             halves: the `dispatch_table!` entry and `CURRENT`."
+        );
+    }
+
     /// Defensive guard against double-tracking. A URI should appear in
     /// exactly one of (`dispatched_uris()`, `REST_ROUTED`,
     /// `KNOWN_FEATURE_GATED_URIS`) — except that `KNOWN_FEATURE_GATED_URIS`


### PR DESCRIPTION
#1147 cut provision-integration over to 0.3 and removed 0.2 outright — 0.2 requires a bare-hex `digest` and forbids the `digestMultibase` 0.3 requires, and both close their response with `additionalProperties: false`, so no single response satisfies the two. The server moved, the REST runner moved, and the response-parsing side moved.

The other three dispatch sites did not:

| site | asked for |
|---|---|
| `provision_client/runner_tsp` | `0.2` (trust-task spine) |
| `provision_client/runner_didcomm` ×2 | `0.1` (DIDComm protocol message) |
| `client/bootstrap` DIDComm arm | `0.1` |

Each held its own literal, and each was correct on the day it was written — TSP and DIDComm genuinely addressed *different* versions of this operation before the cut-over collapsed them onto one URI. So nothing looked wrong on inspection, and nothing failed in CI: both halves were internally consistent.

## What shipped

A VTA that can only be provisioned over REST. Every TSP and DIDComm attempt returns

```
trust task failed [unsupportedType]: unsupported type:
https://trusttasks.org/spec/provision/integration/0.2
```

against a VTA that is otherwise healthy. It surfaces as a `PostAuthFailure` — *after* auth succeeds — so the runner treats it as terminal and never falls back to the REST leg that would have worked. OpenVTC's setup wizard prefers TSP, so this is every fresh OpenVTC install:

```
✓ Resolve VTA DID     ✓ Enumerate service endpoints     ✓ Authenticate via TSP
✗ Provision integration DID + admin credential
    ERROR: AdminRotation provisioning failed after auth.
```

## The fix

`ProvisionSpecVersion::CURRENT` is now the one place a client reads the version from, and all four sites go through it. The older variants stay — they still describe the wire forms `request_body_for_version` and `is_v0_1` case bodies for, and they are public API — but they are no longer something a dispatch site picks. A dispatch site should ask *which version do we speak*, not answer it.

## And a guard

A version cut-over is exactly the change that moves one half of a contract, so `provision_clients_dispatch_the_version_this_service_serves` asserts `CURRENT`'s URI is one the dispatcher registers. Checked both ways — it passes here, and on the shipped `V0_2` it fails with the message that names both halves to move:

```
vta-sdk's provisioning clients dispatch
`https://trusttasks.org/spec/provision/integration/0.2`
(`ProvisionSpecVersion::CURRENT`), but this service does not serve it.
A provision-integration version cut-over has to move both halves:
the `dispatch_table!` entry and `CURRENT`.
```

The existing census tests could not have caught this: they check that everything this service *serves* is specced, never that a client asks for it.

Also fixes the intra-doc link `runner_tsp` still had to the deleted `TASK_PROVISION_INTEGRATION_0_2`.

## Verification

`cargo test -p vta-sdk --all-features` (693 + 181 across suites) and `cargo test -p vta-service --lib` (972) both green; `cargo fmt` and `cargo clippy --all-features --all-targets` clean on both crates.

Needs a `vta-sdk` publish — OpenVTC is blocked on it for setup.
