### PR TITLE
feat(acl): add MemoryRead/MemoryWrite and gate the memory tasks on them

### DIFF
--- a/vta-service/src/trust_tasks/memory.rs
+++ b/vta-service/src/trust_tasks/memory.rs
@@ -1,6 +1,18 @@
 //! Agent-memory trust-task slice (`spec/vta/memory/{put,list,delete}/0.1`).
 //!
 //! A per-context key/value store for AI-agent memory. Each handler is:
+//! - **Capability-gated** — read tasks require [`Capability::MemoryRead`],
+//!   mutating tasks require [`Capability::MemoryWrite`]. Until this pair
+//!   existed the only gate was the context, which is binary: any DID that
+//!   could reach a context could also write and delete every memory in it, so
+//!   there was no way to grant an agent read-only access to your own memory.
+//!   The published specification already assumed otherwise —
+//!   `vta/memory/delete/0.1` reasons about "a VTA whose write capability is
+//!   granted more freely than its read capability". Legacy ACL rows carry no
+//!   explicit capability set and fall back to
+//!   [`derived_capabilities_for_role`], which grants both to `admin`,
+//!   `initiator` and `application` (the role a memory agent runs as), read
+//!   only to `reader`, and neither to `monitor`.
 //! - **Context-gated** — the caller must be permitted to act in
 //!   `payload.contextId`, enforced via [`AuthClaims::require_context`], the
 //!   exact ACL gate the context-scoped key tasks use
@@ -22,12 +34,44 @@ use vta_sdk::protocols::memory::{
     MemoryPutResponse,
 };
 
+use trust_tasks_rs::RejectReason;
+use vti_common::acl::{Capability, role_has_capability};
+
 use crate::audit;
 use crate::auth::AuthClaims;
 use crate::operations::memory;
 use crate::server::AppState;
 
