### PR TITLE
fix(vta): resolve approver sets from one row-first source, not three

### DIFF
--- a/docs/02-vta/task-consent.md
+++ b/docs/02-vta/task-consent.md
@@ -260,6 +260,15 @@ Approve on the device, and the re-submit goes through.
 the block is inert — see [Approvals § Seeding](./approvals.md#seeding-a-new-vta)
 for why re-reading every boot was the trap this replaced.
 
+"The row wins" holds at **every** point the ceremony asks who is in a set: the
+gate that raises the pending, the transport gate that lets a decision past the
+ACL, and the handler that accepts it. All three resolve through one function
+(`policy_gate::effective_approver_sets` — config, overridden per set name by the
+row). Until they did, only the first was row-aware, so a set added with `pnm
+approvals approvers add` raised a request that the other two then refused as
+`not_a_member`, and the only way to get a decision accepted was to also carry the
+set in `config.toml` and restart.
+
 **`vta setup --from` cannot carry them.** `WizardInputs` is
 `#[serde(deny_unknown_fields)]` with no `policy` field
 (`vta-service/src/setup/from_toml.rs:58`), so a `[policy]` section in the wizard

--- a/vta-service/src/trust_tasks/ceremony.rs
+++ b/vta-service/src/trust_tasks/ceremony.rs
@@ -91,14 +91,21 @@ pub(crate) async fn may_attempt_ceremony(
     if type_uri != vta_sdk::trust_tasks::TASK_TASK_CONSENT_DECISION_0_1 {
         return true;
     }
-    state
-        .config
-        .read()
+    // Row-first, via the one resolver the whole ceremony shares. Reading
+    // `config.policy.approver_sets` directly here — as this did — turned an
+    // approver added with `pnm approvals approvers add` away at the *transport*
+    // gate, before the decision reached a handler at all. A store error is not a
+    // membership answer, so it fails closed rather than admitting the sender.
+    super::policy_gate::is_named_approver(state, sender_did)
         .await
-        .policy
-        .approver_sets
-        .values()
-        .any(|members| members.iter().any(|m| m == sender_did))
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                error = %e,
+                "could not resolve approver sets for the ceremony transport gate; \
+                 refusing this decision"
+            );
+            false
+        })
 }
 
 /// Read just the `type` member out of a Trust-Task envelope.

--- a/vta-service/src/trust_tasks/policy_gate.rs
+++ b/vta-service/src/trust_tasks/policy_gate.rs
@@ -234,6 +234,65 @@ async fn decide(
     }
 }
 
+/// Members of the named approver set, resolved **row-first**.
+///
+/// The declarative approvals row is authoritative; config is consulted only as a
+/// fallback, for a VTA whose sets are still declared there and which has not yet
+/// been seeded. Row-first is what makes `pnm approvals approvers` take effect
+/// without a restart.
+///
+/// # Why this is one function
+///
+/// Both halves of the ceremony ask "who is in this set?", and they must get the
+/// same answer. They did not: the gate resolved row-first (here) while the
+/// decision handler read `config.policy.approver_sets` alone. So a set built the
+/// documented way — `pnm approvals approvers add`, which writes the row — raised
+/// a pending, pushed the request, and had the approver's valid decision denied
+/// `not_a_member` against a config table that never had the set.
+///
+/// That made DTTE unusable through its own CLI: the only way to get a decision
+/// accepted was to *also* carry the set in `config.toml` and restart, which is
+/// the very thing row-first exists to avoid. Resolving it in one place is what
+/// stops the two sides drifting apart again.
+/// Every approver set as it effectively stands: config, with the row's entries
+/// overriding it **per set name**.
+///
+/// Per-set rather than whole-model, so an operator who declares three sets in
+/// config and then edits one with `pnm approvals approvers` does not lose the
+/// other two. A whole-model "row wins if non-empty" would strand them, and —
+/// worse — would strand them *inconsistently*, since the named lookup below is
+/// per-set: an approver could pass the membership check and still be turned away
+/// by the transport gate.
+pub(crate) async fn effective_approver_sets(
+    state: &AppState,
+) -> Result<std::collections::HashMap<String, Vec<String>>, AppError> {
+    let mut sets = state.config.read().await.policy.approver_sets.clone();
+    let model = crate::policy::approvals::load(&state.policy_ks).await?;
+    for (name, members) in &model.approver_sets {
+        sets.insert(name.clone(), members.clone());
+    }
+    Ok(sets)
+}
+
+pub(crate) async fn approver_set_members(
+    state: &AppState,
+    set_name: &str,
+) -> Result<Vec<String>, AppError> {
+    Ok(effective_approver_sets(state)
+        .await?
+        .remove(set_name)
+        .unwrap_or_default())
+}
+
+/// Whether `did` is named by *any* approver set — the question the pre-auth
+/// transport gate asks before letting a ceremony task past the ACL.
+pub(crate) async fn is_named_approver(state: &AppState, did: &str) -> Result<bool, AppError> {
+    Ok(effective_approver_sets(state)
+        .await?
+        .values()
+        .any(|members| members.iter().any(|m| m == did)))
+}
+
 /// Resolve the PDP `requireConsent` disposition.
 ///
 /// Proceeds (`None`) when a valid grant for this exact task already exists — but
