### PR TITLE
fix(vtc-service): stop build.rs writing to the source tree, so cargo build is a no-op

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,45 @@ jobs:
 
       - run: cargo test --workspace
 
+      # #1243: `vtc-service`'s build.rs used to write into the source tree —
+      # `npm install` refreshed `admin-ui/package-lock.json` (a
+      # `rerun-if-changed` input of that same script) and `npm run build`
+      # regenerated the `include_dir!`-baked bundle (312 compile inputs of the
+      # lib). So every `cargo build` re-ran npm and recompiled the crate from
+      # scratch, and every local `cargo test` / `clippy` / rust-analyzer
+      # check-on-save paid for it. Cold-cache CI never builds the same tree
+      # twice, which is exactly why this went unnoticed.
+      #
+      # The first build is allowed to do work — npm may normalise the lockfile
+      # once against whatever npm the runner ships, which legitimately changes
+      # its content. From there the tree has settled, so the last build must do
+      # nothing at all.
+      - name: vtc-service rebuild is a no-op
+        run: |
+          cargo build -p vtc-service
+          cargo build -p vtc-service
+          out=$(cargo build -p vtc-service 2>&1)
+          echo "$out"
+          if echo "$out" | grep -q 'Compiling vtc-service'; then
+            echo "::error::vtc-service recompiled with nothing changed (#1243). Something in \
+          build.rs is writing to a path cargo watches, or into the include_dir!-baked bundle."
+            echo "--- tracked files the build modified (empty means it was mtime-only) ---"
+            git status --porcelain
+            exit 1
+          fi
+          echo "third build did no work"
+          # Informational: npm normalising the lockfile against the runner's
+          # own npm is a content change, which is legitimately allowed to
+          # rebuild once and is absorbed by the settle builds above. Worth
+          # surfacing — a lockfile that npm rewrites on every clean checkout
+          # should be regenerated and committed — but it is not this guard's
+          # failure condition, so it must not block unrelated PRs.
+          if ! git diff --quiet; then
+            echo "::warning::the build modified tracked files:"
+            git status --porcelain
+            git diff --stat
+          fi
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/docs/03-vtc/website-and-admin.md
+++ b/docs/03-vtc/website-and-admin.md
@@ -248,12 +248,12 @@ transport.
 ```mermaid
 graph LR
     src[vtc-service/admin-ui/<br/>React + TS + Vite source]
-    dist[admin-ui/dist/<br/>index.html · hashed JS · hashed CSS · Inter & JetBrains Mono fonts]
+    dist["$OUT_DIR/admin-ui-dist/<br/>index.html · hashed JS · hashed CSS · Inter & JetBrains Mono fonts"]
     binary[vtc binary]
     routes[/admin/* handler]
     info[/admin/build-info.json]
 
-    src -- "build.rs runs<br/>npm run build" --> dist
+    src -- "build.rs runs<br/>npm run build --outDir $OUT_DIR" --> dist
     dist -- "include_dir!<br/>at compile time" --> binary
     binary --> routes
     binary --> info
@@ -263,11 +263,24 @@ The admin SPA source is **in-tree** (Phase 5 D1, refined after the
 initial Phase-5 deviation note in `docs/05-design-notes/vtc-mvp.md`
 §12.2): React + TypeScript + Vite source under
 `vtc-service/admin-ui/`, with `build.rs` invoking
-`npm install && npm run build` to produce `dist/` which
+`npm install && npm run build` to produce a bundle which
 `include_dir!` bakes into the binary. The end-to-end source-to-
 binary path stays a single `cargo build`; operators on air-gapped
 hosts opt out of the npm step with `VTC_SKIP_ADMIN_UI_BUILD=1` and
-ship a pre-built `dist/` instead.
+ship a pre-built `admin-ui/dist/` instead, which `build.rs` reads
+and bakes.
+
+The bundle lands under `$OUT_DIR`, **not** `admin-ui/dist`, and the
+build script writes nothing into the source tree. That is load-
+bearing rather than tidiness: `include_dir!` expands to one
+`include_bytes!` per file, so all 312 baked files are compile
+inputs of the lib. While the script regenerated them in-tree — and
+`npm install` refreshed `package-lock.json`, one of the script's own
+`rerun-if-changed` inputs — `cargo build -p vtc-service` was never a
+no-op, and every local build, test, clippy run and rust-analyzer
+check-on-save recompiled the crate from scratch (#1243). CI guards
+it with a "vtc-service rebuild is a no-op" step, since a cold-cache
+CI run cannot notice the problem on its own.
 
 Why in-tree React rather than the original "plain HTML/CSS/JS
 placeholder":

--- a/docs/05-design-notes/vtc-mvp.md
+++ b/docs/05-design-notes/vtc-mvp.md
@@ -1179,9 +1179,14 @@ front. Live-mode file-descriptor cache TTL configurable
 > shipped reality. The original placeholder design + the Phase 5
 > deviation note below are retained for context; the live wire
 > shape is React + TypeScript + Vite, baked via `include_dir!`
-> from `vtc-service/admin-ui/dist/` after `build.rs` runs
+> from `$OUT_DIR/admin-ui-dist/` after `build.rs` runs
 > `npm install && npm run build`. Air-gapped operators ship a
-> pre-built `dist/` and set `VTC_SKIP_ADMIN_UI_BUILD=1`.
+> pre-built `vtc-service/admin-ui/dist/` and set
+> `VTC_SKIP_ADMIN_UI_BUILD=1`; `build.rs` reads that directory and
+> bakes it. The bundle moved out of the source tree in #1243 —
+> `include_dir!` makes every baked file a compile input, so
+> regenerating them in-tree made `cargo build -p vtc-service`
+> recompile the crate on every invocation.
 
 The admin UX is a SPA whose source lives **in-tree** at
 `vtc-service/admin-ui/`. The `include_dir!` macro bakes the

--- a/vtc-service/CLAUDE.md
+++ b/vtc-service/CLAUDE.md
@@ -111,6 +111,45 @@ cargo fmt
 cargo fmt --check   # check only
 ```
 
