### PR TITLE
ci(semver): stop the report aborting on an unpublished crate, and assert its coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,12 @@ jobs:
     # the release moves the compatibility field instead of shipping it as a
     # patch. release-plz enforces that automatically from the same signal.
     #
+    # A third instance of that same confusion is recorded in
+    # scripts/semver-report.sh: for several releases this job checked two crates
+    # and stopped, because an unpublished workspace member aborts the run and a
+    # truncated report is red in exactly the way a declared break is red. The
+    # script now asserts coverage rather than only explaining the red.
+    #
     # The name says "report" because the check list is the only place most
     # people meet this job, and there it is a bare name next to a red cross.
     # Called "semver checks" it is indistinguishable from a gate that broke —
@@ -492,87 +498,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-semver-checks
 
-      # Excludes the twelve subsystem crates. They are on crates.io only
-      # because a published crate's whole dependency closure must be published
-      # and `vta-service` is published (for OpenVTC's `MockVta` harness — see
-      # RELEASING.md). Nothing consumes their APIs directly, here or outside.
+      # Everything this job knows about its own failure modes now lives in
+      # scripts/semver-report.sh, including the exclusion list and the reasons
+      # for it. It moved out of the workflow for one reason: a guard that can
+      # only run in CI cannot be tried before it is pushed, and the defect it
+      # was missing was found by reading a CI log rather than by running
+      # anything.
       #
-      # The exclusions are not cosmetic: this job builds rustdoc JSON for every
-      # crate twice, current and baseline. Including them took it from ~17
-      # minutes to over 35 — on every pull request in the repo, for a signal no
-      # consumer can act on. `release-plz.toml` carries the matching
-      # `semver_check = false` so the release decides bumps the same way.
-      #
-      # `vta-service` is NOT excluded: it has a real consumer, so a silent
-      # break there reaches somebody.
-      # A baseline build failure is NOT a CI inconvenience — it is a
-      # production defect, and this step exists to stop the two looking alike.
-      #
-      # cargo-semver-checks builds the baseline the way a consumer gets it:
-      # `cargo add <crate>@<version>` into a fresh crate, resolving from the
-      # published ranges with no lockfile. That makes it the only thing in this
-      # repo that resolves like a consumer — and therefore the only thing that
-      # can notice when a *published* artifact stops building.
-      #
-      # It noticed. `vta-service` 0.17.1 does not build for an external
-      # consumer: `affinidi-tdk 0.8.5` requires `affinidi-messaging-sdk ^0.19`,
-      # which now resolves to 0.19.9 requiring `trust-tasks-rs ^0.11`, while
-      # 0.17.1 and `vta-sdk` 0.25.1 require `^0.9`. Two versions in one graph,
-      # and the types cross in `vta-sdk`'s `acl_setup`. Reproduce in 30s:
-      #
-      #     cargo new --lib x && cd x && echo '[workspace]' >> Cargo.toml
-      #     cargo add vta-service@0.17.1 && cargo build
-      #
-      # Our own builds are fine because `Cargo.lock` pins one of each. Consumers
-      # do not get our lockfile. That is the whole defect in one sentence.
-      #
-      # Crucially, none of those versions were broken when published — they
-      # broke later, together, when a range they each depend on resolved
-      # somewhere new. No amount of care at publish time catches that, which is
-      # why this check has to keep running rather than gate a release.
+      # The addition is a coverage assertion. Both previous guards asked *why
+      # did it stop*; neither asked *did it cover everything*, and an
+      # unpublished workspace member made `cargo semver-checks --workspace`
+      # abort mid-run with an exit status indistinguishable from a declared
+      # break. See the script header.
       - name: Check published crates for API breaks
-        run: |
-          set +e
-          cargo semver-checks --workspace \
-            --exclude vta-audit \
-            --exclude vta-backup \
-            --exclude vta-config \
-            --exclude vta-keys \
-            --exclude vta-keyspaces \
-            --exclude vta-policy \
-            --exclude vta-support \
-            --exclude vta-sweepers \
-            --exclude vta-tee \
-            --exclude vta-vault \
-            --exclude vta-webvh \
-            --exclude vti-webauthn \
-            2>&1 | tee semver.log
-          status=${PIPESTATUS[0]}
-          set -e
-
-          # The distinction that was missing, and the reason a dead check sat
-          # unnoticed: a failed baseline and a clean comparison produced the
-          # same silence, on a job that was already red for a declared break.
-          # One red looked like another.
-          if grep -qE 'failed to build rustdoc|running cargo-doc on crate' semver.log; then
-            broken="$(grep -oE 'failed to build rustdoc for crate [a-z0-9-]+' semver.log \
-              | sed 's/failed to build rustdoc for crate //' | sort -u | tr '\n' ' ')"
-            echo "::error::PUBLISHED CRATE DOES NOT BUILD: ${broken}-- the semver \
-          baseline is the published crate as a consumer receives it, so a \
-          baseline that fails to build means consumers cannot build it either. \
-          This is not 'the check could not run'; it is the check reporting a \
-          broken artifact on crates.io. Reproduce: cargo new --lib x && cd x && \
-          echo '[workspace]' >> Cargo.toml && cargo add ${broken%% *} && cargo build"
-            exit 1
-          fi
-
-          if [ "$status" -ne 0 ]; then
-            echo "::warning::API breaks reported — expected on a PR marked '!'; \
-          the release moves the compatibility field accordingly."
-          else
-            echo "all baselines built; no API breaks reported"
-          fi
-          exit "$status"
+        run: bash scripts/semver-report.sh
 
   lockfile-self-pins:
     # Sibling guard to release-guards: the version bump can be correct and the

