### PR TITLE
feat(pnm-cli): add memory command group

### DIFF
--- a/docs/02-vta/personal-ai-agents.md
+++ b/docs/02-vta/personal-ai-agents.md
@@ -226,11 +226,14 @@ in the agent runtime, the memory survives the runtime being replaced, is audited
 (`memory.put` / `.list` / `.delete`), and is included in the VTA's encrypted
 backups.
 
-The gate is **context access**, not a capability: `require_context(contextId)`,
-the same check the context-scoped key tasks use. That makes the trust context
-the isolation boundary — a context-A agent cannot read, write, or delete
-context-B memory — and it means the least-privilege grant for a memory-only
-agent is an ACL entry with role `application` naming exactly one context.
+Two gates apply, in this order. **Capability**: `MemoryRead` for
+`memory/list/0.1`, `MemoryWrite` for `put` and `delete` — so a `reader` can be
+given the memory without being given the ability to rewrite it. **Context
+access**: `require_context(contextId)`, the same check the context-scoped key
+tasks use, which makes the trust context the isolation boundary — a context-A
+agent cannot read, write, or delete context-B memory. The least-privilege grant
+for a memory-only agent is an ACL entry with role `application` naming exactly
+one context; `application` carries both memory capabilities.
 
 ```bash
 # One context per agent (or per domain) — this is the isolation boundary.
@@ -245,6 +248,23 @@ From a client, `VtaClient::{memory_put, memory_list, memory_delete}` drive the
 three tasks through the generic Trust-Task dispatcher, so they ride TSP, DIDComm
 or REST according to what both DID documents advertise — the agent writes no
 transport code.
+
+From the operator side the same three tasks are `pnm memory`:
+
+```bash
+pnm memory plant favourite-colour green --context my-agent-memory
+pnm memory recall --context my-agent-memory          # or `recall <key>`
+pnm memory forget favourite-colour --context my-agent-memory
+pnm memory wipe --context my-agent-memory            # confirms; --yes to skip
+```
+
+`--context` is required on every subcommand: a super-admin's access check
+passes for any id and these tasks do not require the context to exist, so a
+defaulted or mistyped id would silently read and write a context that isn't
+there — indistinguishable from an empty one. `wipe` needs both capabilities
+(it lists before it deletes) and is N round-trips, not atomic — there is no
+bulk-delete task — so re-running it after a partial failure is safe and
+finishes the job.
 
 Two boundaries worth stating before anything is stored here:
 
@@ -285,7 +305,8 @@ Lower priority unless your agents do credential work.
 | `pnm device …` / `pnm vault …` CLI     | **Added** (this change) — `VtaClient::{device_*,vault_*}` + `pnm` commands, both transports |
 | Sealed vault upsert/release            | **Added** — `seal_vault_secret` / `open_sealed_secret` on the DIDComm session |
 | `pnm acl --capabilities` flag          | **Gap** (deferred Phase 3) — capabilities derive from role / are set at `device/register` |
-| Agent memory Trust Tasks               | Exists (`trust_tasks/memory.rs`, `VtaClient::memory_*`) — context-gated, audited |
+| Agent memory Trust Tasks               | Exists (`trust_tasks/memory.rs`, `VtaClient::memory_*`) — capability- and context-gated, audited |
+| `pnm memory …` CLI                     | **Added** — `plant` / `recall` / `forget` / `wipe` over the same three tasks |
 | Agent-side connect ladder              | Exists (`vta_sdk::agent_connect::AgentConnect`) — one way in for every agent bridge |
 
 ## References

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -278,6 +278,95 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: DidTemplateCommands,
     },
+
+    /// Play with the VTA's per-context agent memory — the key/value notes the
+    /// hosted agent reads before it answers.
+    ///
+    /// The one-command demo that memory drives the model: `plant` a fact,
+    /// ask the agent, then `wipe` it and watch the answer change. Backed by
+    /// the `spec/vta/memory/{put,list,delete}/0.1` Trust Tasks; every
+    /// operation is gated on access to `--context` (default `default`).
+    #[command(name = "memory")]
+    LlmMemory {
+        #[command(subcommand)]
+        command: LlmMemoryCommands,
+    },
+}
+
+/// CRUD over the agent's memory. `plant` creates/updates, `recall` reads,
+/// `forget` deletes one entry, and `wipe` deletes every entry in the context.
+#[derive(Subcommand)]
+pub(crate) enum LlmMemoryCommands {
+    /// Plant a memory: store `value` under `key` so the agent recalls it.
+    ///
+    /// Upsert — re-planting the same key overwrites the old value.
+    Plant {
+        /// Memory key, unique within the context (e.g. `favorite-color`).
+        key: String,
+        /// The value to store (e.g. `green`).
+        value: String,
+        /// Context whose memory to write.
+        #[arg(
+            long,
+            short = 'c',
+            alias = "context-id",
+            value_name = "ID",
+            default_value = "default"
+        )]
+        context: String,
+    },
+
+    /// Recall what the agent knows: list every memory in the context, or
+    /// just the one at `key`.
+    Recall {
+        /// Show only this key. Omit to list the whole context.
+        key: Option<String>,
+        /// Context whose memory to read.
+        #[arg(
+            long,
+            short = 'c',
+            alias = "context-id",
+            value_name = "ID",
+            default_value = "default"
+        )]
+        context: String,
+    },
+
+    /// Forget a single memory by key — the agent loses just that fact.
+    Forget {
+        /// The memory key to delete.
+        key: String,
+        /// Context whose memory to write.
+        #[arg(
+            long,
+            short = 'c',
+            alias = "context-id",
+            value_name = "ID",
+            default_value = "default"
+        )]
+        context: String,
+    },
+
+    /// Wipe every memory in the context. Prompts for confirmation unless
+    /// `--force`; requires `--force` in `--json` mode.
+    ///
+    /// There is no bulk-delete Trust Task, so this deletes entries one by one
+    /// (N round-trips, not atomic). Re-running is safe and resumes if a delete
+    /// fails partway.
+    Wipe {
+        /// Context whose memory to wipe.
+        #[arg(
+            long,
+            short = 'c',
+            alias = "context-id",
+            value_name = "ID",
+            default_value = "default"
+        )]
+        context: String,
+        /// Skip the confirmation prompt.
+        #[arg(long, short = 'f')]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -279,93 +279,80 @@ pub(crate) enum Commands {
         command: DidTemplateCommands,
     },
 
-    /// Play with the VTA's per-context agent memory — the key/value notes the
-    /// hosted agent reads before it answers.
+    /// Manage the VTA's per-context agent memory — the key/value notes an
+    /// agent reads before it answers.
     ///
-    /// The one-command demo that memory drives the model: `plant` a fact,
-    /// ask the agent, then `wipe` it and watch the answer change. Backed by
-    /// the `spec/vta/memory/{put,list,delete}/0.1` Trust Tasks; every
-    /// operation is gated on access to `--context` (default `default`).
+    /// Backed by the `spec/vta/memory/{put,list,delete}/0.1` Trust Tasks.
+    /// Two gates apply, both server-side: the capability (`MemoryRead` to
+    /// recall, `MemoryWrite` to plant / forget / wipe) and access to
+    /// `--context`, which is the isolation boundary — a caller scoped to one
+    /// context can never reach another's memory.
     #[command(name = "memory")]
-    LlmMemory {
+    Memory {
         #[command(subcommand)]
-        command: LlmMemoryCommands,
+        command: MemoryCommands,
     },
 }
 
 /// CRUD over the agent's memory. `plant` creates/updates, `recall` reads,
 /// `forget` deletes one entry, and `wipe` deletes every entry in the context.
+///
+/// Each carries a hidden alias under the Trust Task's own verb (`put`,
+/// `list`, `delete`, `clear`) so an operator reading the task names finds the
+/// command they expect.
 #[derive(Subcommand)]
-pub(crate) enum LlmMemoryCommands {
+pub(crate) enum MemoryCommands {
     /// Plant a memory: store `value` under `key` so the agent recalls it.
     ///
     /// Upsert — re-planting the same key overwrites the old value.
+    #[command(alias = "put")]
     Plant {
         /// Memory key, unique within the context (e.g. `favorite-color`).
         key: String,
-        /// The value to store (e.g. `green`).
+        /// The value to store (e.g. `green`). Not a secret store — tokens,
+        /// passwords and keys belong in `pnm vault`.
         value: String,
-        /// Context whose memory to write.
-        #[arg(
-            long,
-            short = 'c',
-            alias = "context-id",
-            value_name = "ID",
-            default_value = "default"
-        )]
+        /// TARGET SCOPE: the context whose memory to write.
+        #[arg(long = "context", alias = "context-id", value_name = "ID")]
         context: String,
     },
 
     /// Recall what the agent knows: list every memory in the context, or
     /// just the one at `key`.
+    #[command(alias = "list")]
     Recall {
         /// Show only this key. Omit to list the whole context.
         key: Option<String>,
-        /// Context whose memory to read.
-        #[arg(
-            long,
-            short = 'c',
-            alias = "context-id",
-            value_name = "ID",
-            default_value = "default"
-        )]
+        /// TARGET SCOPE: the context whose memory to read.
+        #[arg(long = "context", alias = "context-id", value_name = "ID")]
         context: String,
     },
 
     /// Forget a single memory by key — the agent loses just that fact.
+    #[command(alias = "delete")]
     Forget {
         /// The memory key to delete.
         key: String,
-        /// Context whose memory to write.
-        #[arg(
-            long,
-            short = 'c',
-            alias = "context-id",
-            value_name = "ID",
-            default_value = "default"
-        )]
+        /// TARGET SCOPE: the context whose memory to write.
+        #[arg(long = "context", alias = "context-id", value_name = "ID")]
         context: String,
     },
 
     /// Wipe every memory in the context. Prompts for confirmation unless
-    /// `--force`; requires `--force` in `--json` mode.
+    /// `--yes`; requires `--yes` in `--json` mode.
     ///
     /// There is no bulk-delete Trust Task, so this deletes entries one by one
     /// (N round-trips, not atomic). Re-running is safe and resumes if a delete
-    /// fails partway.
+    /// fails partway. Needs both memory capabilities: it lists (`MemoryRead`)
+    /// before it deletes (`MemoryWrite`).
+    #[command(alias = "clear")]
     Wipe {
-        /// Context whose memory to wipe.
-        #[arg(
-            long,
-            short = 'c',
-            alias = "context-id",
-            value_name = "ID",
-            default_value = "default"
-        )]
+        /// TARGET SCOPE: the context whose memory to wipe.
+        #[arg(long = "context", alias = "context-id", value_name = "ID")]
         context: String,
-        /// Skip the confirmation prompt.
-        #[arg(long, short = 'f')]
-        force: bool,
+        /// Skip the confirmation prompt (automation only).
+        #[arg(long = "yes", alias = "force")]
+        yes: bool,
     },
 }
 
@@ -2778,5 +2765,88 @@ mod transport_flag_tests {
     #[test]
     fn transport_rejects_unknown_value() {
         assert!(Cli::try_parse_from(["pnm", "--transport", "bogus", "health"]).is_err());
+    }
+}
+
+#[cfg(test)]
+mod memory_flag_tests {
+    use super::*;
+    use clap::Parser;
+
+    /// The scope flag is required, never defaulted. A super-admin's context
+    /// check passes for any id and the memory tasks don't require the context
+    /// to exist, so a defaulted id would read and write a context that isn't
+    /// there and look like an empty one. Clap refusing is the whole guard.
+    #[test]
+    fn every_memory_subcommand_requires_a_context() {
+        for args in [
+            vec!["pnm", "memory", "plant", "k", "v"],
+            vec!["pnm", "memory", "recall"],
+            vec!["pnm", "memory", "forget", "k"],
+            vec!["pnm", "memory", "wipe"],
+        ] {
+            assert!(
+                Cli::try_parse_from(&args).is_err(),
+                "{args:?} parsed without --context"
+            );
+        }
+    }
+
+    #[test]
+    fn context_id_stays_accepted_as_an_alias() {
+        let cli =
+            Cli::try_parse_from(["pnm", "memory", "recall", "--context-id", "agent"]).unwrap();
+        let Commands::Memory {
+            command: MemoryCommands::Recall { context, key },
+        } = cli.command
+        else {
+            panic!("expected memory recall");
+        };
+        assert_eq!(context, "agent");
+        assert_eq!(key, None);
+    }
+
+    /// `--yes` is the workspace's skip-the-prompt flag (`pnm keys create
+    /// --yes`); `--force` means "hard-delete" on the vault commands. Renamed
+    /// to match, with the old spelling kept working.
+    #[test]
+    fn wipe_takes_yes_and_still_honours_force() {
+        for flag in ["--yes", "--force"] {
+            let cli =
+                Cli::try_parse_from(["pnm", "memory", "wipe", "--context", "agent", flag]).unwrap();
+            let Commands::Memory {
+                command: MemoryCommands::Wipe { yes, .. },
+            } = cli.command
+            else {
+                panic!("expected memory wipe");
+            };
+            assert!(yes, "{flag} did not set yes");
+        }
+    }
+
+    #[test]
+    fn trust_task_verbs_alias_the_command_names() {
+        for (alias, expect_plant) in [("put", true), ("plant", true)] {
+            let cli = Cli::try_parse_from(["pnm", "memory", alias, "k", "v", "--context", "agent"])
+                .unwrap();
+            let Commands::Memory { command } = cli.command else {
+                panic!("expected memory");
+            };
+            assert_eq!(
+                matches!(command, MemoryCommands::Plant { .. }),
+                expect_plant
+            );
+        }
+        for alias in ["list", "recall"] {
+            assert!(Cli::try_parse_from(["pnm", "memory", alias, "--context", "agent"]).is_ok());
+        }
+        for alias in ["delete", "forget"] {
+            assert!(
+                Cli::try_parse_from(["pnm", "memory", alias, "k", "--context", "agent"]).is_ok()
+            );
+        }
+        for alias in ["clear", "wipe"] {
+            assert!(Cli::try_parse_from(["pnm", "memory", alias, "--context", "agent"]).is_ok());
+        }
     }
 }

