### PR TITLE
test(vta): measure audit coverage, and close the seven silent successes

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -505,6 +505,17 @@ pub async fn bootstrap_test_vta(ts: &TestStore) -> (String, ProvisionIntegration
 /// [`build_app_state`](crate::server::build_app_state) constructor so the test
 /// state can't diverge from production wiring.
 pub async fn build_signing_test_app_state() -> (crate::server::AppState, tempfile::TempDir) {
+    build_signing_test_app_state_with_sink(None).await
+}
+
+/// As [`build_signing_test_app_state`], with an audit sink installed.
+///
+/// Split out for the audit-coverage census, which needs to observe what a
+/// dispatched task records. Everything else is identical, and the no-sink form
+/// above delegates here so the two states cannot drift.
+pub async fn build_signing_test_app_state_with_sink(
+    audit_sink: Option<vta_audit::SharedAuditSink>,
+) -> (crate::server::AppState, tempfile::TempDir) {
     use crate::server::{AppStateParts, build_app_state};
     use tokio::sync::watch;
 
@@ -533,7 +544,13 @@ pub async fn build_signing_test_app_state() -> (crate::server::AppState, tempfil
         None,
         None,
         restart_tx,
-        AppStateParts::default(),
+        // `..Default::default()` rather than default-then-assign: this is the
+        // same crate, so the non-exhaustive struct literal is available here
+        // even though `tests/audit_sink.rs` cannot use it from outside.
+        AppStateParts {
+            audit_sink,
+            ..Default::default()
+        },
     )
     .await
     .expect("build signing app state");

--- a/vta-service/src/trust_tasks/audit_coverage.rs
+++ b/vta-service/src/trust_tasks/audit_coverage.rs
@@ -1,0 +1,275 @@
+//! Census: every consequential dispatched task leaves an audit trail.
+//!
+//! ## Why this exists
+//!
+//! "Is auditing fully implemented?" had no answer before this file, and could
+//! not be given one by reading the code.
+//!
+//! [`audit_sink`](../../tests/audit_sink.rs) proves the sink *mechanism* — that
+//! entries reach an installed sink rather than the keyspace. It says nothing
+//! about which tasks emit one. And the emitting is scattered by design: the
+//! dispatch spine audits the vault family centrally (`vault_audit`, `None`
+//! elsewhere, with the comment that the rest "audit through their own
+//! handlers/ops"), while everything else records in its handler, or down in
+//! `operations/`, or through the `audit!` macro. Three shapes, no index.
+//!
+//! Grep cannot settle it — following delegation is the whole difficulty, and a
+//! count of `audit::record` in `trust_tasks/` undercounts every task that
+//! audits one layer down. So the census is a **runtime** sweep: drive the task
+//! and see whether an entry appears.
+//!
+//! ## What it asserts, and why that shape
+//!
+//! For every URI in [`dispatched_uris`] whose declared class is not
+//! `SideEffectLevel::None`, dispatching it must produce at least one audit
+//! entry — **whatever the outcome**.
+//!
+//! Success is deliberately not required. Setting up the preconditions for
+//! ~100 tasks (an ACL entry here, a stored key there) would make this a
+//! fixture-maintenance project rather than a census, and it would test the
+//! wrong thing: a *refused* privileged attempt is exactly what an incident
+//! review goes looking for. "Somebody with these claims asked to wipe a device
+//! and was denied" is a sentence the trail has to be able to produce.
+//!
+//! Reads are exempt by class rather than by name. `vta/credentials/list` audits
+//! anyway — enumerating an issuance log is worth a line — but requiring that of
+//! every read would demand an entry for every `whoami` poll, which buries the
+//! signal it exists to preserve.
+//!
+//! ## Three helpers, two destinations
+//!
+//! The first thing this census exposed is that "audits" means two different
+//! things in this codebase, and the call site does not say which:
+//!
+//! - the `audit!` macro emits a `tracing` event on the `audit` target — a **log
+//!   line**. It never touches the `AuditSink`, so nothing it records reaches
+//!   `audit/list` or an operator's external sink.
+//! - `record_with_detail` writes to the sink — the **queryable trail**.
+//! - the ceremony helper in `vta-audit` does both.
+//!
+//! So a handler calling `audit!` and nothing else looks audited when read and
+//! is absent from the trail an operator actually queries. `session.revoke` was
+//! exactly that, and it took a runtime sweep to notice: the source says
+//! `audit!("session.revoke", …)` three lines above the response.
+//!
+//! ## The exception list is the finding
+//!
+//! [`NO_AUDIT_BY_DESIGN`] was seeded from what the first run actually reported,
+//! not from what anyone believed. Each entry names why, and **the list may only
+//! shrink** — a stale one fails the same as a missing entry, so discharging a
+//! gap is a diff rather than a quiet edit.
+//!
+//! Request fixtures come from [`super::conformance::table`], which already
+//! holds a schema-valid payload per dispatched URI. Inventing a second set here
+//! would be a second thing to keep true.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use trust_tasks_rs::{TrustTask, TypeUri};
+use vta_sdk::protocols::audit_management::list::AuditLogEntry;
+use vti_common::error::AppError;
+
+use crate::policy::SideEffectLevel;
+use crate::test_support::{build_signing_test_app_state_with_sink, super_admin_claims};
+
+/// Tasks that dispatch without recording, each with the reason.
+///
+/// An entry is a claim that *no* trail is the correct behaviour for this task —
+/// not that adding one is inconvenient, and not that nobody has got to it. A
+/// gap belongs in the issue tracker and out of this list.
+const NO_AUDIT_BY_DESIGN: &[(&str, &str)] = &[];
+
+/// A sink that keeps what it is given. Deliberately not backed by a keyspace,
+/// so "reached storage" cannot be mistaken for "reached the sink".
+#[derive(Default)]
+struct Recording {
+    seen: Mutex<Vec<AuditLogEntry>>,
+}
+
+#[async_trait]
+impl vta_audit::AuditSink for Recording {
+    async fn record(&self, entry: &AuditLogEntry) -> Result<(), AppError> {
+        self.seen.lock().unwrap().push(entry.clone());
+        Ok(())
+    }
+}
+
+/// The consequential half of the dispatch table, in declaration order.
+fn consequential_uris() -> Vec<&'static str> {
+    super::dispatched_uris()
+        .into_iter()
+        .filter(|u| {
+            super::class_for(u).is_some_and(|class| class.side_effects != SideEffectLevel::None)
+        })
+        .collect()
+}
+
+/// The conformance witness's request payload for `uri`, when it has one.
+fn request_fixture(uri: &str) -> Option<Value> {
+    super::conformance::request_payload_for(uri)
+}
+
+#[tokio::test]
+async fn every_consequential_task_records_an_audit_entry() {
+    let uris = consequential_uris();
+    assert!(
+        uris.len() > 40,
+        "only {} consequential URIs — the dispatch table walk is broken, and a \
+         census that inspects nothing passes vacuously",
+        uris.len()
+    );
+
+    // Silence is split by what the dispatch actually did, because the two mean
+    // very different things and a single number conflates them:
+    //
+    //   - **succeeded and recorded nothing** — an unambiguous gap. The task did
+    //     its work and left no trace.
+    //   - **failed and recorded nothing** — the handler audits on success only.
+    //     Weaker, and still a finding: a refused privileged attempt is exactly
+    //     what an incident review looks for, and this is the shape that hides
+    //     it. Separated so the fix can be sized honestly rather than sounding
+    //     larger than it is.
+    let mut silent_on_success: Vec<&str> = Vec::new();
+    let mut silent_on_failure: Vec<&str> = Vec::new();
+    let mut unfixtured: Vec<&str> = Vec::new();
+    let mut checked = 0usize;
+
+    for uri in &uris {
+        let Some(payload) = request_fixture(uri) else {
+            // No conformance witness means no schema-valid payload to send.
+            // Reported rather than skipped: the two sweeps are meant to cover
+            // the same surface, and a URI in neither is invisible to both.
+            unfixtured.push(uri);
+            continue;
+        };
+
+        let sink = Arc::new(Recording::default());
+        let (state, _dir) = build_signing_test_app_state_with_sink(Some(
+            sink.clone() as vta_audit::SharedAuditSink
+        ))
+        .await;
+
+        let type_uri: TypeUri = uri.parse().expect("dispatched URI parses");
+        let doc = TrustTask::new(
+            format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+            type_uri,
+            payload,
+        );
+
+        // Driven through `dispatch_trust_task_core`, NOT `dispatch_typed`.
+        //
+        // The spine is where the vault family's central audit lives
+        // (`vault_audit`), so a census that called the match arm directly would
+        // report every `vault/*` and `vault/credentials/*` task as silent —
+        // false positives for the one family that audits most thoroughly. I
+        // made exactly that mistake writing this, and "fixed" a task that was
+        // never broken before catching it.
+        let body = serde_json::to_vec(&doc).expect("serialize fixture document");
+        let outcome = super::dispatch_trust_task_core(
+            &state,
+            &super_admin_claims(),
+            &body,
+            super::transport::TransportConfidentiality::EndToEnd,
+        )
+        .await;
+
+        checked += 1;
+        if sink.seen.lock().unwrap().is_empty() && !NO_AUDIT_BY_DESIGN.iter().any(|(u, _)| u == uri)
+        {
+            if outcome.status.is_success() {
+                silent_on_success.push(uri);
+            } else {
+                silent_on_failure.push(uri);
+            }
+        }
+    }
+
+    assert!(
+        checked > 30,
+        "only {checked} tasks were actually driven — too few for this to mean \
+         anything; check that conformance fixtures still resolve"
+    );
+
+    let stale: Vec<&str> = NO_AUDIT_BY_DESIGN
+        .iter()
+        .map(|(u, _)| *u)
+        .filter(|u| !uris.contains(u))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "these NO_AUDIT_BY_DESIGN entries no longer name a consequential \
+         dispatched task — remove them, the list may only shrink:\n  {}",
+        stale.join("\n  ")
+    );
+
+    let fmt = |v: &[&str]| {
+        if v.is_empty() {
+            "  (none)".to_string()
+        } else {
+            format!("  {}", v.join("\n  "))
+        }
+    };
+
+    // ── The hard invariant ───────────────────────────────────────────────
+    //
+    // A task that did its work and left no trace is a gap with no defensible
+    // reading. This one never gets a tolerated count.
+    assert!(
+        silent_on_success.is_empty(),
+        "{} consequential task(s) SUCCEEDED and recorded no audit entry — the \
+         work happened and left no trace:\n{}\n\nRecord one (see \
+         `credentials::handle_list` for the handler form, or the `vault_audit` \
+         arm on the spine for the central one), or add a NO_AUDIT_BY_DESIGN \
+         entry stating why no trail is correct here.",
+        silent_on_success.len(),
+        fmt(&silent_on_success)
+    );
+
+    // ── The ratchet ──────────────────────────────────────────────────────
+    //
+    // Auditing only on success is the weaker defect, and the more common one:
+    // a *refused* privileged attempt leaves nothing, and "who tried to wipe
+    // this device and was denied" is precisely the sentence an incident review
+    // needs. Fixing all of them at once would be ~60 handlers in one diff, so
+    // it is a budget that may only shrink rather than a wall.
+    //
+    // Lower this number in the same commit that fixes one. Never raise it: a
+    // new handler auditing on success only is a new instance of a defect this
+    // file exists to retire, not a reason to move the line.
+    const AUDIT_ON_SUCCESS_ONLY_BUDGET: usize = 72;
+    assert!(
+        silent_on_failure.len() <= AUDIT_ON_SUCCESS_ONLY_BUDGET,
+        "{} consequential task(s) were REFUSED and recorded nothing, over the \
+         budget of {}. These audit on success only, so a denied privileged \
+         attempt leaves no trail:\n{}",
+        silent_on_failure.len(),
+        AUDIT_ON_SUCCESS_ONLY_BUDGET,
+        fmt(&silent_on_failure)
+    );
+    assert!(
+        silent_on_failure.len() == AUDIT_ON_SUCCESS_ONLY_BUDGET,
+        "the audit-on-success-only budget is {} but only {} task(s) hit it — \
+         some were fixed. Lower the constant to {} in this commit, so the \
+         ratchet keeps its teeth.",
+        AUDIT_ON_SUCCESS_ONLY_BUDGET,
+        silent_on_failure.len(),
+        silent_on_failure.len()
+    );
+
+    // ── Reported, not asserted ───────────────────────────────────────────
+    //
+    // A URI with no conformance witness is invisible to this sweep *and* to the
+    // schema one. Not failed here — the schema sweep owns that gap and says so
+    // in its own words — but printed, because a census that quietly skips is
+    // the thing this file exists not to be.
+    if !unfixtured.is_empty() {
+        eprintln!(
+            "audit-coverage census: {} consequential task(s) had no conformance \
+             fixture and were not driven:\n{}",
+            unfixtured.len(),
+            fmt(&unfixtured)
+        );
+    }
+}

