### PR TITLE
feat(rooms): a member can curate a record

### DIFF
--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -60,9 +60,10 @@ use vti_common::error::AppError;
 use vti_common::store::{KeyspaceHandle, Store};
 use vti_rooms::audit as rooms_audit;
 use vti_rooms::wire::{
-    CreateRoomBody, CreateRoomResponse, GetRecordBody, ListRecordsBody, ListRecordsResponse,
-    MintEpochBody, MintEpochResponse, PutRecordBody, PutRecordResponse, ROOMS_CREATE_TYPE,
-    ROOMS_EPOCH_MINT_TYPE, ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE,
+    CreateRoomBody, CreateRoomResponse, CurateRecordBody, CurateRecordResponse, GetRecordBody,
+    ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse, PutRecordBody,
+    PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_RECORDS_CURATE_TYPE,
+    ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE,
 };
 use vti_rooms::{
     ROOM_RECORDS_KEYSPACE, ROOMS_KEYSPACE, Record, RecordStatus, Room,
@@ -225,6 +226,7 @@ async fn trust_task(State(state): State<Arc<HostState>>, body: Bytes) -> axum::r
         ROOMS_RECORDS_PUT_TYPE => put(&state, &doc, payload).await,
         ROOMS_RECORDS_GET_TYPE => get(&state, &doc, payload).await,
         ROOMS_RECORDS_LIST_TYPE => list(&state, &doc, payload).await,
+        ROOMS_RECORDS_CURATE_TYPE => curate(&state, &doc, payload).await,
         ROOMS_EPOCH_MINT_TYPE => mint(&state, &doc, payload).await,
         other => reject(
             &doc,
@@ -322,6 +324,7 @@ async fn put(
         version: 0,
         epoch: req.sealed.as_ref().map(|s| s.epoch),
         status: RecordStatus::Active,
+        pinned: false,
         sealed: req.sealed.as_ref().map(|s| s.ciphertext.clone()),
         nonce: req.sealed.as_ref().map(|s| s.nonce.clone()),
         cleartext: req
@@ -519,6 +522,88 @@ async fn mint(
                 MintEpochResponse {
                     room_id: updated.room_id,
                     epoch: updated.epoch,
+                },
+            )
+        }
+        Err(e) => from_app_error(doc, &e),
+    }
+}
+
+/// `rooms/records/curate/0.1`.
+///
+/// Gated on `Action::Curate` — not implied by `write`, because deciding what a room's shared
+/// knowledge is worth is a different grant from being able to add to it.
+async fn curate(
+    state: &HostState,
+    doc: &TrustTask<Value>,
+    payload: Value,
+) -> axum::response::Response {
+    let req: CurateRecordBody = match serde_json::from_value(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            return reject(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: e.to_string(),
+                },
+            );
+        }
+    };
+    if req.status.is_none() && req.pinned.is_none() {
+        return reject(
+            doc,
+            RejectReason::MalformedRequest {
+                reason: "a curation must change something: supply `status`, `pinned`, or both"
+                    .into(),
+            },
+        );
+    }
+
+    let room = match storage::get_room(&state.rooms, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let (presenter, verifier) = match state.presenter_and_verifier(doc).await {
+        Ok(p) => p,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        Action::Curate,
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
+
+    match storage::curate_record(
+        &state.rooms,
+        &state.records,
+        &req.room_id,
+        &req.key,
+        storage::Curation {
+            status: req.status,
+            pinned: req.pinned,
+            expected_version: req.expected_version,
+        },
+        now(),
+    )
+    .await
+    {
+        Ok(curated) => {
+            audit_room(&room, &authorized, Some(&curated.key), false);
+            respond(
+                doc,
+                CurateRecordResponse {
+                    key: curated.key,
+                    version: curated.version,
+                    status: curated.status,
+                    pinned: curated.pinned,
                 },
             )
         }

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -31,8 +31,9 @@ use vti_rooms::audit as rooms_audit;
 use vti_rooms::authz::{self, Action};
 use vti_rooms::storage;
 use vti_rooms::wire::{
-    CreateRoomBody, CreateRoomResponse, GetRecordBody, ListRecordsBody, ListRecordsResponse,
-    MintEpochBody, MintEpochResponse, PutRecordBody, PutRecordResponse,
+    CreateRoomBody, CreateRoomResponse, CurateRecordBody, CurateRecordResponse, GetRecordBody,
+    ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse, PutRecordBody,
+    PutRecordResponse,
 };
 use vti_rooms::{Record, RecordStatus, Room};
 use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier};
@@ -202,6 +203,7 @@ pub(crate) async fn handle_put_record(state: &AppState, doc: TrustTask<Value>) -
         version: 0, // assigned by the store from the room's counter
         epoch: req.sealed.as_ref().map(|s| s.epoch),
         status: RecordStatus::Active,
+        pinned: false,
         sealed: req.sealed.as_ref().map(|s| s.ciphertext.clone()),
         nonce: req.sealed.as_ref().map(|s| s.nonce.clone()),
         cleartext: req
@@ -381,6 +383,81 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
                 MintEpochResponse {
                     room_id: updated.room_id,
                     epoch: updated.epoch,
+                },
+            )
+        }
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
+}
+
+/// `rooms/records/curate/0.1`.
+///
+/// Gated on `Action::Curate`, which is deliberately not implied by `write`: deciding what a
+/// room's shared knowledge is worth is a different grant from the ability to add to it. A
+/// community can hand an agent `write` without handing it the standing to demote what a
+/// person wrote.
+pub(crate) async fn handle_curate_record(
+    state: &AppState,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: CurateRecordBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if req.status.is_none() && req.pinned.is_none() {
+        return app_error_to_reject(
+            &doc,
+            &vti_common::error::AppError::Validation(
+                "a curation must change something: supply `status`, `pinned`, or both".into(),
+            ),
+        );
+    }
+
+    let room = match storage::get_room(&state.rooms_ks, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let (presenter, verifier) = match presenter_and_verifier(state, &doc).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        Action::Curate,
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    match storage::curate_record(
+        &state.rooms_ks,
+        &state.room_records_ks,
+        &req.room_id,
+        &req.key,
+        storage::Curation {
+            status: req.status,
+            pinned: req.pinned,
+            expected_version: req.expected_version,
+        },
+        now(),
+    )
+    .await
+    {
+        Ok(curated) => {
+            audit_room(state, &room, &authorized, Some(&curated.key), false).await;
+            success_response(
+                &doc,
+                CurateRecordResponse {
+                    key: curated.key,
+                    version: curated.version,
+                    status: curated.status,
+                    pinned: curated.pinned,
                 },
             )
         }
@@ -781,6 +858,153 @@ mod tests {
             .map(|(_, v)| String::from_utf8_lossy(&v).into_owned())
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// The grant separation, end to end. The fixture's agent chain confers `read` alone,
+    /// so an agent that can read a room cannot demote what a person wrote in it.
+    #[tokio::test]
+    async fn curating_needs_its_own_grant_and_is_not_implied_by_write() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create(state, &f).await;
+
+        handle_put_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE,
+                json!({
+                    "roomId": f.room.room_id, "key": "k", "presentation": f.as_owner(),
+                    "cleartext": { "body": "a decision" }
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+
+        let out = handle_curate_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_CURATE_TYPE,
+                json!({
+                    "roomId": f.room.room_id, "key": "k",
+                    "presentation": f.as_agent(), "status": "deprecated"
+                }),
+                &f.agent.did,
+                &f.agent.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            !out.status.is_success(),
+            "a read-only agent must not curate: {}",
+            payload_of(&out)
+        );
+
+        // The owner's chain confers curate.
+        let out = handle_curate_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_CURATE_TYPE,
+                json!({
+                    "roomId": f.room.room_id, "key": "k",
+                    "presentation": f.as_owner(), "status": "deprecated", "pinned": true
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(out.status.is_success(), "{}", payload_of(&out));
+        let body = payload_of(&out);
+        assert_eq!(body["status"], "deprecated");
+        assert_eq!(body["pinned"], true, "pinned and deprecated at once");
+        assert_eq!(body["version"], 2, "curation assigns a new version");
+    }
+
+    /// A retraction drops the body and keeps the tombstone, and the tombstone is what a
+    /// caller synchronising on `sinceVersion` needs in order to converge.
+    #[tokio::test]
+    async fn a_retraction_leaves_a_tombstone_a_listing_still_reports() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create(state, &f).await;
+
+        handle_put_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE,
+                json!({
+                    "roomId": f.room.room_id, "key": "k", "presentation": f.as_owner(),
+                    "cleartext": { "body": "secret-body-text" }
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+
+        handle_curate_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_CURATE_TYPE,
+                json!({
+                    "roomId": f.room.room_id, "key": "k",
+                    "presentation": f.as_owner(), "status": "retracted"
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+
+        let out = handle_list_records(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_LIST_TYPE,
+                json!({ "roomId": f.room.room_id, "presentation": f.as_owner() }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        let text = payload_of(&out).to_string();
+        assert!(
+            text.contains("retracted"),
+            "the tombstone must still be listed, or sync cannot converge: {text}"
+        );
+
+        let out = handle_get_record(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_RECORDS_GET_TYPE,
+                json!({ "roomId": f.room.room_id, "key": "k", "presentation": f.as_owner() }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            !payload_of(&out).to_string().contains("secret-body-text"),
+            "but the body is gone: {}",
+            payload_of(&out)
+        );
     }
 
     #[tokio::test]

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -156,6 +156,9 @@ pub(crate) async fn dispatch_trust_task_core(
         rooms_wire::ROOMS_RECORDS_LIST_TYPE => {
             crate::rooms::handlers::handle_list_records(state, doc).await
         }
+        rooms_wire::ROOMS_RECORDS_CURATE_TYPE => {
+            crate::rooms::handlers::handle_curate_record(state, doc).await
+        }
         rooms_wire::ROOMS_EPOCH_MINT_TYPE => {
             crate::rooms::handlers::handle_mint_epoch(state, doc).await
         }

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -221,6 +221,14 @@ pub struct Record {
     /// Curation state.
     pub status: RecordStatus,
 
+    /// Whether a curator has pinned this record.
+    ///
+    /// Orthogonal to [`Record::status`] — a pinned record is still active, deprecated or
+    /// retracted — because pinning answers *what matters here* and status answers *is this
+    /// still current*. A room may well want its superseded canonical decision kept in view.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pinned: bool,
+
     /// Sealed content, base64url. Present on the sealed tiers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sealed: Option<String>,

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -262,29 +262,97 @@ pub async fn list_records(
     Ok(out)
 }
 
-/// Retract a record: drop the body, keep the tombstone.
+/// What one curation changes.
 ///
-/// Not an erasure. The key, version and epoch remain so that incremental sync converges and
-/// the audit chain still shows the record existed. Hard removal is a separate, higher-trust
-/// operation — two verbs because they are two different acts, and collapsing them makes the
-/// common one too powerful or the rare one impossible.
-pub async fn retract_record(
+/// A struct rather than three parameters because they are one *decision* — a curator
+/// demoting and pinning in the same breath is making a single statement about a record, and
+/// it lands as a single version for others to converge on.
+#[derive(Debug, Clone, Default)]
+pub struct Curation {
+    /// The standing to move to. `None` leaves it alone.
+    pub status: Option<RecordStatus>,
+    /// Whether to pin. `None` leaves it alone.
+    pub pinned: Option<bool>,
+    /// Optional precondition: the record's current version.
+    pub expected_version: Option<u64>,
+}
+
+/// Curate a record: change its standing without rewriting it.
+///
+/// The one entry point for `deprecated`, `retracted`, restoring a demotion, and pinning —
+/// they are one operation because they are one *decision*, and because every one of them
+/// has to assign a new version for the same reason (below).
+///
+/// # Retraction is a tombstone, not an erasure
+///
+/// The body goes; the key, version and epoch stay. Dropping the body is what a member
+/// asking to retract wants. Keeping the rest is what makes incremental sync **converge** —
+/// a caller synchronising on `since_version` learns about the retraction by seeing the
+/// tombstone, and one that never saw it resurrects the record on its next full rebuild.
+/// That is why [`list_records`] returns tombstones rather than filtering them.
+///
+/// Restoring a retracted record to `Active` is refused rather than reported as a success
+/// that restored nothing: the body is already gone, and a status change cannot bring it
+/// back. Hard removal is [`purge_record`], a separate and higher-trust act.
+///
+/// # Every curation assigns a new version
+///
+/// A demotion other members are expected to converge on is a change like any other, and one
+/// that left the version alone would be invisible to every `since_version` watermark in the
+/// room. This is the reason pinning is here too rather than being a cheap side-channel: a
+/// pin nobody syncs is a pin only its author can see.
+pub async fn curate_record(
     rooms: &KeyspaceHandle,
     records: &KeyspaceHandle,
     room_id: &str,
     key: &str,
+    curation: Curation,
     now: u64,
 ) -> Result<Record, AppError> {
+    let Curation {
+        status,
+        pinned,
+        expected_version,
+    } = curation;
     let mut record = get_record(records, room_id, key).await?;
+
+    if let Some(expected) = expected_version
+        && record.version != expected
+    {
+        return Err(AppError::Conflict(format!(
+            "record `{key}` is at version {}, not {expected}",
+            record.version
+        )));
+    }
+
+    if matches!(record.status, RecordStatus::Retracted)
+        && matches!(status, Some(RecordStatus::Active))
+    {
+        return Err(AppError::Validation(format!(
+            "record `{key}` is retracted; its body is gone and a status change cannot bring \
+             it back"
+        )));
+    }
+
     let mut room = get_room(rooms, room_id).await?;
 
-    record.status = RecordStatus::Retracted;
-    record.sealed = None;
-    record.nonce = None;
-    record.cleartext = None;
+    if let Some(status) = status {
+        record.status = status;
+        // Only a retraction drops content. A demotion leaves the body exactly where it is —
+        // `deprecated` means *demote in recall*, not *hide*, and an agent that could no
+        // longer read a deprecated record could not explain why it ranked it lower.
+        if matches!(status, RecordStatus::Retracted) {
+            record.sealed = None;
+            record.nonce = None;
+            record.cleartext = None;
+        }
+    }
+    if let Some(pinned) = pinned {
+        record.pinned = pinned;
+    }
+
     record.version = room.next_version;
     record.updated_at = now;
-
     room.next_version += 1;
     room.updated_at = now;
 
@@ -295,7 +363,9 @@ pub async fn retract_record(
 
 /// Permanently remove a record, tombstone included.
 ///
-/// The erasure path, separate from [`retract_record`] on purpose.
+/// The erasure path, separate from [`curate_record`] on purpose: a retraction keeps the
+/// tombstone that makes sync converge, and removing it is a decision about retention rather
+/// than about the record.
 pub async fn purge_record(
     records: &KeyspaceHandle,
     room_id: &str,
@@ -348,6 +418,7 @@ mod tests {
             version: 0,
             epoch: Some(epoch),
             status: RecordStatus::Active,
+            pinned: false,
             sealed: Some("c2VhbGVk".into()),
             nonce: Some("bm9uY2U".into()),
             cleartext: None,
@@ -362,6 +433,7 @@ mod tests {
             version: 0,
             epoch: None,
             status: RecordStatus::Active,
+            pinned: false,
             sealed: None,
             nonce: None,
             cleartext: Some(serde_json::json!({ "body": "hello" })),
@@ -585,7 +657,20 @@ mod tests {
             .unwrap()
             .version;
 
-        let tomb = retract_record(&rooms, &rec, "r1", "a", 3).await.unwrap();
+        let tomb = curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Retracted),
+                pinned: None,
+                expected_version: None,
+            },
+            3,
+        )
+        .await
+        .unwrap();
         assert!(
             tomb.sealed.is_none() && tomb.cleartext.is_none(),
             "body is dropped"
@@ -602,6 +687,140 @@ mod tests {
         );
     }
 
+    /// A demotion leaves the body where it is. `deprecated` means *demote in recall*, not
+    /// *hide* — an agent that could no longer read a deprecated record could not explain
+    /// why it ranked it lower.
+    #[tokio::test]
+    async fn deprecating_demotes_without_dropping_the_body() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        put_record(&rooms, &rec, "r1", open_record("a"), None, 1)
+            .await
+            .unwrap();
+
+        let out = curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Deprecated),
+                pinned: None,
+                expected_version: None,
+            },
+            2,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.status, RecordStatus::Deprecated);
+        assert!(out.cleartext.is_some(), "a demotion keeps the body");
+        assert_eq!(out.version, 2, "and assigns a new version to converge on");
+    }
+
+    /// The body is already gone. Reporting success would tell a member their record was
+    /// restored when it was not.
+    #[tokio::test]
+    async fn a_retracted_record_cannot_be_restored() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        put_record(&rooms, &rec, "r1", open_record("a"), None, 1)
+            .await
+            .unwrap();
+        curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Retracted),
+                pinned: None,
+                expected_version: None,
+            },
+            2,
+        )
+        .await
+        .unwrap();
+
+        let err = curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Active),
+                pinned: None,
+                expected_version: None,
+            },
+            3,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err}").contains("cannot bring it back"), "{err}");
+    }
+
+    /// Pinning is orthogonal to status — a room may want its superseded canonical decision
+    /// kept in view.
+    #[tokio::test]
+    async fn a_record_can_be_pinned_and_deprecated_at_once() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        put_record(&rooms, &rec, "r1", open_record("a"), None, 1)
+            .await
+            .unwrap();
+
+        let out = curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Deprecated),
+                pinned: Some(true),
+                expected_version: None,
+            },
+            2,
+        )
+        .await
+        .unwrap();
+        assert!(out.pinned);
+        assert_eq!(out.status, RecordStatus::Deprecated);
+    }
+
+    /// A curator who read a record before deciding to demote it can require that nothing
+    /// replaced it in between.
+    #[tokio::test]
+    async fn curation_honours_a_version_precondition() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        put_record(&rooms, &rec, "r1", open_record("a"), None, 1)
+            .await
+            .unwrap();
+
+        let err = curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Deprecated),
+                pinned: None,
+                expected_version: Some(99),
+            },
+            2,
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{err}").contains("is at version 1"), "{err}");
+    }
+
     #[tokio::test]
     async fn purge_removes_the_tombstone_and_is_not_idempotent() {
         let (_d, rooms, rec) = open().await;
@@ -611,7 +830,20 @@ mod tests {
         put_record(&rooms, &rec, "r1", open_record("a"), None, 1)
             .await
             .unwrap();
-        retract_record(&rooms, &rec, "r1", "a", 2).await.unwrap();
+        curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "a",
+            Curation {
+                status: Some(RecordStatus::Retracted),
+                pinned: None,
+                expected_version: None,
+            },
+            2,
+        )
+        .await
+        .unwrap();
 
         purge_record(&rec, "r1", "a").await.unwrap();
         assert!(

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -18,7 +18,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::Visibility;
+use crate::{RecordStatus, Visibility};
 
 /// `rooms/create/0.1`.
 pub const ROOMS_CREATE_TYPE: &str = "https://trusttasks.org/spec/rooms/create/0.1";
@@ -30,6 +30,8 @@ pub const ROOMS_RECORDS_GET_TYPE: &str = "https://trusttasks.org/spec/rooms/reco
 pub const ROOMS_RECORDS_LIST_TYPE: &str = "https://trusttasks.org/spec/rooms/records/list/0.1";
 /// `rooms/epoch/mint/0.1`.
 pub const ROOMS_EPOCH_MINT_TYPE: &str = "https://trusttasks.org/spec/rooms/epoch/mint/0.1";
+/// `rooms/records/curate/0.1`.
+pub const ROOMS_RECORDS_CURATE_TYPE: &str = "https://trusttasks.org/spec/rooms/records/curate/0.1";
 
 /// Every `rooms/*` URI this service dispatches.
 pub const ROOMS_DISPATCHED_URIS: &[&str] = &[
@@ -38,6 +40,7 @@ pub const ROOMS_DISPATCHED_URIS: &[&str] = &[
     ROOMS_RECORDS_GET_TYPE,
     ROOMS_RECORDS_LIST_TYPE,
     ROOMS_EPOCH_MINT_TYPE,
+    ROOMS_RECORDS_CURATE_TYPE,
 ];
 
 /// What a party presents to act on a room.
@@ -168,6 +171,48 @@ pub struct ListRecordsBody {
 pub struct ListRecordsResponse {
     /// Metadata only — never bodies.
     pub records: Vec<serde_json::Value>,
+}
+
+/// `rooms/records/curate/0.1` request.
+///
+/// Separate from [`PutRecordBody`] because a record's *standing* is not its content: on a
+/// sealed tier a host cannot read what it stores, so "replace this with the same body,
+/// marked deprecated" would make a member re-seal and re-upload bytes the host already
+/// holds, to say something that is not about the bytes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CurateRecordBody {
+    pub room_id: String,
+    pub key: String,
+    /// Must confer `curate` — deliberately not implied by `write`. Deciding what a room's
+    /// shared knowledge is worth is a different grant from being able to add to it.
+    pub presentation: AuthorityPresentation,
+    /// The standing to move to. Omit to change only `pinned`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<RecordStatus>,
+    /// Whether to pin. Omit to leave unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
+    /// Why, for the room's audit trail. Member-authored free text — untrusted for both
+    /// rendering and any agent that reads it back.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional precondition: the record's current version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+}
+
+/// `rooms/records/curate/0.1#response`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurateRecordResponse {
+    pub key: String,
+    /// The version the curation assigned. A change others must converge on is a change like
+    /// any other, and one that left the version alone would be invisible to every
+    /// `sinceVersion` watermark in the room.
+    pub version: u64,
+    pub status: RecordStatus,
+    pub pinned: bool,
 }
 
 /// `rooms/epoch/mint/0.1` request.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -260,6 +260,7 @@ fn responses_conform() {
             version: 3,
             epoch: None,
             status: RecordStatus::Active,
+            pinned: false,
             sealed: None,
             nonce: None,
             cleartext: Some(json!({
@@ -275,6 +276,7 @@ fn responses_conform() {
             version: 5,
             epoch: Some(2),
             status: RecordStatus::Retracted,
+            pinned: false,
             sealed: None,
             nonce: None,
             cleartext: None,


### PR DESCRIPTION
`retract_record`, `purge_record`, `Action::Curate` and `RecordStatus::{Deprecated, Retracted}` all existed, were tested, and were **unreachable** — there was no Trust Task that could invoke any of them. A member who had put something into a shared room by mistake had no answer.

Implements `rooms/records/curate/0.1` (trustoverip/dtgwg-trust-tasks-tf#354, merged) in both hosts, against hand-written wire types until the generated bindings publish — the same arrangement the rest of the family shipped under.

## Why not `rooms/records/put`

Two reasons, and the second is load-bearing.

**A record's standing is not its content.** On a sealed tier the host cannot read what it stores, so "replace this with the same body, marked deprecated" would make a member re-seal and re-upload bytes the host already holds, to say something that is not about the bytes.

**`curate` is its own authority action**, deliberately not implied by `write`. Deciding what a room's shared knowledge is *worth* is a different grant from being able to add to it. A test drives this end to end: the fixture's agent chain confers `read` alone, so **an agent that can read a room cannot demote what a person wrote in it**.

## Retraction is a tombstone, not an erasure

The body goes; the key, version and epoch stay — that is what makes incremental sync converge. A caller that never saw the tombstone resurrects the record on its next full rebuild, which is why `list` returns them. A test retracts and then asserts the listing still reports it while the body is gone.

Restoring a retracted record is **refused**, rather than reported as a success that restored nothing.

A *demotion* keeps its body. `deprecated` means demote in recall, not hide — an agent that could no longer read a deprecated record could not explain why it ranked it lower.

## Every curation assigns a new version

A change other members are expected to converge on is a change like any other, and one that left the version alone would be invisible to every `sinceVersion` watermark in the room. That is also why pinning goes through this path rather than being a cheap side-channel: a pin nobody syncs is a pin only its author can see.

`pinned` is orthogonal to `status` — a room may want its superseded canonical decision kept in view — so `Record` carries both.

## Two smaller notes

Curation is a write, so a lapsed room refuses it. The gate is the one added with the lifecycle, not a second copy.

The three curation inputs travel as a `Curation` struct rather than three parameters: they are one decision, they land as one version, and clippy's argument-count lint was right to ask.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `vti-rooms` 42 tests, the VTC's rooms suite 11/11 including the grant-separation and tombstone assertions, `room-host` and `vti-rooms-dtg` green, and the full `vtc-service` suite at 935.