@@ -277,28 +336,8 @@ async fn consent_gate(
     // The approver set as it stands *now*, not as it stood when the request was
     // raised. This is resolved before the grant is consumed, because a grant
     // cannot be honoured against a set that no longer exists.
-    //
-    // The declarative approvals row is authoritative; config is consulted only
-    // as a fallback, for a VTA whose sets are still declared there and which has
-    // not yet been seeded. Row-first is what makes `pnm approvals approvers`
-    // take effect without a restart.
-    let members = match crate::policy::approvals::load(&state.policy_ks).await {
-        Ok(model) => {
-            let from_row = model.approver_set(&require.approver_set);
-            if from_row.is_empty() {
-                state
-                    .config
-                    .read()
-                    .await
-                    .policy
-                    .approver_sets
-                    .get(&require.approver_set)
-                    .cloned()
-                    .unwrap_or_default()
-            } else {
-                from_row.to_vec()
-            }
-        }
+    let members = match approver_set_members(state, &require.approver_set).await {
+        Ok(m) => m,
         Err(e) => return Some(GateReject::Error(e)),
     };
     if members.is_empty() {
@@ -756,6 +795,85 @@ async fn mint_pending(
 mod tests {
     use super::*;
     use crate::policy::types::PolicyModule;
+
+    async fn seed_row(state: &AppState, set: &str, members: &[&str]) {
+        crate::policy::seed_declarative_approvals(
+            &state.policy_ks,
+            &[],
+            &std::collections::HashMap::from([(
+                set.to_string(),
+                members.iter().map(|m| (*m).to_string()).collect::<Vec<_>>(),
+            )]),
+            &chrono::Utc::now().to_rfc3339(),
+        )
+        .await
+        .expect("seed the declarative row");
+    }
+
+    async fn seed_config(state: &AppState, set: &str, members: &[&str]) {
+        state.config.write().await.policy.approver_sets.insert(
+            set.to_string(),
+            members.iter().map(|m| (*m).to_string()).collect(),
+        );
+    }
+
+    /// The regression. A set written to the declarative row — which is what
+    /// `pnm approvals approvers add` does — must resolve.
+    ///
+    /// The decision handler used to read `config.policy.approver_sets` alone, so
+    /// a row-only set resolved as empty there and every decision from an approver
+    /// added the documented way was denied `not_a_member`. The gate had already
+    /// raised the pending and pushed the request off the row, so the two halves
+    /// of one ceremony disagreed about who was in the set.
+    #[tokio::test]
+    async fn a_row_only_set_resolves() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_row(&state, "ops", &["did:key:zApprover"]).await;
+        assert_eq!(
+            approver_set_members(&state, "ops").await.unwrap(),
+            vec!["did:key:zApprover".to_string()]
+        );
+    }
+
+    /// Config remains the fallback for a VTA whose sets are still declared there
+    /// and which has not been seeded.
+    #[tokio::test]
+    async fn a_config_only_set_still_resolves() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_config(&state, "ops", &["did:key:zFromConfig"]).await;
+        assert_eq!(
+            approver_set_members(&state, "ops").await.unwrap(),
+            vec!["did:key:zFromConfig".to_string()]
+        );
+    }
+
+    /// Row-first: once the row carries the set, config no longer decides.
+    /// Otherwise removing an approver with `pnm approvals approvers remove`
+    /// would leave a stale config entry still able to approve.
+    #[tokio::test]
+    async fn the_row_wins_over_config() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        seed_config(&state, "ops", &["did:key:zStaleFromConfig"]).await;
+        seed_row(&state, "ops", &["did:key:zFromRow"]).await;
+        assert_eq!(
+            approver_set_members(&state, "ops").await.unwrap(),
+            vec!["did:key:zFromRow".to_string()],
+            "a stale config entry must not outlive the row that replaced it"
+        );
+    }
+
+    /// An unknown set is empty, not an error — the caller turns that into the
+    /// "unknown or empty" denial with the set's name in it.
+    #[tokio::test]
+    async fn an_unknown_set_is_empty() {
+        let (state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        assert!(
+            approver_set_members(&state, "nobody")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     fn module(id: &str, priority: i32, rego: &str) -> PolicyModule {
         PolicyModule {

--- a/vta-service/src/trust_tasks/task_consent.rs
+++ b/vta-service/src/trust_tasks/task_consent.rs
@@ -201,15 +201,17 @@ pub(super) async fn handle_decision(
     }
 
     // The proven signer must be a member of the policy-named approver set.
-    let members = state
-        .config
-        .read()
-        .await
-        .policy
-        .approver_sets
-        .get(&pending.approver_set)
-        .cloned()
-        .unwrap_or_default();
+    //
+    // Resolved through the same row-first helper the gate uses. Reading
+    // `config.policy.approver_sets` directly here — as this did — meant the side
+    // that *asks* for a decision and the side that *accepts* one disagreed about
+    // who was in the set, so every approver added with `pnm approvals approvers
+    // add` (which writes the declarative row) was denied `not_a_member`.
+    let members = match super::policy_gate::approver_set_members(state, &pending.approver_set).await
+    {
+        Ok(m) => m,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
     if !members.iter().any(|m| m == &approver) {
         crate::audit::record_consent(
             &state.audit_sink,
@@ -442,13 +444,25 @@ mod tests {
         );
 
         // …but it IS a member of the set the policy names.
-        state
-            .config
-            .write()
-            .await
-            .policy
-            .approver_sets
-            .insert("webvh-approvers".into(), vec![approver.clone()]);
+        //
+        // Seeded into the **declarative row**, which is what `pnm approvals
+        // approvers add` writes — deliberately not `config.policy.approver_sets`.
+        // Seeding config was the shape of this test before, and it is why the
+        // field failure went unnoticed: the decision handler read config alone,
+        // so a config-seeded test passed while every set built the documented way
+        // was denied `not_a_member`. Seed the row and the test exercises the path
+        // operators actually use.
+        crate::policy::seed_declarative_approvals(
+            &state.policy_ks,
+            &[],
+            &std::collections::HashMap::from([(
+                "webvh-approvers".to_string(),
+                vec![approver.clone()],
+            )]),
+            &chrono::Utc::now().to_rfc3339(),
+        )
+        .await
+        .expect("seed the approver set into the declarative row");
 
         // An outstanding pending, as the gate would have minted it for a
         // requester that can authorize the task itself (so no delegation is in


### PR DESCRIPTION
A consent decision from an approver added with `pnm approvals approvers add`
was refused:

    audit: action="consent.decision" outcome="denied:not_a_member"

Three places ask "who is in this approver set?", and they disagreed:

| Site | Read |
|---|---|
| `policy_gate` — raise the pending | row first, config fallback |
| `ceremony::may_attempt_ceremony` — transport gate | config only |
| `task_consent` — accept the decision | config only |

`pnm approvals approvers add` writes the declarative policy row. The gate read
that row, found the set, raised the pending and pushed the signed request to the
approver. The approver signed a valid decision — and the two config-only sites
looked in a table that never had the set, so the transport gate turned it away
pre-auth and the handler denied it `not_a_member`.

## Why this matters

DTTE could not be operated through its own CLI. The documented way to manage an
approver set produced a set that could raise requests but never accept an
answer, and the only workaround was to *also* carry the set in `config.toml` and
restart — the very thing row-first exists to avoid, since
`[policy.approver_sets]` is a seed applied once on first boot.

Worse, the two halves fail differently. A row-only set is a **hard lockout** on
every task the rule covers: requests are raised and pushed, and can never be
answered. And because `ceremony.rs` runs *before* authentication, a decision it
rejects never reaches a handler and leaves **no audit line at all** — the
operator sees a request that simply hangs until its 900 s TTL.

## The fix

All three resolve through `policy_gate::effective_approver_sets`: config,
overridden by the row **per set name**.

Per-set rather than whole-model, so an operator with three sets in config who
edits one with the CLI does not strand the other two — and, more importantly,
cannot strand them *inconsistently*. A whole-model "row wins if non-empty" would
let an approver pass the named membership check in `task_consent` while
`may_attempt_ceremony`, which scans every set, still turned it away.

The transport gate fails closed: a store error is not a membership answer, so it
refuses the decision and warns rather than admitting the sender.

## Tests

The existing end-to-end test seeded `config.policy.approver_sets` directly,
which is precisely why this shipped — it made the broken path look covered while
testing the one path operators do not use. It now seeds the declarative row, so
it exercises what `pnm approvals approvers add` actually produces. It fails on
the old code and passes on the new.

Four unit tests pin the resolver:

- a row-only set resolves (the regression)
- a config-only set still resolves (the fallback survives)
- the row wins over a stale config entry — otherwise `pnm approvals approvers
  remove` would leave a config entry still able to approve
- an unknown set is empty rather than an error

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` — clean, zero warnings
- `cargo test -p vta-service` (policy_gate, task_consent, ceremony, messaging::auth)
  — 46 passing
- Full `cargo test --workspace` was still running locally when this was opened;
  CI is authoritative.

## Field evidence

Reproduced on a live VTA. `pnm approvals list` showed the rule and the set in
the row; `config.toml` had no `[policy.approver_sets]` block. Every decision
from the named approver was denied `not_a_member` until the set was duplicated
into config and the VTA restarted, after which the same approver's decision
minted a grant and the DID update published.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>
