### PR TITLE
feat(rooms): the lifecycle §9 describes, with the host never deciding

### DIFF
--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -611,10 +611,20 @@ irreducible row — now as **provable misbehaviour** rather than a deniable
 shrug.
 
 Owner absence must not kill a live room: the nominated successor claims
-(§10), or the k-of-n quorum renews. Read activity counts as liveness — a room
-actively read and never written is an archive, which is exactly what this
-section exists to protect. Where the host stores nothing (owner-hosted
+(§10), or the k-of-n quorum renews. Where the host stores nothing (owner-hosted
 content), lifecycle is wholly the owner's.
+
+**Read activity does not extend the clock, and the implementation departs from
+an earlier draft of this paragraph on purpose.** "A room actively read and
+never written is an archive" is right about what deserves protecting and wrong
+about how. A *host* counting reads to decide a sealed room's lifecycle would
+make that lifecycle depend on the one signal the host can see — which is
+exactly the correlation the tiers exist to deny, and it would give a
+`private` room an access-frequency profile its members were promised it would
+not have. Liveness is expressed by renewing, and a room being read is a room
+whose members are in a position to renew it. The archive case is served by
+`retentionDays`, which is the member's own statement of how long the room
+matters, made at creation where it belongs.
 
 ---
 

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -73,6 +73,12 @@ use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier};
 /// Default retention after a room's epoch lapses without renewal.
 const DEFAULT_RETENTION_DAYS: u32 = 90;
 
+/// One epoch lifetime in seconds — how long a newly created room is live before it needs
+/// renewing. Not a per-room parameter yet: `rooms/create/0.1` has no member for it, and
+/// inventing one locally would put this host's rooms out of conformance with the schema.
+const EPOCH_LIFETIME_DAYS_SECS: u64 =
+    vti_rooms::lifecycle::DEFAULT_EPOCH_LIFETIME_DAYS as u64 * 24 * 60 * 60;
+
 /// Everything this host holds. Two keyspaces and a verifier — and note what is not here.
 #[derive(Clone)]
 pub struct HostState {
@@ -226,6 +232,9 @@ async fn create(
         epoch: 1,
         next_version: 1,
         retention_days: req.retention_days.unwrap_or(DEFAULT_RETENTION_DAYS),
+        // A room is live from creation for one epoch lifetime; minting the next epoch
+        // renews it. Nothing else moves this clock — see `vti_rooms::lifecycle`.
+        epoch_expires_at: Some(now() + EPOCH_LIFETIME_DAYS_SECS),
         created_at: now(),
         updated_at: now(),
     };
@@ -270,6 +279,7 @@ async fn put(
         &req.presentation,
         Action::Write,
         &presenter,
+        now(),
         &verifier,
     )
     .await
@@ -350,6 +360,7 @@ async fn get(
         &req.presentation,
         Action::Read,
         &presenter,
+        now(),
         &verifier,
     )
     .await
@@ -391,6 +402,7 @@ async fn list(
         &req.presentation,
         Action::Read,
         &presenter,
+        now(),
         &verifier,
     )
     .await
@@ -452,6 +464,7 @@ async fn mint(
         &req.presentation,
         Action::Admin,
         &presenter,
+        now(),
         &verifier,
     )
     .await

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -69,6 +69,12 @@ fn now() -> u64 {
 /// month, short enough that an abandoned one does not accumulate forever.
 const DEFAULT_RETENTION_DAYS: u32 = 90;
 
+/// One epoch lifetime in seconds — how long a newly created room is live before it needs
+/// renewing. Not a per-room parameter yet: `rooms/create/0.1` has no member for it, and
+/// inventing one locally would put this host's rooms out of conformance with the schema.
+const EPOCH_LIFETIME_DAYS_SECS: u64 =
+    vti_rooms::lifecycle::DEFAULT_EPOCH_LIFETIME_DAYS as u64 * 24 * 60 * 60;
+
 /// `rooms/create/0.1`.
 ///
 /// The creator brings the room's identifier; this service does not assign one. A room
@@ -87,6 +93,9 @@ pub(crate) async fn handle_create(state: &AppState, doc: TrustTask<Value>) -> Tr
         epoch: 1,
         next_version: 1,
         retention_days: req.retention_days.unwrap_or(DEFAULT_RETENTION_DAYS),
+        // A room is live from creation for one epoch lifetime; minting the next epoch
+        // renews it. Nothing else moves this clock — see `vti_rooms::lifecycle`.
+        epoch_expires_at: Some(now() + EPOCH_LIFETIME_DAYS_SECS),
         created_at: now(),
         updated_at: now(),
     };
@@ -124,6 +133,7 @@ pub(crate) async fn handle_put_record(state: &AppState, doc: TrustTask<Value>) -
         &req.presentation,
         Action::Write,
         &presenter,
+        now(),
         &verifier,
     )
     .await
