### PR TITLE
feat(rooms): audit every room operation, without learning who

### DIFF
--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -582,6 +582,19 @@ members-only view covering writes — reads leave no trace anyone can
 reconstruct, including the owner. Agents read constantly, so read-volume
 anomaly detection is a dead end on every tier.
 
+**Which actor a host may record is one decision, not one per host.** It lives in
+`vti_rooms::audit`, beside the authorization it is derived from, and the type it
+returns has no constructor that takes a DID unconditionally — because the failure
+it prevents is silent. Every host has audit machinery and every one of them wants
+to write the acting party's DID into it; on a `private` room that single line
+hands the host the membership it was built never to learn, assembled one entry at
+a time, with nothing breaking and no test going red. The log even looks exactly
+like an `attributed` room's.
+
+So the tier decision is made once, in the crate both hosts already share for
+authorization, and the hosts differ only in where the trail goes — a VTC's
+hash-chained audit keyspace, or a standalone room host's `tracing` output.
+
 ---
 
 ## 9. Lifecycle: renewed, not reaped — and provably so

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -58,6 +58,7 @@ use uuid::Uuid;
 use vti_common::config::StoreConfig;
 use vti_common::error::AppError;
 use vti_common::store::{KeyspaceHandle, Store};
+use vti_rooms::audit as rooms_audit;
 use vti_rooms::wire::{
     CreateRoomBody, CreateRoomResponse, GetRecordBody, ListRecordsBody, ListRecordsResponse,
     MintEpochBody, MintEpochResponse, PutRecordBody, PutRecordResponse, ROOMS_CREATE_TYPE,
@@ -111,6 +112,34 @@ impl HostState {
             DtgChainVerifier::without_zk(Box::new(DataIntegrityKeys(self.resolver.clone()))),
         ))
     }
+}
+
+/// Record a room operation — §8, with the tier decision made by `vti_rooms::audit`.
+///
+/// This host has no audit chain: it is a delivery service, and standing up an HMAC key
+/// store and a hash chain here would be most of a community service again, which is the
+/// thing it exists not to be. So the trail goes to `tracing`, where an operator's own log
+/// pipeline collects it.
+///
+/// What is **not** different from a VTC is *what may be recorded*. The actor comes from
+/// [`vti_rooms::audit::for_operation`], so a `private` room logs that a member acted and
+/// never who — a host that logged the DID because its own logging happened to be simpler
+/// would have handed itself the membership by the back door.
+fn audit_room(
+    room: &Room,
+    authorized: &authz::AuthorizedAction,
+    record_key: Option<&str>,
+    listed: bool,
+) {
+    let entry = rooms_audit::for_operation(room.visibility, authorized, record_key);
+    tracing::info!(
+        action = rooms_audit::action_name(authorized.action(), listed),
+        room = %entry.room_id,
+        actor = %entry.actor.as_str(),
+        record = entry.record_key.as_deref().unwrap_or("-"),
+        visibility = ?room.visibility,
+        "room operation"
+    );
 }
 
 fn now() -> u64 {
@@ -319,14 +348,17 @@ async fn put(
     )
     .await
     {
-        Ok(stored) => respond(
-            doc,
-            PutRecordResponse {
-                key: stored.key,
-                version: stored.version,
-                epoch: stored.epoch,
-            },
-        ),
+        Ok(stored) => {
+            audit_room(&room, &authorized, Some(&stored.key), false);
+            respond(
+                doc,
+                PutRecordResponse {
+                    key: stored.key,
+                    version: stored.version,
+                    epoch: stored.epoch,
+                },
+            )
+        }
         Err(e) => from_app_error(doc, &e),
     }
 }
@@ -355,7 +387,7 @@ async fn get(
         Ok(p) => p,
         Err(e) => return from_app_error(doc, &e),
     };