--- a/vta-service/src/trust_tasks/auth.rs
+++ b/vta-service/src/trust_tasks/auth.rs
@@ -143,13 +143,33 @@ pub(super) async fn handle_revoke_session(
         );
     }
 
-    // 5. Audit.
+    // 5. Audit — both forms, and they are not redundant.
+    //
+    // The `audit!` macro emits a tracing event on the `audit` target: a log
+    // line. It does NOT reach the `AuditSink`, so nothing it records appears in
+    // `audit/list` or in an operator's external sink. Ending a session is a
+    // change to who can act, and it belongs in the queryable trail, so the
+    // sink-routed `record_with_detail` is what actually satisfies that.
     audit!(
         "session.revoke",
         actor = &auth.did,
         resource = &session_id,
         outcome = "success"
     );
+    if let Err(e) = crate::audit::record_with_detail(
+        &state.audit_sink,
+        "session.revoke",
+        &auth.did,
+        Some(&session_id),
+        "success",
+        Some(super::helpers::TRANSPORT_TRUST_TASK),
+        None,
+        None,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "audit record failed for session.revoke");
+    }
     tracing::info!(
         caller = %auth.did,
         session_id = %session_id,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2884,6 +2884,26 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
     v
 }
 
+/// The request payload this table witnesses for `uri`, if it holds one.
+///
+/// Exposed for the audit-coverage census, which needs a schema-valid payload
+/// per dispatched task and should not carry a second copy of these fixtures —
+/// two sets would drift, and the one that drifted would be the one nobody was
+/// looking at.
+///
+/// `None` for a URI with no witness at all, and for a `KnownDrift` entry: that
+/// variant records a shape the table already knows is wrong, and feeding it to
+/// another sweep would spread one defect across two failures.
+pub(super) fn request_payload_for(uri: &str) -> Option<Value> {
+    table()
+        .into_iter()
+        .find(|(u, _)| *u == uri)
+        .and_then(|(_, c)| match c {
+            Conformance::Checked(w) => Some(w.request),
+            Conformance::KnownDrift(_) => None,
+        })
+}
+
 // ─── The sweep ───────────────────────────────────────────────────────────
 
 /// Coverage: the witness table and the derived census agree exactly, in both

