### PR TITLE
fix(vta): answer provision/integration under the version the body was rendered in

### DIFF
--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -75,15 +75,31 @@ pub const CANONICAL_PROVISION_INTEGRATION_0_3_RESULT: &str =
 
 /// Match the result URI to whichever request URI the caller used.
 /// Centralised here so the routing decision lives next to the URI
-/// constants — handlers downstream just call this. The 0.2 request URI
-/// maps to the 0.2 `#response`; the 0.1 request URI (the only other shape
-/// the router advertises) maps to the 0.1 `#response`.
+/// constants — handlers downstream just call this.
+///
+/// Resolved through [`ProvisionSpecVersion::from_request_uri`] rather than by
+/// testing for one version and falling through, which is what this function
+/// used to do: `== 0.2` picked the 0.2 `#response`, and *everything else* —
+/// including the 0.3 that #1147 made the only version the router accepts —
+/// picked the 0.1 `#response`. The handler beside it rendered a 0.3 body, so
+/// every DIDComm reply went out as a `digestMultibase` body labelled
+/// `provision/integration/0.1#response`: a message invalid under the schema
+/// it names, since 0.1's response requires a bare-hex `digest` and closes
+/// with `additionalProperties: false`. A wallet checking the reply type
+/// rejected a provisioning run that had actually succeeded — the bundle was
+/// sealed and the admin rolled over, and the holder threw the result away.
+///
+/// The same shape of bug was fixed in [`is_v0_1`] for the same reason: a
+/// predicate about one version has to name that version, because the
+/// fall-through arm silently claims every version nobody has written yet.
+///
+/// An unrecognised URI resolves to [`ProvisionSpecVersion::CURRENT`], which
+/// is the version [`response_body_for_version`] renders it in — the URI and
+/// the body it labels stay the same version even here.
 pub fn result_uri_for(request_uri: &str) -> &'static str {
-    if request_uri == CANONICAL_PROVISION_INTEGRATION_0_2 {
-        CANONICAL_PROVISION_INTEGRATION_0_2_RESULT
-    } else {
-        CANONICAL_PROVISION_INTEGRATION_RESULT
-    }
+    ProvisionSpecVersion::from_request_uri(request_uri)
+        .unwrap_or(ProvisionSpecVersion::CURRENT)
+        .result_uri()
 }
 
 pub mod request {
@@ -107,10 +123,13 @@ use crate::provision_integration::http::{
     ProvisionIntegrationRequest, ProvisionIntegrationResponse,
 };
 
-/// Which casing convention a provision-integration body is emitted under. The
-/// 0.1 wire form is snake_case fields + kebab-case `assertion`; the 0.2 form is
-/// lowerCamelCase throughout, per `dtgwg-trust-tasks-tf`'s
-/// `provision/integration/0.2` schema.
+/// Which version of the provision-integration wire form a body is emitted
+/// under. The 0.1 form is snake_case fields + kebab-case `assertion`; 0.2 and
+/// 0.3 are lowerCamelCase throughout, per `dtgwg-trust-tasks-tf`'s schemas.
+/// 0.3 additionally replaces the response's bare-hex `digest` with
+/// `digestMultibase`, which is why it could not be served from the same
+/// response body as its predecessors — both close with
+/// `additionalProperties: false`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProvisionSpecVersion {
     V0_1,
@@ -119,6 +138,15 @@ pub enum ProvisionSpecVersion {
 }
 
 impl ProvisionSpecVersion {
+    /// Every version this crate can name, newest last.
+    ///
+    /// Exists so [`from_request_uri`](Self::from_request_uri) can be a search
+    /// rather than a hand-written reverse map. A reverse map is the half that
+    /// gets forgotten: `request_uri` below is an exhaustive `match`, so a new
+    /// variant cannot compile without an entry, but nothing forced the
+    /// corresponding *inbound* mapping to move — and at 0.3 it did not.
+    pub const ALL: &'static [Self] = &[Self::V0_1, Self::V0_2, Self::V0_3];
+
     /// The version every client in this workspace dispatches under.
     ///
     /// Named once, because the per-transport alternative already failed: when
@@ -143,6 +171,30 @@ impl ProvisionSpecVersion {
             ProvisionSpecVersion::V0_2 => CANONICAL_PROVISION_INTEGRATION_0_2,
             ProvisionSpecVersion::V0_3 => CANONICAL_PROVISION_INTEGRATION_0_3,
         }
+    }
+
+    /// The canonical result URI a request at this version is answered under.
+    ///
+    /// Per SPEC.md §4.4.1 of `dtgwg-trust-tasks-tf` this is always the request
+    /// URI plus a `#response` fragment, which
+    /// `result_uri_is_request_uri_plus_response_fragment` asserts for every
+    /// variant — the constants are written out rather than concatenated so
+    /// that the test compares two independently-derived strings.
+    pub fn result_uri(self) -> &'static str {
+        match self {
+            ProvisionSpecVersion::V0_1 => CANONICAL_PROVISION_INTEGRATION_RESULT,
+            ProvisionSpecVersion::V0_2 => CANONICAL_PROVISION_INTEGRATION_0_2_RESULT,
+            ProvisionSpecVersion::V0_3 => CANONICAL_PROVISION_INTEGRATION_0_3_RESULT,
+        }
+    }
+
+    /// Which version a request URI addresses, or `None` if it names no
+    /// version this crate knows.
+    pub fn from_request_uri(request_uri: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|v| v.request_uri() == request_uri)
     }
 }
 
