### PR TITLE
fix(sdk): accept the `ext` member every payload schema declares

### DIFF
--- a/vta-cli-common/src/commands/config.rs
+++ b/vta-cli-common/src/commands/config.rs
@@ -60,7 +60,10 @@ pub async fn cmd_config_update(
 
     let resp = client
         .update_config(UpdateConfigRequest {
-            patch: UpdateConfigBody { overrides },
+            patch: UpdateConfigBody {
+                overrides,
+                ext: None,
+            },
         })
         .await?;
 

--- a/vta-cli-common/src/commands/policy.rs
+++ b/vta-cli-common/src/commands/policy.rs
@@ -28,6 +28,7 @@ pub async fn cmd_list(
             enabled_only,
             cursor: None,
             page_size: None,
+            ext: None,
         })
         .await?;
 
@@ -129,6 +130,7 @@ pub async fn cmd_delete(
             id: id.to_string(),
             expected_version,
             reason,
+            ext: None,
         })
         .await?;
     println!("Deleted policy {} at {}", result.id, result.deleted_at);

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2698,7 +2698,10 @@ mod tests {
         let mut overrides = std::collections::HashMap::new();
         overrides.insert("vta_name".to_string(), serde_json::json!("Test"));
         let req = UpdateConfigRequest {
-            patch: UpdateConfigBody { overrides },
+            patch: UpdateConfigBody {
+                overrides,
+                ext: None,
+            },
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["overrides"]["vta_name"], "Test");

--- a/vta-sdk/src/client/policy.rs
+++ b/vta-sdk/src/client/policy.rs
@@ -43,7 +43,10 @@ impl VtaClient {
 
     /// `policy/get/0.1` — read one policy module by id.
     pub async fn get_policy(&self, id: &str) -> Result<GetPolicyResultBody, VtaError> {
-        let req = GetPolicyBody { id: id.to_string() };
+        let req = GetPolicyBody {
+            id: id.to_string(),
+            ext: None,
+        };
         self.rpc_tt(
             crate::trust_tasks::TASK_POLICY_GET_0_1,
             serde_json::to_value(&req)?,

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -570,8 +570,10 @@ impl serde::Serialize for CreateAclRequest {
                 }),
                 step_up: has_step_up.then_some(step_up),
                 approve: has_approve.then_some(approve),
+                ext: None,
             },
             reason: None,
+            ext: None,
         };
         body.serialize(s)
     }

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::entry::AclEntry;
+use serde_json::Value;
 
 /// `acl/grant/0.1` request.
 ///
@@ -25,6 +26,19 @@ pub struct CreateAclBody {
     /// Optional human-readable rationale, recorded with the grant.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `acl/grant/0.1` response — the realized entry the maintainer now holds.

--- a/vta-sdk/src/protocols/acl_management/delete.rs
+++ b/vta-sdk/src/protocols/acl_management/delete.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::entry::AclEntry;
+use serde_json::Value;
 
 /// `acl/revoke/0.1` request.
 ///
@@ -27,6 +28,19 @@ pub struct DeleteAclBody {
     /// Optional human-readable rationale, recorded with the revocation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `acl/revoke/0.1` response — the entry as it stood when revoked.

--- a/vta-sdk/src/protocols/acl_management/entry.rs
+++ b/vta-sdk/src/protocols/acl_management/entry.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use crate::acl::ApproveScope;
 
 use super::create::CreateAclResultBody;
+use serde_json::Value;
 
 /// Per-entry step-up configuration — canonical `AclEntry.stepUp`.
 ///
@@ -148,6 +149,19 @@ pub struct AclEntry {
     pub step_up: Option<StepUp>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approve: Option<Approve>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// Unix epoch seconds → RFC 3339, for the wire.
@@ -188,6 +202,10 @@ impl AclEntry {
             expires_at: r.expires_at.and_then(to_rfc3339),
             step_up: (!step_up.is_empty()).then_some(step_up),
             approve: (!approve.is_empty()).then_some(approve),
+            // The VTA does not author extension members; it only carries a
+            // producer's through. Nothing to put here when building the wire
+            // form from our own row.
+            ext: None,
         }
     }
 
@@ -229,6 +247,7 @@ mod tests {
             expires_at: None,
             step_up: None,
             approve: None,
+            ext: None,
         };
         let v = serde_json::to_value(&e).unwrap();
         assert!(v.get("approve").is_none(), "{v}");
@@ -326,6 +345,7 @@ mod tests {
                 require: Some("delegated".into()),
             }),
             approve: None,
+            ext: None,
         };
         let v = serde_json::to_value(&e).unwrap();
         assert!(v.get("expiresAt").is_some(), "{v}");