--- a/vta-service/src/trust_tasks/consent.rs
+++ b/vta-service/src/trust_tasks/consent.rs
@@ -33,7 +33,10 @@ use vti_common::consent::{
 };
 use vti_common::error::AppError;
 
-use super::helpers::{TrustTaskOutcome, app_error_to_reject, parse_payload, success_response};
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, success_response,
+};
+use crate::audit;
 use crate::auth::AuthClaims;
 use crate::server::AppState;
 
@@ -702,6 +705,28 @@ pub(super) async fn handle_revoke(
     if let Err(e) = delete_consent_grant(&state.consent_ks, &subject).await {
         return app_error_to_reject(&doc, e);
     }
+
+    // Withdrawing consent is a change to what an agent may do on someone's
+    // behalf, and the `notFound` path above returns before here on purpose: a
+    // revoke that deleted nothing is not a state change worth a line.
+    if let Err(e) = audit::record_with_detail(
+        &state.audit_sink,
+        "consent.revoke",
+        &auth.did,
+        Some(&subject.conversation_ref),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        None,
+        Some(&format!(
+            "platform={} agent={}",
+            subject.platform, subject.agent
+        )),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "audit record failed for consent.revoke");
+    }
+
     success_response(
         &doc,
         AckResponse {
@@ -769,9 +794,36 @@ pub(super) async fn handle_approver_set(
         route: payload.route,
         route_hint: payload.route_hint,
     };
+    let audit_detail = format!(
+        "platform={} approver={} route={:?}",
+        binding.platform, binding.approver, binding.route
+    );
+    let audit_context = binding.context.clone();
     if let Err(e) = store_approver(&state.consent_approvers_ks, &binding).await {
         return app_error_to_reject(&doc, e);
     }
+
+    // This binding decides *who gets asked* when a task needs a human. Moved
+    // quietly, it is the whole consent path redirected — point it at yourself
+    // and every gated action is approved by you, with the wallet still showing
+    // its prompt to somebody who never sees it. The approver is recorded in the
+    // detail for exactly that reason: knowing the binding changed is not enough,
+    // the reviewer needs to know what it changed *to*.
+    if let Err(e) = audit::record_with_detail(
+        &state.audit_sink,
+        "consent.approver-set",
+        &auth.did,
+        Some(&audit_context),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        Some(&audit_context),
+        Some(&audit_detail),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "audit record failed for consent.approver-set");
+    }
+
     success_response(&doc, ApproverSetResponse { status: "set" })
 }
 