-use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, reject_with, success_response,
+};
+
+/// Capability gate for the memory surface, mirroring the vault slices'
+/// [`super::vault::require_capability`].
+///
+/// Checked **before** the context gate so a caller who holds neither learns
+/// only that the capability is missing — the narrower fact, and the one that
+/// does not reveal whether a given context exists.
+fn require_cap(
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    cap: Capability,
+    action: &str,
+) -> Result<(), super::helpers::TrustTaskOutcome> {
+    if role_has_capability(&auth.role, cap) {
+        Ok(())
+    } else {
+        Err(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "memory {action} denied: role {} does not carry {cap:?} capability",
+                    auth.role
+                ),
+            },
+        ))
+    }
+}
 
 /// Handler for `spec/vta/memory/put/0.1`.
 pub(super) async fn handle_put(
@@ -35,6 +79,9 @@ pub(super) async fn handle_put(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> super::helpers::TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::MemoryWrite, "put") {
+        return r;
+    }
     let req: MemoryPutBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -57,6 +104,9 @@ pub(super) async fn handle_list(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> super::helpers::TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::MemoryRead, "list") {
+        return r;
+    }
     let req: MemoryListBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -78,6 +128,9 @@ pub(super) async fn handle_delete(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> super::helpers::TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::MemoryWrite, "delete") {
+        return r;
+    }
     let req: MemoryDeleteBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -127,6 +180,20 @@ mod tests {
         TASK_VTA_MEMORY_DELETE_0_1, TASK_VTA_MEMORY_LIST_0_1, TASK_VTA_MEMORY_PUT_0_1,
     };
 
+    /// Claims for `role`, scoped to exactly `ctx`.
+    fn claims_for(role: Role, ctx: &str) -> AuthClaims {
+        AuthClaims {
+            did: format!("did:key:z{role}"),
+            role,
+            allowed_contexts: vec![ctx.to_string()],
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            issued_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        }
+    }
+
     /// An admin whose ACL grants exactly `ctx` (not a super-admin — a
     /// super-admin's empty `allowed_contexts` would reach every context, which
     /// is what we must NOT do for the isolation test).
@@ -162,6 +229,19 @@ mod tests {
             TASK_VTA_MEMORY_DELETE_0_1,
             json!({ "contextId": ctx, "key": key }),
         )
+    }
+
+    /// A framework rejection carrying `permission_denied`. The capability gate
+    /// and the context gate both land here, which is the point of §the ordering
+    /// test below.
+    fn is_denied(out: &super::super::helpers::TrustTaskOutcome) -> bool {
+        let doc: Value = serde_json::from_slice(&out.body).expect("response is JSON");
+        !out.status.is_success()
+            || doc
+                .get("payload")
+                .and_then(|p| p.get("reason"))
+                .and_then(Value::as_str)
+                .is_some_and(|r| r.contains("denied"))
     }
 
     fn response_payload(out: &super::super::helpers::TrustTaskOutcome) -> Value {
@@ -282,6 +362,92 @@ mod tests {
         assert_eq!(
             items[0].get("value").and_then(Value::as_str),
             Some("a-only")
+        );
+    }
+
+    /// The gap this pair of capabilities closes: before it existed the only
+    /// gate was the context, which is binary, so *any* role that could reach a
+    /// context could rewrite every memory in it. A `reader` is a read-only
+    /// consumer by definition.
+    #[tokio::test]
+    async fn a_reader_can_list_memory_but_not_write_it() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = claims_for(Role::Reader, "ctx-a");
+
+        let out = handle_list(&state, &auth, list_doc("ctx-a")).await;
+        assert!(
+            out.status.is_success(),
+            "reader holds MemoryRead, so listing must succeed"
+        );
+
+        let out = handle_put(&state, &auth, put_doc("ctx-a", "user/name", "Ada")).await;
+        assert!(
+            is_denied(&out),
+            "reader does not hold MemoryWrite, so put must be refused"
+        );
+
+        let out = handle_delete(&state, &auth, delete_doc("ctx-a", "user/name")).await;
+        assert!(
+            is_denied(&out),
+            "reader does not hold MemoryWrite, so delete must be refused"
+        );
+    }
+
+    /// `monitor` is the least-privileged role and the `Default` for
+    /// `AuthClaims` — a fixture that leaks past its expected reach lands here.
+    /// It must reach nothing, not "everything in whatever context it names".
+    #[tokio::test]
+    async fn a_monitor_reaches_no_memory_at_all() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = claims_for(Role::Monitor, "ctx-a");
+
+        assert!(is_denied(
+            &handle_list(&state, &auth, list_doc("ctx-a")).await
+        ));
+        assert!(is_denied(
+            &handle_put(&state, &auth, put_doc("ctx-a", "user/name", "Ada")).await
+        ));
+    }
+
+    /// `application` is what a memory agent runs as (`vta-agent-memory` grants
+    /// exactly it). If this regresses, every existing install of that plugin
+    /// stops being able to save.
+    #[tokio::test]
+    async fn an_application_keeps_full_memory_access() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = claims_for(Role::Application, "ctx-a");
+
+        assert!(
+            handle_put(&state, &auth, put_doc("ctx-a", "user/name", "Ada"))
+                .await
+                .status
+                .is_success()
+        );
+        assert!(
+            handle_list(&state, &auth, list_doc("ctx-a"))
+                .await
+                .status
+                .is_success()
+        );
+        assert!(
+            handle_delete(&state, &auth, delete_doc("ctx-a", "user/name"))
+                .await
+                .status
+                .is_success()
+        );
+    }
+
+    /// The capability is checked before the context, so a caller missing it
+    /// cannot use the error to probe which contexts exist.
+    #[tokio::test]
+    async fn the_capability_gate_runs_before_the_context_gate() {
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = claims_for(Role::Monitor, "ctx-a");
+        let out = handle_list(&state, &auth, list_doc("ctx-they-cannot-reach")).await;
+        assert!(
+            is_denied(&out),
+            "denied either way — the point is it is refused on the capability, \
+             so the reason text never depends on whether that context exists"
         );
     }
 }

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -143,6 +143,18 @@ pub enum Capability {
     /// *remove* them — removal of a holder's credentials is a higher-trust
     /// action. Granted to the same roles that hold `VaultWrite`.
     CredentialWrite,
+    /// Reading agent memory — `vta/memory/list/0.1`. Split from
+    /// [`Capability::MemoryWrite`] because the published specification already
+    /// assumes the split exists: `vta/memory/delete/0.1` reasons about "a VTA
+    /// whose write capability is granted more freely than its read capability".
+    /// Until this pair, there was no read capability and no write capability —
+    /// only the context gate, which is binary, so any DID that could reach a
+    /// context could also rewrite every memory in it.
+    MemoryRead,
+    /// Writing or deleting agent memory — `vta/memory/{put,delete}/0.1`.
+    /// Deliberately withheld from [`Role::Reader`]: a read-only consumer of a
+    /// context should not be able to rewrite the memories in it.
+    MemoryWrite,
 }
 
 /// Returns true if `role` is granted `cap` by the default capability