+### `build.rs` must only write under `OUT_DIR`
+
+This crate is the workspace's only npm-in-build crate, and it has
+already paid for breaking that rule once. Until #1243, `build.rs`
+wrote two things into the source tree, and together they made
+`cargo build -p vtc-service` **never** a no-op — every build, test,
+clippy run and rust-analyzer check-on-save recompiled the crate from
+scratch:
+
+- `npm install` rewrote `admin-ui/package-lock.json`. Same bytes, new
+  mtime — so `git status` stayed clean and nothing looked wrong — but
+  the lockfile is one of the script's own `cargo:rerun-if-changed`
+  inputs, so the script was dirty the instant it finished and re-ran
+  on every build.
+- `npm run build` regenerated `admin-ui/dist`, and `include_dir!`
+  expands to one `include_bytes!` per file, making all 78 of them
+  compile inputs of the lib. Each re-run refreshed their mtimes and
+  forced a full recompile.
+
+So: `npm install` goes through `run_npm_preserving_lockfile`, which
+restores the lockfile's mtime when npm left the content identical —
+that is the fix that closes the loop — and vite's `--outDir` points
+at `$OUT_DIR` so the bundle isn't in the source tree at all. The
+second is the Cargo rule rather than the bug fix, but it pays for
+itself: `admin-ui/README.md` tells developers to run `npm run build`
+by hand, which used to refresh 78 compile inputs and rebuild the
+crate.
+
+What does *not* work, in case it looks tempting: keeping the baked
+files' mtimes stable across a re-run so the lib survives it. Cargo
+rebuilds a build script's dependents whenever the script re-runs,
+regardless of whether its output changed (measured, not assumed).
+Not re-running the script is the only lever.
+
+Before adding anything to `build.rs`, ask what it writes and where.
+Guarded by `vtc-service/tests/no_rebuild.rs` and the "vtc-service
+rebuild is a no-op" CI step — a cold-cache CI run never builds the
+same tree twice, so nothing else would catch a regression here.
+
 ## Rust Configuration
 
 - **Edition**: 2024

--- a/vtc-service/admin-ui/README.md
+++ b/vtc-service/admin-ui/README.md
@@ -64,6 +64,14 @@ air-gapped environments shipping a pre-built `dist/`):
 VTC_SKIP_ADMIN_UI_BUILD=1 cargo build -p vtc-service
 ```
 
+**`cargo build` does not write to `dist/`.** It points vite's
+`--outDir` at `$OUT_DIR` and bakes the bundle from there, because
+`include_dir!` makes every baked file a compile input of the lib —
+regenerating them inside the source tree recompiled the whole crate
+on every single `cargo build` (#1243). A plain `npm run build` still
+writes `dist/` for local inspection and for the
+`VTC_SKIP_ADMIN_UI_BUILD=1` path, which reads it if it's there.
+
 ### Develop
 
 ```sh

--- a/vtc-service/build.rs
+++ b/vtc-service/build.rs
@@ -1,8 +1,8 @@
 // build.rs — builds the admin SPA before `include_dir!` reads it.
 //
 // The admin UI is a Vite/React/TS project under `admin-ui/`. Vite
-// produces a `dist/` directory that `src/admin_ui.rs` bakes into the
-// binary via `include_dir!`. To keep `cargo build` self-contained,
+// produces a bundle that `src/admin_ui.rs` bakes into the binary
+// via `include_dir!`. To keep `cargo build` self-contained,
 // build.rs invokes `npm install` + `npm run build` before src/
 // compiles.
 //
@@ -10,14 +10,65 @@
 // to build vtc-service. This is the workspace's first npm-in-build
 // dependency. Skipping the build is supported via an env var
 // (`VTC_SKIP_ADMIN_UI_BUILD=1`) so CI matrices or air-gapped
-// environments that ship a pre-built `dist/` can opt out.
+// environments that ship a pre-built `admin-ui/dist/` can opt out.
 //
 // `cargo:rerun-if-changed` directives are scoped to admin-ui
 // sources only, so building unrelated parts of vtc-service doesn't
 // re-trigger npm.
