### PR TITLE
refactor(rooms): move the group-key and sealing layers into vti-rooms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10624,22 +10624,15 @@ dependencies = [
 name = "vtc-client"
 version = "0.5.1"
 dependencies = [
- "base64 0.22.1",
- "chacha20poly1305 0.10.1",
  "chrono",
- "getrandom 0.4.3",
- "openmls",
- "openmls_basic_credential",
- "openmls_rust_crypto",
- "openmls_traits",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "tls_codec",
  "tokio",
  "trust-tasks-rs",
  "vta-sdk",
+ "vti-rooms",
 ]
 
 [[package]]
@@ -10809,10 +10802,19 @@ name = "vti-rooms"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "chacha20poly1305 0.10.1",
  "chrono",
+ "getrandom 0.4.3",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.20",
+ "tls_codec",
  "tokio",
  "trust-tasks-rs",
  "vti-common",

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -322,8 +322,11 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
         alice_group.epoch()
     ));
 
-    let alice_room = SealedRoom::new(session(&f, false), alice_group);
-    let bob_room = SealedRoom::new(session(&f, false), bob_group);
+    // The credentials and the keys are separate objects now, and that is the honest
+    // shape: the session travels to the host on every call, the keys never travel at all.
+    let alice = session(&f, false);
+    let alice_room = SealedRoom::new(&f.room.room_id, alice_group);
+    let bob_room = SealedRoom::new(&f.room.room_id, bob_group);
 
     say(
         "9. Alice mints the epoch the membership change produced",
@@ -331,7 +334,7 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
     );
     let minted = client
         .mint_epoch(
-            alice_room.session(),
+            &alice,
             alice_room.room_epoch(),
             Some("added a member"),
             &f.owner.did,
@@ -363,7 +366,7 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
 
     let put = client
         .put_record(
-            alice_room.session(),
+            &alice,
             &key,
             Some(SealedContent {
                 ciphertext: sealed.ciphertext.clone(),
@@ -383,12 +386,7 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
         "The host served the bytes. It could not read them, and neither can anyone outside.",
     );
     let fetched = client
-        .get_record(
-            alice_room.session(),
-            &key,
-            &f.owner.did,
-            &f.owner.secret_multibase,
-        )
+        .get_record(&alice, &key, &f.owner.did, &f.owner.secret_multibase)
         .await?;
     let from_host = SealedContent {
         ciphertext: fetched["sealed"].as_str().unwrap_or_default().to_string(),
@@ -398,7 +396,7 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
     let opened = bob_room.open_record(&key, put.version, &from_host)?;
     note(&format!("Bob reads: {}", String::from_utf8_lossy(&opened)));
 
-    let outsider = SealedRoom::new(session(&f, false), RoomGroup::create("did:key:zMallory")?);
+    let outsider = SealedRoom::new(&f.room.room_id, RoomGroup::create("did:key:zMallory")?);
     note(match outsider.open_record(&key, put.version, &from_host) {
         Err(_) => "Mallory, holding a perfectly valid group of her own: cannot open it",
         Ok(_) => unreachable!("an outsider must not open a sealed record"),
@@ -419,8 +417,7 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
             alice_room.open_record(&key, put.version + 1, &from_host),
         ),
         ("to another room", {
-            let elsewhere =
-                SealedRoom::new(session(&other, false), RoomGroup::create(&f.owner.did)?);
+            let elsewhere = SealedRoom::new(&other.room.room_id, RoomGroup::create(&f.owner.did)?);
             elsewhere.open_record(&key, put.version, &from_host)
         }),
     ] {

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -12,10 +12,10 @@ repository.workspace = true
 
 [features]
 default = []
-# The MLS group layer (`rooms::mls`). Off by default: OpenMLS is a substantial
-# dependency and a caller that only reads an `open` room needs none of it.
-# Mirrors how `vtc-service` gates its `bbs` verifier.
-mls = ["dep:openmls", "dep:openmls_rust_crypto", "dep:openmls_basic_credential", "dep:openmls_traits", "dep:tls_codec", "dep:chacha20poly1305", "dep:base64", "dep:getrandom"]
+# The MLS group layer and record sealing, re-exported from `vti-rooms` where
+# they now live. Still off by default here, and still the same types — a caller
+# that had `vtc-client` with `mls` keeps working unchanged.
+mls = ["vti-rooms/mls"]
 
 [dependencies]
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
@@ -23,19 +23,11 @@ mls = ["dep:openmls", "dep:openmls_rust_crypto", "dep:openmls_basic_credential",
 # `protocols`.
 vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session"] }
 
-# MLS (RFC 9420) for room group keys, behind the `mls` feature. The design note
-# adopts MLS rather than a hand-rolled epoch scheme: post-compromise security and
-# O(log n) membership change are not things to reimplement.
-openmls = { version = "0.9", optional = true }
-openmls_rust_crypto = { version = "0.6", optional = true }
-openmls_basic_credential = { version = "0.6", optional = true }
-openmls_traits = { version = "0.6", optional = true }
-tls_codec = { version = "0.5", optional = true }
-# Record sealing. The AEAD binds each record to its room, key, version and epoch,
-# so a host that relocates one produces a mismatch rather than a readable record.
-chacha20poly1305 = { version = "0.10", optional = true }
-base64 = { version = "0.22", optional = true }
-getrandom = { version = "0.4", optional = true }
+# The room's wire types, and — under the `mls` feature — its group-key and
+# sealing layers, which this crate re-exports rather than owning. A VTA needs
+# both and must not depend on a VTC client, so they live in the shared leaf.
+vti-rooms = { path = "../vti-rooms", version = "0.1" }
+
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document
 # from, so one shape crosses the boundary.

--- a/vtc-client/src/rooms/mod.rs
+++ b/vtc-client/src/rooms/mod.rs
@@ -28,103 +28,27 @@
 //! bound to the agent. The agent's `RoomSession` is built exactly like the member's — the
 //! difference is entirely in the credentials it was handed, which is the point.
 
+// The group-key and sealing layers live in `vti-rooms` — a VTA needs both to open a
+// record on an agent's behalf, and a VTA must not depend on a VTC client. Re-exported
+// under their old paths so a caller that had `vtc-client` with `mls` is unaffected.
 #[cfg(feature = "mls")]
-pub mod mls;
-#[cfg(feature = "mls")]
-pub mod sealed;
-
-use serde::{Deserialize, Serialize};
+pub use vti_rooms::{mls, sealed};
 
 use crate::{VtcClient, VtcError};
 
-/// `rooms/create/0.1`.
-pub const ROOMS_CREATE_TYPE: &str = "https://trusttasks.org/spec/rooms/create/0.1";
-/// `rooms/records/put/0.1`.
-pub const ROOMS_RECORDS_PUT_TYPE: &str = "https://trusttasks.org/spec/rooms/records/put/0.1";
-/// `rooms/records/get/0.1`.
-pub const ROOMS_RECORDS_GET_TYPE: &str = "https://trusttasks.org/spec/rooms/records/get/0.1";
-/// `rooms/records/list/0.1`.
-pub const ROOMS_RECORDS_LIST_TYPE: &str = "https://trusttasks.org/spec/rooms/records/list/0.1";
-/// `rooms/epoch/mint/0.1`.
-pub const ROOMS_EPOCH_MINT_TYPE: &str = "https://trusttasks.org/spec/rooms/epoch/mint/0.1";
-
-/// Maximum links a host will accept in one chain.
-///
-/// Mirrors the host's own ceiling so a caller finds out here rather than over the wire.
-/// Verification is linear in chain length and runs on every operation, so an unbounded
-/// chain is a denial-of-service surface against the host.
-pub const MAX_CHAIN_DEPTH: usize = 8;
-
-/// How much of a room its host can see. Fixed at creation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Visibility {
-    /// Cleartext, searchable by the host.
-    Open,
-    /// Content sealed; the acting member still disclosed.
-    Attributed,
-    /// Content sealed; membership presented in zero knowledge.
-    Private,
-}
-
-/// The credentials a caller presents to act on a room.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AuthorityPresentation {
-    pub membership: String,
-    /// Leaf first; the last element is the credential the room issued.
-    pub authority: Vec<String>,
-    /// Required on a `private` room.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subject_binding: Option<String>,
-}
-
-/// Sealed record content.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SealedContent {
-    pub ciphertext: String,
-    pub nonce: String,
-    pub epoch: u32,
-}
-
-/// Cleartext record content. `open` rooms only.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CleartextContent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    pub body: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub tags: Vec<String>,
-}
-
-/// What a `put` returns.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PutRecordResponse {
-    pub key: String,
-    pub version: u64,
-    #[serde(default)]
-    pub epoch: Option<u32>,
-}
-
-/// What a `list` returns — metadata, never bodies.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ListRecordsResponse {
-    pub records: Vec<serde_json::Value>,
-}
-
-/// What minting an epoch returns.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MintEpochResponse {
-    pub room_id: String,
-    pub epoch: u32,
-}
+// The wire types and their Type URIs, from the crate that also stores and serves them.
+//
+// These were defined a second time here until the group-key layer moved out and the
+// duplication became a compile error — two structs of one wire form, identical and with
+// nothing checking they stayed that way, which is the drift the schema-conformance suite in
+// `vti-rooms` exists to catch and could not see from over here.
+pub use vti_rooms::Visibility;
+pub use vti_rooms::authz::MAX_CHAIN_DEPTH;
+pub use vti_rooms::wire::{
+    AuthorityPresentation, CleartextContent, ListRecordsResponse, MintEpochResponse,
+    PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_RECORDS_GET_TYPE,
+    ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE, SealedContent,
+};
 
 /// A caller's standing in one room.
 ///

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -8,6 +8,23 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[features]
+default = []
+# The room's group-key layer (`mls`) and record sealing (`sealed`). Off by
+# default: a host that only stores ciphertext needs none of it, and OpenMLS is a
+# substantial dependency to make such a host carry. Mirrors how `vtc-service`
+# gates its `bbs` verifier.
+mls = [
+  "dep:openmls",
+  "dep:openmls_rust_crypto",
+  "dep:openmls_basic_credential",
+  "dep:openmls_traits",
+  "dep:tls_codec",
+  "dep:chacha20poly1305",
+  "dep:base64",
+  "dep:getrandom",
+]
+
 [dependencies]
 # The store abstraction and AppError. This crate's only internal dependency:
 # a room's storage and authorization need nothing from a community service,