--- a/vta-service/src/trust_tasks/contexts.rs
+++ b/vta-service/src/trust_tasks/contexts.rs
@@ -52,6 +52,7 @@ pub(super) async fn handle_create(
         Ok(r) => r,
         Err(resp) => return resp,
     };
+    let audit_id = req.id.clone();
     match operations::contexts::create_context(
         &state.contexts_ks,
         auth,
@@ -63,7 +64,27 @@ pub(super) async fn handle_create(
     )
     .await
     {
-        Ok(body) => success_response(&doc, body),
+        Ok(body) => {
+            // A context is the isolation boundary every key, DID and app-state
+            // record hangs off. Creating one is creating a new compartment, and
+            // "when did this appear, and who made it" is a question the trail
+            // has to answer.
+            if let Err(e) = crate::audit::record_with_detail(
+                &state.audit_sink,
+                "contexts.create",
+                &auth.did,
+                Some(&audit_id),
+                "success",
+                Some(TRANSPORT_TRUST_TASK),
+                Some(&audit_id),
+                None,
+            )
+            .await
+            {
+                tracing::warn!(error = %e, "audit record failed for contexts.create");
+            }
+            success_response(&doc, body)
+        }
         Err(e) => app_error_to_reject(&doc, e),
     }
 }

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -5,6 +5,7 @@
 //! (Application or higher) for sign.
 
 use super::helpers::TrustTaskOutcome;