@@ -163,6 +175,8 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::VaultRead,
             Capability::VaultWrite,
             Capability::CredentialWrite,
+            Capability::MemoryRead,
+            Capability::MemoryWrite,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::PolicyAdmin,
@@ -175,6 +189,8 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::VaultRead,
             Capability::VaultWrite,
             Capability::CredentialWrite,
+            Capability::MemoryRead,
+            Capability::MemoryWrite,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::DeviceAdmin,
@@ -182,14 +198,20 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::SignTrustTask,
             Capability::KeyMint,
         ],
+        // `application` is the role a memory agent runs as — `vta-agent-memory`
+        // grants exactly it, deliberately, so the memory service is not the
+        // user. It must keep both memory capabilities or every existing
+        // deployment of that plugin stops working.
         Role::Application => vec![
             Capability::VaultRead,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::Sign,
             Capability::SignTrustTask,
+            Capability::MemoryRead,
+            Capability::MemoryWrite,
         ],
-        Role::Reader => vec![Capability::VaultRead],
+        Role::Reader => vec![Capability::VaultRead, Capability::MemoryRead],
         Role::Monitor => vec![],
     }
 }


### PR DESCRIPTION
Closes the orthogonal gap called out in `docs/05-design-notes/data-rooms.md` §11.1
(design PR #1233). Independent of that design — the gap exists today.

## The gap

**There is no read-only grant on agent memory.** The gate in
`vta-service/src/trust_tasks/memory.rs` is `auth.require_context(&req.context_id)`
and nothing else, and a context is binary: any DID that can reach one can also
write and delete every memory in it. An operator cannot give an agent read-only
access to their own memory. The `--read-only` flag in `vta-mcp/src/guard.rs` is a
client-side glob filter on the MCP bridge — a caller talking to the VTA directly
never encounters it.

**The published spec already assumes otherwise.**
`specs/vta/memory/delete/0.1/spec.md` reasons at length about *"a VTA whose write
capability is granted more freely than its read capability"* and about a caller
holding write "without ever holding the read capability that `vta/memory/list`
requires". There was no read capability and no write capability. There was a
context.

The ACL supplied nothing finer either: the act axis is
`(role, allowed_contexts)` decoded to a three-valued `ActScope` — a *where* with
no *what*.

## The change

`Capability::{MemoryRead, MemoryWrite}`, wired through
`derived_capabilities_for_role`, checked in all three handlers. Legacy rows carry
no explicit capability set and fall back to the derived mapping, so the roles
that write memory today keep writing it.

| role | before | after |
|---|---|---|
| `admin`, `initiator` | read + write (via context) | read + write |
| `application` | read + write (via context) | read + write |
| `reader` | **read + write** (via context) | **read only** |
| `monitor` | **read + write** (via context) | **none** |

**Two deliberate tightenings**, both of which are the point of the change:

- **`reader` loses memory write.** A read-only consumer of a context should not
  be able to rewrite the memories in it.
- **`monitor` loses memory access entirely.** It is the least-privileged role
  and the `Default` for `AuthClaims` — *"a test fixture that leaks past its
  expected reach now lands on the most-restricted role"* — which it did not,
  while memory was context-gated alone.

**`application` keeps both, deliberately**, with a test saying why:
`vta-agent-memory` grants exactly that role so *the memory service is not you*,
and every existing install would otherwise stop being able to save.

The capability is checked **before** the context, so a caller missing it cannot
use the reason text to probe which contexts exist.

## Tests

Four new, in the existing slice: reader-can-list-not-write,
monitor-reaches-nothing, application-keeps-full-access (the regression guard for
the plugin), and gate-ordering. `cargo test -p vti-common -p vta-service --lib`
1,439 passing; workspace builds clean; clippy clean.

## Follow-up, not done here

The canonical `Capability` enum in the trust-tasks registry
(`specs/device/_shared/0.1/device-binding.schema.json`) is **already behind this
crate** — it carries neither `sign-trust-task` nor `credential-write`, both of
which shipped here without it. A spec PR reconciling all four values follows
separately. Flagging rather than quietly widening the gap.