### PR TITLE
feat(rooms): the presentation oracle, so an agent never holds its human's credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10412,6 +10412,7 @@ dependencies = [
  "dialoguer",
  "didwebvh-rs",
  "dirs",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "fjall",
  "futures-util",

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -422,6 +422,33 @@ material never leaves the VTA's process*) extended to room material, it makes
 agent revocation meaningful, and with §4.2's attenuated VACs the agent holds
 narrow, expiring authority rather than the member's own.
 
+**The proving half is built** — `rooms/keys/present/0.1`, served by the VTA
+(`operations::room_oracle`). It is worth naming what the implementation makes
+*impossible* rather than merely discouraged, because each one closes a way the
+oracle could have quietly become the credential hand-off it exists to replace:
+
+- **More than the principal holds** fails in `attenuate`, which refuses to
+  widen — not at a policy check somebody could forget to write.
+- **A presentation covering everything** is unreachable: `action` is a required
+  member and exactly one action is conferred.
+- **A presentation made out to somebody else** is unreachable: the leaf grants
+  to the DID the *transport* authenticated, never one named in the payload. A
+  presentation minted for A is worthless to B even if B obtains it, because
+  §4.3a's presenter binding refuses it on the far side.
+- **A long-lived leaf** is unreachable: the lifetime is a constant, not a
+  request parameter. A caller that could ask for a year would be asking for the
+  standing credential the oracle exists not to hand over.
+
+It is gated on its own capability (`roomPresent`, registered upstream) rather
+than on `Sign`. An agent that may ask for a scoped, audience-bound presentation
+is not thereby an agent that may sign *anything at all* with its principal's
+key — gating an oracle on the generic signing oracle grants strictly more than
+the task needs, which is the opposite of what an oracle is for.
+
+The opening half (`rooms/keys/open/0.1`) is specified and not yet built: it
+needs the VTA to hold the room's MLS group, which needs a welcome-delivery flow
+no specification covers yet.
+
 ### 5.4 Recovery: a quorum re-admits; total loss is total
 
 A member who loses their VTA lost their leaf. Recovery is **k-of-n

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -116,6 +116,12 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     ("did-management/registry/admin-register", Risk::Sensitive),
     ("did-management/domain/set-default", Risk::Sensitive),
     ("provision/integration", Risk::Sensitive),
+    // The room oracle mints a credential conferring authority on the caller.
+    // It stores nothing, which is why the verb rule would read it as ordinary,
+    // and it belongs here beside `vta/credentials/issue`: an MCP host approves
+    // a *tool*, so a blanket `vta_call` approval must not silently cover
+    // minting a presentation over its principal's standing in a room.
+    ("rooms/keys/present", Risk::Sensitive),
     // Reads that a verb rule would misread.
     ("vta/contexts/preview-delete", Risk::ReadOnly),
     ("vta/webvh/agent-name/check", Risk::ReadOnly),

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -392,6 +392,19 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // ── Memory ──────────────────────────────────────────────────────────
     (trust_tasks::TASK_VTA_MEMORY_PUT_0_1, RetrySafe),
     (trust_tasks::TASK_VTA_MEMORY_LIST_0_1, ReadOnly),
+    // The room oracle mints a presentation and **stores nothing** — the spec's
+    // own `sideEffects: none`. A second execution leaves this VTA's state
+    // byte-identical, which is what `RetrySafe` means; it does not mean the
+    // call is read-only, and this one signs.
+    //
+    // Not `Keyed`, and the reasoning is worth stating because the conservative
+    // instinct points the other way: a retry mints a second short-lived leaf,
+    // and two live presentations sound worse than one. They are not. Both
+    // confer exactly what the first did, both expire on the same 4-hour bound,
+    // and a caller that lost the reply has no way to use the one it never saw.
+    // Keying it would buy a dedup record against a duplicate that costs
+    // nothing, at the price of failing a retry the caller legitimately needs.
+    (trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1, RetrySafe),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),
     // ── Application state ───────────────────────────────────────────────
     //

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -783,6 +783,13 @@ pub const TASK_VTA_MEMORY_PUT_0_1: &str = "https://trusttasks.org/spec/vta/memor
 /// access. Payload: [`crate::protocols::memory::MemoryListBody`].
 pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memory/list/0.1";
 
