### PR TITLE
chore(rooms): take dtg-credentials from the registry, and publish the verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,26 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5be7eee44969838e942b07a3e383e936f2d307f7b2b880daa715817261f132"
-dependencies = [
- "affinidi-data-integrity",
- "affinidi-secrets-resolver",
- "chrono",
- "multibase",
- "serde",
- "serde_json",
- "serde_json_canonicalizer",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tracing",
-]
-
-[[package]]
-name = "dtg-credentials"
 version = "0.6.0"
-source = "git+https://github.com/OpenVTC/dtg-credentials?rev=0c1391adfa67d8ae65498f086675404b8bb50b08#0c1391adfa67d8ae65498f086675404b8bb50b08"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f292eb5ba50d7f69dd9671e87b4d6ceddbeb973cbf0c05715220bee8446ff90"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10666,7 +10649,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "didwebvh-rs",
- "dtg-credentials 0.4.0",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "fjall",
  "flate2",
@@ -10830,7 +10813,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "chrono",
- "dtg-credentials 0.6.0",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "getrandom 0.3.4",
  "multibase",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.4"
+dtg-credentials = "0.6"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.46"

--- a/vtc-service/src/members/inbound_vmc.rs
+++ b/vtc-service/src/members/inbound_vmc.rs
@@ -337,12 +337,18 @@ mod binding_tests {
         )
         .with_id("urn:uuid:grant-1");
 
-        let ack = dtg_credentials::DTGCredential::new_member_vmc(&grant, valid_from, None)
+        // The acknowledgement digests the grant's **wire** form, not a parsed one —
+        // `DTGCommon` does not model `credentialStatus`, so parsing and re-serialising a
+        // real grant drops it and the digest then matches nothing. 0.5.0 changed the
+        // signature to take the JSON for exactly this reason; serialise first.
+        let grant_wire = serde_json::to_value(grant.credential()).expect("grant serialises");
+
+        let ack = dtg_credentials::DTGCredential::new_member_vmc(&grant_wire, valid_from, None)
             .expect("acknowledgement builds")
             .with_id("urn:uuid:ack-1");
 
         (
-            serde_json::to_value(grant.credential()).expect("grant serialises"),
+            grant_wire,
             serde_json::to_value(ack.credential()).expect("ack serialises"),
         )
     }

--- a/vtc-service/src/routes/relationships.rs
+++ b/vtc-service/src/routes/relationships.rs
@@ -2133,12 +2133,15 @@ mod tests {
         let grant_json = serde_json::to_value(grant.credential()).expect("grant serialises");
 
         let role_vec = serde_json::json!({ "id": "urn:uuid:vec-1" });
-        m.record_issued_credentials(grant_json, role_vec);
+        m.record_issued_credentials(grant_json.clone(), role_vec);
 
         if let Some(bound) = ack {
-            let ack = dtg_credentials::DTGCredential::new_member_vmc(&grant, m.joined_at, None)
-                .expect("acknowledgement builds")
-                .with_id("urn:uuid:ack-1");
+            // The grant's **wire** form: `DTGCommon` does not model `credentialStatus`, so
+            // digesting a re-serialised parse would drop it and match nothing.
+            let ack =
+                dtg_credentials::DTGCredential::new_member_vmc(&grant_json, m.joined_at, None)
+                    .expect("acknowledgement builds")
+                    .with_id("urn:uuid:ack-1");
             let ack_json = serde_json::to_value(ack.credential()).expect("ack serialises");
             m.record_member_vmc("urn:uuid:ack-1", ack_json, bound);
             m.member_vmc_received_at = Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 5, 0).unwrap());

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -7,10 +7,16 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
-# Not published, and that is what makes the git dependency below tolerable.
-# A published crate cannot depend on a git source, so this crate is where the
-# bridge lives until dtg-credentials 0.6 is on crates.io.
-publish = false
+# Published, now that it can be. This crate was `publish = false` for exactly
+# one reason — a published crate cannot depend on a git source, and
+# dtg-credentials 0.6 was merged but unreleased — and that reason is gone.
+#
+# It should not stay unpublished by inertia. `vti-rooms` publishes so that a
+# room host can reuse a room's storage, wire types and authorization; but
+# `authz::authorize` refuses everything without a `ChainVerifier`, and this is
+# the only one. A published `vti-rooms` with no published verifier is a crate an
+# external consumer can build a room host out of that serves nothing.
+publish.workspace = true
 
 [features]
 # Signed fixtures for downstream tests and the data_room example. Never a default:
