### PR TITLE
fix(tee): make allow_kms_reinit explicit authorization for reinit regardless of KMS failure type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10537,6 +10537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "tokio-vsock",
  "tracing",

--- a/deploy/nitro/README.md
+++ b/deploy/nitro/README.md
@@ -1262,10 +1262,13 @@ The template format follows the did:webvh spec. Examples:
 | `did:webvh:{SCID}:example.com%3A8080:vta` | `https://example.com:8080/vta` |
 
 > **Note on ciphertext deletion:** If an attacker deletes the ciphertext files,
-> the next boot will generate a new identity. This is a denial-of-service (the old
-> identity and data are lost), not a privilege escalation — the attacker still
-> can't authenticate to the new VTA without admin credentials. Back up the
-> ciphertext files and monitor for unexpected identity changes.
+> the next boot takes the first-boot path and mints a new seed — but the TEE
+> integrity manifest is MAC'd with a key derived from the *old* seed, so it no
+> longer verifies and the boot fails closed rather than silently coming up under
+> a new identity. Either way this is a denial-of-service (the old identity and
+> data are unreachable), not a privilege escalation — the attacker still can't
+> authenticate to the VTA without admin credentials. Back up the ciphertext
+> files and monitor for unexpected boot failures.
 
 **The mnemonic is never displayed.** To export it for backup:
 
@@ -1502,18 +1505,36 @@ curl http://localhost:8443/attestation/status
 > using a custom image during this window. Step 6 removes the old PCR0
 > to close the window completely.
 
-### Auto-recovery (forgot to update KMS policy)
+### Forgot to update the KMS policy (fails closed)
 
 If you deploy a new image without updating the KMS policy, the VTA will:
 1. Find existing ciphertexts in the bootstrap keyspace
-2. Fail to decrypt them (PCR0 mismatch)
-3. Log a warning: *"KMS decrypt failed — clearing stale bootstrap data"*
-4. Clear the old bootstrap data
-5. Do a fresh first boot with a **new identity**
+2. Fail to decrypt them (PCR0 mismatch → `ACCESS_DENIED`)
+3. Log an error: *"KMS decrypt of existing ciphertexts failed. Refusing to
+   auto-clear the bootstrap keyspace…"*
+4. **Refuse to start**, leaving the sealed identity intact
 
-This is safe (denial of service, not privilege escalation) but results in
-a new DID identity. Use the rolling upgrade procedure above to preserve
-the existing identity across image updates.
+Earlier versions treated `ACCESS_DENIED` as the expected post-rebuild signal
+and silently cleared the bootstrap keyspace, minting a new identity. That made
+launching the wrong EIF a *permanent* identity wipe that the correct EIF could
+no longer undo, so it now fails closed: the recovery is to add the new PCR0 to
+the KMS policy and boot again, which restores the original DID. Use the rolling
+upgrade procedure above to avoid the outage entirely.
+
+**`tee.kms.allow_kms_reinit` is not the way back.** It authorizes clearing the
+bootstrap ciphertexts, but the seed it discards is what every other keyspace is
+encrypted under — those rows will not decrypt under the new seed, so a VTA that
+has written any state will still fail to boot. It is only a complete reset on a
+store that holds nothing but the bootstrap rows. For a real reset, wipe the data
+volume (see below). Two further notes:
+
+- The flag alone will not clear the bootstrap keyspace after a `KMS_INTERNAL` or
+  `NETWORK` failure. Those mean KMS never answered, so the ciphertexts have not
+  been shown to be undecryptable — destroying the identity on "no answer" would
+  be the same denial of service by another route.
+- If `tee.kms.anchor` is configured, the external counter still holds the old
+  version after a reinit, so that boot additionally needs
+  `tee.kms.allow_anchor_init` (and `allow_unanchored` to re-anchor the counter).
 
 ### Fresh deployment (new identity)
 