+/// `spec/rooms/keys/present/0.1` — an agent asks the VTA holding its
+/// principal's room credentials to mint a presentation for **one** room
+/// operation. The credentials never cross to the agent; only the presentation
+/// does, and it is scoped to the action and audience it was asked for.
+/// Auth: `roomPresent` capability, plus context access for the principal's key.
+pub const TASK_ROOMS_KEYS_PRESENT_0_1: &str = "https://trusttasks.org/spec/rooms/keys/present/0.1";
+
 /// `spec/vta/memory/delete/0.1` — remove one entry by key (`not_found` if
 /// absent). Auth: context access. Payload:
 /// [`crate::protocols::memory::MemoryDeleteBody`].
@@ -1730,6 +1737,7 @@ pub const ALL_URIS: &[&str] = &[
     // Agent-memory slice (spec/vta/memory/*)
     TASK_VTA_MEMORY_PUT_0_1,
     TASK_VTA_MEMORY_LIST_0_1,
+    TASK_ROOMS_KEYS_PRESENT_0_1,
     TASK_VTA_MEMORY_DELETE_0_1,
     // Application-state slice (spec/vta/app-state/*)
     TASK_VTA_APP_STATE_GET_1_0,
@@ -1890,6 +1898,17 @@ mod tests {
             // Note the family has no sub-path — the version follows the family
             // name directly.
             "https://trusttasks.org/spec/trust-task-discovery/",
+            // Canonical data rooms — `rooms/*`, authored upstream in
+            // dtgwg-trust-tasks-tf#346 / #349 / #354. Top-level rather than
+            // VTA-private because most of the family is a *host's* surface,
+            // not an agent's: a VTC serves it, and so does a standalone room
+            // host that is no kind of agent at all.
+            //
+            // The one member a VTA serves is the oracle side — `rooms/keys/
+            // present`, where a member's own VTA mints a scoped presentation
+            // for their agent. That is squarely an agent's job, and it is why
+            // this prefix appears here for exactly one URI.
+            "https://trusttasks.org/spec/rooms/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -161,6 +161,9 @@ vta-keys = { path = "../vta-keys", version = "0.4" }
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
 vta-vault = { path = "../vta-vault", version = "0.5" }
+
+# The room presentation oracle attenuates a member VAC and signs it.
+dtg-credentials = { workspace = true }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.
 vta-sweepers = { path = "../vta-sweepers", version = "0.3" }

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -67,6 +67,7 @@ pub mod protocol;
 /// `create_did_webvh`.
 #[cfg(feature = "webvh")]
 pub mod provision_integration;
+pub mod room_oracle;
 pub mod seeds;
 pub mod step_up_approval;
 pub mod vault;

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -1,0 +1,199 @@
+//! The room presentation oracle — `rooms/keys/present/0.1`.
+//!
+//! An agent asks the VTA holding its principal's room credentials to produce a presentation
+//! for **one** room operation. The credentials never cross to the agent; only the
+//! presentation does, and it is bound to the operation it was asked for.
+//!
+//! # Why this exists at all
+//!
+//! The data-rooms design turns on a member equipping their agent with strictly less than
+//! they hold — a chain one link longer, conferring `read` for four hours, bound to one host.
+//! Until now nothing *minted* one. A member wanting to give an agent access had two options:
+//! hand over their own credentials, which is the outcome attenuation exists to prevent, or
+//! mint an attenuation by hand, which nobody does.
+//!
+//! So the agent asks, and the VTA — which already holds the member's keys and is already in
+//! their trusted computing base — mints it. A host is not in that base, which is why the
+//! host sees only the result.
+//!
+//! # What a caller cannot obtain by asking
+//!
+//! **More than the principal holds.** [`present`] attenuates from the member's own VAC, and
+//! `dtg_credentials::attenuate` refuses to widen. A request for `admin` against a chain
+//! conferring `read` fails at the credential library, not at a policy check here.
+//!
+//! **A presentation covering everything.** `action` is a required member of the request and
+//! exactly one action is conferred. An oracle that minted one covering every action would
+//! have handed the caller its principal's whole standing in the room, which is precisely the
+//! outcome attenuation exists to prevent.
+//!
+//! **A presentation reusable elsewhere.** Where the caller names an `audience`, the leaf is
+//! bound to it, and `verify_chain` refuses a chain link presented by anyone else. Without an
+//! audience the presentation is bearer-shaped against that room, which is why callers that
+//! know their host should always name it.
+//!
+//! **The keys.** Nothing in the response carries key material in either direction. An oracle
+//! that returned the principal's VAC itself would be a credential-release call wearing a
+//! different name.
+//!
+//! # The lifetime is short and not negotiable
+//!
+//! [`PRESENTATION_LIFETIME`] bounds every leaf this mints. A caller cannot ask for longer:
+//! the whole value of an oracle over a credential hand-off is that withdrawing access is
+//! withdrawing it *here*, and a long-lived leaf reintroduces exactly the standing credential
+//! the oracle exists to avoid handing over.
+
+use chrono::{Duration, Utc};
+use dtg_credentials::DTGCredential;
+use serde_json::Value;
+use vti_common::acl::ActScope;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use crate::auth::AuthClaims;
+use crate::server::AppState;
+
+/// How long a minted presentation is good for.
+///
+/// Deliberately not a request parameter. A caller that could ask for a year would be asking
+/// for the standing credential this task exists not to hand over, and "the agent needed
+/// longer" is a reason to ask again, not a reason to mint longer.
+pub const PRESENTATION_LIFETIME: Duration = Duration::hours(4);
+
+/// The VC `type` tag a room's authority credential carries.
+const AUTHORITY_TYPE: &str = "AuthorityCredential";
+/// The VC `type` tag a room's membership credential carries.
+const MEMBERSHIP_TYPE: &str = "MembershipCredential";
+
+/// What the oracle produces.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MintedPresentation {
+    /// The presentation to send to the host: membership, an authority chain leaf-first, and
+    /// — on a room that withholds the subject — a same-subject binding.
+    pub presentation: Value,
+    /// When it stops being accepted, so a caller can avoid presenting a stale one.
+    pub expires_at: String,
+}
+
+/// Mint a presentation for `agent_did` to perform `action` on `room_id`.
+///
+/// `agent_did` is the party the *transport* authenticated — the caller's own DID, from the
+/// request's proof. It is what the minted leaf grants to, which is what makes the result
+/// unusable by anyone else: `authorize` on the far side refuses a chain whose leaf grants to
+/// somebody other than the party that signed the request.
+pub async fn present(
+    state: &AppState,
+    auth: &AuthClaims,
+    agent_did: &str,
+    room_id: &str,
+    action: &str,
+    audience: Option<&str>,
+    nonce: Option<&str>,
+) -> Result<MintedPresentation, AppError> {
+    let scope = auth.act_scope();
+
+    // The principal's own credentials for this room. Found by issuer, because a room issues
+    // its own — which is the same property the host verifies against, so a credential that
+    // would not verify there is not one this will present.
+    let vac = find_room_credential(&state.vault_ks, room_id, AUTHORITY_TYPE, &scope).await?;
+    let vmc = find_room_credential(&state.vault_ks, room_id, MEMBERSHIP_TYPE, &scope).await?;
+
+    let root: DTGCredential = serde_json::from_value(vac.clone()).map_err(|e| {
+        AppError::Internal(format!("stored authority credential for `{room_id}`: {e}"))
+    })?;
+
+    // Attenuation, not issuance. `attenuate` refuses to widen, so a caller asking for more
+    // than the principal holds fails in the credential library rather than at a check here
+    // that somebody could forget to write.
+    let now = Utc::now();
+    let expires = now + PRESENTATION_LIFETIME;
+    let mut leaf = root
+        .attenuate(
+            agent_did.to_string(),
+            vec![action.to_string()],
+            now,
+            Some(expires),
+            audience.map(str::to_string),
+        )
+        .map_err(|e| {
+            // The common case is asking for an action the principal does not hold, and
+            // saying so plainly is better than a generic refusal the caller cannot act on.
+            AppError::Validation(format!(
+                "cannot attenuate the principal's authority for `{room_id}` to `{action}`: {e}"
+            ))
+        })?;
+
+    // Signed by the **principal**, whose key this VTA holds. The subject of the root VAC is
+    // who the room granted to, so that is the key that may narrow it.
+    let keys = crate::operations::holder_keys::resolve_holder_keys(
+        &state.keys_ks,
+        &state.seed_store,
+        auth,
+        root.subject(),
+    )
+    .await?;
+
+    leaf.sign(&keys.consent_secret, None)
+        .await
+        .map_err(|e| AppError::Internal(format!("sign the attenuated credential: {e}")))?;
+
+    let leaf_json = serde_json::to_value(leaf.credential())
+        .map_err(|e| AppError::Internal(format!("serialise the attenuated credential: {e}")))?;
+
+    // Leaf first, then the credential the room issued. Every link the host will rely on is
+    // present, because the host will not fetch one.
+    let mut presentation = serde_json::json!({
+        "membership": vmc,
+        "authority": [leaf_json, vac],
+    });
+    // Echoed rather than interpreted: the verifier chose it, and its value to them is that
+    // it came back unchanged.
+    if let Some(nonce) = nonce {
+        presentation["nonce"] = Value::String(nonce.to_string());
+    }
+
+    Ok(MintedPresentation {
+        presentation,
+        expires_at: expires.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+    })
+}
+
+/// The principal's credential of `type_tag` issued by `room_id`.
+///
+/// Refuses ambiguity rather than picking. Two authority credentials from one room is a state
+/// this code cannot resolve correctly — choosing the broader one hands out more than
+/// necessary, choosing the narrower one produces a presentation that fails at the host for
+/// reasons the caller cannot see — so it says so and stops.
+async fn find_room_credential(
+    vault: &KeyspaceHandle,
+    room_id: &str,
+    type_tag: &str,
+    scope: &ActScope,
+) -> Result<Value, AppError> {
+    let query = crate::vault::query::CredentialQuery {
+        r#type: Some(type_tag.to_string()),
+        issuer_did: Some(room_id.to_string()),
+        ..Default::default()
+    };
+
+    let found = crate::vault::query::search(vault, &query, scope).await?;
+    match found.len() {
+        0 => Err(AppError::NotFound(format!(
+            "this VTA holds no {type_tag} issued by room `{room_id}`"
+        ))),
+        1 => {
+            let stored = crate::vault::storage::get(vault, &found[0].id)
+                .await?
+                .ok_or_else(|| {
+                    AppError::Internal(format!("credential `{}` vanished mid-read", found[0].id))
+                })?;
+            serde_json::to_value(&stored.body)
+                .map_err(|e| AppError::Internal(format!("stored {type_tag} for `{room_id}`: {e}")))
+        }
+        n => Err(AppError::Conflict(format!(
+            "this VTA holds {n} {type_tag}s issued by room `{room_id}`; which one to \
+             attenuate from is not a question this can answer safely"
+        ))),
+    }
+}

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -1975,6 +1975,38 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 })
             ),
         ),