+use crate::audit;
 use base64::Engine as _;
 use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
@@ -276,7 +277,28 @@ pub(super) async fn handle_derive_and_sign(
     )
     .await
     {
-        Ok(body) => success_response(&doc, body),
+        Ok(body) => {
+            // A signature is the most consequential thing this agent does with a key,
+            // and these two are the only signing paths that persist no key record — so
+            // without a line here, a derived-key signature leaves the agent with no
+            // evidence it ever happened. The derivation path is the resource: it is
+            // what identifies *which* key signed, and it is not itself secret.
+            if let Err(e) = audit::record_with_detail(
+                &state.audit_sink,
+                "keys.derive-and-sign",
+                &auth.did,
+                Some(&req.derivation_path),
+                "success",
+                Some(TRANSPORT_TRUST_TASK),
+                None,
+                Some(&format!("keyType={} alg={}", req.key_type, req.algorithm)),
+            )
+            .await
+            {
+                tracing::warn!(error = %e, "audit record failed for keys.derive-and-sign");
+            }
+            success_response(&doc, body)
+        }
         Err(e) => app_error_to_reject(&doc, e),
     }
 }
@@ -297,6 +319,12 @@ pub(super) async fn handle_derive_and_sign_document(
         Ok(r) => r,
         Err(resp) => return resp,
     };
+    let audit_path = req.derivation_path.clone();
+    let audit_detail = format!(
+        "keyType={} proofPurpose={}",
+        req.key_type,
+        req.proof_purpose.as_deref().unwrap_or("assertionMethod")
+    );
     match operations::keys::derive_and_sign_document(
         &state.keys_ks,
         &state.seed_store,
@@ -309,7 +337,30 @@ pub(super) async fn handle_derive_and_sign_document(
     )
     .await
     {
-        Ok(body) => success_response(&doc, body),
+        Ok(body) => {
+            // Sibling of `derive-and-sign` above, and the same reasoning. The
+            // document itself is deliberately not recorded — it is the caller's
+            // content, may carry anything, and the trail answers "which key
+            // signed, under what purpose", not "what did it say".
+            if let Err(e) = audit::record_with_detail(
+                &state.audit_sink,
+                "keys.derive-and-sign-document",
+                &auth.did,
+                Some(&audit_path),
+                "success",
+                Some(TRANSPORT_TRUST_TASK),
+                None,
+                Some(&audit_detail),
+            )
+            .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    "audit record failed for keys.derive-and-sign-document"
+                );
+            }
+            success_response(&doc, body)
+        }
         Err(e) => app_error_to_reject(&doc, e),
     }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -47,6 +47,8 @@ use crate::server::AppState;
 mod acl;
 mod app_state;
 mod audit;