--- a/pnm-cli/src/commands/llm_memory.rs
+++ b/pnm-cli/src/commands/llm_memory.rs
@@ -1,0 +1,32 @@
+//! `pnm memory …` dispatch — thin shim over the shared memory commands.
+//!
+//! The implementations (rendering included) live in
+//! `vta_cli_common::commands::memory` so any CLI can adopt the same surface;
+//! this module only maps the parsed subcommand onto them.
+
+use vta_cli_common::commands::memory;
+use vta_sdk::client::VtaClient;
+
+use crate::cli::LlmMemoryCommands;
+
+pub(crate) async fn run(
+    client: &VtaClient,
+    command: LlmMemoryCommands,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        LlmMemoryCommands::Plant {
+            key,
+            value,
+            context,
+        } => memory::cmd_memory_plant(client, &context, &key, &value).await,
+        LlmMemoryCommands::Recall { key, context } => {
+            memory::cmd_memory_recall(client, &context, key.as_deref()).await
+        }
+        LlmMemoryCommands::Forget { key, context } => {
+            memory::cmd_memory_forget(client, &context, &key).await
+        }
+        LlmMemoryCommands::Wipe { context, force } => {
+            memory::cmd_memory_wipe(client, &context, force).await
+        }
+    }
+}

--- a/pnm-cli/src/commands/memory.rs
+++ b/pnm-cli/src/commands/memory.rs
@@ -7,26 +7,26 @@
 use vta_cli_common::commands::memory;
 use vta_sdk::client::VtaClient;
 
