### PR TITLE
feat(rooms): a VTA joins a room, keeps up, and opens what it holds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9599,9 +9599,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d429149074f413644d70e356a48ce3ca31764107716f2c5c6442559bacfc95d"
+checksum = "e9560f2e6bb5e0958674adc0625d4eb592e078554a9284d292e286e7fb49c338"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10470,6 +10470,8 @@ dependencies = [
  "vta-vault",
  "vta-webvh",
  "vti-common",
+ "vti-rooms",
+ "vti-rooms-dtg",
  "vti-secrets",
  "vti-webauthn",
  "webauthn-rs",

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -445,9 +445,29 @@ is not thereby an agent that may sign *anything at all* with its principal's
 key — gating an oracle on the generic signing oracle grants strictly more than
 the task needs, which is the opposite of what an oracle is for.
 
-The opening half (`rooms/keys/open/0.1`) is specified and not yet built: it
-needs the VTA to hold the room's MLS group, which needs a welcome-delivery flow
-no specification covers yet.
+**The opening half is built too**, and with it the three tasks that put a group
+into a VTA in the first place — `rooms/keys/{key-package,welcome,commit}`,
+specified in `dtgwg-trust-tasks-tf#355`. Three things about that arrangement are
+worth carrying:
+
+- **The invitation is what makes a Welcome acceptable.** A Welcome carries a
+  group's secrets, so anyone able to reach a VTA could otherwise push group
+  state into it. §4.1 already said joining is consent and the VIC is the
+  artefact; this is where that stops being ceremonial. No matching, unconsumed
+  invitation, no join — and the invitation is consumed only *after* the join
+  succeeds, or a Welcome that failed to process would leave a member with a
+  spent invitation and no membership.
+- **Commits are not optional, and their absence is silent.** A member who misses
+  one is stuck at their last epoch and can open nothing sealed after it. The
+  symptom is "this record does not open", which reads like corruption — so
+  `open` reports *which epoch the VTA holds* when a record is sealed under a
+  later one, turning it into "a commit has not been delivered".
+- **Four tasks, four different gates**, and only one is a capability. The
+  delivery three are *inbound* — a room's owner reaching this VTA — and an ACL
+  of ours has no opinion about who a room's owner is; `commit` in particular is
+  authorized *inside the group*, by MLS, never from a list we keep. Only `open`
+  is our own principal's agent asking us to decrypt, which is what a capability
+  is for.
 
 ### 5.4 Recovery: a quorum re-admits; total loss is total
 

--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -103,6 +103,31 @@ pub const ISSUED_CREDENTIALS: &str = "issued_credentials";
 /// user data → in [`BACKED_UP`].
 pub const MEMORY: &str = "memory";
 
+/// A member's MLS group state for each data room they belong to
+/// (`rooms/keys/{welcome,commit,open}`), keyed `room-group:<roomId>`.
+///
+/// **This holds group secrets.** Whoever reads a row can decrypt every record
+/// the group could, up to its epoch — the same class of material as [`KEYS`],
+/// and it inherits the same protection: the KMS storage key in a TEE
+/// deployment, and a trusted data directory outside one.
+///
+/// In [`BACKED_UP`], and that is a decision rather than a default. A member who
+/// restores a VTA without their room groups has lost the ability to read every
+/// sealed room they belong to, with no way to recover it — the group cannot be
+/// re-derived, and rejoining means a fresh invitation from every owner. The
+/// backup already carries the credential vault and the master seed; group state
+/// belongs with them.
+pub const ROOM_GROUPS: &str = "room_groups";
+
+/// Invitation credentials this VTA has consumed by joining a room
+/// (`rooms/keys/welcome`), keyed `room-vic:<credentialId>`.
+///
+/// Separate from [`ROOM_GROUPS`] because it outlives them: a member who leaves a
+/// room discards the group, and the consumed-invitation record must survive that
+/// or the same invitation would let them be re-added without a fresh one. Single
+/// use means single use.
+pub const ROOM_INVITATIONS: &str = "room_invitations";
+
 /// Versioned, namespaced application state (`vta/app-state/{get,put,list,
 /// delete,get-many,put-many}/1.0`) — the third store, beside [`VAULT`] (secrets
 /// and credentials) and [`MEMORY`] (agent memory), for JSON an application owns
@@ -190,6 +215,8 @@ pub const ALL: &[&str] = &[
     CONSENT_APPROVERS,
     ISSUED_CREDENTIALS,
     MEMORY,
+    ROOM_GROUPS,
+    ROOM_INVITATIONS,
     APP_STATE,
     POLICY,
     TASK_CONSENT,
@@ -210,6 +237,8 @@ pub const BACKED_UP: &[&str] = &[
     CONSENT_APPROVERS,
     // Durable agent memory is user data and must survive a restore.
     MEMORY,
+    ROOM_GROUPS,
+    ROOM_INVITATIONS,
     // Application state IS the user's account for a consumer built on it —
     // labels, relationships, contacts, join history. A restore that came back
     // without it would return a VTA whose applications no longer recognise
@@ -359,6 +388,18 @@ pub const fn did_delete_effect(keyspace: &str) -> Option<DidDeleteEffect> {
         b"consent" | b"task_consent" | b"vault" => Cascade,
         // Per-DID application state the VTA stores on a holder's behalf.
         b"app_state" | b"memory" => Cascade,
+        // A member's room groups, and the invitations they were joined under.
+        // Held for the holder in the same sense the vault is: the group state
+        // decrypts a room *that member* belongs to, and with the member gone
+        // nobody can use it or ever will again. Keeping it would leave group
+        // secrets on disk outliving the only party they were for.
+        //
+        // The consumed-invitation records go with them and not before: while
+        // the member exists, a consumed invitation MUST outlive the group it
+        // let them join, or leaving a room would make the same invitation work
+        // twice. Single use means single use, and the record is the only thing
+        // that remembers.
+        b"room_groups" | b"room_invitations" => Cascade,
 
         // ---- Depends on the DID to function ------------------------------
         // A context whose `did` is this one, a DID named in an advertised

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -122,6 +122,14 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // a *tool*, so a blanket `vta_call` approval must not silently cover
     // minting a presentation over its principal's standing in a room.
     ("rooms/keys/present", Risk::Sensitive),
+    // Secret material, emitted: `open` returns a room record's plaintext. It
+    // belongs beside `vault/release` rather than with the ordinary mutations,
+    // because what comes back is content the room encrypted.
+    ("rooms/keys/open", Risk::Sensitive),
+    // Key material, accepted. A Welcome carries a group's secrets and joining
+    // is a membership change made on the principal's behalf — not something a
+    // blanket `vta_call` approval should cover silently.
+    ("rooms/keys/welcome", Risk::Sensitive),
     // Reads that a verb rule would misread.
     ("vta/contexts/preview-delete", Risk::ReadOnly),
     ("vta/webvh/agent-name/check", Risk::ReadOnly),
@@ -472,6 +480,12 @@ mod tests {
     /// this — `classify` defaults to `Mutating` without consulting it, so a
     /// runtime miss is safe and a compile-time miss is loud.
     const MUTATING_VERBS: &[&str] = &[
+        // Mints a KeyPackage and retains its private half. Consequential, but
+        // what it emits is public by construction — hence Mutating rather than
+        // Sensitive, unlike its siblings `welcome` and `open`.
+        "key-package",
+        // Advances the group one epoch. No secret crosses in either direction.
+        "commit",
         "create",
         "update",
         "update-did",

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -405,6 +405,24 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // Keying it would buy a dedup record against a duplicate that costs
     // nothing, at the price of failing a retry the caller legitimately needs.
     (trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1, RetrySafe),
+    // Reads group state and returns plaintext. Nothing is written, and a second
+    // execution is indistinguishable from one.
+    (trust_tasks::TASK_ROOMS_KEYS_OPEN_0_1, ReadOnly),
+    // Minting retains a private key. A retry after a lost reply mints a SECOND
+    // one and leaves a second private half behind for a Welcome that will
+    // consume at most one — a duplicate that costs real key material, which is
+    // exactly the case a key exists for.
+    (trust_tasks::TASK_ROOMS_KEYS_KEY_PACKAGE_0_1, Keyed),
+    // Joining is once. A retry after a lost reply finds the group already
+    // present and fails `alreadyJoined` — so without a key the caller cannot
+    // tell "my join was lost" from "my join worked and the reply was", and the
+    // conservative reading strands a member who is actually in.
+    (trust_tasks::TASK_ROOMS_KEYS_WELCOME_0_1, Keyed),
+    // Idempotent by specification: a replayed commit is success with the epoch
+    // unchanged. That property exists precisely so delivery can retry, and
+    // keying it would add a dedup record to something already deduplicated by
+    // the epoch it names.
+    (trust_tasks::TASK_ROOMS_KEYS_COMMIT_0_1, RetrySafe),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),
     // ── Application state ───────────────────────────────────────────────
     //

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -790,6 +790,23 @@ pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memo
 /// Auth: `roomPresent` capability, plus context access for the principal's key.
 pub const TASK_ROOMS_KEYS_PRESENT_0_1: &str = "https://trusttasks.org/spec/rooms/keys/present/0.1";
 
+/// `spec/rooms/keys/open/0.1` — an agent sends a sealed record and gets its
+/// plaintext. The key never crosses. Auth: `roomOpen` capability.
+pub const TASK_ROOMS_KEYS_OPEN_0_1: &str = "https://trusttasks.org/spec/rooms/keys/open/0.1";
+
+/// `spec/rooms/keys/key-package/0.1` — mint an MLS KeyPackage so a room's
+/// owner has something to add. Auth: a valid invitation for that room.
+pub const TASK_ROOMS_KEYS_KEY_PACKAGE_0_1: &str =
+    "https://trusttasks.org/spec/rooms/keys/key-package/0.1";
+
+/// `spec/rooms/keys/welcome/0.1` — a room's owner delivers an MLS Welcome and
+/// this VTA joins the group. Auth: the invitation, consumed.
+pub const TASK_ROOMS_KEYS_WELCOME_0_1: &str = "https://trusttasks.org/spec/rooms/keys/welcome/0.1";
+
+/// `spec/rooms/keys/commit/0.1` — a room's owner delivers an MLS Commit and
+/// this VTA advances one epoch. Auth: the group itself.
+pub const TASK_ROOMS_KEYS_COMMIT_0_1: &str = "https://trusttasks.org/spec/rooms/keys/commit/0.1";
+
 /// `spec/vta/memory/delete/0.1` — remove one entry by key (`not_found` if
 /// absent). Auth: context access. Payload:
 /// [`crate::protocols::memory::MemoryDeleteBody`].
@@ -1738,6 +1755,10 @@ pub const ALL_URIS: &[&str] = &[
     TASK_VTA_MEMORY_PUT_0_1,
     TASK_VTA_MEMORY_LIST_0_1,
     TASK_ROOMS_KEYS_PRESENT_0_1,
+    TASK_ROOMS_KEYS_OPEN_0_1,
+    TASK_ROOMS_KEYS_KEY_PACKAGE_0_1,
+    TASK_ROOMS_KEYS_WELCOME_0_1,
+    TASK_ROOMS_KEYS_COMMIT_0_1,
     TASK_VTA_MEMORY_DELETE_0_1,
     // Application-state slice (spec/vta/app-state/*)
     TASK_VTA_APP_STATE_GET_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -164,6 +164,11 @@ vta-vault = { path = "../vta-vault", version = "0.5" }
 
 # The room presentation oracle attenuates a member VAC and signs it.
 dtg-credentials = { workspace = true }
+
+# The room MLS layer (custody, sealing) and the credential verifier whose
+# `VerificationKeys` an invitation check resolves through.
+vti-rooms = { path = "../vti-rooms", version = "0.1", features = ["mls"] }
+vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.1" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.
 vta-sweepers = { path = "../vta-sweepers", version = "0.3" }

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -67,6 +67,8 @@ pub mod protocol;
 /// `create_did_webvh`.
 #[cfg(feature = "webvh")]
 pub mod provision_integration;
+pub mod room_groups;
+pub mod room_invitation;
 pub mod room_oracle;
 pub mod seeds;
 pub mod step_up_approval;

--- a/vta-service/src/operations/room_groups.rs
+++ b/vta-service/src/operations/room_groups.rs
@@ -1,0 +1,320 @@
+//! A member's MLS group for each room they belong to.
+//!
+//! The custody half of the room oracle. [`crate::operations::room_oracle`] mints
+//! presentations from credentials; this holds the *keys*, which is what
+//! `rooms/keys/open` needs and what nothing before this stored.
+//!
+//! # Three steps, and the third is the one people forget
+//!
+//! A group arrives once and then has to be kept current:
+//!
+//! 1. [`mint_key_package`] — the joining side produces something the owner can add.
+//! 2. [`join`] — the owner's Welcome arrives and the group exists.
+//! 3. [`apply_commit`] — every membership change after that. **This is not optional.** A
+//!    member who misses one is stuck at their last epoch and can open nothing sealed after
+//!    it, and the symptom is "this record does not open", which reads like corruption
+//!    rather than a missed message.
+//!
+//! # What authorizes each
+//!
+//! Deliberately three different answers, because they are three different acts:
+//!
+//! - **Minting** is gated on holding an invitation, because minting retains a private key
+//!   against a Welcome that may never come. A key-holder that minted for any room on any
+//!   request is one anyone can fill.
+//! - **Joining** is gated on that same invitation, *consumed*. This is where the design's
+//!   "joining is consent" stops being ceremonial: a Welcome carries a group's secrets, and
+//!   a recipient that accepts an uninvited one has made the invitation decorative.
+//! - **Committing** is gated *inside the group* — MLS authenticates the committer as a
+//!   member of the group we already hold. Never from an ACL of our own, which is the same
+//!   rule the rest of the room family follows.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+use vti_rooms::mls::{GroupSnapshot, IdentitySnapshot, RoomGroup};
+use vti_rooms::sealed::SealedRoom;
+
+/// Storage key for a room's group state.
+fn group_key(room_id: &str) -> String {
+    format!("room-group:{room_id}")
+}
+
+/// Storage key for a consumed invitation.
+pub(super) fn invitation_key(credential_id: &str) -> String {
+    format!("room-vic:{credential_id}")
+}
+
+/// A minted key package, awaiting the Welcome that consumes it.
+///
+/// The private half lives in the snapshot; this row *is* the retained key material, which is
+/// why it is bounded rather than kept forever.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingKeyPackage {
+    /// The identity holding the package's private half.
+    pub snapshot: IdentitySnapshot,
+    /// The KeyPackage itself, base64url — public, and what travels to the owner.
+    pub key_package: String,
+    /// Unix seconds after which this is discarded unused.
+    pub expires_at: u64,
+}
+
+/// What this VTA holds for one room.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomGroupRecord {
+    /// The group, at whatever epoch it last reached.
+    pub snapshot: GroupSnapshot,
+    /// The member this group is for.
+    pub member_did: String,
+    /// Unix seconds of the last change.
+    pub updated_at: u64,
+}
+
+/// Mint an MLS KeyPackage for `room_id` and retain its private half.
+///
+/// **Per room, never reused across rooms.** A KeyPackage is a stable public identifier, so
+/// the same one offered to two rooms tells anyone who sees both that one party is in both —
+/// the correlation a `private` room exists to deny, arriving through the door rather than
+/// the wall.
+pub async fn mint_key_package(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    member_did: &str,
+    lifetime_secs: u64,
+    now: u64,
+) -> Result<PendingKeyPackage, AppError> {
+    let (snapshot, package) = IdentitySnapshot::mint(member_did)
+        .map_err(|e| AppError::Internal(format!("mint a key package: {e}")))?;
+
+    let pending = PendingKeyPackage {
+        snapshot,
+        key_package: B64.encode(&package),
+        expires_at: now + lifetime_secs,
+    };
+    groups
+        .insert(pending_key(room_id), &pending)
+        .await
+        .map_err(|e| AppError::Internal(format!("store the pending key package: {e}")))?;
+    Ok(pending)
+}
+
+/// Storage key for a pending key package.
+fn pending_key(room_id: &str) -> String {
+    format!("room-kp:{room_id}")
+}
+
+/// Join `room_id`'s group from a Welcome.
+///
+/// Refuses a second join rather than merging: two group states for one room is a condition
+/// nothing downstream can resolve — [`open`] has no way to choose, and choosing wrong
+/// returns "did not open" for a record the member can plainly see.
+pub async fn join(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    member_did: &str,
+    welcome: &[u8],
+    now: u64,
+) -> Result<u64, AppError> {
+    if load(groups, room_id).await?.is_some() {
+        return Err(AppError::Conflict(format!(
+            "this VTA already holds group state for room `{room_id}`; leaving and rejoining \
+             is a removal and a fresh invitation, not a second welcome"
+        )));
+    }
+
+    // The KeyPackage the owner added is the one we minted, so the private half is in the
+    // pending record — joining with a fresh identity would produce a group whose leaf
+    // nobody added.
+    let pending: Option<PendingKeyPackage> = groups
+        .get(pending_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("read the pending key package: {e}")))?;
+    let pending = pending.ok_or_else(|| {
+        AppError::Validation(format!(
+            "no key package was minted for room `{room_id}`; a welcome can only be accepted \
+             against the package the owner was given"
+        ))
+    })?;
+
+    let group = RoomGroup::join_from_identity(&pending.snapshot, welcome)
+        .map_err(|e| AppError::Validation(format!("the welcome did not process: {e}")))?;
+    let epoch = group.epoch();
+
+    store(groups, room_id, member_did, &group, now).await?;
+    // The package is consumed. MLS consumes it on add, and a retained private half for a
+    // used package is key material kept for nothing.
+    groups
+        .remove(pending_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("clear the pending key package: {e}")))?;
+    Ok(epoch)
+}
+
+/// Apply a commit, advancing one epoch.
+///
+/// Ordering is the whole contract. A replay is a no-op success — a retry that failed would
+/// make every unreliable transport a liveness problem — and a gap is refused with the epoch
+/// we actually hold, so the sender resumes rather than guesses.
+pub async fn apply_commit(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    commit: &[u8],
+    claimed_epoch: u64,
+    now: u64,
+) -> Result<u64, AppError> {
+    let record = load(groups, room_id).await?.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "this VTA holds no group state for room `{room_id}`"
+        ))
+    })?;
+    let mut group = RoomGroup::restore(&record.snapshot)
+        .map_err(|e| AppError::Internal(format!("restore the group: {e}")))?;
+    let current = group.epoch();
+
+    if claimed_epoch == current {
+        // Already applied. Reporting success with the unchanged epoch is what makes
+        // delivery retryable.
+        return Ok(current);
+    }
+    if claimed_epoch != current + 1 {
+        return Err(AppError::Conflict(format!(
+            "commit produces epoch {claimed_epoch} but room `{room_id}` is at {current}; \
+             resume from {}",
+            current + 1
+        )));
+    }
+
+    group
+        .apply_commit(commit)
+        .map_err(|e| AppError::Validation(format!("the commit did not process: {e}")))?;
+    let epoch = group.epoch();
+    store(groups, room_id, &record.member_did, &group, now).await?;
+    Ok(epoch)
+}
+
+/// Open a sealed record with the room's group key.
+///
+/// The key never leaves. That is the whole design: the caller sends ciphertext and gets
+/// plaintext, and an oracle that returned the key would be a key-release call wearing a
+/// different name.
+pub async fn open_record(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    key: &str,
+    version: u64,
+    ciphertext: &str,
+    nonce: &str,
+    epoch: u32,
+) -> Result<Vec<u8>, AppError> {
+    let record = load(groups, room_id).await?.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "this VTA holds no group state for room `{room_id}`"
+        ))
+    })?;
+    let group = RoomGroup::restore(&record.snapshot)
+        .map_err(|e| AppError::Internal(format!("restore the group: {e}")))?;
+
+    let held = group.epoch() + 1;
+    if u64::from(epoch) > held {
+        // Saying which epoch we hold turns "it does not open" — which reads like corruption
+        // — into "you are behind", which an operator can act on.
+        return Err(AppError::Validation(format!(
+            "record is sealed under epoch {epoch} and this VTA holds room `{room_id}` at \
+             epoch {held}; a commit has not been delivered"
+        )));
+    }
+
+    SealedRoom::new(room_id, group)
+        .open_record(
+            key,
+            version,
+            &vti_rooms::wire::SealedContent {
+                ciphertext: ciphertext.to_string(),
+                nonce: nonce.to_string(),
+                epoch,
+            },
+        )
+        .map_err(|e| AppError::Validation(e.to_string()))
+}
+
+/// Record an invitation as consumed, refusing a second use.
+///
+/// Single use means single use, and this record is the only thing that remembers. It
+/// deliberately outlives the group it admitted: a member who leaves a room discards the
+/// group, and without this row the same invitation would let them be re-added with no fresh
+/// consent from the owner.
+pub async fn consume_invitation(
+    invitations: &KeyspaceHandle,
+    credential_id: &str,
+    room_id: &str,
+    now: u64,
+) -> Result<(), AppError> {
+    let key = invitation_key(credential_id);
+    if invitations
+        .get_raw(key.clone())
+        .await
+        .map_err(|e| AppError::Internal(format!("read the invitation record: {e}")))?
+        .is_some()
+    {
+        return Err(AppError::Conflict(format!(
+            "invitation `{credential_id}` has already been used"
+        )));
+    }
+    invitations
+        .insert(
+            key,
+            &serde_json::json!({ "roomId": room_id, "consumedAt": now }),
+        )
+        .await
+        .map_err(|e| AppError::Internal(format!("record the invitation: {e}")))
+}
+
+/// The group this VTA holds for `room_id`, if any.
+pub async fn load(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+) -> Result<Option<RoomGroupRecord>, AppError> {
+    groups
+        .get(group_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("read group state for `{room_id}`: {e}")))
+}
+
+async fn store(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    member_did: &str,
+    group: &RoomGroup,
+    now: u64,
+) -> Result<(), AppError> {
+    let record = RoomGroupRecord {
+        snapshot: group
+            .snapshot()
+            .map_err(|e| AppError::Internal(format!("snapshot the group: {e}")))?,
+        member_did: member_did.to_string(),
+        updated_at: now,
+    };
+    groups
+        .insert(group_key(room_id), &record)
+        .await
+        .map_err(|e| AppError::Internal(format!("store group state for `{room_id}`: {e}")))
+}
+
+/// Discard everything this VTA holds for a room.
+///
+/// Called on removal from the group. A key-holder that kept its state would retain the
+/// ability to open everything sealed up to the epoch it was removed at — which is exactly
+/// what the removal was for.
+pub async fn forget(groups: &KeyspaceHandle, room_id: &str) -> Result<(), AppError> {
+    groups
+        .remove(group_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("discard group state for `{room_id}`: {e}")))?;
+    groups
+        .remove(pending_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("discard a pending key package: {e}")))
+}

