### PR TITLE
docs(audit): say at the macro that `audit!` never reaches the sink

### DIFF
--- a/vta-audit/src/lib.rs
+++ b/vta-audit/src/lib.rs
@@ -20,7 +20,27 @@ use vti_common::store::KeyspaceHandle;
 pub mod sink;
 pub use sink::{AuditSink, FanOutAuditSink, KeyspaceAuditSink, SharedAuditSink};
 
-/// Emit a structured audit event to the tracing subsystem.
+/// Emit a structured audit event to the tracing subsystem — **a log line, and
+/// nothing else**.
+///
+/// This macro does **not** write to the [`AuditSink`]. Nothing it records
+/// appears in `audit/list`, or in an operator's external sink, or anywhere a
+/// later investigation would query. Persisting is [`record`] /
+/// [`record_with_detail`], and a handler that needs a trail must call one of
+/// those **as well as** this.
+///
+/// The emphasis is here because the call site does not carry it. A handler
+/// containing `audit!("session.revoke", …)` three lines above its response
+/// reads, on every measure a reviewer applies, as a handler that audits. It
+/// compiles, it is named `audit`, it emits an event, and the row an operator
+/// goes looking for is not there.
+///
+/// That is not hypothetical. `vta/management/reload-services` shipped with this
+/// macro and no sink write, so restarting an agent — every open session
+/// dropped, every counterparty disconnected — left nothing in the queryable
+/// trail. It took a runtime census to notice, and the census could not see the
+/// task at all until it was specified upstream (#1239). Two layers of checking
+/// passed over a handler that looked audited and was not.
 ///
 /// Uses `INFO` for successful outcomes and `ERROR` for failures (e.g. `denied:*`).
 #[macro_export]


### PR DESCRIPTION
The module docs in `vta-audit/src/lib.rs` already explain the split: the macro emits a tracing event, `record`/`record_with_detail` persist, call both.

The **macro's own** doc comment said only *"Emit a structured audit event to the tracing subsystem"* — and that is what a reader sees on hover or jump-to-definition at a call site.

## Why the call site needs the warning

A handler containing `audit!("session.revoke", …)` three lines above its response reads, on every measure a reviewer applies, as a handler that audits. It compiles, it is named `audit`, it emits an event. The row an operator goes looking for is not there.

Not hypothetical: `vta/management/reload-services` shipped with this macro and no sink write, so restarting an agent — every open session dropped, every counterparty disconnected — left nothing in `audit/list`. It took a runtime census to notice, and that census could not see the task at all until it was specified upstream (#1239). Two layers of checking passed over a handler that looked audited and was not.

Docs only, no behaviour change. `cargo test -p vta-audit`, `cargo doc -p vta-audit` and `cargo fmt --check` clean.