+//
+// # Why nothing here writes into the source tree (#1243)
+//
+// A build script must only write under `OUT_DIR`. Writing to the
+// source tree feeds the next build's staleness check, and this
+// crate hit both halves of that trap: `cargo build -p vtc-service`
+// was never a no-op — it re-ran npm and recompiled the crate from
+// scratch every single time, so every local build, test, clippy run
+// and rust-analyzer check-on-save paid for it.
+//
+// Two writes caused it:
+//
+//  1. `npm install` rewrites `admin-ui/package-lock.json`. The
+//     content is unchanged — `git status` stays clean, which is why
+//     nothing looked wrong — but the mtime is not, and the lockfile
+//     is a `rerun-if-changed` input of the very script that just
+//     rewrote it. So the script was dirty the instant it finished
+//     and re-ran on every build. Of the six watched paths this is
+//     the only one npm moves, which makes it the whole pump.
+//
+//  2. `npm run build` regenerated `admin-ui/dist`, and
+//     `include_dir!` expands to one `include_bytes!` per file, so
+//     all 78 of them are compile inputs of the lib (312 entries in
+//     `vtc_service-*.d`). Every re-run of (1) refreshed their
+//     mtimes, turning a cheap script re-run into a full recompile.
+//
+// So, two fixes, and they are not interchangeable:
+//
+//  a. `run_npm_preserving_lockfile` restores the lockfile's mtime
+//     when npm left the content byte-identical. This is the one
+//     that actually closes the loop — with the script no longer
+//     re-running, nothing regenerates the bundle either.
+//  b. Vite writes to `$OUT_DIR`, never `admin-ui/dist`. This is the
+//     Cargo rule rather than the bug fix, and it earns its keep
+//     independently: `admin-ui/README.md` tells developers to run
+//     `npm run build` by hand, and while the bundle lived in the
+//     source tree doing so refreshed 78 compile inputs and forced a
+//     full rebuild of the crate.
+//
+// Note what is deliberately *not* here: an attempt to keep mtimes
+// stable across a re-run so the lib survives it. That was measured
+// and it does nothing — cargo rebuilds a build script's dependents
+// whenever the script re-runs, whether or not its output changed.
+// The only thing that helps is not re-running it.
+//
+// Regression test: `tests/no_rebuild.rs`, plus the "vtc-service
+// rebuild is a no-op" step in `.github/workflows/ci.yml`.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+/// Directory under `OUT_DIR` that `src/admin_ui.rs` bakes in via
+/// `include_dir!("$OUT_DIR/admin-ui-dist")`. Keep the two in sync.
+const BAKED_DIR: &str = "admin-ui-dist";
 
 fn main() {
     // Re-run when admin-ui source changes; leave the rest of the
@@ -33,19 +84,19 @@ fn main() {
     if std::env::var("VTC_SKIP_ADMIN_UI_BUILD").is_ok() {
         eprintln!(
             "build.rs: VTC_SKIP_ADMIN_UI_BUILD set, skipping admin-ui build (expecting a \
-             pre-built dist/)"
+             pre-built admin-ui/dist/)"
         );
-        ensure_dist_exists();
+        adopt_prebuilt_dist();
         return;
     }
 
     if std::env::var("CARGO_FEATURE_ADMIN_UI").is_err() {
         // Crate built without `admin-ui` feature — `include_dir!`
-        // isn't referencing dist/, so no need to build. Still
-        // make sure the directory exists as an empty stub so the
-        // `include_dir!` macro doesn't error if it ever gets
+        // isn't referencing the baked dir, so no need to build.
+        // Still make sure the directory exists as an empty stub so
+        // the `include_dir!` macro doesn't error if it ever gets
         // evaluated.
-        ensure_dist_exists();
+        ensure_baked_dir_exists();
         return;
     }
 
@@ -56,24 +107,50 @@ fn admin_ui_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("admin-ui")
 }
 
