### PR TITLE
fix(vta): keep not-found, conflict and gone typed across the Trust-Task boundary

### DIFF
--- a/docs/02-vta/approvals.md
+++ b/docs/02-vta/approvals.md
@@ -65,6 +65,18 @@ https://trusttasks.org/spec/vta/webvh/dids/update/1.0
   approvers: 1 member(s) — fewer than the 2 required, so this task can never run
 ```
 
+On a VTA that has never had an approval rule there is no `approvals` policy row,
+and both commands print an empty model — that is the shipping default, not an
+error. `pnm policy list` shows the same thing from the other side: only the
+`default` baseline row, no `approvals`.
+
+> **If instead you see `trust task failed [taskFailed]: … policy \`approvals\`
+> not found`,** the VTA predates the fix that lets the CLI recognise an absent
+> row. The framework defines no `notFound` code, so the outcome rides out as
+> `taskFailed`; the VTA now marks it with `details.reason: "not_found"` and the
+> SDK maps that back to a typed error. Against an older VTA, use `pnm policy
+> list` to check for the row, or the offline `vta approvals list`.
+
 ## Refusals happen when you write, not when you're blocked
 
 A rule that could never be satisfied is refused at the point you create it:

--- a/vta-cli-common/src/commands/approvals.rs
+++ b/vta-cli-common/src/commands/approvals.rs
@@ -61,6 +61,15 @@ async fn load(client: &VtaClient) -> Result<Model, Box<dyn std::error::Error>> {
         }
         // No row yet: an empty model, which is also the shipping default (a VTA
         // that has never had an approval rule gates nothing).
+        //
+        // This surface is Trust-Task-only, and the framework defines no
+        // `notFound` code — the absent row arrives as `taskFailed` carrying
+        // `details.reason: "not_found"`, which the SDK maps back to this
+        // variant. Before it did, this arm could not fire and *every* command
+        // here failed on a fresh VTA, `require` included: the first rule was
+        // uncreatable because `require` reads the row before writing it. If a
+        // change to that mapping strands this arm again, the same lockout
+        // returns silently.
         Err(VtaError::NotFound(_)) => Ok(Model {
             rules: Vec::new(),
             approver_sets: BTreeMap::new(),

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1961,6 +1961,31 @@ impl VtaClient {
             });
         }
 
+        // The framework has no `notFound` / `conflict` / `gone` standard code,
+        // so all three arrive as `taskFailed` and the code alone cannot tell
+        // them from a genuine failure. The service marks them in
+        // `details.reason` for exactly this reason; recovering the typed
+        // variant here is what keeps a Trust-Task caller able to `match` on the
+        // same variants the REST (`from_http`) and DIDComm protocol-message
+        // (`from_problem_report`) paths already produce.
+        //
+        // Without it, a caller that treats an absent resource as a normal state
+        // cannot recognise one — which is how every `pnm approvals` subcommand
+        // came to fail on a VTA that had simply never had an approval rule.
+        if let Some(reason) = payload
+            .get("details")
+            .and_then(|d| d.get("reason"))
+            .and_then(|r| r.as_str())
+        {
+            use crate::protocols::trust_task_reject_reasons as r;
+            match reason {
+                r::NOT_FOUND => return Some(VtaError::NotFound(message.to_string())),
+                r::CONFLICT => return Some(VtaError::Conflict(message.to_string())),
+                r::GONE => return Some(VtaError::Gone(message.to_string())),
+                _ => {}
+            }
+        }
+
         // `unavailable` is the one rejection that means "ask again" rather
         // than "this failed" — the idempotency layer answers with it while a
         // first attempt on the same key is still running. Collapsing it into