@@ -220,10 +272,11 @@ pub fn request_body_for_version(
 }
 
 /// Serialise a provision-integration **response** body in the casing
-/// `request_uri` implies. 0.2 is the canonical serialization (identity); for
-/// a **0.1** requester the `summary` object's keys are down-cased
-/// (`clientDid` → `client_did`, `bundleIdHex` → `bundle_id_hex`, …). The
-/// top-level `bundle`/`digest` are opaque single-word fields and unchanged.
+/// `request_uri` implies. lowerCamelCase is the canonical serialization
+/// (identity for 0.2 and 0.3); for a **0.1** requester the `summary` object's
+/// keys are down-cased (`clientDid` → `client_did`, `bundleIdHex` →
+/// `bundle_id_hex`, …). The top-level `bundle`/`digestMultibase` are opaque
+/// single-word fields and unchanged.
 pub fn response_body_for_version(
     resp: &ProvisionIntegrationResponse,
     request_uri: &str,
@@ -257,15 +310,76 @@ mod tests {
         );
     }
 
-    /// Unknown / future URIs default to the 0.1 result URI. The router
-    /// only advertises the 0.1 and 0.2 URIs, so this branch is unreachable
-    /// in production — but exercising it pins the fallback so a future
-    /// widening doesn't silently change the default response shape.
     #[test]
-    fn result_uri_for_unknown_request_defaults_to_v0_1() {
+    fn result_uri_for_v0_3_request_emits_v0_3_response() {
+        assert_eq!(
+            result_uri_for(CANONICAL_PROVISION_INTEGRATION_0_3),
+            CANONICAL_PROVISION_INTEGRATION_0_3_RESULT
+        );
+    }
+
+    /// The response URI and the response *body* are two decisions taken off
+    /// the same `request_uri`, one line apart in the DIDComm handler. They
+    /// have to name the same version, and for 0.3 they did not: the body was
+    /// rendered 0.3 and the URI came back 0.1, so the reply announced a
+    /// schema it could not satisfy.
+    ///
+    /// Asserted over `ALL` rather than per-version, because the failure this
+    /// catches is a *new* version arriving and one of the two halves not
+    /// moving with it.
+    #[test]
+    fn result_uri_for_agrees_with_the_version_the_request_uri_names() {
+        for v in ProvisionSpecVersion::ALL {
+            assert_eq!(
+                result_uri_for(v.request_uri()),
+                v.result_uri(),
+                "{v:?}: result_uri_for disagrees with the version's own result URI"
+            );
+        }
+    }
+
+    /// SPEC.md §4.4.1 of `dtgwg-trust-tasks-tf`: a success response is emitted
+    /// under the request URI with a `#response` fragment. Holds for every
+    /// version, so assert the rule rather than three more pinned strings.
+    #[test]
+    fn result_uri_is_request_uri_plus_response_fragment() {
+        for v in ProvisionSpecVersion::ALL {
+            assert_eq!(v.result_uri(), format!("{}#response", v.request_uri()));
+        }
+    }
+
+    /// `ALL` has to list every variant, or `from_request_uri` answers `None`
+    /// for a version this crate can otherwise name — and `result_uri_for`
+    /// then silently falls back to `CURRENT`. The `match` is exhaustive, so
+    /// adding a variant fails to compile here until it is named.
+    #[test]
+    fn all_lists_every_version() {
+        for v in [
+            ProvisionSpecVersion::V0_1,
+            ProvisionSpecVersion::V0_2,
+            ProvisionSpecVersion::V0_3,
+        ] {
+            match v {
+                ProvisionSpecVersion::V0_1
+                | ProvisionSpecVersion::V0_2
+                | ProvisionSpecVersion::V0_3 => {}
+            }
+            assert!(
+                ProvisionSpecVersion::ALL.contains(&v),
+                "{v:?} is missing from ProvisionSpecVersion::ALL"
+            );
+        }
+    }
+
+    /// An unrecognised URI cannot reach the handler — the router binds
+    /// `CURRENT` alone — but if one ever did, the reply must be labelled the
+    /// version its body was actually rendered in. `response_body_for_version`
+    /// recases only for 0.1, so anything unknown is rendered `CURRENT`.
+    #[test]
+    fn result_uri_for_unknown_request_matches_the_body_it_would_render() {
         assert_eq!(
             result_uri_for("https://example.invalid/something-else"),
-            CANONICAL_PROVISION_INTEGRATION_RESULT
+            ProvisionSpecVersion::CURRENT.result_uri()
         );
     }
 

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1522,12 +1522,15 @@ pub async fn handle_provision_integration(
         },
     };
 
