### PR TITLE
feat(vtc): complete the membership edge and draw it on the trust graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,7 +3007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79320f11d8abf62975f95ff10b363598f6635ede485fa9ceafc167668d8bcd09"
+checksum = "cc5be7eee44969838e942b07a3e383e936f2d307f7b2b880daa715817261f132"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -7425,7 +7425,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.3"
+dtg-credentials = "0.4"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.46"

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -444,7 +444,10 @@ const RELATIONSHIPS_GRAPH_TASK =
 export interface GraphNode {
   did: string;
 }
-/** One published VRC: a directed half of an edge. */
+/** One published edge credential: a directed half of an edge. Either a VRC
+ *  between two members, or one of the two VMCs of a membership edge — DTG Core
+ *  Credentials makes both subtypes of *edge credential*, and "in both cases, a
+ *  bi-directional pair of credentials forms a complete DTG edge". */
 export interface GraphHalf {
   id: string;
   issuerDid: string;
@@ -456,9 +459,15 @@ export interface GraphHalf {
    *  entitled to draw between two pairwise identifiers. */
   personaDid?: string;
 }
-/** One edge between a pair of identifiers. A DTG edge is *two* VRCs, one in
- * each direction; `complete` says whether both have been published. A
- * half-edge is one party's unilateral claim, not a mutual relationship. */
+/** One edge between a pair of identifiers. A DTG edge is *two* credentials,
+ * one in each direction; `complete` says whether both stand. A half-edge is one
+ * party's unilateral claim, not a mutual relationship.
+ *
+ * An edge with the community's own DID as an endpoint is a **membership** edge
+ * (the VMC pair); anything else is a relationship edge (the VRC pair). The
+ * response carries no `kind` field to say so — `relationships/graph/0.2` pins
+ * the shape with `additionalProperties: false` — and none is needed: the
+ * community knows its own DID. */
 export interface GraphEdge {
   /** The two endpoints, DID-sorted. Always length 2. */
   endpoints: string[];
@@ -471,12 +480,40 @@ export interface RelationshipsGraph {
   edges: GraphEdge[];
 }
 
-/** The community's relationship (VRC) graph — every trust edge between
- * members, for the connections-graph view. Admin-gated. */
+/** The community's trust graph — every edge, membership (VMC pairs) and
+ * relationship (VRC pairs) alike, for the connections-graph view.
+ * Admin-gated. */
 export const fetchRelationshipsGraph = (): Promise<RelationshipsGraph> =>
   getJson<RelationshipsGraph>("/v1/relationships/graph", {
     trustTask: RELATIONSHIPS_GRAPH_TASK,
   });
+
+const MEMBER_RELATIONSHIPS_TASK =
+  "https://trusttasks.org/spec/vtc/relationships/list/0.2";
+
+/** One relationship row as the community stored it, credential body included.
+ *  Unlike `GraphHalf` — which is body-free by design, because the graph shows
+ *  the shape of the network rather than credential contents — this is the
+ *  credential itself, for an operator who needs to read one. */
+export interface MemberRelationship {
+  id: string;
+  issuerDid: string;
+  subjectDid: string;
+  vrcJsonld: unknown;
+  createdAt: string;
+}
+
+/** Every relationship credential naming this member, either direction.
+ *  Paginated server-side; the console reads the first page, which is the
+ *  operator-relevant case — a member with more than 50 published edges is a
+ *  graph question, not a credential-inspection one. */
+export const fetchMemberRelationships = (
+  did: string,
+): Promise<{ items: MemberRelationship[]; nextCursor?: string | null }> =>
+  getJson<{ items: MemberRelationship[]; nextCursor?: string | null }>(
+    `/v1/members/${encodeURIComponent(did)}/relationships`,
+    { trustTask: MEMBER_RELATIONSHIPS_TASK },
+  );
 
 const RECOGNITION_CHECK_TASK =
   "https://trusttasks.org/spec/vtc/recognition/check/0.1";

--- a/vtc-service/admin-ui/src/pages/Login.tsx
+++ b/vtc-service/admin-ui/src/pages/Login.tsx
@@ -3,6 +3,13 @@
 // Passkey: POST `/v1/auth/passkey-login/start` → `navigator.credentials.get`
 // → POST `/finish` → daemon sets the `vtc_admin_session` + `csrf` cookies.
 //
+// The community's DID is shown before sign-in, from the unauthenticated
+// `/health`. Two reasons it belongs here rather than only on the dashboard:
+// it tells an operator which community this console is for before they
+// authenticate to it — several VTCs look identical at the login screen — and it
+// is the string a prospective member needs in order to join, which until now
+// could only be read from behind a login they did not have.
+//
 // VTA wallet (additive — passkey is unchanged): the browser wallet extension
 // runs a SIOPv2 login against the VTC's header-exempt `/v1/wallet` surface
 // and returns a bearer token; we exchange it for the same cookie session via
@@ -11,10 +18,11 @@
 // probe so the shell re-renders into the authenticated tree.
 
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Fingerprint, Wallet } from "lucide-react";
 
-import { postJson } from "@/lib/api";
+import { fetchHealth, postJson, type HealthResponse } from "@/lib/api";
+import { CopyButton } from "@/components/CopyButton";
 import {
   decodePublicKeyOptions,
   serializeAssertion,
@@ -45,6 +53,16 @@ type Phase =
   | { kind: "error"; message: string; hint?: string };
 
 export function Login() {
+  // `/health` is header-exempt and unauthenticated, so this resolves on the
+  // login screen. It carries only `{status, version, vtc_did}` — the
+  // infrastructure detail moved to the admin-gated diagnostics route, so
+  // reading it here discloses nothing that resolving the DID would not.
+  const health = useQuery<HealthResponse>({
+    queryKey: ["health"],
+    queryFn: fetchHealth,
+  });
+  const vtcDid = health.data?.vtc_did;
+
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const [walletPhase, setWalletPhase] = useState<Phase>({ kind: "idle" });
   const [candidates, setCandidates] = useState<ProxyVaultEntry[] | null>(null);
@@ -210,6 +228,27 @@ export function Login() {
         <p className="lead">
           Sign in with your registered passkey or your VTA wallet.
         </p>
+
+        {/* Absent while `/health` is in flight, and on a daemon that has not
+            been set up yet — which is a real state, not an error, so it says
+            so rather than rendering an empty box or a spinner. */}
+        {vtcDid ? (
+          <p className="login-did">
+            <span className="muted">Community</span>
+            <code>{vtcDid}</code>
+            <CopyButton
+              value={vtcDid}
+              label="Copy VTC DID"
+              successMessage="VTC DID copied"
+            />
+          </p>
+        ) : (
+          health.isSuccess && (
+            <p className="lead muted">
+              This VTC has no DID yet — it has not been set up.
+            </p>
+          )
+        )}
 
         <button
           type="button"

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -4,6 +4,23 @@
 // `GET /v1/members/{did}` for the detail view. Mutations (promote,
 // admin-remove) land in a follow-up commit; this is the read
 // surface only.
+//
+// The detail view also answers "what does this member hold from us, and what
+// have they published?" — which nothing in this console could answer before.
+// Two sources, because `members/show/0.1` cannot be the one:
+//
+//   - the trust graph (`relationships/graph/0.2`) for whether this member's
+//     membership edge is complete. The graph already computes it, so reading it
+//     here keeps one definition of "complete" rather than a second one drifting
+//     alongside the first.
+//   - `relationships/list/0.2` for the relationship credentials naming this
+//     member, bodies included.
+//
+// The membership credential + role VEC *bodies* are not here: the
+// `members/show/0.1` response is `additionalProperties: false` and its own text
+// says "The credential body is not echoed here", so surfacing them needs a task
+// authored upstream rather than a field added locally. Their ids and receipt
+// state are shown, which is what that schema does carry.
 
 import { useState } from "react";
 import {
@@ -22,7 +39,17 @@ import {
   Users as UsersIcon,
 } from "lucide-react";
 
-import { deleteJson, getJson, patchJson, postJson } from "@/lib/api";
+import {
+  deleteJson,
+  fetchMemberRelationships,
+  fetchRelationshipsGraph,
+  getJson,
+  patchJson,
+  postJson,
+  type MemberRelationship,
+  type RelationshipsGraph,
+} from "@/lib/api";
+import { CopyButton } from "@/components/CopyButton";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso as formatDate, shortenDid } from "@/lib/format";
 import {
@@ -447,6 +474,31 @@ function MemberDetail() {
     enabled: decoded.length > 0,
   });
 
+  // Whether this member's membership edge is complete comes from the graph
+  // rather than being recomputed here. One definition, one answer — a second
+  // one living in this file would be free to disagree with the graph the
+  // operator is looking at on the next page.
+  const graph = useQuery<RelationshipsGraph>({
+    queryKey: ["relationships-graph"],
+    queryFn: fetchRelationshipsGraph,
+    enabled: decoded.length > 0,
+  });
+
+  const relationships = useQuery<{ items: MemberRelationship[] }>({
+    queryKey: ["member-relationships", decoded],
+    queryFn: () => fetchMemberRelationships(decoded),
+    enabled: decoded.length > 0,
+  });
+
+  // The membership edge is the one joining this member to the community. The
+  // community is the endpoint that is not the member — no need to know its DID
+  // separately, and it stays right if the community ever rotates its own.
+  const membershipEdge = graph.data?.edges.find(
+    (e) =>
+      e.endpoints.includes(decoded) &&
+      e.halves.some((h) => h.issuerDid !== decoded && h.subjectDid === decoded),
+  );
+
   const promoteMutation = useMutation({
     mutationFn: promoteToAdmin,
     onSuccess: () => {
@@ -563,7 +615,77 @@ function MemberDetail() {
                   </span>
                 )}
               </dd>
+              <dt>Membership edge</dt>
+              <dd>
+                {graph.isPending ? (
+                  <span className="muted">…</span>
+                ) : membershipEdge?.complete ? (
+                  <>
+                    <Check size={14} aria-hidden="true" /> complete — both
+                    credentials stand
+                  </>
+                ) : query.data.memberVmcId ? (
+                  <span className="muted">
+                    incomplete — the member's credential is stored, but its{" "}
+                    <code>digest</code> was not verified against the membership
+                    credential we issued. It may predate that binding, or the
+                    grant may have been re-issued since. Request a fresh one
+                    below.
+                  </span>
+                ) : (
+                  <span className="muted">
+                    half-edge — this community has asserted the membership and
+                    the member has not acknowledged it
+                  </span>
+                )}
+              </dd>
             </dl>
+          </section>
+
+          <section className="card">
+            <h3>Published relationships</h3>
+            <p className="muted">
+              Relationship credentials (VRCs) naming this member, in either
+              direction. These are the member's own edges to other members —
+              separate from their membership edge with this community.
+            </p>
+            {relationships.isPending && <p className="muted">Loading…</p>}
+            {relationships.isError && (
+              <p className="muted">Could not load this member's credentials.</p>
+            )}
+            {relationships.data &&
+              (relationships.data.items.length === 0 ? (
+                <p className="muted">
+                  None published. A member's relationships are private to them
+                  until they publish an edge here.
+                </p>
+              ) : (
+                <ul style={{ paddingLeft: "1.1em", margin: 0 }}>
+                  {relationships.data.items.map((r) => (
+                    <li key={r.id} style={{ marginBottom: "var(--space-3)" }}>
+                      <code>{shortenDid(r.issuerDid)}</code> →{" "}
+                      <code>{shortenDid(r.subjectDid)}</code>
+                      <span className="muted"> · {formatDate(r.createdAt)}</span>
+                      <CopyButton
+                        value={JSON.stringify(r.vrcJsonld, null, 2)}
+                        label="Copy credential JSON"
+                        successMessage="Credential copied"
+                      />
+                      <details>
+                        <summary className="muted">Credential</summary>
+                        <pre
+                          style={{
+                            overflowX: "auto",
+                            fontSize: "var(--text-sm)",
+                          }}
+                        >
+                          {JSON.stringify(r.vrcJsonld, null, 2)}
+                        </pre>
+                      </details>
+                    </li>
+                  ))}
+                </ul>
+              ))}
           </section>
 
           <section className="card">

--- a/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
+++ b/vtc-service/admin-ui/src/plugins/relationshipsGraph.tsx
@@ -1,25 +1,41 @@
-// Relationships plugin — a connections graph of the community's member-to-member
-// trust edges (Verifiable Relationship Credentials, VRCs).
+// Relationships plugin — a connections graph of the community's trust edges.
 //
-// Unlike the recognition graph (external, query-only), member relationships are
-// local + enumerable, so we can draw the whole thing. Layout is a deterministic
-// circle: endpoints are nodes, each edge joins a pair. Click a node to highlight
-// its connections and list its edges.
+// Two kinds of edge, both first-class. DTG Core Credentials makes VRCs and VMCs
+// the two subtypes of *edge credential* — "in both cases, a bi-directional pair
+// of credentials forms a complete DTG edge" — and the community is a node like
+// any other ("DTG node types include persons, devices, AI agents, and VTCs").
 //
-// A DTG edge is *two* VRCs, one in each direction. The two are drawn
-// differently on purpose: a solid double-headed line is a complete edge, where
-// both parties have published; a dashed single-headed line is a half-edge — one
-// party's claim that the other has not reciprocated. These used to render
-// identically, so the view could not tell a mutual relationship from a
-// unilateral one (#1054).
+//   relationship — a VRC pair between two members
+//   membership   — the VMC pair between a member and this community
+//
+// This view rendered only the first, so a community whose members had published
+// no VRCs saw an empty page and read it as "no trust here", when every
+// membership was an edge it was not drawing.
+//
+// There is no `kind` on the wire: `relationships/graph/0.2` pins the response
+// with `additionalProperties: false`, and none is needed — an edge with the
+// community's own DID as an endpoint is the membership one, and the community
+// knows its own DID.
+//
+// Unlike the recognition graph (external, query-only), these are local +
+// enumerable, so we can draw the whole thing. Layout is a deterministic circle:
+// endpoints are nodes, each edge joins a pair. Click a node to highlight its
+// connections and list its edges.
+//
+// A complete edge is a solid double-headed line, where both parties' halves
+// stand; a half-edge is dashed and single-headed — one party's claim the other
+// has not answered. These used to render identically, so the view could not
+// tell a mutual relationship from a unilateral one (#1054).
 
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Share2 } from "lucide-react";
 
 import {
+  fetchHealth,
   fetchRelationshipsGraph,
   type GraphEdge,
+  type HealthResponse,
   type RelationshipsGraph,
 } from "@/lib/api";
 import { useNameBook } from "@/lib/names";
@@ -51,6 +67,22 @@ export function Relationships() {
     queryFn: fetchRelationshipsGraph,
   });
 
+  // The community's own DID is what separates the two kinds of edge. Read from
+  // `/health`, which the dashboard already uses for it — a graph rendered
+  // before it resolves simply shows every edge as a relationship, which is what
+  // this view did for its whole life and is a safe intermediate state.
+  const health = useQuery<HealthResponse>({
+    queryKey: ["health"],
+    queryFn: fetchHealth,
+  });
+  const communityDid = health.data?.vtc_did;
+
+  const isMembership = useMemo(
+    () => (e: GraphEdge) =>
+      communityDid !== undefined && e.endpoints.includes(communityDid),
+    [communityDid],
+  );
+
   const placed = useMemo<Placed[]>(() => {
     const nodes = query.data?.nodes ?? [];
     const n = nodes.length;
@@ -69,6 +101,8 @@ export function Relationships() {
   const edges = query.data?.edges ?? [];
   const completeCount = edges.filter((e) => e.complete).length;
   const halfCount = edges.length - completeCount;
+  const membershipCount = edges.filter(isMembership).length;
+  const relationshipCount = edges.length - membershipCount;
 
   const selectedEdges = selected
     ? edges.filter((e) => e.endpoints.includes(selected))
@@ -86,12 +120,21 @@ export function Relationships() {
           <Share2 size={20} strokeWidth={1.75} /> Relationships
         </h2>
         <p className="muted">
-          The community's trust graph. Each node is an identifier a member
-          published a Verifiable Relationship Credential (VRC) under; each edge
-          joins a pair. An edge is <strong>complete</strong> when both parties
-          have published a VRC naming the other — that reciprocal credential is
-          how a member consents to the edge. A <strong>half-edge</strong> is one
-          party's claim the other has not answered.
+          The community's trust graph. Each node is an identifier — a member, or
+          this community itself — and each edge joins a pair. An edge is{" "}
+          <strong>complete</strong> when both parties have issued a credential
+          naming the other; that reciprocal credential is how each consents to
+          the edge. A <strong>half-edge</strong> is one party's claim the other
+          has not answered.
+        </p>
+        <p className="muted">
+          <strong>Membership</strong> edges join a member to this community: the
+          membership credential (VMC) this community issued, and the member's
+          acknowledgement of it. An acknowledgement counts only when its{" "}
+          <code>digest</code> matches the credential it names, so a member who
+          has not answered — or whose answer predates that binding — shows as a
+          half-edge until they re-issue. <strong>Relationship</strong> edges
+          join two members by a pair of relationship credentials (VRCs).
         </p>
       </header>
 
@@ -108,7 +151,8 @@ export function Relationships() {
       {isEmpty && (
         <section className="card">
           <p className="muted">
-            No relationships published yet — members haven't published any VRCs.
+            Nothing to draw yet — no memberships have been issued and no member
+            has published a relationship credential.
           </p>
         </section>
       )}
@@ -155,6 +199,14 @@ export function Relationships() {
                 const b = posByDid.get(to);
                 if (!a || !b) return null;
                 const active = !selected || e.endpoints.includes(selected);
+                // Membership and relationship edges are both real edges, so
+                // neither is drawn as the lesser: same weights and dash rules,
+                // different hue. Colour alone never carries the complete /
+                // half-edge distinction — that stays in the line style, which
+                // survives greyscale and colour-blindness.
+                const hue = isMembership(e)
+                  ? "var(--accent, #7c5cff)"
+                  : "var(--brand)";
                 return (
                   <line
                     key={edgeKey(e)}
@@ -162,7 +214,7 @@ export function Relationships() {
                     y1={a.y}
                     x2={b.x}
                     y2={b.y}
-                    stroke={active ? "var(--brand)" : "var(--border)"}
+                    stroke={active ? hue : "var(--border)"}
                     strokeWidth={e.complete ? (active ? 2 : 1.5) : active ? 1.5 : 1}
                     strokeDasharray={e.complete ? undefined : "4 3"}
                     opacity={selected && !active ? 0.25 : 0.8}
@@ -184,12 +236,29 @@ export function Relationships() {
                     opacity={dim ? 0.35 : 1}
                     onClick={() => setSelected(isSel ? null : p.did)}
                   >
-                    <circle
-                      r={isSel ? 9 : 6}
-                      fill={isSel ? "var(--brand)" : "var(--brand-tint-strong)"}
-                      stroke="var(--border-strong)"
-                      strokeWidth={1}
-                    />
+                    {p.did === communityDid ? (
+                      // The community is a node, but it is not a peer of its
+                      // members — a square says so without needing a legend
+                      // entry to be read first.
+                      <rect
+                        x={isSel ? -9 : -6}
+                        y={isSel ? -9 : -6}
+                        width={isSel ? 18 : 12}
+                        height={isSel ? 18 : 12}
+                        fill={
+                          isSel ? "var(--accent, #7c5cff)" : "var(--brand-tint-strong)"
+                        }
+                        stroke="var(--border-strong)"
+                        strokeWidth={1}
+                      />
+                    ) : (
+                      <circle
+                        r={isSel ? 9 : 6}
+                        fill={isSel ? "var(--brand)" : "var(--brand-tint-strong)"}
+                        stroke="var(--border-strong)"
+                        strokeWidth={1}
+                      />
+                    )}
                     <text
                       x={p.x > C ? 11 : -11}
                       y={4}
@@ -205,7 +274,7 @@ export function Relationships() {
             </svg>
 
             <svg
-              viewBox="0 0 260 40"
+              viewBox="0 0 260 58"
               style={{ width: "min(100%, 260px)", height: "auto" }}
               role="img"
               aria-label="Legend"
@@ -251,6 +320,19 @@ export function Relationships() {
               <text x={48} y={34} fontSize="10" fill="var(--text-muted)">
                 half-edge — not reciprocated
               </text>
+              <line
+                x1={4}
+                y1={48}
+                x2={40}
+                y2={48}
+                stroke="var(--accent, #7c5cff)"
+                strokeWidth={2}
+                markerStart="url(#rel-arrow-legend)"
+                markerEnd="url(#rel-arrow-legend)"
+              />
+              <text x={48} y={52} fontSize="10" fill="var(--text-muted)">
+                membership — a VMC pair
+              </text>
             </svg>
           </div>
 
@@ -261,6 +343,10 @@ export function Relationships() {
                 {placed.length} identifier{placed.length === 1 ? "" : "s"} ·{" "}
                 {completeCount} complete edge{completeCount === 1 ? "" : "s"} ·{" "}
                 {halfCount} half-edge{halfCount === 1 ? "" : "s"}.
+                <br />
+                {membershipCount} membership
+                {membershipCount === 1 ? "" : "s"} · {relationshipCount}{" "}
+                relationship{relationshipCount === 1 ? "" : "s"}.
                 <br />
                 Select a node to see its edges.
               </p>
@@ -294,7 +380,31 @@ export function Relationships() {
                       );
                       return (
                         <li key={edgeKey(e)} style={{ marginBottom: 4 }}>
-                          {e.complete ? (
+                          {isMembership(e) ? (
+                            // A membership edge reads in the community's
+                            // vocabulary, not the peer-vouching one: "vouched
+                            // for by the community" would describe a
+                            // relationship the VMC pair does not assert.
+                            e.complete ? (
+                              <>
+                                ↔ member of <code>{name}</code>
+                              </>
+                            ) : selected === communityDid ? (
+                              <>
+                                → issued membership to <code>{name}</code>{" "}
+                                <span className="muted">
+                                  (not acknowledged)
+                                </span>
+                              </>
+                            ) : (
+                              <>
+                                ← granted membership by <code>{name}</code>{" "}
+                                <span className="muted">
+                                  (not acknowledged)
+                                </span>
+                              </>
+                            )
+                          ) : e.complete ? (
                             <>
                               ↔ mutual with <code>{name}</code>
                             </>

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1336,6 +1336,25 @@ pre {
   font-size: var(--text-base);
 }
 
+/* The community's DID, shown before sign-in. A DID is long and unbreakable at
+   spaces, so it wraps on any character rather than widening the card past its
+   max-width. */
+.login-did {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.login-did code {
+  flex: 1 1 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
 .login-card button.primary,
 .install-card button.primary {
   width: 100%;

--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -216,8 +216,14 @@ async fn admit(
     let (vmc, role_vec, status_list_index) =
         issue_member_credentials(state, subject_did, role).await?;
     member.status_list_index = Some(status_list_index);
-    member.current_vmc_id = top_level_id(&vmc);
-    member.current_role_vec_id = top_level_id(&role_vec);
+    // Keep the bodies, not just the ids: the member's acknowledgement carries a
+    // digest of the grant, and an id cannot be digested. See
+    // [`crate::members::Member::current_vmc`].
+    let vmc_value = serde_json::to_value(&vmc)
+        .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?;
+    let role_vec_value = serde_json::to_value(&role_vec)
+        .map_err(|e| AppError::Internal(format!("serialise role VEC: {e}")))?;
+    member.record_issued_credentials(vmc_value, role_vec_value);
     store_member(&state.members_ks, &member).await?;
 
     // A new member row exists; keep the cached count in step (still under
@@ -349,7 +355,11 @@ async fn remint(
     // Re-mint the role VEC at the new role + repoint the member.
     let role_vec = issue_role_vec(state, subject_did, new_role).await?;
     if let Some(mut member) = get_member(&state.members_ks, subject_did).await? {
-        member.current_role_vec_id = top_level_id(&role_vec);
+        let role_vec_value = serde_json::to_value(&role_vec)
+            .map_err(|e| AppError::Internal(format!("serialise role VEC: {e}")))?;
+        // The grant is untouched by a role change, so the member's
+        // acknowledgement of it still stands — only the VEC is repointed.
+        member.record_role_vec(role_vec_value);
         store_member(&state.members_ks, &member).await?;
     }
 
@@ -539,5 +549,6 @@ async fn flip_revocation(state: &AppState, slot: u32) -> Result<(), AppError> {
 pub(crate) fn top_level_id(vc: &VerifiableCredential) -> Option<String> {
     serde_json::to_value(vc)
         .ok()
-        .and_then(|v| v.get("id").and_then(|i| i.as_str().map(str::to_string)))
+        .as_ref()
+        .and_then(crate::members::top_level_id)
 }

--- a/vtc-service/src/credentials/ingress.rs
+++ b/vtc-service/src/credentials/ingress.rs
@@ -595,8 +595,11 @@ mod tests {
 /// service and its peer computing different digests for the same credential
 /// and neither able to see why.
 ///
-/// The same recipe `dtg_credentials::DTGCredential::digest_multibase` uses, and
-/// the same one `_framework/0.3#/$defs/DigestMultibase` describes.
+/// This is the **Trust Task framework** digest — what
+/// `_framework/0.3#/$defs/DigestMultibase` describes, used to bind a publish
+/// authorization to the credential it authorizes. It is not the digest a DTG
+/// credential carries in `credentialSubject.digest`; that one is
+/// [`dtg_credential_digest`], and the two differ in both encoding and coverage.
 pub fn digest_multibase(doc: &JsonValue) -> Result<String, AppError> {
     use sha2::{Digest, Sha256};
     let canonical = serde_json_canonicalizer::to_vec(doc)
@@ -605,6 +608,59 @@ pub fn digest_multibase(doc: &JsonValue) -> Result<String, AppError> {
     multihash.extend_from_slice(&[0x12, 0x20]);
     multihash.extend_from_slice(&Sha256::digest(&canonical));
     Ok(multibase::encode(multibase::Base::Base58Btc, multihash))
+}
+
+/// Digest of a credential in the form DTG Core Credentials specifies for
+/// `credentialSubject.digest`: SHA-256 over the RFC 8785 (JCS)
+/// canonicalization of the document **with its top-level `proof` removed**,
+/// encoded as `sha256:` followed by the lowercase hexadecimal digest.
+///
+/// This is what a member-issued VMC carries of the grant it acknowledges, and
+/// what a VWC carries of the edge credential it attests. Distinct from
+/// [`digest_multibase`] in encoding *and* coverage — do not substitute one for
+/// the other.
+///
+/// # Over the document as it stands, not a re-serialised model
+///
+/// Same discipline as [`digest_multibase`], and it matters more here: the
+/// counterparty computed their digest over the JSON they received. A
+/// credential may carry members this service's model does not know, and
+/// digesting a parsed-and-re-serialised model would drop them — leaving the
+/// two sides computing different digests for the same credential, with nothing
+/// to show why.
+///
+/// # Why `proof` is excluded
+///
+/// The digest binds to what the credential *says*, not to a signature over it,
+/// so an acknowledgement survives its grant being re-signed. A re-issued grant
+/// carries different claims and therefore a different digest, which is what
+/// makes renewal force re-acknowledgement.
+pub fn dtg_credential_digest(doc: &JsonValue) -> Result<String, AppError> {
+    use sha2::{Digest, Sha256};
+
+    let proofless = match doc {
+        JsonValue::Object(members) => {
+            let mut members = members.clone();
+            members.remove("proof");
+            JsonValue::Object(members)
+        }
+        // Not an object: canonicalize as-is and let the digest simply not match
+        // anything. A shape check belongs to the caller, which has a better
+        // error to give than this one would.
+        other => other.clone(),
+    };
+
+    let canonical = serde_json_canonicalizer::to_vec(&proofless)
+        .map_err(|e| AppError::Validation(format!("credential is not canonicalizable: {e}")))?;
+
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity("sha256:".len() + 64);
+    out.push_str("sha256:");
+    for byte in Sha256::digest(&canonical) {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -628,6 +684,65 @@ mod digest_tests {
         assert!(
             d.starts_with('z'),
             "expected a base58btc multibase, got {d}"
+        );
+    }
+
+    /// The `sha256:<hex>` digest is an interoperability surface: the member
+    /// computes it and this service recomputes it, in two codebases. Pinned
+    /// against a literal computed outside both — the same fixture
+    /// `dtg-credentials` asserts — so the two implementations are checked
+    /// against one definition rather than against each other.
+    #[test]
+    fn dtg_credential_digest_matches_the_cross_implementation_fixture() {
+        let grant = serde_json::json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
+            "type": ["VerifiableCredential", "DTGCredential", "MembershipCredential"],
+            "id": "urn:uuid:2a4e1d90-6e0c-4d3f-9a4a-6d0a8f7c1b52",
+            "issuer": "did:example:community",
+            "validFrom": "2025-12-11T00:00:00Z",
+            "credentialSubject": { "id": "did:example:member" }
+        });
+
+        assert_eq!(
+            dtg_credential_digest(&grant).unwrap(),
+            "sha256:49c9d5135ab4b5659a343bc79d351e37d64f05add58408cae6eef022828495c2"
+        );
+    }
+
+    /// Signing the grant must not change its digest, or the community could
+    /// never re-sign a credential without silently invalidating every
+    /// acknowledgement already made against it.
+    #[test]
+    fn dtg_credential_digest_ignores_the_proof() {
+        let unsigned = serde_json::json!({
+            "type": ["VerifiableCredential", "DTGCredential", "MembershipCredential"],
+            "issuer": "did:example:community",
+            "credentialSubject": { "id": "did:example:member" }
+        });
+        let mut signed = unsigned.clone();
+        signed["proof"] = serde_json::json!({
+            "type": "DataIntegrityProof",
+            "proofValue": "z3FXQ..."
+        });
+
+        assert_eq!(
+            dtg_credential_digest(&unsigned).unwrap(),
+            dtg_credential_digest(&signed).unwrap()
+        );
+    }
+
+    /// The two digests answer different questions and must never be swapped:
+    /// the framework one binds a publish authorization, the DTG one binds a
+    /// credential to the credential it references.
+    #[test]
+    fn the_two_digests_are_not_interchangeable() {
+        let doc = serde_json::json!({ "a": 1 });
+        assert_ne!(
+            digest_multibase(&doc).unwrap(),
+            dtg_credential_digest(&doc).unwrap()
         );
     }
 

--- a/vtc-service/src/members/inbound_vmc.rs
+++ b/vtc-service/src/members/inbound_vmc.rs
@@ -75,6 +75,10 @@ pub async fn receive_member_vmc_inner(
             AppError::Internal("VTC DID not configured — cannot accept a member VMC".into())
         })?;
 
+    // Credential-level verification first, so a malformed or wrongly-signed
+    // credential is reported as exactly that. Reading the member row ahead of
+    // it would turn a wrong-signer delivery into "no such member", which names
+    // the wrong failure (R6.4).
     let vmc_id = verify_member_vmc(state, &vc, &member_did, &community_did).await?;
 
     // Resolve + validate the join request BEFORE any write, so a bad
@@ -102,6 +106,17 @@ pub async fn receive_member_vmc_inner(
         .filter(|m| !m.is_removed())
         .ok_or_else(|| AppError::NotFound(format!("no active member: {member_did}")))?;
 
+    // Does this acknowledgement bind to the grant we issued? DTG Core
+    // Credentials: "A member-issued VMC whose `digest` does not match a valid
+    // community-issued VMC MUST NOT be treated as completing a membership
+    // edge." A mismatch is refused outright; an *absent* digest is stored but
+    // leaves the edge incomplete — see [`check_acknowledgement_binding`].
+    //
+    // Ahead of the idempotency check below, not after it: once the grant has
+    // been re-issued, an acknowledgement that used to bind no longer does, and
+    // a re-send of it should be refused rather than quietly no-oped.
+    let bound = check_acknowledgement_binding(&vc, member.current_vmc.as_ref(), &member_did)?;
+
     // Idempotency: the same VMC re-sent is a no-op; a *different* VMC replaces
     // the stored one (a renewal — the member rotated/reissued their half).
     if member.member_vmc_id.as_deref() == Some(vmc_id.as_str()) {
@@ -115,7 +130,7 @@ pub async fn receive_member_vmc_inner(
         });
     }
 
-    member.record_member_vmc(vmc_id.clone(), vc);
+    member.record_member_vmc(vmc_id.clone(), vc, bound);
     // Closing a join request: the delivered credential IS the reciprocal half
     // of the join, so the edge is marked reciprocated with the same id.
     if request_id.is_some() {
@@ -157,6 +172,68 @@ pub async fn receive_member_vmc_inner(
 }
 
 /// Verify the member-issued VMC and return its top-level `id`.
+/// Does this acknowledgement bind to the grant the community issued?
+///
+/// Returns whether the edge is **complete**: `true` only when the
+/// acknowledgement carries a `digest` and it matches the stored grant.
+///
+/// # Three outcomes, not two
+///
+/// A mismatch is an error — the member acknowledged *something*, and it was not
+/// this membership. Storing it would leave the community able to show an
+/// acknowledgement that does not answer the grant it holds, which is precisely
+/// the unconsented-membership claim the pair exists to prevent.
+///
+/// An acknowledgement with **no** `digest` is not an error but does not
+/// complete the edge either. Two populations reach here without one: members on
+/// clients that predate the digest requirement, and members whose grant this
+/// service issued before it kept credential bodies (`current_vmc` is `None`, so
+/// there is nothing to check against). Refusing them would unmake memberships
+/// that were validly formed under the rules in force when they were made.
+/// Storing them unbound keeps the credential visible to the operator while
+/// leaving the edge honestly incomplete — which is what
+/// `POST /v1/members/{did}/request-vmc` exists to resolve.
+///
+/// Deliberate asymmetry, and the reason it is safe: an unbound acknowledgement
+/// claims *less* than a bound one, so admitting it grants nothing. A
+/// mismatched one claims something false.
+fn check_acknowledgement_binding(
+    vc: &JsonValue,
+    grant: Option<&JsonValue>,
+    member_did: &str,
+) -> Result<bool, AppError> {
+    let claimed = vc
+        .get("credentialSubject")
+        .and_then(JsonValue::as_object)
+        .and_then(|s| s.get("digest"))
+        .and_then(JsonValue::as_str);
+
+    let (Some(claimed), Some(grant)) = (claimed, grant) else {
+        // R6.3: say which of the two is missing, so an operator looking at an
+        // incomplete edge can tell "the member's client is old" from "we never
+        // kept the grant to check against".
+        tracing::warn!(
+            member = %member_did,
+            digest_present = claimed.is_some(),
+            grant_stored = grant.is_some(),
+            "member VMC stored without a verified digest — the membership edge is \
+             not complete; ask the member to re-issue with `request-vmc`"
+        );
+        return Ok(false);
+    };
+
+    let expected = crate::credentials::ingress::dtg_credential_digest(grant)?;
+    if claimed != expected {
+        return Err(AppError::Validation(format!(
+            "member vmc `credentialSubject.digest` does not match the membership \
+             credential this community issued to {member_did} — it acknowledges a \
+             different grant. Re-issue against the current one."
+        )));
+    }
+
+    Ok(true)
+}
+
 async fn verify_member_vmc(
     state: &AppState,
     vc: &JsonValue,
@@ -237,4 +314,121 @@ async fn verify_member_vmc(
         .and_then(JsonValue::as_str)
         .map(str::to_string)
         .ok_or_else(|| AppError::Validation("member vmc has no top-level `id`".into()))
+}
+
+#[cfg(test)]
+mod binding_tests {
+    use super::*;
+
+    /// A grant and the acknowledgement built from it, in the wire form each
+    /// side actually holds. Built through `dtg_credentials` rather than
+    /// hand-rolled, so the fixture is what the catalog mints — a literal here
+    /// could agree with this module while disagreeing with every real client.
+    fn pair() -> (JsonValue, JsonValue) {
+        use chrono::TimeZone;
+        let valid_from = chrono::Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+
+        let grant = dtg_credentials::DTGCredential::new_vmc(
+            "did:web:community.example".to_string(),
+            "did:key:zMember".to_string(),
+            valid_from,
+            None,
+            false,
+        )
+        .with_id("urn:uuid:grant-1");
+
+        let ack = dtg_credentials::DTGCredential::new_member_vmc(&grant, valid_from, None)
+            .expect("acknowledgement builds")
+            .with_id("urn:uuid:ack-1");
+
+        (
+            serde_json::to_value(grant.credential()).expect("grant serialises"),
+            serde_json::to_value(ack.credential()).expect("ack serialises"),
+        )
+    }
+
+    /// The happy path, and the one that matters most: a digest computed by
+    /// `dtg-credentials` must verify against one computed here, over the wire
+    /// form. Two implementations, one definition — this is the assertion that
+    /// catches either side drifting.
+    #[test]
+    fn an_acknowledgement_of_our_grant_binds() {
+        let (grant, ack) = pair();
+        assert!(
+            check_acknowledgement_binding(&ack, Some(&grant), "did:key:zMember").unwrap(),
+            "the catalog's digest must verify against this service's"
+        );
+    }
+
+    /// The community re-signing a grant must not invalidate consent already
+    /// given — the digest covers claims, not the proof.
+    #[test]
+    fn a_re_signed_grant_still_satisfies_an_existing_acknowledgement() {
+        let (mut grant, ack) = pair();
+        grant["proof"] = serde_json::json!({
+            "type": "DataIntegrityProof",
+            "cryptosuite": "eddsa-jcs-2022",
+            "proofValue": "zSomeOtherSignatureEntirely"
+        });
+
+        assert!(check_acknowledgement_binding(&ack, Some(&grant), "did:key:zMember").unwrap());
+    }
+
+    /// A member who acknowledges some other grant has consented to something,
+    /// but not to this membership. Refused rather than stored: an
+    /// acknowledgement that does not answer the grant we hold would let the
+    /// community show consent it does not have.
+    #[test]
+    fn an_acknowledgement_of_a_different_grant_is_refused() {
+        use chrono::TimeZone;
+        let (_, ack) = pair();
+
+        // Same parties, different grant — a renewal, say.
+        let renewed = dtg_credentials::DTGCredential::new_vmc(
+            "did:web:community.example".to_string(),
+            "did:key:zMember".to_string(),
+            chrono::Utc.with_ymd_and_hms(2027, 1, 1, 0, 0, 0).unwrap(),
+            None,
+            false,
+        )
+        .with_id("urn:uuid:grant-2");
+        let renewed = serde_json::to_value(renewed.credential()).expect("serialises");
+
+        let err = check_acknowledgement_binding(&ack, Some(&renewed), "did:key:zMember")
+            .expect_err("a mismatched digest must be refused");
+        assert!(
+            format!("{err:?}").contains("acknowledges a different grant"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// Two populations arrive without a digest: clients that predate the
+    /// requirement, and members whose grant this service issued before it kept
+    /// bodies. Both are stored and neither completes an edge. Refusing them
+    /// would unmake memberships validly formed under the rules then in force.
+    #[test]
+    fn an_acknowledgement_without_a_digest_is_stored_unbound() {
+        let (grant, _) = pair();
+        let legacy = serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "DTGCredential", "MembershipCredential"],
+            "id": "urn:uuid:legacy-ack",
+            "issuer": "did:key:zMember",
+            "validFrom": "2026-01-01T00:00:00Z",
+            "credentialSubject": { "id": "did:web:community.example" }
+        });
+
+        assert!(
+            !check_acknowledgement_binding(&legacy, Some(&grant), "did:key:zMember").unwrap(),
+            "no digest to check, so nothing was verified"
+        );
+    }
+
+    /// No stored grant means nothing to check against — not a reason to refuse
+    /// a credential the member issued correctly.
+    #[test]
+    fn an_acknowledgement_with_no_stored_grant_is_stored_unbound() {
+        let (_, ack) = pair();
+        assert!(!check_acknowledgement_binding(&ack, None, "did:key:zMember").unwrap());
+    }
 }

--- a/vtc-service/src/members/mod.rs
+++ b/vtc-service/src/members/mod.rs
@@ -40,6 +40,16 @@ pub use storage::{
     list_members, list_members_paginated, store_member,
 };
 
+/// Pull the top-level `id` off a credential in its wire (JSON) form.
+///
+/// The typed `VerifiableCredential` does not expose `id` — issuance splices it
+/// onto the wire form — so the id is only readable from JSON, which is also the
+/// form the bodies are stored in. [`crate::ceremony::execute::top_level_id`] is
+/// the typed front door onto this.
+pub(crate) fn top_level_id(vc: &JsonValue) -> Option<String> {
+    vc.get("id").and_then(JsonValue::as_str).map(str::to_string)
+}
+
 /// One community member. 1:1 with a [`crate::acl::VtcAclEntry`]
 /// row by DID.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -64,10 +74,40 @@ pub struct Member {
     /// Populated by Phase 2's issuance flow.
     #[serde(default)]
     pub current_vmc_id: Option<String>,
+    /// The community-issued VMC itself — the membership **grant**, the
+    /// community → member half of the edge.
+    ///
+    /// Kept, not just pointed at. Three things need the body and not the id:
+    ///
+    /// 1. **Digest verification.** A member-issued VMC carries a `digest` of
+    ///    the grant it acknowledges, and DTG Core Credentials says an
+    ///    acknowledgement whose digest matches no valid grant MUST NOT be
+    ///    treated as completing a membership edge. Checking that needs the
+    ///    grant's claims, which an id does not carry.
+    /// 2. **Re-delivery.** A member who lost their copy could previously only
+    ///    be given a *newly minted* one, which is a different credential with
+    ///    a different digest — silently invalidating the acknowledgement they
+    ///    had already sent.
+    /// 3. **Operator visibility.** "Which credentials does this member hold
+    ///    from us" was unanswerable from this row.
+    ///
+    /// `None` on rows written before this field existed, and on members whose
+    /// issuance predates it; the id is still there, so those rows stay
+    /// readable and are treated as pre-digest (see
+    /// [`crate::members::inbound_vmc`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_vmc: Option<JsonValue>,
     /// ID of the currently-active role VEC (spec §6.1).
     /// Populated by Phase 2's issuance flow.
     #[serde(default)]
     pub current_role_vec_id: Option<String>,
+    /// The role VEC itself, kept for the same reasons as
+    /// [`Self::current_vmc`] — re-delivery and operator visibility. It is not
+    /// digest-bound to anything, so nothing verifies against it; it is here so
+    /// that "what did we issue this member" has one answer rather than two
+    /// half-answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_role_vec: Option<JsonValue>,
     /// Community-defined extensions slot (spec §3-M). Bounded by
     /// [`MEMBER_EXTENSIONS_MAX_BYTES`] = 16 KiB at the route
     /// layer.
@@ -137,6 +177,20 @@ pub struct Member {
     /// [`Self::member_vmc`].
     #[serde(default)]
     pub member_vmc_received_at: Option<DateTime<Utc>>,
+    /// Whether [`Self::member_vmc`]'s `digest` was verified against
+    /// [`Self::current_vmc`] when it arrived — i.e. whether the membership edge
+    /// is **complete**.
+    ///
+    /// Storing the answer rather than recomputing it on read is deliberate:
+    /// what was verified is a fact about the moment of receipt, and the grant
+    /// can be re-issued afterwards. Recomputing would let a later renewal
+    /// silently re-decide a past verification.
+    ///
+    /// `#[serde(default)]` reads `false` on every row written before this
+    /// existed, which is the truthful answer for all of them: nothing checked
+    /// a digest, so nothing verified one.
+    #[serde(default)]
+    pub member_vmc_bound: bool,
 }
 
 impl Member {
@@ -156,7 +210,9 @@ impl Member {
             publish_consent: false,
             departure_preference: Disposition::default_preference(),
             current_vmc_id: None,
+            current_vmc: None,
             current_role_vec_id: None,
+            current_role_vec: None,
             extensions: JsonValue::Null,
             removed_at: None,
             personhood: false,
@@ -166,17 +222,73 @@ impl Member {
             joined_via_invitation: false,
             member_vmc: None,
             member_vmc_id: None,
+            member_vmc_bound: false,
             member_vmc_received_at: None,
         }
     }
 
+    /// Record the community-issued VMC + role VEC this member was granted,
+    /// keeping both the ids and the bodies.
+    ///
+    /// Replacing the grant invalidates any acknowledgement bound to the old
+    /// one — the digest covers the grant's claims, so a re-issued grant has a
+    /// different digest — and the member owes a fresh acknowledgement. That is
+    /// deliberate: it is what stops consent to one membership carrying over to
+    /// a different one. Clearing [`Self::member_vmc`] here is what makes the
+    /// obligation visible rather than leaving a stale acknowledgement standing
+    /// against a grant it no longer matches.
+    pub fn record_issued_credentials(&mut self, vmc: JsonValue, role_vec: JsonValue) {
+        let vmc_id = top_level_id(&vmc);
+        let superseded = self.current_vmc_id.is_some() && self.current_vmc_id != vmc_id;
+
+        self.current_vmc_id = vmc_id;
+        self.current_vmc = Some(vmc);
+        self.current_role_vec_id = top_level_id(&role_vec);
+        self.current_role_vec = Some(role_vec);
+
+        if superseded {
+            self.member_vmc = None;
+            self.member_vmc_id = None;
+            self.member_vmc_received_at = None;
+            self.member_vmc_bound = false;
+        }
+    }
+
+    /// Record a re-minted role VEC, leaving the membership grant alone.
+    ///
+    /// A role change re-mints the VEC only. The grant is untouched, so the
+    /// member's acknowledgement of it still stands and MUST NOT be dropped —
+    /// which is why this is separate from
+    /// [`Self::record_issued_credentials`].
+    pub fn record_role_vec(&mut self, role_vec: JsonValue) {
+        self.current_role_vec_id = top_level_id(&role_vec);
+        self.current_role_vec = Some(role_vec);
+    }
+
     /// Record the member-issued reciprocal VMC (member → community half of the
     /// pair), stamping the receipt time. The caller verifies the credential
-    /// (issuer, subject binding, proof) before calling this.
-    pub fn record_member_vmc(&mut self, vmc_id: impl Into<String>, vmc: JsonValue) {
+    /// (issuer, subject binding, proof, and its digest against
+    /// [`Self::current_vmc`]) before calling this.
+    pub fn record_member_vmc(&mut self, vmc_id: impl Into<String>, vmc: JsonValue, bound: bool) {
         self.member_vmc_id = Some(vmc_id.into());
         self.member_vmc = Some(vmc);
         self.member_vmc_received_at = Some(Utc::now());
+        self.member_vmc_bound = bound;
+    }
+
+    /// Is this membership edge complete — both VMCs of the pair present, with
+    /// the member's half bound to the grant this community issued?
+    ///
+    /// The single definition of "complete" for this row. The graph, the admin
+    /// UI, and anything that asserts this member's membership to a third party
+    /// all have to answer it the same way, and a community asserting a
+    /// membership MUST be able to produce the member-issued VMC that completes
+    /// the edge.
+    ///
+    /// Says nothing about validity windows or revocation: those are questions
+    /// about an instant, and this row does not get to choose the instant.
+    pub fn membership_edge_complete(&self) -> bool {
+        self.current_vmc_id.is_some() && self.member_vmc_id.is_some() && self.member_vmc_bound
     }
 
     /// Record the member-issued reciprocal VC that closes the
@@ -203,7 +315,9 @@ impl Member {
         self.publish_consent = false;
         self.departure_preference = Disposition::default_preference();
         self.current_vmc_id = None;
+        self.current_vmc = None;
         self.current_role_vec_id = None;
+        self.current_role_vec = None;
         self.extensions = JsonValue::Null;
         self.removed_at = Some(Utc::now());
         // Tombstone wipes personhood — it's a PII-bearing
@@ -222,6 +336,7 @@ impl Member {
         self.member_vmc = None;
         self.member_vmc_id = None;
         self.member_vmc_received_at = None;
+        self.member_vmc_bound = false;
     }
 
     /// Mark the row historical — keep all fields verbatim, just

--- a/vtc-service/src/members/storage.rs
+++ b/vtc-service/src/members/storage.rs
@@ -196,7 +196,9 @@ mod tests {
             publish_consent: true,
             departure_preference: Disposition::Historical,
             current_vmc_id: Some("vmc-1".into()),
+            current_vmc: Some(serde_json::json!({ "id": "vmc-1" })),
             current_role_vec_id: Some("vec-1".into()),
+            current_role_vec: Some(serde_json::json!({ "id": "vec-1" })),
             extensions: serde_json::json!({ "team": "platform" }),
             removed_at: None,
             personhood: false,
@@ -206,6 +208,7 @@ mod tests {
             joined_via_invitation: false,
             member_vmc: None,
             member_vmc_id: None,
+            member_vmc_bound: false,
             member_vmc_received_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();
@@ -231,7 +234,9 @@ mod tests {
             publish_consent: false,
             departure_preference: Disposition::PolicyDefault,
             current_vmc_id: None,
+            current_vmc: None,
             current_role_vec_id: None,
+            current_role_vec: None,
             extensions: serde_json::Value::Null,
             removed_at: None,
             personhood: true,
@@ -241,6 +246,7 @@ mod tests {
             joined_via_invitation: false,
             member_vmc: None,
             member_vmc_id: None,
+            member_vmc_bound: false,
             member_vmc_received_at: None,
         };
         let json = serde_json::to_value(&m).unwrap();

--- a/vtc-service/src/routes/members/personhood.rs
+++ b/vtc-service/src/routes/members/personhood.rs
@@ -489,8 +489,16 @@ pub(crate) async fn assert_inner(
     member.personhood = true;
     member.personhood_asserted_at = Some(now);
     member.status_list_index = Some(slot);
-    member.current_vmc_id = Some(vmc_id.clone());
-    member.current_role_vec_id = Some(vec_id.clone());
+    // Keep the bodies, not just the ids — see [`crate::members::Member::current_vmc`].
+    // Asserting or revoking personhood re-mints the grant (the flag is a claim on
+    // it), so the digest changes and the acknowledgement bound to the previous
+    // grant no longer matches: `record_issued_credentials` drops it, leaving the
+    // member visibly owing a fresh one.
+    let vmc_value = serde_json::to_value(&vmc)
+        .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?;
+    let role_vec_value = serde_json::to_value(&role_vec)
+        .map_err(|e| AppError::Internal(format!("serialise role VEC: {e}")))?;
+    member.record_issued_credentials(vmc_value, role_vec_value);
     store_member(&state.members_ks, &member).await?;
 
     // 9. Audit.
@@ -621,8 +629,16 @@ pub async fn revoke(
 
     member.personhood = false;
     member.personhood_asserted_at = None;
-    member.current_vmc_id = Some(vmc_id.clone());
-    member.current_role_vec_id = Some(vec_id.clone());
+    // Keep the bodies, not just the ids — see [`crate::members::Member::current_vmc`].
+    // Asserting or revoking personhood re-mints the grant (the flag is a claim on
+    // it), so the digest changes and the acknowledgement bound to the previous
+    // grant no longer matches: `record_issued_credentials` drops it, leaving the
+    // member visibly owing a fresh one.
+    let vmc_value = serde_json::to_value(&vmc)
+        .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?;
+    let role_vec_value = serde_json::to_value(&role_vec)
+        .map_err(|e| AppError::Internal(format!("serialise role VEC: {e}")))?;
+    member.record_issued_credentials(vmc_value, role_vec_value);
     store_member(&state.members_ks, &member).await?;
 
     audit_writer

--- a/vtc-service/src/routes/members/renew.rs
+++ b/vtc-service/src/routes/members/renew.rs
@@ -195,8 +195,17 @@ pub async fn renew(
 
     // 5. Update the Member row.
     member.status_list_index = Some(slot);
-    member.current_vmc_id = Some(vmc_id.clone());
-    member.current_role_vec_id = Some(vec_id.clone());
+    // Keep the bodies, not just the ids — see [`crate::members::Member::current_vmc`].
+    // A renewed grant carries different claims and therefore a different digest, so
+    // any acknowledgement bound to the previous one no longer matches it and is
+    // dropped: `record_issued_credentials` does that, leaving the member visibly
+    // owing a fresh one rather than a stale consent standing against a grant it
+    // does not match.
+    let vmc_value = serde_json::to_value(&vmc)
+        .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?;
+    let role_vec_value = serde_json::to_value(&role_vec)
+        .map_err(|e| AppError::Internal(format!("serialise role VEC: {e}")))?;
+    member.record_issued_credentials(vmc_value, role_vec_value);
     if downgrade_audit {
         // Renewal-policy downgrade clears the asserted-at
         // timestamp alongside the flag. The member must

--- a/vtc-service/src/routes/members/rotate.rs
+++ b/vtc-service/src/routes/members/rotate.rs
@@ -664,12 +664,15 @@ async fn reissue_credentials(
 
     // Update Member row pointers.
     let mut member_mut = member;
-    member_mut.current_vmc_id = Some(vmc_id.clone());
-    member_mut.current_role_vec_id = Some(vec_id.clone());
-    store_member(&state.members_ks, &member_mut).await?;
-
     let vmc_value = serde_json::to_value(&vmc)
         .map_err(|e| AppError::Internal(format!("serialise VMC: {e}")))?;
+    let role_vec_value = serde_json::to_value(&role_vec)
+        .map_err(|e| AppError::Internal(format!("serialise role VEC: {e}")))?;
+    // Keep the bodies, not just the ids — see [`crate::members::Member::current_vmc`].
+    // Rotation mints a grant naming the new DID, so the acknowledgement the member
+    // sent under the old one no longer matches and is dropped.
+    member_mut.record_issued_credentials(vmc_value.clone(), role_vec_value);
+    store_member(&state.members_ks, &member_mut).await?;
     let vec_value = serde_json::to_value(&role_vec)
         .map_err(|e| AppError::Internal(format!("serialise VEC: {e}")))?;
 

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -1708,14 +1708,116 @@ pub struct RelationshipsGraph {
     pub edges: Vec<GraphEdge>,
 }
 
-/// Group stored VRCs into pair-edges. Pure, so the half/complete rule is
-/// testable without standing up a keyspace.
+/// One directed half of a **membership** edge, lifted out of a member row into
+/// the shape a published VRC contributes to the graph.
+///
+/// DTG Core Credentials makes VRCs and VMCs the two subtypes of *edge
+/// credential*: "a bi-directional pair of credentials forms a complete DTG
+/// edge" in both cases, and the community is a node like any other ("DTG node
+/// types include persons, devices, AI agents, and VTCs"). A graph that renders
+/// only VRC pairs is showing half the trust graph.
+///
+/// Membership halves are lifted rather than stored in the relationships
+/// keyspace: they already exist, verified, on the member row. Copying them into
+/// a second store would create two records of one fact, free to disagree — and
+/// the VMC pair has its own lifecycle (status list, renewal, departure
+/// handling) that the relationships keyspace does not model.
+#[derive(Debug, Clone)]
+pub struct MembershipHalf {
+    /// The credential's own `id`. Not a relationships-keyspace row id, so it is
+    /// not something `DELETE /v1/relationships/{id}` can take — a membership
+    /// half is retracted by leaving the community, not by revoking an edge.
+    pub id: String,
+    pub issuer_did: String,
+    pub subject_did: String,
+    pub created_at: chrono::DateTime<Utc>,
+    /// Whether this half currently stands. For the community's grant that is
+    /// its validity window; for the member's acknowledgement it is the window
+    /// **and** that its digest was verified against the grant — an unbound
+    /// acknowledgement is still shown, but it does not complete an edge.
+    pub in_force: bool,
+}
+
+/// Lift both halves of one member's membership edge.
+///
+/// Returns at most two halves: the community's grant (community → member) and
+/// the member's acknowledgement (member → community). A member who has not
+/// acknowledged yields one, which renders as the half-edge it is: the
+/// community's claim, unanswered.
+///
+/// # A missing grant body does not fabricate a window
+///
+/// Rows written before the service kept credential bodies have the grant's `id`
+/// but not its claims, so its window cannot be read. Such a half is treated as
+/// standing — the ACL row is the community's live assertion of membership, and
+/// it is the better evidence here than an absent document. This cannot
+/// overstate an edge: the acknowledgement on those same rows is unbound, so the
+/// edge is incomplete either way.
+pub fn membership_halves(
+    community_did: &str,
+    member: &crate::members::Member,
+    now: chrono::DateTime<Utc>,
+) -> Vec<MembershipHalf> {
+    /// Is a stored credential body inside its validity window? Absent body →
+    /// `true`, per the doc comment above. Unreadable body → `false`: a document
+    /// we cannot parse is not evidence of anything.
+    fn window_stands(body: Option<&JsonValue>, now: chrono::DateTime<Utc>) -> bool {
+        let Some(body) = body else {
+            return true;
+        };
+        match crate::credentials::ingress::validity_window(body, "MembershipCredential") {
+            Ok(window) => matches!(
+                window.state_at(now),
+                crate::credentials::lifecycle::InForce::Yes
+            ),
+            Err(_) => false,
+        }
+    }
+
+    let mut halves = Vec::with_capacity(2);
+
+    // The community's grant. A member with no `current_vmc_id` was admitted but
+    // never issued to — no half to draw.
+    if let Some(id) = &member.current_vmc_id {
+        halves.push(MembershipHalf {
+            id: id.clone(),
+            issuer_did: community_did.to_string(),
+            subject_did: member.did.clone(),
+            created_at: member.joined_at,
+            in_force: window_stands(member.current_vmc.as_ref(), now),
+        });
+    }
+
+    // The member's acknowledgement.
+    if let Some(id) = &member.member_vmc_id {
+        halves.push(MembershipHalf {
+            id: id.clone(),
+            issuer_did: member.did.clone(),
+            subject_did: community_did.to_string(),
+            created_at: member.member_vmc_received_at.unwrap_or(member.joined_at),
+            // `member_vmc_bound` is the digest check made at receipt. Without
+            // it the acknowledgement names some grant, but not demonstrably
+            // this one, and the spec is explicit that such a credential MUST
+            // NOT be treated as completing a membership edge.
+            in_force: member.member_vmc_bound && window_stands(member.member_vmc.as_ref(), now),
+        });
+    }
+
+    halves
+}
+
+/// Group stored VRCs and lifted membership halves into pair-edges. Pure, so the
+/// half/complete rule is testable without standing up a keyspace.
 ///
 /// `now` is a parameter rather than read here because whether an edge is
 /// complete is a question about an instant, and a test that cannot choose the
 /// instant cannot pin an expiry boundary. Same reason the publish handler
 /// reads `now` once at the top and passes it down.
-fn build_graph(mut rels: Vec<Relationship>, now: chrono::DateTime<Utc>) -> RelationshipsGraph {
+fn build_graph(
+    mut rels: Vec<Relationship>,
+    memberships: Vec<MembershipHalf>,
+    now: chrono::DateTime<Utc>,
+) -> RelationshipsGraph {
     // Oldest first, id-tiebroken, so `halves` ordering is stable across calls
     // rather than inheriting whatever order the keyspace scan produced.
     rels.sort_by_key(|r| (r.created_at, r.id));
@@ -1754,9 +1856,43 @@ fn build_graph(mut rels: Vec<Relationship>, now: chrono::DateTime<Utc>) -> Relat
         ));
     }
 
+    // Membership halves join the same pair map, so one `complete` rule covers
+    // both kinds of edge. They are appended after the VRC halves and the pair's
+    // halves are re-sorted below, rather than being merged in `created_at`
+    // order here, because the two come from different stores and only the
+    // combined list has a meaningful order.
+    for half in memberships {
+        nodes.insert(half.issuer_did.clone());
+        nodes.insert(half.subject_did.clone());
+        let key = if half.issuer_did <= half.subject_did {
+            (half.issuer_did.clone(), half.subject_did.clone())
+        } else {
+            (half.subject_did.clone(), half.issuer_did.clone())
+        };
+        let in_force = half.in_force;
+        pairs.entry(key).or_default().push((
+            GraphHalf {
+                id: half.id,
+                issuer_did: half.issuer_did,
+                subject_did: half.subject_did,
+                created_at: half.created_at.to_rfc3339(),
+                // A VPC annotates a relationship edge; membership is not
+                // pseudonymous, so there is nothing to correlate here.
+                persona_did: None,
+            },
+            in_force,
+        ));
+    }
+
     let edges = pairs
         .into_iter()
-        .map(|((lo, hi), halves)| {
+        .map(|((lo, hi), mut halves)| {
+            // Oldest first across both sources, matching the `halves` contract.
+            halves.sort_by(|a, b| {
+                a.0.created_at
+                    .cmp(&b.0.created_at)
+                    .then(a.0.id.cmp(&b.0.id))
+            });
             // A self-issued VRC (`lo == hi`) has no counterparty who could ever
             // reciprocate, so it can never be complete — without the `lo != hi`
             // guard the two `any` checks below would both match the same row
@@ -1806,8 +1942,27 @@ pub async fn graph(
     _auth: crate::auth::AdminAuth,
     State(state): State<AppState>,
 ) -> Result<Json<RelationshipsGraph>, AppError> {
+    let now = Utc::now();
     let rels = crate::relationships::list_all(&state.relationships_ks).await?;
-    Ok(Json(build_graph(rels, Utc::now())))
+
+    // Membership halves come from the member rows, where they already sit
+    // verified — see [`membership_halves`] for why they are lifted rather than
+    // copied into the relationships keyspace. A community with no DID
+    // configured has no node to draw them against; the VRC graph still renders.
+    let community_did = state.config.read().await.vtc_did.clone();
+    let memberships = match community_did {
+        Some(community_did) if !community_did.is_empty() => {
+            crate::members::list_members(&state.members_ks)
+                .await?
+                .iter()
+                .filter(|m| !m.is_removed())
+                .flat_map(|m| membership_halves(&community_did, m, now))
+                .collect()
+        }
+        _ => Vec::new(),
+    };
+
+    Ok(Json(build_graph(rels, memberships, now)))
 }
 
 #[cfg(test)]
@@ -1961,9 +2116,164 @@ mod tests {
         Utc.with_ymd_and_hms(2026, 2, day, 0, 0, 0).unwrap()
     }
 
+    /// A member row with both halves of its membership pair, digest verified.
+    fn member_row(did: &str, ack: Option<bool>) -> crate::members::Member {
+        use chrono::TimeZone;
+        let mut m = crate::members::Member::fresh(did);
+        m.joined_at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+
+        let grant = dtg_credentials::DTGCredential::new_vmc(
+            COMMUNITY.to_string(),
+            did.to_string(),
+            m.joined_at,
+            None,
+            false,
+        )
+        .with_id("urn:uuid:grant-1");
+        let grant_json = serde_json::to_value(grant.credential()).expect("grant serialises");
+
+        let role_vec = serde_json::json!({ "id": "urn:uuid:vec-1" });
+        m.record_issued_credentials(grant_json, role_vec);
+
+        if let Some(bound) = ack {
+            let ack = dtg_credentials::DTGCredential::new_member_vmc(&grant, m.joined_at, None)
+                .expect("acknowledgement builds")
+                .with_id("urn:uuid:ack-1");
+            let ack_json = serde_json::to_value(ack.credential()).expect("ack serialises");
+            m.record_member_vmc("urn:uuid:ack-1", ack_json, bound);
+            m.member_vmc_received_at = Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 5, 0).unwrap());
+        }
+
+        m
+    }
+
+    const COMMUNITY: &str = "did:web:community.example";
+
+    /// The membership pair is a DTG edge in exactly the way a VRC pair is —
+    /// "in both cases, a bi-directional pair of credentials forms a complete
+    /// DTG edge" — and the community is a node like any other. A graph that
+    /// rendered only VRC pairs was showing half the trust graph.
+    #[test]
+    fn an_acknowledged_membership_is_one_complete_edge() {
+        let member = member_row(A, Some(true));
+        let g = build_graph(vec![], membership_halves(COMMUNITY, &member, at(1)), at(1));
+
+        assert_eq!(g.edges.len(), 1, "grant + acknowledgement are ONE edge");
+        assert_eq!(
+            g.edges[0].endpoints,
+            {
+                let mut e = vec![COMMUNITY.to_string(), A.to_string()];
+                e.sort();
+                e
+            },
+            "endpoints are DID-sorted, as for any edge"
+        );
+        assert_eq!(g.edges[0].halves.len(), 2);
+        assert!(g.edges[0].complete);
+        assert_eq!(g.nodes.len(), 2, "the community is a node in its own graph");
+    }
+
+    /// A membership the member has not answered is the community's claim, not
+    /// a relationship — the same reading a one-sided VRC gets.
+    #[test]
+    fn an_unacknowledged_membership_is_a_half_edge() {
+        let member = member_row(A, None);
+        let g = build_graph(vec![], membership_halves(COMMUNITY, &member, at(1)), at(1));
+
+        assert_eq!(g.edges.len(), 1);
+        assert_eq!(g.edges[0].halves.len(), 1);
+        assert!(!g.edges[0].complete);
+        assert_eq!(g.edges[0].halves[0].issuer_did, COMMUNITY);
+    }
+
+    /// The spec is explicit: an acknowledgement whose digest does not match a
+    /// valid grant MUST NOT be treated as completing a membership edge. It is
+    /// still *shown* — a published fact is not hidden because it is unbound —
+    /// but it does not stand in for the member's consent.
+    #[test]
+    fn an_unbound_acknowledgement_does_not_complete_the_edge() {
+        let member = member_row(A, Some(false));
+        let g = build_graph(vec![], membership_halves(COMMUNITY, &member, at(1)), at(1));
+
+        assert_eq!(g.edges.len(), 1);
+        assert_eq!(
+            g.edges[0].halves.len(),
+            2,
+            "both halves are listed; a stored credential is not hidden"
+        );
+        assert!(
+            !g.edges[0].complete,
+            "an unverified digest is not the member's consent to THIS membership"
+        );
+    }
+
+    /// Membership and relationship edges share one graph and one `complete`
+    /// rule. They must not merge into each other: a member's VRC to a peer and
+    /// their VMC pair with the community are different edges.
+    #[test]
+    fn membership_and_relationship_edges_coexist() {
+        let member = member_row(A, Some(true));
+        let g = build_graph(
+            vec![row(A, B, 0), row(B, A, 1)],
+            membership_halves(COMMUNITY, &member, at(1)),
+            at(1),
+        );
+
+        assert_eq!(g.edges.len(), 2, "A—B and A—community are separate edges");
+        assert!(g.edges.iter().all(|e| e.complete));
+        assert_eq!(g.nodes.len(), 3, "A, B, and the community");
+
+        // An edge touching the community DID is the membership one. This is how
+        // a consumer tells them apart without a schema change: the community
+        // knows its own DID, and `relationships/graph/0.2` pins the response
+        // shape with `additionalProperties: false`.
+        let membership = g
+            .edges
+            .iter()
+            .find(|e| e.endpoints.contains(&COMMUNITY.to_string()))
+            .expect("the membership edge");
+        assert_eq!(membership.halves.len(), 2);
+    }
+
+    /// An expired grant stops standing for a current membership, exactly as an
+    /// expired VRC stops completing a relationship edge (#1079).
+    #[test]
+    fn an_expired_grant_does_not_complete_the_edge() {
+        use chrono::TimeZone;
+        let mut member = member_row(A, Some(true));
+
+        // Re-issue the stored grant with a window that has already closed.
+        if let Some(grant) = member.current_vmc.as_mut() {
+            grant["validUntil"] = serde_json::Value::String(
+                Utc.with_ymd_and_hms(2026, 1, 2, 0, 0, 0)
+                    .unwrap()
+                    .to_rfc3339(),
+            );
+        }
+
+        let g = build_graph(vec![], membership_halves(COMMUNITY, &member, at(9)), at(9));
+        assert_eq!(g.edges[0].halves.len(), 2, "both are still listed");
+        assert!(!g.edges[0].complete);
+    }
+
+    /// Rows written before the service kept credential bodies still render a
+    /// half — the id is enough to say the grant exists — and are honestly
+    /// incomplete, because nothing verified the acknowledgement against it.
+    #[test]
+    fn a_pre_digest_row_renders_as_an_incomplete_edge() {
+        let mut member = crate::members::Member::fresh(A);
+        member.current_vmc_id = Some("urn:uuid:legacy-grant".into());
+        member.member_vmc_id = Some("urn:uuid:legacy-ack".into());
+        // `member_vmc_bound` defaults false: nothing checked a digest.
+
+        let g = build_graph(vec![], membership_halves(COMMUNITY, &member, at(1)), at(1));
+        assert_eq!(g.edges[0].halves.len(), 2);
+        assert!(!g.edges[0].complete);
+    }
+
     #[test]
     fn a_reciprocated_pair_is_one_complete_edge() {
-        let g = build_graph(vec![row(A, B, 0), row(B, A, 1)], at(1));
+        let g = build_graph(vec![row(A, B, 0), row(B, A, 1)], vec![], at(1));
         assert_eq!(g.edges.len(), 1, "two VRCs one each way are ONE edge");
         assert_eq!(g.edges[0].endpoints, vec![A.to_string(), B.to_string()]);
         assert_eq!(g.edges[0].halves.len(), 2);
@@ -1973,7 +2283,7 @@ mod tests {
 
     #[test]
     fn an_unreciprocated_vrc_is_a_half_edge() {
-        let g = build_graph(vec![row(A, B, 0)], at(1));
+        let g = build_graph(vec![row(A, B, 0)], vec![], at(1));
         assert_eq!(g.edges.len(), 1);
         assert_eq!(g.edges[0].halves.len(), 1);
         assert!(
@@ -1989,7 +2299,11 @@ mod tests {
     /// parties are not evidence of reciprocity if they all point one way.
     #[test]
     fn repeated_vrcs_in_one_direction_do_not_complete_an_edge() {
-        let g = build_graph(vec![row(A, B, 0), row(A, B, 1), row(A, B, 2)], at(1));
+        let g = build_graph(
+            vec![row(A, B, 0), row(A, B, 1), row(A, B, 2)],
+            vec![],
+            at(1),
+        );
         assert_eq!(g.edges.len(), 1);
         assert_eq!(g.edges[0].halves.len(), 3);
         assert!(!g.edges[0].complete);
@@ -2000,8 +2314,8 @@ mod tests {
     /// edges depending on publish order.
     #[test]
     fn pair_identity_does_not_depend_on_publish_order() {
-        let forward = build_graph(vec![row(A, B, 0), row(B, A, 1)], at(1));
-        let reverse = build_graph(vec![row(B, A, 0), row(A, B, 1)], at(1));
+        let forward = build_graph(vec![row(A, B, 0), row(B, A, 1)], vec![], at(1));
+        let reverse = build_graph(vec![row(B, A, 0), row(A, B, 1)], vec![], at(1));
         assert_eq!(forward.edges[0].endpoints, reverse.edges[0].endpoints);
         assert!(forward.edges[0].complete && reverse.edges[0].complete);
     }
@@ -2011,7 +2325,7 @@ mod tests {
     /// "a VRC each way" test would report it complete.
     #[test]
     fn a_self_issued_vrc_is_never_complete() {
-        let g = build_graph(vec![row(A, A, 0)], at(1));
+        let g = build_graph(vec![row(A, A, 0)], vec![], at(1));
         assert_eq!(g.edges.len(), 1);
         assert_eq!(g.edges[0].endpoints, vec![A.to_string(), A.to_string()]);
         assert!(!g.edges[0].complete);
@@ -2020,7 +2334,7 @@ mod tests {
     #[test]
     fn distinct_pairs_stay_distinct_and_ordering_is_stable() {
         let rows = vec![row(B, C, 2), row(A, B, 0), row(B, A, 1)];
-        let g = build_graph(rows, at(1));
+        let g = build_graph(rows, vec![], at(1));
         assert_eq!(g.edges.len(), 2);
         // BTreeMap keyed on the sorted pair: (A,B) before (B,C).
         assert_eq!(g.edges[0].endpoints, vec![A.to_string(), B.to_string()]);
@@ -2059,13 +2373,13 @@ mod tests {
     fn an_expired_reciprocal_no_longer_completes_an_edge() {
         let rows = || vec![row(A, B, 0), row_expiring(B, A, 1, 10)];
 
-        let live = build_graph(rows(), at(9));
+        let live = build_graph(rows(), vec![], at(9));
         assert!(
             live.edges[0].complete,
             "both halves in date: this is a mutual relationship"
         );
 
-        let lapsed = build_graph(rows(), at(11));
+        let lapsed = build_graph(rows(), vec![], at(11));
         assert!(
             !lapsed.edges[0].complete,
             "B's half has expired, so B no longer consents to anything"
@@ -2094,13 +2408,13 @@ mod tests {
             .expect("first event on a fresh log");
 
         assert!(
-            !build_graph(vec![row(A, B, 0), suspended.clone()], at(6)).edges[0].complete,
+            !build_graph(vec![row(A, B, 0), suspended.clone()], vec![], at(6)).edges[0].complete,
             "a suspended half is not consent"
         );
         // And it was genuinely the event doing the work: an instant before it
         // was recorded, the same rows read as complete.
         assert!(
-            build_graph(vec![row(A, B, 0), suspended], at(4)).edges[0].complete,
+            build_graph(vec![row(A, B, 0), suspended], vec![], at(4)).edges[0].complete,
             "the suspension must not apply before it was recorded"
         );
     }
@@ -2119,8 +2433,8 @@ mod tests {
             )
             .unwrap();
 
-        assert!(!build_graph(vec![row(A, B, 0), half.clone()], at(6)).edges[0].complete);
-        assert!(build_graph(vec![row(A, B, 0), half], at(8)).edges[0].complete);
+        assert!(!build_graph(vec![row(A, B, 0), half.clone()], vec![], at(6)).edges[0].complete);
+        assert!(build_graph(vec![row(A, B, 0), half], vec![], at(8)).edges[0].complete);
     }
 
     /// A superseded half is displaced, not deleted — and the replacement is
@@ -2140,13 +2454,17 @@ mod tests {
             .unwrap();
         let replacement = row(A, B, 2);
 
-        let g = build_graph(vec![old_half.clone(), replacement, row(B, A, 1)], at(6));
+        let g = build_graph(
+            vec![old_half.clone(), replacement, row(B, A, 1)],
+            vec![],
+            at(6),
+        );
         assert_eq!(g.edges[0].halves.len(), 3);
         assert!(g.edges[0].complete, "the replacement carries A's direction");
 
         // Remove the replacement and the pair is no longer complete: the
         // displaced half cannot stand in for it.
-        let without = build_graph(vec![old_half, row(B, A, 1)], at(6));
+        let without = build_graph(vec![old_half, row(B, A, 1)], vec![], at(6));
         assert!(!without.edges[0].complete);
     }
 
@@ -2163,6 +2481,6 @@ mod tests {
             broken.in_force_at(at(1)),
             crate::relationships::InForce::Indeterminate { .. }
         ));
-        assert!(!build_graph(vec![row(A, B, 0), broken], at(1)).edges[0].complete);
+        assert!(!build_graph(vec![row(A, B, 0), broken], vec![], at(1)).edges[0].complete);
     }
 }


### PR DESCRIPTION
## Why

DTG Core Credentials makes VRCs and VMCs the two subtypes of *edge credential*:

> Edge credentials establish relationships between existing entities (nodes) in the DTG: VRCs attest to relationships between two entities, and VMCs attest to community membership. **In both cases, a bi-directional pair of credentials forms a complete DTG edge.**

and the community a node like any other — *"DTG node types include persons, devices, AI agents, and VTCs."*

The Relationships page calls itself "the community's trust graph" and drew only VRC pairs. A community whose members had published no VRCs saw an empty page and read it as "no trust here", while every membership was an edge it was not drawing.

Completing that edge needs the digest binding the spec requires, and that needed something this service did not keep.

## What changed

**Keep the credentials we issue.** `admit` minted the VMC + role VEC, sent them, and stored `top_level_id(&vmc)` — the id, not the body. Three things needed the body: verifying a member's `digest` against the grant (an id cannot be digested), re-delivering a grant a member lost without minting a *different* credential that silently invalidates the acknowledgement they already sent, and answering "what does this member hold from us" at all. Every issuance path now stores both bodies.

**Verify the acknowledgement.** `verify_member_vmc` checked issuer, type, subject and proof, and never looked for a digest — so no membership edge in the system was ever complete. Three outcomes now, not two:

| | Outcome | Why |
| --- | --- | --- |
| digest matches | edge complete | the member consented to *this* membership |
| digest mismatches | **refused** | an acknowledgement that does not answer the grant we hold would let the community show consent it does not have |
| digest absent | stored, edge incomplete | refusing would unmake memberships validly formed under the rules then in force |

The asymmetry is deliberate and safe: an unbound acknowledgement claims *less* than a bound one, so admitting it grants nothing; a mismatched one claims something false. Two populations arrive unbound — clients predating the requirement, and members whose grant we issued before we kept bodies — and both are visibly incomplete rather than silently accepted.

**Draw both kinds of edge.** `build_graph` now takes membership halves lifted from the member rows, where they already sit verified. Lifted rather than copied into the relationships keyspace: two records of one fact are free to disagree, and the VMC pair has its own lifecycle (status list, renewal, departure handling) that keyspace does not model. One `complete` rule covers both kinds.

**No wire change.** `relationships/graph/0.2` pins the response with `additionalProperties: false`, and no `kind` field is needed — an edge with the community's own DID as an endpoint is the membership one, and the community knows its own DID. `GraphHalfId` is `{"type":"string","minLength":1}` and endpoints only need `^did:`, so a VMC half fits the schema as it stands.

**Re-issuing a grant clears the acknowledgement bound to the previous one.** The digest covers claims, so a renewed grant no longer matches, and the member visibly owes a fresh one rather than a stale consent standing against a membership they never agreed to. `POST /v1/members/{did}/request-vmc` is how an operator asks for it — the member detail page already has the button.

## Admin console

- **Member detail** gains the membership-edge state and the relationship credentials naming that member, bodies included, from `relationships/list/0.2` — an endpoint that already existed and which nothing in this console had ever called. Completeness is read from the graph rather than recomputed here, so there is one definition of it.
- **Relationships** renders membership edges in their own hue with a square node for the community. Colour never carries the complete/half distinction — that stays in the line style, which survives greyscale.
- **Login page** shows the community's DID with a copy button, from the unauthenticated `/health`. Several VTCs look identical at the login screen, and the DID a prospective member needs in order to join was readable only from behind a login they did not have.

## Known gap

The VMC and role VEC **bodies** are still not on `members/show/0.1`: that response is `additionalProperties: false` and its own text says *"The credential body is not echoed here"*. Surfacing them needs a task authored upstream (`vtc/members/credentials/0.1`) rather than a field added locally, and the conformance harness would rightly reject the local version. Same reason `memberVmcBound` is not on that response — the console reads completeness from the graph instead.

## Testing

Full `vtc-service` suite green (921 lib + all integration); clippy clean; admin UI typechecks and builds.

New coverage:

- **the cross-implementation digest** — `dtg-credentials`' `digest()` verifying against this service's `dtg_credential_digest()`, plus both pinned to the same literal computed outside either codebase. That literal is the assertion that catches either side drifting.
- a re-signed grant still satisfying an existing acknowledgement (the digest excludes `proof`)
- a *renewed* grant not satisfying it (the digest covers claims)
- an acknowledgement of a different grant being refused, and one with no digest stored unbound
- membership edges: complete, unacknowledged, unbound-acknowledgement, expired grant, and a pre-digest row — plus membership and relationship edges coexisting without merging

One existing test moved me: reordering verification to fetch the member first turned a wrong-signer delivery into "no such member" (`vmc_rejects_a_wrong_holder_signature`, 422 instead of 400). Ordering restored so the error still names the actual failure class (R6.4); the digest check sits after the member read and before every write.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect — the digest check runs before every write, and a failure writes nothing (R2.1, R7.5)
- [x] Every retry is bounded + backed off (n/a — no retries added)
- [x] Accept/poll/listen loops survive transient errors (n/a)
- [x] Acks/deletes happen only after durable handoff (n/a)
- [x] New/changed wire types: none. The new SPA task URI is bound by a route, asserted by `every_admin_ui_task_is_enforced_by_a_route` (R3.*)
- [x] Config absence = most restrictive; a community with no DID configured draws no membership edges rather than guessing one (R5.1)
- [x] Logs/status claim only what was verified — an unverified digest is reported as unverified, and the warning says which of the two halves was missing (R6.3)
- [x] "Process dies on the next line" answered for every mutation touched
- [x] New Member fields are `#[serde(default)]`; existing rows read as unverified, which is the truthful answer for all of them
- [x] No deviations from the guide
```

## Next

openvtc: `build_member_vmc` sets no digest, and the acknowledgement it sends is never stored locally. That lands next, against `dtg-credentials` 0.4 (published).