--- a/vta-sdk/src/protocols/acl_management/get.rs
+++ b/vta-sdk/src/protocols/acl_management/get.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::entry::AclEntry;
+use serde_json::Value;
 
 /// `acl/show/0.1` request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -11,6 +12,19 @@ use super::entry::AclEntry;
 pub struct GetAclBody {
     /// VID of the entry to read. Was `did` before the canonical fold.
     pub subject: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `acl/show/0.1` response.

--- a/vta-sdk/src/protocols/acl_management/list.rs
+++ b/vta-sdk/src/protocols/acl_management/list.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::entry::AclEntry;
 use crate::acl::ContextDirection;
+use serde_json::Value;
 
 /// `acl/list/0.1` request. Every member is an optional filter.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -33,6 +34,19 @@ pub struct ListAclBody {
     pub page_size: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `acl/list/0.1` response.

--- a/vta-sdk/src/protocols/app_state.rs
+++ b/vta-sdk/src/protocols/app_state.rs
@@ -477,6 +477,19 @@ pub struct AppStateWrite {
     /// write in the batch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `spec/vta/app-state/put-many/1.0` request body.

--- a/vta-sdk/src/protocols/credentials_issuance.rs
+++ b/vta-sdk/src/protocols/credentials_issuance.rs
@@ -38,6 +38,19 @@ pub struct IssueCredentialBody {
     /// signed into the issued VC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authorization_context: Option<Value>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `spec/vta/credentials/issue/0.2` response body.
@@ -74,6 +87,19 @@ pub struct RevokeCredentialBody {
     /// Optional reason (recorded in the audit trail + revocation tombstone).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `spec/vta/credentials/revoke/0.1` response body.

--- a/vta-sdk/src/protocols/memory.rs
+++ b/vta-sdk/src/protocols/memory.rs
@@ -15,6 +15,7 @@
 //! memory.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// `spec/vta/memory/put/0.1` request body. Upsert: re-putting the same
 /// `(contextId, key)` replaces the stored value.
@@ -27,6 +28,19 @@ pub struct MemoryPutBody {
     pub key: String,
     /// The value to store.
     pub value: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `spec/vta/memory/put/0.1` response body.
@@ -43,6 +57,19 @@ pub struct MemoryPutResponse {
 pub struct MemoryListBody {
     /// The context whose entries to list. The caller must have ACL access to it.
     pub context_id: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// A single stored memory entry returned by `spec/vta/memory/list/0.1`.
@@ -71,6 +98,19 @@ pub struct MemoryDeleteBody {
     pub context_id: String,
     /// The entry key to delete. `not_found` if absent.
     pub key: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `spec/vta/memory/delete/0.1` response body.

--- a/vta-sdk/src/protocols/policy_management.rs
+++ b/vta-sdk/src/protocols/policy_management.rs
@@ -22,6 +22,7 @@
 //! them) — they are exactly how this maintainer selects.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Canonical `policy/_shared` **PolicyModule** — the projection of a stored
 /// policy row returned by `list`, `get`, and `upsert`.
@@ -69,6 +70,19 @@ pub struct ListPoliciesBody {
     pub cursor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page_size: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `policy/list/0.2` response.
@@ -89,6 +103,19 @@ pub struct ListPoliciesResultBody {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetPolicyBody {
     pub id: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `policy/get/0.1` response.
@@ -161,6 +188,19 @@ pub struct DeletePolicyBody {
     /// Operator rationale, recorded in the audit row.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// `policy/delete/0.1` response.

--- a/vta-sdk/src/protocols/vta_management/get_config.rs
+++ b/vta-sdk/src/protocols/vta_management/get_config.rs
@@ -8,6 +8,7 @@
 //! every other agent.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// `config/show/0.1` request. `keys` narrows the result; omitted returns every
 /// registered key.
@@ -17,6 +18,19 @@ use serde::{Deserialize, Serialize};
 pub struct GetConfigBody {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keys: Option<Vec<String>>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// One configuration key as the operator currently sees it — canonical

--- a/vta-sdk/src/protocols/vta_management/update_config.rs
+++ b/vta-sdk/src/protocols/vta_management/update_config.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use super::get_config::GetConfigResultBody;
+use serde_json::Value;
 
 /// `config/patch/0.1` request: `key → value`. Keys outside the registry, and
 /// keys that are immutable at runtime, come back under `rejected` rather than
@@ -38,6 +39,19 @@ use super::get_config::GetConfigResultBody;
 pub struct UpdateConfigBody {
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub overrides: HashMap<String, serde_json::Value>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// A key the patch declined to apply, and why — canonical

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -357,6 +357,7 @@ async fn update_config_sends_the_overrides_map() {
         .update_config(UpdateConfigRequest {
             patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
                 overrides,
+                ext: None,
             },
         })
         .await
@@ -390,6 +391,7 @@ async fn update_config_reports_identity_as_rejected() {
         .update_config(UpdateConfigRequest {
             patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
                 overrides,
+                ext: None,
             },
         })
         .await

--- a/vta-sdk/tests/payload_ext_census.rs
+++ b/vta-sdk/tests/payload_ext_census.rs
@@ -1,0 +1,196 @@
+//! Census: a `deny_unknown_fields` wire type must carry an `ext` member.
+//!
+//! ## The invariant
+//!
+//! SPEC.md §4.5.1 gives every Trust Task payload an `ext` slot for
+//! ecosystem-defined extension members, and the published schemas declare it —
+//! `acl/list/0.1`, `policy/list/0.2` and the rest all list `ext` among their
+//! properties. So a conforming producer may send one.
+//!
+//! `#[serde(deny_unknown_fields)]` on a struct that has no `ext` field turns
+//! that permission into a hard rejection of the whole document:
+//!
+//! ```text
+//! malformed request: payload parse: unknown field `ext`, expected one of
+//! `role`, `scope`, `direction`, `subjectPrefix`, `pageSize`, `cursor`
+//! ```
+//!
+//! The two clauses are not in conflict and the fix is not to drop
+//! `deny_unknown_fields`: carrying `ext` explicitly keeps a *typo* refused,
+//! which is the guard that clause was there for, while letting through the one
+//! member the spec says is always allowed.
+//!
+//! ## Why a census rather than another fixture
+//!
+//! Seven of these structs already carry `ext`, with the reasoning written out
+//! on each. Sixteen did not — including `acl/list`, `policy/list`, every
+//! `vta/memory/*` body, `app-state` writes, config read and patch, and both
+//! credential-issuance bodies. Nothing failed at build time and nothing failed
+//! in the conformance table, because both of those exercise the members a
+//! fixture happens to set and this defect lives in the member it leaves unset.
+//!
+//! It surfaced from a browser-based management console: two of its panes died
+//! outright, and the operator was shown a parse error naming a field the spec
+//! had told the client it could send. Whether a caller trips this is decided
+//! entirely by whether it populates `ext` — so a partial fix reads as a working
+//! system right up until a conforming peer appears.
+//!
+//! The invariant is a property of the *source*, so it is checked against the
+//! source, once, for every wire type at the same time.
+//!
+//! ## Scope
+//!
+//! Every `deny_unknown_fields` struct under `vta-sdk/src/protocols/`. Genuine
+//! exceptions go in [`NO_EXT_BY_DESIGN`] with a reason; there is no way to pass
+//! by silence.
+//!
+//! Parsed with `syn`, not grepped — the attribute is routinely written across
+//! several lines, and a line-oriented regex misreads that in exactly the
+//! direction that lets a violation through.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use syn::{Fields, Item, ItemStruct, Meta};
+
+/// Types that legitimately admit no `ext`, each with the reason.
+///
+/// An entry here is a claim that the *published schema* declares no `ext` slot
+/// for this type — not that adding the field is inconvenient. A type whose
+/// schema has one, listed here, re-opens the defect this file exists to
+/// prevent.
+const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[];
+
+/// One `deny_unknown_fields` type that would reject a conforming `ext`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Violation {
+    file: String,
+    strukt: String,
+}
+
+fn protocols_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("protocols")
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("protocols/ is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn denies_unknown_fields(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("serde")
+            && matches!(&attr.meta, Meta::List(l) if l.tokens.to_string().contains("deny_unknown_fields"))
+    })
+}
+
+/// `#[cfg(test)]` items are not wire types.
+fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("cfg")
+            && matches!(&attr.meta, Meta::List(l) if l.tokens.to_string().contains("test"))
+    })
+}
+
+fn inspect_struct(s: &ItemStruct, file: &str, inspected: &mut usize, out: &mut Vec<Violation>) {
+    if !denies_unknown_fields(&s.attrs) {
+        return;
+    }
+    let Fields::Named(fields) = &s.fields else {
+        return;
+    };
+    *inspected += 1;
+
+    let has_ext = fields
+        .named
+        .iter()
+        .any(|f| f.ident.as_ref().is_some_and(|i| i == "ext"));
+    if has_ext {
+        return;
+    }
+    if NO_EXT_BY_DESIGN.iter().any(|(st, _)| s.ident == st) {
+        return;
+    }
+
+    out.push(Violation {
+        file: file.to_string(),
+        strukt: s.ident.to_string(),
+    });
+}
+
+fn walk_items(items: &[Item], file: &str, inspected: &mut usize, out: &mut Vec<Violation>) {
+    for item in items {
+        match item {
+            Item::Struct(s) if !is_cfg_test(&s.attrs) => inspect_struct(s, file, inspected, out),
+            Item::Mod(m) if !is_cfg_test(&m.attrs) => {
+                if let Some((_, inner)) = &m.content {
+                    walk_items(inner, file, inspected, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn deny_unknown_fields_types_accept_ext() {
+    let root = protocols_dir();
+    let mut files = Vec::new();
+    rust_sources(&root, &mut files);
+    files.sort();
+
+    assert!(
+        files.len() > 10,
+        "found only {} source files under {} — the walk is broken, and a \
+         census that inspects nothing passes vacuously",
+        files.len(),
+        root.display()
+    );
+
+    let mut inspected = 0usize;
+    let mut violations = Vec::new();
+
+    for path in &files {
+        let src = fs::read_to_string(path).expect("source file is readable");
+        let parsed = syn::parse_file(&src)
+            .unwrap_or_else(|e| panic!("{}: does not parse: {e}", path.display()));
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+        walk_items(&parsed.items, &rel, &mut inspected, &mut violations);
+    }
+
+    assert!(
+        inspected > 15,
+        "inspected only {inspected} deny_unknown_fields types — the walk is \
+         broken, and a census that inspects nothing passes vacuously"
+    );
+
+    violations.sort();
+    assert!(
+        violations.is_empty(),
+        "{} wire type(s) deny unknown fields but carry no `ext`, so a producer \
+         doing exactly what SPEC §4.5.1 and the published schema allow has its \
+         whole document rejected:\n{}\n\nAdd:\n\n    /// Ecosystem-defined \
+         extension members (SPEC §4.5.1).\n    #[serde(default, \
+         skip_serializing_if = \"Option::is_none\")]\n    pub ext: \
+         Option<Value>,\n\nKeep `deny_unknown_fields` — it is what still \
+         refuses a typo.",
+        violations.len(),
+        violations
+            .iter()
+            .map(|v| format!("  {}::{}", v.file, v.strukt))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}

--- a/vta-sdk/tests/trust_task_decode.rs
+++ b/vta-sdk/tests/trust_task_decode.rs
@@ -110,6 +110,7 @@ fn agent_acl_entry() -> AclEntry {
         expires_at: Some(ts()),
         step_up: None,
         approve: None,
+        ext: None,
     }
 }
 

--- a/vta-service/src/operations/app_state.rs
+++ b/vta-service/src/operations/app_state.rs
@@ -2564,6 +2564,7 @@ mod tests {
                 value: Some(json!(2)),
                 merge_patch: None,
                 expected_version: Some(a.version),
+                ext: None,
             },
             AppStateWrite {
                 key: "b".into(),
@@ -2571,12 +2572,14 @@ mod tests {
                 merge_patch: None,
                 // Stale on purpose.
                 expected_version: Some(999),
+                ext: None,
             },
             AppStateWrite {
                 key: "c".into(),
                 value: Some(json!(1)),
                 merge_patch: None,
                 expected_version: Some(0),
+                ext: None,
             },
         ];
         let (results, high) = put_many(
@@ -2619,12 +2622,14 @@ mod tests {
                 value: Some(json!({"label": "Cyprus"})),
                 merge_patch: None,
                 expected_version: Some(0),
+                ext: None,
             },
             AppStateWrite {
                 key: "index".into(),
                 value: Some(json!({"ids": ["cyprus"]})),
                 merge_patch: None,
                 expected_version: Some(999), // stale
+                ext: None,
             },
         ];
         let err = put_many(&ks, &locks, "ctx", "openvtc", &writes, PutManyMode::Atomic)
@@ -2665,12 +2670,14 @@ mod tests {
                 value: Some(json!({"label": "Cyprus"})),
                 merge_patch: None,
                 expected_version: Some(0),
+                ext: None,
             },
             AppStateWrite {
                 key: "index".into(),
                 value: Some(json!({"ids": ["cyprus"]})),
                 merge_patch: None,
                 expected_version: Some(idx.version),
+                ext: None,
             },
         ];
         let (results, _) = put_many(&ks, &locks, "ctx", "openvtc", &writes, PutManyMode::Atomic)
@@ -2688,12 +2695,14 @@ mod tests {
                 value: Some(json!(1)),
                 merge_patch: None,
                 expected_version: None,
+                ext: None,
             },
             AppStateWrite {
                 key: "k".into(),
                 value: Some(json!(2)),
                 merge_patch: None,
                 expected_version: None,
+                ext: None,
             },
         ];
         let err = put_many(

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -414,6 +414,7 @@ fn acl_entry() -> AclEntry {
         // grants and only a present value proves the member survives the
         // wire under its canonical `allowedKeys` spelling.
         allowed_keys: Some(vec!["tenant-key-a".into()]),
+        ext: None,
     }
 }
 
@@ -731,6 +732,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     subject_prefix: Some("did:key:z6Mk".into()),
                     page_size: Some(50),
                     cursor: Some("cur-1".into()),
+                    ext: None,
                 }),
                 to_v(ListAclResultBody {
                     entries: vec![acl_entry()],
@@ -748,6 +750,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(CreateAclBody {
                     entry: acl_entry(),
                     reason: Some("onboarding".into()),
+                    ext: None,
                 }),
                 to_v(CreateAclResponseBody { entry: acl_entry() })
             ),
@@ -759,6 +762,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::acl::show::v0_1::Response,
                 to_v(GetAclBody {
                     subject: SUBJECT.into(),
+                    ext: None,
                 }),
                 to_v(GetAclResultBody {
                     entry: acl_entry(),
@@ -819,6 +823,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     subject: SUBJECT.into(),
                     scopes: Some(vec!["ctx-a".into()]),
                     reason: Some("offboarding".into()),
+                    ext: None,
                 }),
                 to_v(DeleteAclResultBody { entry: acl_entry() })
             ),
@@ -1388,6 +1393,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     // published schema does not define, so a producer cannot
                     // send it through the validated transport at all.
                     authorization_context: None,
+                    ext: None,
                 }),
                 to_v(IssueCredentialResponse {
                     credential_id: "cred-1".into(),
@@ -1405,6 +1411,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(RevokeCredentialBody {
                     credential_id: "cred-1".into(),
                     reason: Some("holder offboarded".into()),
+                    ext: None,
                 }),
                 to_v(RevokeCredentialResponse {
                     credential_id: "cred-1".into(),
@@ -1422,6 +1429,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     context_id: "ctx-a".into(),
                     key: "greeting".into(),
                     value: "hello".into(),
+                    ext: None,
                 }),
                 to_v(MemoryPutResponse {
                     key: "greeting".into(),
@@ -1435,6 +1443,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::vta::memory::list::v0_1::Response,
                 to_v(MemoryListBody {
                     context_id: "ctx-a".into(),
+                    ext: None,
                 }),
                 to_v(MemoryListResponse {
                     items: vec![MemoryItem {
@@ -1452,6 +1461,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(MemoryDeleteBody {
                     context_id: "ctx-a".into(),
                     key: "greeting".into(),
+                    ext: None,
                 }),
                 to_v(MemoryDeleteResponse {
                     key: "greeting".into(),
@@ -1589,12 +1599,14 @@ fn table() -> Vec<(&'static str, Conformance)> {
                             value: None,
                             merge_patch: Some(serde_json::json!({ "role": "owner" })),
                             expected_version: Some(52),
+                            ext: None,
                         },
                         AppStateWrite {
                             key: "profile/labels".into(),
                             value: Some(serde_json::json!({ "colours": { "acme": "blue" } })),
                             merge_patch: None,
                             expected_version: Some(0),
+                            ext: None,
                         },
                     ],
                     ext: None,
@@ -1648,6 +1660,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     enabled_only: true,
                     cursor: None,
                     page_size: Some(50),
+                    ext: None,
                 }),
                 to_v(ListPoliciesResultBody {
                     policies: vec![policy_module_view()],
@@ -1663,6 +1676,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::policy::get::v0_1::Response,
                 to_v(GetPolicyBody {
                     id: "approvals".into(),
+                    ext: None,
                 }),
                 to_v(GetPolicyResultBody {
                     policy: policy_module_view(),
@@ -1700,6 +1714,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     id: "legacy-rego".into(),
                     expected_version: Some(2),
                     reason: Some("superseded by the declarative rules".into()),
+                    ext: None,
                 }),
                 to_v(DeletePolicyResultBody {
                     id: "legacy-rego".into(),
@@ -1715,6 +1730,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 specs::config::show::v0_1::Response,
                 to_v(GetConfigBody {
                     keys: Some(vec!["public_url".into()]),
+                    ext: None,
                 }),
                 to_v(GetConfigResultBody {
                     fields: vec![ConfigField {
@@ -1735,6 +1751,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     overrides: [("public_url".to_string(), json!("https://vta.example"))]
                         .into_iter()
                         .collect(),
+                    ext: None,
                 }),
                 to_v(UpdateConfigResultBody {
                     applied: vec!["public_url".into()],

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -261,6 +261,7 @@ async fn config_registry_round_trips_and_identity_stays_read_only() {
         .update_config(vta_sdk::client::UpdateConfigRequest {
             patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
                 overrides,
+                ext: None,
             },
         })
         .await
@@ -282,6 +283,7 @@ async fn config_registry_round_trips_and_identity_stays_read_only() {
         .update_config(vta_sdk::client::UpdateConfigRequest {
             patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
                 overrides,
+                ext: None,
             },
         })
         .await


### PR DESCRIPTION
SPEC §4.5.1 gives every Trust Task payload an `ext` slot for ecosystem-defined extension members, and the published schemas declare it. Sixteen `deny_unknown_fields` structs had no field for it, so a producer doing exactly what the schema permits had its whole document rejected.

## The failure

```
malformed request: payload parse: unknown field `ext`,
expected one of `role`, `scope`, `direction`, `subjectPrefix`, `pageSize`, `cursor`
```

`specs/acl/list/0.1/payload.schema.json` lists `ext` among its properties. So does `policy/list/0.2`. The client was told it could send one; the agent rejected the document for containing it.

## Scope

| Family | Structs |
|---|---|
| `acl/*` | `CreateAclBody`, `DeleteAclBody`, `GetAclBody`, `ListAclBody`, `AclEntry` |
| `vta/memory/*` | `MemoryPutBody`, `MemoryListBody`, `MemoryDeleteBody` |
| `policy/*` | `ListPoliciesBody`, `GetPolicyBody`, `DeletePolicyBody` |
| `vta/credentials/*` | `IssueCredentialBody`, `RevokeCredentialBody` |
| `vta/app-state/*` | `AppStateWrite` |
| `config/*` | `GetConfigBody`, `UpdateConfigBody` |

Seven sibling structs already carry `ext`, with the reasoning written out on each — `AppStateGetBody` and `UpsertPolicyBody` among them. **This completes that work rather than starting it**, and reuses their wording verbatim.

`deny_unknown_fields` stays. Carrying `ext` explicitly is what keeps a *typo* refused, which is the guard that clause was there for, while letting through the one member the spec says is always allowed. Relaxing the clause instead would trade a real defect for a worse one.

## How it was found, and why nothing caught it

A browser-based VTA management console. Its Access and Policy panes died outright, and the operator was shown a parse error naming a field the spec had told the client it could send.

Whether a caller trips this is decided entirely by whether it populates `ext` — so the same agent looks healthy to one client and broken to another. The conformance table did not catch it because it exercises the members its fixtures *set*, and this defect lives in the member they leave unset. `keys/list/0.1` worked fine throughout, which is why only two panes failed rather than all of them.

## The guard

Another fixture would have the same blind spot, so the guard is a census over the source, matching the existing `payload_null_census.rs`:

`vta-sdk/tests/payload_ext_census.rs` fails on any `deny_unknown_fields` type under `protocols/` that carries no `ext`, naming each one and printing the field to add. Exceptions go in `NO_EXT_BY_DESIGN` and must state a reason — there is no way to pass by silence. It asserts it inspected a plausible number of types, so a broken walk fails rather than passing vacuously.

Parsed with `syn`, not grepped: the attribute is routinely written across several lines, and a line-oriented regex misreads that in the direction that lets a violation through.

**Verified to fail:** reverting `ListAclBody` alone produces

```
1 wire type(s) deny unknown fields but carry no `ext` …
  acl_management/list.rs::ListAclBody
```

## Checks

- `cargo check --workspace --all-targets` — clean
- `cargo test -p vta-sdk` — 300 + all integration suites pass
- `cargo test -p vta-service --lib trust_tasks::conformance` — 2 passed
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo fmt --all --check` — clean

## Not in this PR

Two adjacent gaps found from the same console, both needing spec work rather than a code fix — happy to open either if wanted:

1. **`vta/credentials` has no list task.** Only `issue` and `revoke` are specified, so a client can mint and revoke a credential but cannot enumerate what it has issued. The console renders an explicit "there is no list, and this is not an empty one" notice rather than a blank table it has no basis for.
2. **`vault/credentials/*` is implemented but unspecified.** `vta-sdk/src/client/vault.rs` dispatches `TASK_VAULT_CREDENTIALS_QUERY_0_1` and friends (query, get, receive, archive, unarchive, delete, restore, purge), and `pnm cred-vault` drives them, but there is no entry under `specs/vault/credentials/` and so no generated bindings. Any TypeScript client wanting the holder-side credential store has to hand-transcribe the shapes from the Rust — a copy that drifts.