@@ -2303,6 +2328,81 @@ mod tests {
             "code": "malformedRequest",
             "message": "payload does not conform",
             "details": { "reason": "schema:invalid" }
+        });
+        assert!(matches!(
+            VtaClient::trust_task_error(&payload),
+            Some(VtaError::Protocol(_))
+        ));
+    }
+
+    // ── outcome typing across the Trust-Task boundary ───────────────
+
+    /// The regression: an absent resource must arrive as [`VtaError::NotFound`],
+    /// not as an opaque string.
+    ///
+    /// A VTA that has never had an approval rule has no `approvals` policy row —
+    /// the shipping default. Every `pnm approvals` subcommand reads that row and
+    /// is written to treat a missing one as an empty model, but the framework
+    /// defines no `notFound` code, so the outcome rode out under `taskFailed`
+    /// and that arm could never fire. The whole surface failed on a fresh VTA,
+    /// `require` included — which made the *first* rule uncreatable, since
+    /// `require` must read the row before it can write it.
+    ///
+    /// The fixture is the service's real shape: `app_error_to_reject` puts the
+    /// discriminator in `details.reason`, the same channel the consent gate
+    /// uses, because `code` is `taskFailed` for all three of these outcomes.
+    #[test]
+    fn a_missing_resource_arrives_as_not_found() {
+        let payload = serde_json::json!({
+            "code": "taskFailed",
+            "message": "task failed: not found: policy `approvals` not found",
+            "details": { "reason": "not_found" }
+        });
+        match VtaClient::trust_task_error(&payload) {
+            Some(VtaError::NotFound(m)) => assert!(m.contains("`approvals`")),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    /// `Conflict` is the variant the CLI switches on to print the command the
+    /// operator should have run instead, so collapsing it costs the guidance as
+    /// well as the type.
+    #[test]
+    fn a_conflict_arrives_as_conflict() {
+        let payload = serde_json::json!({
+            "code": "taskFailed",
+            "message": "task failed: conflict: context `default` already exists",
+            "details": { "reason": "conflict" }
+        });
+        assert!(matches!(
+            VtaClient::trust_task_error(&payload),
+            Some(VtaError::Conflict(_))
+        ));
+    }
+
+    /// `Gone` is terminal: a consumed single-use resource can never succeed
+    /// again, so a caller must be able to tell it from a retryable failure.
+    #[test]
+    fn a_consumed_resource_arrives_as_gone() {
+        let payload = serde_json::json!({
+            "code": "taskFailed",
+            "message": "task failed: gone: the bootstrap carve-out is closed",
+            "details": { "reason": "gone" }
+        });
+        assert!(matches!(
+            VtaClient::trust_task_error(&payload),
+            Some(VtaError::Gone(_))
+        ));
+    }
+
+    /// A `taskFailed` carrying no `details` is a genuine failure and must stay
+    /// one. That is also the shape an older VTA emits, so this fallback is what
+    /// keeps a new client from misreading every pre-upgrade failure as typed.
+    #[test]
+    fn an_undiscriminated_task_failure_is_still_a_protocol_error() {
+        let payload = serde_json::json!({
+            "code": "taskFailed",
+            "message": "task failed: the mediator refused the handshake",
         });
         assert!(matches!(
             VtaClient::trust_task_error(&payload),

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -71,6 +71,53 @@ pub mod problem_report_codes {
     pub const PROVISION_CONTEXT_REQUIRED: &str = "provision/integration:contextRequired";
 }
 
+/// Machine-readable `details.reason` values the VTA puts on a Trust-Task
+/// rejection so the client can recover the outcome the server actually had.
+///
+/// # Why this exists
+///
+/// The Trust-Task framework defines no `notFound` / `conflict` / `gone`
+/// standard code, so all three ride out under `taskFailed`
+/// ([`RejectReason::TaskFailed`]). The code alone therefore cannot distinguish
+/// "the row you asked for is absent" — routinely a *normal* state a caller
+/// handles — from "this operation genuinely failed". Collapsing them loses
+/// information that both the REST path (HTTP 404 / 409 / 410, see
+/// [`VtaError::from_http`]) and the DIDComm protocol-message path
+/// ([`problem_report_codes`], see [`VtaError::from_problem_report`]) preserve,
+/// leaving the Trust-Task transport the only one that hands the caller an
+/// opaque string.
+///
+/// The concrete failure this was written for: a VTA that has never had an
+/// approval rule has no `approvals` policy row, which is the shipping default.
+/// `pnm approvals list` reads that row through `policy/get/0.1` and is written
+/// to treat a missing one as an empty model — but the `NotFound` never arrived
+/// as `NotFound`, so *every* `pnm approvals` subcommand failed on a fresh VTA,
+/// including the `require` that would have created the first rule.
+///
+/// The channel is the one the consent gate already established: `code` is
+/// `taskFailed` for everything, so a consumer keys on a stable `details.reason`
+/// instead.
+///
+/// [`RejectReason::TaskFailed`]: https://docs.rs/trust-tasks-rs
+/// [`VtaError::from_http`]: crate::error::VtaError::from_http
+/// [`VtaError::from_problem_report`]: crate::error::VtaError::from_problem_report
+pub mod trust_task_reject_reasons {
+    /// The requested resource does not exist. Recovers [`VtaError::NotFound`].
+    ///
+    /// [`VtaError::NotFound`]: crate::error::VtaError::NotFound
+    pub const NOT_FOUND: &str = "not_found";
+    /// The request conflicts with existing state (duplicate id, stale
+    /// `expectedVersion`). Recovers [`VtaError::Conflict`].
+    ///
+    /// [`VtaError::Conflict`]: crate::error::VtaError::Conflict
+    pub const CONFLICT: &str = "conflict";
+    /// The resource existed but is permanently gone (a consumed single-use
+    /// carve-out). Recovers [`VtaError::Gone`].
+    ///
+    /// [`VtaError::Gone`]: crate::error::VtaError::Gone
+    pub const GONE: &str = "gone";
+}
+
 /// Extract code and comment from a problem-report message body.
 pub fn extract_problem_report(body: &serde_json::Value) -> (String, String) {
     let code = body

--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -29,6 +29,7 @@ use trust_tasks_rs::{
     ErrorPayload, ErrorResponse, RejectReason, TrustTask, TrustTaskCode, TypeUri,
 };
 use uuid::Uuid;
+use vta_sdk::protocols::trust_task_reject_reasons as reasons;
 
 use crate::error::AppError;
 
@@ -82,13 +83,25 @@ pub(super) fn parse_payload<T: serde::de::DeserializeOwned>(
     })
 }
 
+/// A `taskFailed` carrying a machine-readable `details.reason`.
+///
+/// See the `NotFound` / `Conflict` / `Gone` arms of [`app_error_to_reject`] for
+/// why the code alone is not enough.
+fn task_failed_because(message: String, reason: &str) -> RejectReason {
+    RejectReason::TaskFailed {
+        reason: message,
+        details: Some(serde_json::json!({ "reason": reason })),
+    }
+}
+
 /// Map an `AppError` (the operation-layer error type) into a routed
 /// trust-task error response with the appropriate framework reject
 /// code:
 ///
 /// - `Authentication` / `Unauthorized` / `Forbidden` → `permission_denied`
 /// - `Validation` / `TrustTaskMalformed` / `InvalidCursor` → `malformed_request`
-/// - `NotFound` / `Conflict` / `Gone` → `task_failed`
+/// - `NotFound` / `Conflict` / `Gone` → `task_failed`, each discriminated by a
+///   `details.reason` from [`vta_sdk::protocols::trust_task_reject_reasons`]
 /// - everything else → `internal_error`
 pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> TrustTaskOutcome {
     let message = err.to_string();
@@ -103,18 +116,35 @@ pub(super) fn app_error_to_reject(doc: &TrustTask<Value>, err: AppError) -> Trus
         AppError::Validation(_) | AppError::TrustTaskMalformed(_) | AppError::InvalidCursor => {
             RejectReason::MalformedRequest { reason: message }
         }
-        // `Gone` rides with these rather than the `internal_error`
-        // fallback. No task produces it today (its producers are REST-only),
-        // but the fallback is the wrong default for it: a consumed single-use
-        // resource is a terminal *caller-visible* outcome, and reporting it as
-        // an internal error tells the client to retry something that can never
-        // succeed again.
-        AppError::NotFound(_) | AppError::Conflict(_) | AppError::Gone(_) => {
-            RejectReason::TaskFailed {
-                reason: message,
-                details: None,
-            }
-        }
+        // These three have no standard code of their own — §8.3 defines no
+        // `notFound` / `conflict` / `gone` — so all of them ride out under
+        // `taskFailed`. That is the correct wire code, but it is not enough on
+        // its own: a caller cannot tell "the row you asked for is absent" (very
+        // often a *normal* state it knows how to handle) from "this operation
+        // genuinely failed", and it loses the distinction the REST path keeps
+        // in an HTTP status and the DIDComm protocol-message path keeps in a
+        // problem-report code.
+        //
+        // So the discriminator goes in `details.reason`, the channel the
+        // consent gate already established for exactly this problem, and
+        // `VtaClient::trust_task_error` maps it back to the same typed
+        // `VtaError` variant the other two transports produce.
+        //
+        // Concretely: a VTA that has never had an approval rule has no
+        // `approvals` policy row, which is the shipping default. Every `pnm
+        // approvals` subcommand reads it through `policy/get/0.1` and is
+        // written to treat a missing row as an empty model — but with the type
+        // erased, that arm could never fire, so the whole surface failed on a
+        // fresh VTA, `require` included. That made the first rule
+        // uncreatable: `require` has to read the row before writing it.
+        //
+        // `Gone` rides here rather than in the `internal_error` fallback for a
+        // related reason: a consumed single-use resource is a terminal
+        // *caller-visible* outcome, and reporting it as an internal error tells
+        // the client to retry something that can never succeed again.
+        AppError::NotFound(_) => task_failed_because(message, reasons::NOT_FOUND),
+        AppError::Conflict(_) => task_failed_because(message, reasons::CONFLICT),
+        AppError::Gone(_) => task_failed_because(message, reasons::GONE),
         // Framework 0.5.0, *What a `message` May Not Say*: a `message` MUST NOT
         // reveal consumer-internal state. That rule is now normative for every
         // code, and `internalError` is where this service leaked hardest — the
@@ -388,6 +418,55 @@ mod tests {
             .as_str()
             .expect("payload carries a message")
             .to_string()
+    }
+
+    fn details_of(outcome: TrustTaskOutcome) -> Value {
+        let doc: Value = serde_json::from_slice(&outcome.body).expect("error doc parses");
+        doc["payload"]["details"].clone()
+    }
+
+    /// The regression: three distinct outcomes all leave as `taskFailed`, so
+    /// without a discriminator a caller cannot tell an absent resource from a
+    /// genuine failure — and an absent resource is very often a normal state.
+    ///
+    /// `pnm approvals list` is the case that broke. A VTA that has never had an
+    /// approval rule has no `approvals` policy row (the shipping default); the
+    /// CLI reads it and treats a missing row as an empty model, but with the
+    /// type erased that arm could never fire. Every `pnm approvals` subcommand
+    /// failed on a fresh VTA, `require` among them — so the first rule could
+    /// not be created, because `require` reads the row before writing it.
+    ///
+    /// REST keeps this distinction in an HTTP status and DIDComm
+    /// protocol-messages keep it in a problem-report code. This is what stops
+    /// the Trust-Task transport being the one that loses it.
+    #[test]
+    fn a_not_found_is_discriminated_from_a_plain_task_failure() {
+        let outcome = app_error_to_reject(&doc(), AppError::NotFound("policy `x`".into()));
+        assert_eq!(details_of(outcome)["reason"], reasons::NOT_FOUND);
+    }
+
+    #[test]
+    fn a_conflict_is_discriminated_from_a_plain_task_failure() {
+        let outcome = app_error_to_reject(&doc(), AppError::Conflict("already exists".into()));
+        assert_eq!(details_of(outcome)["reason"], reasons::CONFLICT);
+    }
+
+    #[test]
+    fn a_gone_is_discriminated_from_a_plain_task_failure() {
+        let outcome = app_error_to_reject(&doc(), AppError::Gone("carve-out closed".into()));
+        assert_eq!(details_of(outcome)["reason"], reasons::GONE);
+    }
+
+    /// The three reasons must stay distinct. Collapsing any pair would let a
+    /// caller act on the wrong one — retrying a `Gone` that can never succeed,
+    /// or reading a `Conflict` as "absent" and creating a duplicate.
+    #[test]
+    fn the_three_reasons_are_distinct() {
+        let all = [reasons::NOT_FOUND, reasons::CONFLICT, reasons::GONE];
+        let mut seen = std::collections::BTreeSet::new();
+        for r in all {
+            assert!(seen.insert(r), "`{r}` is used for more than one outcome");
+        }
     }
 
     /// An extended code reaches the wire in its `<slug>:<local>` spelling.


### PR DESCRIPTION
`pnm approvals list` failed on a VTA that had never had an approval rule:

    Protocol error: trust task failed [taskFailed]:
    task failed: not found: policy `approvals` not found

A VTA with no approval rule has no `approvals` policy row — that is the
shipping default, and the CLI is written for it: `load()` maps a missing
row to an empty model. The arm could never fire.

The Trust-Task framework defines no `notFound` / `conflict` / `gone`
standard code, so `app_error_to_reject` sent all three out as `taskFailed`
with `details: None`. The SDK had nothing to key on and fell through to
`VtaError::Protocol(String)`, so the `Err(VtaError::NotFound(_))` arm in
the approvals CLI was dead code on the only transport that surface uses
(it is Trust-Task-only; no `/policies` REST route exists).

The blast radius is the whole surface, not just `list`: every `pnm
approvals` subcommand reads the row through the same `load()`, `require`
included. Since `require` must read before it writes, the *first* rule was
uncreatable — DTTE could not be configured on a fresh VTA at all.

REST keeps this distinction in an HTTP status (`from_http`) and DIDComm
protocol-messages keep it in a problem-report code (`from_problem_report`).
The Trust-Task path was the only one that lost it, against the workspace
rule to preserve type information across every transport.

`taskFailed` remains the correct wire code — there is no other. The
discriminator goes in `details.reason`, the channel the consent gate
already established for exactly this reason, with the values defined once
in `vta_sdk::protocols::trust_task_reject_reasons` so both sides derive
from one definition. `VtaClient::trust_task_error` maps them back to
`NotFound` / `Conflict` / `Gone`.

Fixing `Conflict` alongside `NotFound` also restores the CLI's
suggest-the-fix guidance, which switches on the typed variant.

A `taskFailed` with no `details` stays `Protocol` — that is both a genuine
failure and the shape an older VTA emits, so a new client does not misread
every pre-upgrade failure as typed. Against such a VTA the workarounds are
`pnm policy list` or the offline `vta approvals list`, both documented.

## How this was found

The offline `vta approvals list` works fine on the same VTA — it reads the
same row straight from fjall via `vta_policy::approvals::load`, which
returns an empty model for a missing row (there is a test named "a missing
row reads as empty"). Two halves of one command disagreeing, with the
transport as the only difference, is what pointed at the mapping rather
than at the approvals surface itself.

## Changes

| File | Change |
|---|---|
| `vta-sdk/src/protocols/mod.rs` | New `trust_task_reject_reasons` module — the three values, defined once so both sides derive from one definition |
| `vta-service/src/trust_tasks/helpers.rs` | `app_error_to_reject` splits the collapsed arm into three, each attaching `details.reason` |
| `vta-sdk/src/client/mod.rs` | `trust_task_error` reads `details.reason` and returns the typed variant |
| `vta-cli-common/src/commands/approvals.rs` | Comment only — why that `NotFound` arm is reachable, and what breaks if it is stranded again |
| `docs/02-vta/approvals.md` | An empty model on a fresh VTA is normal; workarounds against an unfixed VTA |

The `details` payload is a single member, far inside the existing
`bound_details` limits, so it is never dropped.

## Compatibility

- **Old VTA, new client** — an undiscriminated `taskFailed` still maps to
  `VtaError::Protocol`, so nothing is misread as typed. The documented
  workarounds cover the approvals surface until the VTA is upgraded.
- **New VTA, old client** — `details` is additive and ignored by a client
  that does not read it; behaviour is unchanged.
- No caller in the workspace matches on `VtaError::Protocol` to detect an
  absent resource, so nothing regresses on the newly-typed path. The CLI
  renderer gains its better `NotFound` / `Conflict` guidance.

## Tests

- 4 in `vta-sdk` — each variant recovered from `details.reason`; an
  undiscriminated `taskFailed` stays `Protocol` (also the older-VTA shape).
- 4 in `vta-service` — each reason emitted on the real reject path, and the
  three stay distinct (collapsing any pair would let a caller retry a `Gone`
  that can never succeed, or read a `Conflict` as "absent" and duplicate).

## Verification

- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean, zero warnings
- `cargo test --workspace` — green

## Not addressed here

`policy.enforcement`, the DTTE master switch, is readable from no wire
surface — `pnm config get` returns only the config-patch registry
(`vta_did` / `vta_name` / `public_url`). Answering "is DTTE enforcing?"
still requires reading `config.toml` on the host. Separate gap, left alone.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>