+        // ─── rooms/keys ──────────────────────────────────────────
+        //
+        // The only `rooms/*` task this agent serves: the oracle side, where a
+        // member's own VTA mints a scoped presentation for their agent. The
+        // room tasks proper are a host's surface, not an agent's.
+        //
+        // The response witness pins the chain **leaf first**, because that
+        // ordering is the contract with every verifier — a witness that showed
+        // it either way round would check nothing about the half that matters.
+        (
+            uris::TASK_ROOMS_KEYS_PRESENT_0_1,
+            checked!(
+                specs::rooms::keys::present::v0_1::Payload,
+                specs::rooms::keys::present::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "action": "read",
+                    "audience": "did:key:z6MkHost",
+                    "nonce": "n-1"
+                }),
+                json!({
+                    "presentation": {
+                        "membership": { "id": "urn:uuid:vmc-1" },
+                        "authority": [
+                            { "id": "urn:uuid:vac-agent" },
+                            { "id": "urn:uuid:vac-member" }
+                        ]
+                    },
+                    "expiresAt": TS
+                })
+            ),
+        ),
     ];
 
     // ─── vta/did-templates ────────────────────────────────────────

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -83,6 +83,7 @@ mod policy_gate;
 mod produced_census;
 #[cfg(feature = "webvh")]
 mod provision_integration;