@@ -204,6 +214,7 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
         &req.presentation,
         Action::Read,
         &presenter,
+        now(),
         &verifier,
     )
     .await
@@ -243,6 +254,7 @@ pub(crate) async fn handle_list_records(
         &req.presentation,
         Action::Read,
         &presenter,
+        now(),
         &verifier,
     )
     .await
@@ -297,6 +309,7 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
         &req.presentation,
         Action::Admin,
         &presenter,
+        now(),
         &verifier,
     )
     .await

--- a/vti-rooms-dtg/src/lib.rs
+++ b/vti-rooms-dtg/src/lib.rs
@@ -373,6 +373,7 @@ mod tests {
             epoch: 1,
             next_version: 1,
             retention_days: 90,
+            epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
         }
@@ -624,6 +625,7 @@ mod signed {
                 epoch: 1,
                 next_version: 1,
                 retention_days: 90,
+                epoch_expires_at: None,
                 created_at: 0,
                 updated_at: 0,
             },
@@ -957,6 +959,7 @@ pub mod test_support {
                     epoch: 1,
                     next_version: 1,
                     retention_days: 90,
+                    epoch_expires_at: None,
                     created_at: 0,
                     updated_at: 0,
                 },

--- a/vti-rooms/src/authz.rs
+++ b/vti-rooms/src/authz.rs
@@ -205,6 +205,7 @@ pub async fn authorize(
     presentation: &AuthorityPresentation,
     action: Action,
     presenter: &str,
+    now: u64,
     verifier: &dyn ChainVerifier,
 ) -> Result<AuthorizedAction, AppError> {
     // Depth first: it is the cheapest check and the one that bounds the cost of every
@@ -254,6 +255,24 @@ pub async fn authorize(
         ));
     }
 
+    // A room whose epoch has expired is read-only until somebody renews it (§9). Nothing
+    // is destroyed, nothing is hidden, and reads keep working in every state — a lapse is a
+    // condition a member can notice and fix, not a punishment.
+    //
+    // `Admin` is exempt, and the exemption is what makes the state machine have an exit:
+    // minting an epoch *is* the renewal, so a gate that refused it would leave a lapsed
+    // room lapsed forever. It is checked before verification for the same reason depth is —
+    // no point verifying a chain for an operation the room cannot accept.
+    let lifecycle = room.lifecycle(now);
+    if !matches!(action, Action::Admin) && !lifecycle.accepts_writes() && action != Action::Read {
+        return Err(AppError::Forbidden(format!(
+            "room `{}` is {} and accepts no writes until its epoch is renewed; reads and \
+             export still work, and a single `rooms/epoch/mint` restores it",
+            room.room_id,
+            lifecycle.as_str()
+        )));
+    }
+
     // Everything above is shape. This is the decision.
     let verified = verifier
         .verify(room, presentation, action, presenter)
@@ -301,6 +320,7 @@ mod tests {
             epoch: 1,
             next_version: 1,
             retention_days: 90,
+            epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
         }