-    // Match the response URI to whichever request URI the caller used.
-    // A client targeting the canonical Trust Task URI
-    // (`https://trusttasks.org/spec/provision/integration/0.1`) receives
-    // the canonical `#response` fragment; the legacy FPN URI gets the
-    // legacy `…-result`. Both share one handler so the routing decision
-    // lives in `result_uri_for` rather than two parallel branches here.
+    // Match the response URI to whichever request URI the caller used: the
+    // request URI plus a `#response` fragment, per SPEC.md §4.4.1. The
+    // decision lives in `result_uri_for` rather than in a literal here, so
+    // that it stays beside the URI constants it chooses between.
+    //
+    // It has to name the same version as `response_body_for_version` below,
+    // which is the pairing that came apart at 0.3: the body was rendered 0.3
+    // and this line answered 0.1, so a successful provisioning went out under
+    // a schema its own body could not satisfy and holders discarded it.
     let result_uri =
         vta_sdk::protocols::provision_integration_management::result_uri_for(&message.typ);
 

--- a/vta-service/src/messaging/router.rs
+++ b/vta-service/src/messaging/router.rs
@@ -546,10 +546,14 @@ pub async fn dispatch(
     // ── Provision-integration (webvh) ────────────────────────────────
     #[cfg(feature = "webvh")]
     {
-        // 0.3 only, matching the Trust-Task dispatcher: the response carries
-        // `digestMultibase`, which 0.1's and 0.2's closed response schemas
-        // reject.
-        if t == provision_integration_management::CANONICAL_PROVISION_INTEGRATION_0_3 {
+        // One version only, matching the Trust-Task dispatcher: the response
+        // carries `digestMultibase`, which 0.1's and 0.2's closed response
+        // schemas reject. Read from `CURRENT` rather than pinned to the 0.3
+        // constant so that the URI this accepts, the URI the handler answers
+        // under, and the URI vta-sdk's clients dispatch are one knob — the
+        // 0.3 cut-over moved two of those three and left provisioning broken
+        // on both counts.
+        if t == provision_integration_management::ProvisionSpecVersion::CURRENT.request_uri() {
             return finish(
                 handlers::handle_provision_integration(ctx, msg, Extension(vta_state)).await,
             );


### PR DESCRIPTION
## The symptom

Provisioning a wallet against a current VTA over DIDComm **succeeds** — bundle
sealed, admin rolled over, secret written, `context_created` decided — and the
holder reports it as a failure and throws the result away.

What the operator sees, from the browser wallet:

```
provision-integration: https://trusttasks.org/spec/provision/integration/0.1#response
— {"bundle":"-----BEGIN VTA SEALED BUNDLE-----…","digestMultibase":"zQmUwTgAa8…",
   "summary":{"adminDid":"did:key:z6Mkgauk…","adminRolledOver":true,
   "adminTemplateName":"vta-admin","bundleIdHex":"c51633ee…","secretCount":1}}
```

That is not a problem-report. It is the wallet's "unexpected reply type" guard,
quoting a perfectly good response back at the operator: the body is correct and
the **label on it is wrong**.

## The cause

`result_uri_for` tested for one version and fell through:

```rust
if request_uri == CANONICAL_PROVISION_INTEGRATION_0_2 {
    CANONICAL_PROVISION_INTEGRATION_0_2_RESULT
} else {
    CANONICAL_PROVISION_INTEGRATION_RESULT   // 0.1, for everything else
}
```

#1147 made 0.3 the only version the DIDComm router accepts, so 0.3 is now the
only URI that reaches this function — and it takes the `else` arm.
`CANONICAL_PROVISION_INTEGRATION_0_3_RESULT` was declared and never read.

Two lines apart in `handle_provision_integration`, the result URI comes from
`result_uri_for` and the body from `response_body_for_version`. The body was
rendered 0.3; the URI said 0.1. So every DIDComm reply went out as a
`digestMultibase` body labelled `provision/integration/0.1#response` — a
message that cannot satisfy the schema it names: 0.1's response requires a
bare-hex `digest` and closes with `additionalProperties: false`, and
`ProvisionIntegrationResponse` has carried `digest_multibase` and no `digest`
since #1147.

## Why nothing here caught it

Both halves were wrong the same way. `provision_integration/didcomm.rs`
computes the reply type it waits for with **the same `result_uri_for`**, so the
Rust client asked for `0.1#response`, the server sent `0.1#response`, and they
agreed. Every in-workspace test and every Rust-to-Rust integration run passes.

It takes an independent client to see it. The browser wallet reads the URI from
the `@openvtc/trust-tasks` registry bindings, expects `0.3#response`, and
rejects the reply — which is the correct behaviour, and how this was found.

This is the same failure mode as #1200 one layer down: that one was clients
dispatching a version the server no longer served; this one is the server
answering under a version it no longer serves. Both halves of the 0.3 cut-over
have now been moved separately, twice.

## The fix

- `result_uri_for` resolves through `ProvisionSpecVersion` instead of falling
  through. The enum grows the two halves a reverse map needs: `ALL`, and
  `from_request_uri` as a search over it rather than a second hand-written
  table. `request_uri` is an exhaustive `match`, so a new variant cannot compile
  without an entry — but nothing forced the *inbound* mapping to move, and at
  0.3 it did not.
- This is the correction `is_v0_1` already carries, for the reason its
  doc-comment gives: a predicate about one version has to name that version,
  because a fall-through arm silently claims every version nobody has written
  yet.
- An unrecognised URI resolves to `CURRENT` — the version
  `response_body_for_version` renders it as — so the label and the body agree
  even on the branch the router cannot reach.
- The router dispatches on `CURRENT.request_uri()` rather than the 0.3
  constant, so the URI it accepts, the URI the handler answers under, and the
  URI the clients send are one knob rather than three.

## Guards

Asserting `result_uri_for(0.3) == 0.3#response` would pin the symptom, so the
new tests assert the rule over `ALL`:

- `result_uri_is_request_uri_plus_response_fragment` — every version's result
  URI is its request URI plus `#response` (SPEC.md §4.4.1).
- `result_uri_for_agrees_with_the_version_the_request_uri_names` — the URI half
  and the body half name the same version.
- `all_lists_every_version` — `ALL` stays complete, via an exhaustive `match`.

Both of the first two fail on the old implementation, naming `V0_3`:

```
assertion `left == right` failed: V0_3: result_uri_for disagrees with the
version's own result URI
```

The test they replace, `result_uri_for_unknown_request_defaults_to_v0_1`,
asserted the fallback *was* 0.1 and justified it as "unreachable in production,
the router only advertises the 0.1 and 0.2 URIs" — true when written, false
since #1147, and it held the defect in place.

## Also

Three comments that outlived their subject: the `ProvisionSpecVersion` doc
stopped at 0.2, `response_body_for_version` still named the removed `digest`,
and the handler still described a "legacy FPN URI" retired several releases ago.

## Verification

- `cargo clippy --workspace --all-features --all-targets` — clean.
- `cargo test --workspace --all-features` — green.
- The 13 tests in `provision_integration_management` pass; reverting
  `result_uri_for` alone turns three of them red.

## Coordination

No wallet-side change is needed — `pnm-browser-plugin` already sends 0.3 and
expects 0.3, and adding a dual-accept arm for `0.1#response` there would mean
accepting a message that fails its own schema. Once this lands, the wallet's
DIDComm provisioning works unmodified.