--- a/vta-service/src/operations/room_invitation.rs
+++ b/vta-service/src/operations/room_invitation.rs
@@ -1,0 +1,168 @@
+//! Verifying a room invitation, and consuming it exactly once.
+//!
+//! This is the gate `rooms/keys/welcome` puts its weight on. A Welcome carries a group's
+//! secrets, so anyone able to reach a VTA could otherwise push group state into it — filling
+//! its storage at best, and at worst making it hold keys for a room nobody agreed to join.
+//!
+//! The answer was already in the design and only needed connecting: **joining a room is a
+//! two-party act, and the invitation is the consent artefact**. This module is where that
+//! stops being ceremonial. A VTA that accepted an uninvited Welcome would have made the
+//! invitation decorative.
+//!
+//! # Five checks, and none of them is optional
+//!
+//! 1. It parses as a DTG credential, and it is an **invitation** — not some other credential
+//!    the sender had lying around.
+//! 2. Its **proof verifies**. Everything below is a claim until this holds; a well-formed
+//!    invitation naming anyone is trivial to write.
+//! 3. The **issuer is the room**. An invitation to a different room is not an invitation to
+//!    this one, however valid.
+//! 4. The **subject is us**. An invitation issued to somebody else is not transferable, and
+//!    accepting one would let a third party place a member into a room they were invited to.
+//! 5. It is **within its validity window**, and **not already consumed**.
+//!
+//! Dropping any one of them leaves a way in. The order is deliberate too: the cheap
+//! structural checks come before the signature verification, which comes before the storage
+//! read, so a malformed or irrelevant credential costs nothing.
+
+use chrono::Utc;
+use dtg_credentials::{DTGCredential, DTGCredentialType};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+use vti_rooms_dtg::VerificationKeys;
+
+/// A verified, not-yet-consumed invitation.
+///
+/// Constructible only by [`verify`], so a caller cannot reach the consumption step with an
+/// invitation nobody checked — the same typestate discipline the workspace uses for verified
+/// wire forms.
+#[derive(Debug)]
+pub struct VerifiedInvitation {
+    credential_id: String,
+    subject: String,
+}
+
+impl VerifiedInvitation {
+    /// The credential's own id, which is what consumption records.
+    pub fn credential_id(&self) -> &str {
+        &self.credential_id
+    }
+    /// The party invited — established by the credential, not claimed by the sender.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+}
+
+/// Verify an invitation for `room_id` naming `expected_subject`.
+///
+/// `keys` resolves the issuer's verification method. Failing to resolve is a refusal, never
+/// a pass: a VTA that treated an unresolvable issuer as "probably fine" would have stopped
+/// checking signatures.
+pub async fn verify(
+    encoded: &str,
+    room_id: &str,
+    expected_subject: &str,
+    keys: &dyn VerificationKeys,
+) -> Result<VerifiedInvitation, AppError> {
+    let credential: DTGCredential = decode(encoded)?;
+
+    if !matches!(credential.type_(), DTGCredentialType::Invitation) {
+        return Err(AppError::Validation(format!(
+            "the presented credential is a {}, not an invitation",
+            credential.type_()
+        )));
+    }
+    if credential.issuer() != room_id {
+        return Err(AppError::Validation(format!(
+            "the invitation was issued by `{}`, not by room `{room_id}`",
+            credential.issuer()
+        )));
+    }
+    if credential.subject() != expected_subject {
+        return Err(AppError::Validation(format!(
+            "the invitation names `{}`, not this member; an invitation is not transferable",
+            credential.subject()
+        )));
+    }
+
+    let now = Utc::now();
+    let common = credential.credential();
+    if common.valid_from > now {
+        return Err(AppError::Validation(
+            "the invitation is not valid yet".into(),
+        ));
+    }
+    if let Some(until) = common.valid_until
+        && until < now
+    {
+        return Err(AppError::Validation("the invitation has expired".into()));
+    }
+
+    // Everything above is a claim until this holds.
+    let proof = common
+        .proof
+        .as_ref()
+        .ok_or_else(|| AppError::Validation("the invitation carries no proof".into()))?;
+    let key = keys
+        .public_key(&proof.verification_method)
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                verification_method = %proof.verification_method,
+                error = %e,
+                "could not resolve an invitation's verification method"
+            );
+            AppError::Validation("the invitation could not be verified".into())
+        })?;
+    credential.verify_proof_with_public_key(&key).map_err(|e| {
+        tracing::warn!(error = %e, "an invitation's proof did not verify");
+        AppError::Validation("the invitation could not be verified".into())
+    })?;
+
+    Ok(VerifiedInvitation {
+        credential_id: credential
+            .id()
+            .ok_or_else(|| {
+                // Without an id there is nothing to record as consumed, so single-use
+                // cannot be enforced — and an invitation that cannot be spent is one that
+                // can be spent forever.
+                AppError::Validation(
+                    "the invitation carries no id, so it cannot be recorded as used".into(),
+                )
+            })?
+            .to_string(),
+        subject: credential.subject().to_string(),
+    })
+}
+
+/// Accept base64url or bare JSON — the same profile the room verifier reads.
+fn decode(encoded: &str) -> Result<DTGCredential, AppError> {
+    use base64::Engine as _;
+    let bytes = if encoded.trim_start().starts_with('{') {
+        encoded.as_bytes().to_vec()
+    } else {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded.trim())
+            .map_err(|_| {
+                AppError::Validation(
+                    "the invitation is neither base64url nor JSON; one that cannot be read \
+                     cannot be verified"
+                        .into(),
+                )
+            })?
+    };
+    serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Validation(format!("the invitation is not a DTG credential: {e}")))
+}
+
+/// Whether this invitation has already been spent.
+pub async fn is_consumed(
+    invitations: &KeyspaceHandle,
+    credential_id: &str,
+) -> Result<bool, AppError> {
+    Ok(invitations
+        .get_raw(super::room_groups::invitation_key(credential_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("read the invitation record: {e}")))?
+        .is_some())
+}

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -181,6 +181,11 @@ pub struct AppState {
     /// delete}/0.1`). Entries keyed `mem:<contextId>:<key>`; gated on context
     /// access. Durable user data.
     pub memory_ks: KeyspaceHandle,
+    /// A member's MLS group for each room they belong to. Group secrets — see
+    /// [`crate::keyspaces::ROOM_GROUPS`].
+    pub room_groups_ks: KeyspaceHandle,
+    /// Invitations already spent joining a room.
+    pub room_invitations_ks: KeyspaceHandle,
     /// Versioned, namespaced application state (`vta/app-state/*`) — the third
     /// store, beside the vault and agent memory, for JSON an application owns
     /// and the VTA does not interpret. Records keyed
@@ -431,6 +436,11 @@ pub async fn build_app_state(
     let issued_credentials_ks =
         apply_encryption(store.keyspace(crate::keyspaces::ISSUED_CREDENTIALS)?);
     let memory_ks = apply_encryption(store.keyspace(crate::keyspaces::MEMORY)?);
+    // Encrypted alongside the key store where a TEE deployment provides a storage key: a
+    // group snapshot decrypts every record its room holds, which is the same class of
+    // material as a derived key and deserves the same treatment.
+    let room_groups_ks = apply_encryption(store.keyspace(crate::keyspaces::ROOM_GROUPS)?);
+    let room_invitations_ks = apply_encryption(store.keyspace(crate::keyspaces::ROOM_INVITATIONS)?);
     let app_state_ks = apply_encryption(store.keyspace(crate::keyspaces::APP_STATE)?);
     let policy_ks = apply_encryption(store.keyspace(crate::keyspaces::POLICY)?);
     let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
@@ -510,6 +520,8 @@ pub async fn build_app_state(
         consent_approvers_ks,
         issued_credentials_ks,
         memory_ks,
+        room_groups_ks,
+        room_invitations_ks,
         app_state_ks,
         app_state_locks: crate::operations::app_state::NamespaceLocks::default(),
         policy_ks,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1192,6 +1192,8 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
             .keyspace(crate::keyspaces::ISSUED_CREDENTIALS)
             .unwrap(),
         memory_ks: store.keyspace(crate::keyspaces::MEMORY).unwrap(),
+        room_groups_ks: store.keyspace(crate::keyspaces::ROOM_GROUPS).unwrap(),
+        room_invitations_ks: store.keyspace(crate::keyspaces::ROOM_INVITATIONS).unwrap(),
         app_state_ks: store.keyspace(crate::keyspaces::APP_STATE).unwrap(),
         app_state_locks: crate::operations::app_state::NamespaceLocks::default(),
         policy_ks: policy_ks.clone(),

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -1977,6 +1977,72 @@ fn table() -> Vec<(&'static str, Conformance)> {
         ),
         // ─── rooms/keys ──────────────────────────────────────────
         //
+        // `open` is the decryption oracle: ciphertext in, plaintext out, and
+        // the key crosses in neither direction. The witness pins both halves
+        // base64url, because a plaintext returned as anything else would be a
+        // wire change nobody declared.
+        // The three delivery tasks. Each witness pins the member the *other* side
+        // depends on: the invitation (without which a Welcome is refused), the
+        // epoch a commit claims (which is how a replay is told from a gap), and
+        // the expiry on a minted package (which is what bounds retained key
+        // material).
+        (
+            uris::TASK_ROOMS_KEYS_KEY_PACKAGE_0_1,
+            checked!(
+                specs::rooms::keys::key_package::v0_1::Payload,
+                specs::rooms::keys::key_package::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "invitation": "eyJpZCI6InVybjp1dWlkOnZpYy0xIn0"
+                }),
+                json!({ "keyPackage": "AAECAwQFBgcICQ", "expiresAt": TS })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_KEYS_WELCOME_0_1,
+            checked!(
+                specs::rooms::keys::welcome::v0_1::Payload,
+                specs::rooms::keys::welcome::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "welcome": "AAECAwQFBgcICQ",
+                    "invitation": "eyJpZCI6InVybjp1dWlkOnZpYy0xIn0"
+                }),
+                json!({ "epoch": 7 })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_KEYS_COMMIT_0_1,
+            checked!(
+                specs::rooms::keys::commit::v0_1::Payload,
+                specs::rooms::keys::commit::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "commit": "AAECAwQFBgcICQ",
+                    "epoch": 8
+                }),
+                json!({ "epoch": 8 })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_KEYS_OPEN_0_1,
+            checked!(
+                specs::rooms::keys::open::v0_1::Payload,
+                specs::rooms::keys::open::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "key": "giXFLTGBdnnQJRoIsktuIg",
+                    "version": 1,
+                    "sealed": {
+                        "ciphertext": "1ep1PJuf8-yNmTndwcuMxA",
+                        "nonce": "AAAAAAAAAAAAAAAA",
+                        "epoch": 1
+                    }
+                }),
+                json!({ "plaintext": "YSBkZWNpc2lvbg" })
+            ),
+        ),
+        //
         // The only `rooms/*` task this agent serves: the oracle side, where a
         // member's own VTA mints a scoped presentation for their agent. The
         // room tasks proper are a host's surface, not an agent's.

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -83,6 +83,7 @@ mod policy_gate;
 mod produced_census;
 #[cfg(feature = "webvh")]
 mod provision_integration;
