### PR TITLE
fix(vta): refuse an ambiguous provisioning context with the code its spec declares

### DIFF
--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -25,7 +25,9 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde_json::Value;
 use trust_tasks_https::status_for_code;
-use trust_tasks_rs::{ErrorPayload, ErrorResponse, RejectReason, TrustTask, TypeUri};
+use trust_tasks_rs::{
+    ErrorPayload, ErrorResponse, RejectReason, TrustTask, TrustTaskCode, TypeUri,
+};
 use uuid::Uuid;
 
 use crate::error::AppError;
@@ -211,6 +213,40 @@ pub(super) fn reject_with(doc: &TrustTask<Value>, reason: RejectReason) -> Trust
     error_response(routed)
 }
 
+/// Reject with a **specification-extended** code (SPEC.md §8.5,
+/// `<slug>:<local>`) rather than one of the framework's standard codes.
+///
+/// [`RejectReason`] cannot express one: every variant maps to a
+/// [`StandardCode`](trust_tasks_rs::StandardCode), so a task whose own
+/// specification declares an error code has no way to put it on the wire
+/// through [`reject_with`] — the nearest fit, `TaskFailed`, says "attempted
+/// and could not complete", which is the wrong thing to tell a producer whose
+/// request was refused before anything was attempted. The framework itself is
+/// not the limitation: `ErrorPayload::new` takes any [`TrustTaskCode`], and
+/// `TrustTask::reject_with` takes a payload. This is the missing seam between
+/// the two.
+///
+/// Use it only for a code the task's specification actually declares. A code
+/// invented here is one no consumer can look up, which is worse than
+/// `taskFailed` — that at least means something everywhere.
+///
+/// `details` passes through [`bound_details`] exactly as in [`reject_with`],
+/// so this cannot become the construction site that skips the framework's
+/// size bound.
+pub(super) fn reject_with_code(
+    doc: &TrustTask<Value>,
+    code: TrustTaskCode,
+    message: impl Into<String>,
+    details: Option<Value>,
+) -> TrustTaskOutcome {
+    let mut payload = ErrorPayload::new(code).with_message(message);
+    if let Some(d) = bound_details(details) {
+        payload = payload.with_details(d);
+    }
+    let routed = doc.reject_with(format!("urn:uuid:{}", Uuid::new_v4()), payload);
+    error_response(routed)
+}
+
 /// Build a routed success document with the given payload and wrap
 /// it in an HTTP 200 response.
 pub(super) fn success_response<R: serde::Serialize>(
@@ -352,6 +388,56 @@ mod tests {
             .as_str()
             .expect("payload carries a message")
             .to_string()
+    }
+
+    /// An extended code reaches the wire in its `<slug>:<local>` spelling.
+    ///
+    /// `RejectReason` cannot express one — every variant maps to a standard
+    /// code — so before `reject_with_code` a task whose own specification
+    /// declared an error code had to render it as prose in `message` and let
+    /// the caller string-match, which is the thing machine-readable codes
+    /// exist to prevent.
+    #[test]
+    fn an_extended_code_survives_to_the_wire() {
+        let code: TrustTaskCode = "provision/integration:contextRequired"
+            .parse()
+            .expect("a legal extended code");
+        let outcome = reject_with_code(
+            &doc(),
+            code,
+            "which context?",
+            Some(json!({ "candidates": ["a", "b"] })),
+        );
+        let parsed: Value = serde_json::from_slice(&outcome.body).expect("error doc");
+        assert_eq!(
+            parsed["payload"]["code"],
+            "provision/integration:contextRequired"
+        );
+        assert_eq!(parsed["payload"]["details"]["candidates"][1], "b");
+    }
+
+    /// The `details` bound is enforced on this path too.
+    ///
+    /// `reject_with`'s comment calls itself "the one funnel every rejection
+    /// passes through, so a new site cannot be added that skips the check" —
+    /// `reject_with_code` is a second funnel, and this is what keeps that
+    /// sentence true.
+    #[test]
+    fn an_extended_code_rejection_bounds_its_details_too() {
+        let code: TrustTaskCode = "provision/integration:contextRequired"
+            .parse()
+            .expect("a legal extended code");
+        let huge = json!({ "explanation": "x".repeat(DETAILS_MAX_JCS_BYTES + 1) });
+        let outcome = reject_with_code(&doc(), code, "which context?", Some(huge));
+        let parsed: Value = serde_json::from_slice(&outcome.body).expect("error doc");
+        assert_eq!(
+            parsed["payload"]["code"], "provision/integration:contextRequired",
+            "an oversized annex must never cost the code: {parsed}"
+        );
+        assert!(
+            parsed["payload"]["details"].is_null(),
+            "the oversized details should have been dropped: {parsed}"
+        );
     }
 
     /// An oversized `details` is dropped, and the `code` still goes out.

--- a/vta-service/src/trust_tasks/provision_integration.rs
+++ b/vta-service/src/trust_tasks/provision_integration.rs
@@ -33,7 +33,9 @@ use crate::operations::provision_integration::{
 };
 use crate::server::AppState;
 
-use super::helpers::{app_error_to_reject, parse_payload, reject_with, success_response};
+use super::helpers::{
+    app_error_to_reject, parse_payload, reject_with, reject_with_code, success_response,
+};
 
 /// Handler for canonical `provision/integration/0.2`. Admin
 /// role on the target context required; super-admin required if the
@@ -85,11 +87,25 @@ pub(super) async fn handle_request(
     let vc_validity = req.vc_validity_seconds.map(chrono::Duration::seconds);
     let deps = ProvisionIntegrationDeps::from(state);
 
-    // Resolve the target context. When the caller sent one, use it
-    // verbatim; otherwise run the spec's inference rules. Ambiguous
-    // → MalformedRequest with the candidates inline (trust-task
-    // envelopes don't carry the canonical `provision/integration:
-    // context_required` code yet — REST surfaces what we have here).
+    // Resolve the target context. When the caller sent one, use it verbatim;
+    // otherwise run the spec's inference rules.
+    //
+    // Ambiguous → the canonical `provision/integration:contextRequired` code
+    // with `details.candidates`, which is the shape
+    // `ProvisionIntegrationRequest::context` documents and the shape a wallet
+    // branches on to show the operator a context picker. It used to be a
+    // `MalformedRequest` with the candidates joined into the human message,
+    // on the grounds that "trust-task envelopes don't carry the canonical code
+    // yet" — they do; `reject_with_code` is the seam that was missing, not the
+    // capability. Recovering a list from a rendered sentence is precisely the
+    // string-matching a machine-readable code exists to avoid.
+    //
+    // This is also the one refusal that had three different shapes across the
+    // three transports: DIDComm a problem-report with `args`, REST a bare 400
+    // with the message inline, and the spine this stringified reason — none of
+    // them the documented one. The spine is the path all three converge on, so
+    // fixing it here is what makes the refusal transport-agnostic rather than
+    // one more rendering.
     let context = match req.context {
         Some(c) => c,
         None => match infer_target_context(auth, &deps.contexts_ks).await {
@@ -98,12 +114,7 @@ pub(super) async fn handle_request(
                 candidates,
                 message,
             })) => {
-                return reject_with(
-                    &doc,
-                    trust_tasks_rs::RejectReason::MalformedRequest {
-                        reason: format!("{message} (candidates: {})", candidates.join(", ")),
-                    },
-                );
+                return context_required(&doc, &message, &candidates);
             }
             Err(e) => return app_error_to_reject(&doc, e),
         },
@@ -178,5 +189,72 @@ impl From<AssertionModeOpAdapter> for crate::operations::provision_integration::
                 crate::operations::provision_integration::AssertionMode::PinnedOnly
             }
         }
