### PR TITLE
feat(vta): implement vta/credentials/list, and check the vault/credentials family

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8769,9 +8769,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d841bf16638473fed22f94ce446cadcc932afc60ca3f623eef184d546d945b"
+checksum = "84ea8a0b30f49df3227e7f1adaf52ca2bad7591740059be7a629906a743f8dfa"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-sdk/src/protocols/credentials_issuance.rs
+++ b/vta-sdk/src/protocols/credentials_issuance.rs
@@ -1,5 +1,5 @@
 //! Wire payloads for the issued-credential lifecycle Trust Tasks
-//! (`spec/vta/credentials/issue/0.2` and `spec/vta/credentials/revoke/0.1`).
+//! (`spec/vta/credentials/{issue/0.2, revoke/0.1, list/0.1}`).
 //!
 //! These mint / revoke a VTA-signed W3C Verifiable Credential addressed to a
 //! holder DID, distinct from the credential-vault slice (`vault/credentials/*`)
@@ -110,4 +110,122 @@ pub struct RevokeCredentialResponse {
     pub credential_id: String,
     /// RFC 3339 timestamp at which the credential was revoked.
     pub revoked_at: String,
+}
+
+/// The state of an issued credential, as reported by `list`.
+///
+/// **Derived when the list is answered, never stored.** A stored status is a
+/// copy of a fact about the clock and is wrong from the first second after it
+/// is written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IssuedCredentialStatus {
+    /// Neither revoked nor past its expiry.
+    Active,
+    /// Not revoked, and `expiresAt` has passed.
+    Expired,
+    /// A revocation was recorded.
+    ///
+    /// **Takes precedence over expiry.** A credential revoked before its
+    /// window closed is revoked; reporting it as merely expired would hide
+    /// that somebody acted.
+    Revoked,
+}
+
+/// `spec/vta/credentials/list/0.1` request body.
+///
+/// Every member is an optional filter, AND-combined. An unfiltered request is
+/// answered — unlike `vault/credentials/query`, which refuses one. The two look
+/// alike and are not: there the caller reads a *holder's* private store, here
+/// the issuer reads a record of its own past actions, and refusing to enumerate
+/// would withhold from a party what it did itself.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ListCredentialsBody {
+    /// Only credentials issued to this DID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub holder: Option<String>,
+    /// Only credentials carrying this type tag beyond `VerifiableCredential`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_type: Option<String>,
+    /// Only credentials in this state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<IssuedCredentialStatus>,
+    /// Maximum records to return. The agent caps this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+    /// Continue a previous page. Opaque to the caller.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// One row of a `list` response — a **body-free** projection of an issuance
+/// record.
+///
+/// The credential itself is deliberately absent. `vault/list/0.1` states the
+/// rule this follows — *list exists to enumerate; release exists to use* — and
+/// a response carrying every claim body would turn reading a roster into a bulk
+/// disclosure of everything the issuer ever asserted about anyone.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct IssuedCredentialSummary {
+    /// The id `vta/credentials/revoke` is keyed on.
+    pub credential_id: String,
+    /// Who the credential was issued to.
+    pub holder: String,
+    /// The type tag beyond `VerifiableCredential`, when the credential has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_type: Option<String>,
+    pub issued_at: String,
+    pub expires_at: String,
+    pub status: IssuedCredentialStatus,
+    /// Set iff `status` is `revoked`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<String>,
+    /// Free text recorded at revocation, disclosed to every caller entitled to
+    /// this list. An issuer must not write anything here it would not show that
+    /// audience.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revocation_reason: Option<String>,
+}
+
+/// `spec/vta/credentials/list/0.1` response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ListCredentialsResponse {
+    /// One summary per matching credential. Empty when nothing matched — a
+    /// successful answer, not an error.
+    pub credentials: Vec<IssuedCredentialSummary>,
+    /// The agent stopped early. A consumer must not read a truncated page as a
+    /// complete account of what was issued.
+    pub truncated: bool,
+    /// Pass to the next request to continue. Absent on the last page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than swept up by relaxing
+    /// `deny_unknown_fields`: the published payload schemas declare an `ext`
+    /// slot, so a conforming producer may send one, and rejecting the whole
+    /// document over it would break interop with a peer doing exactly what the
+    /// spec allows. Keeping `deny_unknown_fields` alongside it means a *typo*
+    /// is still refused rather than silently ignored — which is the guard that
+    /// clause was there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -385,6 +385,10 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // and unknown to the holder.
     (trust_tasks::TASK_VTA_CREDENTIALS_ISSUE_0_2, Keyed),
     (trust_tasks::TASK_VTA_CREDENTIALS_REVOKE_0_1, RetrySafe),
+    // A read, like `acl/list` and `policy/list`. No durable effect, nothing to
+    // dedup, and `status` is derived at read time — so a retry is not merely
+    // safe, it is the way to get a fresher answer.
+    (trust_tasks::TASK_VTA_CREDENTIALS_LIST_0_1, ReadOnly),
     // ── Memory ──────────────────────────────────────────────────────────
     (trust_tasks::TASK_VTA_MEMORY_PUT_0_1, RetrySafe),
     (trust_tasks::TASK_VTA_MEMORY_LIST_0_1, ReadOnly),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -751,6 +751,19 @@ pub const TASK_VTA_CREDENTIALS_ISSUE_0_2: &str =
 pub const TASK_VTA_CREDENTIALS_REVOKE_0_1: &str =
     "https://trusttasks.org/spec/vta/credentials/revoke/0.1";
 
+/// `vta/credentials/list/0.1` — enumerate what this agent has issued, as
+/// metadata.
+///
+/// Bodies are not returned: `vault/list/0.1` states the rule this follows —
+/// *list exists to enumerate; release exists to use*. An issuer that needs a
+/// body minted it and got it back from `issue`.
+///
+/// Exists because `revoke` is keyed on a `credentialId` that `issue` returns
+/// exactly once. Before this, a caller that did not record it at that moment
+/// could not recover it from the agent at all.
+pub const TASK_VTA_CREDENTIALS_LIST_0_1: &str =
+    "https://trusttasks.org/spec/vta/credentials/list/0.1";
+
 // ─── Agent-memory slice (spec/vta/memory/*) ──────────────────────────────
 //
 // A per-context key/value store for AI-agent memory. Dispatcher-routed like
