### PR TITLE
chore(vtc-admin): drop the walletProfile capability probe

### DIFF
--- a/vtc-service/admin-ui/src/lib/wallet.ts
+++ b/vtc-service/admin-ui/src/lib/wallet.ts
@@ -125,25 +125,20 @@ export function isWalletAvailable(): boolean {
   );
 }
 
-/** True iff the wallet additionally exposes the proxy-login + vault-list
- *  APIs (newer extension builds). */
+/** True iff the wallet exposes the whole proxy-login surface this page drives:
+ *  `walletProfile` to resolve the identity, `proxyLogin` to mint as it, and
+ *  `vaultList` for the pick-a-different-identity path.
+ *
+ *  Presence detection, not version negotiation — the extension may simply not
+ *  be installed. There is deliberately no separate probe per method: every
+ *  build that has one has all three, so a second probe would only describe a
+ *  wallet that does not exist. */
 export function isWalletProxyAvailable(): boolean {
   return (
     isWalletAvailable() &&
+    typeof window.vtaWallet?.walletProfile === "function" &&
     typeof window.vtaWallet?.proxyLogin === "function" &&
     typeof window.vtaWallet?.vaultList === "function"
-  );
-}
-
-/** True iff the wallet can resolve-or-bind a persona for this origin itself.
- *
- *  A capability probe, not a compatibility fold: without it the proxy path can
- *  only work for an operator who has already bound an entry by hand, and the
- *  difference is worth an accurate message rather than a `TypeError`. */
-export function isWalletProfileAvailable(): boolean {
-  return (
-    isWalletProxyAvailable() &&
-    typeof window.vtaWallet?.walletProfile === "function"
   );
 }
 
@@ -243,11 +238,8 @@ export async function loginWithWalletProxy(
  * `proxyLogin` as a single call.
  */
 export async function loginWithWalletProfile(): Promise<VtaWalletLoginResult> {
-  if (!isWalletProfileAvailable()) {
-    throw new Error(
-      "This VTA wallet build cannot choose an identity for a site. " +
-        "Update the extension, or pin a did-self-issued vault entry to this VTC by hand.",
-    );
+  if (!isWalletProxyAvailable()) {
+    throw new Error("VTA wallet doesn't expose proxy-login APIs.");
   }
   const rp = await rpDid();
   const profile = await window.vtaWallet!.walletProfile!({

--- a/vtc-service/admin-ui/src/pages/Login.tsx
+++ b/vtc-service/admin-ui/src/pages/Login.tsx
@@ -22,7 +22,6 @@ import {
 } from "@/lib/webauthn";
 import {
   isWalletAvailable,
-  isWalletProfileAvailable,
   isWalletProxyAvailable,
   listProxyCandidates,
   loginWithWallet,
@@ -54,7 +53,6 @@ export function Login() {
 
   const walletAvailable = isWalletAvailable();
   const proxyAvailable = isWalletProxyAvailable();
-  const profileAvailable = isWalletProfileAvailable();
   const busy = phase.kind === "running" || walletPhase.kind === "running";
 
   // Shared success tail: the wallet returned a bearer; mirror it into the
@@ -267,33 +265,30 @@ export function Login() {
           </p>
         )}
 
-        {profileAvailable && (
-          <button
-            type="button"
-            className="secondary"
-            onClick={handleProxyStart}
-            disabled={busy}
-          >
-            Sign in via VTA-proxied SIOP
-          </button>
-        )}
-
-        {/* Secondary, and worded as the exception it is. The primary button
-            uses whichever identity the wallet has bound to this site; this is
-            for an operator holding more than one here. On a wallet too old to
-            resolve an identity itself it is the only proxy route, so it stays
-            visible in that case. */}
         {proxyAvailable && (
-          <button
-            type="button"
-            className="link"
-            onClick={handleChooseIdentity}
-            disabled={busy}
-          >
-            {profileAvailable
-              ? "Sign in as a different identity…"
-              : "Sign in via VTA-proxied SIOP (choose an entry)"}
-          </button>
+          <>
+            <button
+              type="button"
+              className="secondary"
+              onClick={handleProxyStart}
+              disabled={busy}
+            >
+              Sign in via VTA-proxied SIOP
+            </button>
+
+            {/* Secondary, and worded as the exception it is. The button above
+                uses whichever identity the wallet has bound to this site; this
+                is for an operator holding more than one here, and it costs a
+                consent prompt that enumerates the vault to this page. */}
+            <button
+              type="button"
+              className="link"
+              onClick={handleChooseIdentity}
+              disabled={busy}
+            >
+              Sign in as a different identity…
+            </button>
+          </>
         )}
 
         {candidates && (


### PR DESCRIPTION
Follow-up to #1212. `isWalletProfileAvailable()` existed so that PR could merge before the wallet method it depends on did — the "land in either order" property. OpenVTC/vta-browser-plugin#145 has now shipped, so the second probe describes a wallet build that does not exist: **every extension that exposes `proxyLogin` exposes `walletProfile` too.**

Folded into `isWalletProxyAvailable()`, which now checks the three methods this page actually calls.

## What goes

- The proxy button was hidden unless `profileAvailable` — an arm for a wallet nobody has.
- The secondary button changed its label to stand in as the primary route on an older wallet — same.
- `loginWithWalletProfile`'s "This VTA wallet build cannot choose an identity for a site. Update the extension…" message, which can no longer be reached.

## What stays

**Presence detection**, which is not the same thing — the extension may simply not be installed, and that is why the buttons are gated at all. The probe now just asks for everything the page uses instead of splitting into two questions with one possible answer.

**"Sign in as a different identity…"** and the entry picker behind it. That is a real capability for an operator holding more than one persona at this VTC, not a compatibility arm, and it stays behind an explicit click because reaching it discloses the vault to this page.

Nothing about the flow changes: `walletProfile` → `/auth/challenge` → `proxyLogin` is untouched.

## Checks

- [x] `tsc -b --noEmit` clean
- [x] `npm run build` clean
- [x] No references to `isWalletProfileAvailable` / `profileAvailable` remain
- [x] No daemon-side change