-    if let Err(e) = authz::authorize(
+    let authorized = match authz::authorize(
         &room,
         &req.presentation,
         Action::Read,
@@ -365,10 +397,14 @@ async fn get(
     )
     .await
     {
-        return from_app_error(doc, &e);
-    }
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
     match storage::get_record(&state.records, &req.room_id, &req.key).await {
-        Ok(record) => respond(doc, record),
+        Ok(record) => {
+            audit_room(&room, &authorized, Some(&req.key), false);
+            respond(doc, record)
+        }
         Err(e) => from_app_error(doc, &e),
     }
 }
@@ -397,7 +433,7 @@ async fn list(
         Ok(p) => p,
         Err(e) => return from_app_error(doc, &e),
     };
-    if let Err(e) = authz::authorize(
+    let authorized = match authz::authorize(
         &room,
         &req.presentation,
         Action::Read,
@@ -407,8 +443,9 @@ async fn list(
     )
     .await
     {
-        return from_app_error(doc, &e);
-    }
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
     match storage::list_records(
         &state.records,
         &req.room_id,
@@ -421,6 +458,8 @@ async fn list(
             let limit = req.limit.unwrap_or(usize::MAX);
             // Metadata, never bodies — the same rule the VTC serves under, because it is a
             // property of the task rather than of any one host.
+            // A listing names no single record; the event is that the room was surveyed.
+            audit_room(&room, &authorized, None, true);
             respond(
                 doc,
                 ListRecordsResponse {
@@ -459,7 +498,7 @@ async fn mint(
         Ok(p) => p,
         Err(e) => return from_app_error(doc, &e),
     };
-    if let Err(e) = authz::authorize(
+    let authorized = match authz::authorize(
         &room,
         &req.presentation,
         Action::Admin,
@@ -469,16 +508,20 @@ async fn mint(
     )
     .await
     {
-        return from_app_error(doc, &e);
-    }
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
     match storage::advance_epoch(&state.rooms, &req.room_id, req.epoch, now()).await {
-        Ok(updated) => respond(
-            doc,
-            MintEpochResponse {
-                room_id: updated.room_id,
-                epoch: updated.epoch,
-            },
-        ),
+        Ok(updated) => {
+            audit_room(&room, &authorized, None, false);
+            respond(
+                doc,
+                MintEpochResponse {
+                    room_id: updated.room_id,
+                    epoch: updated.epoch,
+                },
+            )
+        }
         Err(e) => from_app_error(doc, &e),
     }
 }

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -26,6 +26,8 @@ use crate::server::AppState;
 use crate::trust_tasks::helpers::{
     TrustTaskOutcome, app_error_to_reject, parse_payload, success_response, verify_trust_task_proof,
 };
+use vti_common::audit::{AuditEvent, RoomOperationData};
+use vti_rooms::audit as rooms_audit;
 use vti_rooms::authz::{self, Action};
 use vti_rooms::storage;
 use vti_rooms::wire::{
@@ -53,6 +55,48 @@ async fn presenter_and_verifier(
         presenter,
         DtgChainVerifier::without_zk(Box::new(DataIntegrityKeys(state.trust_task_vm_resolver()))),
     ))
+}
+
+/// Record a room operation, per §8 of the design note.
+///
+/// **What may be recorded is decided by `vti_rooms::audit`, never here.** On a `private`
+/// room the actor is the actorless marker rather than a DID, because an audit log naming
+/// every actor *is* the membership this service was built never to learn — assembled one
+/// entry at a time by the component least able to notice it is doing so.
+///
+/// A failed write is logged and swallowed. The alternative is refusing an operation that
+/// already succeeded, which turns an audit outage into a room outage and tells the caller
+/// their write failed when it did not. The audit chain's own integrity is protected by its
+/// hash chain, which makes a gap visible to a verifier — that is the right place for this
+/// to be noticed, not in a handler's return value.
+async fn audit_room(
+    state: &AppState,
+    room: &Room,
+    authorized: &authz::AuthorizedAction,
+    record_key: Option<&str>,
+    listed: bool,
+) {
+    let Some(writer) = state.audit_writer.as_ref() else {
+        return;
+    };
+    let entry = rooms_audit::for_operation(room.visibility, authorized, record_key);
+    let action = rooms_audit::action_name(authorized.action(), listed);
+
+    if let Err(e) = writer
+        .write(
+            entry.actor.as_str(),
+            None,
+            AuditEvent::RoomOperation(RoomOperationData {
+                room_id: entry.room_id,
+                action: action.to_string(),
+                record_key: entry.record_key,
+                visibility: format!("{:?}", room.visibility).to_lowercase(),
+            }),
+        )
+        .await
+    {
+        tracing::error!(error = %e, action, "failed to record a room audit entry");
+    }
 }
 
 /// Seconds since the Unix epoch.
@@ -178,14 +222,17 @@ pub(crate) async fn handle_put_record(state: &AppState, doc: TrustTask<Value>) -
     )
     .await
     {
-        Ok(stored) => success_response(
-            &doc,
-            PutRecordResponse {
-                key: stored.key,
-                version: stored.version,
-                epoch: stored.epoch,
-            },
-        ),
+        Ok(stored) => {
+            audit_room(state, &room, &authorized, Some(&stored.key), false).await;
+            success_response(
+                &doc,
+                PutRecordResponse {
+                    key: stored.key,
+                    version: stored.version,
+                    epoch: stored.epoch,
+                },
+            )
+        }
         Err(e) => app_error_to_reject(&doc, &e),
     }
 }
@@ -209,7 +256,7 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
         Ok(p) => p,
         Err(e) => return app_error_to_reject(&doc, &e),
     };
-    if let Err(e) = authz::authorize(
+    let authorized = match authz::authorize(
         &room,
         &req.presentation,
         Action::Read,
@@ -219,11 +266,15 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
     )
     .await
     {
-        return app_error_to_reject(&doc, &e);
-    }
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
 
     match storage::get_record(&state.room_records_ks, &req.room_id, &req.key).await {
-        Ok(record) => success_response(&doc, record),
+        Ok(record) => {
+            audit_room(state, &room, &authorized, Some(&req.key), false).await;
+            success_response(&doc, record)
+        }
         Err(e) => app_error_to_reject(&doc, &e),
     }
 }
@@ -249,7 +300,7 @@ pub(crate) async fn handle_list_records(
         Ok(p) => p,
         Err(e) => return app_error_to_reject(&doc, &e),
     };
-    if let Err(e) = authz::authorize(
+    let authorized = match authz::authorize(
         &room,
         &req.presentation,
         Action::Read,
@@ -259,8 +310,9 @@ pub(crate) async fn handle_list_records(
     )
     .await
     {
-        return app_error_to_reject(&doc, &e);
-    }
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
 
     let records = match storage::list_records(
         &state.room_records_ks,
@@ -275,6 +327,9 @@ pub(crate) async fn handle_list_records(
     };
 
     let limit = req.limit.unwrap_or(usize::MAX);
+    // A listing names no single record, so the entry records the room and the fact of a
+    // listing — which is the event: who has seen what this room holds.
+    audit_room(state, &room, &authorized, None, true).await;
     success_response(
         &doc,
         ListRecordsResponse {
@@ -304,7 +359,7 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
         Ok(p) => p,
         Err(e) => return app_error_to_reject(&doc, &e),
     };
-    if let Err(e) = authz::authorize(
+    let authorized = match authz::authorize(
         &room,
         &req.presentation,
         Action::Admin,
@@ -314,17 +369,21 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
     )
     .await
     {
-        return app_error_to_reject(&doc, &e);
-    }
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
 
     match storage::advance_epoch(&state.rooms_ks, &req.room_id, req.epoch, now()).await {
-        Ok(updated) => success_response(
-            &doc,
-            MintEpochResponse {
-                room_id: updated.room_id,
-                epoch: updated.epoch,
-            },
-        ),
+        Ok(updated) => {
+            audit_room(state, &room, &authorized, None, false).await;
+            success_response(
+                &doc,
+                MintEpochResponse {
+                    room_id: updated.room_id,
+                    epoch: updated.epoch,
+                },
+            )
+        }
         Err(e) => app_error_to_reject(&doc, &e),
     }
 }
@@ -587,6 +646,141 @@ mod tests {
             "{}",
             payload_of(&out)
         );
+    }
+
+    /// Every room operation leaves a trail. §8: on shared material, reads are the
+    /// interesting event — a write log says what a room holds, a read log says who has
+    /// seen it.
+    #[tokio::test]
+    async fn room_operations_are_audited() {
+        let tv = crate::test_support::TestVtc::builder()
+            .with_audit(true)
+            .build()
+            .await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create(state, &f).await;
+
+        handle_put_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE,
+                json!({
+                    "roomId": f.room.room_id, "key": "k", "presentation": f.as_owner(),
+                    "cleartext": { "body": "x" }
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+
+        handle_get_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_GET_TYPE,
+                json!({ "roomId": f.room.room_id, "key": "k", "presentation": f.as_owner() }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+
+        let rows = audit_rows(state).await;
+        assert!(
+            rows.contains("room.records.put") && rows.contains("room.records.get"),
+            "both the write and the read must be recorded: {rows}"
+        );
+        assert!(
+            rows.contains(&f.owner.did),
+            "an open room discloses the actor: {rows}"
+        );
+    }
+
+    /// The property this whole slice exists to protect. An audit log naming every actor on
+    /// a private room *is* the membership the service was built never to learn — assembled
+    /// one entry at a time, with nothing breaking and no test going red.
+    #[tokio::test]
+    async fn a_private_rooms_audit_trail_never_names_the_actor() {
+        let tv = crate::test_support::TestVtc::builder()
+            .with_audit(true)
+            .build()
+            .await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Private).await;
+        create(state, &f).await;
+
+        // A private room is refused for want of a ZK profile, so drive the audit path
+        // directly with an authorization the verifier produced — the point under test is
+        // what gets *recorded*, not what gets served.
+        let room = storage::get_room(&state.rooms_ks, &f.room.room_id)
+            .await
+            .expect("room");
+        let mut presentation = f.as_owner();
+        presentation.subject_binding = Some("a-binding".into());
+        let authorized = authz::authorize(
+            &room,
+            &presentation,
+            Action::Read,
+            &f.owner.did,
+            now(),
+            &AlwaysVouches,
+        )
+        .await
+        .expect("authorized");
+
+        audit_room(state, &room, &authorized, Some("opaque-key"), false).await;
+
+        let rows = audit_rows(state).await;
+        assert!(
+            rows.contains("room.records.get"),
+            "the operation is recorded: {rows}"
+        );
+        assert!(
+            rows.contains("opaque-key"),
+            "the record is recorded — an opaque key identifies without describing: {rows}"
+        );
+        assert!(
+            !rows.contains(&f.owner.did),
+            "but the actor must appear nowhere in the audit trail: {rows}"
+        );
+    }
+
+    /// Stands in for the chain verifier so the audit path can be reached on a tier the
+    /// service otherwise refuses to serve.
+    struct AlwaysVouches;
+
+    #[async_trait::async_trait]
+    impl vti_rooms::authz::ChainVerifier for AlwaysVouches {
+        async fn verify(
+            &self,
+            _: &vti_rooms::Room,
+            _: &vti_rooms::wire::AuthorityPresentation,
+            _: Action,
+            presenter: &str,
+        ) -> Result<vti_rooms::authz::VerifiedChain, vti_common::error::AppError> {
+            Ok(vti_rooms::authz::VerifiedChain {
+                subject: presenter.to_string(),
+                actions: vec!["read".into()],
+            })
+        }
+    }
+
+    /// Every audit row, as one string to assert over.
+    async fn audit_rows(state: &AppState) -> String {
+        let raw = state
+            .audit_ks
+            .prefix_iter_raw(Vec::<u8>::new())
+            .await
+            .expect("read the audit keyspace");
+        raw.into_iter()
+            .map(|(_, v)| String::from_utf8_lossy(&v).into_owned())
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[tokio::test]

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -57,6 +57,18 @@ pub enum AuditEvent {
     /// miss.
     EmergencyBootstrapInvoked(EmergencyBootstrapData),
 
+    /// A data-room operation — §8 of `docs/05-design-notes/data-rooms.md`.
+    ///
+    /// One variant for reads and writes alike, because on shared material **reads are the
+    /// interesting event**: a write log says what a room contains, a read log says who has
+    /// seen it, and the second is the question an incident review asks.
+    ///
+    /// **`actor_did` is not always a DID here.** On a `private` room the caller passes the
+    /// actorless marker, because an audit log naming every actor *is* the membership the
+    /// host was built never to learn — assembled one entry at a time. What may be recorded
+    /// per tier is decided once, in `vti_rooms::audit`, and never at a call site.
+    RoomOperation(RoomOperationData),
+
     /// A passkey was registered against an admin DID (initial enrol
     /// at install **or** a subsequent additional-device enrolment).
     AdminPasskeyRegistered(AdminPasskeyData),
@@ -461,6 +473,7 @@ impl AuditEvent {
             Self::ConfigChanged(..) => "ConfigChanged",
             Self::ConfigReloaded(..) => "ConfigReloaded",
             Self::RestartRequested(..) => "RestartRequested",
+            Self::RoomOperation(..) => "RoomOperation",
             Self::CommunityProfileUpdated(..) => "CommunityProfileUpdated",
             Self::AuditKeyRotated(..) => "AuditKeyRotated",
             Self::MemberUpdated(..) => "MemberUpdated",
@@ -735,6 +748,23 @@ pub struct ConfigReloadedData {
     /// Keys that actually re-applied. Excludes keys whose new value
     /// equalled the live value (no-op).
     pub keys_reloaded: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomOperationData {
+    /// The room's own identifier.
+    pub room_id: String,
+    /// The `room.*` action — `room.records.get`, `room.records.put`, `room.epoch.mint`, …
+    pub action: String,
+    /// The record acted on, where the operation named one.
+    ///
+    /// Opaque on the sealed tiers by schema requirement, so it identifies a record without
+    /// describing it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub record_key: Option<String>,
+    /// The room's visibility, so a reader can tell an actorless entry from a missing one.
+    pub visibility: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -50,8 +50,8 @@ pub use event::{
     MembershipRenewedData, PersonhoodAssertedData, PersonhoodRevokedData, PolicyActivatedData,
     PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
     RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
-    SchemaChangeData, SessionRevokedData, SignedOutData, StatusListFlippedData, VpcAnnotationData,
-    VrcLifecycleData, VrcPublishedData, VrcRevokedData, VrcSupersededData,
+    RoomOperationData, SchemaChangeData, SessionRevokedData, SignedOutData, StatusListFlippedData,
+    VpcAnnotationData, VrcLifecycleData, VrcPublishedData, VrcRevokedData, VrcSupersededData,
     WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
     WebsiteGenerationRolledBackData,
 };

--- a/vti-rooms/src/audit.rs
+++ b/vti-rooms/src/audit.rs
@@ -1,0 +1,238 @@
+//! What a host may record about a room operation — §8 of the design note.
+//!
+//! # The trap this module exists to close
+//!
+//! Every host has audit machinery and every one of them wants to write the acting party's
+//! DID into it. On a `private` room that single line destroys the tier: the host was built
+//! never to learn the membership, and an audit log naming every actor *is* the membership,
+//! assembled one entry at a time by the component least able to notice it is doing so.
+//!
+//! It is a quiet failure, too. Nothing breaks, no test goes red, and the log looks exactly
+//! like the log of an `attributed` room. So the decision is a function here rather than a
+//! judgement at each of the two hosts' call sites, and [`AuditActor`] has no constructor
+//! that takes a DID unconditionally.
+//!
+//! # What each tier records
+//!
+//! | | `Open` | `Attributed` | `Private` |
+//! |---|---|---|---|
+//! | Who acted | the DID | the DID | **that a member did** |
+//! | Which room | yes | yes | yes |
+//! | Which record | the key | the opaque key | the opaque key |
+//!
+//! On `private`, who-did-what exists only *inside* the room, as in-body signatures the
+//! members reconstruct client-side. That view covers writes. Reads leave no trace anyone
+//! can reconstruct, including the owner — which is the design's position, not an omission.
+//!
+//! # Reads are audited, and that is the point
+//!
+//! §8: "reads are the interesting event on shared material". A write log tells you what a
+//! room contains; a read log tells you who has seen it, which on shared material is the
+//! question an incident review actually asks. It is also why the read log is itself a
+//! privacy artifact — on a VTC the actor hash is operator-reversible — and why the
+//! `private` tier's actorless recording is not a nicety.
+//!
+//! Read-volume anomaly detection is a dead end on every tier: agents read constantly, and a
+//! design whose whole point is agents reading a room cannot treat reading a lot as a signal.
+
+use crate::Visibility;
+use crate::authz::{Action, AuthorizedAction};
+
+/// The actor a host may record for one room operation.
+///
+/// Constructed only by [`for_operation`], so a host cannot reach for the DID on a tier that
+/// withholds it — the one mistake this module exists to make unavailable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuditActor {
+    /// The tier discloses the actor: record this DID.
+    Did(String),
+    /// The tier withholds it: record that *a member* acted, and nothing more.
+    ///
+    /// Not "unknown" and not an empty DID. The host knows a verified member acted — it
+    /// verified the chain — and recording that is both true and the most it may say.
+    Member,
+}
+
+impl AuditActor {
+    /// The DID, where the tier discloses one.
+    pub fn did(&self) -> Option<&str> {
+        match self {
+            AuditActor::Did(d) => Some(d),
+            AuditActor::Member => None,
+        }
+    }
+
+    /// A stable string for a log line or a `tracing` field.
+    pub fn as_str(&self) -> &str {
+        match self {
+            AuditActor::Did(d) => d,
+            AuditActor::Member => "member",
+        }
+    }
+}
+
+/// What a host records about one authorized operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoomAudit {
+    /// Who acted, as much as the tier permits saying.
+    pub actor: AuditActor,
+    /// The room.
+    pub room_id: String,
+    /// The action, as its wire string.
+    pub action: &'static str,
+    /// The record, where the operation named one.
+    ///
+    /// Safe on every tier: on the sealed tiers a key is required to be opaque, so it
+    /// identifies a record without describing it. A host that logged a *descriptive* key
+    /// would be logging content, which is why the schema requires opacity there.
+    pub record_key: Option<String>,
+}
+
+/// Decide what may be recorded about `authorized` on `visibility`.
+///
+/// The only way to build a [`RoomAudit`]. Takes the [`AuthorizedAction`] rather than a
+/// presenter string so the subject recorded is the one the *verifier* established — a host
+/// cannot record an actor for an operation it did not authorize, and cannot record a
+/// different actor from the one it authorized.
+pub fn for_operation(
+    visibility: Visibility,
+    authorized: &AuthorizedAction,
+    record_key: Option<&str>,
+) -> RoomAudit {
+    RoomAudit {
+        actor: if visibility.discloses_actor() {
+            AuditActor::Did(authorized.subject().to_string())
+        } else {
+            AuditActor::Member
+        },
+        room_id: authorized.room_id().to_string(),
+        action: authorized.action().as_str(),
+        record_key: record_key.map(str::to_string),
+    }
+}
+
+/// The `room.*` audit action name for an operation.
+///
+/// Named per the design's `room.*` vocabulary rather than reusing the authority action, so
+/// a log distinguishes "read a record" from "listed the room" — both are `read` on the
+/// authority axis and different events to anyone reading a log.
+pub fn action_name(action: Action, listed: bool) -> &'static str {
+    match (action, listed) {
+        (Action::Read, true) => "room.records.list",
+        (Action::Read, false) => "room.records.get",
+        (Action::Write, _) => "room.records.put",
+        (Action::Curate, _) => "room.records.curate",
+        (Action::Admin, _) => "room.epoch.mint",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Room;
+    use crate::authz::{ChainVerifier, VerifiedChain, authorize};
+    use crate::wire::AuthorityPresentation;
+    use vti_common::error::AppError;
+
+    const PRESENTER: &str = "did:key:zAgent";
+    const NOW: u64 = 1_800_000_000;
+
+    struct Vouches;
+
+    #[async_trait::async_trait]
+    impl ChainVerifier for Vouches {
+        async fn verify(
+            &self,
+            _: &Room,
+            _: &AuthorityPresentation,
+            _: Action,
+            presenter: &str,
+        ) -> Result<VerifiedChain, AppError> {
+            Ok(VerifiedChain {
+                subject: presenter.to_string(),
+                actions: vec!["read".into(), "write".into()],
+            })
+        }
+    }
+
+    async fn authorized(visibility: Visibility) -> AuthorizedAction {
+        let room = Room {
+            room_id: "did:key:zRoom".into(),
+            owner_did: "did:key:zOwner".into(),
+            visibility,
+            epoch: 1,
+            next_version: 1,
+            retention_days: 90,
+            epoch_expires_at: None,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let presentation = AuthorityPresentation {
+            membership: "vmc".into(),
+            authority: vec!["vac".into()],
+            subject_binding: Some("binding".into()),
+        };
+        authorize(&room, &presentation, Action::Read, PRESENTER, NOW, &Vouches)
+            .await
+            .expect("authorized")
+    }
+
+    #[tokio::test]
+    async fn a_disclosing_tier_records_the_actor() {
+        for v in [Visibility::Open, Visibility::Attributed] {
+            let a = authorized(v).await;
+            let entry = for_operation(v, &a, Some("k1"));
+            assert_eq!(entry.actor, AuditActor::Did(PRESENTER.into()), "{v:?}");
+            assert_eq!(entry.actor.did(), Some(PRESENTER));
+        }
+    }
+
+    /// The whole reason this module exists. An audit log naming every actor on a private
+    /// room *is* the membership the host was built never to learn.
+    #[tokio::test]
+    async fn a_private_room_records_that_a_member_acted_and_never_who() {
+        let a = authorized(Visibility::Private).await;
+        let entry = for_operation(Visibility::Private, &a, Some("opaque-key"));
+
+        assert_eq!(entry.actor, AuditActor::Member);
+        assert_eq!(
+            entry.actor.did(),
+            None,
+            "there must be no way to get a DID back out"
+        );
+        assert!(
+            !format!("{entry:?}").contains(PRESENTER),
+            "the presenter must not survive anywhere in the entry: {entry:?}"
+        );
+    }
+
+    /// The room and the record are recorded on every tier — an opaque key identifies a
+    /// record without describing it, which is why the sealed tiers require opacity.
+    #[tokio::test]
+    async fn the_room_and_record_are_recorded_on_every_tier() {
+        for v in [
+            Visibility::Open,
+            Visibility::Attributed,
+            Visibility::Private,
+        ] {
+            let a = authorized(v).await;
+            let entry = for_operation(v, &a, Some("k1"));
+            assert_eq!(entry.room_id, "did:key:zRoom");
+            assert_eq!(entry.record_key.as_deref(), Some("k1"));
+            assert_eq!(entry.action, "read");
+        }
+    }
+
+    /// Listing and fetching are both `read` on the authority axis and different events to
+    /// anyone reading a log.
+    #[test]
+    fn listing_and_fetching_are_distinct_actions_in_the_log() {
+        assert_eq!(action_name(Action::Read, true), "room.records.list");
+        assert_eq!(action_name(Action::Read, false), "room.records.get");
+        assert_ne!(
+            action_name(Action::Read, true),
+            action_name(Action::Read, false)
+        );
+        assert_eq!(action_name(Action::Admin, false), "room.epoch.mint");
+    }
+}

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -59,6 +59,7 @@
 //! and a spine is not extractable — see `docs/05-design-notes/vta-service-decomposition.md`.
 //! Each host writes its own thin handlers over these three layers.
 
+pub mod audit;
 pub mod authz;
 pub mod error;
 pub mod lifecycle;


### PR DESCRIPTION
Room operations wrote **no audit entry at all**. Every other consequential VTC surface does — join, members, credentials, backup — and the VTA has a census whose stated position is that a task which did its work and left no trace is "a gap with no defensible reading". The rooms family was that gap.

Reads are audited alongside writes, and §8 is right that on shared material they are the more interesting half: a write log says what a room *contains*, a read log says who has *seen* it, which is the question an incident review actually asks. Listing and fetching are distinct actions in the log — both are `read` on the authority axis, and different events to anyone reading it.

## The part worth the review time

Every host has audit machinery and every one of them wants to write the acting party's DID into it. **On a `private` room that single line hands the host the membership it was built never to learn** — assembled one entry at a time by the component least able to notice it is doing so.

It is a silent failure. Nothing breaks, no test goes red, and the log looks exactly like an `attributed` room's.

So the decision is a function in `vti_rooms::audit` rather than a judgement at each host's call sites, and `AuditActor` has **no constructor that takes a DID unconditionally**:

| | `Open` | `Attributed` | `Private` |
|---|---|---|---|
| Who acted | the DID | the DID | **that a member did** |
| Which room | yes | yes | yes |
| Which record | the key | the opaque key | the opaque key |

`AuditActor::Member` is not "unknown" and not an empty DID. The host verified a chain, so it *knows* a verified member acted — recording that is both true and the most it may say. A test asserts the presenter appears nowhere in a private room's audit trail, including in the `Debug` rendering.

`for_operation` takes the `AuthorizedAction` rather than a presenter string, so a host cannot record an actor for an operation it did not authorize, and cannot record a *different* actor from the one it did.

The record key is recorded on every tier. An opaque key identifies a record without describing it — which is exactly why the schema requires opacity on the sealed tiers, and why a host logging a *descriptive* key would be logging content.

## Two hosts, one decision, two destinations

A VTC writes to its hash-chained audit keyspace. `room-host` has no chain and no business growing one — it is a delivery service, and an HMAC key store plus a hash chain is most of a community service again — so it emits `tracing`, where an operator's own pipeline collects it. What is *not* different is what may be recorded: a host that logged the DID because its own logging happened to be simpler would have handed itself the membership by the back door.

## One deliberate swallow

A failed audit write is logged and swallowed. Refusing an operation that already succeeded turns an audit outage into a room outage and tells the caller their write failed when it did not. The chain's own hash makes a gap visible to a verifier, which is the right place for that to be noticed.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `vti-rooms` 50 tests, `vti-common` 465, `vtc-service` rooms 9/9 including the private-tier assertion, `room-host` and `vti-rooms-dtg` green.