### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,7 +2487,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -6346,7 +6346,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9321,7 +9321,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9463,7 +9463,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "multibase",
@@ -9483,7 +9483,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.32.2"
+version = "0.32.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9547,7 +9547,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -9686,7 +9686,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes 0.9.3",
  "aes-gcm 0.11.1",
@@ -9720,7 +9720,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -9754,7 +9754,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9874,7 +9874,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -9978,7 +9978,7 @@ dependencies = [
 
 [[package]]
 name = "vti-webauthn"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.2...cnm-cli-v0.13.3) — 2026-09-01
+
+
 ## [0.13.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.1...cnm-cli-v0.13.2) — 2026-08-29
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.13.2"
+version = "0.13.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.2...pnm-cli-v0.14.3) — 2026-09-01
+
+
 ## [0.14.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.1...pnm-cli-v0.14.2) — 2026-08-29
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.14.2"
+version = "0.14.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.1...vta-backup-v0.3.2) — 2026-09-01
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.0...vta-backup-v0.3.1) — 2026-08-29
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.12.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.2...vta-cli-common-v0.12.3) — 2026-09-01
+
+
+### Fixed
+
+- **vta**: Keep not-found, conflict and gone typed across the Trust-Task boundary ([#1219](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1219))
+
+`pnm approvals list` failed on a VTA that had never had an approval rule:
+
+      Protocol error: trust task failed [taskFailed]:
+      task failed: not found: policy `approvals` not found
+
+  A VTA with no approval rule has no `approvals` policy row — that is the
+  shipping default, and the CLI is written for it: `load()` maps a missing
+  row to an empty model. The arm could never fire.
+
+  The Trust-Task framework defines no `notFound` / `conflict` / `gone`
+  standard code, so `app_error_to_reject` sent all three out as `taskFailed`
+  with `details: None`. The SDK had nothing to key on and fell through to
+  `VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
+  the approvals CLI was dead code on the only transport that surface uses
+  (it is Trust-Task-only; no `/policies` REST route exists).
+
+  The blast radius is the whole surface, not just `list`: every `pnm
+  approvals` subcommand reads the row through the same `load()`, `require`
+  included. Since `require` must read before it writes, the *first* rule was
+  uncreatable — DTTE could not be configured on a fresh VTA at all.
+
+  REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
+  protocol-messages keep it in a problem-report code (`from_problem_report`).
+  The Trust-Task path was the only one that lost it, against the workspace
+  rule to preserve type information across every transport.
+
+  `taskFailed` remains the correct wire code — there is no other. The
+  discriminator goes in `details.reason`, the channel the consent gate
+  already established for exactly this reason, with the values defined once
+  in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
+  from one definition. `VtaClient::trust_task_error` maps them back to
+  `NotFound` / `Conflict` / `Gone`.
+
+  Fixing `Conflict` alongside `NotFound` also restores the CLI's
+  suggest-the-fix guidance, which switches on the typed variant.
+
+  A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
+  failure and the shape an older VTA emits, so a new client does not misread
+  every pre-upgrade failure as typed. Against such a VTA the workarounds are
+  `pnm policy list` or the offline `vta approvals list`, both documented.
+
+
+
 ## [0.12.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.1...vta-cli-common-v0.12.2) — 2026-08-29
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.1...vta-keys-v0.4.2) — 2026-09-01
+
+
 ## [0.4.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.0...vta-keys-v0.4.1) — 2026-08-29
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.1...vta-policy-v0.3.2) — 2026-09-01
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.0...vta-policy-v0.3.1) — 2026-08-29
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.32.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.2...vta-sdk-v0.32.3) — 2026-09-01
+
+
+### Fixed
+
+- **provisioning**: Say which side is out of date, and check authorization before minting ([#1220](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1220))
+
+An operator ran OpenVTC's setup wizard against a VTA and got:
+
+      X Provision integration DID + admin credential — trust task failed
+        [unsupportedType]: unsupported type:
+        https://trusttasks.org/spec/provision/integration/0.3
+
+  with a green tick on the row above it. Two things were wrong — no ACL grant
+  for the setup DID on the VTA they had reached, and it was not the VTA they
+  meant — and the run reported neither. It took an hour and a wrong diagnosis
+  before anyone suspected the VTA rather than provisioning.
+
+  Every fact needed was already on hand. The VTA was serving
+  `provision/integration/0.2` two lines further down the dispatch table it had
+  just failed to match. The wizard held the VTA's DID and the setup DID. Nothing
+  put the two together, and the message that did reach the operator said only
+  what could not be done.
+
+  **The rejection now names what it can do.** `method_not_found` compares the
+  unknown URI's family against `dispatched_uris()`; a family this VTA serves at
+  another version is `unsupportedVersion` — SPEC's code for exactly this, "the
+  consumer recognizes the type but not at this MAJOR.MINOR" — carrying the
+  served versions in `message` and in `details.servedVersions`. A family it does
+  not serve stays `unsupportedType`. Both now carry `details.requestedType`,
+  because the framework puts the rejected URI only in prose and a client should
+  not have to slice a sentence to recover it. Derived from the dispatch table,
+  not a second list: a migration hint naming a version the VTA does not serve is
+  worse than no hint.
+
+  This half only helps the next skew, since the VTA that produced the bad message
+  is by definition the old one. The other two halves help now.
+
+- **vta**: Keep not-found, conflict and gone typed across the Trust-Task boundary ([#1219](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1219))
+
+`pnm approvals list` failed on a VTA that had never had an approval rule:
+
+      Protocol error: trust task failed [taskFailed]:
+      task failed: not found: policy `approvals` not found
+
+  A VTA with no approval rule has no `approvals` policy row — that is the
+  shipping default, and the CLI is written for it: `load()` maps a missing
+  row to an empty model. The arm could never fire.
+
+  The Trust-Task framework defines no `notFound` / `conflict` / `gone`
+  standard code, so `app_error_to_reject` sent all three out as `taskFailed`
+  with `details: None`. The SDK had nothing to key on and fell through to
+  `VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
+  the approvals CLI was dead code on the only transport that surface uses
+  (it is Trust-Task-only; no `/policies` REST route exists).
+
+  The blast radius is the whole surface, not just `list`: every `pnm
+  approvals` subcommand reads the row through the same `load()`, `require`
+  included. Since `require` must read before it writes, the *first* rule was
+  uncreatable — DTTE could not be configured on a fresh VTA at all.
+
+  REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
+  protocol-messages keep it in a problem-report code (`from_problem_report`).
+  The Trust-Task path was the only one that lost it, against the workspace
+  rule to preserve type information across every transport.
+
+  `taskFailed` remains the correct wire code — there is no other. The
+  discriminator goes in `details.reason`, the channel the consent gate
+  already established for exactly this reason, with the values defined once
+  in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
+  from one definition. `VtaClient::trust_task_error` maps them back to
+  `NotFound` / `Conflict` / `Gone`.
+
+  Fixing `Conflict` alongside `NotFound` also restores the CLI's
+  suggest-the-fix guidance, which switches on the typed variant.
+
+  A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
+  failure and the shape an older VTA emits, so a new client does not misread
+  every pre-upgrade failure as typed. Against such a VTA the workarounds are
+  `pnm policy list` or the offline `vta approvals list`, both documented.
+
+
+
 ## [0.32.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.1...vta-sdk-v0.32.2) — 2026-08-29
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.32.2"
+version = "0.32.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,189 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.23.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.3...vta-service-v0.23.4) — 2026-09-01
+
+
+### Fixed
+
+- **vta**: Resolve approver sets from one row-first source, not three ([#1221](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1221))
+
+A consent decision from an approver added with `pnm approvals approvers
+  add` was refused:
+
+      audit: action="consent.decision" outcome="denied:not_a_member"
+
+  Three places ask "who is in this approver set?", and they disagreed:
+
+  | Site | Read |
+  |---|---|
+  | `policy_gate` — raise the pending | row first, config fallback |
+  | `ceremony::may_attempt_ceremony` — transport gate | config only |
+  | `task_consent` — accept the decision | config only |
+
+  `pnm approvals approvers add` writes the declarative policy row. The gate
+  read that row, found the set, raised the pending and pushed the signed
+  request to the approver. The approver signed a valid decision — and the
+  two config-only sites looked in a table that never had the set, so the
+  transport gate turned it away pre-auth and the handler denied it
+  `not_a_member`.
+
+  The effect is that DTTE could not be operated through its own CLI. The
+  documented way to manage an approver set produced a set that could raise
+  requests but never accept an answer, and the only workaround was to *also*
+  carry the set in `config.toml` and restart — the very thing row-first
+  exists to avoid, since `[policy.approver_sets]` is a seed applied once.
+
+  All three now resolve through `policy_gate::effective_approver_sets`:
+  config, overridden by the row **per set name**. Per-set rather than
+  whole-model, so an operator with three sets in config who edits one with
+  the CLI does not strand the other two — and, more importantly, cannot
+  strand them inconsistently, since a whole-model rule would have let an
+  approver pass the named membership check while the transport gate, which
+  scans every set, still turned it away.
+
+  The transport gate fails closed: a store error is not a membership answer,
+  so it refuses the decision and warns rather than admitting the sender.
+
+  `ceremony.rs` was the site that failed most quietly — it runs before
+  authentication, so a decision it rejects never reaches a handler and never
+  appears in the audit trail at all.
+
+- **provisioning**: Say which side is out of date, and check authorization before minting ([#1220](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1220))
+
+An operator ran OpenVTC's setup wizard against a VTA and got:
+
+      X Provision integration DID + admin credential — trust task failed
+        [unsupportedType]: unsupported type:
+        https://trusttasks.org/spec/provision/integration/0.3
+
+  with a green tick on the row above it. Two things were wrong — no ACL grant
+  for the setup DID on the VTA they had reached, and it was not the VTA they
+  meant — and the run reported neither. It took an hour and a wrong diagnosis
+  before anyone suspected the VTA rather than provisioning.
+
+  Every fact needed was already on hand. The VTA was serving
+  `provision/integration/0.2` two lines further down the dispatch table it had
+  just failed to match. The wizard held the VTA's DID and the setup DID. Nothing
+  put the two together, and the message that did reach the operator said only
+  what could not be done.
+
+  **The rejection now names what it can do.** `method_not_found` compares the
+  unknown URI's family against `dispatched_uris()`; a family this VTA serves at
+  another version is `unsupportedVersion` — SPEC's code for exactly this, "the
+  consumer recognizes the type but not at this MAJOR.MINOR" — carrying the
+  served versions in `message` and in `details.servedVersions`. A family it does
+  not serve stays `unsupportedType`. Both now carry `details.requestedType`,
+  because the framework puts the rejected URI only in prose and a client should
+  not have to slice a sentence to recover it. Derived from the dispatch table,
+  not a second list: a migration hint naming a version the VTA does not serve is
+  worse than no hint.
+
+  This half only helps the next skew, since the VTA that produced the bad message
+  is by definition the old one. The other two halves help now.
+
+- **vta**: Keep not-found, conflict and gone typed across the Trust-Task boundary ([#1219](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1219))
+
+`pnm approvals list` failed on a VTA that had never had an approval rule:
+
+      Protocol error: trust task failed [taskFailed]:
+      task failed: not found: policy `approvals` not found
+
+  A VTA with no approval rule has no `approvals` policy row — that is the
+  shipping default, and the CLI is written for it: `load()` maps a missing
+  row to an empty model. The arm could never fire.
+
+  The Trust-Task framework defines no `notFound` / `conflict` / `gone`
+  standard code, so `app_error_to_reject` sent all three out as `taskFailed`
+  with `details: None`. The SDK had nothing to key on and fell through to
+  `VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
+  the approvals CLI was dead code on the only transport that surface uses
+  (it is Trust-Task-only; no `/policies` REST route exists).
+
+  The blast radius is the whole surface, not just `list`: every `pnm
+  approvals` subcommand reads the row through the same `load()`, `require`
+  included. Since `require` must read before it writes, the *first* rule was
+  uncreatable — DTTE could not be configured on a fresh VTA at all.
+
+  REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
+  protocol-messages keep it in a problem-report code (`from_problem_report`).
+  The Trust-Task path was the only one that lost it, against the workspace
+  rule to preserve type information across every transport.
+
+  `taskFailed` remains the correct wire code — there is no other. The
+  discriminator goes in `details.reason`, the channel the consent gate
+  already established for exactly this reason, with the values defined once
+  in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
+  from one definition. `VtaClient::trust_task_error` maps them back to
+  `NotFound` / `Conflict` / `Gone`.
+
+  Fixing `Conflict` alongside `NotFound` also restores the CLI's
+  suggest-the-fix guidance, which switches on the typed variant.
+
+  A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
+  failure and the shape an older VTA emits, so a new client does not misread
+  every pre-upgrade failure as typed. Against such a VTA the workarounds are
+  `pnm policy list` or the offline `vta approvals list`, both documented.
+
+- **vta**: Scope device list, disable and wipe to the caller's contexts ([#1217](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1217))
+
+`device/list`, `device/disable` and `device/wipe` gated on
+  `auth.require_manage()` and nothing else. That check is role-only —
+  `Role::Admin || Role::Initiator`, with no reference to `allowed_contexts` —
+  and all three then reached for `list_acl_entries()`, an unfiltered scan of
+  the `acl` keyspace. At no point was the caller's context scope applied.
+
+  So a context-scoped admin read every `DeviceBinding` on the VTA: the
+  `displayName`, `platform` and `lastSeenAt` of machines belonging to
+  principals in contexts they hold no rights in. For the OpenVTC producer
+  `displayName` is `OpenVTC on {hostname} ({profile})`, so that is a hostname
+  — frequently a person's name — plus an activity window, disclosed to an
+  admin whose grant was deliberately scoped elsewhere.
+
+  The two mutations were worse than the listing. Neither checked anything
+  after finding a binding by `deviceId`, so any context admin could disable or
+  wipe *any* device on the VTA, a super-admin's included. That is authority
+  over another context's principals, not merely visibility into them.
+
+  All three now go through `is_acl_entry_visible`, the existing management
+  predicate the ACL mutation paths already use, so device management and ACL
+  management answer the same question the same way. The two mutations share a
+  new `find_manageable_device` helper for the same reason — they had already
+  drifted apart from the listing, and one lookup means they cannot drift
+  again.
+
+  `is_acl_entry_visible` and not the wider `is_acl_entry_auditable` used by
+  `acl list`: both mutations plainly need management authority, and the
+  listing reads the same way on purpose. A binding carries operational
+  metadata about a *machine*, which is a different and more revealing
+  disclosure than the entry's authority that the auditable predicate exists to
+  surface. Read and mutations now agree — you see the devices you may manage.
+
+  An out-of-scope binding conflates to the same `NotFound` an absent id
+  returns, rather than a distinct `Forbidden` that would confirm the id exists
+  and make the error an oracle for enumerating device ids.
+
+  Behaviour change worth noting for operators: an `Initiator` with an empty
+  `allowed_contexts` is authorized *nowhere*, not everywhere, so it now lists
+  no devices where it previously listed all of them. That is the documented
+  `ActScope` reading — an empty context list means unrestricted only for
+  `Role::Admin` — and it is the specific misreading this defect class keeps
+  producing (#746, #769, #770). Super-admins are unaffected.
+
+  Tests cover the context admin, subtree ancestry, the super-admin
+  no-regression control, the acts-nowhere case, the `ActScope::All` edge (a
+  super-admin's own device names no context, so it is not inside any context
+  admin's subtree), and both refused mutations asserting no write occurred.
+  Six of the seven behavioural tests fail against the pre-fix code; the two
+  controls pass either way.
+
+  Found while assessing sankarshanmukhopadhyay/rahp-toolkit#285, which
+  reported a different and unfounded cross-context correlation claim about the
+  same `displayName` value. This is the real cross-context exposure of that
+  field, and it was not what that finding tested.
+
+
+
 ## [0.23.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.2...vta-service-v0.23.3) — 2026-08-30
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.23.3"
+version = "0.23.4"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.1...vta-tee-v0.2.2) — 2026-09-01
+
+
 ## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.0...vta-tee-v0.2.1) — 2026-08-29
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.1...vta-vault-v0.5.2) — 2026-09-01
+
+
 ## [0.5.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.0...vta-vault-v0.5.1) — 2026-08-29
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.2...vta-webvh-v0.2.3) — 2026-09-01
+
+
 ## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.1...vta-webvh-v0.2.2) — 2026-08-30
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.16.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.16.0...vti-common-v0.16.1) — 2026-09-01
+
+
 ## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.15.0...vti-common-v0.16.0) — 2026-08-29
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-webauthn/CHANGELOG.md
+++ b/vti-webauthn/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-webauthn-v0.2.0...vti-webauthn-v0.2.1) — 2026-09-01
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-webauthn-v0.1.1...vti-webauthn-v0.2.0) — 2026-08-26
 
 

--- a/vti-webauthn/Cargo.toml
+++ b/vti-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vti-webauthn"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.32.2 -> 0.32.3 (✓ API compatible changes)
* `vti-common`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `vta-cli-common`: 0.12.2 -> 0.12.3 (✓ API compatible changes)
* `cnm-cli`: 0.13.2 -> 0.13.3
* `pnm-cli`: 0.14.2 -> 0.14.3
* `vta-keys`: 0.4.1 -> 0.4.2
* `vta-backup`: 0.3.1 -> 0.3.2
* `vta-policy`: 0.3.1 -> 0.3.2
* `vta-vault`: 0.5.1 -> 0.5.2
* `vta-tee`: 0.2.1 -> 0.2.2
* `vta-webvh`: 0.2.2 -> 0.2.3
* `vti-webauthn`: 0.2.0 -> 0.2.1
* `vta-service`: 0.23.3 -> 0.23.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.32.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.2...vta-sdk-v0.32.3) — 2026-09-01

### Fixed

- **provisioning**: Say which side is out of date, and check authorization before minting ([#1220](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1220))

An operator ran OpenVTC's setup wizard against a VTA and got:

      X Provision integration DID + admin credential — trust task failed
        [unsupportedType]: unsupported type:
        https://trusttasks.org/spec/provision/integration/0.3

  with a green tick on the row above it. Two things were wrong — no ACL grant
  for the setup DID on the VTA they had reached, and it was not the VTA they
  meant — and the run reported neither. It took an hour and a wrong diagnosis
  before anyone suspected the VTA rather than provisioning.

  Every fact needed was already on hand. The VTA was serving
  `provision/integration/0.2` two lines further down the dispatch table it had
  just failed to match. The wizard held the VTA's DID and the setup DID. Nothing
  put the two together, and the message that did reach the operator said only
  what could not be done.

  **The rejection now names what it can do.** `method_not_found` compares the
  unknown URI's family against `dispatched_uris()`; a family this VTA serves at
  another version is `unsupportedVersion` — SPEC's code for exactly this, "the
  consumer recognizes the type but not at this MAJOR.MINOR" — carrying the
  served versions in `message` and in `details.servedVersions`. A family it does
  not serve stays `unsupportedType`. Both now carry `details.requestedType`,
  because the framework puts the rejected URI only in prose and a client should
  not have to slice a sentence to recover it. Derived from the dispatch table,
  not a second list: a migration hint naming a version the VTA does not serve is
  worse than no hint.

  This half only helps the next skew, since the VTA that produced the bad message
  is by definition the old one. The other two halves help now.

- **vta**: Keep not-found, conflict and gone typed across the Trust-Task boundary ([#1219](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1219))

`pnm approvals list` failed on a VTA that had never had an approval rule:

      Protocol error: trust task failed [taskFailed]:
      task failed: not found: policy `approvals` not found

  A VTA with no approval rule has no `approvals` policy row — that is the
  shipping default, and the CLI is written for it: `load()` maps a missing
  row to an empty model. The arm could never fire.

  The Trust-Task framework defines no `notFound` / `conflict` / `gone`
  standard code, so `app_error_to_reject` sent all three out as `taskFailed`
  with `details: None`. The SDK had nothing to key on and fell through to
  `VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
  the approvals CLI was dead code on the only transport that surface uses
  (it is Trust-Task-only; no `/policies` REST route exists).

  The blast radius is the whole surface, not just `list`: every `pnm
  approvals` subcommand reads the row through the same `load()`, `require`
  included. Since `require` must read before it writes, the *first* rule was
  uncreatable — DTTE could not be configured on a fresh VTA at all.

  REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
  protocol-messages keep it in a problem-report code (`from_problem_report`).
  The Trust-Task path was the only one that lost it, against the workspace
  rule to preserve type information across every transport.

  `taskFailed` remains the correct wire code — there is no other. The
  discriminator goes in `details.reason`, the channel the consent gate
  already established for exactly this reason, with the values defined once
  in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
  from one definition. `VtaClient::trust_task_error` maps them back to
  `NotFound` / `Conflict` / `Gone`.

  Fixing `Conflict` alongside `NotFound` also restores the CLI's
  suggest-the-fix guidance, which switches on the typed variant.

  A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
  failure and the shape an older VTA emits, so a new client does not misread
  every pre-upgrade failure as typed. Against such a VTA the workarounds are
  `pnm policy list` or the offline `vta approvals list`, both documented.
</blockquote>


## `vta-cli-common`

<blockquote>

## [0.12.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.2...vta-cli-common-v0.12.3) — 2026-09-01

### Fixed

- **vta**: Keep not-found, conflict and gone typed across the Trust-Task boundary ([#1219](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1219))

`pnm approvals list` failed on a VTA that had never had an approval rule:

      Protocol error: trust task failed [taskFailed]:
      task failed: not found: policy `approvals` not found

  A VTA with no approval rule has no `approvals` policy row — that is the
  shipping default, and the CLI is written for it: `load()` maps a missing
  row to an empty model. The arm could never fire.

  The Trust-Task framework defines no `notFound` / `conflict` / `gone`
  standard code, so `app_error_to_reject` sent all three out as `taskFailed`
  with `details: None`. The SDK had nothing to key on and fell through to
  `VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
  the approvals CLI was dead code on the only transport that surface uses
  (it is Trust-Task-only; no `/policies` REST route exists).

  The blast radius is the whole surface, not just `list`: every `pnm
  approvals` subcommand reads the row through the same `load()`, `require`
  included. Since `require` must read before it writes, the *first* rule was
  uncreatable — DTTE could not be configured on a fresh VTA at all.

  REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
  protocol-messages keep it in a problem-report code (`from_problem_report`).
  The Trust-Task path was the only one that lost it, against the workspace
  rule to preserve type information across every transport.

  `taskFailed` remains the correct wire code — there is no other. The
  discriminator goes in `details.reason`, the channel the consent gate
  already established for exactly this reason, with the values defined once
  in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
  from one definition. `VtaClient::trust_task_error` maps them back to
  `NotFound` / `Conflict` / `Gone`.

  Fixing `Conflict` alongside `NotFound` also restores the CLI's
  suggest-the-fix guidance, which switches on the typed variant.

  A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
  failure and the shape an older VTA emits, so a new client does not misread
  every pre-upgrade failure as typed. Against such a VTA the workarounds are
  `pnm policy list` or the offline `vta approvals list`, both documented.
</blockquote>










## `vta-service`

<blockquote>

## [0.23.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.3...vta-service-v0.23.4) — 2026-09-01

### Fixed

- **vta**: Resolve approver sets from one row-first source, not three ([#1221](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1221))

A consent decision from an approver added with `pnm approvals approvers
  add` was refused:

      audit: action="consent.decision" outcome="denied:not_a_member"

  Three places ask "who is in this approver set?", and they disagreed:

  | Site | Read |
  |---|---|
  | `policy_gate` — raise the pending | row first, config fallback |
  | `ceremony::may_attempt_ceremony` — transport gate | config only |
  | `task_consent` — accept the decision | config only |

  `pnm approvals approvers add` writes the declarative policy row. The gate
  read that row, found the set, raised the pending and pushed the signed
  request to the approver. The approver signed a valid decision — and the
  two config-only sites looked in a table that never had the set, so the
  transport gate turned it away pre-auth and the handler denied it
  `not_a_member`.

  The effect is that DTTE could not be operated through its own CLI. The
  documented way to manage an approver set produced a set that could raise
  requests but never accept an answer, and the only workaround was to *also*
  carry the set in `config.toml` and restart — the very thing row-first
  exists to avoid, since `[policy.approver_sets]` is a seed applied once.

  All three now resolve through `policy_gate::effective_approver_sets`:
  config, overridden by the row **per set name**. Per-set rather than
  whole-model, so an operator with three sets in config who edits one with
  the CLI does not strand the other two — and, more importantly, cannot
  strand them inconsistently, since a whole-model rule would have let an
  approver pass the named membership check while the transport gate, which
  scans every set, still turned it away.

  The transport gate fails closed: a store error is not a membership answer,
  so it refuses the decision and warns rather than admitting the sender.

  `ceremony.rs` was the site that failed most quietly — it runs before
  authentication, so a decision it rejects never reaches a handler and never
  appears in the audit trail at all.

- **provisioning**: Say which side is out of date, and check authorization before minting ([#1220](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1220))

An operator ran OpenVTC's setup wizard against a VTA and got:

      X Provision integration DID + admin credential — trust task failed
        [unsupportedType]: unsupported type:
        https://trusttasks.org/spec/provision/integration/0.3

  with a green tick on the row above it. Two things were wrong — no ACL grant
  for the setup DID on the VTA they had reached, and it was not the VTA they
  meant — and the run reported neither. It took an hour and a wrong diagnosis
  before anyone suspected the VTA rather than provisioning.

  Every fact needed was already on hand. The VTA was serving
  `provision/integration/0.2` two lines further down the dispatch table it had
  just failed to match. The wizard held the VTA's DID and the setup DID. Nothing
  put the two together, and the message that did reach the operator said only
  what could not be done.

  **The rejection now names what it can do.** `method_not_found` compares the
  unknown URI's family against `dispatched_uris()`; a family this VTA serves at
  another version is `unsupportedVersion` — SPEC's code for exactly this, "the
  consumer recognizes the type but not at this MAJOR.MINOR" — carrying the
  served versions in `message` and in `details.servedVersions`. A family it does
  not serve stays `unsupportedType`. Both now carry `details.requestedType`,
  because the framework puts the rejected URI only in prose and a client should
  not have to slice a sentence to recover it. Derived from the dispatch table,
  not a second list: a migration hint naming a version the VTA does not serve is
  worse than no hint.

  This half only helps the next skew, since the VTA that produced the bad message
  is by definition the old one. The other two halves help now.

- **vta**: Keep not-found, conflict and gone typed across the Trust-Task boundary ([#1219](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1219))

`pnm approvals list` failed on a VTA that had never had an approval rule:

      Protocol error: trust task failed [taskFailed]:
      task failed: not found: policy `approvals` not found

  A VTA with no approval rule has no `approvals` policy row — that is the
  shipping default, and the CLI is written for it: `load()` maps a missing
  row to an empty model. The arm could never fire.

  The Trust-Task framework defines no `notFound` / `conflict` / `gone`
  standard code, so `app_error_to_reject` sent all three out as `taskFailed`
  with `details: None`. The SDK had nothing to key on and fell through to
  `VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
  the approvals CLI was dead code on the only transport that surface uses
  (it is Trust-Task-only; no `/policies` REST route exists).

  The blast radius is the whole surface, not just `list`: every `pnm
  approvals` subcommand reads the row through the same `load()`, `require`
  included. Since `require` must read before it writes, the *first* rule was
  uncreatable — DTTE could not be configured on a fresh VTA at all.

  REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
  protocol-messages keep it in a problem-report code (`from_problem_report`).
  The Trust-Task path was the only one that lost it, against the workspace
  rule to preserve type information across every transport.

  `taskFailed` remains the correct wire code — there is no other. The
  discriminator goes in `details.reason`, the channel the consent gate
  already established for exactly this reason, with the values defined once
  in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
  from one definition. `VtaClient::trust_task_error` maps them back to
  `NotFound` / `Conflict` / `Gone`.

  Fixing `Conflict` alongside `NotFound` also restores the CLI's
  suggest-the-fix guidance, which switches on the typed variant.

  A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
  failure and the shape an older VTA emits, so a new client does not misread
  every pre-upgrade failure as typed. Against such a VTA the workarounds are
  `pnm policy list` or the offline `vta approvals list`, both documented.

- **vta**: Scope device list, disable and wipe to the caller's contexts ([#1217](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1217))

`device/list`, `device/disable` and `device/wipe` gated on
  `auth.require_manage()` and nothing else. That check is role-only —
  `Role::Admin || Role::Initiator`, with no reference to `allowed_contexts` —
  and all three then reached for `list_acl_entries()`, an unfiltered scan of
  the `acl` keyspace. At no point was the caller's context scope applied.

  So a context-scoped admin read every `DeviceBinding` on the VTA: the
  `displayName`, `platform` and `lastSeenAt` of machines belonging to
  principals in contexts they hold no rights in. For the OpenVTC producer
  `displayName` is `OpenVTC on {hostname} ({profile})`, so that is a hostname
  — frequently a person's name — plus an activity window, disclosed to an
  admin whose grant was deliberately scoped elsewhere.

  The two mutations were worse than the listing. Neither checked anything
  after finding a binding by `deviceId`, so any context admin could disable or
  wipe *any* device on the VTA, a super-admin's included. That is authority
  over another context's principals, not merely visibility into them.

  All three now go through `is_acl_entry_visible`, the existing management
  predicate the ACL mutation paths already use, so device management and ACL
  management answer the same question the same way. The two mutations share a
  new `find_manageable_device` helper for the same reason — they had already
  drifted apart from the listing, and one lookup means they cannot drift
  again.

  `is_acl_entry_visible` and not the wider `is_acl_entry_auditable` used by
  `acl list`: both mutations plainly need management authority, and the
  listing reads the same way on purpose. A binding carries operational
  metadata about a *machine*, which is a different and more revealing
  disclosure than the entry's authority that the auditable predicate exists to
  surface. Read and mutations now agree — you see the devices you may manage.

  An out-of-scope binding conflates to the same `NotFound` an absent id
  returns, rather than a distinct `Forbidden` that would confirm the id exists
  and make the error an oracle for enumerating device ids.

  Behaviour change worth noting for operators: an `Initiator` with an empty
  `allowed_contexts` is authorized *nowhere*, not everywhere, so it now lists
  no devices where it previously listed all of them. That is the documented
  `ActScope` reading — an empty context list means unrestricted only for
  `Role::Admin` — and it is the specific misreading this defect class keeps
  producing (#746, #769, #770). Super-admins are unaffected.

  Tests cover the context admin, subtree ancestry, the super-admin
  no-regression control, the acts-nowhere case, the `ActScope::All` edge (a
  super-admin's own device names no context, so it is not inside any context
  admin's subtree), and both refused mutations asserting no write occurred.
  Six of the seven behavioural tests fail against the pre-fix code; the two
  controls pass either way.

  Found while assessing sankarshanmukhopadhyay/rahp-toolkit#285, which
  reported a different and unfounded cross-context correlation claim about the
  same `displayName` value. This is the real cross-context exposure of that
  field, and it was not what that finding tested.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).