+mod room_keys;
 mod seeds;
 // `operations::protocol` — every service operation these handlers call — is
 // `#[cfg(feature = "webvh")]`, because advertising a transport means editing
@@ -1527,6 +1528,12 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_VTA_MEMORY_DELETE_0_1 => memory::handle_delete
         [ Mutating None false ],
+    // ─── Room oracle (spec/rooms/keys/*) ─────────────────────────
+    // An agent asks for a scoped presentation over its principal's room
+    // credentials. Gated on the `roomPresent` capability plus context access
+    // for the principal's key — NOT on `Sign`, which would grant far more.
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1 => room_keys::handle_present
+        [ None Metadata false ],
     // ─── Application-state slice (spec/vta/app-state/*) ──────────
     // Versioned, namespaced per-context JSON the VTA stores but never
     // interprets. Gated on context access (require_context), NOT operator

--- a/vta-service/src/trust_tasks/room_keys.rs
+++ b/vta-service/src/trust_tasks/room_keys.rs
@@ -1,0 +1,118 @@
+//! The room-oracle slice — `spec/rooms/keys/present/0.1`.
+//!
+//! An agent asks its principal's VTA to mint a presentation for one room operation. The
+//! orchestration is [`crate::operations::room_oracle`]; this is the dispatch surface.
+//!
+//! Three gates, in order, and the order matters:
+//!
+//! 1. **Capability.** [`Capability::RoomPresent`], registered upstream as `roomPresent`.
+//!    Deliberately not [`Capability::Sign`]: an agent that may ask for a scoped,
+//!    audience-bound presentation is not thereby an agent that may sign *anything at all*
+//!    with its principal's key. Gating an oracle on the generic signing oracle would grant
+//!    strictly more than the task needs, which is the opposite of what an oracle is for.
+//! 2. **Context**, inside `resolve_holder_keys` — the caller must be permitted to act in the
+//!    context that owns the principal's key. That is the privilege boundary a context exists
+//!    to draw, and it is enforced where the key is resolved rather than re-derived here.
+//! 3. **Attenuation**, inside the credential library — a caller cannot obtain more than the
+//!    principal holds, because `attenuate` refuses to widen.
+//!
+//! # The presenter is the caller, always
+//!
+//! The minted leaf grants to the DID the *transport* authenticated, never to one named in
+//! the payload. A caller cannot ask for a presentation made out to somebody else, which is
+//! what stops this becoming a credential-minting service for third parties: the far side's
+//! `authorize` refuses a chain whose leaf grants to anyone but the party that signed the
+//! request, so a presentation minted for A is worthless to B even if B obtains it.
+
+use serde_json::Value;
+use trust_tasks_rs::{RejectReason, TrustTask};
+use vti_common::acl::{Capability, role_has_capability};
+
+use crate::audit;
+use crate::auth::AuthClaims;
+use crate::operations::room_oracle;
+use crate::server::AppState;
+
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, reject_with,
+    success_response,
+};
+
+/// Refuse unless the caller's role carries `cap`.
+fn require_cap(
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    cap: Capability,
+) -> Result<(), TrustTaskOutcome> {
+    if role_has_capability(&auth.role, cap) {
+        Ok(())
+    } else {
+        Err(reject_with(
+            doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "minting a room presentation denied: role {} does not carry {cap:?}",
+                    auth.role
+                ),
+            },
+        ))
+    }
+}
+
+/// `rooms/keys/present/0.1`.
+pub(super) async fn handle_present(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = require_cap(auth, &doc, Capability::RoomPresent) {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::keys::present::v0_1::Payload = match parse_payload(&doc)
+    {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    // The action as its wire string. The generated enum is the spec's own vocabulary, so a
+    // value outside it never reaches here — one fewer thing to validate by hand.
+    let action = serde_json::to_value(req.action)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_default();
+
+    let minted = match room_oracle::present(
+        state,
+        auth,
+        &auth.did,
+        &req.room_id,
+        &action,
+        req.audience.as_deref(),
+        req.nonce.as_ref().map(|n| n.as_ref()),
+    )
+    .await
+    {
+        Ok(m) => m,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Audited because it is consequential: a presentation was minted on the principal's
+    // behalf, and "which agent obtained what standing in which room, and when" is the
+    // sentence an incident review needs. The room is the resource; the agent is the actor.
+    if let Err(e) = audit::record(
+        &state.audit_sink,
+        "rooms.keys.present",
+        &auth.did,
+        Some(&req.room_id),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        None,
+    )
+    .await
+    {
+        tracing::error!(error = %e, "failed to record a room-oracle audit entry");
+    }
+
+    success_response(&doc, minted)
+}

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -155,6 +155,19 @@ pub enum Capability {
     /// Deliberately withheld from [`Role::Reader`]: a read-only consumer of a
     /// context should not be able to rewrite the memories in it.
     MemoryWrite,
+    /// Asking this VTA to mint a scoped room presentation —
+    /// `rooms/keys/present/0.1`.
+    ///
+    /// Registered upstream as `roomPresent` (`trustoverip/dtgwg-trust-tasks-tf`
+    /// #351). Deliberately **not** [`Capability::Sign`]: an agent that may ask
+    /// for a scoped, audience-bound presentation is not thereby an agent that
+    /// may sign anything at all with its principal's key, and gating this on
+    /// the generic signing oracle would grant strictly more than the task
+    /// needs — the opposite of what an oracle is for.
+    ///
+    /// Withheld from [`Role::Reader`]: minting a credential on a principal's
+    /// behalf is not a read.
+    RoomPresent,
 }
 
 /// Returns true if `role` is granted `cap` by the default capability
@@ -177,6 +190,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::CredentialWrite,
             Capability::MemoryRead,
             Capability::MemoryWrite,
+            Capability::RoomPresent,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::PolicyAdmin,
@@ -191,6 +205,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::CredentialWrite,
             Capability::MemoryRead,
             Capability::MemoryWrite,
+            Capability::RoomPresent,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::DeviceAdmin,


### PR DESCRIPTION
Implements `rooms/keys/present/0.1`. The last unbuilt piece of the data-rooms design that isn't a working-group decision.

The design turns on a member equipping their agent with **strictly less than they hold** — a chain one link longer, conferring `read` for four hours, bound to one host. Nothing minted one. A member wanting to give an agent access had two options: hand over their own credentials, which is the outcome attenuation exists to prevent, or mint an attenuation by hand, which nobody does.

So the agent asks, and the VTA mints. The VTA already holds the member's keys and is already in their trusted computing base; a host is not, which is why the host only ever sees the result.

## Four things a caller cannot obtain by asking

Each closes a way this could have quietly become the credential hand-off it replaces.

- **More than the principal holds** fails in `attenuate`, which refuses to widen — not at a policy check somebody could forget to write.
- **A presentation covering everything** is unreachable: `action` is required and exactly one action is conferred.
- **A presentation made out to somebody else** is unreachable: the leaf grants to the DID the *transport* authenticated, never one named in the payload. One minted for A is worthless to B even if B obtains it, because the presenter binding refuses it on the far side.
- **A long-lived leaf** is unreachable: the lifetime is a constant, not a request parameter. A caller that could ask for a year would be asking for the standing credential the oracle exists not to hand over.

## Not gated on `Sign`

`Capability::RoomPresent`, registered upstream as `roomPresent` (trustoverip/dtgwg-trust-tasks-tf#351). An agent that may ask for a scoped, audience-bound presentation is not thereby an agent that may sign *anything at all* with its principal's key — gating an oracle on the generic signing oracle grants strictly more than the task needs, which is the opposite of what an oracle is for.

The credentials are found by **issuer**, because a room issues its own — the same property the host verifies against, so a credential that would not verify there is not one this will present. Two authority credentials from one room is **refused rather than resolved**: picking the broader one hands out more than necessary, picking the narrower produces a presentation that fails at the host for reasons the caller cannot see.

## Five censuses had something to say, and all five were right

- **Conformance witness** — added, with the chain pinned leaf-first because that ordering is the contract with every verifier.
- **Retry safety** — `RetrySafe`. The oracle stores nothing (the spec's own `sideEffects: none`), and a retry mints a second leaf conferring exactly what the first did on the same expiry. Keying it would buy a dedup record against a harmless duplicate at the price of failing a retry the caller legitimately needs.
- **MCP guard** — joins *"authority, moved"* beside `vta/credentials/issue`. An MCP host approves a *tool*, so a blanket `vta_call` approval must not silently cover minting a presentation over its principal's standing in a room.
- **Canonical namespaces** — gains `spec/rooms/` for exactly one URI. Most of that family is a *host's* surface; this is the one member a VTA serves.
- **`ALL_URIS`** — the retry census reads from it, so without the entry the classification census passed vacuously. Caught by checking rather than trusting the green.

## Deliberately not here

`rooms/keys/open/0.1` — the decryption half. It needs the VTA to hold the room's MLS group, which needs a welcome-delivery flow no specification covers yet. That is a spec-first piece, not something to invent in a handler.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `cargo test --workspace` with no failures, including all 223 `vta-service` trust-task censuses.