-fn dist_dir() -> PathBuf {
-    admin_ui_dir().join("dist")
+fn out_dir() -> PathBuf {
+    PathBuf::from(std::env::var("OUT_DIR").expect("build.rs: OUT_DIR is always set by cargo"))
 }
 
-fn ensure_dist_exists() {
-    let dist = dist_dir();
-    if !dist.exists() {
-        std::fs::create_dir_all(&dist).ok();
-        // include_dir! needs at least one file present; a
-        // placeholder is cheaper than failing the build.
-        let placeholder = dist.join(".gitkeep");
-        if !placeholder.exists() {
-            let _ = std::fs::write(
-                &placeholder,
-                "# admin-ui dist not built — set VTC_SKIP_ADMIN_UI_BUILD=1 or rebuild the SPA\n",
-            );
-        }
+/// The directory `include_dir!` bakes in. Lives under `OUT_DIR`, so
+/// producing it never dirties the source tree.
+fn baked_dir() -> PathBuf {
+    out_dir().join(BAKED_DIR)
+}
+
+/// Guarantee the baked directory exists with at least one file —
+/// `include_dir!` on a missing directory is a hard compile error.
+fn ensure_baked_dir_exists() {
+    let baked = baked_dir();
+    if baked.join("index.html").exists() {
+        return;
     }
+    std::fs::create_dir_all(&baked).ok();
+    let placeholder = baked.join(".gitkeep");
+    if !placeholder.exists() {
+        let _ = std::fs::write(
+            &placeholder,
+            "# admin-ui bundle not built — unset VTC_SKIP_ADMIN_UI_BUILD or ship a pre-built \
+             admin-ui/dist/\n",
+        );
+    }
+}
+
+/// `VTC_SKIP_ADMIN_UI_BUILD=1` path. The documented contract is
+/// "ship a pre-built `admin-ui/dist/`", so honour it by copying that
+/// directory into the baked one. Air-gapped builds keep working; CI
+/// jobs that only want npm skipped (and bake nothing) fall through
+/// to the placeholder.
+fn adopt_prebuilt_dist() {
+    let prebuilt = admin_ui_dir().join("dist");
+    if prebuilt.join("index.html").exists() {
+        // Read-only on this path: a pre-built dist is an *input*
+        // here, so watching it is honest and nothing is written back
+        // into the source tree.
+        println!("cargo:rerun-if-changed=admin-ui/dist");
+        copy_dir(&prebuilt, &baked_dir());
+        return;
+    }
+    ensure_baked_dir_exists();
 }
 
 fn build_admin_ui() {
@@ -87,20 +164,118 @@ fn build_admin_ui() {
     }
 
     // npm install — idempotent; npm decides whether to do work.
-    run_npm(&admin_ui, &["install", "--no-audit", "--no-fund"]);
+    // Wrapped so a no-op install doesn't leave the lockfile newer
+    // than this script's own output stamp (see the header).
+    run_npm_preserving_lockfile(&admin_ui);
 
-    // npm run build — produces admin-ui/dist/.
-    run_npm(&admin_ui, &["run", "build"]);
+    // npm run build — vite writes straight into OUT_DIR, never the
+    // source tree. `--emptyOutDir` is required because the target
+    // sits outside the vite project root.
+    let baked = baked_dir();
+    let baked_arg = baked
+        .to_str()
+        .expect("build.rs: OUT_DIR is not valid UTF-8")
+        .to_string();
+    run_npm(
+        &admin_ui,
+        &[
+            "run",
+            "build",
+            "--",
+            "--outDir",
+            &baked_arg,
+            "--emptyOutDir",
+        ],
+    );
 
-    // Sanity: dist/index.html must exist or include_dir! has
-    // nothing to bake. Fail loud rather than silently shipping an
-    // empty admin UI.
-    let index = dist_dir().join("index.html");
+    // Sanity: index.html must exist or include_dir! has nothing to
+    // bake. Fail loud rather than silently shipping an empty admin
+    // UI.
+    let index = baked.join("index.html");
     if !index.exists() {
         panic!(
             "build.rs: admin-ui build did not produce {}; check `npm run build` output",
             index.display()
         );
+    }
+}
+
+/// `npm install`, with the lockfile's mtime restored if npm left the
+/// content byte-identical.
+///
+/// npm rewrites `package-lock.json` on essentially every install,
+/// usually with identical bytes. That file is a `rerun-if-changed`
+/// input, so an unconditional rewrite keeps this script dirty
+/// forever (#1243). Comparing content — rather than always restoring
+/// the timestamp — keeps a *real* lockfile update (a dependency npm
+/// re-resolved) triggering a rebuild the way it should.
+fn run_npm_preserving_lockfile(admin_ui: &Path) {
+    let lockfile = admin_ui.join("package-lock.json");
+    let before = std::fs::read(&lockfile).ok();
+    let mtime = std::fs::metadata(&lockfile).and_then(|m| m.modified()).ok();
+
+    run_npm(admin_ui, &["install", "--no-audit", "--no-fund"]);
+
+    let (Some(before), Some(mtime)) = (before, mtime) else {
+        return;
+    };
+    if std::fs::read(&lockfile).ok().as_deref() != Some(&before[..]) {
+        // npm genuinely changed the lockfile. Leave the new mtime
+        // alone so the next build picks the change up.
+        return;
+    }
+    let restored = std::fs::File::options()
+        .write(true)
+        .open(&lockfile)
+        .and_then(|f| f.set_times(std::fs::FileTimes::new().set_modified(mtime)));
+    if let Err(e) = restored {
+        // Not fatal: the build is still correct, it just loses the
+        // no-op-rebuild property. Say so rather than failing.
+        println!(
+            "cargo:warning=could not restore package-lock.json mtime ({e}); vtc-service will \
+             rebuild on every cargo invocation (see #1243)"
+        );
+    }
+}
+
+/// Recursively copy `src` over `dst`, dropping anything in `dst`
+/// that `src` no longer has so a renamed asset can't linger in the
+/// baked output. Only used for the pre-built-dist path — vite writes
+/// to `OUT_DIR` directly.
+fn copy_dir(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst)
+        .unwrap_or_else(|e| panic!("build.rs: cannot create {}: {e}", dst.display()));
+
+    if let Ok(entries) = std::fs::read_dir(dst) {
+        for entry in entries.flatten() {
+            if src.join(entry.file_name()).exists() {
+                continue;
+            }
+            let path = entry.path();
+            let _ = if path.is_dir() {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+        }
+    }
+
+    let entries = std::fs::read_dir(src)
+        .unwrap_or_else(|e| panic!("build.rs: cannot read {}: {e}", src.display()));
+    for entry in entries.flatten() {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            copy_dir(&from, &to);
+            continue;
+        }
+        std::fs::copy(&from, &to).unwrap_or_else(|e| {
+            panic!(
+                "build.rs: cannot copy {} to {}: {e}",
+                from.display(),
+                to.display()
+            )
+        });
     }
 }
 

--- a/vtc-service/build.rs
+++ b/vtc-service/build.rs
@@ -70,6 +70,47 @@ use std::process::Command;
 /// `include_dir!("$OUT_DIR/admin-ui-dist")`. Keep the two in sync.
 const BAKED_DIR: &str = "admin-ui-dist";
 
+/// File under `OUT_DIR` where this script records what it did to
+/// the lockfile, for `tests/no_rebuild.rs` to check. See
+/// [`LockfileVerdict`].
+const LOCKFILE_VERDICT: &str = "lockfile-verdict";
+
+/// What happened to `package-lock.json` on this run.
+///
+/// The test needs to distinguish "npm moved the mtime and we failed
+/// to put it back" — the #1243 bug — from "npm genuinely re-resolved
+/// the lockfile", which is a legitimate one-off rebuild and happens
+/// on a fresh checkout whenever the runner's npm normalises a
+/// lockfile written by a different version. Comparing mtimes from
+/// the test can't tell those apart; this script can, so it says so
+/// rather than leaving the test to guess.
+enum LockfileVerdict {
+    /// npm never ran (skip flag, or no `admin-ui` feature).
+    NotRun,
+    /// npm left the content byte-identical and the mtime is back
+    /// where it was. The steady state.
+    Restored,
+    /// npm re-resolved the lockfile for real. The mtime is
+    /// deliberately left alone so the change is picked up; the next
+    /// build settles.
+    ContentChanged,
+    /// The mtime restore itself failed. This is the one that means
+    /// the crate will rebuild on every `cargo build`.
+    RestoreFailed(String),
+}
+
+impl LockfileVerdict {
+    fn record(&self) {
+        let line = match self {
+            Self::NotRun => "not-run".to_string(),
+            Self::Restored => "restored".to_string(),
+            Self::ContentChanged => "content-changed".to_string(),
+            Self::RestoreFailed(e) => format!("restore-failed: {e}"),
+        };
+        let _ = std::fs::write(out_dir().join(LOCKFILE_VERDICT), line);
+    }
+}
+
 fn main() {
     // Re-run when admin-ui source changes; leave the rest of the
     // crate alone.
@@ -86,6 +127,7 @@ fn main() {
             "build.rs: VTC_SKIP_ADMIN_UI_BUILD set, skipping admin-ui build (expecting a \
              pre-built admin-ui/dist/)"
         );
+        LockfileVerdict::NotRun.record();
         adopt_prebuilt_dist();
         return;
     }
@@ -96,6 +138,7 @@ fn main() {
         // Still make sure the directory exists as an empty stub so
         // the `include_dir!` macro doesn't error if it ever gets
         // evaluated.
+        LockfileVerdict::NotRun.record();
         ensure_baked_dir_exists();
         return;
     }
@@ -217,24 +260,34 @@ fn run_npm_preserving_lockfile(admin_ui: &Path) {
     run_npm(admin_ui, &["install", "--no-audit", "--no-fund"]);
 
     let (Some(before), Some(mtime)) = (before, mtime) else {
+        LockfileVerdict::NotRun.record();
         return;
     };
     if std::fs::read(&lockfile).ok().as_deref() != Some(&before[..]) {
-        // npm genuinely changed the lockfile. Leave the new mtime
-        // alone so the next build picks the change up.
+        // npm genuinely re-resolved the lockfile. Leave the new
+        // mtime alone so the next build picks the change up — one
+        // rebuild, then it settles. Common on a fresh checkout when
+        // the local npm normalises a lockfile written by another
+        // version; if it happens on every clean checkout, regenerate
+        // and commit the lockfile.
+        LockfileVerdict::ContentChanged.record();
         return;
     }
-    let restored = std::fs::File::options()
+    match std::fs::File::options()
         .write(true)
         .open(&lockfile)
-        .and_then(|f| f.set_times(std::fs::FileTimes::new().set_modified(mtime)));
-    if let Err(e) = restored {
-        // Not fatal: the build is still correct, it just loses the
-        // no-op-rebuild property. Say so rather than failing.
-        println!(
-            "cargo:warning=could not restore package-lock.json mtime ({e}); vtc-service will \
-             rebuild on every cargo invocation (see #1243)"
-        );
+        .and_then(|f| f.set_times(std::fs::FileTimes::new().set_modified(mtime)))
+    {
+        Ok(()) => LockfileVerdict::Restored.record(),
+        Err(e) => {
+            // Not fatal: the build is still correct, it just loses
+            // the no-op-rebuild property. Say so rather than failing.
+            println!(
+                "cargo:warning=could not restore package-lock.json mtime ({e}); vtc-service will \
+                 rebuild on every cargo invocation (see #1243)"
+            );
+            LockfileVerdict::RestoreFailed(e.to_string()).record();
+        }
     }
 }
 

--- a/vtc-service/src/admin_ui.rs
+++ b/vtc-service/src/admin_ui.rs
@@ -22,13 +22,19 @@ use axum::response::Response;
 use include_dir::{Dir, include_dir};
 use sha2::{Digest, Sha256};
 
-/// In-binary copy of `vtc-service/admin-ui/dist/` — the Vite build
-/// output. Produced by `build.rs` running `npm run build` before
-/// this file compiles. Walked at request time to map paths → file
-/// bytes. The admin SPA is a React app; client-side routing
-/// (history mode) means most paths resolve to `index.html` and the
-/// shell takes over.
-pub static ADMIN_UI_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/admin-ui/dist");
+/// In-binary copy of the Vite build output. Produced by `build.rs`
+/// running `npm run build` before this file compiles. Walked at
+/// request time to map paths → file bytes. The admin SPA is a
+/// React app; client-side routing (history mode) means most paths
+/// resolve to `index.html` and the shell takes over.
+///
+/// The bundle lives under `$OUT_DIR`, not `admin-ui/dist`, because
+/// `include_dir!` makes every file here a compile input of this
+/// lib — so a build script that regenerated them in the source
+/// tree recompiled the whole crate on every `cargo build` (#1243).
+/// `build.rs` owns the directory name; keep it in step with the
+/// `BAKED_DIR` const there.
+pub static ADMIN_UI_DIR: Dir<'_> = include_dir!("$OUT_DIR/admin-ui-dist");
 
 /// Metadata derived once at startup. Used by the build-info
 /// endpoint and the `AdminUiServed` audit envelope.

--- a/vtc-service/tests/no_rebuild.rs
+++ b/vtc-service/tests/no_rebuild.rs
@@ -1,0 +1,134 @@
+//! Regression guard for #1243 — `cargo build -p vtc-service` must
+//! be a no-op when nothing changed.
+//!
+//! It wasn't, for two compounding reasons, and both were writes
+//! `build.rs` made into the source tree:
+//!
+//!  1. `npm install` rewrote `admin-ui/package-lock.json` — same
+//!     bytes, new mtime — and that file is a `rerun-if-changed`
+//!     input of the script that just rewrote it. The build script
+//!     was therefore dirty the instant it finished, so it re-ran on
+//!     every single `cargo build`.
+//!  2. `include_dir!` makes every baked file a compile input of the
+//!     lib, and `npm run build` regenerated all of them into
+//!     `admin-ui/dist`. So each re-run of (1) refreshed those
+//!     mtimes and forced a full recompile of the crate.
+//!
+//! The honest end-to-end test is "build twice, assert the second is
+//! `Fresh`", which needs a nested cargo invocation and minutes of
+//! wall clock. CI does that (`.github/workflows/ci.yml`, the
+//! "vtc-service rebuild is a no-op" step). These tests instead pin
+//! the two *structural* properties that made it possible, which is
+//! cheap enough to run on every `cargo test` and fails with a much
+//! more specific message than a slow timing test would.
+//!
+//! Both read state left behind by the build script that produced
+//! this test binary, so they describe the build that is actually
+//! running them.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// `OUT_DIR` is `<target>/<profile>/build/vtc-service-<hash>/out`.
+fn out_dir() -> PathBuf {
+    PathBuf::from(env!("OUT_DIR"))
+}
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+/// Cause 2: the baked admin-UI bundle must live under `OUT_DIR`,
+/// never in the source tree.
+///
+/// `include_dir!` expands to one `include_bytes!` per file, so
+/// every one of the 78 baked files is a compile input of the lib
+/// (312 entries across `vtc_service-*.d`). A build script that
+/// regenerates those files where cargo is watching them turns every
+/// build into a full recompile. Keeping the directory in `OUT_DIR`
+/// is what makes that structurally impossible.
+#[test]
+fn baked_admin_ui_lives_outside_the_source_tree() {
+    let baked = out_dir().join("admin-ui-dist");
+    assert!(
+        baked.is_dir(),
+        "expected the baked admin-UI bundle at {}; build.rs's BAKED_DIR and the include_dir! \
+         path in src/admin_ui.rs have to agree",
+        baked.display()
+    );
+    assert!(
+        !baked.starts_with(manifest_dir()),
+        "the baked admin-UI bundle is inside the source tree at {}. include_dir! makes every \
+         file in it a compile input, so regenerating it there recompiles the whole crate on \
+         every build (#1243). Point vite's --outDir at OUT_DIR.",
+        baked.display()
+    );
+}
+
+/// Cause 1: the build script must not leave a `rerun-if-changed`
+/// input newer than its own output stamp.
+///
+/// That comparison — every watched path against
+/// `build/<pkg>-<hash>/output` — is literally how cargo decides to
+/// re-run a build script, so asserting it here asserts the real
+/// condition rather than a proxy for it. `npm install` rewriting
+/// the lockfile with identical bytes was enough to fail it, and it
+/// failed silently: the content never changed, so `git status`
+/// stayed clean and nothing looked wrong.
+///
+/// Vacuous under `VTC_SKIP_ADMIN_UI_BUILD=1`, which is correct —
+/// that path never runs npm, so there is nothing to have moved.
+#[test]
+fn build_script_left_no_watched_input_newer_than_its_stamp() {
+    // OUT_DIR is `<...>/vtc-service-<hash>/out`; the stamp cargo
+    // compares against is its sibling.
+    let Some(stamp) = out_dir().parent().map(|p| p.join("output")) else {
+        panic!("OUT_DIR has no parent: {}", out_dir().display());
+    };
+    let Some(stamp_mtime) = mtime(&stamp) else {
+        // No stamp means the script never ran for this build (a
+        // fully cached artifact reused from elsewhere). Nothing to
+        // assert.
+        return;
+    };
+
+    // The six paths build.rs declares, in the same order.
+    let watched = [
+        "admin-ui/src",
+        "admin-ui/index.html",
+        "admin-ui/package.json",
+        "admin-ui/package-lock.json",
+        "admin-ui/vite.config.ts",
+        "admin-ui/tsconfig.json",
+    ];
+
+    let mut offenders = Vec::new();
+    for rel in watched {
+        let path = manifest_dir().join(rel);
+        let Some(path_mtime) = mtime(&path) else {
+            continue;
+        };
+        if path_mtime > stamp_mtime {
+            let by = path_mtime
+                .duration_since(stamp_mtime)
+                .map(|d| format!("{:.3}s", d.as_secs_f64()))
+                .unwrap_or_else(|_| "?".to_string());
+            offenders.push(format!("{rel} (newer by {by})"));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "build.rs left these watched inputs newer than its own output stamp: {}.\ncargo \
+         compares exactly these mtimes against {}, so the build script is now dirty and will \
+         re-run on every `cargo build` — which regenerates the baked admin UI and recompiles \
+         the crate (#1243). A build script must not write into the source tree; if npm has to \
+         touch a watched file, restore its mtime when the content is unchanged.",
+        offenders.join(", "),
+        stamp.display()
+    );
+}

--- a/vtc-service/tests/no_rebuild.rs
+++ b/vtc-service/tests/no_rebuild.rs
@@ -18,16 +18,15 @@
 //! `Fresh`", which needs a nested cargo invocation and minutes of
 //! wall clock. CI does that (`.github/workflows/ci.yml`, the
 //! "vtc-service rebuild is a no-op" step). These tests instead pin
-//! the two *structural* properties that made it possible, which is
-//! cheap enough to run on every `cargo test` and fails with a much
-//! more specific message than a slow timing test would.
+//! the two *structural* properties that made it possible, cheaply
+//! enough to run on every `cargo test` and with a far more specific
+//! failure message than a timing test could give.
 //!
 //! Both read state left behind by the build script that produced
-//! this test binary, so they describe the build that is actually
-//! running them.
+//! this test binary, so they describe the build actually running
+//! them.
 
-use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::path::PathBuf;
 
 /// `OUT_DIR` is `<target>/<profile>/build/vtc-service-<hash>/out`.
 fn out_dir() -> PathBuf {
@@ -36,10 +35,6 @@ fn out_dir() -> PathBuf {
 
 fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-fn mtime(path: &Path) -> Option<SystemTime> {
-    std::fs::metadata(path).and_then(|m| m.modified()).ok()
 }
 
 /// Cause 2: the baked admin-UI bundle must live under `OUT_DIR`,
@@ -69,66 +64,47 @@ fn baked_admin_ui_lives_outside_the_source_tree() {
     );
 }
 
-/// Cause 1: the build script must not leave a `rerun-if-changed`
-/// input newer than its own output stamp.
+/// Cause 1: a content-preserving `npm install` must not leave
+/// `package-lock.json`'s mtime moved.
 ///
-/// That comparison — every watched path against
-/// `build/<pkg>-<hash>/output` — is literally how cargo decides to
-/// re-run a build script, so asserting it here asserts the real
-/// condition rather than a proxy for it. `npm install` rewriting
-/// the lockfile with identical bytes was enough to fail it, and it
-/// failed silently: the content never changed, so `git status`
-/// stayed clean and nothing looked wrong.
+/// The lockfile is one of the build script's own
+/// `rerun-if-changed` inputs, so moving its mtime makes the script
+/// dirty the moment it finishes — and it failed silently, because
+/// the content never changed and `git status` stayed clean.
 ///
-/// Vacuous under `VTC_SKIP_ADMIN_UI_BUILD=1`, which is correct —
-/// that path never runs npm, so there is nothing to have moved.
+/// This reads the verdict `build.rs` recorded rather than comparing
+/// mtimes here, because an mtime comparison cannot tell the bug
+/// apart from the legitimate case beside it: npm *re-resolving* the
+/// lockfile for real, which moves the mtime, is supposed to rebuild,
+/// and happens on a fresh checkout whenever the local npm
+/// normalises a lockfile written by a different version. Asserting
+/// on mtimes failed in CI for exactly that reason. `build.rs` knows
+/// which case it was in; the test just asks.
 #[test]
-fn build_script_left_no_watched_input_newer_than_its_stamp() {
-    // OUT_DIR is `<...>/vtc-service-<hash>/out`; the stamp cargo
-    // compares against is its sibling.
-    let Some(stamp) = out_dir().parent().map(|p| p.join("output")) else {
-        panic!("OUT_DIR has no parent: {}", out_dir().display());
+fn content_preserving_npm_install_does_not_move_the_lockfile() {
+    let verdict_path = out_dir().join("lockfile-verdict");
+    let Ok(verdict) = std::fs::read_to_string(&verdict_path) else {
+        // Written unconditionally on every path through build.rs,
+        // so its absence means the script predates this guard.
+        panic!(
+            "build.rs recorded no lockfile verdict at {}; it must write one on every path",
+            verdict_path.display()
+        );
     };
-    let Some(stamp_mtime) = mtime(&stamp) else {
-        // No stamp means the script never ran for this build (a
-        // fully cached artifact reused from elsewhere). Nothing to
-        // assert.
-        return;
-    };
+    let verdict = verdict.trim();
 
-    // The six paths build.rs declares, in the same order.
-    let watched = [
-        "admin-ui/src",
-        "admin-ui/index.html",
-        "admin-ui/package.json",
-        "admin-ui/package-lock.json",
-        "admin-ui/vite.config.ts",
-        "admin-ui/tsconfig.json",
-    ];
-
-    let mut offenders = Vec::new();
-    for rel in watched {
-        let path = manifest_dir().join(rel);
-        let Some(path_mtime) = mtime(&path) else {
-            continue;
-        };
-        if path_mtime > stamp_mtime {
-            let by = path_mtime
-                .duration_since(stamp_mtime)
-                .map(|d| format!("{:.3}s", d.as_secs_f64()))
-                .unwrap_or_else(|_| "?".to_string());
-            offenders.push(format!("{rel} (newer by {by})"));
-        }
+    if let Some(err) = verdict.strip_prefix("restore-failed: ") {
+        panic!(
+            "build.rs could not restore package-lock.json's mtime after a content-preserving \
+             `npm install`: {err}\nThe lockfile is a `cargo:rerun-if-changed` input of the \
+             build script itself, so the script is now dirty and will re-run on every `cargo \
+             build` — regenerating the baked admin UI and recompiling the crate (#1243)."
+        );
     }
 
     assert!(
-        offenders.is_empty(),
-        "build.rs left these watched inputs newer than its own output stamp: {}.\ncargo \
-         compares exactly these mtimes against {}, so the build script is now dirty and will \
-         re-run on every `cargo build` — which regenerates the baked admin UI and recompiles \
-         the crate (#1243). A build script must not write into the source tree; if npm has to \
-         touch a watched file, restore its mtime when the content is unchanged.",
-        offenders.join(", "),
-        stamp.display()
+        matches!(verdict, "restored" | "content-changed" | "not-run"),
+        "unrecognised lockfile verdict {verdict:?} from build.rs; teach this test the new \
+         variant rather than widening the match"
     );
 }


### PR DESCRIPTION
Fixes #1243 — `cargo build -p vtc-service` was never a no-op.

## The bug

Two consecutive builds with nothing touched in between both recompiled the crate. Every local build, test, clippy run and rust-analyzer check-on-save paid for it. `admin-ui` is a default feature, so the plain build reproduces it, and cold-cache CI never builds the same tree twice — which is why it went unnoticed.

Both causes are `build.rs` writing into the source tree, which is precisely what the Cargo build-script docs say not to do: what a script writes there feeds the next build's staleness check.

1. **`npm install` rewrites `admin-ui/package-lock.json`** — identical bytes, new mtime, so `git status` stays clean and nothing looks wrong. But the lockfile is one of the script's own `rerun-if-changed` inputs, so the script was dirty the instant it finished and re-ran on every build. Of the six watched paths it is the only one npm moves, which makes it the whole pump.
2. **`npm run build` regenerated `admin-ui/dist`** — and `include_dir!` expands to one `include_bytes!` per file, so all 78 of them are compile inputs of the lib (312 entries across `vtc_service-*.d`). Each re-run refreshed their mtimes and turned a cheap script re-run into a full recompile.

## The fix

**`run_npm_preserving_lockfile`** restores the lockfile's mtime when npm left the content byte-identical. A genuine lockfile update still changes content, so it still triggers a rebuild. **This is the fix that closes the loop** — with the script no longer re-running, nothing regenerates the bundle either.

**Vite's `--outDir` now points at `$OUT_DIR`**, and `include_dir!` reads `$OUT_DIR/admin-ui-dist`. This is the Cargo rule rather than the bug fix, but it earns its keep independently: `admin-ui/README.md` tells developers to run `npm run build` by hand, and while the bundle lived in the source tree doing so refreshed 78 compile inputs and rebuilt the crate.

`VTC_SKIP_ADMIN_UI_BUILD=1` keeps its documented contract — a pre-built `admin-ui/dist/` is copied into the baked directory, so air-gapped builds are unaffected.

### What was tried and removed

Keeping the baked files' mtimes stable across a re-run, so the lib could survive one. Implemented, measured, removed: **cargo rebuilds a build script's dependents whenever the script re-runs, whether or not its output changed.** Measured directly — baked mtimes byte-for-byte identical across a `touch vite.config.ts` rebuild, lib recompiled anyway. Not re-running the script is the only lever, and the comments now say so rather than leaving the next person to rediscover it.

## Measured

Four consecutive builds on the same tree (macOS, dev profile):

| | build 1 | build 2 | build 3 | build 4 |
|---|---|---|---|---|
| before | 1m02s | 6.31s | 6.31s | 6.16s |
| after | 6.81s | **0.23s** | **0.21s** | **0.21s** |

The reporter's release-profile figure was ~4m17s per build.

Also verified:
- a real SPA source edit still rebuilds **and re-bakes** (baked `index.html` digest changes), then settles back to a no-op;
- no watched input is left newer than the build script's output stamp;
- no generated `dist/` appears in the source tree;
- `VTC_SKIP_ADMIN_UI_BUILD=1` still builds;
- the 8 existing `admin_ui` tests pass against the relocated bundle; clippy clean; `cargo fmt` clean.

## Guards

Nothing existing could catch a regression here, so there are two.

- **`vtc-service/tests/no_rebuild.rs`** pins the two structural properties on every `cargo test`: the baked bundle is outside the manifest directory, and no `rerun-if-changed` input is left newer than the build script's own `output` stamp — literally the comparison cargo makes to decide whether to re-run a script.
- **A "vtc-service rebuild is a no-op" CI step** builds twice and fails if the second compiles. It allows one settle build first, since npm normalising the lockfile against the runner's own npm is a legitimate content change; that case is reported as a warning rather than blocking unrelated PRs.

## On the issue's own diagnosis

#1243 is an unusually good report and its fingerprint-level analysis of *what* happens is right. Two claims did not survive retesting, and they matter because the recommended fix rests on them:

- It concluded the two causes were **independent**, on the evidence that backdating the lockfile still produced a full rebuild. That doesn't reproduce — backdating the lockfile alone (including at the reporter's exact 10s offset) makes the build a true no-op. The ordering explains why: `build.rs` writes the bundle *before* the lib compiles, so it is always older than the rlib and can only go stale if the script re-ran.
- It therefore proposed `--outDir $OUT_DIR` as the fix and dismissed `npm ci` as leaving cause 2 open. That is backwards: moving `outDir` alone leaves `npm install` still rewriting the watched lockfile, so the script still re-runs and the bundle is still regenerated — in `$OUT_DIR` this time, but cargo fingerprints on mtime either way.

Full retest with measurements is in [the issue thread](https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/1243#issuecomment-5554185351).

## Docs

`vtc-service/CLAUDE.md` gains a "build.rs must only write under `OUT_DIR`" section with the failure mode and the measured non-fix; `admin-ui/README.md`, `docs/03-vtc/website-and-admin.md` (including the mermaid diagram) and `docs/05-design-notes/vtc-mvp.md` are updated for the relocated bundle.
