### PR TITLE
feat(rooms): succession, so a room outlives one person's availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9599,9 +9599,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9560f2e6bb5e0958674adc0625d4eb592e078554a9284d292e286e7fb49c338"
+checksum = "c858ac6e7f0c8b7600bf643312c90ed5ac3c5cb4637d2baacd9fa0ccf64ee688"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10826,6 +10826,7 @@ dependencies = [
  "vta-sdk",
  "vti-common",
  "vti-rooms",
+ "vti-rooms-dtg",
 ]
 
 [[package]]

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -769,6 +769,31 @@ not the host's.
 The specs were corrected upstream rather than worked around
 (`dtgwg-trust-tasks-tf#361`), which is what implementation is for.
 
+### 10.5 DID rotation — open
+
+Two places in this note point here for an answer (§5.4, §14.2) and there has
+never been a §10.5 to point at. It is written now as an explicitly open
+subsection rather than left as a dangling forward reference, because the two
+readers who followed it deserved to find the question rather than nothing.
+
+**The question.** An owner rotates the key controlling the room's DID. Every
+credential the room ever issued names a `verificationMethod` under the old key.
+Witnessed pre-rotation (§3.2) is what makes the rotation itself verifiable, and
+it settles the *chain of control* — it does not settle **identity assurance**:
+who confirms the party presenting the rotated key is the same person, and on
+what evidence.
+
+That is human judgement, and it is the same judgement §5.4's k-of-n re-admission
+quorum has to exercise about a returning member. Neither has an answer here, and
+inventing two separate ones would be worse than having none: they are the same
+problem, and a design that solved it twice would be solving it differently.
+
+**What succession does not need it for.** Worth stating so the dependency is not
+assumed. Transfer and claim both turn on credentials the room issued and on the
+room's own lifecycle clock — neither asks who a party *is*, only what the room
+said about them. Succession is therefore implementable, and implemented, while
+this stays open.
+
 ---
 
 ## 11. Prior art, taken and declined

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -704,6 +704,71 @@ committer, accountable party, lifecycle addressee (I1's several jobs).
   reaching a room, not the room's possession of what was contributed.
 - **Deletion** in-room stays tombstone-then-purge, two verbs, per §6.
 
+### 10.1 The two verbs, and what each one has to prove
+
+`rooms/owner/transfer` and `rooms/owner/claim` are the same storage effect
+reached along two entirely different routes. Transfer is the owner acting while
+present, gated on `admin` — the same grant that mints epochs, since handing over
+the room is the more consequential of the two. Claim is what happens when they
+are not, and it needs three things at once:
+
+1. a **nomination** the room itself issued, naming this claimant, in its window;
+2. the room **dormant** — not merely lapsed;
+3. the claimant's own **membership**, presented as every other room task does.
+
+Each closes a different route to a takeover. A nomination alone does nothing
+while the owner renews; a dormant room alone does nothing without a nomination;
+and neither helps a claimant who could not commit once they had it.
+
+**A nomination is a VAC granting `succeed`** — deliberately a word no room task
+accepts. It confers nothing at all while the owner is present, and is redeemable
+through exactly one path. That is also why `succeed` is not a `vti_rooms::authz::Action`
+variant: `authorize` cannot be handed it, so no later edit there can quietly turn
+a nomination into a working grant.
+
+### 10.2 Renewing is the defence, and it is the same act as ordinary use
+
+The property worth noticing is in condition 2. An owner who was merely away
+defeats every pending claim by minting an epoch — which is what they would have
+done anyway. Nothing has to be revoked, no dispute has to be raised, and an owner
+who is present is structurally safe from succession **without ever thinking about
+it.** Security that requires no vigilance is the only kind that survives contact
+with people on holiday.
+
+Hence dormancy rather than lapse. An epoch expiring is frequently somebody away
+for a fortnight; a room still unrenewed after the grace window is a room whose
+owner has stopped, and has had a notice saying so. A takeover window that opened
+the moment an epoch expired would make every holiday one.
+
+### 10.3 A claim does not renew the room
+
+`set_owner` hands over a dormant room and leaves it dormant. The new owner's
+first act should be the one that proves they can perform it — a claim that
+silently renewed would hand the room to someone who might turn out to be unable
+to commit, with the room looking healthy until the next lapse a year later. If
+they do not renew, the next nominee can claim in turn, which is the succession
+chain working rather than failing.
+
+### 10.4 What a host cannot check, and must not pretend to
+
+Both specs required a host to confirm the incoming owner is a member of the MLS
+group. **A host cannot see the group** — it holds no roster and no group state,
+by construction (I5, §7.2). Two wrong responses were available and both are worse
+than doing nothing: refusing what it cannot verify fails *every* transfer,
+including every correct one; and treating its own ignorance as evidence converts
+"I don't know" into "no".
+
+So on transfer the check is simply absent, and what protects the incoming owner
+is that the outgoing one holds `admin` and knows the roster. On claim the host
+uses the one signal it does have — the VMC the room itself issued, which is the
+room's own statement that this party is a member. That is a proxy and a good one,
+but an exact one: a party removed from the group while still holding an unexpired
+VMC would pass. Closing that gap is the room's job, by revoking the credential,
+not the host's.
+
+The specs were corrected upstream rather than worked around
+(`dtgwg-trust-tasks-tf#361`), which is what implementation is for.
+
 ---
 
 ## 11. Prior art, taken and declined

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -24,6 +24,10 @@
 //!    refused, because the chain is bound to whoever signed the request.
 //! 4. **The host holds every byte and can neither read nor move one.** Act III seals
 //!    *through* the host, and then fails to open a relocated record three different ways.
+//! 5. **A room outlives one person.** Act IV transfers one deliberately and claims another
+//!    that was abandoned — then shows the same nomination stop working the instant its
+//!    owner renewed, which is the whole defence against a hostile claim and is also just
+//!    ordinary use.
 
 use std::net::SocketAddr;
 
@@ -60,14 +64,19 @@ fn why(e: &impl std::fmt::Display) -> String {
 async fn main() -> anyhow::Result<()> {
     println!("\n\x1b[1;4mA data room, end to end\x1b[0m");
 
-    let (addr, _dir) = start_host().await?;
+    let (addr, state, _dir) = start_host().await?;
     let client = VtcClient::anonymous(&format!("http://{addr}"), "did:key:zHost");
 
     act_one(&client).await?;
     act_two(&client).await?;
     act_three(&client).await?;
+    act_four(&client, &state).await?;
 
     println!("\n\x1b[1mWhat was and was not proved\x1b[0m");
+    note("A room outlives one person: Act IV hands one over deliberately and takes another");
+    note("that had been abandoned — and shows the same nomination stop working the moment");
+    note("its owner renewed. The defence against a hostile claim is ordinary use.");
+    note("");
     note("Every credential above was signed and every signature verified. The host stored");
     note("ciphertext it had no key for, and authorized every call from a chain the room");
     note("itself issued — never from anything the host holds.");
@@ -429,6 +438,186 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// Act IV — the room outlives its owner
+// ---------------------------------------------------------------------------
+
+async fn act_four(
+    client: &VtcClient,
+    state: &std::sync::Arc<room_host::HostState>,
+) -> anyhow::Result<()> {
+    println!("\n\x1b[1;4mAct IV — succession\x1b[0m");
+
+    // ── The deliberate handover ───────────────────────────────────────────
+    let f = RoomFixture::new(vti_rooms::Visibility::Open).await;
+    client
+        .create_room(
+            &f.room.room_id,
+            &f.owner.did,
+            Visibility::Open,
+            None,
+            &f.owner.did,
+            &f.owner.secret_multibase,
+        )
+        .await?;
+
+    say(
+        "Alice hands the room to Bob",
+        "`rooms/owner/transfer`, gated on `admin` — the same grant that mints epochs,",
+    );
+    note("because handing over the room is the more consequential of the two.");
+
+    let handed = client
+        .transfer_owner(
+            &session(&f, false),
+            &f.successor.did,
+            Some("stepping back from this project"),
+            &f.owner.did,
+            &f.owner.secret_multibase,
+        )
+        .await?;
+    note(&format!("owner is now {}", short(&handed.owner_did)));
+
+    // The host took Alice's word for it, and had no choice: it holds no roster and no MLS
+    // group state, so "is Bob a member?" is a question it cannot ask. Saying so is better
+    // than inventing a check — one that refused what it could not verify would refuse every
+    // correct transfer too.
+    note("the host did not check that Bob is a member — it holds no roster and cannot;");
+    note("that obligation is Alice's, who can see the group");
+
+    // ── A room whose owner stopped ────────────────────────────────────────
+    let g = RoomFixture::new(vti_rooms::Visibility::Open).await;
+    say(
+        "A room nobody has renewed",
+        "Written straight to the store with an epoch that expired sixty days ago.",
+    );
+    note("Succession is entirely about the passage of time, and the honest way to show it");
+    note("in a demo is to write the room in the state a year would produce rather than");
+    note("pretend some wire call can age it.");
+
+    vti_rooms::storage::create_room(
+        state.rooms(),
+        &vti_rooms::Room {
+            epoch_expires_at: Some(now_secs() - 60 * 24 * 60 * 60),
+            ..g.room.clone()
+        },
+    )
+    .await?;
+
+    let nomination = g.nominate(&g.successor.did, Some(24 * 365)).await;
+    note("the room issued this nomination to its successor long ago, granting `succeed` —");
+    note("a word no room task accepts, so it confers nothing at all while Alice is present");
+
+    // ── Renewing is the defence ───────────────────────────────────────────
+    //
+    // The same room, the same nomination — the only thing that changes is that its owner
+    // came back. Anything less than that would be a demo refusing for some other reason and
+    // taking credit for this one.
+    say(
+        "Alice returns and mints an epoch",
+        "Ordinary use. Nothing about it is succession-specific.",
+    );
+    client
+        .mint_epoch(
+            &session(&g, false),
+            2,
+            Some("still here"),
+            &g.owner.did,
+            &g.owner.secret_multibase,
+        )
+        .await?;
+    note("the room is live again, and renewing is all it took");
+
+    say(
+        "The successor presents the same nomination a moment later",
+        "It would have worked before Alice minted. It does not work now.",
+    );
+    let live = client
+        .claim_owner(
+            &successor_session(&g),
+            &nomination,
+            None,
+            &g.successor.did,
+            &g.successor.secret_multibase,
+        )
+        .await;
+    match live {
+        Ok(_) => anyhow::bail!("a live room must not be claimable"),
+        Err(e) => {
+            let reason = why(&e);
+            // The refusal has to be about the room's lifecycle. A demo that accepted any
+            // refusal here would pass just as happily on a nomination that was never valid,
+            // and would be claiming to show something it had not shown.
+            anyhow::ensure!(
+                reason.contains("live") || reason.contains("claimable"),
+                "the refusal must be about the lifecycle, not something else: {reason}"
+            );
+            note(&format!("refused: {reason}"));
+        }
+    }
+    note("an owner who was merely away defeats every pending claim by minting an epoch —");
+    note("which is what they would have done anyway. Nothing has to be revoked and no");
+    note("dispute has to be raised: an owner who is present is safe without thinking about it.");
+
+    // ── And dormancy alone is not enough ──────────────────────────────────
+    //
+    // A second room, because the first is live again now.
+    let h = RoomFixture::new(vti_rooms::Visibility::Open).await;
+    vti_rooms::storage::create_room(
+        state.rooms(),
+        &vti_rooms::Room {
+            epoch_expires_at: Some(now_secs() - 60 * 24 * 60 * 60),
+            ..h.room.clone()
+        },
+    )
+    .await?;
+
+    say(
+        "A member of a dormant room, holding no nomination of their own",
+        "Dormancy alone confers nothing, or any member of any quiet room could take it.",
+    );
+    let unnamed = client
+        .claim_owner(
+            &successor_session(&h),
+            // A nomination the room really did issue — naming somebody else.
+            &h.nominate(&h.agent.did, Some(24)).await,
+            None,
+            &h.successor.did,
+            &h.successor.secret_multibase,
+        )
+        .await;
+    match unnamed {
+        Ok(_) => anyhow::bail!("a nomination must be bound to the party it names"),
+        Err(e) => note(&format!("refused: {}", why(&e))),
+    }
+
+    // ── The claim ─────────────────────────────────────────────────────────
+    say(
+        "The nominated successor claims",
+        "All three conditions at once: the nomination, the dormancy, and their membership.",
+    );
+    let claimed = client
+        .claim_owner(
+            &successor_session(&h),
+            &h.nominate(&h.successor.did, Some(24 * 365)).await,
+            Some("the owner has been unreachable since March"),
+            &h.successor.did,
+            &h.successor.secret_multibase,
+        )
+        .await?;
+    note(&format!("owner is now {}", short(&claimed.owner_did)));
+
+    let after = vti_rooms::storage::get_room(state.rooms(), &h.room.room_id).await?;
+    note("and the room is still dormant — a claim hands one over, it does not revive one.");
+    note("The new owner's first act should be the epoch mint that proves they can commit.");
+    anyhow::ensure!(
+        !after.lifecycle(now_secs()).accepts_writes(),
+        "a claim must not renew the room"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
 
@@ -450,12 +639,19 @@ fn session(f: &RoomFixture, as_agent: bool) -> RoomSession {
 /// be demonstrating the network.
 ///
 /// The returned `TempDir` must outlive the run: dropping it deletes every room.
-async fn start_host() -> anyhow::Result<(SocketAddr, tempfile::TempDir)> {
+async fn start_host() -> anyhow::Result<(
+    SocketAddr,
+    std::sync::Arc<room_host::HostState>,
+    tempfile::TempDir,
+)> {
     let dir = tempfile::tempdir()?;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 
-    let app = room_host::router(room_host::open_state(dir.path())?);
+    // The state is handed back as well as served, because Act IV needs a room older than
+    // this process. Every other act goes over the wire like any client.
+    let state = room_host::open_state(dir.path())?;
+    let app = room_host::router(state.clone());
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
@@ -464,5 +660,31 @@ async fn start_host() -> anyhow::Result<(SocketAddr, tempfile::TempDir)> {
         "\n  host listening on {addr}, storing to {}",
         dir.path().display()
     );
-    Ok((addr, dir))
+    Ok((addr, state, dir))
+}
+
+/// A session over the fixture's *successor* — their own membership, their own chain.
+fn successor_session(f: &RoomFixture) -> RoomSession {
+    RoomSession::new(
+        &f.room.room_id,
+        f.successor_membership.clone(),
+        f.successor_chain.clone(),
+    )
+    .expect("the fixture's chains are within the depth bound")
+}
+
+/// Seconds since the Unix epoch.
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// A DID, short enough to read in a terminal.
+fn short(did: &str) -> String {
+    match did.len() {
+        n if n > 22 => format!("{}…{}", &did[..14], &did[n - 6..]),
+        _ => did.to_string(),
+    }
 }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -58,19 +58,20 @@ use uuid::Uuid;
 use vti_common::config::StoreConfig;
 use vti_common::error::AppError;
 use vti_common::store::{KeyspaceHandle, Store};
-use vti_rooms::audit as rooms_audit;
+use vti_rooms::audit::{self as rooms_audit, RoomOperation};
 use vti_rooms::wire::{
-    CreateRoomBody, CreateRoomResponse, CurateRecordBody, CurateRecordResponse, GetRecordBody,
-    ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse, PutRecordBody,
-    PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_RECORDS_CURATE_TYPE,
-    ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE,
+    ClaimOwnerBody, CreateRoomBody, CreateRoomResponse, CurateRecordBody, CurateRecordResponse,
+    GetRecordBody, ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse,
+    OwnerResponse, PutRecordBody, PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE,
+    ROOMS_OWNER_CLAIM_TYPE, ROOMS_OWNER_TRANSFER_TYPE, ROOMS_RECORDS_CURATE_TYPE,
+    ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE, TransferOwnerBody,
 };
 use vti_rooms::{
     ROOM_RECORDS_KEYSPACE, ROOMS_KEYSPACE, Record, RecordStatus, Room,
     authz::{self, Action},
     storage,
 };
-use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier};
+use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier, nomination};
 
 /// Default retention after a room's epoch lapses without renewal.
 const DEFAULT_RETENTION_DAYS: u32 = 90;
@@ -96,6 +97,21 @@ pub struct HostState {
 }
 
 impl HostState {
+    /// The room keyspace.
+    ///
+    /// This crate already exports `open_state` and `router` so a host can be embedded; this
+    /// is the third thing an embedder needs — placing a room in a state no wire call can
+    /// produce. Restoring from a backup is one such case. Ageing a room past its epoch, so
+    /// succession can be demonstrated without waiting a year, is the one the `data_room`
+    /// example uses it for.
+    ///
+    /// It is deliberately the *rooms* keyspace and not the records one: seeding rooms is a
+    /// legitimate administrative act, and handing out the record store would let an embedder
+    /// write records around every authorization check in this file.
+    pub fn rooms(&self) -> &KeyspaceHandle {
+        &self.rooms
+    }
+
     /// The presenter — proven, not claimed — and the verifier to judge their chain with.
     async fn presenter_and_verifier(
         &self,
@@ -129,12 +145,12 @@ impl HostState {
 fn audit_room(
     room: &Room,
     authorized: &authz::AuthorizedAction,
+    operation: RoomOperation,
     record_key: Option<&str>,
-    listed: bool,
 ) {
     let entry = rooms_audit::for_operation(room.visibility, authorized, record_key);
     tracing::info!(
-        action = rooms_audit::action_name(authorized.action(), listed),
+        action = operation.action_name(),
         room = %entry.room_id,
         actor = %entry.actor.as_str(),
         record = entry.record_key.as_deref().unwrap_or("-"),
@@ -228,6 +244,8 @@ async fn trust_task(State(state): State<Arc<HostState>>, body: Bytes) -> axum::r
         ROOMS_RECORDS_LIST_TYPE => list(&state, &doc, payload).await,
         ROOMS_RECORDS_CURATE_TYPE => curate(&state, &doc, payload).await,
         ROOMS_EPOCH_MINT_TYPE => mint(&state, &doc, payload).await,
+        ROOMS_OWNER_TRANSFER_TYPE => transfer_owner(&state, &doc, payload).await,
+        ROOMS_OWNER_CLAIM_TYPE => claim_owner(&state, &doc, payload).await,
         other => reject(
             &doc,
             // The framework's own code for this: a host that does not implement a task
@@ -352,7 +370,12 @@ async fn put(
     .await
     {
         Ok(stored) => {
-            audit_room(&room, &authorized, Some(&stored.key), false);
+            audit_room(
+                &room,
+                &authorized,
+                RoomOperation::PutRecord,
+                Some(&stored.key),
+            );
             respond(
                 doc,
                 PutRecordResponse {
@@ -405,7 +428,7 @@ async fn get(
     };
     match storage::get_record(&state.records, &req.room_id, &req.key).await {
         Ok(record) => {
-            audit_room(&room, &authorized, Some(&req.key), false);
+            audit_room(&room, &authorized, RoomOperation::GetRecord, Some(&req.key));
             respond(doc, record)
         }
         Err(e) => from_app_error(doc, &e),
@@ -462,7 +485,7 @@ async fn list(
             // Metadata, never bodies — the same rule the VTC serves under, because it is a
             // property of the task rather than of any one host.
             // A listing names no single record; the event is that the room was surveyed.
-            audit_room(&room, &authorized, None, true);
+            audit_room(&room, &authorized, RoomOperation::ListRecords, None);
             respond(
                 doc,
                 ListRecordsResponse {
@@ -516,12 +539,157 @@ async fn mint(
     };
     match storage::advance_epoch(&state.rooms, &req.room_id, req.epoch, now()).await {
         Ok(updated) => {
-            audit_room(&room, &authorized, None, false);
+            audit_room(&room, &authorized, RoomOperation::MintEpoch, None);
             respond(
                 doc,
                 MintEpochResponse {
                     room_id: updated.room_id,
                     epoch: updated.epoch,
+                },
+            )
+        }
+        Err(e) => from_app_error(doc, &e),
+    }
+}
+
+/// `rooms/owner/transfer/0.1`.
+///
+/// The owner hands the room to another member while still present. Gated on `admin`, the
+/// same grant that mints epochs.
+///
+/// **This host cannot check that the incoming owner is a member** — it holds no roster and
+/// no group state, and a delivery service never will. The spec's `notAMember` is for a host
+/// that "could independently establish" it; inventing a check here would refuse every
+/// correct transfer, which is a worse failure than the one it imagines it is preventing.
+async fn transfer_owner(
+    state: &HostState,
+    doc: &TrustTask<Value>,
+    payload: Value,
+) -> axum::response::Response {
+    let req: TransferOwnerBody = match serde_json::from_value(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            return reject(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: e.to_string(),
+                },
+            );
+        }
+    };
+    let room = match storage::get_room(&state.rooms, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let (presenter, verifier) = match state.presenter_and_verifier(doc).await {
+        Ok(p) => p,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let operation = RoomOperation::TransferOwner;
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        operation.required_action(),
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    match storage::set_owner(&state.rooms, &req.room_id, &req.new_owner_did, now()).await {
+        Ok(updated) => {
+            audit_room(&room, &authorized, operation, None);
+            respond(
+                doc,
+                OwnerResponse {
+                    room_id: updated.room_id,
+                    owner_did: updated.owner_did,
+                },
+            )
+        }
+        Err(e) => from_app_error(doc, &e),
+    }
+}
+
+/// `rooms/owner/claim/0.1`.
+///
+/// A nominated successor takes a room whose owner stopped renewing it. Three conditions,
+/// all required: a nomination the room issued to this claimant, a room that has gone
+/// dormant, and membership.
+///
+/// Checked nomination-first, because a bad nomination is the answer a claimant can act on
+/// and "the room is still live" would send them back in a month to hear the real one.
+///
+/// The claim does not renew the room — see [`storage::set_owner`].
+async fn claim_owner(
+    state: &HostState,
+    doc: &TrustTask<Value>,
+    payload: Value,
+) -> axum::response::Response {
+    let req: ClaimOwnerBody = match serde_json::from_value(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            return reject(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: e.to_string(),
+                },
+            );
+        }
+    };
+    let room = match storage::get_room(&state.rooms, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let (presenter, verifier) = match state.presenter_and_verifier(doc).await {
+        Ok(p) => p,
+        Err(e) => return from_app_error(doc, &e),
+    };
+
+    // Against the party who signed the request, never a DID from the payload.
+    let keys = DataIntegrityKeys(state.resolver.clone());
+    if let Err(e) = nomination::verify(&req.nomination, &room.room_id, &presenter, &keys).await {
+        return from_app_error(doc, &e);
+    }
+
+    let lifecycle = room.lifecycle(now());
+    if !lifecycle.admits_a_claim() {
+        return from_app_error(
+            doc,
+            &AppError::Forbidden(format!(
+                "room `{}` is {} — a room becomes claimable only once its epoch has \
+                 lapsed and the grace window after it has also passed without a renewal",
+                room.room_id,
+                lifecycle.as_str()
+            )),
+        );
+    }
+
+    let operation = RoomOperation::ClaimOwner;
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        operation.required_action(),
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    match storage::set_owner(&state.rooms, &req.room_id, &presenter, now()).await {
+        Ok(updated) => {
+            audit_room(&room, &authorized, operation, None);
+            respond(
+                doc,
+                OwnerResponse {
+                    room_id: updated.room_id,
+                    owner_did: updated.owner_did,
                 },
             )
         }
@@ -596,7 +764,12 @@ async fn curate(
     .await
     {
         Ok(curated) => {
-            audit_room(&room, &authorized, Some(&curated.key), false);
+            audit_room(
+                &room,
+                &authorized,
+                RoomOperation::CurateRecord,
+                Some(&curated.key),
+            );
             respond(
                 doc,
                 CurateRecordResponse {
@@ -971,5 +1144,201 @@ mod tests {
             body["code"], "unsupportedType",
             "and says so with the framework's own code: {body}"
         );
+    }
+
+    /// Register `f`'s room with a chosen epoch expiry, bypassing the create handler.
+    ///
+    /// Succession is entirely about the passage of time, and the only honest way to test it
+    /// without waiting a year is to write the room in the state a year would produce.
+    async fn register_expiring(
+        st: &Arc<HostState>,
+        f: &RoomFixture,
+        epoch_expires_at: Option<u64>,
+    ) {
+        let room = Room {
+            epoch_expires_at,
+            ..f.room.clone()
+        };
+        storage::create_room(&st.rooms, &room)
+            .await
+            .expect("register the room");
+    }
+
+    fn days_ago(n: u64) -> Option<u64> {
+        Some(now() - n * 24 * 60 * 60)
+    }
+
+    #[tokio::test]
+    async fn an_owner_transfers_the_room_to_another_member() {
+        let (_d, st) = state();
+        let app = router(st);
+        let f = RoomFixture::new(Visibility::Open).await;
+        register(&app, &f).await;
+
+        let (status, body) = call(
+            &app,
+            ROOMS_OWNER_TRANSFER_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "newOwnerDid": f.successor.did,
+                "presentation": f.as_owner(),
+                "reason": "stepping back from this project",
+            }),
+            &f.owner,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["ownerDid"], f.successor.did);
+    }
+
+    /// `admin`, not `read`. The agent's chain is the narrower one a member hands their
+    /// agent, and an agent that could give the room away would make attenuation pointless.
+    #[tokio::test]
+    async fn read_may_not_transfer_the_room() {
+        let (_d, st) = state();
+        let app = router(st);
+        let f = RoomFixture::new(Visibility::Open).await;
+        register(&app, &f).await;
+
+        let (status, _) = call(
+            &app,
+            ROOMS_OWNER_TRANSFER_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "newOwnerDid": f.agent.did,
+                "presentation": f.as_agent(),
+            }),
+            &f.agent,
+        )
+        .await;
+        assert!(!status.is_success(), "an agent may not hand away the room");
+    }
+
+    /// The whole point: a room outlives one person's availability.
+    #[tokio::test]
+    async fn a_nominated_successor_claims_a_dormant_room() {
+        let (_d, st) = state();
+        let f = RoomFixture::new(Visibility::Open).await;
+        register_expiring(&st, &f, days_ago(60)).await;
+        let app = router(st.clone());
+
+        let (status, body) = call(
+            &app,
+            ROOMS_OWNER_CLAIM_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "presentation": f.as_successor(),
+                "reason": "the owner has been unreachable since March",
+            }),
+            &f.successor,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["ownerDid"], f.successor.did);
+
+        // And the claim did not renew it. The new owner's first act should be the one that
+        // proves they can perform it.
+        let room = storage::get_room(&st.rooms, &f.room.room_id).await.unwrap();
+        assert!(
+            !room.lifecycle(now()).accepts_writes(),
+            "a claim hands over a dormant room, it does not revive one"
+        );
+    }
+
+    /// The defence against a hostile claim, and it is the same act as ordinary use: an
+    /// owner who was merely away renews, and every pending claim stops working.
+    #[tokio::test]
+    async fn a_live_room_cannot_be_claimed() {
+        let (_d, st) = state();
+        let f = RoomFixture::new(Visibility::Open).await;
+        register_expiring(&st, &f, Some(now() + 30 * 24 * 60 * 60)).await;
+        let app = router(st);
+
+        let (status, body) = call(
+            &app,
+            ROOMS_OWNER_CLAIM_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "presentation": f.as_successor(),
+            }),
+            &f.successor,
+        )
+        .await;
+        assert!(!status.is_success(), "the owner is still here: {body}");
+    }
+
+    /// A lapse is not dormancy. An epoch expiring is frequently somebody on holiday, and a
+    /// takeover window that opened the moment one expired would make every holiday one.
+    #[tokio::test]
+    async fn a_merely_lapsed_room_is_not_yet_claimable() {
+        let (_d, st) = state();
+        let f = RoomFixture::new(Visibility::Open).await;
+        register_expiring(&st, &f, days_ago(3)).await;
+        let app = router(st);
+
+        let (status, body) = call(
+            &app,
+            ROOMS_OWNER_CLAIM_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "presentation": f.as_successor(),
+            }),
+            &f.successor,
+        )
+        .await;
+        assert!(
+            !status.is_success(),
+            "three days is a holiday, not an abandonment: {body}"
+        );
+    }
+
+    /// Dormancy alone confers nothing. Otherwise any member of any quiet room could take it.
+    #[tokio::test]
+    async fn a_member_without_a_nomination_cannot_claim() {
+        let (_d, st) = state();
+        let f = RoomFixture::new(Visibility::Open).await;
+        register_expiring(&st, &f, days_ago(60)).await;
+        let app = router(st);
+
+        // A real nomination — for somebody else.
+        let (status, body) = call(
+            &app,
+            ROOMS_OWNER_CLAIM_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "presentation": f.as_successor(),
+            }),
+            &f.successor,
+        )
+        .await;
+        assert!(
+            !status.is_success(),
+            "a nomination is bound to the party it names: {body}"
+        );
+    }
+
+    /// Every URI `vti_rooms::wire` says is dispatched must actually route here.
+    ///
+    /// The failure this catches is adding a handler to the wire crate's list and forgetting
+    /// the `match` arm — which does not fail to compile, and shows up as `unsupportedType`
+    /// on a verb the host claims to serve.
+    #[tokio::test]
+    async fn every_dispatched_uri_routes() {
+        let (_d, st) = state();
+        let app = router(st);
+        let signer = Party::new();
+
+        for uri in vti_rooms::wire::ROOMS_DISPATCHED_URIS {
+            // An empty payload, so every one of these fails — the question is only *how*.
+            let (_, body) = call(&app, uri, serde_json::json!({}), &signer).await;
+            assert_ne!(
+                body["code"], "unsupportedType",
+                "{uri} is declared dispatched but has no route"
+            );
+        }
     }
 }

--- a/vtc-client/src/rooms/mod.rs
+++ b/vtc-client/src/rooms/mod.rs
@@ -45,9 +45,10 @@ use crate::{VtcClient, VtcError};
 pub use vti_rooms::Visibility;
 pub use vti_rooms::authz::MAX_CHAIN_DEPTH;
 pub use vti_rooms::wire::{
-    AuthorityPresentation, CleartextContent, ListRecordsResponse, MintEpochResponse,
-    PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_RECORDS_GET_TYPE,
-    ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE, SealedContent,
+    AuthorityPresentation, CleartextContent, ListRecordsResponse, MintEpochResponse, OwnerResponse,
+    PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_OWNER_CLAIM_TYPE,
+    ROOMS_OWNER_TRANSFER_TYPE, ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE,
+    ROOMS_RECORDS_PUT_TYPE, SealedContent,
 };
 
 /// A caller's standing in one room.
@@ -292,6 +293,91 @@ impl VtcClient {
         serde_json::from_value(value).map_err(|e| VtcError::Http {
             status: 200,
             body: format!("mint response is not a MintEpochResponse: {e}"),
+        })
+    }
+
+    /// Hand the room to another member, deliberately and while still present.
+    ///
+    /// Requires a chain conferring `admin` — the same grant that mints epochs, since
+    /// transferring is the more consequential of the two.
+    ///
+    /// **The host does not check that `new_owner_did` is a member**, and cannot: it holds no
+    /// roster and no MLS group state. That obligation is the outgoing owner's, who can see
+    /// the group. Give the room to someone who cannot commit and they inherit a room they
+    /// cannot renew.
+    pub async fn transfer_owner(
+        &self,
+        session: &RoomSession,
+        new_owner_did: &str,
+        reason: Option<&str>,
+        signer_did: &str,
+        private_key_multibase: &str,
+    ) -> Result<OwnerResponse, VtcError> {
+        let mut payload = serde_json::json!({
+            "roomId": session.room_id,
+            "newOwnerDid": new_owner_did,
+            "presentation": session.presentation,
+        });
+        if let Some(r) = reason {
+            payload["reason"] = serde_json::json!(r);
+        }
+        self.owner_task(
+            ROOMS_OWNER_TRANSFER_TYPE,
+            payload,
+            signer_did,
+            private_key_multibase,
+        )
+        .await
+    }
+
+    /// Claim a room whose owner has stopped renewing it.
+    ///
+    /// `nomination` is the succession credential the room issued to this claimant in
+    /// advance. All three of the host's conditions must hold together: a valid nomination,
+    /// a room that has been **dormant** past its grace window — not merely lapsed — and the
+    /// claimant's own membership, which is what `session` carries.
+    ///
+    /// A claim does not renew the room. It hands over a dormant room, and the new owner's
+    /// first act should be the epoch mint that proves they can perform it.
+    pub async fn claim_owner(
+        &self,
+        session: &RoomSession,
+        nomination: &str,
+        reason: Option<&str>,
+        signer_did: &str,
+        private_key_multibase: &str,
+    ) -> Result<OwnerResponse, VtcError> {
+        let mut payload = serde_json::json!({
+            "roomId": session.room_id,
+            "nomination": nomination,
+            "presentation": session.presentation,
+        });
+        if let Some(r) = reason {
+            payload["reason"] = serde_json::json!(r);
+        }
+        self.owner_task(
+            ROOMS_OWNER_CLAIM_TYPE,
+            payload,
+            signer_did,
+            private_key_multibase,
+        )
+        .await
+    }
+
+    /// The shared tail of the two succession verbs, which answer with one shape.
+    async fn owner_task(
+        &self,
+        type_uri: &str,
+        payload: serde_json::Value,
+        signer_did: &str,
+        private_key_multibase: &str,
+    ) -> Result<OwnerResponse, VtcError> {
+        let value = self
+            .room_task(type_uri, payload, signer_did, private_key_multibase)
+            .await?;
+        serde_json::from_value(value).map_err(|e| VtcError::Http {
+            status: 200,
+            body: format!("{type_uri} response is not an OwnerResponse: {e}"),
         })
     }
 

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -27,16 +27,16 @@ use crate::trust_tasks::helpers::{
     TrustTaskOutcome, app_error_to_reject, parse_payload, success_response, verify_trust_task_proof,
 };
 use vti_common::audit::{AuditEvent, RoomOperationData};
-use vti_rooms::audit as rooms_audit;
+use vti_rooms::audit::{self as rooms_audit, RoomOperation};
 use vti_rooms::authz::{self, Action};
 use vti_rooms::storage;
 use vti_rooms::wire::{
-    CreateRoomBody, CreateRoomResponse, CurateRecordBody, CurateRecordResponse, GetRecordBody,
-    ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse, PutRecordBody,
-    PutRecordResponse,
+    ClaimOwnerBody, CreateRoomBody, CreateRoomResponse, CurateRecordBody, CurateRecordResponse,
+    GetRecordBody, ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse,
+    OwnerResponse, PutRecordBody, PutRecordResponse, TransferOwnerBody,
 };
 use vti_rooms::{Record, RecordStatus, Room};
-use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier};
+use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier, nomination};
 
 /// The DID that actually signed this request, and the verifier to judge its chain with.
 ///
@@ -74,14 +74,14 @@ async fn audit_room(
     state: &AppState,
     room: &Room,
     authorized: &authz::AuthorizedAction,
+    operation: RoomOperation,
     record_key: Option<&str>,
-    listed: bool,
 ) {
     let Some(writer) = state.audit_writer.as_ref() else {
         return;
     };
     let entry = rooms_audit::for_operation(room.visibility, authorized, record_key);
-    let action = rooms_audit::action_name(authorized.action(), listed);
+    let action = operation.action_name();
 
     if let Err(e) = writer
         .write(
@@ -225,7 +225,14 @@ pub(crate) async fn handle_put_record(state: &AppState, doc: TrustTask<Value>) -
     .await
     {
         Ok(stored) => {
-            audit_room(state, &room, &authorized, Some(&stored.key), false).await;
+            audit_room(
+                state,
+                &room,
+                &authorized,
+                RoomOperation::PutRecord,
+                Some(&stored.key),
+            )
+            .await;
             success_response(
                 &doc,
                 PutRecordResponse {
@@ -274,7 +281,14 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
 
     match storage::get_record(&state.room_records_ks, &req.room_id, &req.key).await {
         Ok(record) => {
-            audit_room(state, &room, &authorized, Some(&req.key), false).await;
+            audit_room(
+                state,
+                &room,
+                &authorized,
+                RoomOperation::GetRecord,
+                Some(&req.key),
+            )
+            .await;
             success_response(&doc, record)
         }
         Err(e) => app_error_to_reject(&doc, &e),
@@ -331,7 +345,7 @@ pub(crate) async fn handle_list_records(
     let limit = req.limit.unwrap_or(usize::MAX);
     // A listing names no single record, so the entry records the room and the fact of a
     // listing — which is the event: who has seen what this room holds.
-    audit_room(state, &room, &authorized, None, true).await;
+    audit_room(state, &room, &authorized, RoomOperation::ListRecords, None).await;
     success_response(
         &doc,
         ListRecordsResponse {
@@ -377,12 +391,176 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
 
     match storage::advance_epoch(&state.rooms_ks, &req.room_id, req.epoch, now()).await {
         Ok(updated) => {
-            audit_room(state, &room, &authorized, None, false).await;
+            audit_room(state, &room, &authorized, RoomOperation::MintEpoch, None).await;
             success_response(
                 &doc,
                 MintEpochResponse {
                     room_id: updated.room_id,
                     epoch: updated.epoch,
+                },
+            )
+        }
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
+}
+
+/// `rooms/owner/transfer/0.1`.
+///
+/// An owner hands the room to another member, deliberately and while still present.
+///
+/// Gated on `admin` — the same grant that mints epochs, because transferring is the more
+/// consequential of the two and it would be strange for the lesser act to ask for more.
+///
+/// # What this handler does not check, and why that is correct
+///
+/// That the incoming owner is a member. The spec requires them to be one, and **this host
+/// cannot see the MLS group**: it holds no roster and no group state. The temptation is to
+/// invent a check anyway — demand a credential, or refuse when unsure — and both are worse
+/// than doing nothing. A host that refuses what it cannot verify fails *every* transfer,
+/// including every correct one, and a host that treats its own ignorance as evidence has
+/// converted "I don't know" into "no".
+///
+/// The spec says as much in the error code itself: `notAMember` is raised only when a host
+/// "could independently establish" it, and this one cannot. What protects the incoming
+/// owner is that the outgoing one holds `admin` and knows the roster.
+pub(crate) async fn handle_transfer_owner(
+    state: &AppState,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: TransferOwnerBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let room = match storage::get_room(&state.rooms_ks, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let (presenter, verifier) = match presenter_and_verifier(state, &doc).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let operation = RoomOperation::TransferOwner;
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        operation.required_action(),
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    match storage::set_owner(&state.rooms_ks, &req.room_id, &req.new_owner_did, now()).await {
+        Ok(updated) => {
+            audit_room(state, &room, &authorized, operation, None).await;
+            success_response(
+                &doc,
+                OwnerResponse {
+                    room_id: updated.room_id,
+                    owner_did: updated.owner_did,
+                },
+            )
+        }
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
+}
+
+/// `rooms/owner/claim/0.1`.
+///
+/// A nominated successor takes a room whose owner has stopped renewing it.
+///
+/// # Three conditions, checked in the order that gives the most useful answer
+///
+/// 1. **A nomination the room issued**, naming this claimant, in its window, rooted at the
+///    room. [`vti_rooms_dtg::nomination`].
+/// 2. **The room is dormant** — not merely lapsed. [`Lifecycle::admits_a_claim`].
+/// 3. **The claimant holds membership**, which is the presentation every other room task
+///    carries, gated at `read`.
+///
+/// The order is deliberate. A claimant whose nomination is bad should hear that first,
+/// because it is the one they can do nothing about by waiting; telling them "the room is
+/// still live" when their credential was never valid sends them back in thirty days to
+/// receive the real answer.
+///
+/// # Renewing is the defence, and it is the same act as ordinary use
+///
+/// Condition 2 is why a hostile nomination is survivable. An owner who was merely away
+/// defeats every pending claim by minting an epoch — which is what they would have done
+/// anyway. Nothing has to be revoked and no dispute has to be raised, so an owner who is
+/// present is structurally safe from succession without ever thinking about it.
+///
+/// # And a claim does not renew the room
+///
+/// [`storage::set_owner`] leaves a dormant room dormant. The new owner's first act should
+/// be the one that proves they can perform it; see that function for why.
+pub(crate) async fn handle_claim_owner(
+    state: &AppState,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: ClaimOwnerBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let room = match storage::get_room(&state.rooms_ks, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let (presenter, verifier) = match presenter_and_verifier(state, &doc).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    // 1. The nomination, against the party who actually signed this request — never against
+    //    a DID named in the payload, which the claimant chooses.
+    let keys = DataIntegrityKeys(state.trust_task_vm_resolver());
+    if let Err(e) = nomination::verify(&req.nomination, &room.room_id, &presenter, &keys).await {
+        return app_error_to_reject(&doc, &e);
+    }
+
+    // 2. Dormant, not merely lapsed. An epoch expiring is frequently somebody on holiday.
+    let lifecycle = room.lifecycle(now());
+    if !lifecycle.admits_a_claim() {
+        return app_error_to_reject(
+            &doc,
+            &vti_common::error::AppError::Forbidden(format!(
+                "room `{}` is {} — a room becomes claimable only once its epoch has \
+                 lapsed and the grace window after it has also passed without a renewal",
+                room.room_id,
+                lifecycle.as_str()
+            )),
+        );
+    }
+
+    // 3. Membership, which is also the pooling defence and the chain-reaches-the-room check.
+    let operation = RoomOperation::ClaimOwner;
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        operation.required_action(),
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    match storage::set_owner(&state.rooms_ks, &req.room_id, &presenter, now()).await {
+        Ok(updated) => {
+            audit_room(state, &room, &authorized, operation, None).await;
+            success_response(
+                &doc,
+                OwnerResponse {
+                    room_id: updated.room_id,
+                    owner_did: updated.owner_did,
                 },
             )
         }
@@ -450,7 +628,14 @@ pub(crate) async fn handle_curate_record(
     .await
     {
         Ok(curated) => {
-            audit_room(state, &room, &authorized, Some(&curated.key), false).await;
+            audit_room(
+                state,
+                &room,
+                &authorized,
+                RoomOperation::CurateRecord,
+                Some(&curated.key),
+            )
+            .await;
             success_response(
                 &doc,
                 CurateRecordResponse {
@@ -810,7 +995,14 @@ mod tests {
         .await
         .expect("authorized");
 
-        audit_room(state, &room, &authorized, Some("opaque-key"), false).await;
+        audit_room(
+            state,
+            &room,
+            &authorized,
+            RoomOperation::GetRecord,
+            Some("opaque-key"),
+        )
+        .await;
 
         let rows = audit_rows(state).await;
         assert!(
@@ -1106,5 +1298,227 @@ mod tests {
         )
         .await;
         assert!(!out.status.is_success(), "an epoch may not skip");
+    }
+
+    /// Register the fixture's room with a chosen epoch expiry, bypassing the handler.
+    ///
+    /// Succession is entirely about the passage of time; writing the room in the state a
+    /// year would produce is the only way to test it without waiting one.
+    async fn create_expiring(state: &AppState, f: &RoomFixture, epoch_expires_at: Option<u64>) {
+        storage::create_room(
+            &state.rooms_ks,
+            &Room {
+                epoch_expires_at,
+                ..f.room.clone()
+            },
+        )
+        .await
+        .expect("register the room");
+    }
+
+    fn days_ago(n: u64) -> Option<u64> {
+        Some(now() - n * 24 * 60 * 60)
+    }
+
+    async fn claim(state: &AppState, f: &RoomFixture, payload: Value) -> TrustTaskOutcome {
+        handle_claim_owner(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_OWNER_CLAIM_TYPE,
+                payload,
+                &f.successor.did,
+                &f.successor.secret_multibase,
+            )
+            .await,
+        )
+        .await
+    }
+
+    /// `admin`, and the audit entry names the operation rather than the authority.
+    #[tokio::test]
+    async fn transferring_requires_admin_and_names_the_new_owner() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create(state, &f).await;
+
+        // `read` is not enough; the agent's chain is the narrower one a member delegates.
+        let out = handle_transfer_owner(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_OWNER_TRANSFER_TYPE,
+                json!({
+                    "roomId": f.room.room_id,
+                    "newOwnerDid": f.agent.did,
+                    "presentation": f.as_agent(),
+                }),
+                &f.agent.did,
+                &f.agent.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            !out.status.is_success(),
+            "an agent may not hand away the room"
+        );
+
+        let out = handle_transfer_owner(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_OWNER_TRANSFER_TYPE,
+                json!({
+                    "roomId": f.room.room_id,
+                    "newOwnerDid": f.successor.did,
+                    "presentation": f.as_owner(),
+                    "reason": "stepping back",
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(out.status.is_success(), "{}", payload_of(&out));
+        assert_eq!(payload_of(&out)["ownerDid"], f.successor.did);
+
+        let stored = storage::get_room(&state.rooms_ks, &f.room.room_id)
+            .await
+            .unwrap();
+        assert_eq!(stored.owner_did, f.successor.did, "and it persisted");
+    }
+
+    /// The whole point of the pair: a room outlives one person's availability.
+    #[tokio::test]
+    async fn a_nominated_successor_claims_a_dormant_room() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create_expiring(state, &f, days_ago(60)).await;
+
+        let out = claim(
+            state,
+            &f,
+            json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "presentation": f.as_successor(),
+                "reason": "unreachable since March",
+            }),
+        )
+        .await;
+        assert!(out.status.is_success(), "{}", payload_of(&out));
+        assert_eq!(payload_of(&out)["ownerDid"], f.successor.did);
+
+        // A claim hands over a dormant room; it does not revive one. The new owner's first
+        // act should be the one that proves they can perform it.
+        let stored = storage::get_room(&state.rooms_ks, &f.room.room_id)
+            .await
+            .unwrap();
+        assert!(!stored.lifecycle(now()).accepts_writes());
+    }
+
+    /// The defence, and it is the same act as ordinary use: an owner who was merely away
+    /// renews, and every pending claim stops working. Nothing has to be revoked.
+    #[tokio::test]
+    async fn renewing_defeats_a_pending_claim() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create_expiring(state, &f, days_ago(60)).await;
+
+        let nomination = f.nominate(&f.successor.did, Some(24)).await;
+
+        // The owner returns and mints an epoch — ordinary use, nothing succession-specific.
+        let out = handle_mint_epoch(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_EPOCH_MINT_TYPE,
+                json!({ "roomId": f.room.room_id, "epoch": 2, "presentation": f.as_owner() }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(out.status.is_success(), "{}", payload_of(&out));
+
+        let out = claim(
+            state,
+            &f,
+            json!({
+                "roomId": f.room.room_id,
+                "nomination": nomination,
+                "presentation": f.as_successor(),
+            }),
+        )
+        .await;
+        assert!(
+            !out.status.is_success(),
+            "the same nomination that would have worked a moment ago: {}",
+            payload_of(&out)
+        );
+
+        let stored = storage::get_room(&state.rooms_ks, &f.room.room_id)
+            .await
+            .unwrap();
+        assert_eq!(stored.owner_did, f.owner.did, "and the owner kept the room");
+    }
+
+    /// Dormancy alone confers nothing, or any member of any quiet room could take it.
+    #[tokio::test]
+    async fn a_member_of_a_dormant_room_cannot_claim_without_being_named() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create_expiring(state, &f, days_ago(60)).await;
+
+        // A genuine nomination the room issued — naming somebody else.
+        let out = claim(
+            state,
+            &f,
+            json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "presentation": f.as_successor(),
+            }),
+        )
+        .await;
+        assert!(
+            !out.status.is_success(),
+            "a nomination is bound to the party it names: {}",
+            payload_of(&out)
+        );
+    }
+
+    /// The order the handler checks in, which is the difference between an answer a
+    /// claimant can act on and one that sends them back in a month for the real one.
+    #[tokio::test]
+    async fn a_bad_nomination_is_reported_before_the_room_is_still_live() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        create_expiring(state, &f, Some(now() + 30 * 24 * 60 * 60)).await;
+
+        let out = claim(
+            state,
+            &f,
+            json!({
+                "roomId": f.room.room_id,
+                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "presentation": f.as_successor(),
+            }),
+        )
+        .await;
+        assert!(!out.status.is_success());
+        let body = payload_of(&out).to_string();
+        assert!(
+            !body.contains("dormant"),
+            "the nomination was never valid; saying `still live` hides that: {body}"
+        );
     }
 }

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -162,6 +162,12 @@ pub(crate) async fn dispatch_trust_task_core(
         rooms_wire::ROOMS_EPOCH_MINT_TYPE => {
             crate::rooms::handlers::handle_mint_epoch(state, doc).await
         }
+        rooms_wire::ROOMS_OWNER_TRANSFER_TYPE => {
+            crate::rooms::handlers::handle_transfer_owner(state, doc).await
+        }
+        rooms_wire::ROOMS_OWNER_CLAIM_TYPE => {
+            crate::rooms::handlers::handle_claim_owner(state, doc).await
+        }
         PERSONHOOD_CHALLENGE_TYPE => handle_personhood_challenge(state, ctx, doc).await,
         PERSONHOOD_ASSERT_TYPE => handle_personhood_assert(state, ctx, doc).await,
         other => unsupported_type_or_version(&doc, other),
@@ -274,6 +280,9 @@ pub(crate) const DISPATCHED_URIS: &[&str] = &[
     rooms_wire::ROOMS_RECORDS_GET_TYPE,
     rooms_wire::ROOMS_RECORDS_LIST_TYPE,
     rooms_wire::ROOMS_EPOCH_MINT_TYPE,
+    rooms_wire::ROOMS_RECORDS_CURATE_TYPE,
+    rooms_wire::ROOMS_OWNER_TRANSFER_TYPE,
+    rooms_wire::ROOMS_OWNER_CLAIM_TYPE,
 ];
 
 /// `vtc/members/personhood/challenge/0.1` — mint the single-use nonce
@@ -824,26 +833,37 @@ mod tests {
             mem::MEMBER_VMC_TYPE,
             <pc::Payload as trust_tasks_rs::Payload>::TYPE_URI,
             <pa::Payload as trust_tasks_rs::Payload>::TYPE_URI,
-            // rooms/* names hand-written constants rather than a generated
-            // `TYPE_URI`, because its schemas are still in review upstream
-            // (trustoverip/dtgwg-trust-tasks-tf#346). The property this test
-            // exists for is weaker for them until those bindings publish: it
-            // pins the dispatcher against `wire`'s constants, not against the
-            // registry. **Swap these for the generated `TYPE_URI`s when the
-            // crate ships them** — that is what restores the guarantee.
-            rooms_wire::ROOMS_CREATE_TYPE,
-            rooms_wire::ROOMS_RECORDS_PUT_TYPE,
-            rooms_wire::ROOMS_RECORDS_GET_TYPE,
-            rooms_wire::ROOMS_RECORDS_LIST_TYPE,
-            rooms_wire::ROOMS_EPOCH_MINT_TYPE,
         ];
+        // rooms/* comes from `vti_rooms::wire`'s own list rather than a hand-copy.
+        //
+        // The copy was the defect: `rooms/records/curate` was dispatched by the `match`
+        // above and named in neither array, so the census passed while curate was missing
+        // from every version hint this VTC emits. A second list of the same thing agrees
+        // right up until someone adds to one of them.
+        //
+        // rooms/* still names hand-written constants rather than generated `TYPE_URI`s,
+        // and no longer needs to be swapped for them: the bindings have published, and
+        // `vti-rooms/tests/schema_conformance.rs::every_dispatched_uri_is_the_published_one`
+        // pins every one of those constants against its generated `TYPE_URI`. This test
+        // therefore does reach the registry — through that one — rather than only checking
+        // that two of our own lists agree, which is what it could do before.
         for u in DISPATCHED_URIS {
             assert!(
-                declared.contains(u),
+                declared.contains(u) || rooms_wire::ROOMS_DISPATCHED_URIS.contains(u),
                 "dispatched URI is not a declared request URI: {u}"
             );
         }
-        assert_eq!(DISPATCHED_URIS.len(), declared.len());
+        for u in rooms_wire::ROOMS_DISPATCHED_URIS {
+            assert!(
+                DISPATCHED_URIS.contains(u),
+                "`vti_rooms::wire` dispatches {u}, but this VTC does not declare it — a \
+                 client would be told it is unsupported at every version"
+            );
+        }
+        assert_eq!(
+            DISPATCHED_URIS.len(),
+            declared.len() + rooms_wire::ROOMS_DISPATCHED_URIS.len()
+        );
     }
 
     /// The request URIs must parse as framework `TypeUri`s (the `/spec/`

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -49,6 +49,14 @@ vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm"], optio
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]
+# The crate's own tests, on itself, with `test-support` on.
+#
+# Not a curiosity: the signed tests need the real keys that feature carries, and
+# without this line they compile only when some *other* workspace member happens
+# to enable the feature and cargo unifies it. `cargo test -p vti-rooms-dtg` alone
+# failed to build — the tests that matter most were reachable by luck.
+vti-rooms-dtg = { path = ".", features = ["test-support"] }
+
 tokio = { workspace = true }
 # Real keys and real signatures for the end-to-end test. A verifier tested only on
 # refusals would pass every test while refusing everything.

--- a/vti-rooms-dtg/src/lib.rs
+++ b/vti-rooms-dtg/src/lib.rs
@@ -56,6 +56,10 @@ use vti_rooms::authz::{Action, ChainVerifier, VerifiedChain};
 use vti_rooms::wire::AuthorityPresentation;
 use vti_rooms::{Room, Visibility};
 
+pub mod nomination;
+
+pub use vti_rooms::authz::ACTION_SUCCEED;
+
 /// Resolve a credential's `verificationMethod` to the public key that signed it.
 ///
 /// One implementation per host, because a VTC resolves DIDs through its own resolver and a
@@ -170,58 +174,74 @@ impl DtgChainVerifier {
     }
 
     /// Decode one presented credential and verify its proof.
-    ///
-    /// Accepts base64url or bare JSON. Both are unambiguous — a JSON document starts with
-    /// `{` and base64url has no `{` in its alphabet — and accepting both means a caller
-    /// hand-building a request for a demo or a test does not have to encode by hand. The
-    /// serialization is a profile question the schema leaves open ("serialized per the
-    /// governing profile"); this is the profile this implementation reads.
     async fn open_credential(&self, encoded: &str, what: &str) -> Result<DTGCredential, AppError> {
-        let bytes = if encoded.trim_start().starts_with('{') {
-            encoded.as_bytes().to_vec()
-        } else {
-            base64::engine::general_purpose::URL_SAFE_NO_PAD
-                .decode(encoded.trim())
-                .map_err(|_| {
-                    AppError::Forbidden(format!(
-                        "{what} is neither base64url nor JSON; a credential that cannot be \
-                         read cannot be verified"
-                    ))
-                })?
-        };
-
-        let credential: DTGCredential = serde_json::from_slice(&bytes)
-            .map_err(|e| AppError::Forbidden(format!("{what} is not a DTG credential: {e}")))?;
-
-        let proof = credential
-            .credential()
-            .proof
-            .as_ref()
-            .ok_or_else(|| AppError::Forbidden(format!("{what} carries no proof")))?;
-
-        let key = self
-            .keys
-            .public_key(&proof.verification_method)
+        open_credential(encoded, what, self.keys.as_ref())
             .await
-            .map_err(|e| {
-                // The resolver's own error is for the operator; the caller learns only that
-                // it did not verify, so an unresolvable method is not an oracle for which
-                // DIDs this host can reach.
-                tracing::warn!(
-                    verification_method = %proof.verification_method,
-                    error = %e,
-                    "could not resolve a room credential's verification method"
-                );
-                AppError::Forbidden(format!("{what} could not be verified"))
-            })?;
+            // Everything this verifier refuses is a `Forbidden`; the shared opener is also
+            // used by a path where a bad credential is a malformed request rather than a
+            // denied one, so it reports `Validation` and this maps it back.
+            .map_err(|e| AppError::Forbidden(e.to_string()))
+    }
+}
 
-        credential.verify_proof_with_public_key(&key).map_err(|e| {
-            tracing::warn!(error = %e, "room credential proof did not verify");
-            AppError::Forbidden(format!("{what} could not be verified"))
+/// Decode one credential and verify its proof against the key its own proof names.
+///
+/// Shared because the alternative is two decoders that agree today. They would not stay
+/// agreed: the serialization is a profile question the schema leaves open, and a second copy
+/// is a second place to accept a form the first does not — which is how one path ends up
+/// verifying something another would refuse.
+///
+/// Accepts base64url or bare JSON. Both are unambiguous — a JSON document starts with `{`
+/// and base64url has no `{` in its alphabet — and accepting both means a caller
+/// hand-building a request for a demo or a test does not have to encode by hand.
+pub async fn open_credential(
+    encoded: &str,
+    what: &str,
+    keys: &dyn VerificationKeys,
+) -> Result<DTGCredential, AppError> {
+    let bytes = if encoded.trim_start().starts_with('{') {
+        encoded.as_bytes().to_vec()
+    } else {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded.trim())
+            .map_err(|_| {
+                AppError::Validation(format!(
+                    "{what} is neither base64url nor JSON; a credential that cannot be \
+                     read cannot be verified"
+                ))
+            })?
+    };
+
+    let credential: DTGCredential = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Validation(format!("{what} is not a DTG credential: {e}")))?;
+
+    let proof = credential
+        .credential()
+        .proof
+        .as_ref()
+        .ok_or_else(|| AppError::Validation(format!("{what} carries no proof")))?;
+
+    let key = keys
+        .public_key(&proof.verification_method)
+        .await
+        .map_err(|e| {
+            // The resolver's own error is for the operator; the caller learns only that it
+            // did not verify, so an unresolvable method is not an oracle for which DIDs this
+            // host can reach.
+            tracing::warn!(
+                verification_method = %proof.verification_method,
+                error = %e,
+                "could not resolve a room credential's verification method"
+            );
+            AppError::Validation(format!("{what} could not be verified"))
         })?;
 
-        Ok(credential)
-    }
+    credential.verify_proof_with_public_key(&key).map_err(|e| {
+        tracing::warn!(error = %e, "room credential proof did not verify");
+        AppError::Validation(format!("{what} could not be verified"))
+    })?;
+
+    Ok(credential)
 }
 
 /// An [`AuthorityError`] as a refusal.
@@ -229,7 +249,7 @@ impl DtgChainVerifier {
 /// Every variant becomes the same `Forbidden`, with the specifics in the message for an
 /// operator reading logs. A caller learns that the chain did not carry the authority — not
 /// which link to adjust, which would make the verifier a tool for assembling one.
-fn chain_refusal(room_id: &str, e: AuthorityError) -> AppError {
+pub(crate) fn chain_refusal(room_id: &str, e: AuthorityError) -> AppError {
     AppError::Forbidden(format!(
         "the authority chain does not confer this on room `{room_id}`: {e}"
     ))
@@ -544,7 +564,7 @@ mod signed {
 
     /// Resolves a `did:key`'s verification method to its own public key, which is what a
     /// `did:key` is. No network, and no opportunity to resolve to the wrong key.
-    struct DidKeyResolver;
+    pub(crate) struct DidKeyResolver;
 
     #[async_trait::async_trait]
     impl VerificationKeys for DidKeyResolver {
@@ -885,12 +905,21 @@ pub mod test_support {
         pub room_key: Party,
         pub owner: Party,
         pub agent: Party,
+        /// A second member — the one succession is for. Everything a claimant needs and
+        /// nothing more: their own membership and their own chain from the room, at
+        /// `read`. Deliberately *not* an admin, because a successor who already held
+        /// `admin` would prove nothing about whether a nomination is what admitted them.
+        pub successor: Party,
         /// The owner's chain: one link, from the room.
         pub owner_chain: Vec<String>,
         /// The agent's chain: the owner's, with a read-only leaf on top.
         pub agent_chain: Vec<String>,
         /// The owner's membership credential.
         pub membership: String,
+        /// The successor's chain: one link from the room, conferring `read`.
+        pub successor_chain: Vec<String>,
+        /// The successor's own membership credential.
+        pub successor_membership: String,
     }
 
     impl RoomFixture {
@@ -899,6 +928,7 @@ pub mod test_support {
             let room_key = Party::new();
             let owner = Party::new();
             let agent = Party::new();
+            let successor = Party::new();
             let now = Utc::now();
 
             let mut owner_vac = DTGCredential::new_vac(
@@ -949,6 +979,33 @@ pub mod test_support {
                 .await
                 .expect("sign the VMC");
 
+            let mut successor_vac = DTGCredential::new_vac(
+                room_key.did.clone(),
+                successor.did.clone(),
+                room_key.did.clone(),
+                vec!["read".into()],
+                now - Duration::minutes(1),
+                Some(now + Duration::days(30)),
+            )
+            .expect("successor VAC")
+            .with_id("urn:uuid:vac-successor");
+            successor_vac
+                .sign(&room_key.secret, None)
+                .await
+                .expect("sign the successor VAC");
+
+            let mut successor_vmc = DTGCredential::new_vmc(
+                room_key.did.clone(),
+                successor.did.clone(),
+                now - Duration::minutes(1),
+                Some(now + Duration::days(30)),
+                false,
+            );
+            successor_vmc
+                .sign(&room_key.secret, None)
+                .await
+                .expect("sign the successor VMC");
+
             let enc = |c: &DTGCredential| serde_json::to_string(c).expect("serialise");
 
             Self {
@@ -966,9 +1023,12 @@ pub mod test_support {
                 owner_chain: vec![enc(&owner_vac)],
                 agent_chain: vec![enc(&agent_vac), enc(&owner_vac)],
                 membership: enc(&vmc),
+                successor_chain: vec![enc(&successor_vac)],
+                successor_membership: enc(&successor_vmc),
                 room_key,
                 owner,
                 agent,
+                successor,
             }
         }
 
@@ -988,6 +1048,38 @@ pub mod test_support {
                 authority: self.agent_chain.clone(),
                 subject_binding: None,
             }
+        }
+
+        /// The successor's presentation — their own membership, their own chain.
+        pub fn as_successor(&self) -> AuthorityPresentation {
+            AuthorityPresentation {
+                membership: self.successor_membership.clone(),
+                authority: self.successor_chain.clone(),
+                subject_binding: None,
+            }
+        }
+
+        /// A succession nomination: the room grants `succeed` to `successor`.
+        ///
+        /// Signed by the **room**, because that is the only issuer a nomination can have —
+        /// an owner nominating in their own name would be a chain rooted at a person, and
+        /// the whole point is that it is rooted at the room they are stepping away from.
+        pub async fn nominate(&self, successor: &str, valid_until: Option<i64>) -> String {
+            let now = Utc::now();
+            let mut vac = DTGCredential::new_vac(
+                self.room_key.did.clone(),
+                successor.to_string(),
+                self.room_key.did.clone(),
+                vec![crate::ACTION_SUCCEED.into()],
+                now - Duration::minutes(1),
+                valid_until.map(|h| now + Duration::hours(h)),
+            )
+            .expect("nomination VAC")
+            .with_id("urn:uuid:vac-nomination");
+            vac.sign(&self.room_key.secret, None)
+                .await
+                .expect("sign the nomination");
+            serde_json::to_string(&vac).expect("serialise")
         }
     }
 }

--- a/vti-rooms-dtg/src/nomination.rs
+++ b/vti-rooms-dtg/src/nomination.rs
@@ -1,0 +1,319 @@
+//! Verifying a succession nomination.
+//!
+//! The gate `rooms/owner/claim` rests on. A claim is a takeover — whoever holds a valid
+//! nomination can take a dormant room — and what makes that tolerable is that the *previous
+//! owner issued it themselves*, in advance. A host verifies a decision; it never makes one
+//! about who should own a room.
+//!
+//! # A nomination is a VAC, and it grants nothing
+//!
+//! It is an authority credential the room issues to its successor, granting
+//! [`ACTION_SUCCEED`] at the room's own scope. That word is deliberately one no room task
+//! accepts: a nomination confers no power at all while the owner is present, and becomes
+//! redeemable only through `rooms/owner/claim` against a room that has gone dormant.
+//!
+//! Modelling it as a VAC rather than a bespoke document is what buys the structural checks
+//! for free — that the chain's root reaches *the room* and not some party the host happens
+//! to recognise, that no link widens what its parent granted, that every link is in its
+//! window. Those are the properties that make a nomination worth anything, they are already
+//! implemented and tested in [`dtg_credentials::authority::verify_chain`], and a second
+//! hand-rolled copy would differ from it in some detail nobody notices until it matters.
+//!
+//! # What is deliberately not checked here
+//!
+//! **Whether the room is claimable.** That is a question about the room's lifecycle rather
+//! than about the credential, the host answers it from its own clock, and keeping them
+//! apart means a nomination presented early reads as "the owner is still here" rather than
+//! "your credential is bad" — which is the difference between an answer a successor can act
+//! on and one that sends them looking for a new nomination.
+
+use dtg_credentials::authority::verify_chain;
+use vti_common::error::AppError;
+use vti_rooms::authz::ACTION_SUCCEED;
+
+use crate::{VerificationKeys, chain_refusal, open_credential};
+
+/// A verified nomination.
+///
+/// Constructible only by [`verify`], so a caller cannot reach ownership transfer holding
+/// something nobody checked.
+#[derive(Debug)]
+pub struct VerifiedNomination {
+    successor: String,
+}
+
+impl VerifiedNomination {
+    /// The party the room nominated — established by the credential, never asserted by the
+    /// sender.
+    pub fn successor(&self) -> &str {
+        &self.successor
+    }
+}
+
+/// Verify a nomination for `room_id` presented by `claimant`.
+pub async fn verify(
+    encoded: &str,
+    room_id: &str,
+    claimant: &str,
+    keys: &dyn VerificationKeys,
+) -> Result<VerifiedNomination, AppError> {
+    let nomination = open_credential(encoded, "the nomination", keys).await?;
+
+    // Both the governing party and the requested scope are the room. A nomination issued by
+    // the community the room belongs to, or by its host, or by a previous owner personally,
+    // reaches nothing here — which is the same rule every other room credential lives under,
+    // and the reason a room can change hosts without reissuing anything.
+    let verified = verify_chain(
+        std::slice::from_ref(&nomination),
+        room_id,
+        room_id,
+        ACTION_SUCCEED,
+        claimant,
+        chrono::Utc::now(),
+    )
+    .map_err(|e| chain_refusal(room_id, e))?;
+
+    // `verify_chain` uses `claimant` only for the audience check; it does not require the
+    // grant to name them. Without this a nomination would be a bearer token, and anyone who
+    // ever observed one could take the room the moment it went dormant.
+    if verified.subject != claimant {
+        return Err(AppError::Forbidden(format!(
+            "the nomination names `{}`, not the party claiming; a nomination is not \
+             transferable",
+            verified.subject
+        )));
+    }
+
+    Ok(VerifiedNomination {
+        successor: verified.subject,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_tdk::dids::{DID, KeyType};
+    use chrono::{Duration, Utc};
+    use dtg_credentials::DTGCredential;
+
+    use crate::signed::DidKeyResolver;
+
+    struct Fixture {
+        room_did: String,
+        room_secret: affinidi_tdk::secrets_resolver::secrets::Secret,
+        successor_did: String,
+    }
+
+    async fn fixture() -> Fixture {
+        let (room_did, room_secret) = DID::generate_did_key(KeyType::Ed25519).expect("room key");
+        let (successor_did, _) = DID::generate_did_key(KeyType::Ed25519).expect("successor key");
+        Fixture {
+            room_did,
+            room_secret,
+            successor_did,
+        }
+    }
+
+    /// Mint a nomination, with every knob a test might want to turn wrong.
+    async fn nomination(
+        issuer: &str,
+        signer: &affinidi_tdk::secrets_resolver::secrets::Secret,
+        subject: &str,
+        scope: &str,
+        actions: Vec<String>,
+        valid_until: Option<chrono::DateTime<Utc>>,
+    ) -> String {
+        let now = Utc::now();
+        let mut vac = DTGCredential::new_vac(
+            issuer.to_string(),
+            subject.to_string(),
+            scope.to_string(),
+            actions,
+            now - Duration::minutes(1),
+            valid_until,
+        )
+        .expect("build the nomination")
+        .with_id("urn:uuid:vac-nomination");
+        vac.sign(signer, None).await.expect("sign");
+        serde_json::to_string(&vac).expect("serialise")
+    }
+
+    async fn good(f: &Fixture) -> String {
+        nomination(
+            &f.room_did,
+            &f.room_secret,
+            &f.successor_did,
+            &f.room_did,
+            vec![ACTION_SUCCEED.into()],
+            Some(Utc::now() + Duration::days(365)),
+        )
+        .await
+    }
+
+    /// The one that must pass, or every refusal below proves nothing.
+    #[tokio::test]
+    async fn the_room_s_own_nomination_verifies() {
+        let f = fixture().await;
+        let verified = verify(
+            &good(&f).await,
+            &f.room_did,
+            &f.successor_did,
+            &DidKeyResolver,
+        )
+        .await
+        .expect("the room nominated this party");
+        assert_eq!(verified.successor(), f.successor_did);
+    }
+
+    /// The property the whole design rests on: a nomination is worth something because it
+    /// reaches *the room*, not because a host recognises the issuer.
+    #[tokio::test]
+    async fn a_nomination_from_anyone_but_the_room_reaches_nothing() {
+        let f = fixture().await;
+        let (impostor_did, impostor_secret) =
+            DID::generate_did_key(KeyType::Ed25519).expect("impostor key");
+
+        // Perfectly valid as a credential. Signed correctly, in date, naming the right
+        // party — and it names the right room's scope, which is exactly the document
+        // anyone can write.
+        let forged = nomination(
+            &impostor_did,
+            &impostor_secret,
+            &f.successor_did,
+            &f.room_did,
+            vec![ACTION_SUCCEED.into()],
+            Some(Utc::now() + Duration::days(365)),
+        )
+        .await;
+
+        verify(&forged, &f.room_did, &f.successor_did, &DidKeyResolver)
+            .await
+            .expect_err("a self-issued nomination for someone else's room is worthless");
+    }
+
+    /// Without this a nomination is a bearer token: anyone who ever saw one could take the
+    /// room the moment it went dormant.
+    #[tokio::test]
+    async fn a_nomination_is_not_transferable() {
+        let f = fixture().await;
+        let (opportunist, _) = DID::generate_did_key(KeyType::Ed25519).expect("key");
+
+        let err = verify(&good(&f).await, &f.room_did, &opportunist, &DidKeyResolver)
+            .await
+            .expect_err("presenting someone else's nomination confers nothing");
+        assert!(
+            format!("{err}").contains("not transferable"),
+            "the refusal should say why: {err}"
+        );
+    }
+
+    /// A nomination for one room says nothing about another. Both are the room's own
+    /// credentials; only one is about this room.
+    #[tokio::test]
+    async fn a_nomination_for_another_room_does_not_carry() {
+        let f = fixture().await;
+        let (other_room, _) = DID::generate_did_key(KeyType::Ed25519).expect("other room");
+
+        let elsewhere = nomination(
+            &f.room_did,
+            &f.room_secret,
+            &f.successor_did,
+            &other_room,
+            vec![ACTION_SUCCEED.into()],
+            Some(Utc::now() + Duration::days(365)),
+        )
+        .await;
+
+        verify(&elsewhere, &f.room_did, &f.successor_did, &DidKeyResolver)
+            .await
+            .expect_err("a nomination scoped to another room does not claim this one");
+    }
+
+    /// The spec's advice — nominations SHOULD expire — is only advice if an expired one
+    /// still works.
+    #[tokio::test]
+    async fn an_expired_nomination_is_refused() {
+        let f = fixture().await;
+        let stale = nomination(
+            &f.room_did,
+            &f.room_secret,
+            &f.successor_did,
+            &f.room_did,
+            vec![ACTION_SUCCEED.into()],
+            Some(Utc::now() - Duration::days(1)),
+        )
+        .await;
+
+        verify(&stale, &f.room_did, &f.successor_did, &DidKeyResolver)
+            .await
+            .expect_err("a standing right to take the room should not outlive its window");
+    }
+
+    /// The separation that keeps `succeed` inert. An ordinary admin grant — the one a
+    /// co-admin legitimately holds — must not double as a nomination, or every admin is a
+    /// silent successor.
+    #[tokio::test]
+    async fn an_admin_grant_is_not_a_nomination() {
+        let f = fixture().await;
+        let admin = nomination(
+            &f.room_did,
+            &f.room_secret,
+            &f.successor_did,
+            &f.room_did,
+            vec![
+                "read".into(),
+                "write".into(),
+                "curate".into(),
+                "admin".into(),
+            ],
+            Some(Utc::now() + Duration::days(365)),
+        )
+        .await;
+
+        verify(&admin, &f.room_did, &f.successor_did, &DidKeyResolver)
+            .await
+            .expect_err("holding admin today is not the same as being named successor");
+    }
+
+    /// And the converse, which is the reason `succeed` is not an `Action`: a nomination
+    /// confers no power in the room it nominates for.
+    #[tokio::test]
+    async fn a_nomination_confers_nothing_in_the_room() {
+        let f = fixture().await;
+        let nom = good(&f).await;
+
+        let room = vti_rooms::Room {
+            room_id: f.room_did.clone(),
+            owner_did: "did:key:z6MkSomeoneElse".into(),
+            visibility: vti_rooms::Visibility::Open,
+            epoch: 1,
+            next_version: 1,
+            retention_days: 90,
+            epoch_expires_at: None,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let verifier = crate::DtgChainVerifier::without_zk(Box::new(DidKeyResolver));
+
+        for action in [
+            vti_rooms::authz::Action::Read,
+            vti_rooms::authz::Action::Write,
+            vti_rooms::authz::Action::Curate,
+            vti_rooms::authz::Action::Admin,
+        ] {
+            vti_rooms::authz::ChainVerifier::verify(
+                &verifier,
+                &room,
+                &vti_rooms::wire::AuthorityPresentation {
+                    membership: nom.clone(),
+                    authority: vec![nom.clone()],
+                    subject_binding: None,
+                },
+                action,
+                &f.successor_did,
+            )
+            .await
+            .expect_err("a nomination grants `succeed`, which no room action accepts");
+        }
+    }
+}

--- a/vti-rooms/src/audit.rs
+++ b/vti-rooms/src/audit.rs
@@ -111,18 +111,68 @@ pub fn for_operation(
     }
 }
 
-/// The `room.*` audit action name for an operation.
+/// A room operation, as an audit log names it.
 ///
-/// Named per the design's `room.*` vocabulary rather than reusing the authority action, so
-/// a log distinguishes "read a record" from "listed the room" — both are `read` on the
-/// authority axis and different events to anyone reading a log.
-pub fn action_name(action: Action, listed: bool) -> &'static str {
-    match (action, listed) {
-        (Action::Read, true) => "room.records.list",
-        (Action::Read, false) => "room.records.get",
-        (Action::Write, _) => "room.records.put",
-        (Action::Curate, _) => "room.records.curate",
-        (Action::Admin, _) => "room.epoch.mint",
+/// The authority action is not enough to name an operation, and the gap is not cosmetic.
+/// Three distinct operations gate on `admin` — minting an epoch, handing the room to
+/// someone, and a successor taking it — and an audit trail that recorded all three as
+/// `room.epoch.mint` would be at its least informative at exactly the moment someone reads
+/// it, which is after an ownership change they did not expect.
+///
+/// So the handler names the operation and the required action is *derived* from it
+/// ([`RoomOperation::required_action`]). That direction matters: it is the one that cannot
+/// drift. A handler cannot gate on `read` while logging a transfer, because it does not get
+/// to choose both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoomOperation {
+    /// Read one record.
+    GetRecord,
+    /// Enumerate the room's records. Distinct from a read on the same authority: both are
+    /// `read`, and "read one document" and "took an inventory of the room" are different
+    /// events to anyone reading a log.
+    ListRecords,
+    /// Write a record.
+    PutRecord,
+    /// Change a record's standing.
+    CurateRecord,
+    /// Advance the epoch — which is also what renews the room.
+    MintEpoch,
+    /// The owner hands the room to another member.
+    TransferOwner,
+    /// A nominated successor takes a dormant room.
+    ClaimOwner,
+}
+
+impl RoomOperation {
+    /// The `room.*` audit action name, per the design's vocabulary.
+    pub fn action_name(self) -> &'static str {
+        match self {
+            RoomOperation::GetRecord => "room.records.get",
+            RoomOperation::ListRecords => "room.records.list",
+            RoomOperation::PutRecord => "room.records.put",
+            RoomOperation::CurateRecord => "room.records.curate",
+            RoomOperation::MintEpoch => "room.epoch.mint",
+            RoomOperation::TransferOwner => "room.owner.transfer",
+            RoomOperation::ClaimOwner => "room.owner.claim",
+        }
+    }
+
+    /// The authority action a party must hold to perform it.
+    ///
+    /// `ClaimOwner` is `Read`, and that is not a weaker gate by accident. A successor is
+    /// being checked for *membership* — the room's own statement that they are a member and
+    /// so could renew what they are claiming — not for authority they were never given. What
+    /// authorizes the claim is the nomination, which is verified separately and is the only
+    /// thing that makes the operation possible at all.
+    pub fn required_action(self) -> Action {
+        match self {
+            RoomOperation::GetRecord | RoomOperation::ListRecords | RoomOperation::ClaimOwner => {
+                Action::Read
+            }
+            RoomOperation::PutRecord => Action::Write,
+            RoomOperation::CurateRecord => Action::Curate,
+            RoomOperation::MintEpoch | RoomOperation::TransferOwner => Action::Admin,
+        }
     }
 }
 
@@ -227,12 +277,55 @@ mod tests {
     /// anyone reading a log.
     #[test]
     fn listing_and_fetching_are_distinct_actions_in_the_log() {
-        assert_eq!(action_name(Action::Read, true), "room.records.list");
-        assert_eq!(action_name(Action::Read, false), "room.records.get");
-        assert_ne!(
-            action_name(Action::Read, true),
-            action_name(Action::Read, false)
+        assert_eq!(
+            RoomOperation::ListRecords.action_name(),
+            "room.records.list"
         );
-        assert_eq!(action_name(Action::Admin, false), "room.epoch.mint");
+        assert_eq!(RoomOperation::GetRecord.action_name(), "room.records.get");
+        assert_eq!(
+            RoomOperation::ListRecords.required_action(),
+            RoomOperation::GetRecord.required_action(),
+            "the same authority, and that is exactly why the action name has to differ"
+        );
+    }
+
+    /// The defect this enum exists to prevent: three operations gate on `admin`, and a log
+    /// that called all three `room.epoch.mint` would be least useful precisely when someone
+    /// is trying to find out who took the room.
+    #[test]
+    fn every_operation_has_its_own_name() {
+        let all = [
+            RoomOperation::GetRecord,
+            RoomOperation::ListRecords,
+            RoomOperation::PutRecord,
+            RoomOperation::CurateRecord,
+            RoomOperation::MintEpoch,
+            RoomOperation::TransferOwner,
+            RoomOperation::ClaimOwner,
+        ];
+        let mut names: Vec<_> = all.iter().map(|o| o.action_name()).collect();
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+        assert_eq!(names.len(), count, "two operations share an audit name");
+
+        for op in all {
+            assert!(
+                op.action_name().starts_with("room."),
+                "{op:?} is outside the room.* vocabulary"
+            );
+        }
+    }
+
+    /// A claim is gated on membership, not on authority the successor was never given —
+    /// what authorizes it is the nomination, checked elsewhere.
+    #[test]
+    fn a_claim_asks_for_membership_not_admin() {
+        assert_eq!(RoomOperation::ClaimOwner.required_action(), Action::Read);
+        assert_eq!(
+            RoomOperation::TransferOwner.required_action(),
+            Action::Admin,
+            "an owner handing the room away is the most consequential thing they do"
+        );
     }
 }

--- a/vti-rooms/src/authz.rs
+++ b/vti-rooms/src/authz.rs
@@ -78,6 +78,21 @@ impl Action {
     }
 }
 
+/// The action a succession nomination grants, and the reason it is not an [`Action`].
+///
+/// A nomination is a VAC the room issues to a successor, and it has to grant *something*
+/// for a chain verifier to check it against. It must not grant `admin`: that would make the
+/// nominee an administrator today, which is precisely the power a nomination must withhold
+/// while the owner is present — the whole point is a right that lies dormant until the
+/// owner does.
+///
+/// So it grants `succeed`, which no room task accepts. It is redeemable through exactly one
+/// path, `rooms/owner/claim`, and only against a dormant room. Keeping it out of [`Action`]
+/// is what makes that true by construction rather than by discipline: [`authorize`] cannot
+/// be passed it, so no amount of future editing there can quietly turn a nomination into a
+/// working grant.
+pub const ACTION_SUCCEED: &str = "succeed";
+
 /// What a verifier concludes about a presentation.
 ///
 /// Deliberately narrow: the caller gets the subject and the actions the chain confers, and

--- a/vti-rooms/src/lifecycle.rs
+++ b/vti-rooms/src/lifecycle.rs
@@ -104,6 +104,20 @@ impl Lifecycle {
         true
     }
 
+    /// Whether a nominated successor may claim a room in this state.
+    ///
+    /// **Dormant, not merely lapsed.** An epoch expiring is frequently somebody on holiday;
+    /// a room still unrenewed after the grace window is a room whose owner has stopped, and
+    /// has had a notice saying so. Allowing a claim the instant an epoch lapsed would make
+    /// every holiday a takeover window.
+    ///
+    /// `Reclaimable` counts too: a room past its retention is more claimable, not less —
+    /// refusing there would mean the only party who could save it loses the right at exactly
+    /// the moment it matters.
+    pub fn admits_a_claim(&self) -> bool {
+        matches!(self, Lifecycle::Dormant | Lifecycle::Reclaimable)
+    }
+
     /// The wire form.
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -259,6 +273,43 @@ mod tests {
         ] {
             assert!(s.serves_reads(), "{s:?} must still serve reads");
         }
+    }
+
+    /// The window a claim opens in, and the one it must not.
+    #[test]
+    fn a_claim_needs_dormancy_not_merely_a_lapse() {
+        let r = room(Some(NOW), 90);
+
+        assert!(
+            !r.lifecycle(NOW + DAY).admits_a_claim(),
+            "an epoch expiring is often somebody on holiday, not an abandoned room"
+        );
+        assert!(
+            !r.lifecycle(NOW + 29 * DAY).admits_a_claim(),
+            "still inside the grace window"
+        );
+        assert!(
+            r.lifecycle(NOW + 31 * DAY).admits_a_claim(),
+            "past the grace window, and the owner has had their notice"
+        );
+        assert!(
+            r.lifecycle(NOW + 91 * DAY).admits_a_claim(),
+            "a room past retention is more claimable, not less — the only party who could \
+             save it must not lose the right exactly when it matters"
+        );
+    }
+
+    /// Renewing is what cancels a pending claim, which is the property that makes an absent
+    /// owner safe without them ever thinking about it.
+    #[test]
+    fn a_live_room_is_never_claimable() {
+        assert!(!room(Some(NOW + DAY), 90).lifecycle(NOW).admits_a_claim());
+        assert!(
+            !room(None, 90)
+                .lifecycle(NOW + 10_000 * DAY)
+                .admits_a_claim(),
+            "a room that never lapses is never claimable"
+        );
     }
 
     #[test]

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -21,6 +21,7 @@
 //! duplicate would make two records indistinguishable to a watermark; a gap costs nothing.
 
 use vti_common::error::AppError;
+use vti_common::identifier::validate_did;
 use vti_common::store::KeyspaceHandle;
 
 use super::{Record, RecordStatus, Room};
@@ -48,6 +49,7 @@ fn record_prefix(room_id: &str) -> String {
 /// Refuses to replace an existing one: re-registering would silently reset the epoch and
 /// the version counter, which a client would read as the room having been rolled back.
 pub async fn create_room(rooms: &KeyspaceHandle, room: &Room) -> Result<(), AppError> {
+    validate_did("ownerDid", &room.owner_did)?;
     if rooms.get_raw(room_key(&room.room_id)).await?.is_some() {
         return Err(AppError::Conflict(format!(
             "room `{}` is already registered here",
@@ -106,6 +108,36 @@ pub async fn advance_epoch(
     }
     room.epoch = new_epoch;
     room.epoch_expires_at = Some(now + epoch_lifetime_seconds());
+    room.updated_at = now;
+    rooms.insert(room_key(room_id), &room).await?;
+    Ok(room)
+}
+
+/// Record a new owner.
+///
+/// Both `rooms/owner/transfer` and `rooms/owner/claim` end here — they differ entirely in
+/// what has to be true *before* this is reached, and not at all in what it does.
+///
+/// **Does not renew the room.** A claim takes a dormant room and leaves it dormant; only
+/// minting an epoch makes it live again. That is deliberate: the new owner's first act
+/// should be the one that proves they can perform it, and a claim that silently renewed
+/// would hand ownership to someone who might turn out to be unable to commit — with the
+/// room looking healthy until the next lapse a year later. If they do not renew, the next
+/// nominee can claim in turn, which is the succession chain working rather than failing.
+pub async fn set_owner(
+    rooms: &KeyspaceHandle,
+    room_id: &str,
+    new_owner_did: &str,
+    now: u64,
+) -> Result<Room, AppError> {
+    // The owner is what a host addresses about quota, abuse and lifecycle, so a value that
+    // is not an identifier at all is a room nobody can be reached about. Cheap to refuse
+    // here and impossible to fix later, since the party who could correct it is the one the
+    // bad value replaced.
+    validate_did("ownerDid", new_owner_did)?;
+
+    let mut room = get_room(rooms, room_id).await?;
+    room.owner_did = new_owner_did.to_string();
     room.updated_at = now;
     rooms.insert(room_key(room_id), &room).await?;
     Ok(room)
@@ -856,5 +888,34 @@ mod tests {
             purge_record(&rec, "r1", "a").await.is_err(),
             "purging an absent record reports not-found rather than succeeding quietly"
         );
+    }
+
+    /// The owner is who a host addresses about quota, abuse and lifecycle. A transfer to
+    /// something that is not an identifier produces a room nobody can be reached about —
+    /// and the party who could correct it is exactly the one the bad value replaced.
+    #[tokio::test]
+    async fn an_owner_must_be_a_did() {
+        let (_d, rooms, _records) = open().await;
+        create_room(&rooms, &room("did:key:zRoom", Visibility::Open))
+            .await
+            .expect("a real DID");
+
+        for bad in ["", "alice@example.com", "did:key:z Alice", "not-a-did"] {
+            set_owner(&rooms, "did:key:zRoom", bad, 1)
+                .await
+                .unwrap_err();
+        }
+
+        assert_eq!(
+            get_room(&rooms, "did:key:zRoom").await.unwrap().owner_did,
+            "did:key:zOwner",
+            "and a refused transfer left the room where it was"
+        );
+
+        let moved = set_owner(&rooms, "did:key:zRoom", "did:key:zBob", 99)
+            .await
+            .expect("a real DID");
+        assert_eq!(moved.owner_did, "did:key:zBob");
+        assert_eq!(moved.updated_at, 99);
     }
 }

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -1,16 +1,25 @@
 //! Wire types for the `rooms/*` Trust Tasks.
 //!
-//! # Why these are hand-written
+//! # Why these are hand-written, now that the generated ones exist
 //!
-//! They mirror the payload schemas proposed in
-//! `trustoverip/dtgwg-trust-tasks-tf#346`, and are written here rather than taken from
-//! `trust_tasks_rs::specs` because that PR is still in review — the generated bindings do
-//! not exist yet. This is the same shape `vta_sdk::protocols::*` already uses for the VTA's
-//! families: hand-written wire types beside the generated ones.
+//! They began as a mirror of schemas still in review upstream. Those schemas have since
+//! published and `trust_tasks_rs::specs::rooms` carries generated bindings — so the earlier
+//! instruction here, to replace these with the generated types on publication, has come due
+//! and is **deliberately not being followed.**
 //!
-//! **When #346 merges and `trust-tasks-rs` publishes, replace these with the generated
-//! types rather than keeping both.** Two definitions of one wire format is how casing drift
-//! gets in, and this workspace has paid for that before.
+//! The reason is that the generated types are shaped for a different job. They use newtypes
+//! and `NonZeroU64` where a storage layer wants plain `String` and `u64`, they are
+//! `#[non_exhaustive]`, and they are built through builders — all correct for a client
+//! constructing a request, all friction for a crate whose types are also its storage
+//! records. Converting would push that friction into every handler and every host.
+//!
+//! What the original instruction was actually protecting against is two descriptions of one
+//! wire format drifting apart, and that danger is real: a `snake_case` field where the
+//! schema says `camelCase` is invisible to every Rust test, because both sides of a
+//! round-trip use the same struct. So the protection is kept and the conversion is not:
+//! `tests/schema_conformance.rs` validates what these types actually serialise to against
+//! the published schemas. **Every type here must appear in that file.** Agreeing on the
+//! wire is the requirement; agreeing on the Rust shape never was.
 //!
 //! Every struct is `camelCase` and `deny_unknown_fields`: these carry authorization
 //! decisions, and an unknown member on one of those is a request that means something the
@@ -30,6 +39,10 @@ pub const ROOMS_RECORDS_GET_TYPE: &str = "https://trusttasks.org/spec/rooms/reco
 pub const ROOMS_RECORDS_LIST_TYPE: &str = "https://trusttasks.org/spec/rooms/records/list/0.1";
 /// `rooms/epoch/mint/0.1`.
 pub const ROOMS_EPOCH_MINT_TYPE: &str = "https://trusttasks.org/spec/rooms/epoch/mint/0.1";
+/// `rooms/owner/transfer/0.1`.
+pub const ROOMS_OWNER_TRANSFER_TYPE: &str = "https://trusttasks.org/spec/rooms/owner/transfer/0.1";
+/// `rooms/owner/claim/0.1`.
+pub const ROOMS_OWNER_CLAIM_TYPE: &str = "https://trusttasks.org/spec/rooms/owner/claim/0.1";
 /// `rooms/records/curate/0.1`.
 pub const ROOMS_RECORDS_CURATE_TYPE: &str = "https://trusttasks.org/spec/rooms/records/curate/0.1";
 
@@ -41,6 +54,8 @@ pub const ROOMS_DISPATCHED_URIS: &[&str] = &[
     ROOMS_RECORDS_LIST_TYPE,
     ROOMS_EPOCH_MINT_TYPE,
     ROOMS_RECORDS_CURATE_TYPE,
+    ROOMS_OWNER_TRANSFER_TYPE,
+    ROOMS_OWNER_CLAIM_TYPE,
 ];
 
 /// What a party presents to act on a room.
@@ -213,6 +228,55 @@ pub struct CurateRecordResponse {
     pub version: u64,
     pub status: RecordStatus,
     pub pinned: bool,
+}
+
+/// `rooms/owner/transfer/0.1` request.
+///
+/// The deliberate handover, by an owner who is still present. Its counterpart
+/// [`ClaimOwnerBody`] is what happens when they are not — two shapes because they are two
+/// acts, differing in who initiates, what authorizes, and whether the room must have lapsed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TransferOwnerBody {
+    pub room_id: String,
+    /// The member taking ownership.
+    ///
+    /// **The host cannot check that they are one.** It holds no roster, and this party
+    /// presents nothing — the obligation sits with the transferring owner, who can see the
+    /// group. A host must not invent a check it has no basis for, nor treat its own
+    /// ignorance as evidence: doing so would fail every transfer on a correct host.
+    pub new_owner_did: String,
+    /// Must confer `admin` — the same grant that mints epochs.
+    pub presentation: AuthorityPresentation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `rooms/owner/claim/0.1` request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClaimOwnerBody {
+    pub room_id: String,
+    /// The succession credential the room issued to this claimant, serialized per the
+    /// governing profile. The previous owner decided this in advance; a host checks a
+    /// decision rather than making one.
+    pub nomination: String,
+    /// The claimant's own membership and authority.
+    ///
+    /// A host cannot see the MLS group, so this — the room's own statement that the claimant
+    /// is a member — is the only membership signal available, and it is the same one every
+    /// other room task presents.
+    pub presentation: AuthorityPresentation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `rooms/owner/{transfer,claim}/0.1#response`. One shape, because both end the same way.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnerResponse {
+    pub room_id: String,
+    pub owner_did: String,
 }
 
 /// `rooms/epoch/mint/0.1` request.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -300,3 +300,198 @@ fn responses_conform() {
 
     check::<ListResponse>("ListRecordsResponse", &json!({ "records": records }));
 }
+
+/// Curate shipped without an entry here — the same omission as its missing dispatch-census
+/// entry, and from the same cause: a second list of the same thing agrees right up until
+/// someone adds to one of them.
+#[test]
+fn curate_conforms() {
+    use trust_tasks_rs::specs::rooms::records::curate::v0_1::Payload;
+
+    let body = CurateRecordBody {
+        room_id: "did:webvh:example.com:rooms:northwind".into(),
+        key: "decision/pricing-2026".into(),
+        presentation: presentation(),
+        status: Some(RecordStatus::Deprecated),
+        pinned: Some(false),
+        reason: Some("superseded by the Q3 renewal".into()),
+        expected_version: Some(4),
+    };
+    check::<Payload>(
+        "CurateRecordBody",
+        &serde_json::to_value(&body).expect("serialise"),
+    );
+
+    // Every member but the first three is optional, and a curation that changes only
+    // `pinned` is the ordinary case rather than the exotic one.
+    check::<Payload>(
+        "CurateRecordBody pinning only",
+        &serde_json::to_value(CurateRecordBody {
+            status: None,
+            pinned: Some(true),
+            reason: None,
+            expected_version: None,
+            ..body
+        })
+        .expect("serialise"),
+    );
+}
+
+#[test]
+fn curate_response_conforms() {
+    use trust_tasks_rs::specs::rooms::records::curate::v0_1::Response;
+
+    check::<Response>(
+        "CurateRecordResponse",
+        &serde_json::to_value(CurateRecordResponse {
+            key: "decision/pricing-2026".into(),
+            version: 5,
+            status: RecordStatus::Deprecated,
+            pinned: false,
+        })
+        .expect("serialise"),
+    );
+}
+
+// ─── Succession ──────────────────────────────────────────────────────────
+
+#[test]
+fn transfer_owner_conforms() {
+    use trust_tasks_rs::specs::rooms::owner::transfer::v0_1::Payload;
+
+    check::<Payload>(
+        "TransferOwnerBody",
+        &serde_json::to_value(TransferOwnerBody {
+            room_id: "did:webvh:example.com:rooms:northwind".into(),
+            new_owner_did: "did:key:z6MkBob".into(),
+            presentation: presentation(),
+            reason: Some("stepping back from this project".into()),
+        })
+        .expect("serialise"),
+    );
+}
+
+#[test]
+fn claim_owner_conforms() {
+    use trust_tasks_rs::specs::rooms::owner::claim::v0_1::Payload;
+
+    let body = ClaimOwnerBody {
+        room_id: "did:webvh:example.com:rooms:northwind".into(),
+        nomination: "urn:uuid:55555555-5555-5555-5555-555555555555".into(),
+        presentation: presentation(),
+        reason: Some("the owner has been unreachable since March".into()),
+    };
+    let value = serde_json::to_value(&body).expect("serialise");
+    check::<Payload>("ClaimOwnerBody", &value);
+
+    // The correction in #361: a claim carries the claimant's own presentation, because it
+    // is the only membership signal a host has. Its absence was an unimplementable
+    // condition, so its presence is worth pinning rather than assuming.
+    assert!(
+        value["presentation"].is_object(),
+        "a claim must carry a presentation: {value}"
+    );
+
+    // And `reason` really is optional — a schema that quietly required it would make every
+    // terse claim fail at the host rather than here.
+    let bare = ClaimOwnerBody {
+        reason: None,
+        ..body
+    };
+    check::<Payload>(
+        "ClaimOwnerBody without a reason",
+        &serde_json::to_value(&bare).expect("serialise"),
+    );
+}
+
+/// Both succession tasks answer with the same shape, and the schemas are separate
+/// documents — so "the same shape" is a claim to check, not one to assume.
+#[test]
+fn owner_responses_conform() {
+    use trust_tasks_rs::specs::rooms::owner::claim::v0_1::Response as ClaimResponse;
+    use trust_tasks_rs::specs::rooms::owner::transfer::v0_1::Response as TransferResponse;
+
+    let response = serde_json::to_value(OwnerResponse {
+        room_id: "did:webvh:example.com:rooms:northwind".into(),
+        owner_did: "did:key:z6MkBob".into(),
+    })
+    .expect("serialise");
+
+    check::<TransferResponse>("OwnerResponse (transfer)", &response);
+    check::<ClaimResponse>("OwnerResponse (claim)", &response);
+}
+
+// ─── The URIs themselves ─────────────────────────────────────────────────
+
+/// Every `rooms/*` URI constant must be the one the registry publishes.
+///
+/// This is the guarantee the hosts' dispatch censuses could not give on their own. They pin
+/// a dispatcher against `vti_rooms::wire`, which answers "do these two lists agree" — and
+/// two lists agreeing says nothing if both are wrong. Comparing against the generated
+/// `TYPE_URI` is what makes the answer "and they agree with the spec".
+///
+/// It matters because a URI is matched as a string. A version segment that drifted, or a
+/// path this crate spelled differently from the schema, produces a service that answers
+/// `unsupportedType` to a document the registry says it serves — with nothing in Rust
+/// noticing, because every test on both sides uses the same constant.
+#[test]
+fn every_dispatched_uri_is_the_published_one() {
+    use trust_tasks_rs::specs::rooms;
+
+    let published: Vec<(&str, &str)> = vec![
+        (
+            ROOMS_CREATE_TYPE,
+            <rooms::create::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_RECORDS_PUT_TYPE,
+            <rooms::records::put::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_RECORDS_GET_TYPE,
+            <rooms::records::get::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_RECORDS_LIST_TYPE,
+            <rooms::records::list::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_RECORDS_CURATE_TYPE,
+            <rooms::records::curate::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_EPOCH_MINT_TYPE,
+            <rooms::epoch::mint::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_OWNER_TRANSFER_TYPE,
+            <rooms::owner::transfer::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_OWNER_CLAIM_TYPE,
+            <rooms::owner::claim::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+    ];
+
+    for (ours, registry) in &published {
+        assert_eq!(ours, registry, "this crate's URI is not the published one");
+    }
+
+    // And the dispatch list is exactly those — so a URI cannot be added to `wire` without
+    // being checked against the registry here.
+    assert_eq!(
+        ROOMS_DISPATCHED_URIS.len(),
+        published.len(),
+        "a dispatched URI has no registry check: {:?}",
+        ROOMS_DISPATCHED_URIS
+            .iter()
+            .filter(|u| !published.iter().any(|(ours, _)| ours == *u))
+            .collect::<Vec<_>>()
+    );
+    for u in ROOMS_DISPATCHED_URIS {
+        assert!(
+            published.iter().any(|(ours, _)| ours == u),
+            "{u} is dispatched but not checked against the registry"
+        );
+    }
+}


### PR DESCRIPTION
Implements `rooms/owner/transfer` and `rooms/owner/claim` (specs #359, #361,
published in trust-tasks-rs 0.17.9) across `vti-rooms`, `vti-rooms-dtg`,
`vtc-service`, `room-host` and `vtc-client`.

Ownership is load-bearing for liveness, not just administration: a room's owner
is its sole committer, so a room with no reachable owner cannot advance an epoch
— and one that cannot advance an epoch cannot be renewed, cannot admit anyone,
and lapses to read-only. Without succession, one person becoming unreachable
ends a shared space.

Transfer is the owner acting while present, gated on `admin`. Claim needs three
things at once: a nomination the room itself issued naming this claimant, a room
that has gone *dormant* rather than merely lapsed, and the claimant's own
membership. Each closes a different route to a takeover.

A nomination is a VAC granting `succeed` — deliberately a word no room task
accepts, so it confers nothing at all while the owner is present. Keeping it out
of the `Action` enum is what makes that structural rather than a matter of
discipline: `authorize` cannot be handed it, so no later edit there can quietly
turn a nomination into a working grant. Verification goes through
`authority::verify_chain` so the property that matters — the chain reaches *the
room* — comes from the library rather than a second hand-rolled copy.

The defence against a hostile claim is the same act as ordinary use. An owner
who was merely away defeats every pending claim by minting an epoch, which is
what they would have done anyway; nothing has to be revoked and no dispute has
to be raised. Hence dormancy rather than lapse — a window that opened the moment
an epoch expired would make every holiday one.

A claim does not renew the room. `set_owner` hands over a dormant room and
leaves it dormant, so the new owner's first act is the one that proves they can
perform it. A claim that silently renewed would hand the room to someone who
might turn out to be unable to commit, with the room looking healthy until the
next lapse a year later.

Neither host checks that an incoming owner is a member of the MLS group, because
neither can: a host holds no roster and no group state. Refusing what it cannot
verify would fail every correct transfer, and treating its own ignorance as
evidence would convert "I don't know" into "no". On claim the host uses the one
signal it has — the VMC the room issued — and the spec is exact about what that
proxy is worth.

Three defects found on the way, fixed rather than worked around:

`audit::action_name` mapped `Admin` to `room.epoch.mint`, so a transfer would
have been logged as an epoch mint — least informative exactly when someone reads
the log after an unexpected ownership change. Replaced the `(Action, bool)` pair
with a `RoomOperation` enum from which the required action is derived, so a
handler cannot gate on one thing and log another.

`wire::ROOMS_DISPATCHED_URIS` had no consumer, so `rooms/records/curate` was
dispatched by the VTC while appearing in neither the declared-URI census nor the
schema-conformance suite. Both censuses now read that constant, `room-host` gains
the routing census it never had, and curate gains its conformance entries.

Those censuses could only ever check that two of our own lists agreed, which says
nothing if both are wrong — a URI is matched as a string, so a drifted version
segment produces a service answering `unsupportedType` to a document the registry
says it serves, with nothing in Rust noticing. Now that the bindings have
published, `every_dispatched_uri_is_the_published_one` pins each constant against
its generated `TYPE_URI`, so the chain reaches the registry.

`vti-rooms-dtg`'s signed tests compiled only when another workspace member
happened to enable `test-support` and cargo unified the feature — `cargo test -p
vti-rooms-dtg` alone failed to build. A self dev-dependency fixes it.

`storage::set_owner` and `create_room` now validate the owner DID. The owner is
what a host addresses about quota, abuse and lifecycle, and the party who could
correct a bad value is the one it replaced.

The `data_room` example gains Act IV, which transfers a room, shows the same
nomination stop working the instant its owner renews, and claims an abandoned
one. §10 of the data-rooms design note gains the reasoning.

## Verification

- `cargo test --workspace --all-features` — clean, 165 test binaries
- `cargo clippy --workspace --all-targets --all-features` — clean
- `cargo run -p room-host --example data_room` — runs end to end, Act IV included

## Pre-merge checklist (cross-service)

- Wire types are camelCase and `deny_unknown_fields`; both new bodies validate
  against their published schemas in `vti-rooms/tests/schema_conformance.rs`.
- No new retry loop; neither verb is wrapped in one.
- No `version =` field edited. The semver report will go red on `vti-rooms` and
  `vti-rooms-dtg` — `RoomOperation` replaces `audit::action_name`, and there are
  new public items. That is the report working; release-plz puts the bump in the
  Release PR.