@@ -18,19 +24,12 @@ publish = false
 test-support = ["dep:ed25519-dalek", "dep:getrandom", "dep:multibase", "dep:vta-sdk", "dep:affinidi-tdk"]
 
 [dependencies]
-vti-rooms = { path = "../vti-rooms" }
-vti-common = { path = "../vti-common" }
+vti-rooms = { path = "../vti-rooms", version = "0.1" }
+vti-common = { path = "../vti-common", version = "0.16" }
 
-# TEMPORARY, and the only reason this crate is not published: `authority::
-# verify_chain` and the VAC/VDC types landed in dtg-credentials 0.6.0, which is
-# merged but not yet released — that repository had no release path at all until
-# OpenVTC/dtg-credentials#17. Swap this whole line for
-#   dtg-credentials = "0.6"
-# the moment the v0.6.0 tag publishes; nothing else changes.
-#
-# It is pinned to a rev rather than a branch on purpose: a moving branch would
-# change what verifies a credential without changing this repository.
-dtg-credentials = { git = "https://github.com/OpenVTC/dtg-credentials", rev = "0c1391adfa67d8ae65498f086675404b8bb50b08" }
+# `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
+# 0.6.0 sat merged and unreleased; released 2026-09-03.
+dtg-credentials = "0.6"
 
 async-trait = "0.1"
 # Both hosts already carry a `VerificationMethodResolver`, so the key adapter wraps
@@ -46,7 +45,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { version = "0.3", optional = true }
 multibase = { workspace = true, optional = true }
-vta-sdk = { path = "../vta-sdk", features = ["didcomm"], optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm"], optional = true }
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
`dtg-credentials` 0.6.0 released, so the pinned git rev in `vti-rooms-dtg` becomes `dtg-credentials = "0.6"` and the git source leaves the lockfile entirely.

## `vti-rooms-dtg` now publishes

It was `publish = false` for **exactly one reason** — a published crate cannot depend on a git source — and that reason is gone. It should not stay unpublished by inertia.

`vti-rooms` publishes so an external consumer can reuse a room's storage, wire types and authorization. But `authz::authorize` refuses everything without a `ChainVerifier`, and this is the only one — so a published `vti-rooms` with no published verifier is a crate someone can build a room host out of that **serves nothing**. Its whole closure publishes, so it can.

## The workspace was resolving two credential libraries

`vtc-service` was on `dtg-credentials` 0.4 and the verifier on 0.6 — two incompatible `DTGCredential` types in one graph, which is the public-dependency hazard the workspace guidance warns about. Unified on 0.6.

## What that surfaced, and why it is worth reading

The 0.5.0 breaking change: **`new_member_vmc` takes the grant's *wire* form, not a parsed credential.**

`DTGCommon` does not model `credentialStatus`, which every VMC issued against a status list carries. So parsing a *received* grant and re-serialising it silently drops that member — and the acknowledgement then digests a document the community never issued. Both credentials still verify perfectly; only the digest comparison fails, with nothing in either to say why.

Two call sites hit it. Both now serialise the grant first and carry a comment saying why, so the next person does not have to rediscover it from a failing digest.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `cargo test --workspace` with no failures; one `dtg-credentials` in `Cargo.lock` and no `git+` source.