### PR TITLE
fix(ci): the semver report broke the first time every crate had a baseline

### DIFF
--- a/scripts/semver-report.sh
+++ b/scripts/semver-report.sh
@@ -165,12 +165,25 @@ if [ ${#unpublished[@]} -gt 0 ]; then
   echo "  expected once. If one of these is still here after a release has gone out,"
   echo "  the release did not publish it and that is the thing to look at."
 fi
+if [ ${#expected[@]} -eq 0 ]; then
+  echo "::error::nothing to check — every publishable library is either excluded or \
+unpublished. That is not a pass; it is the report covering nothing."
+  exit 1
+fi
+
 echo
 echo "checking: ${expected[*]}"
 echo
 
+# `${arr[@]+"${arr[@]}"}` rather than a plain `"${arr[@]}"`: expanding an EMPTY
+# array under `set -u` is an unbound-variable error in bash 3.2, and `unpublished`
+# is empty exactly when every crate has a baseline — the normal, healthy state
+# this script is meant to reach. It failed the first time it got there.
+#
+# Bash 4.4+ made the plain form safe, so CI (bash 5) would never have shown this.
+# The portability that let the script run on a laptop is also what found it.
 args=(--workspace)
-for c in "${EXCLUDED[@]}" "${unpublished[@]}"; do
+for c in "${EXCLUDED[@]}" ${unpublished[@]+"${unpublished[@]}"}; do
   args+=(--exclude "$c")
 done
 
@@ -213,7 +226,7 @@ fi
 # nobody has met yet — the missing names are printed instead of the shortfall
 # passing as an ordinary red.
 missing=()
-for crate in "${expected[@]}"; do
+for crate in ${expected[@]+"${expected[@]}"}; do
   grep -qE "Finished \[[^]]*\] ${crate}\$" semver.log || missing+=("$crate")
 done
 


### PR DESCRIPTION
Follow-up to #1252, found by running the script minutes after `vti-rooms` and
`vti-rooms-dtg` were published.

```
scripts/semver-report.sh: line 175: unpublished[@]: unbound variable
```

`"${unpublished[@]}"` on an **empty** array under `set -u` is an
unbound-variable error in bash 3.2. That array is empty precisely when every
publishable library has a crates.io baseline — the healthy state the script
exists to reach. So it worked while the two crates were unpublished and broke
the moment they were not, which is the reverse of what a guard should do.

Bash 4.4+ made the plain expansion safe, so CI on ubuntu would never have shown
it. The bash-3.2 portability added in #1252 so the script could be run on a
laptop is the only reason this surfaced before it mattered — the same property
that caught that PR's other bug (expecting binary-only crates).

Fixed with `${arr[@]+"${arr[@]}"}` on both empty-capable expansions.

Also adds the case this bug's shape suggests: if the expected set ends up empty
— everything excluded or unpublished — that is now an error rather than a run
that checks nothing and exits 0. A report covering nothing should never be
green.

## Verification

Real run on the workspace with both crates now published:

```
publishable libraries: 20   excluded for runtime: 12
checking: vta-cli-common vta-sdk vta-service vtc-client vti-common vti-rooms vti-rooms-dtg vti-secrets
coverage: all 8 expected crates were checked
```

The "NOT CHECKED — no crates.io baseline yet" line is gone and the two new
crates joined the checked set with no edit here, which is the self-healing
property #1252 claimed and could not yet demonstrate.
