### PR TITLE
chore(deps): move coset, affinidi-mdoc and affinidi-tdk together to 0.4 / 0.3 / 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,14 +274,14 @@ dependencies = [
 
 [[package]]
 name = "affinidi-mdoc"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a923616197dc73661b1b57ad8dfaef7d9297c51c137062c9435b6edd6c98a3"
+checksum = "d69ac8bedce32dcf6798e480166e3601b73b0408e2d51ae40964d09de3457ebc"
 dependencies = [
  "aes-gcm 0.10.3",
  "ciborium",
  "ciborium-io",
- "coset 0.3.8",
+ "coset 0.4.2",
  "hex",
  "hkdf 0.12.4",
  "hmac 0.12.1",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3858685de0deba7be2b6b7481c2eb0823b7b64dbe6852b474fed4c23360a019f"
+checksum = "3446c5fa52b875a2ad0251a61b95de2cfc50710c121e275bac09b8825677d863"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715c365fa19276fb50332e10b922822b25d52d6119721f28abb6cac02029a365"
+checksum = "abceec2e934dfffbc31924d970d650c972660125cd26fe7ecd14e4552713f43f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -3011,7 +3011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9734,7 +9734,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "chrono",
- "coset 0.3.8",
+ "coset 0.4.2",
  "ed25519-dalek",
  "multibase",
  "rcgen 0.14.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,13 +78,13 @@ repository = "https://github.com/OpenVTC/verifiable-trust-infrastructure"
 uniffi = "0.32"
 
 # Affinidi Trust Development Kit.
-# Pinned to a minimum patch (not bare `0.8`) because 0.8.5 is the first release
-# carrying the enforced-authcrypt fix (affinidi-tdk-rs #671): it depends on
-# `affinidi-messaging-sdk` 0.19 + `affinidi-messaging-didcomm` 0.15.8, where
-# `unpack` rejects plaintext / anoncrypt / forged-`from` envelopes by default.
-# `0.8` would let a fresh resolve on a clean checkout land on a pre-fix 0.8.x,
-# silently moving sender authentication back out of the library. Do not relax it.
-affinidi-tdk = "0.10"
+# The enforced-authcrypt fix (affinidi-tdk-rs #671 — `unpack` rejects plaintext
+# / anoncrypt / forged-`from` envelopes by default) landed in 0.8.5, which is
+# why this once carried a minimum-patch pin. Every 0.9+ release is past it, so
+# the floor is now structural rather than a specific patch: do not move this
+# back below 0.9, and do not drop to a bare major.
+# 0.11 re-exports `affinidi-mdoc` 0.3 — see the coupling note on `coset` below.
+affinidi-tdk = "0.11"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -122,12 +122,20 @@ affinidi-sd-jwt-vc = "0.2"
 affinidi-sd-jwt = "0.1.2"
 affinidi-bbs = "0.3"
 affinidi-openid4vp = "0.1.2"
-affinidi-mdoc = { version = "0.2.7", default-features = false, features = ["es256"] }
+affinidi-mdoc = { version = "0.3", default-features = false, features = ["es256"] }
 # Both already enter the graph through `affinidi-mdoc`; declared here because
 # the mdoc receive path names their types directly (`coset` for the COSE_Sign1
 # `alg` header, `time` for the `validityInfo` window) and depending on a
 # transitive is how a version bump elsewhere breaks an unrelated crate.
-coset = "0.3"
+#
+# `coset` and `affinidi-mdoc` move TOGETHER, and `affinidi-tdk` with them.
+# `coset` is in `affinidi-mdoc`'s public API — `IssuerSigned::issuer_auth` is a
+# `pub coset::CoseSign1` — and `affinidi-tdk` re-exports `affinidi-mdoc`. Moving
+# any one of the three alone puts two semver-incompatible copies of a shared
+# type in the graph, which fails as `E0308: mismatched types` in `vta-vault`
+# rather than as a version conflict. That is #1225, and this is what closing it
+# took.
+coset = "0.4"
 time = "0.3"
 # X.509 for the mdoc IACA trust path. `verify-aws` rather than the default
 # `verify` feature: that one pulls `ring`, which currently only reaches this


### PR DESCRIPTION
Replaces #1225, which moved `coset` alone and could not build.

## Why it takes three pins

`coset` is in `affinidi-mdoc`'s **public API** — `IssuerSigned::issuer_auth` is
a `pub coset::CoseSign1`. So `vta-vault/src/receive.rs:439`, which compares an
`alg` taken from `IssuerSigned` against one it builds itself, is comparing two
*different* types the moment the two sides resolve different `coset` versions:

```
error[E0308]: mismatched types
   --> vta-vault/src/receive.rs:439:29
note: there are multiple different versions of crate `coset` in the graph
```

A shared type in a public API fails that way rather than as a version conflict,
which is why dependabot's single-pin bump could never land.

And the coupling is transitive: `affinidi-tdk` re-exports `affinidi-mdoc`, and
0.10 requires 0.2. Moving `coset` + `affinidi-mdoc` while leaving `affinidi-tdk`
behind pulls a second `affinidi-mdoc` in through the re-export and reinstates
the same split one level up. Hence:

```toml
affinidi-tdk  = "0.11"   # re-exports affinidi-mdoc; 0.10 pins it to 0.2
affinidi-mdoc = "0.3"    # carries coset in its public API
coset         = "0.4"    # dependabot's original half
```

The upstream half is affinidi/affinidi-tdk-rs#751, which moved all three on its
side for the same reason and is now published.

## No source change

coset 0.4.0's one breaking change is the `crit` field on `Header` gaining
private-use label support ([RFC 9052
§3.1](https://datatracker.ietf.org/doc/html/rfc9052#name-common-cose-header-paramete)),
which nothing in this workspace touches. 0.4.1/0.4.2 are additive. Same upstream:
`affinidi-mdoc` compiled unmodified with all 126 of its tests passing.

## Graph

`affinidi-mdoc` and `affinidi-tdk` are now single-version. `Cargo.lock` also
moves `affinidi-messaging-test-mediator` 0.4.0 → 0.4.3 — already inside the
existing `"0.4"` requirement, so no manifest change, and 0.4.3 is the release
that requires `affinidi-tdk` 0.11. Without it the graph keeps a second
`affinidi-tdk` for the dev-dependency tree: resolvable, but a duplicate this
change would otherwise have created.

**One `coset` remains, at 0.3.8**, held by `nitro_attest` — an external crate we
don't control, reached only as a **dev-dependency** of `vta-sdk`. It is not on
the mdoc path and not in any production graph. Before this change `coset 0.3.8`
had two consumers; now it has that one.

## Also

The `affinidi-tdk` pin comment argued about `0.8` vs `0.8.5` and described a
minimum-patch pin the line stopped expressing several bumps ago. Corrected while
the line is being touched, since a reviewer reads the two together. And the
`coset` comment — which predicted this exact failure before it happened
(*"depending on a transitive is how a version bump elsewhere breaks an unrelated
crate"*) — now names the constraint outright, so the next person bumping any of
the three doesn't have to rediscover that they move as a set.

## Testing

`cargo test --workspace` exit 0; `cargo check --workspace --all-targets` and
`cargo clippy --workspace --all-targets` clean.