+#[cfg(test)]
+mod audit_coverage;
 mod auth;
 mod backup;
 /// The ceremony-task predicate + the zero-authority claim an unenrolled


### PR DESCRIPTION
Answers a question that could not be answered before: **is auditing fully implemented?**

`tests/audit_sink.rs` proves the sink *mechanism* — entries reach an installed sink rather than the keyspace. It says nothing about which tasks emit one. And the emitting is scattered by design: the spine audits the vault family centrally (`vault_audit`), everything else records in its handler, or down in `operations/`, or through the `audit!` macro. Three shapes, no index.

Grep cannot settle it — I miscounted twice before accepting that following delegation is the whole difficulty. So this is a **runtime** sweep: for every dispatched task whose declared class is not `SideEffectLevel::None`, drive it and see whether an entry appears. Request fixtures come from the conformance table, which already holds a schema-valid payload per URI.

## The headline finding: two things are called "audit"

| helper | destination |
|---|---|
| `audit!` macro | a `tracing` event on the `audit` target — **a log line** |
| `record_with_detail` | the `AuditSink` — **the queryable trail** |
| the `vta-audit` ceremony helper | both |

Nothing at the call site says which. A handler calling `audit!` alone reads as audited and is **absent from `audit/list` and from any operator's external sink**.

`session.revoke` was exactly that — `audit!("session.revoke", …)` three lines above the response, and nothing in the trail. It took a runtime sweep to notice.

That split is worth a decision beyond this PR. 36 call sites use the macro; some of those actions are *also* recorded to the sink elsewhere and some are not, and only the census can tell them apart. Happy to open an issue for consolidating the two if you want it tracked separately.

## Seven consequential tasks succeeded and recorded nothing

Now zero. Ordered by what I'd worry about:

- **`consent/approver-set`** — this binding decides *who gets asked* when a task needs a human. Moved quietly, it is the entire consent path redirected: point it at yourself and every gated action is approved by you, with the wallet still raising its prompt to somebody who never sees it. Now records, with the approver in the detail — knowing the binding changed is not enough, the reviewer needs to know what it changed *to*.
- **`keys/derive-and-sign`** and **`keys/derive-and-sign-document`** — the only signing paths that persist no key record, so without a line the signature left no evidence anywhere. The derivation path is the resource; the signed document deliberately is not recorded (it is the caller's content and may carry anything).
- `consent/revoke`, `auth/revoke-session`, `contexts/create`.

## A flaw in the census, caught before it did damage

The first version drove `dispatch_typed` rather than `dispatch_trust_task_core` — skipping the spine, which is where the vault family's central audit lives. Every `vault/*` task therefore read as silent, and I was one edit from "fixing" `vault/credentials/delete`, which had been correct all along.

The census now drives the spine, and the module header says why, so the next person does not repeat it. Worth flagging in review because it is the kind of mistake that makes a census actively harmful — a false positive here produces a "fix" to working code.

## Two ratchets, deliberately different

**Success with no trail is a hard assert.** A task that did its work and left no trace has no defensible reading, so it never gets a tolerated count.

**Audit-on-success-only is a budget** — currently **72**. These record nothing when *refused*, so a denied privileged attempt leaves no trail, and "who tried to wipe this device and was denied" is precisely the entry an incident review goes looking for. Fixing them is ~70 handlers in one diff, so the number may only shrink: lower it in the commit that fixes one, never raise it. A new handler auditing on success only is a new instance of the defect, not a reason to move the line.

Twelve consequential tasks have **no conformance fixture** and were not driven — invisible to this sweep *and* the schema one. Reported rather than asserted, since the schema sweep owns that gap. They are the `vta/backup/*`, `vta/seeds/*`, `vault/*` lifecycle and `reload-services` families, all of which are unspecced; specifying them upstream is what closes it.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets` (no warnings), `cargo test -p vta-service --lib` — 1014 passed, and `cargo check --workspace` (CI's exact command, **not** `--all-targets`, which masked a cfg bug on a previous PR).