-use crate::cli::LlmMemoryCommands;
+use crate::cli::MemoryCommands;
 
 pub(crate) async fn run(
     client: &VtaClient,
-    command: LlmMemoryCommands,
+    command: MemoryCommands,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match command {
-        LlmMemoryCommands::Plant {
+        MemoryCommands::Plant {
             key,
             value,
             context,
         } => memory::cmd_memory_plant(client, &context, &key, &value).await,
-        LlmMemoryCommands::Recall { key, context } => {
+        MemoryCommands::Recall { key, context } => {
             memory::cmd_memory_recall(client, &context, key.as_deref()).await
         }
-        LlmMemoryCommands::Forget { key, context } => {
+        MemoryCommands::Forget { key, context } => {
             memory::cmd_memory_forget(client, &context, &key).await
         }
-        LlmMemoryCommands::Wipe { context, force } => {
-            memory::cmd_memory_wipe(client, &context, force).await
+        MemoryCommands::Wipe { context, yes } => {
+            memory::cmd_memory_wipe(client, &context, yes).await
         }
     }
 }

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod device;
 pub(crate) mod did_templates;
 pub(crate) mod health;
 pub(crate) mod keys;
+pub(crate) mod llm_memory;
 pub(crate) mod policy;
 pub(crate) mod services;
 pub(crate) mod setup;

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod device;
 pub(crate) mod did_templates;
 pub(crate) mod health;
 pub(crate) mod keys;
-pub(crate) mod llm_memory;
+pub(crate) mod memory;
 pub(crate) mod policy;
 pub(crate) mod services;
 pub(crate) mod setup;

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -301,7 +301,7 @@ async fn main() {
         Commands::Audit { command } => commands::audit::run(&client, command).await,
         Commands::Backup { command } => commands::backup::run(&client, command).await,
         Commands::Keys { command } => commands::keys::run(&client, command).await,
-        Commands::LlmMemory { command } => commands::llm_memory::run(&client, command).await,
+        Commands::Memory { command } => commands::memory::run(&client, command).await,
     };
 
     client.shutdown().await;

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -301,6 +301,7 @@ async fn main() {
         Commands::Audit { command } => commands::audit::run(&client, command).await,
         Commands::Backup { command } => commands::backup::run(&client, command).await,
         Commands::Keys { command } => commands::keys::run(&client, command).await,
+        Commands::LlmMemory { command } => commands::llm_memory::run(&client, command).await,
     };
 
     client.shutdown().await;

--- a/vta-cli-common/src/commands/memory.rs
+++ b/vta-cli-common/src/commands/memory.rs
@@ -1,0 +1,257 @@
+//! `pnm memory …` (and any CLI that adopts it) — CRUD over the VTA's
+//! per-context agent memory (`spec/vta/memory/{put,list,delete}/0.1`).
+//!
+//! A per-context key/value store the hosted agent reads before it answers:
+//! `plant` upserts an entry, `recall` lists (optionally one key), `forget`
+//! deletes one, and `wipe` clears the whole context. Each maps onto one of
+//! the SDK memory methods; every operation is gated server-side on access to
+//! the target context, so a caller can only touch memory in a context it is
+//! permitted to act in.
+
+use serde_json::json;
+use vta_sdk::prelude::*;
+use vta_sdk::protocols::memory::{MemoryItem, MemoryListResponse};
+
+use crate::render::{BOLD, CYAN, DIM, GREEN, RED, RESET, is_json_output, print_json};
+
+/// `plant` → `memory_put`. Upserts `value` under `(context, key)`; re-planting
+/// the same key overwrites the stored value.
+pub async fn cmd_memory_plant(
+    client: &VtaClient,
+    context: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resp = client.memory_put(context, key, value).await?;
+    if is_json_output() {
+        print_json(&resp)?;
+        return Ok(());
+    }
+    println!("{GREEN}\u{2713}{RESET} Planted {BOLD}{key}{RESET} in context '{context}'.");
+    println!("  {DIM}{value}{RESET}");
+    Ok(())
+}
+
+/// `recall` → `memory_list`, optionally filtered to a single key.
+pub async fn cmd_memory_recall(
+    client: &VtaClient,
+    context: &str,
+    key: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut items = list_items(client, context).await?;
+    if let Some(k) = key {
+        items.retain(|item| item.key == k);
+    }
+
+    if is_json_output() {
+        // The SDK's own response shape *is* the stable `--json` contract here,
+        // so re-emit it rather than hand-building an equivalent that could
+        // drift from it.
+        print_json(&MemoryListResponse { items })?;
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        match key {
+            Some(k) => println!("No memory under '{k}' in context '{context}'."),
+            None => println!("Context '{context}' has no memories."),
+        }
+        return Ok(());
+    }
+
+    println!();
+    println!("{BOLD}Memory for context '{context}'{RESET}");
+    println!();
+    for item in &items {
+        println!("  {CYAN}{}{RESET}  {}", item.key, item.value);
+    }
+    println!();
+    Ok(())
+}
+
+/// `forget` → `memory_delete` for one key.
+pub async fn cmd_memory_forget(
+    client: &VtaClient,
+    context: &str,
+    key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resp = client.memory_delete(context, key).await?;
+    if is_json_output() {
+        print_json(&resp)?;
+        return Ok(());
+    }
+    println!("{GREEN}\u{2713}{RESET} Forgot {BOLD}{key}{RESET} in context '{context}'.");
+    Ok(())
+}
+
+/// `wipe` → list, then `memory_delete` every key. There is no bulk-delete
+/// Trust Task, so this is N round-trips and *not* atomic.
+///
+/// The confirmation is where the operator consents to a destructive op;
+/// `--force` is the only thing allowed to stand in for it. `--json` selects an
+/// output format, not consent — so with neither a prompt (JSON mode) nor
+/// `--force`, this refuses rather than proceeds. See [`wipe_guard`].
+pub async fn cmd_memory_wipe(
+    client: &VtaClient,
+    context: &str,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let items = list_items(client, context).await?;
+
+    if items.is_empty() {
+        if is_json_output() {
+            print_json(&json!({ "wiped": Vec::<String>::new() }))?;
+        } else {
+            println!("{DIM}Context '{context}' is already empty — nothing to wipe.{RESET}");
+        }
+        return Ok(());
+    }
+
+    match wipe_guard(force, is_json_output()) {
+        WipeGuard::RefuseJson => {
+            return Err("`memory wipe` needs `--force` in --json mode: there is no \
+                        prompt to confirm to"
+                .into());
+        }
+        WipeGuard::Confirm => {
+            println!(
+                "{RED}This wipes all {} in context '{context}'.{RESET}",
+                count_memories(items.len())
+            );
+            let go = dialoguer::Confirm::new()
+                .with_prompt("Wipe every memory in this context?")
+                .default(false)
+                .interact()?;
+            if !go {
+                println!("Cancelled — nothing was wiped.");
+                return Ok(());
+            }
+        }
+        WipeGuard::Proceed => {}
+    }
+
+    // Not atomic: on a mid-loop failure, name what did delete before surfacing
+    // the error. Re-running `wipe` is safe and finishes the job — but only if
+    // the operator can see where it stopped.
+    let mut wiped: Vec<String> = Vec::with_capacity(items.len());
+    for item in &items {
+        if let Err(e) = client.memory_delete(context, &item.key).await {
+            return Err(format!(
+                "wiped {} of {} before failing on '{}': {e}",
+                wiped.len(),
+                items.len(),
+                item.key,
+            )
+            .into());
+        }
+        wiped.push(item.key.clone());
+    }
+
+    if is_json_output() {
+        print_json(&json!({ "wiped": wiped }))?;
+        return Ok(());
+    }
+    println!(
+        "{RED}\u{2713}{RESET} Wiped {} from context '{context}'.",
+        count_memories(wiped.len())
+    );
+    Ok(())
+}
+
+/// Fetch and typed-decode a context's memory. Decoding into the SDK body means
+/// a malformed response is an error, not a silently-shortened list — which
+/// matters most for `wipe`, which derives *what to delete* from it.
+async fn list_items(
+    client: &VtaClient,
+    context: &str,
+) -> Result<Vec<MemoryItem>, Box<dyn std::error::Error>> {
+    let resp = client.memory_list(context).await?;
+    Ok(decode_items(resp)?)
+}
+
+/// Typed decode of a `vta/memory/list` response body into its entries.
+/// Factored out so the "malformed → error" contract is unit-testable without a
+/// live VTA.
+fn decode_items(resp: serde_json::Value) -> Result<Vec<MemoryItem>, serde_json::Error> {
+    let parsed: MemoryListResponse = serde_json::from_value(resp)?;
+    Ok(parsed.items)
+}
+
+/// What `wipe` should do about the confirmation, given the two inputs that
+/// decide it. Pulled out as a pure function because getting it wrong is
+/// destructive (see the `--json` finding): `--force` always proceeds; without
+/// it, JSON mode has no one to prompt so it refuses, and otherwise we confirm.
+#[derive(Debug, PartialEq, Eq)]
+enum WipeGuard {
+    Proceed,
+    Confirm,
+    RefuseJson,
+}
+
+fn wipe_guard(force: bool, json: bool) -> WipeGuard {
+    match (force, json) {
+        (true, _) => WipeGuard::Proceed,
+        (false, true) => WipeGuard::RefuseJson,
+        (false, false) => WipeGuard::Confirm,
+    }
+}
+
+/// "1 memory" / "N memories" — count with the noun agreed.
+fn count_memories(n: usize) -> String {
+    if n == 1 {
+        "1 memory".to_string()
+    } else {
+        format!("{n} memories")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wipe_force_always_proceeds() {
+        // --force is the operator saying "yes"; it overrides both other inputs.
+        assert_eq!(wipe_guard(true, false), WipeGuard::Proceed);
+        assert_eq!(wipe_guard(true, true), WipeGuard::Proceed);
+    }
+
+    #[test]
+    fn wipe_json_without_force_refuses() {
+        // The core finding: an output-format flag is not consent, and there is
+        // no prompt to answer — so refuse rather than delete unguarded.
+        assert_eq!(wipe_guard(false, true), WipeGuard::RefuseJson);
+    }
+
+    #[test]
+    fn wipe_interactive_without_force_confirms() {
+        assert_eq!(wipe_guard(false, false), WipeGuard::Confirm);
+    }
+
+    #[test]
+    fn decode_reads_camelcase_items() {
+        let v = json!({ "items": [
+            { "key": "a", "value": "1" },
+            { "key": "b", "value": "2" },
+        ] });
+        let items = decode_items(v).expect("well-formed body decodes");
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].key, "a");
+        assert_eq!(items[1].value, "2");
+    }
+
+    #[test]
+    fn decode_of_a_malformed_body_errors_rather_than_shortening() {
+        // A non-string value must fail the whole decode — never be dropped,
+        // which would make `wipe` under-count what it leaves behind.
+        let v = json!({ "items": [ { "key": "a", "value": 7 } ] });
+        assert!(decode_items(v).is_err());
+    }
+
+    #[test]
+    fn count_memories_agrees_the_noun() {
+        assert_eq!(count_memories(0), "0 memories");
+        assert_eq!(count_memories(1), "1 memory");
+        assert_eq!(count_memories(2), "2 memories");
+    }
+}

--- a/vta-cli-common/src/commands/memory.rs
+++ b/vta-cli-common/src/commands/memory.rs
@@ -4,9 +4,24 @@
 //! A per-context key/value store the hosted agent reads before it answers:
 //! `plant` upserts an entry, `recall` lists (optionally one key), `forget`
 //! deletes one, and `wipe` clears the whole context. Each maps onto one of
-//! the SDK memory methods; every operation is gated server-side on access to
-//! the target context, so a caller can only touch memory in a context it is
-//! permitted to act in.
+//! the SDK memory methods.
+//!
+//! Two server-side gates gate every operation, and both matter to what an
+//! operator sees here:
+//!
+//! - **Capability** — `MemoryRead` for `list`, `MemoryWrite` for `put` and
+//!   `delete` (`vta-service/src/trust_tasks/memory.rs`). `wipe` therefore
+//!   needs both: it lists before it deletes. A `reader` holds only
+//!   `MemoryRead`, so `plant` / `forget` / `wipe` are refused for that role.
+//! - **Context access** — the isolation boundary. A caller can only touch
+//!   memory in a context it is permitted to act in, so a context-A agent
+//!   never reaches context-B memory.
+//!
+//! The context is never defaulted at this layer. A super-admin's access check
+//! passes for *any* context id and the memory tasks do not require the context
+//! to exist, so a guessed or mistyped id would read and write a context that
+//! is not there — silently, and looking exactly like an empty one. The caller
+//! names the context or there is no call.
 
 use serde_json::json;
 use vta_sdk::prelude::*;
@@ -85,16 +100,17 @@ pub async fn cmd_memory_forget(
 }
 
 /// `wipe` → list, then `memory_delete` every key. There is no bulk-delete
-/// Trust Task, so this is N round-trips and *not* atomic.
+/// Trust Task, so this is N round-trips and *not* atomic. Needs both memory
+/// capabilities — `MemoryRead` for the list, `MemoryWrite` for the deletes.
 ///
 /// The confirmation is where the operator consents to a destructive op;
-/// `--force` is the only thing allowed to stand in for it. `--json` selects an
+/// `--yes` is the only thing allowed to stand in for it. `--json` selects an
 /// output format, not consent — so with neither a prompt (JSON mode) nor
-/// `--force`, this refuses rather than proceeds. See [`wipe_guard`].
+/// `--yes`, this refuses rather than proceeds. See [`wipe_guard`].
 pub async fn cmd_memory_wipe(
     client: &VtaClient,
     context: &str,
-    force: bool,
+    assume_yes: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let items = list_items(client, context).await?;
 
@@ -107,9 +123,9 @@ pub async fn cmd_memory_wipe(
         return Ok(());
     }
 
-    match wipe_guard(force, is_json_output()) {
+    match wipe_guard(assume_yes, is_json_output()) {
         WipeGuard::RefuseJson => {
-            return Err("`memory wipe` needs `--force` in --json mode: there is no \
+            return Err("`memory wipe` needs `--yes` in --json mode: there is no \
                         prompt to confirm to"
                 .into());
         }
@@ -179,7 +195,7 @@ fn decode_items(resp: serde_json::Value) -> Result<Vec<MemoryItem>, serde_json::
 
 /// What `wipe` should do about the confirmation, given the two inputs that
 /// decide it. Pulled out as a pure function because getting it wrong is
-/// destructive (see the `--json` finding): `--force` always proceeds; without
+/// destructive (see the `--json` finding): `--yes` always proceeds; without
 /// it, JSON mode has no one to prompt so it refuses, and otherwise we confirm.
 #[derive(Debug, PartialEq, Eq)]
 enum WipeGuard {
@@ -188,8 +204,8 @@ enum WipeGuard {
     RefuseJson,
 }
 
-fn wipe_guard(force: bool, json: bool) -> WipeGuard {
-    match (force, json) {
+fn wipe_guard(assume_yes: bool, json: bool) -> WipeGuard {
+    match (assume_yes, json) {
         (true, _) => WipeGuard::Proceed,
         (false, true) => WipeGuard::RefuseJson,
         (false, false) => WipeGuard::Confirm,
@@ -210,21 +226,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wipe_force_always_proceeds() {
-        // --force is the operator saying "yes"; it overrides both other inputs.
+    fn wipe_yes_always_proceeds() {
+        // --yes is the operator saying "yes"; it overrides both other inputs.
         assert_eq!(wipe_guard(true, false), WipeGuard::Proceed);
         assert_eq!(wipe_guard(true, true), WipeGuard::Proceed);
     }
 
     #[test]
-    fn wipe_json_without_force_refuses() {
+    fn wipe_json_without_yes_refuses() {
         // The core finding: an output-format flag is not consent, and there is
         // no prompt to answer — so refuse rather than delete unguarded.
         assert_eq!(wipe_guard(false, true), WipeGuard::RefuseJson);
     }
 
     #[test]
-    fn wipe_interactive_without_force_confirms() {
+    fn wipe_interactive_without_yes_confirms() {
         assert_eq!(wipe_guard(false, false), WipeGuard::Confirm);
     }
 

--- a/vta-cli-common/src/commands/mod.rs
+++ b/vta-cli-common/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod credentials;
 pub mod device;
 pub mod did_templates;
 pub mod keys;
+pub mod memory;
 /// Raw Rego policy management over the canonical `policy/*` family.
 pub mod policy;
 pub mod services;


### PR DESCRIPTION
Adds a `pnm memory` command group wrapping the VTA's per-context agent-memory Trust Tasks (`spec/vta/memory/{put,list,delete}/0.1`).

Subcommands:
- `plant <key> <value>` — upsert an entry
- `recall [key]` — list entries, or one by key
- `forget <key>` — delete one entry
- `wipe` — delete all entries in a context (confirmation unless `--force`)

All are context-scoped via `--context` (default `default`) and support `--json`.