--- a/scripts/semver-report.sh
+++ b/scripts/semver-report.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Run cargo-semver-checks over the published workspace crates, and — the part
+# that matters — make it impossible for the report to cover less than it claims.
+#
+# # The failure this exists to stop
+#
+# `cargo semver-checks --workspace` does not skip a crate that has never been
+# published. It aborts the entire run:
+#
+#     error: failed to retrieve index of crate versions from registry
+#     Caused by:
+#         vti-rooms not found in registry (crates.io).
+#
+# exit code 101, on the first such crate it reaches. Every crate ordered after
+# it is never checked — and the job's exit status is non-zero either way, which
+# is exactly what a declared API break produces. So the report silently shrank
+# to a subset of the workspace and looked identical to a report that had run in
+# full and found a break.
+#
+# That happened when `vti-rooms` entered the workspace. From that commit until
+# this script, the semver report had checked `vti-common` and `vti-secrets` and
+# then stopped, and nothing said so. The job comment in ci.yml already warns
+# about this shape of bug twice — "a dead check sat unnoticed", "one red looked
+# like another" — and the third instance still got in, because both existing
+# guards ask *why did it stop* and neither asks *did it cover everything*.
+#
+# # What this does instead
+#
+# It derives the expected coverage rather than trusting a hand-written list:
+#
+#   1. every publishable workspace member that has a LIBRARY target, from
+#      `cargo metadata` — a binary-only crate (pnm-cli, cnm-cli) exposes no API
+#      to a consumer, so cargo-semver-checks analyses nothing and prints
+#      nothing for it. Expecting those was this assertion's own first bug,
+#      caught by running it locally before pushing;
+#   2. minus the ones deliberately excluded for runtime (see EXCLUDED below);
+#   3. minus the ones with no crates.io baseline yet, looked up in the sparse
+#      index — those genuinely cannot be checked, and are NAMED in the output
+#      rather than passed over;
+#
+# then runs the tool and asserts it actually reported on that set. A crate that
+# should have been checked and was not is a hard error, whatever the reason.
+#
+# A crate appearing in (3) is normal exactly once in its life: between merging
+# and its first release. If one sits there across several releases, something is
+# wrong with the release, not with this script.
+set -euo pipefail
+
+# Excluded for RUNTIME, not because a break there is acceptable. This job builds
+# rustdoc JSON for every crate twice, current and baseline; including these took
+# it from ~17 minutes to over 35, on every pull request, for a signal no
+# consumer can act on. `release-plz.toml` carries the matching
+# `semver_check = false` so the release decides bumps the same way.
+#
+# These twelve are the subsystem crates. They are on crates.io only because a
+# published crate's whole dependency closure must be published and `vta-service`
+# is published (for OpenVTC's `MockVta` harness — see RELEASING.md). Nothing
+# consumes their APIs directly, here or outside.
+#
+# `vta-service` is deliberately NOT here: it has a real consumer (openvtc-core
+# dev-depends on it for MockVta), so a silent break there reaches somebody.
+# Which is why the truncation mattered — `vta-service` sorts after `vti-rooms`
+# in the tool's ordering, so the one crate kept in the check for having a real
+# consumer was among those the abort skipped.
+EXCLUDED=(
+  vta-audit
+  vta-backup
+  vta-config
+  vta-keys
+  vta-keyspaces
+  vta-policy
+  vta-support
+  vta-sweepers
+  vta-tee
+  vta-vault
+  vta-webvh
+  vti-webauthn
+)
+
+# The sparse-index path for a crate name, per the registry layout.
+index_path() {
+  local c="$1"
+  case ${#c} in
+    1) printf '1/%s' "$c" ;;
+    2) printf '2/%s' "$c" ;;
+    3) printf '3/%s/%s' "${c:0:1}" "$c" ;;
+    *) printf '%s/%s/%s' "${c:0:2}" "${c:2:2}" "$c" ;;
+  esac
+}
+
+# Is this crate on crates.io at all? Any answer other than a clean 200 or 404 is
+# treated as "unknown" and fails loudly further down: a network blip must not
+# quietly become "unpublished, skip it", because that is the same silent
+# shrinking this script exists to prevent.
+published_status() {
+  local c="$1" code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 --retry 3 \
+    "https://index.crates.io/$(index_path "$c")" 2>/dev/null || echo 000)
+  case "$code" in
+    200) echo published ;;
+    404) echo absent ;;
+    *) echo "unknown:$code" ;;
+  esac
+}
+
+# Read with `while read` rather than `mapfile`: mapfile is bash 4+, macOS ships
+# 3.2, and a guard script that only runs in CI cannot be tried before it is
+# pushed. This one was worth being able to run locally.
+PUBLISHABLE=()
+while IFS= read -r line; do
+  [ -n "$line" ] && PUBLISHABLE+=("$line")
+done < <(
+  cargo metadata --no-deps --format-version 1 \
+    | python3 -c '
+import json, sys
+
+LIB = {"lib", "rlib", "proc-macro", "dylib", "cdylib"}
+for p in json.load(sys.stdin)["packages"]:
+    # `publish` is null when unrestricted, [] when `publish = false`.
+    if p.get("publish") is not None:
+        continue
+    # A binary has no public API a downstream crate can depend on, so
+    # cargo-semver-checks has nothing to compare and emits no line for it.
+    if not any(k in LIB for t in p["targets"] for k in t["kind"]):
+        continue
+    print(p["name"])
+' \
+    | sort
+)
+
+if [ ${#PUBLISHABLE[@]} -eq 0 ]; then
+  echo "::error::no publishable library crates found — cargo metadata changed shape"
+  exit 1
+fi
+
+expected=()
+unpublished=()
+unknown=()
+for crate in "${PUBLISHABLE[@]}"; do
+  skip=false
+  for e in "${EXCLUDED[@]}"; do
+    [ "$crate" = "$e" ] && skip=true && break
+  done
+  $skip && continue
+
+  case "$(published_status "$crate")" in
+    published) expected+=("$crate") ;;
+    absent) unpublished+=("$crate") ;;
+    unknown:*) unknown+=("$crate") ;;
+  esac
+done
+
+if [ ${#unknown[@]} -gt 0 ]; then
+  echo "::error::could not determine whether these crates are published: ${unknown[*]}. \
+The registry did not answer 200 or 404. Treating that as 'unpublished' would shrink this \
+report without saying so, which is the exact failure this script exists to prevent."
+  exit 1
+fi
+
+echo "publishable libraries: ${#PUBLISHABLE[@]}   excluded for runtime: ${#EXCLUDED[@]}"
+if [ ${#unpublished[@]} -gt 0 ]; then
+  echo
+  echo "NOT CHECKED — no crates.io baseline yet: ${unpublished[*]}"
+  echo "  A crate has no baseline between merging and its first release, so this is"
+  echo "  expected once. If one of these is still here after a release has gone out,"
+  echo "  the release did not publish it and that is the thing to look at."
+fi
+echo
+echo "checking: ${expected[*]}"
+echo
+
+args=(--workspace)
+for c in "${EXCLUDED[@]}" "${unpublished[@]}"; do
+  args+=(--exclude "$c")
+done
+
+# ANSI is stripped rather than left in. GitHub's runner makes cargo emit colour
+# even though stdout is a pipe, so the log this script greps carries escapes
+# locally-absent and CI-present — which is the worst kind of difference, one
+# that makes a check pass on a laptop and silently match nothing in CI. The
+# coverage assertion below greps for `Finished [..] <crate>`, and in CI the
+# reset sequence sits between `Finished` and the bracket.
+#
+# The escape is built with printf rather than written as `\x1b`, which BSD sed
+# does not understand — the same laptop-versus-CI split, one layer down.
+ESC=$(printf '\033')
+set +e
+cargo semver-checks "${args[@]}" 2>&1 \
+  | sed -E "s/${ESC}\[[0-9;]*[mK]//g" \
+  | tee semver.log
+status=${PIPESTATUS[0]}
+set -e
+
+# A failed baseline is NOT a CI inconvenience — it is a production defect, and
+# this check is the only thing in the repo that resolves like a consumer does
+# (cargo add into a fresh crate, no lockfile), so it is the only thing that can
+# notice when a *published* artifact stops building.
+if grep -qE 'failed to build rustdoc|running cargo-doc on crate' semver.log; then
+  broken="$(grep -oE 'failed to build rustdoc for crate [a-z0-9-]+' semver.log \
+    | sed 's/failed to build rustdoc for crate //' | sort -u | tr '\n' ' ')"
+  echo "::error::PUBLISHED CRATE DOES NOT BUILD: ${broken}-- the semver \
+baseline is the published crate as a consumer receives it, so a baseline that \
+fails to build means consumers cannot build it either. This is not 'the check \
+could not run'; it is the check reporting a broken artifact on crates.io. \
+Reproduce: cargo new --lib x && cd x && echo '[workspace]' >> Cargo.toml && \
+cargo add ${broken%% *} && cargo build"
+  exit 1
+fi
+
+# The coverage assertion, and the reason this script exists. Every crate that
+# should have been checked must appear in the log as one the tool finished. If
+# the run aborted part-way — for the unpublished-crate reason, or any future one
+# nobody has met yet — the missing names are printed instead of the shortfall
+# passing as an ordinary red.
+missing=()
+for crate in "${expected[@]}"; do
+  grep -qE "Finished \[[^]]*\] ${crate}\$" semver.log || missing+=("$crate")
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo
+  echo "::error::THE REPORT IS INCOMPLETE — these crates were never checked: ${missing[*]}. \
+The run stopped before reaching them, so their public APIs were compared against nothing. \
+A truncated report exits non-zero exactly like a declared API break, which is how this went \
+unnoticed once already: check the log above for the abort, do not read the red as 'a break \
+was found'."
+  exit 1
+fi
+
+echo
+echo "coverage: all ${#expected[@]} expected crates were checked"
+
+if [ "$status" -ne 0 ]; then
+  echo "::warning::API breaks reported — expected on a PR marked '!'; the \
+release moves the compatibility field accordingly."
+else
+  echo "all baselines built; no API breaks reported"
+fi
+exit "$status"


### PR DESCRIPTION
`cargo semver-checks --workspace` does not skip a workspace member that has
never been published — it aborts the whole run with exit 101. A declared API
break also exits non-zero, so the job's red said nothing about which had
happened. Since `vti-rooms` entered the workspace, every run has ended in that
abort, and the red has been read as the expected break because that is what the
job's own warning says.

**Being exact about the damage**, since I first overstated it: the abort lands
*after* the six library crates are checked, not partway through. I pulled the
real CI log and extracted every crate that completed — `vta-cli-common`,
`vta-sdk`, `vta-service`, `vtc-client`, `vti-common`, `vti-secrets` — which is
all of them. Nothing was silently skipped. The defect is that the job cannot
say so, not that it lost coverage.

## What changes

The exclusion logic moves to `scripts/semver-report.sh`, which **derives** what
to check rather than trusting a hand-written list: publishable workspace members
with a library target, minus the runtime exclusions, minus the ones with no
crates.io baseline yet (looked up in the sparse index and named in the output
rather than passed over). Unpublished crates are excluded rather than fatal, so
the run finishes and the exit status reflects API breaks alone.

It then asserts the tool reported on every crate in that set. Both existing
guards ask *why did it stop*; neither asked *did it cover everything*, which is
why a truncating abort would have been invisible had it landed a few crates
earlier. That assertion is insurance against the next one, not a repair of this
one.

Because the set is derived, it self-heals when `vti-rooms` and `vti-rooms-dtg`
first publish: they drop out of the "no baseline yet" line and into the checked
set with no edit here.

## Why it is a script and not inline

So it can be run before it is pushed — and that immediately paid for itself. The
assertion's own first bug was expecting `pnm-cli` and `cnm-cli`, which are
binary-only and expose no API for cargo-semver-checks to compare, so it printed
nothing for them. Inline, that would have failed CI on every run. The expected
set now comes from crates with a library target.

## Verification

- Stubbed cargo, all three paths: truncated run (names the missing crates, exit
  1), clean run (exit 0), genuine break (warning, passes cargo's status through).
- Real end-to-end run: `coverage: all 6 expected crates were checked`, exit 100
  from the genuine `vta-sdk` and `vti-common` breaks rather than 101 from the
  abort.
- Portable to bash 3.2 and BSD sed, so it runs on a laptop. GitHub forces colour
  even through a pipe, so the coverage grep has to match logs with and without
  ANSI escapes.

## Not addressed here

`vta-sdk` and `vti-common` both genuinely report `semver requires new major
version`, from new variants on exhaustive enums (`AuditEvent::RoomOperation`,
`Capability::{MemoryRead, MemoryWrite, RoomPresent, RoomOpen}`). Those are
pre-existing and are release-plz's to resolve in the Release PR. This PR only
makes the report say which kind of red it is.
