### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9510,7 +9510,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.23.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.2...vta-service-v0.23.3) — 2026-08-30
+
+
 ## [0.23.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.1...vta-service-v0.23.2) — 2026-08-29
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.23.2"
+version = "0.23.3"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.


### PR DESCRIPTION



## 🤖 New release

* `vta-webvh`: 0.2.1 -> 0.2.2
* `vta-service`: 0.23.2 -> 0.23.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-webvh`

<blockquote>

## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.1...vta-webvh-v0.2.2) — 2026-08-30

### Documentation

- **webvh**: The authenticate alias window has closed ([#1205](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1205))

`webvh_auth.rs` described did-hosting as recognising the historical
  `affinidi.com/webvh/1.0/authenticate` form "via its alias table during the
  migration window", and its test looked forward to "once that alias is dropped
  (Phase 3 cleanup on did-hosting)".

  It was dropped: affinidi-webvh-service #172 removed the alias from the three
  REST acceptors and moved their clients, and #174 moved the witness's DIDComm
  router. The canonical URI is not merely preferred now, it is the only one that
  routes anywhere.

  No behaviour change — this crate has always sent the canonical form. What
  changes is that the assertion is load-bearing rather than forward-looking, and
  a reader is no longer told a fallback exists that does not.
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).