### PR TITLE
fix(vtc): surface the daemon's message when wallet sign-in fails

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -80,6 +80,31 @@ export interface ApiError {
   message: string;
 }
 
+/**
+ * The daemon's own error message for a failed response, falling back to the
+ * status line when the body isn't the JSON error shape.
+ *
+ * `vti_common::error::AppError` serialises as `{ "error": "<display>" }` for
+ * every variant bar the Trust-Task ones, which carry `message`. Reading it
+ * matters most where the status code alone is ambiguous: `/auth/challenge`
+ * answers 403 for "DID not in ACL", "ACL entry expired" and "DID is not
+ * permitted to authenticate on this VTC" alike, and only the body says which.
+ *
+ * Consumes the response body, so call it at most once per response.
+ */
+export async function daemonErrorMessage(
+  res: Response,
+  fallback: string = `${res.status} ${res.statusText}`,
+): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string; message?: string };
+    return body.error || body.message || fallback;
+  } catch {
+    /* non-JSON body */
+    return fallback;
+  }
+}
+
 function csrfTokenFromCookie(): string | null {
   // The CSRF cookie is set by login (`/v1/auth/passkey-login/finish`
   // or `/v1/auth/admin-session`). HttpOnly is **not** set on this
@@ -111,14 +136,7 @@ async function request<T>(
   });
 
   if (!res.ok) {
-    let message = `${res.status} ${res.statusText}`;
-    try {
-      const body = (await res.json()) as { error?: string; message?: string };
-      if (body.error) message = body.error;
-      else if (body.message) message = body.message;
-    } catch {
-      /* non-JSON body */
-    }
+    const message = await daemonErrorMessage(res);
     // 401/403 on a request issued *while authenticated* means the
     // session has expired (cookie cleared server-side, JWT past
     // `exp`, or admin role revoked). Dispatch a window event so the

--- a/vtc-service/admin-ui/src/lib/wallet.ts
+++ b/vtc-service/admin-ui/src/lib/wallet.ts
@@ -18,7 +18,7 @@
 // with no Trust-Task header, so we point `baseUrl` at the VTC's header-exempt
 // `/v1/wallet` surface.
 
-import { fetchHealth } from "@/lib/api";
+import { daemonErrorMessage, fetchHealth } from "@/lib/api";
 
 interface VtaWalletLoginParams {
   rpDid: string;
@@ -202,7 +202,16 @@ export async function loginWithWalletProxy(
     body: JSON.stringify({ did: entry.principalDid }),
   });
   if (!chRes.ok) {
-    throw new Error(`/auth/challenge failed (${chRes.status})`);
+    // Carry the daemon's message, not just the code. A 403 here is the ACL
+    // gate in `handle_challenge` and it has three distinct causes — the
+    // principal DID is absent from the VTC ACL, its entry has expired, or its
+    // role is not `Admin` — which the status code alone cannot tell apart.
+    throw new Error(
+      `/auth/challenge failed (${chRes.status}): ${await daemonErrorMessage(
+        chRes,
+        chRes.statusText,
+      )}`,
+    );
   }
   // Challenge response is camelCase; the authenticate payload is snake_case.
   const ch = (await chRes.json()) as { challenge: string; sessionId: string };
@@ -232,7 +241,12 @@ export async function loginWithWalletProxy(
     }),
   });
   if (!authRes.ok) {
-    throw new Error(`/auth/ failed (${authRes.status})`);
+    throw new Error(
+      `/auth/ failed (${authRes.status}): ${await daemonErrorMessage(
+        authRes,
+        authRes.statusText,
+      )}`,
+    );
   }
   const tokenResp = (await authRes.json()) as {
     session: { id: string };


### PR DESCRIPTION
The admin console's VTA-proxied SIOP login threw on the status code alone — `/auth/challenge failed (403)` — and discarded the response body, which is where the daemon says what actually went wrong. `Login.tsx` renders that message verbatim in the sign-in error card, so the operator got a number and nothing else.

403 is the ambiguous one. `handle_challenge`'s second gate is `check_acl`, and `resolve_auth_role` (`vtc-service/src/acl/storage.rs:72`) answers it three different ways:

| cause | message |
|---|---|
| no ACL row for the DID | `forbidden: DID not in ACL: <did>` |
| row present, past its expiry | `forbidden: ACL entry expired: <did>` |
| row present, role is not `Admin` | `forbidden: DID is not permitted to authenticate on this VTC` |

The distinction exists only in the body, so diagnosing a failed sign-in meant reading the daemon log — or the source. Worth noting the DID that needs the row is the chosen vault entry's **`principalDid`**, not the VTA's own DID; `loginWithWalletProxy` posts that as the challenge subject.

## Change

The message extraction `request()` already did privately is now `daemonErrorMessage()`, exported from `lib/api.ts` and used by both. The wallet path cannot route through `request()` itself: it deliberately uses raw `fetch` so it sends no `X-CSRF-Token` and does not fire `vtc-session-expired` mid-ceremony. Sharing the helper keeps one implementation of the `{ error | message }` shape rather than a second copy that can drift from `AppError`.

The messages stay as terse as they were on the unauthenticated path — this forwards what the daemon already chose to say (P0.16 keeps it free of role names and serde internals), it does not widen it.

An operator now reads:

```
/auth/challenge failed (403): forbidden: DID not in ACL: did:key:z...
```

## Scope

Both throw sites in `loginWithWalletProxy` (`/auth/challenge` and `/auth/`). `Install.tsx` has three more bare-status toasts on the install ceremony — same shape, different flow, left alone here.

## Verification

- `npm run lint` (`wire:check` + `tsc -b --noEmit`) — clean
- `npm run build` — clean
