### PR TITLE
fix(vtc): point the admin UI at relationships/graph/0.2

### DIFF
--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -439,7 +439,7 @@ export const revokeInvitation = (
   );
 
 const RELATIONSHIPS_GRAPH_TASK =
-  "https://trusttasks.org/spec/vtc/relationships/graph/0.1";
+  "https://trusttasks.org/spec/vtc/relationships/graph/0.2";
 
 export interface GraphNode {
   did: string;

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -598,16 +598,96 @@ fn collect_prefixed(dir: &Path, prefix: &str, out: &mut BTreeSet<String>) {
             .extension()
             .is_some_and(|e| e == "rs" || e == "ts" || e == "tsx")
         {
-            let text = std::fs::read_to_string(&path).expect("read source file");
-            for (idx, _) in text.match_indices(prefix) {
-                if idx == 0 || !text[..idx].ends_with('"') {
-                    continue;
-                }
-                let rest = &text[idx..];
-                let Some(end) = rest.find('"') else { continue };
-                let uri = rest[..end].split('#').next().expect("head").to_owned();
-                out.insert(uri);
-            }
+            collect_prefixed_in_file(&path, prefix, out);
         }
     }
+}
+
+/// As [`collect_prefixed`], for one named file — the router wiring is a
+/// single file, and scanning the crate instead would let a URI mentioned in
+/// a test fixture stand in for a route that binds a different one.
+fn collect_prefixed_in_file(path: &Path, prefix: &str, out: &mut BTreeSet<String>) {
+    let text = std::fs::read_to_string(path).expect("read source file");
+    for (idx, _) in text.match_indices(prefix) {
+        if idx == 0 || !text[..idx].ends_with('"') {
+            continue;
+        }
+        let rest = &text[idx..];
+        let Some(end) = rest.find('"') else { continue };
+        let uri = rest[..end].split('#').next().expect("head").to_owned();
+        out.insert(uri);
+    }
+}
+
+// ─── The admin SPA against the router (#1211) ──────────────────────────────
+
+/// The admin console is the router's only in-repo REST client, and every call
+/// it makes carries a `Trust-Task` header that
+/// [`vti_common::trust_task`]'s gate matches **exactly**. A URI the router
+/// does not bind is a 415 before the handler runs.
+///
+/// Nothing checked the two against each other. The census above asks whether a
+/// bound URI *exists upstream*, which `relationships/graph/0.1` did — it is a
+/// real published task, just not the one the service mounts after #1112
+/// retargeted the mount to `/0.2` and left the SPA's copy behind. The result
+/// was a Relationships page that could only ever render "Could not load the
+/// relationships graph.", shipped by a `!`-flagged commit whose whole subject
+/// was conformance.
+///
+/// The generated wire types cannot catch this. `utoipa` does not put the
+/// Trust-Task value in the OpenAPI document — the `graph` operation comes out
+/// as `header?: never` — so the URI is hand-copied on both sides, in two
+/// languages, and only this assertion pairs them.
+///
+/// There is no exception table. A header the router does not enforce is not a
+/// case to document; it is a dead page.
+#[test]
+fn every_admin_ui_task_is_enforced_by_a_route() {
+    const SPEC_PREFIX: &str = "https://trusttasks.org/spec/";
+    let root = workspace_root();
+
+    let mut sent = BTreeSet::new();
+    collect_prefixed(
+        &root.join("vtc-service/admin-ui/src"),
+        SPEC_PREFIX,
+        &mut sent,
+    );
+
+    // `routes/mod.rs` is the sole binding site: every `tt` / `ttl` call in the
+    // crate lives there. Scanning it alone rather than `src/` keeps a task URI
+    // that only appears in a test fixture from vouching for a route that
+    // binds a different one.
+    let mut enforced = BTreeSet::new();
+    collect_prefixed_in_file(
+        &root.join("vtc-service/src/routes/mod.rs"),
+        SPEC_PREFIX,
+        &mut enforced,
+    );
+
+    // Both scans read paths that a directory move would silently empty, and an
+    // empty set on either side passes the difference below vacuously. Floors,
+    // not exact counts — this is a guard against reading nothing, not a census.
+    assert!(
+        sent.len() >= 10,
+        "found only {} Trust-Task URIs in the admin UI — the scan path is wrong",
+        sent.len()
+    );
+    assert!(
+        enforced.len() >= 20,
+        "found only {} Trust-Task URIs in routes/mod.rs — the scan path is wrong",
+        enforced.len()
+    );
+
+    let orphans: Vec<&String> = sent.difference(&enforced).collect();
+    assert!(
+        orphans.is_empty(),
+        "the admin UI sends {} Trust-Task header(s) no route enforces — each is \
+         a 415 and a dead page. Point the SPA at the URI the router binds:\n  {}",
+        orphans.len(),
+        orphans
+            .iter()
+            .map(|u| u.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
 }


### PR DESCRIPTION
The Relationships page in the VTC admin console could only ever render "Could not load the relationships graph."

## Cause

#1112 retargeted the mount to the 0.2 task from trustoverip/dtgwg-trust-tasks-tf#266 and left the admin console's copy of the URI on 0.1:

| | Trust-Task URI |
|---|---|
| `admin-ui/src/lib/api.ts:441` | `.../spec/vtc/relationships/graph/0.1` |
| `src/routes/mod.rs:655` | `.../spec/vtc/relationships/graph/0.2` |

Every VTC route matches its `Trust-Task` header exactly, so the request was rejected **415** before the handler ran and React Query rendered its error card. The graph endpoint itself was never reached and is fine. Checked every task URI the SPA sends against the router: this was the only orphan.

## Why nothing caught it

The console is the router's only in-repo REST client and nothing paired the two. The existing census asks whether a bound URI *exists upstream*, which `graph/0.1` does — it is a real published task, just not the one the service mounts. The generated wire types cannot help either: utoipa does not put the Trust-Task value in the OpenAPI document (the `graph` operation comes out as `header?: never`), so the URI is hand-copied on both sides in two languages.

## The guard

The fix is one character, so the guard is the change. `every_admin_ui_task_is_enforced_by_a_route` asserts every `trusttasks.org/spec/` literal in the SPA appears in `routes/mod.rs`, which is the sole binding site — scanning that file rather than all of `src/` stops a URI mentioned in a test fixture from vouching for a route that binds a different one. No exception table: a header no route enforces is not a case to document, it is a dead page. Both scans assert a floor, because a directory move would empty them and pass the difference vacuously.

## Verification

- Guard fails on the pre-fix tree, naming the URI and the fix:
  ```
  the admin UI sends 1 Trust-Task header(s) no route enforces — each is a 415
  and a dead page. Point the SPA at the URI the router binds:
    https://trusttasks.org/spec/vtc/relationships/graph/0.1
  ```
- `cargo test -p vtc-service --test trust_task_manifest` — 8 passed.
- `npm run lint` in `admin-ui` (wire:check + `tsc -b --noEmit`) — clean.

No version bump: `vtc-service` is `publish = false` and the other change is TypeScript.