@@ -308,6 +328,8 @@ mod tests {
 
     /// The DID the request's own proof established.
     const PRESENTER: &str = "did:key:zAgent";
+    /// Any time at all: the fixtures below have no epoch expiry, so they never lapse.
+    const NOW: u64 = 1_800_000_000;
 
     fn presentation(depth: usize, binding: bool) -> AuthorityPresentation {
         AuthorityPresentation {
@@ -380,6 +402,7 @@ mod tests {
             &presentation(2, false),
             Action::Write,
             PRESENTER,
+            NOW,
             &Vouches::for_all(),
         )
         .await
@@ -402,6 +425,7 @@ mod tests {
             &presentation(2, false),
             Action::Write,
             PRESENTER,
+            NOW,
             &Vouches::read_only(),
         )
         .await
@@ -416,6 +440,7 @@ mod tests {
             &presentation(2, false),
             Action::Read,
             PRESENTER,
+            NOW,
             &Vouches::read_only(),
         )
         .await
@@ -430,6 +455,7 @@ mod tests {
             &presentation(1, false),
             Action::Admin,
             PRESENTER,
+            NOW,
             &Vouches(vec!["read".into(), "write".into(), "curate".into()]),
         )
         .await
@@ -448,6 +474,7 @@ mod tests {
             &presentation(0, false),
             Action::Read,
             PRESENTER,
+            NOW,
             &Vouches::for_all(),
         )
         .await
@@ -462,6 +489,7 @@ mod tests {
             &presentation(MAX_CHAIN_DEPTH + 1, false),
             Action::Read,
             PRESENTER,
+            NOW,
             &Vouches::for_all(),
         )
         .await
@@ -497,6 +525,7 @@ mod tests {
                     &p,
                     Action::Read,
                     PRESENTER,
+                    NOW,
                     &Panics
                 )
                 .await
@@ -513,6 +542,7 @@ mod tests {
             &presentation(2, false),
             Action::Read,
             PRESENTER,
+            NOW,
             &Vouches::for_all(),
         )
         .await
@@ -534,6 +564,7 @@ mod tests {
                 &presentation(2, true),
                 Action::Read,
                 PRESENTER,
+                NOW,
                 &RefusesEverything,
             )
             .await
@@ -554,6 +585,7 @@ mod tests {
             &presentation(2, false),
             Action::Read,
             "   ",
+            NOW,
             &Vouches::for_all(),
         )
         .await
@@ -572,6 +604,7 @@ mod tests {
             &presentation(2, false),
             Action::Read,
             PRESENTER,
+            NOW,
             &VouchesForSomeoneElse,
         )
         .await
@@ -591,6 +624,7 @@ mod tests {
             &p,
             Action::Read,
             PRESENTER,
+            NOW,
             &Vouches::for_all(),
         )
         .await
@@ -599,6 +633,104 @@ mod tests {
             format!("{err}").contains("no membership credential"),
             "{err}"
         );
+    }
+
+    /// A lapsed room is read-only, and the refusal says how to fix it.
+    #[tokio::test]
+    async fn a_lapsed_room_refuses_writes_and_keeps_serving_reads() {
+        let mut r = room(Visibility::Open);
+        r.epoch_expires_at = Some(NOW - 1);
+
+        let err = authorize(
+            &r,
+            &presentation(2, false),
+            Action::Write,
+            PRESENTER,
+            NOW,
+            &Vouches::for_all(),
+        )
+        .await
+        .unwrap_err();
+        let text = format!("{err}");
+        assert!(text.contains("accepts no writes"), "{text}");
+        assert!(
+            text.contains("rooms/epoch/mint"),
+            "the refusal must say how to fix it: {text}"
+        );
+
+        authorize(
+            &r,
+            &presentation(2, false),
+            Action::Read,
+            PRESENTER,
+            NOW,
+            &Vouches::for_all(),
+        )
+        .await
+        .expect("a lapse hides nothing — reads keep working");
+    }
+
+    /// The exemption that gives the state machine an exit. Minting an epoch *is* the
+    /// renewal, so a gate that refused it would leave a lapsed room lapsed forever — and
+    /// that holds all the way to `Reclaimable`, because until the bytes are deleted the
+    /// members' choice is renew or export.
+    #[tokio::test]
+    async fn every_lapsed_state_still_accepts_the_operation_that_renews_it() {
+        let mut r = room(Visibility::Open);
+        r.retention_days = 90;
+
+        for (days_past_expiry, state) in [(1, "lapsed"), (31, "dormant"), (91, "reclaimable")] {
+            r.epoch_expires_at = Some(NOW - days_past_expiry * 24 * 60 * 60);
+            assert_eq!(
+                r.lifecycle(NOW).as_str(),
+                state,
+                "fixture should be {state}"
+            );
+
+            authorize(
+                &r,
+                &presentation(2, false),
+                Action::Admin,
+                PRESENTER,
+                NOW,
+                &Vouches::for_all(),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("a {state} room must still accept a renewal: {e}"));
+
+            let err = authorize(
+                &r,
+                &presentation(2, false),
+                Action::Write,
+                PRESENTER,
+                NOW,
+                &Vouches::for_all(),
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                format!("{err}").contains("accepts no writes"),
+                "a {state} room must refuse ordinary writes: {err}"
+            );
+        }
+    }
+
+    /// Curation is a write. A room nobody has renewed should not be quietly reorganised.
+    #[tokio::test]
+    async fn a_lapsed_room_refuses_curation() {
+        let mut r = room(Visibility::Open);
+        r.epoch_expires_at = Some(NOW - 1);
+        let err = authorize(
+            &r,
+            &presentation(2, false),
+            Action::Curate,
+            PRESENTER,
+            NOW,
+            &Vouches::for_all(),
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err}").contains("accepts no writes"), "{err}");
     }
 
     /// No action implies another — the property that keeps a permission model from

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -61,6 +61,7 @@
 
 pub mod authz;
 pub mod error;
+pub mod lifecycle;
 /// The room's group-key layer (RFC 9420), behind the `mls` feature.
 ///
 /// Off by default: a host that only stores ciphertext needs none of it, and OpenMLS is a
@@ -158,6 +159,19 @@ pub struct Room {
     /// Stated at creation rather than discovered later: a reclamation that surprises a
     /// member is a failure of the design, not of the member.
     pub retention_days: u32,
+
+    /// When the current epoch expires, in unix seconds. `None` never lapses.
+    ///
+    /// The clock the whole lifecycle hangs off — see [`lifecycle`]. Set when an epoch is
+    /// minted, and moved by nothing else: a room that is being used renews itself in the
+    /// course of being used, and one nobody has committed to in a year has said something
+    /// real about itself.
+    ///
+    /// `None` is what a room stored before this field existed deserialises to, and it means
+    /// *never lapses* rather than *already lapsed* — a migration should not turn every
+    /// existing room read-only on deploy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epoch_expires_at: Option<u64>,
 
     /// Unix-epoch seconds.
     pub created_at: u64,

--- a/vti-rooms/src/lifecycle.rs
+++ b/vti-rooms/src/lifecycle.rs
@@ -1,0 +1,275 @@
+//! When a room stops being live, and what that does — §9 of the design note.
+//!
+//! # The host never decides
+//!
+//! No host can promise to hold every room forever, and on a sealed room the host is the
+//! worst-placed party to judge value: it cannot read the content, and inactivity is not
+//! worthlessness. So nothing in this module is a judgement. Every transition is a function
+//! of two numbers the room already carries — when its epoch expires, and how long its owner
+//! said to keep it afterwards — and every one of them is undone by a single renewal until
+//! the last.
+//!
+//! That is why [`Lifecycle`] is **computed, not stored**. A stored state is a decision
+//! somebody made and can get wrong; a computed one cannot drift from the facts, and there
+//! is no code path where a host marks a room dormant. Ask [`Room::lifecycle`] at the moment
+//! you need to know.
+//!
+//! # The clock is the epoch
+//!
+//! MLS epochs have a maximum lifetime, and renewal is a commit — so a room that is being
+//! used renews itself in the course of being used, and one that nobody has committed to in
+//! a year has said something real about itself. `epoch_expires_at` is set when an epoch is
+//! minted; nothing else moves it.
+//!
+//! ```text
+//!   Live  ──epoch expires──▶  Lapsed  ──grace──▶  Dormant  ──retention──▶  Reclaimable
+//!    ▲                          │                    │                        │
+//!    └──────────────────────────┴────────────────────┴─── a single renewal ───┘
+//! ```
+//!
+//! - **Live** — normal.
+//! - **Lapsed** — read-only. Nothing is destroyed and nothing is even hidden; the room
+//!   simply stops accepting writes, which is a state a member can notice and fix.
+//! - **Dormant** — the owner has been notified and a notice belongs in the room. Still
+//!   read-only, still complete.
+//! - **Reclaimable** — the retention period stated *at creation* has run out. Even here
+//!   this module only reports; deleting is a separate, deliberate act.
+//!
+//! Reads do not extend anything, and that is deliberate against a plausible-sounding
+//! alternative. §9 says read activity counts as liveness — but a *host* counting reads
+//! would mean a sealed room's lifecycle depended on the one signal the host can see, which
+//! is exactly the correlation the tiers exist to deny. Liveness is expressed by renewing,
+//! and a room being read is a room whose members can renew it.
+//!
+//! # What this module is not
+//!
+//! It does not anchor renewals in the room's witnessed DID log, and it cannot: that log is
+//! controlled by the room's DID controller, which is the **owner**, not the host. The
+//! anchoring in §9 — epoch authenticator and version watermark, per renewal — is a client
+//! and owner concern. What a host contributes is the half above: never deciding, and never
+//! destroying anything a renewal could have saved.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Room;
+
+/// How long a lapsed room waits before it is called dormant.
+///
+/// A grace window rather than an immediate transition, because "lapsed" is frequently just
+/// somebody being on holiday, and notifying an owner that their room is dormant the minute
+/// an epoch expires trains them to ignore the notice.
+pub const DORMANT_AFTER_LAPSE_DAYS: u32 = 30;
+
+/// Default maximum epoch lifetime, in days.
+///
+/// The MLS layer imposes its own; this is the room's, and it is the clock §9 refers to. A
+/// year is long enough that renewal is not busywork and short enough that a room nobody has
+/// touched says something by not being renewed.
+pub const DEFAULT_EPOCH_LIFETIME_DAYS: u32 = 365;
+
+const DAY: u64 = 24 * 60 * 60;
+
+/// Where a room is in its life. Computed from the room's own timestamps — never stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Lifecycle {
+    /// Normal: reads and writes.
+    Live,
+    /// The epoch expired. Read-only; nothing destroyed, nothing hidden.
+    Lapsed,
+    /// Lapsed long enough that the owner should have been told.
+    Dormant,
+    /// The retention period stated at creation has run out.
+    Reclaimable,
+}
+
+impl Lifecycle {
+    /// Whether a room in this state accepts writes.
+    ///
+    /// The single question the authorization layer asks. Curation and epoch minting are
+    /// writes too — but minting is how a room is *renewed*, so it is exempted at the call
+    /// site rather than here: a state machine that refused the one operation that escapes
+    /// it would have no exit.
+    pub fn accepts_writes(&self) -> bool {
+        matches!(self, Lifecycle::Live)
+    }
+
+    /// Whether a room in this state still serves reads.
+    ///
+    /// True everywhere, including `Reclaimable`. A room whose retention has run out is one
+    /// a host *may* delete, and until it does the members' choice is renew or export — so
+    /// reading has to keep working right up to the moment the bytes are gone. §9: "the
+    /// members' choice is renew or take it with you."
+    pub fn serves_reads(&self) -> bool {
+        true
+    }
+
+    /// The wire form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Lifecycle::Live => "live",
+            Lifecycle::Lapsed => "lapsed",
+            Lifecycle::Dormant => "dormant",
+            Lifecycle::Reclaimable => "reclaimable",
+        }
+    }
+}
+
+impl Room {
+    /// Where this room is at `now` (unix seconds).
+    ///
+    /// A room whose `epoch_expires_at` is `None` never lapses. That is the shape a room
+    /// created before this existed has, and treating a missing expiry as "expired" would
+    /// have made every one of them read-only on deploy — the wrong direction for a
+    /// migration to fail in.
+    pub fn lifecycle(&self, now: u64) -> Lifecycle {
+        let Some(expires) = self.epoch_expires_at else {
+            return Lifecycle::Live;
+        };
+        if now < expires {
+            return Lifecycle::Live;
+        }
+
+        let lapsed_for = now - expires;
+        let grace = u64::from(DORMANT_AFTER_LAPSE_DAYS) * DAY;
+        if lapsed_for < grace {
+            return Lifecycle::Lapsed;
+        }
+
+        // Retention runs from the **lapse**, not from the dormancy notice: the period
+        // stated at creation is what the owner agreed to, and starting its clock at a later
+        // internal transition would quietly turn 90 days into 120.
+        //
+        // The floor is the other half of that. A room whose retention is shorter than the
+        // grace window would otherwise become reclaimable before its owner was ever told it
+        // was dormant, which makes the notice pointless and is the surprise §9 exists to
+        // prevent. So reclamation never happens sooner than the notice — a short retention
+        // skips `Dormant` entirely rather than reclaiming early. Erring later destroys
+        // nothing; erring earlier destroys a room somebody would have renewed.
+        let reclaim_after = std::cmp::max(u64::from(self.retention_days) * DAY, grace);
+        if lapsed_for < reclaim_after {
+            return Lifecycle::Dormant;
+        }
+        Lifecycle::Reclaimable
+    }
+
+    /// When this room's current epoch expires, if it ever does.
+    pub fn expires_at(&self) -> Option<u64> {
+        self.epoch_expires_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Visibility;
+
+    const NOW: u64 = 1_800_000_000;
+
+    fn room(expires_at: Option<u64>, retention_days: u32) -> Room {
+        Room {
+            room_id: "did:key:zRoom".into(),
+            owner_did: "did:key:zOwner".into(),
+            visibility: Visibility::Open,
+            epoch: 1,
+            next_version: 1,
+            retention_days,
+            epoch_expires_at: expires_at,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn a_room_inside_its_epoch_is_live() {
+        assert_eq!(room(Some(NOW + DAY), 90).lifecycle(NOW), Lifecycle::Live);
+    }
+
+    #[test]
+    fn the_states_follow_the_two_clocks() {
+        let r = room(Some(NOW), 90);
+        assert_eq!(r.lifecycle(NOW), Lifecycle::Lapsed, "the moment it expires");
+        assert_eq!(
+            r.lifecycle(NOW + 29 * DAY),
+            Lifecycle::Lapsed,
+            "still inside the grace window"
+        );
+        assert_eq!(
+            r.lifecycle(NOW + 31 * DAY),
+            Lifecycle::Dormant,
+            "past the grace window, inside retention"
+        );
+        assert_eq!(
+            r.lifecycle(NOW + 91 * DAY),
+            Lifecycle::Reclaimable,
+            "past the retention stated at creation"
+        );
+    }
+
+    /// Retention runs from the lapse, not from the dormancy notice — otherwise the period
+    /// an owner agreed to at creation would silently be retention + grace.
+    #[test]
+    fn retention_runs_from_the_lapse_not_from_dormancy() {
+        let r = room(Some(NOW), 90);
+        assert_eq!(r.lifecycle(NOW + 90 * DAY), Lifecycle::Reclaimable);
+        assert_ne!(
+            r.lifecycle(NOW + 90 * DAY),
+            Lifecycle::Dormant,
+            "90 days of retention must not become 120"
+        );
+    }
+
+    /// A retention shorter than the grace window does not reclaim early. It reclaims at
+    /// the notice and skips `Dormant` — a room must never be reclaimable before its owner
+    /// could have been told, or the notice means nothing.
+    #[test]
+    fn a_short_retention_never_reclaims_before_the_notice() {
+        let r = room(Some(NOW), 7);
+        assert_eq!(r.lifecycle(NOW + DAY), Lifecycle::Lapsed);
+        assert_eq!(
+            r.lifecycle(NOW + 8 * DAY),
+            Lifecycle::Lapsed,
+            "past its stated retention, but the owner has not been told yet"
+        );
+        assert_eq!(
+            r.lifecycle(NOW + 31 * DAY),
+            Lifecycle::Reclaimable,
+            "reclaimable at the notice, with no dormant period"
+        );
+    }
+
+    /// The migration direction that matters: a room stored before expiry existed must not
+    /// become read-only the moment this ships.
+    #[test]
+    fn a_room_with_no_expiry_never_lapses() {
+        let r = room(None, 1);
+        assert_eq!(r.lifecycle(NOW), Lifecycle::Live);
+        assert_eq!(r.lifecycle(NOW + 10_000 * DAY), Lifecycle::Live);
+    }
+
+    /// Reads keep working in every state, including the last one. Until the bytes are
+    /// deleted the members' choice is renew or export, and both need reading.
+    #[test]
+    fn every_state_still_serves_reads() {
+        for s in [
+            Lifecycle::Live,
+            Lifecycle::Lapsed,
+            Lifecycle::Dormant,
+            Lifecycle::Reclaimable,
+        ] {
+            assert!(s.serves_reads(), "{s:?} must still serve reads");
+        }
+    }
+
+    #[test]
+    fn only_a_live_room_accepts_writes() {
+        assert!(Lifecycle::Live.accepts_writes());
+        for s in [
+            Lifecycle::Lapsed,
+            Lifecycle::Dormant,
+            Lifecycle::Reclaimable,
+        ] {
+            assert!(!s.accepts_writes(), "{s:?} must be read-only");
+        }
+    }
+}

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -57,6 +57,15 @@ pub async fn create_room(rooms: &KeyspaceHandle, room: &Room) -> Result<(), AppE
     rooms.insert(room_key(&room.room_id), room).await
 }
 
+/// How long a minted epoch is good for, in seconds.
+///
+/// Not yet a per-room parameter: `rooms/create/0.1` has no member for it, and inventing one
+/// locally would put this implementation's rooms out of conformance with the published
+/// schema. A room that wants a different lifetime is a spec change first.
+fn epoch_lifetime_seconds() -> u64 {
+    u64::from(crate::lifecycle::DEFAULT_EPOCH_LIFETIME_DAYS) * 24 * 60 * 60
+}
+
 /// Fetch a room, or [`AppError::NotFound`].
 pub async fn get_room(rooms: &KeyspaceHandle, room_id: &str) -> Result<Room, AppError> {
     let raw = rooms
@@ -75,6 +84,13 @@ pub async fn get_room(rooms: &KeyspaceHandle, room_id: &str) -> Result<Room, App
 /// point of advancing.
 ///
 /// This service records the number. It never learns the key.
+///
+/// **Minting an epoch is how a room is renewed.** It resets `epoch_expires_at`, which is the
+/// clock the whole lifecycle hangs off (§9) — so a room in use renews itself in the course
+/// of being used, and a lapsed one is brought back by the single operation its members were
+/// already going to perform. There is no separate "renew" verb, and there should not be: one
+/// that could be called without committing would let a room look live while its key material
+/// stood still.
 pub async fn advance_epoch(
     rooms: &KeyspaceHandle,
     room_id: &str,
@@ -89,6 +105,7 @@ pub async fn advance_epoch(
         )));
     }
     room.epoch = new_epoch;
+    room.epoch_expires_at = Some(now + epoch_lifetime_seconds());
     room.updated_at = now;
     rooms.insert(room_key(room_id), &room).await?;
     Ok(room)
@@ -319,6 +336,7 @@ mod tests {
             epoch: 1,
             next_version: 1,
             retention_days: 90,
+            epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
         }
@@ -478,6 +496,38 @@ mod tests {
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("room `r1` is at 2"), "{err}");
+    }
+
+    /// The round trip §9 turns on: a room lapses, and the single operation its members
+    /// were already going to perform brings it back. Nothing else moves the clock.
+    #[tokio::test]
+    async fn minting_an_epoch_renews_a_lapsed_room() {
+        use crate::lifecycle::Lifecycle;
+        let (_d, rooms, _rec) = open().await;
+
+        let mut r = room("r1", Visibility::Open);
+        r.epoch_expires_at = Some(1_000);
+        create_room(&rooms, &r).await.expect("create");
+
+        let now = 2_000;
+        assert_eq!(
+            get_room(&rooms, "r1").await.unwrap().lifecycle(now),
+            Lifecycle::Lapsed,
+            "expired an epoch ago"
+        );
+
+        let renewed = advance_epoch(&rooms, "r1", 2, now).await.expect("renew");
+        assert_eq!(renewed.lifecycle(now), Lifecycle::Live);
+        assert!(
+            renewed.epoch_expires_at.expect("renewal sets an expiry") > now,
+            "a renewal moves the clock forward, it does not merely clear it"
+        );
+
+        // And it is durable, not just returned.
+        assert_eq!(
+            get_room(&rooms, "r1").await.unwrap().lifecycle(now),
+            Lifecycle::Live
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
`retention_days` was stored and nothing read it. A room, once created, was live forever — so §9 of the design note existed entirely on paper.

```
Live ──epoch expires──▶ Lapsed ──grace──▶ Dormant ──retention──▶ Reclaimable
 ▲                        │                  │                       │
 └────────────────────────┴──────────────────┴─── a single renewal ──┘
```

**Lapsed is read-only.** Nothing is destroyed, nothing is even hidden — the room stops accepting writes, which is a condition a member can notice and fix. Reads keep working in *every* state including `Reclaimable`, because until the bytes are gone the members' choice is renew or export.

## The host never decides

The state is **computed, never stored**. A stored state is a decision somebody made and can get wrong; a computed one cannot drift from the facts, and there is no code path where a host marks a room dormant. That is §9's "the host never decides" made structural rather than promised — on a sealed room the host cannot read the content, and inactivity is not worthlessness, so it is the worst-placed party to judge value.

**Minting an epoch is the renewal.** No separate verb, and there should not be one: a renewal callable without committing would let a room look live while its key material stood still. `Admin` is therefore exempt from the write gate — a gate that refused the one operation that escapes it would leave a lapsed room lapsed forever — and the exemption holds all the way to `Reclaimable`.

## Two rules that are easy to get subtly wrong

Both are pinned by tests, and the first one is why the second exists.

- **Retention runs from the lapse, not from the dormancy notice.** Otherwise the 90 days an owner agreed to at creation silently becomes 120.
- **Reclamation never happens before the notice.** A retention shorter than the grace window skips `Dormant` rather than reclaiming early. Erring later destroys nothing; erring earlier destroys a room somebody would have renewed. My first draft got this backwards and a test caught it.

## Migration

`epoch_expires_at` is `Option<u64>`, and `None` means **never lapses**, not *already lapsed*. A room stored before this field existed deserialises to `None`, and the other reading would have turned every existing room read-only on deploy — the wrong direction for a migration to fail in.

## A correction to the design note, not a quiet divergence

§9 said read activity counts as liveness. The implementation does not do that, and the note now says why: a *host* counting reads to decide a sealed room's lifecycle would make it depend on the one signal the host can see — the exact correlation the tiers exist to deny, and an access-frequency profile a `private` room's members were promised they would not have. The archive case is served by `retentionDays`, which is the member's own statement of how long the room matters, made at creation where it belongs.

## Deliberately not here

**Anchoring renewals in the room's witnessed DID log**, and it cannot be: that log is controlled by the room's DID controller, which is the **owner**, not the host. A host's half of §9 is the above — never deciding, and never destroying anything a renewal could have saved.

**A per-room epoch lifetime.** `rooms/create/0.1` has no member for it, and inventing one locally would put these rooms out of conformance with the published schema. A room that wants a different lifetime is a spec change first.

**A way to read the state over the wire.** The refusal names the state and says how to fix it, which is the minimum a member needs. A `rooms/status` task is the spec-first way to expose it properly.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `vti-rooms` 45 tests; `vtc-service` 931; `room-host`, `vti-rooms-dtg` and every integration suite green.