@@ -15,9 +32,22 @@ publish.workspace = true
 vti-common = { path = "../vti-common", version = "0.16" }
 
 serde = { workspace = true }
+thiserror = { workspace = true }
 serde_json = { workspace = true }
 # The published schema types `updatedAt` as an RFC 3339 string.
 chrono = { workspace = true }
+
+# MLS (RFC 9420) for room group keys, behind the `mls` feature. The design note
+# adopts MLS rather than a hand-rolled epoch scheme: post-compromise security and
+# O(log n) membership change are not things to reimplement.
+openmls = { version = "0.9", optional = true }
+openmls_rust_crypto = { version = "0.6", optional = true }
+openmls_basic_credential = { version = "0.6", optional = true }
+openmls_traits = { version = "0.6", optional = true }
+tls_codec = { version = "0.5", optional = true }
+chacha20poly1305 = { version = "0.10", optional = true }
+base64 = { version = "0.22", optional = true }
+getrandom = { version = "0.4", optional = true }
 # Verification may resolve a DID, so ChainVerifier is async; async-trait keeps it
 # dyn-compatible, as it does for vti_common::auth::backend.
 async-trait = "0.1"

--- a/vti-rooms/src/error.rs
+++ b/vti-rooms/src/error.rs
@@ -1,0 +1,35 @@
+//! Failures from a room's key layer.
+//!
+//! Deliberately not `vti_common::error::AppError`. The rest of this crate speaks `AppError`
+//! because storage and authorization *are* a service's concerns; key material is not. A
+//! record that does not open is a legitimate outcome with a specific meaning, and folding it
+//! into `Internal` would say "this service is broken" about the one case the design most
+//! wants to be loud and precise: a host relocated a record.
+//!
+//! Kept small on purpose. A caller can tell a group-state problem from a sealing problem
+//! from a record that did not open, and that is the whole distinction anything needs.
+
+/// What can go wrong holding or using a room's keys.
+#[derive(Debug, thiserror::Error)]
+pub enum RoomKeyError {
+    /// The MLS group could not be created, joined, or advanced.
+    #[error("room group: {0}")]
+    Group(String),
+
+    /// A record could not be sealed, or its inputs could not be decoded.
+    #[error("seal record: {0}")]
+    Seal(String),
+
+    /// A record did not open.
+    ///
+    /// One variant for every reason, and that is the design rather than laziness: the
+    /// AEAD cannot distinguish "wrong key" from "relocated record" from "tampered
+    /// ciphertext", and a caller that acted on a guess would be acting on nothing. What it
+    /// can say is that the bytes are not the bytes that were sealed here, which is the
+    /// property the binding exists to give.
+    #[error(
+        "record did not open: it was sealed under a different key, epoch, or location — a \
+         relocated record fails here rather than decrypting wrongly"
+    )]
+    DidNotOpen,
+}

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -60,6 +60,15 @@
 //! Each host writes its own thin handlers over these three layers.
 
 pub mod authz;