@@ -1713,6 +1726,7 @@ pub const ALL_URIS: &[&str] = &[
     // Issued-credential lifecycle (spec/vta/credentials/*)
     TASK_VTA_CREDENTIALS_ISSUE_0_2,
     TASK_VTA_CREDENTIALS_REVOKE_0_1,
+    TASK_VTA_CREDENTIALS_LIST_0_1,
     // Agent-memory slice (spec/vta/memory/*)
     TASK_VTA_MEMORY_PUT_0_1,
     TASK_VTA_MEMORY_LIST_0_1,

--- a/vta-sdk/tests/payload_ext_census.rs
+++ b/vta-sdk/tests/payload_ext_census.rs
@@ -59,7 +59,17 @@ use syn::{Fields, Item, ItemStruct, Meta};
 /// for this type — not that adding the field is inconvenient. A type whose
 /// schema has one, listed here, re-opens the defect this file exists to
 /// prevent.
-const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[];
+const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[(
+    "IssuedCredentialSummary",
+    "`vault`-style list row, not a payload root. \
+     `vta/credentials/list/0.1`'s published schema closes \
+     `IssuedCredentialSummary` with `additionalProperties: false` and declares \
+     no `ext` slot on it — SPEC §4.5.1 gives the slot to the payload, which \
+     this type is a member of rather than being. So no conforming producer can \
+     send one here, and adding the field would let this crate emit a document \
+     the schema rejects: the opposite of the defect this census exists to \
+     prevent. Revisit only if that schema gains the slot.",
+)];
 
 /// One `deny_unknown_fields` type that would reject a conforming `ext`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/vta-service/src/operations/credentials.rs
+++ b/vta-service/src/operations/credentials.rs
@@ -29,13 +29,23 @@ use crate::operations::internal_authority::InternalAuthority;
 use crate::server::AppState;
 use crate::store::KeyspaceHandle;
 use vta_sdk::did_key::decode_private_key_multibase;
+use vta_sdk::protocols::credentials_issuance::{
+    IssuedCredentialStatus, IssuedCredentialSummary, ListCredentialsBody, ListCredentialsResponse,
+};
 
 /// VC Data Model 2.0 base context — every issued VC carries this.
 const VC_V2_CONTEXT: &str = "https://www.w3.org/ns/credentials/v2";
 
-/// Storage-key prefix for an issued-credential record (`cred:<id>`).
+/// Storage-key prefix for issued-credential records.
+///
+/// Named rather than inlined because two things depend on it agreeing: the
+/// writer below, and `list_issued`'s prefix scan. A literal in each is a pair
+/// that can drift into a list that silently returns nothing.
+pub(crate) const CRED_KEY_PREFIX: &str = "cred:";
+
+/// Storage key for an issued-credential record (`cred:<id>`).
 fn store_key(id: &str) -> String {
-    format!("cred:{id}")
+    format!("{CRED_KEY_PREFIX}{id}")
 }
 
 /// A persisted issued-credential record. The signed VC itself is stored
@@ -239,4 +249,314 @@ async fn store_get(
 /// RFC 3339 with a `Z` suffix (UTC), matching the workspace's VC timestamps.
 fn rfc3339(dt: DateTime<Utc>) -> String {
     dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+// ─── Listing what this agent has issued ──────────────────────────────────────
+//
+// `revoke` is keyed on a `credentialId` that `issue` returns exactly once, so
+// before this an issuer that did not record it at that moment could not recover
+// it from the agent at all. This reads records that already exist: the scan is
+// over the same `cred:` prefix `store_put` writes under, and revocation is a
+// tombstone rather than a delete, so a revoked credential is still there to
+// list.
+
+/// One row of a list answer — the record with its body removed.
+///
+/// The projection happens in one place so "a summary never carries the
+/// credential" is enforced here rather than remembered at each call site. The
+/// `credential` field of [`IssuedCredentialRecord`] is not read.
+fn summarise(record: &IssuedCredentialRecord, now: DateTime<Utc>) -> IssuedCredentialSummary {
+    IssuedCredentialSummary {
+        credential_id: record.id.clone(),
+        holder: record.holder.clone(),
+        credential_type: credential_type_of(&record.credential),
+        issued_at: record.issued_at.clone(),
+        expires_at: record.expires_at.clone(),
+        status: status_of(record, now),
+        revoked_at: record.revoked_at.clone(),
+        revocation_reason: record.revocation_reason.clone(),
+    }
+}
+
+/// The credential's own type tag beyond `VerifiableCredential`.
+///
+/// Read out of the stored VC rather than kept alongside it: the VC is what was
+/// signed, so a separately-stored copy could disagree with the document a
+/// verifier sees. Absent when the credential carries only the base type.
+fn credential_type_of(credential: &Value) -> Option<String> {
+    credential
+        .get("type")?
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|t| *t != "VerifiableCredential")
+        .map(str::to_string)
+}
+
+/// Derive the state at read time.
+///
+/// **Revoked takes precedence over expired.** A credential revoked before its
+/// window closed is revoked; reporting it as merely expired would hide that
+/// somebody acted, which is the one thing a caller reading this list is most
+/// likely to be asking about.
+///
+/// An `expires_at` that will not parse is treated as **not** expired rather
+/// than as expired: guessing "expired" from an unreadable timestamp would
+/// report a live credential as dead, and the failure should be visible as a
+/// credential that never expires rather than one that silently did.
+fn status_of(record: &IssuedCredentialRecord, now: DateTime<Utc>) -> IssuedCredentialStatus {
+    if record.is_revoked() {
+        return IssuedCredentialStatus::Revoked;
+    }
+    match DateTime::parse_from_rfc3339(&record.expires_at) {
+        Ok(expires) if expires.with_timezone(&Utc) <= now => IssuedCredentialStatus::Expired,
+        _ => IssuedCredentialStatus::Active,
+    }
+}
+
+/// The agent's ceiling on a page, whatever the caller asked for.
+const LIST_PAGE_MAX: usize = 200;
+/// What a caller gets when it expresses no preference.
+const LIST_PAGE_DEFAULT: usize = 50;
+
+/// Enumerate issued credentials, filtered and paged.
+///
+/// Filters are AND-combined and every one is optional; an unfiltered request is
+/// answered. Unlike `vault/credentials/query`, which refuses a filter that
+/// constrains nothing, the caller here is the issuer reading a record of its
+/// own past actions rather than a delegate reading a holder's private store.
+///
+/// Ordering is by storage key, which is `cred:<id>` — stable, so the cursor
+/// below means the same thing across calls. It is deliberately not "newest
+/// first": that would need a sort of the whole set before paging, and the
+/// answer a caller wants ordered is one they can order themselves.
+pub async fn list_issued(
+    state: &AppState,
+    filter: &ListCredentialsBody,
+) -> Result<ListCredentialsResponse, AppError> {
+    let now = Utc::now();
+    let limit = filter
+        .page_size
+        .map_or(LIST_PAGE_DEFAULT, |n| (n as usize).min(LIST_PAGE_MAX))
+        .max(1);
+
+    let mut rows: Vec<(String, IssuedCredentialSummary)> = Vec::new();
+    for (raw_key, bytes) in state
+        .issued_credentials_ks
+        .prefix_iter_raw(CRED_KEY_PREFIX.as_bytes().to_vec())
+        .await?
+    {
+        let record: IssuedCredentialRecord = serde_json::from_slice(&bytes)
+            .map_err(|e| AppError::Internal(format!("decode issued-credential record: {e}")))?;
+        let summary = summarise(&record, now);
+
+        if let Some(h) = &filter.holder
+            && summary.holder != *h
+        {
+            continue;
+        }
+        if let Some(t) = &filter.credential_type
+            && summary.credential_type.as_deref() != Some(t.as_str())
+        {
+            continue;
+        }
+        if let Some(s) = filter.status
+            && summary.status != s
+        {
+            continue;
+        }
+        rows.push((String::from_utf8_lossy(&raw_key).into_owned(), summary));
+    }
+
+    Ok(page_rows(rows, filter.cursor.as_deref(), limit))
+}
+
+/// Order, resume and cut one page out of the matched rows.
+///
+/// Split out of [`list_issued`] because this is the part with the sharp edges,
+/// and the rest of that function needs an `AppState` to exercise at all. Kept
+/// pure so the cursor's exact semantics are pinned by unit tests rather than
+/// inferred from an integration run.
+///
+/// **The cursor is the last storage key of the page before**, and resumption is
+/// strictly *after* it rather than at an offset. That matters because issuance
+/// is concurrent with paging: an offset shifts when a credential is issued
+/// mid-walk, which silently skips a row the caller has not seen. A key does not
+/// move.
+fn page_rows(
+    mut rows: Vec<(String, IssuedCredentialSummary)>,
+    cursor: Option<&str>,
+    limit: usize,
+) -> ListCredentialsResponse {
+    rows.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if let Some(cursor) = cursor {
+        rows.retain(|(k, _)| k.as_str() > cursor);
+    }
+
+    let truncated = rows.len() > limit;
+    rows.truncate(limit);
+    // Emitted only when there is more, so a caller stops on its absence rather
+    // than needing one empty page to learn it is done.
+    let cursor = truncated
+        .then(|| rows.last().map(|(k, _)| k.clone()))
+        .flatten();
+
+    ListCredentialsResponse {
+        credentials: rows.into_iter().map(|(_, s)| s).collect(),
+        truncated,
+        cursor,
+        ext: None,
+    }
+}
+
+#[cfg(test)]
+mod list_tests {
+    use super::*;
+
+    fn record(id: &str, expires: &str, revoked: Option<&str>) -> IssuedCredentialRecord {
+        IssuedCredentialRecord {
+            id: id.into(),
+            holder: "did:key:zHolder".into(),
+            credential: serde_json::json!({
+                "type": ["VerifiableCredential", "MembershipCredential"],
+            }),
+            issued_at: "2026-01-01T00:00:00Z".into(),
+            expires_at: expires.into(),
+            revoked_at: revoked.map(str::to_string),
+            revocation_reason: revoked.map(|_| "role ended".to_string()),
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn revoked_takes_precedence_over_expired() {
+        // Both true at once. Reporting `expired` would hide that somebody
+        // acted, which is the thing a caller reading this list most wants.
+        let r = record("a", "2026-02-01T00:00:00Z", Some("2026-01-15T00:00:00Z"));
+        assert_eq!(status_of(&r, now()), IssuedCredentialStatus::Revoked);
+    }
+
+    #[test]
+    fn expiry_is_measured_against_the_clock() {
+        assert_eq!(
+            status_of(&record("a", "2026-02-01T00:00:00Z", None), now()),
+            IssuedCredentialStatus::Expired
+        );
+        assert_eq!(
+            status_of(&record("a", "2027-01-01T00:00:00Z", None), now()),
+            IssuedCredentialStatus::Active
+        );
+    }
+
+    #[test]
+    fn an_unreadable_expiry_reads_as_active_not_expired() {
+        // Guessing `expired` from a timestamp we could not parse would report a
+        // live credential as dead, and a caller would go and reissue something
+        // that was working.
+        let r = record("a", "not-a-timestamp", None);
+        assert_eq!(status_of(&r, now()), IssuedCredentialStatus::Active);
+    }
+
+    #[test]
+    fn the_type_tag_skips_the_base_type() {
+        let r = record("a", "2027-01-01T00:00:00Z", None);
+        assert_eq!(
+            credential_type_of(&r.credential).as_deref(),
+            Some("MembershipCredential")
+        );
+    }
+
+    #[test]
+    fn a_credential_with_only_the_base_type_has_none() {
+        let mut r = record("a", "2027-01-01T00:00:00Z", None);
+        r.credential = serde_json::json!({ "type": ["VerifiableCredential"] });
+        assert_eq!(credential_type_of(&r.credential), None);
+    }
+
+    #[test]
+    fn a_summary_never_carries_the_credential() {
+        // The invariant this whole task rests on. Serialising the summary is
+        // the check that matters: a field added to the projection later would
+        // show up here, not in a review.
+        let r = record("a", "2027-01-01T00:00:00Z", None);
+        let wire = serde_json::to_value(summarise(&r, now())).unwrap();
+        assert!(wire.get("credential").is_none());
+        assert!(!wire.to_string().contains("VerifiableCredential"));
+    }
+
+    fn rows(ids: &[&str]) -> Vec<(String, IssuedCredentialSummary)> {
+        ids.iter()
+            .map(|id| {
+                (
+                    format!("cred:{id}"),
+                    summarise(&record(id, "2027-01-01T00:00:00Z", None), now()),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_short_page_is_not_truncated_and_offers_no_cursor() {
+        let page = page_rows(rows(&["a", "b"]), None, 10);
+        assert_eq!(page.credentials.len(), 2);
+        assert!(!page.truncated);
+        // A caller must be able to stop on the cursor's absence rather than
+        // needing to fetch an empty page to find out.
+        assert_eq!(page.cursor, None);
+    }
+
+    #[test]
+    fn a_full_page_reports_truncation_and_the_key_to_resume_after() {
+        let page = page_rows(rows(&["a", "b", "c"]), None, 2);
+        assert_eq!(page.credentials.len(), 2);
+        assert!(page.truncated);
+        assert_eq!(page.cursor.as_deref(), Some("cred:b"));
+    }
+
+    #[test]
+    fn a_cursor_resumes_strictly_after_it() {
+        let page = page_rows(rows(&["a", "b", "c"]), Some("cred:b"), 10);
+        let ids: Vec<_> = page
+            .credentials
+            .iter()
+            .map(|c| c.credential_id.as_str())
+            .collect();
+        assert_eq!(ids, ["c"], "the cursor row itself must not repeat");
+    }
+
+    #[test]
+    fn a_row_issued_mid_walk_does_not_displace_an_unseen_one() {
+        // The reason the cursor is a key rather than an offset. Page one is
+        // a,b; `a0` then appears before both. With an offset of 2 the next page
+        // would start at `c` and `b` would never be seen.
+        let page_one = page_rows(rows(&["a", "b", "c"]), None, 2);
+        assert_eq!(page_one.cursor.as_deref(), Some("cred:b"));
+
+        let page_two = page_rows(rows(&["a0", "a", "b", "c"]), page_one.cursor.as_deref(), 2);
+        let ids: Vec<_> = page_two
+            .credentials
+            .iter()
+            .map(|c| c.credential_id.as_str())
+            .collect();
+        assert_eq!(ids, ["c"]);
+    }
+
+    #[test]
+    fn ordering_is_stable_regardless_of_scan_order() {
+        let forward = page_rows(rows(&["a", "b", "c"]), None, 10);
+        let reversed = page_rows(rows(&["c", "b", "a"]), None, 10);
+        let ids = |p: &ListCredentialsResponse| {
+            p.credentials
+                .iter()
+                .map(|c| c.credential_id.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ids(&forward), ids(&reversed));
+    }
 }

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -99,6 +99,9 @@ use trust_tasks_rs::specs;
 use trust_tasks_rs::validate::ValidatedPayload;
 use vta_sdk::trust_tasks as uris;
 
+use crate::trust_tasks::cred_vault;
+use crate::vault::model::{CredentialPurpose, CredentialStatus};
+use crate::vault::query::{CredentialDescriptor, CredentialQuery};
 use vta_sdk::acl::ContextDirection;
 use vta_sdk::keys::{KeyOrigin, KeyRecord, KeyStatus, KeyType};
 use vta_sdk::protocols::acl_management::change_role::ChangeRoleBody;
@@ -128,7 +131,8 @@ use vta_sdk::protocols::credential_exchange::{
     PendingPresentationSummary, PresentBody, RequestedCredentialSummary,
 };
 use vta_sdk::protocols::credentials_issuance::{
-    IssueCredentialBody, IssueCredentialResponse, RevokeCredentialBody, RevokeCredentialResponse,
+    IssueCredentialBody, IssueCredentialResponse, IssuedCredentialStatus, IssuedCredentialSummary,
+    ListCredentialsBody, ListCredentialsResponse, RevokeCredentialBody, RevokeCredentialResponse,
 };
 use vta_sdk::protocols::device_management::{
     DeviceDisableBody, DeviceHeartbeatBody, DeviceRegisterBody, DeviceSetWakeBody, DeviceWipeBody,
@@ -169,6 +173,7 @@ use vta_sdk::protocols::vta_management::get_config::{
 use vta_sdk::protocols::vta_management::update_config::{
     RejectedKey, UpdateConfigBody, UpdateConfigResultBody,
 };
+use vti_common::vault::VaultStatus;
 
 use super::dispatched_uris;
 
@@ -1416,6 +1421,213 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 to_v(RevokeCredentialResponse {
                     credential_id: "cred-1".into(),
                     revoked_at: TS.into(),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VTA_CREDENTIALS_LIST_0_1,
+            checked!(
+                specs::vta::credentials::list::v0_1::Payload,
+                specs::vta::credentials::list::v0_1::Response,
+                // Every filter set at once: the members are AND-combined, and a
+                // witness that set one would not prove the others reach the
+                // wire under their canonical spellings.
+                to_v(ListCredentialsBody {
+                    holder: Some("did:key:z6MkSubject".into()),
+                    credential_type: Some("MembershipCredential".into()),
+                    status: Some(IssuedCredentialStatus::Active),
+                    page_size: Some(50),
+                    cursor: Some("cred:cred-1".into()),
+                    ext: None,
+                }),
+                // Two rows on purpose, one of each shape: the revocation
+                // members are `skip_serializing_if` and an all-active fixture
+                // would never carry them, so the response schema's optional
+                // half would go unexercised.
+                to_v(ListCredentialsResponse {
+                    credentials: vec![
+                        IssuedCredentialSummary {
+                            credential_id: "cred-1".into(),
+                            holder: "did:key:z6MkSubject".into(),
+                            credential_type: Some("MembershipCredential".into()),
+                            issued_at: TS.into(),
+                            expires_at: TS.into(),
+                            status: IssuedCredentialStatus::Active,
+                            revoked_at: None,
+                            revocation_reason: None,
+                        },
+                        IssuedCredentialSummary {
+                            credential_id: "cred-2".into(),
+                            holder: "did:key:z6MkSubject".into(),
+                            credential_type: None,
+                            issued_at: TS.into(),
+                            expires_at: TS.into(),
+                            status: IssuedCredentialStatus::Revoked,
+                            revoked_at: Some(TS.into()),
+                            revocation_reason: Some("role ended".into()),
+                        },
+                    ],
+                    truncated: true,
+                    cursor: Some("cred:cred-2".into()),
+                    ext: None,
+                })
+            ),
+        ),
+        // ─── vault/credentials ───────────────────────────────────
+        //
+        // Dispatched by `cred_vault` since before the family had a
+        // specification. Specifying it (trust-tasks-tf#338) is what made these
+        // URIs *published*, and therefore what made this sweep able to see
+        // them — until then the slice's structs were checked against nothing.
+        (
+            uris::TASK_VAULT_CREDENTIALS_RECEIVE_0_1,
+            checked!(
+                specs::vault::credentials::receive::v0_1::Payload,
+                specs::vault::credentials::receive::v0_1::Response,
+                to_v(cred_vault::ReceiveBody {
+                    credential: Some(json!({
+                        "@context": ["https://www.w3.org/ns/credentials/v2"],
+                        "type": ["VerifiableCredential", "MembershipCredential"],
+                    })),
+                    credential_base64: None,
+                    format: None,
+                    id: Some("cred-1".into()),
+                    context_id: Some("ctx-a".into()),
+                }),
+                to_v(cred_vault::ReceiveResponse {
+                    id: "cred-1".into(),
+                    types: vec!["VerifiableCredential".into(), "MembershipCredential".into()],
+                    purpose: Some(CredentialPurpose::Membership),
+                    status: CredentialStatus::Valid,
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_QUERY_0_1,
+            checked!(
+                specs::vault::credentials::query::v0_1::Payload,
+                specs::vault::credentials::query::v0_1::Response,
+                // Every filter plus both modifiers: the modifiers are
+                // `skip_serializing_if` on a bool, so a fixture leaving them
+                // false would never put them on the wire to be checked.
+                to_v(CredentialQuery {
+                    r#type: Some("MembershipCredential".into()),
+                    community_did: Some("did:web:community.example".into()),
+                    issuer_did: Some("did:web:issuer.example".into()),
+                    purpose: Some(CredentialPurpose::Membership),
+                    status: Some(CredentialStatus::Valid),
+                    include_archived: true,
+                    include_deleted: true,
+                }),
+                to_v(cred_vault::QueryResponse {
+                    credentials: vec![CredentialDescriptor {
+                        id: "cred-1".into(),
+                        types: vec!["VerifiableCredential".into()],
+                        issuer_did: Some("did:web:issuer.example".into()),
+                        purpose: Some(CredentialPurpose::Membership),
+                        status: CredentialStatus::Valid,
+                        lifecycle: VaultStatus::Active,
+                        valid_from: Some(TS.into()),
+                        valid_until: Some(TS.into()),
+                        archived_at: None,
+                        deleted_at: None,
+                        grace_until: None,
+                    }],
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_GET_0_1,
+            checked!(
+                specs::vault::credentials::get::v0_1::Payload,
+                specs::vault::credentials::get::v0_1::Response,
+                to_v(cred_vault::GetBody { id: "cred-1".into() }),
+                to_v(cred_vault::GetResponse {
+                    credential: json!({
+                        "@context": ["https://www.w3.org/ns/credentials/v2"],
+                        "type": ["VerifiableCredential"],
+                    }),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_ARCHIVE_0_1,
+            checked!(
+                specs::vault::credentials::archive::v0_1::Payload,
+                specs::vault::credentials::archive::v0_1::Response,
+                to_v(cred_vault::CredLifecycleBody {
+                    id: "cred-1".into(),
+                    reason: Some("holder offboarded".into()),
+                }),
+                to_v(cred_vault::CredLifecycleResponse {
+                    id: "cred-1".into(),
+                    lifecycle: VaultStatus::Archived,
+                    grace_until: None,
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_UNARCHIVE_0_1,
+            checked!(
+                specs::vault::credentials::unarchive::v0_1::Payload,
+                specs::vault::credentials::unarchive::v0_1::Response,
+                to_v(cred_vault::CredLifecycleBody {
+                    id: "cred-1".into(),
+                    reason: Some("holder offboarded".into()),
+                }),
+                to_v(cred_vault::CredLifecycleResponse {
+                    id: "cred-1".into(),
+                    lifecycle: VaultStatus::Active,
+                    grace_until: None,
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_DELETE_0_1,
+            checked!(
+                specs::vault::credentials::delete::v0_1::Payload,
+                specs::vault::credentials::delete::v0_1::Response,
+                to_v(cred_vault::CredDeleteBody {
+                    id: "cred-1".into(),
+                    reason: Some("holder offboarded".into()),
+                    force: true,
+                }),
+                to_v(cred_vault::CredLifecycleResponse {
+                    id: "cred-1".into(),
+                    lifecycle: VaultStatus::Deleted,
+                    grace_until: Some("2026-02-01T00:00:00Z".into()),
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_RESTORE_0_1,
+            checked!(
+                specs::vault::credentials::restore::v0_1::Payload,
+                specs::vault::credentials::restore::v0_1::Response,
+                to_v(cred_vault::CredLifecycleBody {
+                    id: "cred-1".into(),
+                    reason: Some("holder offboarded".into()),
+                }),
+                to_v(cred_vault::CredLifecycleResponse {
+                    id: "cred-1".into(),
+                    lifecycle: VaultStatus::Active,
+                    grace_until: None,
+                })
+            ),
+        ),
+        (
+            uris::TASK_VAULT_CREDENTIALS_PURGE_0_1,
+            checked!(
+                specs::vault::credentials::purge::v0_1::Payload,
+                specs::vault::credentials::purge::v0_1::Response,
+                to_v(cred_vault::CredLifecycleBody {
+                    id: "cred-1".into(),
+                    reason: Some("holder offboarded".into()),
+                }),
+                to_v(cred_vault::CredLifecycleResponse {
+                    id: "cred-1".into(),
+                    lifecycle: VaultStatus::Deleted,
+                    grace_until: None,
                 })
             ),
         ),

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -17,6 +17,12 @@
 //!   presentation. Not-found is conflated with permission-denied to deny
 //!   enumeration.
 
+// The wire shapes below are `pub(super)` so the conformance table can build a
+// witness from them. That table is what proves this slice's structs and the
+// published `vault/credentials/*` schemas agree, and it could not reach them
+// while they were private — which is why the family went unchecked for as long
+// as it had no specification to be checked against.
+
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::Utc;
@@ -62,9 +68,9 @@ fn require_cap(
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ReceiveBody {
+pub(super) struct ReceiveBody {
     /// The credential to store — a Data-Integrity W3C VC (object form, with its
     /// own `proof`).
     ///
@@ -72,58 +78,58 @@ struct ReceiveBody {
     /// instead. Exactly one of the two must be present; a body carrying neither,
     /// or both, is rejected. Existing clients send this field alone and are
     /// unaffected.
-    #[serde(default)]
-    credential: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) credential: Option<Value>,
     /// A binary credential, base64url-no-pad. Required when `format` names a
     /// binary format (today: `mso_mdoc`, CBOR `IssuerSigned`), which cannot be
     /// carried as JSON.
-    #[serde(default)]
-    credential_base64: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) credential_base64: Option<String>,
     /// Wire format tag. Absent means a Data-Integrity W3C VC — the shape every
     /// existing client sends — so omitting it keeps the current behaviour
     /// exactly.
-    #[serde(default)]
-    format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) format: Option<String>,
     /// Optional explicit storage id; defaults to the VC's top-level `id`, else a
     /// fresh `urn:uuid`.
-    #[serde(default)]
-    id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) id: Option<String>,
     /// Optional custody context override — which context owns the credential
     /// (and whose `ContextPolicy` governs its disclosure). Must be a context the
     /// caller can access. When omitted, the credential auto-binds to the caller's
     /// context iff they have exactly one; a super-admin / multi-context caller
     /// stores it unscoped.
-    #[serde(default)]
-    context_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) context_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ReceiveResponse {
-    id: String,
-    types: Vec<String>,
+pub(super) struct ReceiveResponse {
+    pub(super) id: String,
+    pub(super) types: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    purpose: Option<CredentialPurpose>,
-    status: CredentialStatus,
+    pub(super) purpose: Option<CredentialPurpose>,
+    pub(super) status: CredentialStatus,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct QueryResponse {
-    credentials: Vec<CredentialDescriptor>,
+pub(super) struct QueryResponse {
+    pub(super) credentials: Vec<CredentialDescriptor>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct GetBody {
-    id: String,
+pub(super) struct GetBody {
+    pub(super) id: String,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct GetResponse {
+pub(super) struct GetResponse {
     /// The stored credential's full body, for presentation.
-    credential: Value,
+    pub(super) credential: Value,
 }
 
 /// Handler for `spec/vault/credentials/receive/0.1`.
@@ -470,25 +476,43 @@ pub(super) async fn handle_get(
 /// (`archive` / `unarchive` / `delete` / `restore` / `purge`). `reason` is
 /// lifted into the audit row's `detail` by the dispatch spine; `force` is
 /// honoured only by `delete` (skip the grace window → immediate hard delete).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct CredLifecycleBody {
-    id: String,
-    #[serde(default)]
+pub(super) struct CredLifecycleBody {
+    pub(super) id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[allow(dead_code)] // read generically by the spine for the audit `detail`
-    reason: Option<String>,
-    #[serde(default)]
-    force: bool,
+    pub(super) reason: Option<String>,
+}
+
+/// `delete`'s body — the one lifecycle verb with a forced form.
+///
+/// Split from [`CredLifecycleBody`] rather than sharing it with a `force` the
+/// other four ignore. Sharing was not merely untidy: `archive`, `unarchive`,
+/// `restore` and `purge` all *accepted* `force` and silently dropped it, so a
+/// caller asking for something stronger than the verb it named got the weaker
+/// thing and a success. Their published schemas declare no such member, and now
+/// neither do their types — the request is refused instead.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct CredDeleteBody {
+    pub(super) id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[allow(dead_code)] // read generically by the spine for the audit `detail`
+    pub(super) reason: Option<String>,
+    /// Erase immediately rather than tombstoning. Irrecoverable.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(super) force: bool,
 }
 
 /// Post-transition view for archive / unarchive / delete / restore.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct CredLifecycleResponse {
-    id: String,
-    lifecycle: VaultStatus,
+pub(super) struct CredLifecycleResponse {
+    pub(super) id: String,
+    pub(super) lifecycle: VaultStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
-    grace_until: Option<String>,
+    pub(super) grace_until: Option<String>,
 }
 
 /// `not_found` rejection for a missing credential id on a lifecycle verb.
@@ -619,7 +643,7 @@ pub(super) async fn handle_delete(
     if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, "delete") {
         return r;
     }
-    let req: CredLifecycleBody = match parse_payload(&doc) {
+    let req: CredDeleteBody = match parse_payload(&doc) {
         Ok(r) => r,
         Err(resp) => return resp,
     };

--- a/vta-service/src/trust_tasks/credentials.rs
+++ b/vta-service/src/trust_tasks/credentials.rs
@@ -1,5 +1,5 @@
 //! Issued-credential lifecycle trust-task slice
-//! (`spec/vta/credentials/{issue,revoke}/0.1`).
+//! (`spec/vta/credentials/{issue,revoke,list}`).
 //!
 //! Mints a VTA-signed, scoped, time-boxed W3C Verifiable Credential to a holder
 //! DID and revokes it by id. Distinct from the credential-vault slice
@@ -22,7 +22,8 @@ use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 
 use vta_sdk::protocols::credentials_issuance::{
-    IssueCredentialBody, IssueCredentialResponse, RevokeCredentialBody, RevokeCredentialResponse,
+    IssueCredentialBody, IssueCredentialResponse, ListCredentialsBody, RevokeCredentialBody,
+    RevokeCredentialResponse,
 };
 
 use crate::audit;
@@ -146,6 +147,65 @@ pub(super) async fn handle_revoke(
 }
 
 #[cfg(any(test, feature = "test-support"))]
+/// Handler for `spec/vta/credentials/list/0.1`.
+///
+/// ## Why this is gated differently from its siblings
+///
+/// `issue` and `revoke` are `require_admin` plus a step-up floor, because each
+/// changes what a holder can prove. This is a read, and it is gated on
+/// `require_manage` — the same gate `acl::handle_list` uses for the equivalent
+/// question about authority.
+///
+/// Admin-only would have been the easy consistency, and the wrong one: it would
+/// mean an operator who may read the ACL and the policy set may not read what
+/// their own agent has issued, which is the same category of question. A
+/// step-up on a read would be worse still — a gate that fires on every page of
+/// a list is a gate people learn to clear without reading.
+///
+/// What the read does disclose is real and is not a per-credential fact: the
+/// response is a map of the issuer's holder set, and the *pattern* of issuance
+/// can be sensitive where no single credential is. That is why the gate is here
+/// at all rather than the task being open to any authenticated caller.
+pub(super) async fn handle_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> super::helpers::TrustTaskOutcome {
+    if let Err(e) = auth.require_manage() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: ListCredentialsBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let page = match credentials::list_issued(state, &req).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Audited like the mutating siblings. A read that maps the holder set is
+    // worth a trail entry even though it changes nothing — "who enumerated the
+    // issuance log, and when" is exactly the question an incident review asks,
+    // and it cannot be answered afterwards if nothing recorded it.
+    if let Err(e) = audit::record_with_detail(
+        &state.audit_sink,
+        "credentials.list",
+        &auth.did,
+        req.holder.as_deref(),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        None,
+        None,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "audit record failed for credentials.list");
+    }
+
+    success_response(&doc, page)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/trust_tasks/credentials.rs
+++ b/vta-service/src/trust_tasks/credentials.rs
@@ -146,7 +146,6 @@ pub(super) async fn handle_revoke(
     )
 }
 
-#[cfg(any(test, feature = "test-support"))]
 /// Handler for `spec/vta/credentials/list/0.1`.
 ///
 /// ## Why this is gated differently from its siblings
@@ -206,6 +205,7 @@ pub(super) async fn handle_list(
     success_response(&doc, page)
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -265,14 +265,11 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     "https://trusttasks.org/spec/vault/unarchive/0.1",
     "https://trusttasks.org/spec/vault/restore/0.1",
     "https://trusttasks.org/spec/vault/purge/0.1",
-    "https://trusttasks.org/spec/vault/credentials/receive/0.1",
-    "https://trusttasks.org/spec/vault/credentials/query/0.1",
-    "https://trusttasks.org/spec/vault/credentials/get/0.1",
-    "https://trusttasks.org/spec/vault/credentials/archive/0.1",
-    "https://trusttasks.org/spec/vault/credentials/unarchive/0.1",
-    "https://trusttasks.org/spec/vault/credentials/delete/0.1",
-    "https://trusttasks.org/spec/vault/credentials/restore/0.1",
-    "https://trusttasks.org/spec/vault/credentials/purge/0.1",
+    //   The eight `vault/credentials/*` entries that sat here are gone: the
+    //   family was specified upstream (trust-tasks-tf#338) and shipped in
+    //   trust-tasks-rs 0.17.4, so it has a published schema, a conformance
+    //   witness, and payload validation on the dispatch spine. Debt discharged
+    //   by specification rather than by deletion.
 ];
 
 /// Declarative Trust-Task dispatch table.
@@ -1425,6 +1422,13 @@ dispatch_table! {
         [ Mutating None true ],
     vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_REVOKE_0_1 => credentials::handle_revoke
         [ Destructive None false ],
+    // A read. `None` side-effect and no step-up: gated on `require_manage`
+    // like `acl/list`, because "what has my agent issued" is the same category
+    // of question as "who may act at it". What it discloses is the issuer's
+    // holder set rather than any one credential's claims — bodies are never
+    // returned — so the exposure class stays `None` too.
+    vta_sdk::trust_tasks::TASK_VTA_CREDENTIALS_LIST_0_1 => credentials::handle_list
+        [ None None false ],
     // ─── Agent-memory slice (spec/vta/memory/*) ──────────────────
     // Per-context key/value store; gated on context access (require_context),
     // NOT operator step-up.

--- a/vta-service/tests/producer_payload_conformance.rs
+++ b/vta-service/tests/producer_payload_conformance.rs
@@ -81,17 +81,10 @@ where
 /// not reached, and that is the useful signal: the unvalidatable surface is
 /// exactly the un-folded surface, so each of these closes for free when its
 /// family is folded onto a published spec.
-const UNPUBLISHED: &[(&str, &str)] = &[
-    (
-        "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
-        "The canonical `keys/*` fold (#888) did not reach the seed family.",
-    ),
-    (
-        "https://trusttasks.org/spec/vault/credentials/receive/0.1",
-        "The `vault/*` fold published query/get/upsert/delete but not \
-         `credentials/receive`.",
-    ),
-];
+const UNPUBLISHED: &[(&str, &str)] = &[(
+    "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
+    "The canonical `keys/*` fold (#888) did not reach the seed family.",
+)];
 
 /// Every captured payload conforms to its task's published schema.
 ///

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -438,15 +438,21 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
         1,
         "framework error envelope — a response type, not a task; absent from the task index by design",
     ),
-    // The vault + credential-store archival lifecycle (PR #540): archive,
-    // unarchive, restore, purge over both stores. Authored as local
-    // "openvtc 0.1 extensions" and never taken upstream, so each claims a
-    // `trusttasks.org/spec/vault/` ID the registry does not serve. The registry
-    // publishes vault {delete,get,list,proxy-login,release,sign-trust-task,
-    // sync,upsert,usage} — and none of these.
+    // The vault archival lifecycle (PR #540): archive, unarchive, restore,
+    // purge. Authored as local "openvtc 0.1 extensions" and never taken
+    // upstream, so each claims a `trusttasks.org/spec/vault/` ID the registry
+    // does not serve.
+    //
+    // 12 -> 4: the credential-store half of that lifecycle is no longer debt.
+    // The whole `vault/credentials/*` family — receive, query, get, and its
+    // four lifecycle verbs — was specified upstream
+    // (trustoverip/dtgwg-trust-tasks-tf#338) and ships in trust-tasks-rs
+    // 0.17.4, so those eight URIs now resolve against the registry that serves
+    // them. What is left is the four *secrets*-store verbs, which still have
+    // no spec.
     (
         "https://trusttasks.org/spec/vault/",
-        12,
+        4,
         "vault + credential-store archival lifecycle (#540) — never authored upstream",
     ),
     // The bulk of the VTA's own Trust Task surface at 1.0 — keys, contexts,


### PR DESCRIPTION
Implements `vta/credentials/list/0.1`, specified upstream in [trustoverip/dtgwg-trust-tasks-tf#342](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/342) and shipped in `trust-tasks-rs` 0.17.4.

`vta/credentials` served `issue` and `revoke` and nothing else, so an issuer could not ask its own agent what it had issued. `revoke` is keyed on a `credentialId` that `issue` returns exactly once — a caller that did not record it at that moment could not recover it at all.

## A read over records that already exist

`IssuedCredentialRecord` already carries the id, holder, both instants and the revocation instant and reason, and revocation is a **tombstone rather than a delete** — the comment on it says that is precisely so the audit and verifier trail survives. So a revoked credential is still there to list. No new storage.

- **Bodies are never returned.** `summarise` is the one place the projection happens, so "a summary never carries the credential" is enforced in a single spot rather than remembered at each call site. `vault/list/0.1`'s rule — *list enumerates, release uses* — is what this follows.
- **`status` is derived at read time**, `revoked` beating `expired`. A stored status is a copy of a fact about the clock and is wrong one second after it is written; reporting a revoked credential as merely expired would hide that somebody acted.
- **Gated on `require_manage`**, not the Admin-plus-step-up its mutating siblings use. An operator who may read the ACL and the policy set may read what their own agent issued — same category of question — and a step-up firing on every page of a list is one people learn to clear without reading. It is audited anyway: *who enumerated the issuance log* is what an incident review asks, and nothing else would record it.

## The dep bump found two real defects

Bumping `trust-tasks-rs` to 0.17.4 made the eight `vault/credentials/*` URIs *published*. They have been **dispatched since before they had a specification**, so the conformance sweep could not see them — `resolved_uris()` filters dispatched URIs through `schema_for()`. Specifying the family (#338) is what finally let it look, and it found:

**1. `ReceiveBody` serialized `credentialBase64: null`.**

```
vault/credentials/receive/0.1: request is not canonical:
data did not match any variant of untagged enum Payload
  { …, "credentialBase64": null, "format": null, … }
```

`#[serde(default)]` without `skip_serializing_if` leaves an unset member as `null`, and the schema's `oneOf` counts a null member as *present* — so the body matched neither branch. Same defect class as the sibling registry's `payload_null_census`.

**2. `force` was accepted by four verbs that ignore it.**

`CredLifecycleBody` was shared across archive, unarchive, delete, restore and purge, but only `handle_delete` reads `force`. A caller asking for something stronger than the verb it named got the weaker thing **and a success**. `delete` now has its own `CredDeleteBody`; the other four refuse the member, which is what their schemas always said.

Neither breaks anything today — these are request bodies the service parses and never sends — but both would bite the first typed client built on them, and #2 is a silent-wrong-outcome rather than an error.

## Three debt ratchets moved down

Each discharged by specification rather than deletion:

| Ratchet | Change |
|---|---|
| `UNSPECCED_DISPATCHED_URIS` | −8 entries |
| producer-payload census `UNPUBLISHED` | −1 (that payload is now *validated*, not skipped — and it passes) |
| vtc-service bound-URI count | 12 → 4 |

What remains in the last one is the four *secrets*-store lifecycle verbs, which still have no spec — named in the comment so the residue is not mistaken for the whole.

## Tests

`page_rows` is split out of `list_issued` and unit-tested, because the cursor is where a bug hides. It is the last storage key of the previous page and resumption is **strictly after it**, not at an offset — so a credential issued mid-walk cannot shift the window and skip a row nobody has seen. That is a test, not a comment:

```
a_row_issued_mid_walk_does_not_displace_an_unseen_one
a_cursor_resumes_strictly_after_it
a_full_page_reports_truncation_and_the_key_to_resume_after
a_short_page_is_not_truncated_and_offers_no_cursor
```

Plus status precedence, an unreadable expiry reading as **active** rather than expired (guessing "expired" would report a live credential as dead and send someone to reissue something that works), and that a serialized summary contains no credential.

The conformance table gains nine witnesses — the new task, and the eight `vault/credentials/*` that had none.

`IssuedCredentialSummary` is `payload_ext_census`'s first `NO_EXT_BY_DESIGN` entry, with the reason recorded: it is a list row rather than a payload root and its published schema declares no `ext` slot, so adding the field would make this crate emit documents the schema rejects — the inverse of the defect that census catches.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets` (no warnings), `cargo test -p vta-sdk` (18 suites), `cargo test -p vta-service --lib` (1009 passed), `producer_payload_conformance` (5), `vtc-service --test trust_task_manifest` (8). The full-workspace run is slow locally; CI is the arbiter.

## Downstream

This is what lets the browser VTA console replace its "there is no list of issued credentials, and this is not an empty one" notice with a real table. That notice stays until an agent can actually answer — a console claiming a list before one existed would be the failure it was written to avoid.
