### PR TITLE
build(deps): dtg-credentials 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c722ab4e0ca0f145c0e391320fe28d9043c889a0a5ba8d186bc527cf0ce2cace"
+checksum = "79320f11d8abf62975f95ff10b363598f6635ede485fa9ceafc167668d8bcd09"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.2"
+dtg-credentials = "0.3"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.46"


### PR DESCRIPTION
0.3.0 adds `id` to `DTGCommon` — the OPTIONAL top-level credential identifier of the W3C VC Data Model, which the catalog previously had no field for at all, plus `with_id()` / `set_id()` / `id()` to write and read it. The crate marks the new public field breaking; nothing in this workspace constructs `DTGCommon` by exhaustive struct literal, so the bump is source-compatible here.

The identifier is what `members::inbound_vmc` requires of a member-issued reciprocal VMC (`"member vmc has no top-level `id`"`). A member issuing that credential with 0.2 could not set one, so the VTC rejected every reciprocal it received — and the rejection travelled as a problem-report the member's client discarded, leaving the failure silent on both sides. The fix lands on the issuing side; this bump keeps VTI on the same version as the `openvtc` workspace, which is already pinned to `"0.3"`.

No behaviour change in `vtc-service`. Its own issuance path (`credentials::dtg::finalize`) splices `id` into the serialized document before signing, alongside `credentialStatus` and subject `scopes`, neither of which 0.3 gives a typed home — so that splice stays as it is.

## Lockfile

Dependency requirements are unchanged between 0.2.0 and 0.3.0 (`affinidi-data-integrity` 0.7 in both), so `cargo update -p dtg-credentials` locked exactly one package. Two unrelated edges were re-resolved incidentally in the same pass (`data-encoding-macro-internal`'s `syn 1.0.109 → 3.0.4`, and `base64 0.21.7 → 0.22.1` under the regorus subtree — both loose requirements cargo re-picked, neither a package version change). Those hunks were reverted so the diff is the bump alone; `--locked` re-verified afterwards.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo check --workspace --all-targets --locked` — clean
- `cargo test -p vtc-service --lib` — 907 passed, 0 failed, 1 ignored
- `cargo fmt --all --check` — clean