+pub mod error;
+/// The room's group-key layer (RFC 9420), behind the `mls` feature.
+///
+/// Off by default: a host that only stores ciphertext needs none of it, and OpenMLS is a
+/// substantial dependency to make it carry.
+#[cfg(feature = "mls")]
+pub mod mls;
+#[cfg(feature = "mls")]
+pub mod sealed;
 pub mod storage;
 pub mod wire;
 

--- a/vti-rooms/src/mls.rs
+++ b/vti-rooms/src/mls.rs
@@ -57,7 +57,7 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 use openmls_traits::OpenMlsProvider;
 use tls_codec::{Deserialize as _, Serialize as _};
 
-use crate::VtcError;
+use crate::error::RoomKeyError;
 
 /// The MLS ciphersuite every room uses.
 ///
@@ -88,12 +88,12 @@ pub struct RoomIdentity {
 
 impl RoomIdentity {
     /// Create an identity for `member_did`.
-    pub fn new(member_did: &str, provider: &impl OpenMlsProvider) -> Result<Self, VtcError> {
+    pub fn new(member_did: &str, provider: &impl OpenMlsProvider) -> Result<Self, RoomKeyError> {
         let signer = SignatureKeyPair::new(ROOM_CIPHERSUITE.signature_algorithm())
-            .map_err(|e| VtcError::Signing(format!("generate MLS signature key: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("generate MLS signature key: {e:?}")))?;
         signer
             .store(provider.storage())
-            .map_err(|e| VtcError::Signing(format!("store MLS signature key: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("store MLS signature key: {e:?}")))?;
 
         let credential = Credential::new(CredentialType::Basic, member_did.as_bytes().to_vec());
         Ok(Self {
@@ -110,7 +110,7 @@ impl RoomIdentity {
     /// Published to whoever is inviting them — **over the invitation channel, never through
     /// the host**. A host that collected key packages would learn who is being invited to
     /// what, which un-blinds a sealed room at the door.
-    pub fn key_package(&self, provider: &impl OpenMlsProvider) -> Result<KeyPackage, VtcError> {
+    pub fn key_package(&self, provider: &impl OpenMlsProvider) -> Result<KeyPackage, RoomKeyError> {
         KeyPackage::builder()
             .build(
                 ROOM_CIPHERSUITE,
@@ -119,7 +119,7 @@ impl RoomIdentity {
                 self.credential.clone(),
             )
             .map(|b| b.key_package().clone())
-            .map_err(|e| VtcError::Signing(format!("build MLS key package: {e:?}")))
+            .map_err(|e| RoomKeyError::Group(format!("build MLS key package: {e:?}")))
     }
 }
 
@@ -146,7 +146,7 @@ pub struct MembershipChange {
 
 impl RoomGroup {
     /// Create a room's group. The creator is its first member and its owner.
-    pub fn create(member_did: &str) -> Result<Self, VtcError> {
+    pub fn create(member_did: &str) -> Result<Self, RoomKeyError> {
         let provider = OpenMlsRustCrypto::default();
         let identity = RoomIdentity::new(member_did, &provider)?;
 
@@ -161,7 +161,7 @@ impl RoomGroup {
             &config,
             identity.credential.clone(),
         )
-        .map_err(|e| VtcError::Signing(format!("create MLS group: {e:?}")))?;
+        .map_err(|e| RoomKeyError::Group(format!("create MLS group: {e:?}")))?;
 
         Ok(Self {
             group,
@@ -171,7 +171,7 @@ impl RoomGroup {
     }
 
     /// Join a room from the welcome its owner sent.
-    pub fn join(member_did: &str, welcome: &[u8]) -> Result<Self, VtcError> {
+    pub fn join(member_did: &str, welcome: &[u8]) -> Result<Self, RoomKeyError> {
         let provider = OpenMlsRustCrypto::default();
         let identity = RoomIdentity::new(member_did, &provider)?;
         Self::join_with(identity, provider, welcome)
@@ -186,13 +186,13 @@ impl RoomGroup {
         identity: RoomIdentity,
         provider: OpenMlsRustCrypto,
         welcome: &[u8],
-    ) -> Result<Self, VtcError> {
+    ) -> Result<Self, RoomKeyError> {
         let msg = MlsMessageIn::tls_deserialize_exact(welcome)
-            .map_err(|e| VtcError::Signing(format!("parse welcome: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("parse welcome: {e:?}")))?;
         let welcome = match msg.extract() {
             MlsMessageBodyIn::Welcome(w) => w,
             _ => {
-                return Err(VtcError::Signing(
+                return Err(RoomKeyError::Group(
                     "expected a Welcome message, got another MLS body".into(),
                 ));
             }
@@ -202,10 +202,10 @@ impl RoomGroup {
             .use_ratchet_tree_extension(true)
             .build();
         let staged = StagedWelcome::new_from_welcome(&provider, &config, welcome, None)
-            .map_err(|e| VtcError::Signing(format!("stage welcome: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("stage welcome: {e:?}")))?;
         let group = staged
             .into_group(&provider)
-            .map_err(|e| VtcError::Signing(format!("join group from welcome: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("join group from welcome: {e:?}")))?;
 
         Ok(Self {
             group,
@@ -220,24 +220,27 @@ impl RoomGroup {
     /// precisely because a group where any key-holder can commit is a group where any
     /// member can evict any other. MLS itself does not enforce that; the room's authority
     /// credentials do, and the host checks them before accepting the epoch advance.
-    pub fn add_member(&mut self, key_package: KeyPackage) -> Result<MembershipChange, VtcError> {
+    pub fn add_member(
+        &mut self,
+        key_package: KeyPackage,
+    ) -> Result<MembershipChange, RoomKeyError> {
         let (commit, welcome, _) = self
             .group
             .add_members(&self.provider, &self.identity.signer, &[key_package])
-            .map_err(|e| VtcError::Signing(format!("add member: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("add member: {e:?}")))?;
 
         self.group
             .merge_pending_commit(&self.provider)
-            .map_err(|e| VtcError::Signing(format!("merge add commit: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("merge add commit: {e:?}")))?;
 
         Ok(MembershipChange {
             commit: commit
                 .tls_serialize_detached()
-                .map_err(|e| VtcError::Signing(format!("serialise commit: {e:?}")))?,
+                .map_err(|e| RoomKeyError::Group(format!("serialise commit: {e:?}")))?,
             welcome: Some(
                 welcome
                     .tls_serialize_detached()
-                    .map_err(|e| VtcError::Signing(format!("serialise welcome: {e:?}")))?,
+                    .map_err(|e| RoomKeyError::Group(format!("serialise welcome: {e:?}")))?,
             ),
             epoch: self.group.epoch().as_u64(),
         })
@@ -249,46 +252,49 @@ impl RoomGroup {
     /// could already read; they held the plaintext. What they lose is everything sealed
     /// under the new epoch. An interface that implies otherwise has mis-stated the
     /// guarantee.
-    pub fn remove_member(&mut self, index: LeafNodeIndex) -> Result<MembershipChange, VtcError> {
+    pub fn remove_member(
+        &mut self,
+        index: LeafNodeIndex,
+    ) -> Result<MembershipChange, RoomKeyError> {
         let (commit, _, _) = self
             .group
             .remove_members(&self.provider, &self.identity.signer, &[index])
-            .map_err(|e| VtcError::Signing(format!("remove member: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("remove member: {e:?}")))?;
 
         self.group
             .merge_pending_commit(&self.provider)
-            .map_err(|e| VtcError::Signing(format!("merge remove commit: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("merge remove commit: {e:?}")))?;
 
         Ok(MembershipChange {
             commit: commit
                 .tls_serialize_detached()
-                .map_err(|e| VtcError::Signing(format!("serialise commit: {e:?}")))?,
+                .map_err(|e| RoomKeyError::Group(format!("serialise commit: {e:?}")))?,
             welcome: None,
             epoch: self.group.epoch().as_u64(),
         })
     }
 
     /// Apply a commit produced by another member.
-    pub fn apply_commit(&mut self, commit: &[u8]) -> Result<u64, VtcError> {
+    pub fn apply_commit(&mut self, commit: &[u8]) -> Result<u64, RoomKeyError> {
         let msg = MlsMessageIn::tls_deserialize_exact(commit)
-            .map_err(|e| VtcError::Signing(format!("parse commit: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("parse commit: {e:?}")))?;
         let protocol_message: ProtocolMessage = msg
             .try_into_protocol_message()
-            .map_err(|e| VtcError::Signing(format!("not a protocol message: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("not a protocol message: {e:?}")))?;
 
         let processed = self
             .group
             .process_message(&self.provider, protocol_message)
-            .map_err(|e| VtcError::Signing(format!("process commit: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("process commit: {e:?}")))?;
 
         match processed.into_content() {
             ProcessedMessageContent::StagedCommitMessage(staged) => {
                 self.group
                     .merge_staged_commit(&self.provider, *staged)
-                    .map_err(|e| VtcError::Signing(format!("merge staged commit: {e:?}")))?;
+                    .map_err(|e| RoomKeyError::Group(format!("merge staged commit: {e:?}")))?;
                 Ok(self.group.epoch().as_u64())
             }
-            _ => Err(VtcError::Signing(
+            _ => Err(RoomKeyError::Group(
                 "expected a commit, got another message type".into(),
             )),
         }
@@ -307,7 +313,7 @@ impl RoomGroup {
     /// Derived from the MLS exporter under a room-specific label rather than borrowed from
     /// the group's own message keys — so a change to how records are sealed cannot weaken
     /// the group's messaging, and vice versa.
-    pub fn storage_key(&self) -> Result<[u8; STORAGE_KEY_LEN], VtcError> {
+    pub fn storage_key(&self) -> Result<[u8; STORAGE_KEY_LEN], RoomKeyError> {
         let secret = self
             .group
             .export_secret(
@@ -316,7 +322,7 @@ impl RoomGroup {
                 &[],
                 STORAGE_KEY_LEN,
             )
-            .map_err(|e| VtcError::Signing(format!("export storage key: {e:?}")))?;
+            .map_err(|e| RoomKeyError::Group(format!("export storage key: {e:?}")))?;
         let mut key = [0u8; STORAGE_KEY_LEN];
         key.copy_from_slice(&secret);
         Ok(key)

--- a/vti-rooms/src/sealed.rs
+++ b/vti-rooms/src/sealed.rs
@@ -39,29 +39,37 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
 use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 
-use super::mls::RoomGroup;
-use super::{RoomSession, SealedContent};
-use crate::VtcError;
+use crate::error::RoomKeyError;
+use crate::mls::RoomGroup;
+use crate::wire::SealedContent;
 
 /// A room whose records are sealed, and the group state that seals them.
 ///
-/// Pairs a [`RoomSession`] — the credentials the host authorizes against — with a
-/// [`RoomGroup`] — the key material the host never sees. Those are two different things and
-/// this type is the only place they meet: authorization travels to the host, keys do not.
+/// Holds the room's identifier and its [`RoomGroup`] — nothing about *credentials*. That
+/// separation is deliberate and it is the reason this type moved out of the client: the
+/// credentials a caller presents travel to the host on every request, and the keys never
+/// travel anywhere. Pairing them in one struct made a client the only place a room could be
+/// opened, which is wrong the moment a VTA has to open one on an agent's behalf.
+///
+/// The identifier is here because it is bound into every record's associated data, not
+/// because this type does anything with it.
 pub struct SealedRoom {
-    session: RoomSession,
+    room_id: String,
     group: RoomGroup,
 }
 
 impl SealedRoom {
-    /// Pair a session with its group.
-    pub fn new(session: RoomSession, group: RoomGroup) -> Self {
-        Self { session, group }
+    /// Pair a room identifier with its group.
+    pub fn new(room_id: impl Into<String>, group: RoomGroup) -> Self {
+        Self {
+            room_id: room_id.into(),
+            group,
+        }
     }
 
-    /// The credentials to present.
-    pub fn session(&self) -> &RoomSession {
-        &self.session
+    /// The room these keys are for.
+    pub fn room_id(&self) -> &str {
+        &self.room_id
     }
 
     /// The group, for membership changes and epoch anchoring.
@@ -103,10 +111,10 @@ impl SealedRoom {
         key: &str,
         version: u64,
         plaintext: &[u8],
-    ) -> Result<SealedContent, VtcError> {
+    ) -> Result<SealedContent, RoomKeyError> {
         let epoch = self.room_epoch();
         let storage_key = self.group.storage_key()?;
-        let aad = associated_data(self.session.room_id(), key, version, epoch);
+        let aad = associated_data(&self.room_id, key, version, epoch);
 
         let cipher = ChaCha20Poly1305::new(Key::from_slice(&storage_key));
         let mut nonce_bytes = [0u8; 12];
@@ -120,7 +128,7 @@ impl SealedRoom {
                     aad: &aad,
                 },
             )
-            .map_err(|e| VtcError::Signing(format!("seal record: {e}")))?;
+            .map_err(|e| RoomKeyError::Seal(format!("seal record: {e}")))?;
 
         Ok(SealedContent {
             ciphertext: B64.encode(ciphertext),
@@ -138,18 +146,18 @@ impl SealedRoom {
         key: &str,
         version: u64,
         sealed: &SealedContent,
-    ) -> Result<Vec<u8>, VtcError> {
+    ) -> Result<Vec<u8>, RoomKeyError> {
         let storage_key = self.group.storage_key()?;
-        let aad = associated_data(self.session.room_id(), key, version, sealed.epoch);
+        let aad = associated_data(&self.room_id, key, version, sealed.epoch);
 
         let ciphertext = B64
             .decode(&sealed.ciphertext)
-            .map_err(|e| VtcError::Signing(format!("decode ciphertext: {e}")))?;
+            .map_err(|e| RoomKeyError::Seal(format!("decode ciphertext: {e}")))?;
         let nonce = B64
             .decode(&sealed.nonce)
-            .map_err(|e| VtcError::Signing(format!("decode nonce: {e}")))?;
+            .map_err(|e| RoomKeyError::Seal(format!("decode nonce: {e}")))?;
         if nonce.len() != 12 {
-            return Err(VtcError::Signing(format!(
+            return Err(RoomKeyError::Seal(format!(
                 "nonce is {} bytes, expected 12",
                 nonce.len()
             )));
@@ -164,13 +172,7 @@ impl SealedRoom {
                     aad: &aad,
                 },
             )
-            .map_err(|_| {
-                VtcError::Signing(
-                    "record did not open: it was sealed under a different key, epoch, or \
-                     location — a relocated record fails here rather than decrypting wrongly"
-                        .into(),
-                )
-            })
+            .map_err(|_| RoomKeyError::DidNotOpen)
     }
 
     /// The value to anchor in the room's witnessed DID log for this epoch.
@@ -197,9 +199,8 @@ mod tests {
     use super::*;
 
     fn room(did: &str) -> SealedRoom {
-        let session = RoomSession::new(did, "vmc", vec!["vac".into()]).expect("session");
         let group = RoomGroup::create("did:key:zAlice").expect("group");
-        SealedRoom::new(session, group)
+        SealedRoom::new(did, group)
     }
 
     #[test]
@@ -233,8 +234,10 @@ mod tests {
             "relabelling the epoch must fail authentication, not decrypt wrongly"
         );
 
-        let other_room = RoomSession::new("did:webvh:zOther", "vmc", vec!["vac".into()]).unwrap();
-        let moved = SealedRoom::new(other_room, RoomGroup::create("did:key:zAlice").unwrap());
+        let moved = SealedRoom::new(
+            "did:webvh:zOther",
+            RoomGroup::create("did:key:zAlice").unwrap(),
+        );
         assert!(
             moved.open_record("k1", 1, &sealed).is_err(),
             "moving it to another room must fail"
@@ -248,7 +251,7 @@ mod tests {
 
         // A different group is a different key, however identical everything else looks.
         let outsider = SealedRoom::new(
-            RoomSession::new("did:webvh:zRoom", "vmc", vec!["vac".into()]).unwrap(),
+            "did:webvh:zRoom",
             RoomGroup::create("did:key:zMallory").unwrap(),
         );
         assert!(outsider.open_record("k1", 1, &sealed).is_err());

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -81,7 +81,7 @@ pub struct SealedContent {
 }
 
 /// Cleartext record content. `open` rooms only.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CleartextContent {
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Preparation for `rooms/keys/open`, and it fixes a duplication that was invisible while it compiled.

## Why

**A VTA must not depend on a VTC client.** `rooms/keys/open` — the oracle that opens a sealed record on an agent's behalf so the agent never holds the key — has to live in `vta-service`, because the VTA is what holds the principal's key material. Both layers it needs are currently in `vtc-client`, so that task could not be written without a layering inversion.

`vti-rooms` is already the shared home for "the parts of a room that are not a service", and it is where the ciphertext is stored. That closes the other half of the argument: a record's associated data commits to `roomId | key | version | epoch`, and until now the code that *seals* those four fields and the code that *stores* them were in different crates. That is how a binding drifts.

Both live behind an `mls` feature, off by default, so a host that only stores ciphertext still compiles no OpenMLS.

## The duplication this surfaced

`vtc-client` defined its own `Visibility`, `AuthorityPresentation`, `SealedContent`, `CleartextContent`, three response types, and all five Type URI constants — identical to `vti-rooms`' and with nothing checking they stayed identical.

The schema-conformance suite added with the open tier validates `vti-rooms`' copies against the published schemas and **could not see the client's at all**, so those could have drifted freely. They are re-exports now, which makes the suite cover both. The move turned a silent duplication into a compile error, which is the only reason it was found.

## API change

`SealedRoom` no longer holds a `RoomSession`; it holds the room id and the group. The separation is the honest shape rather than a concession to the move — the credentials a caller presents travel to the host on every request, and the keys never travel anywhere. Pairing them in one struct made a client the only place a room could be opened.

`RoomKeyError` replaces `VtcError` for this layer, and deliberately isn't `vti_common::AppError`: a record that does not open is a legitimate outcome with a specific meaning, and folding it into `Internal` would say "this service is broken" about the one case the design most wants to be loud and precise — a host relocated a record.

`vtc_client::rooms::{mls, sealed}` are re-exports, so a caller that had `vtc-client` with `mls` is unaffected. Nothing has shipped on that feature in any case: it merged in #1237 and has not been released.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `vti-rooms` 35 tests with `mls` and 23 without; the `data_room` example still runs the full path end to end.