+    }
+}
+
+/// Refuse an under-specified provisioning request with the code its own
+/// specification declares.
+///
+/// The code string is parsed from `vta_sdk`'s single constant rather than
+/// rebuilt from a slug/local pair here, so the spine and the DIDComm
+/// problem-report cannot drift into two spellings of the same refusal — that
+/// drift is exactly what SPEC §4.10 rule 4 was written about.
+///
+/// A parse failure would mean the constant itself stopped being a legal
+/// extended code, which is a bug in this workspace rather than anything the
+/// producer did. It falls back to `taskFailed` carrying the same `details`:
+/// the candidates still reach the caller, and the alternative — dropping the
+/// refusal or panicking a request thread — serves nobody.
+fn context_required(
+    doc: &TrustTask<Value>,
+    message: &str,
+    candidates: &[String],
+) -> TrustTaskOutcome {
+    let details = serde_json::json!({ "candidates": candidates });
+    match vta_sdk::protocols::problem_report_codes::PROVISION_CONTEXT_REQUIRED
+        .parse::<trust_tasks_rs::TrustTaskCode>()
+    {
+        Ok(code) => reject_with_code(doc, code, message, Some(details)),
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                code = vta_sdk::protocols::problem_report_codes::PROVISION_CONTEXT_REQUIRED,
+                "provision-integration contextRequired code is not a legal extended code; \
+                 falling back to taskFailed"
+            );
+            reject_with(
+                doc,
+                trust_tasks_rs::RejectReason::TaskFailed {
+                    reason: message.to_string(),
+                    details: Some(details),
+                },
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The constant this slice refuses with must be a legal extended code.
+    ///
+    /// `context_required` parses it at runtime and falls back to `taskFailed`
+    /// when it does not parse. That fallback exists so a malformed constant
+    /// cannot panic a request thread — but it would also silently downgrade
+    /// the refusal to a code no wallet branches on, and nothing at runtime
+    /// would say so. This test is what makes the fallback unreachable rather
+    /// than merely unlikely.
+    #[test]
+    fn the_context_required_constant_is_a_legal_extended_code() {
+        let raw = vta_sdk::protocols::problem_report_codes::PROVISION_CONTEXT_REQUIRED;
+        let code: trust_tasks_rs::TrustTaskCode = raw
+            .parse()
+            .expect("PROVISION_CONTEXT_REQUIRED must parse as an extended code");
+        assert_eq!(
+            code.to_string(),
+            raw,
+            "the parsed code must round-trip to the constant the DIDComm \
+             problem-report also sends, or the two transports refuse in two \
+             different spellings"
+        );
     }
 }


### PR DESCRIPTION
## The contract, and the three things we send instead

`provision/integration` declares one error code of its own. `ProvisionIntegrationRequest::context` documents it:

> Otherwise the maintainer refuses with `provision/integration:contextRequired` and `details.candidates: Vec<String>` listing the plausible contexts.

Nothing sends that.

| transport | what it actually sends |
|---|---|
| DIDComm | a problem-report — code right, candidates under `args` |
| REST | a bare 400, message inline, **no code at all** |
| Trust-Task spine | `malformedRequest`, candidates joined into the human sentence |

Three renderings of one refusal, none of them the documented one — on the only provisioning error a wallet has a recovery UX for. The wallet shows `candidates` as a picker so the operator chooses a context and retries inside the ephemeral grant's 1h TTL. Off the spine, that recovery has to be recovered from a rendered sentence, which is precisely the string-matching a machine-readable code exists to prevent (guide rule R3.7).

This fixes the spine, because the spine is the path all three transports converge on: a client that provisions through the dispatcher gets the documented shape whichever channel carried the bytes. That is what makes the refusal transport-agnostic rather than adding a fourth rendering.

## Why it was stringified

Not an oversight — the handler said so:

```rust
// → MalformedRequest with the candidates inline (trust-task
// envelopes don't carry the canonical `provision/integration:
// context_required` code yet — REST surfaces what we have here).
```

They do carry it. `RejectReason` doesn't: every variant maps to a `StandardCode`, so a task whose own specification declares a code had no way to put it on the wire. The nearest fit, `TaskFailed`, means "attempted and could not complete" — the wrong thing to tell a producer whose request was refused before anything was attempted.

The framework was never the limitation. `ErrorPayload::new` takes any `TrustTaskCode`, including `Extended { slug, local }`, and `TrustTask::reject_with` takes a payload rather than a reason. The seam between the two was missing. `reject_with_code` is that seam, and it is deliberately narrow: for a code the task's specification actually declares, and nothing else. A code invented at a call site is one no consumer can look up, which is worse than `taskFailed` — that at least means the same thing everywhere.

## Keeping the funnel a funnel

`reject_with` describes itself as

> the one funnel every rejection passes through, so a new site cannot be added that skips the check

`reject_with_code` is a second funnel, so it runs `bound_details` too. A rejection path that skipped the framework's size bound would falsify that sentence quietly — which is how the unbounded-`details` bug arrived the first time, via a policy denial carrying a Rego `explanation` of unbounded length written by whoever authored the policy.

## Not drifting into two spellings

The code is parsed from vta-sdk's existing `PROVISION_CONTEXT_REQUIRED` constant rather than rebuilt from a slug/local pair here, so the spine and the DIDComm problem-report cannot end up as two spellings of one refusal — the drift SPEC §4.10 rule 4 exists to prevent.

`context_required` falls back to `taskFailed` carrying the same `details` if that constant ever stops parsing as a legal extended code. Panicking a request thread over a malformed constant serves nobody, and the candidates still reach the caller. But a silent downgrade to a code no wallet branches on is not something to leave to chance, so a test asserts the constant parses **and round-trips to itself** — that is what makes the fallback unreachable rather than merely unlikely.

## Tests

- `an_extended_code_survives_to_the_wire` — the `<slug>:<local>` spelling and `details.candidates` both reach the response document.
- `an_extended_code_rejection_bounds_its_details_too` — an oversized annex is dropped and the code still goes out.
- `the_context_required_constant_is_a_legal_extended_code` — the guard above.

`cargo clippy --workspace --all-features --all-targets` clean; `cargo test -p vta-service --all-features` green (29 suites, no failures).

## Context

Part of making provisioning transport-agnostic. The wallet currently provisions over the bespoke DIDComm protocol message rather than the dispatcher — the one VTA operation with no TSP/DIDComm/REST chain, and the only path that touches the version→URI map fixed in #1202. Moving it onto the spine needs this code to exist there first, or the migration would trade a working context picker for a string match.