+mod room_group;
 mod room_keys;
 mod seeds;
 // `operations::protocol` — every service operation these handlers call — is
@@ -1533,6 +1534,17 @@ dispatch_table! {
     // credentials. Gated on the `roomPresent` capability plus context access
     // for the principal's key — NOT on `Sign`, which would grant far more.
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1 => room_keys::handle_present
+        [ None Metadata false ],
+    // Group custody: how a group reaches this VTA, and what it does with one.
+    // Three inbound (a room's owner reaching us) and one outbound-facing; only
+    // `open` is capability-gated, because only it is our own principal asking.
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_KEY_PACKAGE_0_1 => room_group::handle_key_package
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_WELCOME_0_1 => room_group::handle_welcome
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_COMMIT_0_1 => room_group::handle_commit
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_OPEN_0_1 => room_group::handle_open
         [ None Metadata false ],
     // ─── Application-state slice (spec/vta/app-state/*) ──────────
     // Versioned, namespaced per-context JSON the VTA stores but never

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -1,0 +1,329 @@
+//! The room group slice — `spec/rooms/keys/{key-package,welcome,commit,open}`.
+//!
+//! How a group reaches a key-holding agent, and what it does once it has one. The
+//! orchestration is [`crate::operations::room_groups`]; this is the dispatch surface.
+//!
+//! # Four tasks, four different gates
+//!
+//! Deliberately not one gate applied four times, because these are four different acts:
+//!
+//! | | authorized by |
+//! |---|---|
+//! | `key-package` | an invitation — minting retains a private key, so a VTA that minted for anyone is one anyone can fill |
+//! | `welcome` | that same invitation, **consumed** |
+//! | `commit` | the group itself — MLS authenticates the committer as a member of the group we already hold |
+//! | `open` | [`Capability::RoomOpen`] |
+//!
+//! Only the last is a capability, and that asymmetry is the point. The first three are
+//! *inbound* — a room's owner reaching this VTA — and an ACL of ours has no opinion about
+//! who a room's owner is. The fourth is our own principal's agent asking us to decrypt, and
+//! that is exactly what a capability is for.
+//!
+//! # Every request type here is generated
+//!
+//! `rooms/keys/{key-package,welcome,commit}` merged upstream in
+//! `trustoverip/dtgwg-trust-tasks-tf#355` and released in `trust-tasks-rs` 0.17.8, so none
+//! of the four needs a hand-written request body. Only the responses are local, because a
+//! handler returns a struct rather than a `Value`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use trust_tasks_rs::{RejectReason, TrustTask};
+use vti_common::acl::{Capability, role_has_capability};
+
+use crate::audit;
+use crate::auth::AuthClaims;
+use crate::operations::{room_groups, room_invitation};
+use crate::server::AppState;
+
+use super::helpers::{
+    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, reject_with,
+    success_response,
+};
+
+/// How long an unused KeyPackage's private half is retained.
+///
+/// Bounded because the private half *is* retained key material: a caller that minted and
+/// never joined has left a key behind, and one that minted repeatedly has left a pile.
+const KEY_PACKAGE_LIFETIME_SECS: u64 = 7 * 24 * 60 * 60;
+
+// ─── Response types ──────────────────────────────────────────────────────
+//
+// Requests come from the generated bindings; only the responses are written
+// here, and only because a handler returns a struct rather than a `Value`.
+
+/// `rooms/keys/key-package/0.1#response`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyPackageResponse {
+    pub key_package: String,
+    pub expires_at: String,
+}
+
+/// `rooms/keys/welcome/0.1#response`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WelcomeResponse {
+    pub epoch: u64,
+}
+
+/// `rooms/keys/commit/0.1#response`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitResponse {
+    pub epoch: u64,
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────
+
+/// `rooms/keys/key-package/0.1`.
+pub(super) async fn handle_key_package(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: trust_tasks_rs::specs::rooms::keys::key_package::v0_1::Payload =
+        match parse_payload(&doc) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
+
+    // Minting retains a private key against a Welcome that may never come, so it is not
+    // free and is not offered unconditionally.
+    if let Err(e) =
+        require_invitation(state, req.invitation.as_deref(), &req.room_id, &auth.did).await
+    {
+        return app_error_to_reject(&doc, e);
+    }
+
+    let minted = match room_groups::mint_key_package(
+        &state.room_groups_ks,
+        &req.room_id,
+        &auth.did,
+        KEY_PACKAGE_LIFETIME_SECS,
+        now(),
+    )
+    .await
+    {
+        Ok(m) => m,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    record(state, "rooms.keys.key-package", auth, &req.room_id).await;
+    success_response(
+        &doc,
+        KeyPackageResponse {
+            key_package: minted.key_package,
+            expires_at: rfc3339(minted.expires_at),
+        },
+    )
+}
+
+/// `rooms/keys/welcome/0.1`.
+pub(super) async fn handle_welcome(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: trust_tasks_rs::specs::rooms::keys::welcome::v0_1::Payload = match parse_payload(&doc)
+    {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    // The load-bearing gate. A Welcome carries a group's secrets; without a matching
+    // invitation this VTA would be accepting key material for a room nobody agreed to join.
+    let invitation =
+        match require_invitation(state, req.invitation.as_deref(), &req.room_id, &auth.did).await {
+            Ok(i) => i,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+
+    let welcome = match decode_b64(&req.welcome, "welcome") {
+        Ok(b) => b,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    let epoch = match room_groups::join(
+        &state.room_groups_ks,
+        &req.room_id,
+        invitation.subject(),
+        &welcome,
+        now(),
+    )
+    .await
+    {
+        Ok(e) => e,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // Consumed only after the join succeeded. Burning it on a Welcome that then failed to
+    // process would strand the member: the invitation is spent and they are not in.
+    if let Err(e) = room_groups::consume_invitation(
+        &state.room_invitations_ks,
+        invitation.credential_id(),
+        &req.room_id,
+        now(),
+    )
+    .await
+    {
+        return app_error_to_reject(&doc, e);
+    }
+
+    record(state, "rooms.keys.welcome", auth, &req.room_id).await;
+    success_response(&doc, WelcomeResponse { epoch })
+}
+
+/// `rooms/keys/commit/0.1`.
+pub(super) async fn handle_commit(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: trust_tasks_rs::specs::rooms::keys::commit::v0_1::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let commit = match decode_b64(&req.commit, "commit") {
+        Ok(b) => b,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // No gate of ours. MLS authenticates the committer as a member of the group we already
+    // hold, and an ACL here would be this service deciding who may commit to a room it is
+    // not part of — the mistake the whole family is arranged to avoid.
+    let epoch = match room_groups::apply_commit(
+        &state.room_groups_ks,
+        &req.room_id,
+        &commit,
+        u64::from(req.epoch),
+        now(),
+    )
+    .await
+    {
+        Ok(e) => e,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    record(state, "rooms.keys.commit", auth, &req.room_id).await;
+    success_response(&doc, CommitResponse { epoch })
+}
+
+/// `rooms/keys/open/0.1`.
+pub(super) async fn handle_open(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if !role_has_capability(&auth.role, Capability::RoomOpen) {
+        return reject_with(
+            &doc,
+            RejectReason::PermissionDenied {
+                reason: format!(
+                    "opening a room record denied: role {} does not carry RoomOpen",
+                    auth.role
+                ),
+            },
+        );
+    }
+
+    let req: trust_tasks_rs::specs::rooms::keys::open::v0_1::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let plaintext = match room_groups::open_record(
+        &state.room_groups_ks,
+        &req.room_id,
+        &req.key,
+        u64::from(req.version),
+        &req.sealed.ciphertext,
+        &req.sealed.nonce,
+        u32::try_from(u64::from(req.sealed.epoch)).unwrap_or(u32::MAX),
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    record(state, "rooms.keys.open", auth, &req.room_id).await;
+    success_response(
+        &doc,
+        serde_json::json!({
+            "plaintext": base64::Engine::encode(
+                &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+                &plaintext,
+            )
+        }),
+    )
+}
+
+// ─── Shared ──────────────────────────────────────────────────────────────
+
+/// Verify the invitation, and refuse if it is missing, bad, or already spent.
+async fn require_invitation(
+    state: &AppState,
+    encoded: Option<&str>,
+    room_id: &str,
+    member_did: &str,
+) -> Result<room_invitation::VerifiedInvitation, vti_common::error::AppError> {
+    let encoded = encoded.ok_or_else(|| {
+        vti_common::error::AppError::Validation(format!(
+            "no invitation presented for room `{room_id}`; joining a room is a two-party \
+             act and the invitation is the other party's half"
+        ))
+    })?;
+
+    let keys = vti_rooms_dtg::DataIntegrityKeys(state.trust_task_vm_resolver());
+    let invitation = room_invitation::verify(encoded, room_id, member_did, &keys).await?;
+
+    if room_invitation::is_consumed(&state.room_invitations_ks, invitation.credential_id()).await? {
+        return Err(vti_common::error::AppError::Conflict(format!(
+            "invitation `{}` has already been used",
+            invitation.credential_id()
+        )));
+    }
+    Ok(invitation)
+}
+
+fn decode_b64(s: &str, what: &str) -> Result<Vec<u8>, vti_common::error::AppError> {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(s.trim())
+        .map_err(|e| vti_common::error::AppError::Validation(format!("decode the {what}: {e}")))
+}
+
+fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn rfc3339(unix_seconds: u64) -> String {
+    chrono::DateTime::from_timestamp(unix_seconds as i64, 0)
+        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).expect("epoch is in range"))
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+/// Audit one group operation.
+///
+/// Every one of these is consequential: joining a room, advancing its keys, or opening one
+/// of its records. "Which agent got into which room, and when" is the sentence an incident
+/// review needs, and none of it is reconstructible from anywhere else.
+async fn record(state: &AppState, action: &str, auth: &AuthClaims, room_id: &str) {
+    if let Err(e) = audit::record(
+        &state.audit_sink,
+        action,
+        &auth.did,
+        Some(room_id),
+        "success",
+        Some(TRANSPORT_TRUST_TASK),
+        None,
+    )
+    .await
+    {
+        tracing::error!(error = %e, action, "failed to record a room-group audit entry");
+    }
+}

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -168,6 +168,14 @@ pub enum Capability {
     /// Withheld from [`Role::Reader`]: minting a credential on a principal's
     /// behalf is not a read.
     RoomPresent,
+    /// Asking this VTA to open a sealed room record — `rooms/keys/open/0.1`.
+    ///
+    /// Registered upstream as `roomOpen` alongside `roomPresent`
+    /// (`trustoverip/dtgwg-trust-tasks-tf` #351), and separate from it on
+    /// purpose: producing a presentation and decrypting a record are different
+    /// powers. An agent that indexes a room — walking the listing and building
+    /// a searchable view — should not thereby be able to read it.
+    RoomOpen,
 }
 
 /// Returns true if `role` is granted `cap` by the default capability
@@ -191,6 +199,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::MemoryRead,
             Capability::MemoryWrite,
             Capability::RoomPresent,
+            Capability::RoomOpen,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::PolicyAdmin,
@@ -206,6 +215,7 @@ pub fn derived_capabilities_for_role(role: &Role) -> Vec<Capability> {
             Capability::MemoryRead,
             Capability::MemoryWrite,
             Capability::RoomPresent,
+            Capability::RoomOpen,
             Capability::ProxyLogin,
             Capability::FillRelease,
             Capability::DeviceAdmin,


### PR DESCRIPTION
Implements `rooms/keys/{key-package,welcome,commit,open}` — the delivery flow specified in trustoverip/dtgwg-trust-tasks-tf#355 and the decryption oracle from #349, on the custody layer from #1248.

**This is the piece that makes a data room readable by an agent that never holds a key.**

## Four tasks, four different gates — and only one is a capability

| | authorized by |
|---|---|
| `key-package` | an invitation — minting retains a private key, so a VTA that minted for anyone is one anyone can fill |
| `welcome` | that same invitation, **consumed** |
| `commit` | the group itself — MLS authenticates the committer as a member of the group we already hold |
| `open` | `Capability::RoomOpen` |

The asymmetry is the point. The delivery three are *inbound* — a room's owner reaching this VTA — and an ACL of ours has no opinion about who a room's owner is. `commit` especially: a list we kept would be this service deciding who may commit to a room it isn't part of. Only `open` is our own principal's agent asking us to decrypt.

## The invitation is what makes a Welcome acceptable

A Welcome carries a **group's secrets**, so anyone able to reach a VTA could otherwise push group state into it. §4.1 already said joining is consent and the VIC is the artefact; this is where that stops being ceremonial.

Five checks, none optional — it parses as an invitation, its proof verifies, the issuer is the room, the subject is us, and it's live and unspent. Dropping any one leaves a way in. `VerifiedInvitation` is constructible only by the verifier, so a caller can't reach consumption with something nobody checked.

**Consumed only after the join succeeds.** Burning it on a Welcome that then failed to process would strand the member: invitation spent, not in the room.

**Joining twice is refused, not merged.** Two group states for one room is a condition nothing downstream can resolve — `open` has no way to choose, and choosing wrong returns "did not open" for a record the member can plainly see.

## A missed commit says so

`open` reports **which epoch the VTA holds** when a record is sealed under a later one. A member who missed a commit is stuck at their last epoch, and the raw symptom is "this record does not open" — which reads like corruption. Naming the epoch turns it into "a commit has not been delivered", which an operator can act on.

## Two keyspaces, both `Cascade`

`room_groups` holds group secrets and belongs at the same protection level as the key store. `room_invitations` **outlives the groups it admitted**: while the member exists, a consumed invitation must survive leaving a room, or the same invitation would work twice.

## Four censuses, and the retry one earned its keep

- **MCP guard** — `open` and `welcome` are `Sensitive` (plaintext out, key material in); `key-package` and `commit` are ordinary mutations.
- **Retry safety** — four *different* answers, which is a good sign the classification is real: `open` is `ReadOnly`; `commit` is `RetrySafe` because the spec made replay a no-op precisely so delivery could retry; `key-package` and `welcome` are `Keyed` — one leaves a second private half behind, the other can't tell a lost reply from a completed join.
- Conformance witnesses and the canonical-namespace list.

## A note on timing

`trust-tasks-rs` 0.17.8 landed mid-build carrying #351, #354 and #355 — so all four request types are **generated** rather than hand-written, and the debt census that would otherwise have blocked three of them is satisfied at the source rather than by an allowlist entry.

## Verified

`cargo clippy --workspace --all-targets --all-features` clean; `cargo test --workspace` with no failures, including all `vta-service` trust-task censuses.