@@ -1529,8 +1550,10 @@ rm -rf /mnt/vta-data/store/*
 # 3. Start the enclave — it will do a fresh first boot
 ```
 
-Or simply deploy without updating the KMS policy — the auto-recovery
-will handle it (see above).
+Step 1 is what makes this work: with the store empty there are no ciphertexts to
+decrypt, so the enclave takes the first-boot path. Deploying against a populated
+store without updating the KMS policy does **not** produce a fresh identity — it
+fails closed (see above).
 
 ### CI/CD upgrade workflow
 

--- a/docs/01-concepts/security-model.md
+++ b/docs/01-concepts/security-model.md
@@ -207,6 +207,14 @@ keyspace and causes the VTA to refuse to start. Only an explicit
 minting a fresh identity. Resetting a live identity is therefore always a
 deliberate, logged action.
 
+The flag is the sole *authorization* but is not on its own *sufficient*: a
+transient class (`KMS_INTERNAL`, `NETWORK`) means KMS never answered, so the
+ciphertexts have not been shown to be undecryptable and the reset is refused
+even with the flag set. And because the discarded seed is what every other
+keyspace is encrypted under, an in-place reinit is a complete reset only on a
+store holding nothing but the bootstrap rows — otherwise the reset is a wipe of
+the data volume.
+
 ## Authentication Flow
 
 ```

--- a/docs/01-concepts/security-model.md
+++ b/docs/01-concepts/security-model.md
@@ -200,13 +200,12 @@ graph LR
 
 **Boot with a KMS decrypt failure (fail-closed).** On a subsequent boot, if
 `KMS Decrypt` of the stored `seed.enc` / `jwt.enc` fails, the VTA does **not**
-blindly regenerate its identity. Only an `AccessDenied` result -- the expected
-signal after an image rebuild changes PCR0 -- or an explicit
-`tee.kms.allow_kms_reinit = true` clears the bootstrap keyspace and mints a
-fresh identity. Every other error class (KMS internal, network, invalid
-ciphertext, unknown) is treated as a transient outage or possible tampering:
-the VTA refuses to start rather than silently reset its DID and keys. Resetting
-a live identity is thus always a deliberate, logged action.
+blindly regenerate its identity. Every error class, including `AccessDenied`
+from a wrong or tampered image whose PCRs do not match, preserves the bootstrap
+keyspace and causes the VTA to refuse to start. Only an explicit
+`tee.kms.allow_kms_reinit = true` permits clearing the bootstrap keyspace and
+minting a fresh identity. Resetting a live identity is therefore always a
+deliberate, logged action.
 
 ## Authentication Flow
 

--- a/docs/02-vta/tee-architecture.md
+++ b/docs/02-vta/tee-architecture.md
@@ -789,7 +789,8 @@ The manifest pins four singletons (see design note §5.1): the **carve-out
 sentinel**, the **ACL keyspace root** (canonical hash over all `acl:{did}`
 rows), the **JWT fingerprint**, and the **path/context counters**. The
 KMS-protected bootstrap ciphertexts are *not* covered — their delete-and-reinit
-is already gated by `allow_kms_reinit` plus the JWT-fingerprint check.
+is gated by the explicit `allow_kms_reinit` reset flag, while the JWT-fingerprint
+check protects against substituting JWT signing key.
 
 ## Implementation Phases
 

--- a/docs/02-vta/tee-architecture.md
+++ b/docs/02-vta/tee-architecture.md
@@ -788,9 +788,22 @@ writer_credential_ciphertext = "AQIDAH…"
 The manifest pins four singletons (see design note §5.1): the **carve-out
 sentinel**, the **ACL keyspace root** (canonical hash over all `acl:{did}`
 rows), the **JWT fingerprint**, and the **path/context counters**. The
-KMS-protected bootstrap ciphertexts are *not* covered — their delete-and-reinit
-is gated by the explicit `allow_kms_reinit` reset flag, while the JWT-fingerprint
-check protects against substituting JWT signing key.
+KMS-protected bootstrap ciphertexts are *not* covered directly, because the two
+ways they can go away are each already caught:
+
+- A **failed decrypt** clears them only under the explicit `allow_kms_reinit`
+  reset flag — no KMS error class, `ACCESS_DENIED` included, authorizes a reset
+  implicitly.
+- A **parent-host deletion** of them consults no flag at all: the rows are simply
+  absent, so boot takes the first-boot path. What stops that from silently
+  re-issuing an identity is the manifest itself — a new seed means a new storage
+  key, hence a new MAC key, so the surviving manifest fails verification and the
+  boot fails closed. (An *authorized* reinit therefore clears the manifest along
+  with the ciphertexts, so the reset the operator asked for isn't reported back
+  to them as tampering.)
+
+The JWT-fingerprint check is a separate control, against substituting the JWT
+signing key.
 
 ## Implementation Phases
 

--- a/tasks/vta-architecture-plan.md
+++ b/tasks/vta-architecture-plan.md
@@ -475,9 +475,9 @@ The "reset identity vs first boot vs subsequent boot" policy — the
 highest-consequence decision in the TCB — is buried in a decrypt-error match arm
 (`kms_bootstrap.rs:119-157`). Extract `enum BootDecision` + a pure resolver
 `(ciphertexts_present, kms_error_class, config_flags) -> BootDecision`,
-unit-test every cell of the truth table (identity auto-clear ONLY on
-`AccessDenied` or explicit `allow_kms_reinit` — that coupling IS the
-PCR-rotation flow and must be preserved).
+unit-test every cell of the truth table (identity auto-clear ONLY when the
+explicit `allow_kms_reinit` flag is enabled; no KMS error class, including
+`AccessDenied`, may grant reset permission implicitly).
 
 ### P3.7 — Naming + decomposition hygiene (M, several small PRs)
 - Split `operations/credential_exchange.rs` (2,349 LOC) by flow into
@@ -538,8 +538,9 @@ Security/crypto:
   archive-old-seed-before-write-new in `rotate_seed`.
 - `take_raw` atomicity (Local) — refresh-token single-use.
 - Attested-KMS failure terminal on real hardware unless
-  `allow_unattested_fallback`; identity auto-clear only on `AccessDenied`/
-  explicit reinit; env-override lockout when `kms.is_some()`.
+  `allow_unattested_fallback`; identity auto-clear requires explicit
+  `allow_kms_reinit` for every KMS error class; env-override lockout when
+  `kms.is_some()`.
 - Step-up challenges single-use, consumed-on-read even when expired.
 - Signed payloads never byte-transformed in 0.2 dual-accept (typed handlers
   only).

--- a/tasks/vta-architecture-plan.md
+++ b/tasks/vta-architecture-plan.md
@@ -470,14 +470,17 @@ never built in CI (only 3 of 15 vta-service feature combos are checked). Add
 `--no-default-features --features rest,keyring,cli-synthesis` test job
 (~15 lines of YAML).
 
-### P3.6 — Extract the TEE boot decision as a pure function (M)
+### P3.6 — Extract the TEE boot decision as a pure function (M) — partly done
 The "reset identity vs first boot vs subsequent boot" policy — the
-highest-consequence decision in the TCB — is buried in a decrypt-error match arm
-(`kms_bootstrap.rs:119-157`). Extract `enum BootDecision` + a pure resolver
-`(ciphertexts_present, kms_error_class, config_flags) -> BootDecision`,
-unit-test every cell of the truth table (identity auto-clear ONLY when the
-explicit `allow_kms_reinit` flag is enabled; no KMS error class, including
-`AccessDenied`, may grant reset permission implicitly).
+highest-consequence decision in the TCB — was buried in a decrypt-error match
+arm. The **reset half** is now extracted: `enum ReinitDecision` + the pure
+resolver `resolve_reinit(kms_error_class, allow_kms_reinit)` in
+`kms_bootstrap.rs`, with both halves of the truth table unit-tested (identity
+auto-clear ONLY when the explicit `allow_kms_reinit` flag is enabled — no KMS
+error class, `AccessDenied` included, may grant reset permission implicitly —
+and, with the flag, still refused for the transient classes, which mean KMS
+never answered). Remaining: fold `ciphertexts_present` in as well so the whole
+`BootDecision` (first boot vs subsequent boot vs reset) is one resolver.
 
 ### P3.7 — Naming + decomposition hygiene (M, several small PRs)
 - Split `operations/credential_exchange.rs` (2,349 LOC) by flow into

--- a/vta-config/src/lib.rs
+++ b/vta-config/src/lib.rs
@@ -580,6 +580,18 @@ pub struct TeeKmsConfig {
     /// VTA's identity and refuses to start. Set to `true` only when you have
     /// diagnosed the cause and explicitly intend to reset the VTA to a fresh
     /// first-boot state.
+    ///
+    /// Necessary but not sufficient. A transient class (KMS_INTERNAL,
+    /// NETWORK) means KMS never answered, so the ciphertexts have not been
+    /// *shown* to be undecryptable — the reset is refused even with this
+    /// flag, because destroying a recoverable identity on "no answer" would
+    /// be the same denial of service by another route.
+    ///
+    /// This is also **not a full reset**: the seed it discards is what every
+    /// other keyspace is encrypted under, and those rows will not decrypt
+    /// under the new one. It only produces a bootable VTA on a store holding
+    /// nothing but the bootstrap rows; otherwise wipe the data volume
+    /// instead. See `deploy/nitro/README.md`.
     #[serde(default)]
     pub allow_kms_reinit: bool,
     /// Allow establishing the TEE integrity-manifest baseline when none is

--- a/vta-config/src/lib.rs
+++ b/vta-config/src/lib.rs
@@ -572,18 +572,14 @@ pub struct TeeKmsConfig {
     /// once to store the fingerprint, then set back to `false`.
     #[serde(default)]
     pub allow_fingerprint_init: bool,
-    /// Allow auto-clearing existing bootstrap ciphertexts when a KMS
-    /// decrypt **other than ACCESS_DENIED** fails on a subsequent boot.
+    /// Allow auto-clearing existing bootstrap ciphertexts after a KMS decrypt
+    /// failure on a subsequent boot.
     ///
-    /// **Default: false.** ACCESS_DENIED is the legitimate post-rebuild
-    /// signal (PCR mismatch — the enclave's measurements changed and KMS
-    /// won't decrypt the old data key); the bootstrap keyspace is
-    /// auto-cleared without this flag in that case. Any other class
-    /// of decrypt failure (transient KMS error, network glitch,
-    /// ciphertext corruption, attacker-induced byte flip) is *not*
-    /// auto-cleared, because doing so would silently delete the VTA's
-    /// identity. Set to `true` only when you have diagnosed the cause
-    /// and intend to reset the VTA to a fresh first-boot state.
+    /// **Default: false.** Every KMS failure class, including ACCESS_DENIED
+    /// from a wrong or tampered image whose PCRs do not match, preserves the
+    /// VTA's identity and refuses to start. Set to `true` only when you have
+    /// diagnosed the cause and explicitly intend to reset the VTA to a fresh
+    /// first-boot state.
     #[serde(default)]
     pub allow_kms_reinit: bool,
     /// Allow establishing the TEE integrity-manifest baseline when none is

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -66,3 +66,8 @@ tokio = { workspace = true, features = ["io-util"] }
 # Only pulled in by the `tenant-overlay` feature (fleet builds) for the vsock
 # config-envelope fetch.
 tokio-vsock = { workspace = true, optional = true }
+
+[dev-dependencies]
+# `authorized_reinit_leaves_no_state_sealed_against_the_old_seed` opens a real
+# fjall store to assert what the reinit clear leaves behind.
+tempfile = "3"

--- a/vta-tee/src/kms_bootstrap.rs
+++ b/vta-tee/src/kms_bootstrap.rs
@@ -118,35 +118,29 @@ pub async fn bootstrap_secrets(
             }
             Err((class, e)) => {
                 // Auto-clearing the bootstrap keyspace silently re-issues the
-                // VTA's identity. Only ACCESS_DENIED is a legitimate signal
-                // for "expected after an image rebuild with a new PCR0" —
-                // every other class (KMS_INTERNAL, NETWORK, INVALID_CIPHERTEXT,
-                // UNKNOWN) could be a transient outage or active tampering,
-                // and silently nuking the identity would be the wrong move.
-                // Operators who deliberately want to reset must set
-                // `tee.kms.allow_kms_reinit = true` in config.
-                let auto_clear =
-                    matches!(class, KmsErrorClass::AccessDenied) || kms_config.allow_kms_reinit;
-                if !auto_clear {
+                // VTA's identity. Every KMS error class, including
+                // ACCESS_DENIED (for example, a wrong or tampered image),
+                // preserves the identity unless an operator explicitly opts
+                // into a reset with `tee.kms.allow_kms_reinit = true`.
+                if !kms_config.allow_kms_reinit {
                     error!(
                         error = %e,
                         class = ?class,
-                        "KMS decrypt of existing ciphertexts failed with a non-ACCESS_DENIED \
-                         class. Refusing to auto-clear the bootstrap keyspace because doing \
-                         so would silently reset the VTA's identity. Diagnose the cause \
-                         (KMS health, vsock proxy reachability, ciphertext integrity) and, \
-                         if you are certain the existing identity is unrecoverable, set \
-                         tee.kms.allow_kms_reinit = true for a one-time reset."
+                        "KMS decrypt of existing ciphertexts failed. Refusing to auto-clear the \
+                         bootstrap keyspace because doing so would silently reset the VTA's \
+                         identity. Diagnose the cause (PCR policy, KMS health, vsock proxy \
+                         reachability, ciphertext integrity) and, if you are certain the \
+                         existing identity is unrecoverable, set tee.kms.allow_kms_reinit = true \
+                         for a one-time reset."
                     );
                     return Err(e);
                 }
                 warn!(
                     error = %e,
                     class = ?class,
-                    "KMS decrypt of existing ciphertexts failed — clearing stale \
-                     bootstrap data and starting fresh. ACCESS_DENIED is expected after \
-                     an image rebuild with a new PCR0; other classes were authorized \
-                     by allow_kms_reinit. The VTA will generate a new identity."
+                    "KMS decrypt of existing ciphertexts failed — clearing bootstrap data and \
+                     starting fresh because allow_kms_reinit is explicitly enabled. The VTA \
+                     will generate a new identity."
                 );
                 bs_ks.remove(BOOTSTRAP_DK_CT_KEY).await?;
                 bs_ks.remove(BOOTSTRAP_SEED_CT_KEY).await?;
@@ -471,9 +465,9 @@ pub async fn attested_decrypt(
 ///
 /// Without `/dev/nsm` (simulated mode), uses direct KMS Decrypt.
 ///
-/// Returns `(class, AppError)` on failure so the bootstrap path can
-/// branch on `KmsErrorClass::AccessDenied` (legitimate post-rebuild
-/// PCR mismatch) without auto-clearing on every other class.
+/// Returns `(class, AppError)` on failure so the bootstrap path can report the
+/// KMS failure class. No class implicitly permits clearing existing identity
+/// ciphertexts; that requires `allow_kms_reinit`.
 async fn kms_decrypt_data_key(
     config: &TeeKmsConfig,
     ciphertext: &[u8],
@@ -1340,10 +1334,10 @@ mod cms_der {
     }
 }
 
-/// Typed classification of a KMS error. The bootstrap path branches
-/// on this to decide whether to auto-clear stale ciphertexts: only
-/// `AccessDenied` (the post-rebuild PCR-mismatch signal) is treated
-/// as legitimate; anything else preserves the VTA's identity.
+/// Typed classification of a KMS error. The bootstrap path uses this for
+/// diagnostics only: no error class implicitly permits clearing stale
+/// ciphertexts, and every class preserves the VTA's identity unless the
+/// explicit `allow_kms_reinit` flag is enabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KmsErrorClass {
     AccessDenied,

--- a/vta-tee/src/kms_bootstrap.rs
+++ b/vta-tee/src/kms_bootstrap.rs
@@ -74,6 +74,30 @@ const BOOTSTRAP_SEED_CT_KEY: &str = "bootstrap:seed_ciphertext";
 const BOOTSTRAP_JWT_CT_KEY: &str = "bootstrap:jwt_ciphertext";
 const BOOTSTRAP_JWT_FINGERPRINT_KEY: &str = "bootstrap:jwt_fingerprint";
 
+/// Drop every bootstrap row that is sealed against the seed an authorised
+/// reinit discards, so the next boot is a coherent first boot.
+///
+/// That is the four KMS-protected rows **and the TEE integrity manifest**.
+/// The manifest is MAC'd with a key derived from the storage key, which is
+/// derived from the seed being discarded, so a surviving manifest makes the
+/// next boot abort in `vti_common::integrity::boot_verify_and_install` with
+/// "manifest MAC verification failed — tampered with or the storage key
+/// changed" — reporting the reset the operator just authorised back to them
+/// as parent-host compromise. It lives in this same (unencrypted,
+/// KMS-protected) keyspace, so it is cleared here alongside the ciphertexts.
+///
+/// This does **not** make the reinit a complete reset: every other keyspace
+/// is encrypted under the old storage key and stays unreadable. See the
+/// caller's warning, and `deploy/nitro/README.md`.
+async fn clear_reinit_state(bs_ks: &vti_common::store::KeyspaceHandle) -> Result<(), AppError> {
+    bs_ks.remove(BOOTSTRAP_DK_CT_KEY).await?;
+    bs_ks.remove(BOOTSTRAP_SEED_CT_KEY).await?;
+    bs_ks.remove(BOOTSTRAP_JWT_CT_KEY).await?;
+    bs_ks.remove(BOOTSTRAP_JWT_FINGERPRINT_KEY).await?;
+    bs_ks.remove(vti_common::integrity::MANIFEST_KEY).await?;
+    Ok(())
+}
+
 /// Bootstrap secrets from KMS.
 ///
 /// - If ciphertext files exist: decrypt via KMS, verify JWT fingerprint (subsequent boot)
@@ -121,18 +145,35 @@ pub async fn bootstrap_secrets(
                 // VTA's identity. Every KMS error class, including
                 // ACCESS_DENIED (for example, a wrong or tampered image),
                 // preserves the identity unless an operator explicitly opts
-                // into a reset with `tee.kms.allow_kms_reinit = true`.
-                if !kms_config.allow_kms_reinit {
-                    error!(
-                        error = %e,
-                        class = ?class,
-                        "KMS decrypt of existing ciphertexts failed. Refusing to auto-clear the \
-                         bootstrap keyspace because doing so would silently reset the VTA's \
-                         identity. Diagnose the cause (PCR policy, KMS health, vsock proxy \
-                         reachability, ciphertext integrity) and, if you are certain the \
-                         existing identity is unrecoverable, set tee.kms.allow_kms_reinit = true \
-                         for a one-time reset."
-                    );
+                // into a reset with `tee.kms.allow_kms_reinit = true` — and
+                // the transient classes preserve it even then. The whole
+                // truth table is `resolve_reinit`, below.
+                if resolve_reinit(class, kms_config.allow_kms_reinit) == ReinitDecision::FailClosed
+                {
+                    if kms_config.allow_kms_reinit {
+                        error!(
+                            error = %e,
+                            class = ?class,
+                            "KMS decrypt of existing ciphertexts failed with a transient class. \
+                             allow_kms_reinit is set, but KMS never answered — the ciphertexts \
+                             have NOT been shown to be undecryptable, so there is nothing here \
+                             to reset from and clearing them would destroy a recoverable \
+                             identity. Restore KMS reachability (vsock proxy, allowlist, \
+                             endpoint) and boot again."
+                        );
+                    } else {
+                        error!(
+                            error = %e,
+                            class = ?class,
+                            "KMS decrypt of existing ciphertexts failed. Refusing to auto-clear \
+                             the bootstrap keyspace because doing so would silently reset the \
+                             VTA's identity. Diagnose the cause (PCR policy, KMS health, vsock \
+                             proxy reachability, ciphertext integrity). To reset deliberately, \
+                             wipe the data volume and boot fresh — or, if the store holds \
+                             nothing but these bootstrap rows, set tee.kms.allow_kms_reinit = \
+                             true for a one-time in-place reset."
+                        );
+                    }
                     return Err(e);
                 }
                 warn!(
@@ -140,12 +181,15 @@ pub async fn bootstrap_secrets(
                     class = ?class,
                     "KMS decrypt of existing ciphertexts failed — clearing bootstrap data and \
                      starting fresh because allow_kms_reinit is explicitly enabled. The VTA \
-                     will generate a new identity."
+                     will generate a new identity. NOTE: every other keyspace is still \
+                     encrypted under the storage key derived from the seed being discarded and \
+                     will not decrypt under the new one, so unless this store held nothing but \
+                     the bootstrap rows the next boot will still fail — wipe the data volume \
+                     instead. If an external anchor counter is configured it also still holds \
+                     the old version, and that boot additionally needs \
+                     tee.kms.allow_anchor_init (plus allow_unanchored to re-anchor the counter)."
                 );
-                bs_ks.remove(BOOTSTRAP_DK_CT_KEY).await?;
-                bs_ks.remove(BOOTSTRAP_SEED_CT_KEY).await?;
-                bs_ks.remove(BOOTSTRAP_JWT_CT_KEY).await?;
-                bs_ks.remove(BOOTSTRAP_JWT_FINGERPRINT_KEY).await?;
+                clear_reinit_state(&bs_ks).await?;
                 store.persist().await?;
                 // Fall through to first boot path below
             }
@@ -1334,8 +1378,49 @@ mod cms_der {
     }
 }
 
-/// Typed classification of a KMS error. The bootstrap path uses this for
-/// diagnostics only: no error class implicitly permits clearing stale
+/// What the bootstrap path does when the existing ciphertexts fail to
+/// decrypt on a subsequent boot. Resolved by [`resolve_reinit`] so the
+/// truth table is a unit-testable pure function rather than a condition
+/// buried in a match arm (plan P3.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReinitDecision {
+    /// Preserve the sealed identity and refuse to start.
+    FailClosed,
+    /// Clear the bootstrap keyspace and mint a fresh identity.
+    Reinit,
+}
+
+/// Resolve "reset the identity, or fail closed?" from the KMS failure class
+/// and the operator's explicit reset flag.
+///
+/// `allow_kms_reinit` is the **sole authorization**: no error class grants a
+/// reset implicitly. That coupling is what made launching the wrong EIF a
+/// destructive denial of service — an `AccessDenied` from a rebuilt image and
+/// an `AccessDenied` from an attacker's image are the same signal.
+///
+/// The flag is necessary but not sufficient. `KMS_INTERNAL` and `NETWORK`
+/// mean KMS never answered, so the ciphertexts have not been *shown* to be
+/// undecryptable and there is nothing to reset from; destroying the identity
+/// on "no answer" would reopen the same DoS by another route, via a config
+/// that still carries the flag from an earlier deliberate reset. Those two
+/// classes fail closed even with the flag set. The remaining classes are
+/// positive evidence that this enclave cannot unwrap this data key.
+pub(crate) fn resolve_reinit(class: KmsErrorClass, allow_kms_reinit: bool) -> ReinitDecision {
+    if !allow_kms_reinit {
+        return ReinitDecision::FailClosed;
+    }
+    match class {
+        // "retry may help" / "cannot reach KMS endpoint" — see `label()`.
+        KmsErrorClass::KmsInternal | KmsErrorClass::Network => ReinitDecision::FailClosed,
+        KmsErrorClass::AccessDenied
+        | KmsErrorClass::KeyNotFound
+        | KmsErrorClass::InvalidCiphertext
+        | KmsErrorClass::Unknown => ReinitDecision::Reinit,
+    }
+}
+
+/// Typed classification of a KMS error. The bootstrap path feeds this to
+/// [`resolve_reinit`]: no error class implicitly permits clearing stale
 /// ciphertexts, and every class preserves the VTA's identity unless the
 /// explicit `allow_kms_reinit` flag is enabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1428,6 +1513,94 @@ mod tests {
             vti_common::integrity::CARVEOUT_KEY,
             "carve-out sentinel key drifted from vti_common::integrity"
         );
+    }
+
+    // ── reinit truth table (plan P3.6) ──────────────────────────────────
+    //
+    // The highest-consequence decision in the TCB: whether a failed decrypt
+    // of the existing ciphertexts clears them and re-mints the VTA's
+    // identity. Every cell is asserted so the next edit to this arm has
+    // something holding it.
+
+    const ALL_CLASSES: [KmsErrorClass; 6] = [
+        KmsErrorClass::AccessDenied,
+        KmsErrorClass::KeyNotFound,
+        KmsErrorClass::InvalidCiphertext,
+        KmsErrorClass::KmsInternal,
+        KmsErrorClass::Network,
+        KmsErrorClass::Unknown,
+    ];
+
+    /// Without the flag, no class may reset the identity — `AccessDenied`
+    /// included. Granting it implicitly is what turned launching the wrong
+    /// EIF into a permanent, unrecoverable identity wipe.
+    #[test]
+    fn no_kms_error_class_authorizes_reinit_without_the_flag() {
+        for class in ALL_CLASSES {
+            assert_eq!(
+                resolve_reinit(class, false),
+                ReinitDecision::FailClosed,
+                "{class:?} must preserve the identity when allow_kms_reinit is false"
+            );
+        }
+    }
+
+    /// With the flag, the classes that positively establish "this enclave
+    /// cannot unwrap this data key" reset; the two transient classes still
+    /// fail closed, because KMS never answered and the identity may well be
+    /// recoverable on the next boot.
+    #[test]
+    fn the_flag_authorizes_reinit_only_for_non_transient_classes() {
+        for class in ALL_CLASSES {
+            let expected = match class {
+                KmsErrorClass::KmsInternal | KmsErrorClass::Network => ReinitDecision::FailClosed,
+                _ => ReinitDecision::Reinit,
+            };
+            assert_eq!(
+                resolve_reinit(class, true),
+                expected,
+                "{class:?} resolved the wrong way with allow_kms_reinit = true"
+            );
+        }
+    }
+
+    /// The reset clears the integrity manifest along with the ciphertexts.
+    /// The manifest's MAC key is derived from the storage key, which is
+    /// derived from the seed the reset discards, so a surviving manifest
+    /// would abort the *next* boot as "tampered with or the storage key
+    /// changed" — reporting an authorised reset as parent-host compromise.
+    #[tokio::test]
+    async fn authorized_reinit_leaves_no_state_sealed_against_the_old_seed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = vti_common::store::Store::open(&vti_common::config::StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let bs_ks = store.keyspace(vta_keyspaces::BOOTSTRAP).unwrap();
+
+        // A bootstrap keyspace shaped like a VTA that has booted once:
+        // sealed ciphertexts, a JWT fingerprint, and a sealed manifest.
+        let sealed = [
+            BOOTSTRAP_DK_CT_KEY,
+            BOOTSTRAP_SEED_CT_KEY,
+            BOOTSTRAP_JWT_CT_KEY,
+            BOOTSTRAP_JWT_FINGERPRINT_KEY,
+            vti_common::integrity::MANIFEST_KEY,
+        ];
+        for key in sealed {
+            bs_ks.insert_raw(key, b"stale".to_vec()).await.unwrap();
+        }
+
+        clear_reinit_state(&bs_ks).await.unwrap();
+
+        for key in sealed {
+            assert_eq!(
+                bs_ks.get_raw(key).await.unwrap(),
+                None,
+                "{key} survived an authorised reinit — anything sealed against \
+                 the discarded seed aborts the next boot"
+            );
+        }
     }
 
     /// Build a synthetic CMS EnvelopedData that mimics what KMS returns


### PR DESCRIPTION
## Summary

Make `allow_kms_reinit` the sole authorization for clearing existing TEE bootstrap ciphertexts. `AccessDenied` and all other KMS failures now preserve the existing identity and fail closed unless explicit reinitialization is enabled.

## Motivation

Previously, any KMS `AccessDenied` during a subsequent boot automatically cleared the sealed seed, JWT, and data-key ciphertexts and generated a new VTA identity.

That behavior created a destructive denial of service: launching the wrong EIF could permanently erase the persisted VTA identity, and the correct EIF could no longer recover it. The fix makes this fail closed and preserves the sealed identity material.

## Changes

- Removed the implicit `AccessDenied` reset path.
- Made `allow_kms_reinit` the only authorization for clearing bootstrap ciphertexts.
- Updated KMS configuration and security documentation.
- Preserved the tenant-overlay restriction preventing runtime injection of `allow_*` flags.
- Kept KMS error classification for diagnostics only.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vta-tee kms_bootstrap --lib`
- `cargo test -p vta-config overlay_rejects_allow_flags_admin_did_and_mode --lib`
- `cargo clippy -p vta-tee -p vta-config --all-targets -- -D warnings`

Manual Nitro validation confirmed:

- `AccessDenied` fails closed without identity reset.
- A temporary KMS denial preserves the existing identity.
- A non-`AccessDenied` proxy transport failure also fails closed, and recovery restores the same DID.