### PR TITLE
feat(persona): the holder's own identity, and a boundary a context cannot read across

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10491,6 +10491,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
+ "vta-persona",
  "vta-policy",
  "vta-sdk",
  "vta-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10313,6 +10313,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempfile",
+ "tokio",
  "tracing",
  "trust-tasks-rs",
  "ulid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8264,7 +8264,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -9734,6 +9734,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.5",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10289,6 +10300,23 @@ dependencies = [
  "trust-tasks-rs",
  "uniffi",
  "vta-sdk",
+]
+
+[[package]]
+name = "vta-persona"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "hmac 0.13.0",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "subtle",
+ "tempfile",
+ "tracing",
+ "ulid",
+ "vta-keyspaces",
+ "vti-common",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8264,7 +8264,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -10314,6 +10314,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tracing",
+ "trust-tasks-rs",
  "ulid",
  "vta-keyspaces",
  "vti-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "vta-sweepers",
   "vta-vault",
   "vta-webvh",
+  "vta-persona",
   "vta-service",
   "vta-enclave",
   "vtc-client",
@@ -55,6 +56,7 @@ default-members = [
   "vta-service",
   "vta-vault",
   "vta-webvh",
+  "vta-persona",
   "vta-enclave",
   "vtc-client",
   "vtc-service",
@@ -217,6 +219,9 @@ sha2 = "0.11"
 # server-stored hash against a caller-supplied value (e.g.
 # backup-bundle bearer tokens). Already used by vtc-service.
 subtle = "2.6"
+# ULIDs for persona-store record identifiers: the leading 48 bits are a
+# timestamp, so a key-ordered scan is also creation-ordered.
+ulid = { version = "1", features = ["serde"] }
 x25519-dalek = { version = "3", features = ["static_secrets"] }
 multibase = "0.9"
 

--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -138,6 +138,7 @@ COPY vta-keys/ vta-keys/
 COPY vta-policy/ vta-policy/
 COPY vta-mcp/ vta-mcp/
 COPY vta-mobile-core/ vta-mobile-core/
+COPY vta-persona/ vta-persona/
 COPY vta-sdk/ vta-sdk/
 COPY vta-support/ vta-support/
 COPY vta-tee/ vta-tee/

--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -128,6 +128,61 @@ pub const ROOM_GROUPS: &str = "room_groups";
 /// use means single use.
 pub const ROOM_INVITATIONS: &str = "room_invitations";
 
+/// The holder's identity attributes, profiles, bindings and contacts
+/// (`persona/*`) — the fourth store, beside [`VAULT`] (secrets and
+/// credentials), [`MEMORY`] (agent memory) and [`APP_STATE`] (uninterpreted
+/// application JSON).
+///
+/// It is a distinct store because disclosure control is its point, and a
+/// maintainer that cannot read a record cannot decide which of its members may
+/// leave, cannot audit which ones did, and cannot answer "what have I shared
+/// with whom". [`APP_STATE`] promises never to interpret its records, so it
+/// cannot host this; and a namespace there is collision avoidance rather than a
+/// trust boundary, so a compromised application sharing a context could remove
+/// the holder's identity data.
+///
+/// **Two scopes share the keyspace, and the split is a security control rather
+/// than a filing decision.** The pool and profiles are *agent-scoped* — above
+/// every context — so that the correlation index can see the risk it most needs
+/// to report: the same value presented by two personas in two different
+/// contexts, which a per-context index cannot see by construction. Bindings,
+/// contacts and disclosure records are context-scoped, because a persona lives
+/// in a context and so do its counterparties.
+///
+/// Nothing inside a context may read the agent-scoped prefixes. The holder
+/// pushes a materialised projection down; a context never pulls. That is
+/// enforced at dispatch, not here, but the prefix split is what makes the
+/// enforcement expressible.
+///
+/// Agent-scoped:
+///
+/// - `pa:<attributeId>` — one attribute of the pool.
+/// - `pp:<profileId>` — one profile.
+/// - `pxi:<hmac>` — correlation index, keyed by a keyed hash of the value so
+///   exact-match lookup works with no plaintext index over personal data.
+/// - `pxr:<attributeId>:<profileId>` — attribute → profile reverse index, so a
+///   delete can name its referring profiles without scanning every profile.
+///
+/// Context-scoped:
+///
+/// - `pb:<contextId>:<personaDid>` — binding of a profile to a persona DID.
+/// - `pc:<contextId>:<contactId>` — a contact's current revision.
+/// - `pcr:<contextId>:<contactId>:<rev>` — superseded contact revisions,
+///   reference-counted rather than reaped on a flat TTL: a revision behind a
+///   disclosure record is evidence the holder can still be asked to account for.
+/// - `pd:<contextId>:<seq:020>` — append-only disclosure record.
+/// - `plp:<contextId>:<profileId>` — context-local profile (inline entries
+///   only). A *separate prefix*, not a flag on `pp:`, so a context-scoped list
+///   scans a space that structurally cannot contain a pool profile — a filter
+///   bug there would be the same one-line leak the authorization rule exists to
+///   remove.
+/// - `plb:<contextId>:<personaDid>` — binding of a local profile.
+///
+/// The holder's identity is the account → in [`BACKED_UP`]. A restored agent
+/// that came back without it would be an agent that no longer knows who its
+/// holder is.
+pub const PERSONA: &str = "persona";
+
 /// Versioned, namespaced application state (`vta/app-state/{get,put,list,
 /// delete,get-many,put-many}/1.0`) — the third store, beside [`VAULT`] (secrets
 /// and credentials) and [`MEMORY`] (agent memory), for JSON an application owns
@@ -218,6 +273,7 @@ pub const ALL: &[&str] = &[
     ROOM_GROUPS,
     ROOM_INVITATIONS,
     APP_STATE,
+    PERSONA,
     POLICY,
     TASK_CONSENT,
     OUTBOX,
@@ -244,6 +300,10 @@ pub const BACKED_UP: &[&str] = &[
     // without it would return a VTA whose applications no longer recognise
     // their own data, which is the failure the store exists to prevent.
     APP_STATE,
+    // The holder's own identity — attributes, profiles, bindings, contacts.
+    // A restore that came back without it would return an agent that no longer
+    // knows who its holder is, which is most of what the restore was for.
+    PERSONA,
     // Operator security policy — must survive a restore, else enforcement
     // silently reverts to whatever defaults boot-install provides.
     POLICY,
@@ -400,6 +460,18 @@ pub const fn did_delete_effect(keyspace: &str) -> Option<DidDeleteEffect> {
         // twice. Single use means single use, and the record is the only thing
         // that remembers.
         b"room_groups" | b"room_invitations" => Cascade,
+
+        // Persona is two scopes in one keyspace and only one half is DID-keyed,
+        // which the per-keyspace enum cannot say — so it is said here. The
+        // context-scoped rows DO belong to a DID: a binding is keyed by the
+        // persona DID, and a contact records the persona that knows it. Those
+        // cascade, because a binding for a DID that can no longer be resolved is
+        // the ACL orphan again in a different keyspace. The agent-scoped rows —
+        // the attribute pool, the profiles, and their indexes — are keyed to no
+        // DID and survive, which is correct: a profile may be bound to several
+        // personas, and deleting one persona must not destroy facts the holder
+        // still presents through another.
+        b"persona" => Cascade,
 
         // ---- Depends on the DID to function ------------------------------
         // A context whose `did` is this one, a DID named in an advertised

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -130,6 +130,13 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // is a membership change made on the principal's behalf — not something a
     // blanket `vta_call` approval should cover silently.
     ("rooms/keys/welcome", Risk::Sensitive),
+    // The holder's own identity, emitted. `disclosure/present` is the one
+    // persona task that hands claims to a named verifier, under a persona DID,
+    // and writes the record saying it did. It sits beside `rooms/keys/present`
+    // for the same reason: an MCP host approves a *tool*, so a blanket
+    // `vta_call` approval must not silently cover deciding who learns the
+    // principal's name.
+    ("persona/disclosure/present", Risk::Sensitive),
     // Reads that a verb rule would misread.
     ("vta/contexts/preview-delete", Risk::ReadOnly),
     ("vta/webvh/agent-name/check", Risk::ReadOnly),
@@ -159,6 +166,14 @@ const READ_VERBS: &[&str] = &[
     "explain",
     "get-retention",
     "approver-list",
+    // Reads the record of what was disclosed to whom. Only ever a read — the
+    // disclosure itself is written by `present`, not by looking at it later.
+    "history",
+    // Reports how linkable a value would make the holder. It reads the pool
+    // and writes nothing; classifying it above ReadOnly while
+    // `persona/attribute/list` — which returns the values themselves — stays
+    // ReadOnly would be incoherent.
+    "analyze",
 ];
 
 /// Final-segment verbs that remove state or access.
@@ -486,6 +501,12 @@ mod tests {
         "key-package",
         // Advances the group one epoch. No secret crosses in either direction.
         "commit",
+        // `persona/disclosure/preview` reads like a read and is not one: it
+        // mints the single-use token `present` consumes, so a replayed preview
+        // hands out a second authorisation to disclose. `--read-only` must not
+        // permit it. Nothing leaves the agent, which is why it stops here and
+        // does not join `present` among the sensitive slugs.
+        "preview",
         "create",
         "update",
         "update-did",

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }
 # Keyed hash for the correlation index. HMAC-SHA256 over a per-agent key, so
 # exact-match lookup works with no plaintext index over the holder's PII.
 hmac = { workspace = true }
@@ -31,6 +32,7 @@ ulid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 # The generated payload types are the contract this crate stores against.
 # A dev-dependency rather than a real one: storage does not need them, and
 # taking them here means a spec change that lands upstream without a matching

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -31,3 +31,8 @@ ulid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+# The generated payload types are the contract this crate stores against.
+# A dev-dependency rather than a real one: storage does not need them, and
+# taking them here means a spec change that lands upstream without a matching
+# change to our models fails a test rather than a production dispatch.
+trust-tasks-rs = { workspace = true }

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "vta-persona"
+description = "VTA persona store — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose"
+readme = "README.md"
+version = "0.1.0"
+edition.workspace = true
+# Published for the same reason vta-vault is: `vta-service` is published, and a
+# crate cannot go to crates.io without its whole dependency closure. Nothing
+# outside this workspace is expected to depend on it directly.
+publish.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
+vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+# Keyed hash for the correlation index. HMAC-SHA256 over a per-agent key, so
+# exact-match lookup works with no plaintext index over the holder's PII.
+hmac = { workspace = true }
+sha2 = { workspace = true }
+subtle = { workspace = true }
+# ULIDs: the leading 48 bits are a timestamp, so a key-ordered scan of the
+# store is also creation-ordered and a list needs no secondary sort.
+ulid = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/vta-persona/src/binding.rs
+++ b/vta-persona/src/binding.rs
@@ -283,6 +283,49 @@ impl PersonaStore {
             .collect())
     }
 
+    /// Every persona bound to a profile, across **every** context.
+    ///
+    /// Holder-only by consequence: it spans contexts, which is exactly the view
+    /// a context-scoped caller must not have. Used by profile deletion to name
+    /// what a removal would leave presenting nothing.
+    pub async fn personas_bound_to_anywhere(
+        &self,
+        profile_id: &str,
+    ) -> Result<Vec<String>, AppError> {
+        let rows = self.ks.prefix_iter_raw(b"pb:".to_vec()).await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(_k, v)| serde_json::from_slice::<BindingRecord>(&v).ok())
+            .filter(|r| r.binding.profile_id.as_deref() == Some(profile_id))
+            .map(|r| r.binding.persona_did)
+            .collect())
+    }
+
+    /// Clear every binding to a profile, across every context.
+    ///
+    /// The deliberate half of profile deletion: it leaves those personas
+    /// presenting nothing, which is a legal state and one the holder is told
+    /// about rather than discovering.
+    pub async fn unbind_everywhere(&self, profile_id: &str) -> Result<usize, AppError> {
+        let _guard = self.write_lock.lock().await;
+        let rows = self.ks.prefix_iter_raw(b"pb:".to_vec()).await?;
+        let mut cleared = 0usize;
+        for (k, v) in rows {
+            let Ok(mut record) = serde_json::from_slice::<BindingRecord>(&v) else {
+                continue;
+            };
+            if record.binding.profile_id.as_deref() != Some(profile_id) {
+                continue;
+            }
+            record.binding.profile_id = None;
+            record.profile_name = None;
+            record.claims.clear();
+            self.ks.insert(k, &record).await?;
+            cleared += 1;
+        }
+        Ok(cleared)
+    }
+
     /// Re-push every projection that draws on a profile.
     ///
     /// "Edit once, everywhere" survives the boundary because this is a **write

--- a/vta-persona/src/binding.rs
+++ b/vta-persona/src/binding.rs
@@ -1,0 +1,486 @@
+//! Bindings: assigning a profile to a persona DID, and the push that carries a
+//! composition across the context boundary.
+//!
+//! This is where the one-way rule stops being a key layout and becomes
+//! behaviour. The pool and profiles are agent-scoped; a binding is
+//! context-scoped. Setting one is the moment a composition crosses, and the
+//! crossing has a direction: **the holder pushes a materialised projection
+//! down, and a context never pulls.**
+//!
+//! # The projection carries no back-reference
+//!
+//! What lands in the context is [`MaterialisedClaim`] — values, flat, with no
+//! `attributeId`. That is a distinct type from [`crate::ResolvedClaim`] rather
+//! than the same one with a field left empty, because the difference is the
+//! security property: a function handed a `MaterialisedClaim` *cannot* obtain a
+//! pool identifier, so no future edit can accidentally leak one across the
+//! boundary by forgetting to clear it.
+//!
+//! That is what makes the boundary hold under compromise. An attacker with
+//! administrative access to the context sees exactly what was pushed, and
+//! nothing there leads anywhere else — the rest of the pool is not merely
+//! forbidden to them, it is absent.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+
+use crate::model::{Binding, Provenance, Ulid, Version};
+use crate::profile::ProfileSlot;
+use crate::storage;
+use crate::store::{PersonaStore, check_precondition, now_rfc3339};
+
+/// One claim as it exists *inside a context*, after being pushed down.
+///
+/// Deliberately has no `attribute_id`. See the module docs: the absence is the
+/// control, and making it a separate type means the compiler enforces it rather
+/// than a reviewer noticing.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterialisedClaim {
+    pub r#type: String,
+    pub value: Option<serde_json::Value>,
+    pub provenance: Provenance,
+    /// A stale claim is materialised so the holder can see the projection is
+    /// short, and MUST NOT be disclosed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stale: bool,
+}
+
+/// The binding plus the claims it pushed into the context.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BindingRecord {
+    pub binding: Binding,
+    /// Cached label so a context-scoped read can name the composition without
+    /// reaching across the boundary to the profile.
+    pub profile_name: Option<String>,
+    pub claims: Vec<MaterialisedClaim>,
+}
+
+/// What a context-scoped caller may learn about a binding.
+///
+/// Whether a profile is bound, the holder's label for it, and how many claims
+/// are available — never their contents. With the disclosure path this exhausts
+/// what an application inside a context can obtain: being inside confers no
+/// privilege over identity data.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BindingSummary {
+    pub persona_did: String,
+    pub bound: bool,
+    pub profile_id: Option<Ulid>,
+    pub profile_name: Option<String>,
+    pub claim_count: usize,
+    pub bound_at: Option<String>,
+}
+
+/// Outcome of a push.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Bound {
+    pub version: Version,
+    pub materialised_claim_count: usize,
+    /// How many *other* personas are bound to this same profile.
+    ///
+    /// A count, not identifiers: the association between the holder's personas
+    /// is exactly what an attacker wants, and a count is enough to warn.
+    /// Non-zero means the two personas are the same person by construction, and
+    /// no later narrowing undoes that.
+    pub also_bound_persona_count: usize,
+}
+
+impl PersonaStore {
+    /// Assign a profile to a persona in a context, or clear the assignment.
+    ///
+    /// `profile_id: None` clears. A persona with no profile is a legitimate and
+    /// common state — a throwaway identity that presents nothing — so it is a
+    /// first-class value rather than an absence to be inferred.
+    pub async fn set_binding(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+        profile_id: Option<&str>,
+        public_entries: Vec<Ulid>,
+        expected_version: Option<Version>,
+    ) -> Result<Bound, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let existing = self.binding_record(context_id, persona_did).await?;
+        check_precondition(
+            expected_version,
+            existing.as_ref().map(|r| r.binding.version),
+        )?;
+
+        let (profile_name, claims) = match profile_id {
+            None => (None, Vec::new()),
+            Some(id) => {
+                // Refuse rather than write a binding that presents nothing while
+                // appearing configured.
+                let Some(ProfileSlot::Live(p)) = self.profile_slot(id).await? else {
+                    return Err(AppError::NotFound(format!(
+                        "profile {id} does not exist; refusing to bind a persona to it"
+                    )));
+                };
+                (Some(p.name.clone()), self.materialise(id).await?)
+            }
+        };
+
+        let also_bound = match profile_id {
+            Some(id) => self
+                .personas_bound_to(context_id, id)
+                .await?
+                .into_iter()
+                .filter(|d| d != persona_did)
+                .count(),
+            None => 0,
+        };
+
+        let version = self.next_version().await?;
+        let record = BindingRecord {
+            binding: Binding {
+                persona_did: persona_did.to_string(),
+                profile_id: profile_id.map(str::to_string),
+                public_entries,
+                version,
+                bound_at: now_rfc3339(),
+            },
+            profile_name,
+            claims,
+        };
+        let count = record.claims.len();
+
+        self.ks
+            .insert(storage::binding_key(context_id, persona_did), &record)
+            .await?;
+
+        Ok(Bound {
+            version,
+            materialised_claim_count: count,
+            also_bound_persona_count: also_bound,
+        })
+    }
+
+    /// Resolve a profile and strip every pool identifier from the result.
+    ///
+    /// The strip is the whole point, and it happens by *construction* — the
+    /// output type has nowhere to put an identifier.
+    async fn materialise(&self, profile_id: &str) -> Result<Vec<MaterialisedClaim>, AppError> {
+        Ok(self
+            .resolve_profile(profile_id)
+            .await?
+            .into_iter()
+            .map(|c| MaterialisedClaim {
+                r#type: c.r#type,
+                value: c.value,
+                provenance: c.provenance,
+                stale: c.stale,
+            })
+            .collect())
+    }
+
+    pub(crate) async fn binding_record(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+    ) -> Result<Option<BindingRecord>, AppError> {
+        self.ks
+            .get::<BindingRecord>(storage::binding_key(context_id, persona_did))
+            .await
+    }
+
+    /// What a context-scoped caller may learn. Never the claim values.
+    pub async fn binding_summary(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+    ) -> Result<BindingSummary, AppError> {
+        let record = self.binding_record(context_id, persona_did).await?;
+        Ok(match record {
+            None => BindingSummary {
+                persona_did: persona_did.to_string(),
+                bound: false,
+                profile_id: None,
+                profile_name: None,
+                claim_count: 0,
+                bound_at: None,
+            },
+            Some(r) => BindingSummary {
+                persona_did: persona_did.to_string(),
+                // A binding row with a null profile is bound-to-nothing, which
+                // is not the same as having no binding at all — but a
+                // context-scoped caller is told the same thing either way,
+                // because the distinction is the holder's business.
+                bound: r.binding.profile_id.is_some(),
+                profile_id: r.binding.profile_id.clone(),
+                profile_name: r.profile_name.clone(),
+                claim_count: r.claims.len(),
+                bound_at: Some(r.binding.bound_at.clone()),
+            },
+        })
+    }
+
+    /// The claims pushed into a context for one persona.
+    ///
+    /// This is what a disclosure draws on. It cannot reach the pool — the return
+    /// type has no identifiers — so a disclosure serves what was pushed and
+    /// nothing else.
+    pub async fn materialised_claims(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+    ) -> Result<Vec<MaterialisedClaim>, AppError> {
+        Ok(self
+            .binding_record(context_id, persona_did)
+            .await?
+            .map(|r| r.claims)
+            .unwrap_or_default())
+    }
+
+    /// Every persona in a context bound to a given profile.
+    pub async fn personas_bound_to(
+        &self,
+        context_id: &str,
+        profile_id: &str,
+    ) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .list_bindings(context_id)
+            .await?
+            .into_iter()
+            .filter(|r| r.binding.profile_id.as_deref() == Some(profile_id))
+            .map(|r| r.binding.persona_did)
+            .collect())
+    }
+
+    pub(crate) async fn list_bindings(
+        &self,
+        context_id: &str,
+    ) -> Result<Vec<BindingRecord>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::binding_prefix(context_id).into_bytes())
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(_k, v)| serde_json::from_slice::<BindingRecord>(&v).ok())
+            .collect())
+    }
+
+    /// Summaries for every persona in a context.
+    pub async fn list_binding_summaries(
+        &self,
+        context_id: &str,
+    ) -> Result<Vec<BindingSummary>, AppError> {
+        Ok(self
+            .list_bindings(context_id)
+            .await?
+            .into_iter()
+            .map(|r| BindingSummary {
+                persona_did: r.binding.persona_did,
+                bound: r.binding.profile_id.is_some(),
+                profile_id: r.binding.profile_id,
+                profile_name: r.profile_name,
+                claim_count: r.claims.len(),
+                bound_at: Some(r.binding.bound_at),
+            })
+            .collect())
+    }
+
+    /// Re-push every projection that draws on a profile.
+    ///
+    /// "Edit once, everywhere" survives the boundary because this is a **write
+    /// initiated above it**, never a read from below. A context that could pull
+    /// its projection fresh would be reaching into the pool, which is the thing
+    /// the direction rule forbids.
+    ///
+    /// Returns how many projections were refreshed.
+    pub async fn rematerialise(&self, profile_id: &str) -> Result<usize, AppError> {
+        let _guard = self.write_lock.lock().await;
+        let claims = self.materialise(profile_id).await?;
+
+        let mut refreshed = 0usize;
+        let rows = self.ks.prefix_iter_raw(b"pb:".to_vec()).await?;
+        for (k, v) in rows {
+            let Ok(mut record) = serde_json::from_slice::<BindingRecord>(&v) else {
+                continue;
+            };
+            if record.binding.profile_id.as_deref() != Some(profile_id) {
+                continue;
+            }
+            record.claims = claims.clone();
+            self.ks.insert(k, &record).await?;
+            refreshed += 1;
+        }
+        Ok(refreshed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ProfileEntry, ValueType};
+    use crate::profile::new_profile;
+    use crate::store::new_attribute;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(vta_keyspaces::PERSONA).unwrap();
+        (dir, PersonaStore::new(ks, [11u8; 32]))
+    }
+
+    async fn pool_profile(s: &PersonaStore, value: &str) -> (String, String) {
+        let a = new_attribute(
+            "phone.mobile",
+            ValueType::String,
+            serde_json::json!(value),
+            Provenance::SelfAsserted,
+        );
+        s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+        (a.attribute_id, p.profile_id)
+    }
+
+    #[tokio::test]
+    async fn the_projection_carries_no_pool_identifier() {
+        // The security property, asserted on the serialised bytes rather than
+        // the type — because what crosses the boundary is what was written.
+        let (_d, s) = fresh().await;
+        let (attr_id, profile_id) = pool_profile(&s, "+61 4").await;
+        s.set_binding("ctx", "did:persona:a", Some(&profile_id), vec![], None)
+            .await
+            .unwrap();
+
+        let raw =
+            s.ks.get_raw(storage::binding_key("ctx", "did:persona:a"))
+                .await
+                .unwrap()
+                .expect("row");
+        let text = String::from_utf8_lossy(&raw);
+        assert!(
+            !text.contains(&attr_id),
+            "a materialised projection must carry no back-reference into the pool"
+        );
+        assert!(
+            text.contains("+61 4"),
+            "but it does carry the value it pushed"
+        );
+    }
+
+    #[tokio::test]
+    async fn binding_to_a_missing_profile_is_refused() {
+        // Writing it would leave a persona that appears configured and presents
+        // nothing.
+        let (_d, s) = fresh().await;
+        let err = s
+            .set_binding("ctx", "did:persona:a", Some("01MISSING"), vec![], None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn clearing_is_a_first_class_state_not_an_absence() {
+        let (_d, s) = fresh().await;
+        let (_a, p) = pool_profile(&s, "x").await;
+        s.set_binding("ctx", "did:p", Some(&p), vec![], None)
+            .await
+            .unwrap();
+        assert!(s.binding_summary("ctx", "did:p").await.unwrap().bound);
+
+        s.set_binding("ctx", "did:p", None, vec![], None)
+            .await
+            .unwrap();
+        let sum = s.binding_summary("ctx", "did:p").await.unwrap();
+        assert!(!sum.bound);
+        assert_eq!(sum.claim_count, 0, "clearing removes the projection");
+        assert!(
+            s.materialised_claims("ctx", "did:p")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_second_persona_on_one_profile_is_counted_and_warned() {
+        // Binding one profile to a second persona makes them the same person by
+        // construction, and no later narrowing undoes it.
+        let (_d, s) = fresh().await;
+        let (_a, p) = pool_profile(&s, "x").await;
+
+        let first = s
+            .set_binding("ctx", "did:p1", Some(&p), vec![], None)
+            .await
+            .unwrap();
+        assert_eq!(first.also_bound_persona_count, 0);
+
+        let second = s
+            .set_binding("ctx", "did:p2", Some(&p), vec![], None)
+            .await
+            .unwrap();
+        assert_eq!(second.also_bound_persona_count, 1);
+    }
+
+    #[tokio::test]
+    async fn a_summary_names_the_composition_and_never_its_contents() {
+        let (_d, s) = fresh().await;
+        let (_a, p) = pool_profile(&s, "+61 4xx secret").await;
+        s.set_binding("ctx", "did:p", Some(&p), vec![], None)
+            .await
+            .unwrap();
+
+        let sum = s.binding_summary("ctx", "did:p").await.unwrap();
+        assert_eq!(sum.profile_name.as_deref(), Some("Work"));
+        assert_eq!(sum.claim_count, 1);
+        // There is nowhere in a summary to put a value, which is the point.
+        let rendered = format!("{sum:?}");
+        assert!(!rendered.contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn editing_the_pool_refreshes_pushed_projections() {
+        // "Edit once, everywhere" survives the boundary because this is a write
+        // from above, not a read from below.
+        let (_d, s) = fresh().await;
+        let (attr_id, p) = pool_profile(&s, "old").await;
+        s.set_binding("ctx", "did:p", Some(&p), vec![], None)
+            .await
+            .unwrap();
+        assert_eq!(
+            s.materialised_claims("ctx", "did:p").await.unwrap()[0].value,
+            Some(serde_json::json!("old"))
+        );
+
+        let mut updated = s.get(&attr_id).await.unwrap().unwrap();
+        updated.value = Some(serde_json::json!("new"));
+        s.put(updated, None).await.unwrap();
+
+        assert_eq!(s.rematerialise(&p).await.unwrap(), 1);
+        assert_eq!(
+            s.materialised_claims("ctx", "did:p").await.unwrap()[0].value,
+            Some(serde_json::json!("new"))
+        );
+    }
+
+    #[tokio::test]
+    async fn a_context_sees_only_its_own_bindings() {
+        let (_d, s) = fresh().await;
+        let (_a, p) = pool_profile(&s, "x").await;
+        s.set_binding("ctx-a", "did:p", Some(&p), vec![], None)
+            .await
+            .unwrap();
+
+        assert_eq!(s.list_binding_summaries("ctx-a").await.unwrap().len(), 1);
+        assert!(s.list_binding_summaries("ctx-b").await.unwrap().is_empty());
+        assert!(!s.binding_summary("ctx-b", "did:p").await.unwrap().bound);
+    }
+}

--- a/vta-persona/src/contact.rs
+++ b/vta-persona/src/contact.rs
@@ -1,0 +1,650 @@
+//! Contacts: what a peer disclosed, filed by revision.
+//!
+//! Two properties are not negotiable, and both exist because an address book
+//! that quietly changes is worse than one that does not exist.
+//!
+//! **Revisioned, never overwritten.** When a peer re-discloses, the previous
+//! document is kept and the new one becomes current. An address book that
+//! silently replaces a payment address is a phishing surface; one that reports
+//! *"this changed four minutes ago, here is what it was"* is a defence. A
+//! revision history nobody is shown is an archive, not a defence — which is
+//! what [`ContactSummary::has_unreviewed_change`] and [`Filed::changed_claims`]
+//! are for.
+//!
+//! **A contact belongs to a relationship, not to the holder at large.** The
+//! same peer met through two personas is two contacts. Collapsing them would
+//! correlate the holder's own personas *inside their own address book* — the
+//! one place nobody would think to look for that linkage.
+//!
+//! # Retention is reference-counted, not a timer
+//!
+//! A superseded revision is reaped after a retention window **unless something
+//! still points at it**. A revision behind a disclosure record is evidence of
+//! what the holder was shown before they presented, and a flat TTL would delete
+//! it precisely when it mattered. See [`PersonaStore::reap_contact_revisions`].
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+
+use crate::model::Ulid;
+use crate::storage;
+use crate::store::{PersonaStore, now_rfc3339};
+
+/// A claim as a peer disclosed it.
+///
+/// Structurally the claim set a holder composes — a profile and a contact card
+/// are one schema seen from two sides — which is why one validator serves both.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactClaim {
+    pub r#type: String,
+    pub value: serde_json::Value,
+    /// As **asserted by the publisher**. A recipient must not treat a claimed
+    /// credential-backed provenance as verified: it states what the publisher
+    /// says backs the claim, and verification is a separate act against the
+    /// credential itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<crate::Provenance>,
+}
+
+/// What a peer published, as received.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactDocument {
+    /// The DID that published it. Normally pairwise, so it names the
+    /// relationship rather than the person across all of theirs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+    /// The publisher's own counter, if supplied. **Advisory**: it orders the
+    /// publisher's revisions relative to each other and must never be used to
+    /// order them against anything else — a recipient counts what it received,
+    /// which is the only sequence it can vouch for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub card_version: Option<u64>,
+    pub claims: Vec<ContactClaim>,
+}
+
+/// One received version of a contact's document.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactRevision {
+    /// Assigned by the recipient, monotonic per contact.
+    pub rev: u64,
+    pub received_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_at: Option<String>,
+    pub document: ContactDocument,
+    /// Set when a disclosure record cites this revision. A cited revision is
+    /// evidence the holder can still be asked to account for, so retention
+    /// counts references rather than days.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub cited: bool,
+}
+
+/// A contact's current state.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Contact {
+    pub contact_id: Ulid,
+    pub subject_did: String,
+    /// Which of the holder's personas knows this contact. Part of the identity
+    /// of the record, not a tag on it.
+    pub known_by_persona: String,
+    pub rev: u64,
+    pub document: ContactDocument,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credential_refs: Vec<String>,
+    /// The holder's private note. Never disclosed to anyone, including the
+    /// contact it is about — which makes it the most sensitive member here,
+    /// because its subject cannot see it and never consented to it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    pub has_unreviewed_change: bool,
+}
+
+/// Outcome of filing a disclosure.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Filed {
+    pub contact_id: Ulid,
+    pub rev: u64,
+    pub created: bool,
+    /// Claim **types** whose value differs from the previous revision.
+    ///
+    /// Types, not values: this is what turns a history into a defence, and a
+    /// producer that needs the old value reads the prior revision, which is an
+    /// explicit act.
+    pub changed_claims: Vec<String>,
+}
+
+/// What a listing shows. No claim values — finding one contact does not require
+/// disclosing the details of every contact.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContactSummary {
+    pub contact_id: Ulid,
+    pub subject_did: String,
+    pub known_by_persona: String,
+    pub rev: u64,
+    pub claim_count: usize,
+    pub received_at: String,
+    pub has_unreviewed_change: bool,
+}
+
+impl PersonaStore {
+    /// File what a peer disclosed, appending a revision.
+    ///
+    /// Keyed on `(context, subject, known_by_persona)`: the same peer met
+    /// through two personas is two contacts, deliberately.
+    pub async fn file_contact(
+        &self,
+        context_id: &str,
+        subject_did: &str,
+        known_by_persona: &str,
+        document: ContactDocument,
+        credential_refs: Vec<String>,
+    ) -> Result<Filed, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let existing = self
+            .find_contact(context_id, subject_did, known_by_persona)
+            .await?;
+
+        let (contact_id, rev, created, changed, notes) = match existing {
+            None => (ulid::Ulid::new().to_string(), 1u64, true, Vec::new(), None),
+            Some(prev) => {
+                let changed = diff_claims(&prev.document, &document);
+                // Archive the outgoing revision before the new one lands, so a
+                // crash leaves a duplicate rather than a gap. A gap in a history
+                // that exists to prove what changed is worse than a repeat.
+                self.ks
+                    .insert(
+                        storage::contact_revision_key(context_id, &prev.contact_id, prev.rev),
+                        &ContactRevision {
+                            rev: prev.rev,
+                            received_at: now_rfc3339(),
+                            superseded_at: Some(now_rfc3339()),
+                            document: prev.document.clone(),
+                            cited: false,
+                        },
+                    )
+                    .await?;
+                (prev.contact_id, prev.rev + 1, false, changed, prev.notes)
+            }
+        };
+
+        let contact = Contact {
+            contact_id: contact_id.clone(),
+            subject_did: subject_did.to_string(),
+            known_by_persona: known_by_persona.to_string(),
+            rev,
+            document,
+            credential_refs,
+            notes,
+            // A change nobody has looked at yet is the whole reason to keep
+            // revisions; a producer clears it when the holder has seen the diff.
+            has_unreviewed_change: !created && !changed.is_empty(),
+        };
+        self.ks
+            .insert(storage::contact_key(context_id, &contact_id), &contact)
+            .await?;
+
+        Ok(Filed {
+            contact_id,
+            rev,
+            created,
+            changed_claims: changed,
+        })
+    }
+
+    pub async fn get_contact(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+    ) -> Result<Option<Contact>, AppError> {
+        self.ks
+            .get::<Contact>(storage::contact_key(context_id, contact_id))
+            .await
+    }
+
+    /// A specific revision.
+    ///
+    /// `Gone` — not `NotFound` — for a revision that existed and was reaped. A
+    /// caller comparing a current value against history must tell *never
+    /// existed* from *no longer kept*: the first means their premise was wrong,
+    /// the second means their comparison is unsound. Collapsing the two lets a
+    /// producer conclude "nothing changed" from an absence that means the
+    /// opposite.
+    pub async fn get_contact_revision(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+        rev: u64,
+    ) -> Result<ContactRevision, AppError> {
+        if let Some(r) = self
+            .ks
+            .get::<ContactRevision>(storage::contact_revision_key(context_id, contact_id, rev))
+            .await?
+        {
+            return Ok(r);
+        }
+        let current = self.get_contact(context_id, contact_id).await?;
+        match current {
+            Some(c) if c.rev == rev => Ok(ContactRevision {
+                rev: c.rev,
+                received_at: now_rfc3339(),
+                superseded_at: None,
+                document: c.document,
+                cited: false,
+            }),
+            Some(c) if rev < c.rev => Err(AppError::Gone(format!(
+                "revision {rev} of contact {contact_id} has been reaped"
+            ))),
+            _ => Err(AppError::NotFound(format!(
+                "contact {contact_id} has no revision {rev}"
+            ))),
+        }
+    }
+
+    /// Revision metadata without documents — a timeline is cheap and the
+    /// documents behind it are not.
+    pub async fn contact_history(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+    ) -> Result<Vec<(u64, String, bool)>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::contact_revision_prefix(context_id, contact_id).into_bytes())
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(_k, v)| serde_json::from_slice::<ContactRevision>(&v).ok())
+            .map(|r| (r.rev, r.received_at, r.cited))
+            .collect())
+    }
+
+    async fn find_contact(
+        &self,
+        context_id: &str,
+        subject_did: &str,
+        known_by_persona: &str,
+    ) -> Result<Option<Contact>, AppError> {
+        Ok(self
+            .list_contacts(context_id, None)
+            .await?
+            .into_iter()
+            .find(|c| c.subject_did == subject_did && c.known_by_persona == known_by_persona))
+    }
+
+    /// Contacts in a context, optionally narrowed to one persona.
+    ///
+    /// The unfiltered view puts the holder's personas side by side, which is a
+    /// map of their compartmentalisation — a producer should offer it
+    /// deliberately rather than by default.
+    pub async fn list_contacts(
+        &self,
+        context_id: &str,
+        known_by_persona: Option<&str>,
+    ) -> Result<Vec<Contact>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::contact_prefix(context_id).into_bytes())
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(_k, v)| serde_json::from_slice::<Contact>(&v).ok())
+            .filter(|c| known_by_persona.is_none_or(|p| c.known_by_persona == p))
+            .collect())
+    }
+
+    pub async fn list_contact_summaries(
+        &self,
+        context_id: &str,
+        known_by_persona: Option<&str>,
+    ) -> Result<Vec<ContactSummary>, AppError> {
+        Ok(self
+            .list_contacts(context_id, known_by_persona)
+            .await?
+            .into_iter()
+            .map(|c| ContactSummary {
+                contact_id: c.contact_id,
+                subject_did: c.subject_did,
+                known_by_persona: c.known_by_persona,
+                rev: c.rev,
+                claim_count: c.document.claims.len(),
+                received_at: now_rfc3339(),
+                has_unreviewed_change: c.has_unreviewed_change,
+            })
+            .collect())
+    }
+
+    /// Mark a revision as cited by a disclosure record, exempting it from
+    /// reaping.
+    pub async fn cite_contact_revision(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+        rev: u64,
+    ) -> Result<(), AppError> {
+        let key = storage::contact_revision_key(context_id, contact_id, rev);
+        if let Some(mut r) = self.ks.get::<ContactRevision>(key.clone()).await? {
+            r.cited = true;
+            self.ks.insert(key, &r).await?;
+        }
+        Ok(())
+    }
+
+    /// Remove a contact and every revision **not cited by a disclosure record**.
+    ///
+    /// Returns `(existed, removed, retained)`. A maintainer must report the
+    /// retained count rather than let the holder believe the deletion was
+    /// total: an incomplete erasure the holder thinks is complete is worse than
+    /// one they know about, because they will make the next decision on a false
+    /// premise.
+    pub async fn delete_contact(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+    ) -> Result<(bool, usize, usize), AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let existed = self.get_contact(context_id, contact_id).await?.is_some();
+        if existed {
+            self.ks
+                .remove(storage::contact_key(context_id, contact_id))
+                .await?;
+        }
+
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::contact_revision_prefix(context_id, contact_id).into_bytes())
+            .await?;
+        let (mut removed, mut retained) = (0usize, 0usize);
+        for (k, v) in rows {
+            match serde_json::from_slice::<ContactRevision>(&v) {
+                Ok(r) if r.cited => retained += 1,
+                _ => {
+                    self.ks.remove(k).await?;
+                    removed += 1;
+                }
+            }
+        }
+        Ok((existed, removed, retained))
+    }
+
+    /// Reap superseded revisions older than `retain_days`, **except** those a
+    /// disclosure record cites.
+    ///
+    /// Reference-counted rather than a flat timer, because a flat timer deletes
+    /// the evidence behind a disclosure precisely when it matters. Returns how
+    /// many were removed.
+    pub async fn reap_contact_revisions(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+        retain_days: i64,
+    ) -> Result<usize, AppError> {
+        let _guard = self.write_lock.lock().await;
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(retain_days);
+
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::contact_revision_prefix(context_id, contact_id).into_bytes())
+            .await?;
+        let mut removed = 0usize;
+        for (k, v) in rows {
+            let Ok(r) = serde_json::from_slice::<ContactRevision>(&v) else {
+                continue;
+            };
+            if r.cited {
+                continue;
+            }
+            let superseded = r
+                .superseded_at
+                .as_deref()
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok());
+            if superseded.is_some_and(|t| t < cutoff) {
+                self.ks.remove(k).await?;
+                removed += 1;
+            }
+        }
+        Ok(removed)
+    }
+}
+
+/// Claim types whose value differs between two documents.
+///
+/// A type appearing in one and not the other counts as changed: a claim that
+/// vanished is exactly as much of an event as one that moved, and a diff that
+/// reported only mutations would stay quiet when a peer stopped disclosing
+/// their payment address.
+fn diff_claims(previous: &ContactDocument, next: &ContactDocument) -> Vec<String> {
+    let mut changed = Vec::new();
+    for c in &next.claims {
+        match previous.claims.iter().find(|p| p.r#type == c.r#type) {
+            Some(p) if p.value == c.value => {}
+            _ => changed.push(c.r#type.clone()),
+        }
+    }
+    for p in &previous.claims {
+        if !next.claims.iter().any(|c| c.r#type == p.r#type) {
+            changed.push(p.r#type.clone());
+        }
+    }
+    changed.sort();
+    changed.dedup();
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(vta_keyspaces::PERSONA).unwrap();
+        (dir, PersonaStore::new(ks, [13u8; 32]))
+    }
+
+    fn doc(pairs: &[(&str, &str)]) -> ContactDocument {
+        ContactDocument {
+            publisher: Some("did:peer:2.Ez6".into()),
+            card_version: None,
+            claims: pairs
+                .iter()
+                .map(|(t, v)| ContactClaim {
+                    r#type: (*t).into(),
+                    value: serde_json::json!(v),
+                    provenance: None,
+                })
+                .collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn re_disclosure_appends_and_reports_what_changed() {
+        // The whole reason to keep revisions: a silently replaced payment
+        // address is a phishing surface, and naming the change is the defence.
+        let (_d, s) = fresh().await;
+        let first = s
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:me",
+                doc(&[("payment.address", "acct-1")]),
+                vec![],
+            )
+            .await
+            .unwrap();
+        assert!(first.created && first.rev == 1 && first.changed_claims.is_empty());
+
+        let second = s
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:me",
+                doc(&[("payment.address", "acct-2")]),
+                vec![],
+            )
+            .await
+            .unwrap();
+        assert!(!second.created);
+        assert_eq!(second.rev, 2);
+        assert_eq!(second.changed_claims, vec!["payment.address"]);
+        assert_eq!(
+            second.contact_id, first.contact_id,
+            "same relationship, same contact"
+        );
+
+        let c = s
+            .get_contact("ctx", &first.contact_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            c.has_unreviewed_change,
+            "a change nobody has seen must be badgeable"
+        );
+        // And the prior document survives.
+        let prev = s
+            .get_contact_revision("ctx", &first.contact_id, 1)
+            .await
+            .unwrap();
+        assert_eq!(prev.document.claims[0].value, serde_json::json!("acct-1"));
+    }
+
+    #[tokio::test]
+    async fn a_claim_that_vanishes_counts_as_a_change() {
+        // A diff reporting only mutations stays quiet when a peer STOPS
+        // disclosing something, which is exactly when it should speak up.
+        let (_d, s) = fresh().await;
+        s.file_contact(
+            "ctx",
+            "did:bob",
+            "did:me",
+            doc(&[("email", "a"), ("phone", "b")]),
+            vec![],
+        )
+        .await
+        .unwrap();
+        let f = s
+            .file_contact("ctx", "did:bob", "did:me", doc(&[("email", "a")]), vec![])
+            .await
+            .unwrap();
+        assert_eq!(f.changed_claims, vec!["phone"]);
+    }
+
+    #[tokio::test]
+    async fn the_same_peer_through_two_personas_is_two_contacts() {
+        // Collapsing them would correlate the holder's own personas inside
+        // their own address book — the one place nobody would look.
+        let (_d, s) = fresh().await;
+        let a = s
+            .file_contact("ctx", "did:bob", "did:work", doc(&[("email", "x")]), vec![])
+            .await
+            .unwrap();
+        let b = s
+            .file_contact("ctx", "did:bob", "did:play", doc(&[("email", "x")]), vec![])
+            .await
+            .unwrap();
+        assert_ne!(a.contact_id, b.contact_id);
+        assert!(b.created, "the second persona starts its own history");
+
+        assert_eq!(
+            s.list_contacts("ctx", Some("did:work"))
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(s.list_contacts("ctx", None).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_reaped_revision_is_gone_not_missing() {
+        // A caller comparing against history must tell "never existed" from
+        // "no longer kept": only the second means their comparison is unsound.
+        let (_d, s) = fresh().await;
+        let f = s
+            .file_contact("ctx", "did:bob", "did:me", doc(&[("email", "a")]), vec![])
+            .await
+            .unwrap();
+        s.file_contact("ctx", "did:bob", "did:me", doc(&[("email", "b")]), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.reap_contact_revisions("ctx", &f.contact_id, 0)
+                .await
+                .unwrap(),
+            1
+        );
+
+        let err = s
+            .get_contact_revision("ctx", &f.contact_id, 1)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Gone(_)), "reaped, got {err:?}");
+
+        let never = s
+            .get_contact_revision("ctx", &f.contact_id, 99)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(never, AppError::NotFound(_)),
+            "never existed, got {never:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cited_revision_survives_reaping_and_deletion() {
+        // Retention counts references, not days: a revision behind a disclosure
+        // record is evidence the holder can still be asked to account for.
+        let (_d, s) = fresh().await;
+        let f = s
+            .file_contact("ctx", "did:bob", "did:me", doc(&[("email", "a")]), vec![])
+            .await
+            .unwrap();
+        s.file_contact("ctx", "did:bob", "did:me", doc(&[("email", "b")]), vec![])
+            .await
+            .unwrap();
+        s.cite_contact_revision("ctx", &f.contact_id, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            s.reap_contact_revisions("ctx", &f.contact_id, 0)
+                .await
+                .unwrap(),
+            0,
+            "a cited revision is exempt from the retention window"
+        );
+
+        let (existed, removed, retained) = s.delete_contact("ctx", &f.contact_id).await.unwrap();
+        assert!(existed);
+        assert_eq!(removed, 0);
+        assert_eq!(retained, 1, "and the deletion must report what it kept");
+    }
+
+    #[tokio::test]
+    async fn a_summary_carries_no_claim_values() {
+        let (_d, s) = fresh().await;
+        s.file_contact(
+            "ctx",
+            "did:bob",
+            "did:me",
+            doc(&[("email", "secret-address")]),
+            vec![],
+        )
+        .await
+        .unwrap();
+        let sums = s.list_contact_summaries("ctx", None).await.unwrap();
+        assert_eq!(sums[0].claim_count, 1);
+        assert!(!format!("{sums:?}").contains("secret-address"));
+    }
+}

--- a/vta-persona/src/correlation.rs
+++ b/vta-persona/src/correlation.rs
@@ -193,3 +193,119 @@ mod tests {
         assert_eq!(severity(false, false, ProofRung::Whole), Severity::None);
     }
 }
+
+// ─── Findings ────────────────────────────────────────────────────────────
+
+use serde::Serialize;
+
+/// One place the holder's identities link, and what can be done about it.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Finding {
+    pub attribute_id: Option<String>,
+    pub severity: &'static str,
+    /// Plain-language cause. A severity with no explanation is a warning a
+    /// holder learns to dismiss.
+    pub why: String,
+    pub shared_with_profile_count: usize,
+    /// What the holder can actually do.
+    ///
+    /// `reissueCredentialToThisDid` matters more than it looks: without it, a
+    /// holder told "this links your personas" has no action available but to
+    /// abandon the attribute, and the honest fix — a credential re-issued
+    /// against the persona actually using it — stays invisible unless the
+    /// analysis names it.
+    pub remedies: Vec<&'static str>,
+}
+
+impl crate::PersonaStore {
+    /// Report where the holder's identities link.
+    ///
+    /// Accepts a **candidate** the holder is considering but has not written,
+    /// which is the difference between a guard and a report: it can warn before
+    /// the mistake rather than after. A candidate is analysed and never stored.
+    pub async fn analyze_correlation(
+        &self,
+        attribute_id: Option<&str>,
+        candidate: Option<&serde_json::Value>,
+    ) -> Result<Vec<Finding>, vti_common::error::AppError> {
+        let mut findings = Vec::new();
+
+        if let Some(value) = candidate {
+            let count = self.correlation_count(value, "").await?;
+            if count > 0 {
+                findings.push(Finding {
+                    attribute_id: None,
+                    severity: "high",
+                    why: format!(
+                        "this value is already held by {count} other attribute(s); presenting \
+                         both links the personas that carry them, permanently, to anyone who \
+                         sees both"
+                    ),
+                    shared_with_profile_count: count,
+                    remedies: vec![
+                        "useDifferentValue",
+                        "reissueCredentialToThisDid",
+                        "correlateDeliberately",
+                        "proceedAndRecord",
+                    ],
+                });
+            }
+        }
+
+        let subjects: Vec<crate::Attribute> = match attribute_id {
+            Some(id) => self.get(id).await?.into_iter().collect(),
+            None => self.list_attributes(None, true).await?,
+        };
+
+        for a in subjects {
+            let Some(value) = &a.value else { continue };
+            let count = self.correlation_count(value, &a.attribute_id).await?;
+            if count == 0 {
+                continue;
+            }
+            let credential_backed =
+                matches!(a.provenance, crate::Provenance::CredentialBacked { .. });
+            let rung = match &a.provenance {
+                crate::Provenance::CredentialBacked { proof, .. } => {
+                    proof.unwrap_or(crate::ProofRung::Whole)
+                }
+                _ => crate::ProofRung::Whole,
+            };
+            let sev = severity(true, credential_backed, rung);
+            findings.push(Finding {
+                attribute_id: Some(a.attribute_id.clone()),
+                severity: match sev {
+                    Severity::High => "high",
+                    Severity::Low => "low",
+                    Severity::None => "none",
+                },
+                why: if credential_backed {
+                    format!(
+                        "credential-backed and presented at the {rung:?} rung. A credential \
+                         presented whole carries the same issuer signature to every verifier, \
+                         so it links them however few claims each received"
+                    )
+                } else {
+                    format!("the same value is held by {count} other attribute(s)")
+                },
+                shared_with_profile_count: count,
+                remedies: if credential_backed {
+                    vec![
+                        "reissueCredentialToThisDid",
+                        "correlateDeliberately",
+                        "proceedAndRecord",
+                    ]
+                } else {
+                    vec![
+                        "useDifferentValue",
+                        "correlateDeliberately",
+                        "proceedAndRecord",
+                    ]
+                },
+            });
+        }
+
+        Ok(findings)
+    }
+}

--- a/vta-persona/src/correlation.rs
+++ b/vta-persona/src/correlation.rs
@@ -1,0 +1,195 @@
+//! The blinded correlation index.
+//!
+//! Multiple personas exist to be unlinkable, and a composition tool is a machine
+//! for accidentally linking them: the same value in two profiles correlates the
+//! personas presenting them, permanently, for anyone who sees both. The holder
+//! will not notice while composing, which is why this is a first-class output
+//! rather than a lint.
+//!
+//! # Why a keyed hash and not an index
+//!
+//! Answering "does this value appear elsewhere" needs exact-match lookup and
+//! nothing more. A plaintext index would provide it and would also put every
+//! value the holder holds into a structure a database dump reveals — enlarging
+//! the risk the index exists to measure.
+//!
+//! So the index is keyed by `HMAC-SHA256(agent_key, canonical(value))`. Exact
+//! match works; a dump reveals nothing; and prefix or substring search over
+//! values is **out of scope by construction**, which is a deliberate trade
+//! rather than a missing feature.
+//!
+//! # Scope
+//!
+//! The index is **agent-scoped**, which is what lets it see the risk it most
+//! needs to report: the same value presented by two personas in two different
+//! *contexts*. A per-context index cannot see that by construction, and the
+//! whole reason the pool sits above the context boundary is to make this
+//! possible.
+
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// A blinded index key for one value.
+///
+/// Canonicalisation is JSON with sorted object members, so that two values a
+/// holder would consider identical hash identically regardless of how a producer
+/// happened to serialise them. Without it, `{"a":1,"b":2}` and `{"b":2,"a":1}`
+/// would be two different facts and the guard would miss the reuse it exists to
+/// catch.
+#[must_use]
+pub fn blind(agent_key: &[u8; 32], value: &serde_json::Value) -> String {
+    let mut mac = HmacSha256::new_from_slice(agent_key).expect("HMAC accepts any key length");
+    mac.update(canonical(value).as_bytes());
+    hex(&mac.finalize().into_bytes())
+}
+
+/// Whether two blinded keys match, in constant time.
+///
+/// A timing side channel here would let an attacker who can submit candidate
+/// values learn which of them the holder already holds — turning the guard into
+/// an oracle over the pool it protects.
+#[must_use]
+pub fn matches(a: &str, b: &str) -> bool {
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
+
+/// Deterministic JSON with object members in sorted order.
+fn canonical(value: &serde_json::Value) -> String {
+    use std::fmt::Write as _;
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_unstable();
+            let mut s = String::from("{");
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    s.push(',');
+                }
+                let _ = write!(
+                    s,
+                    "{}:{}",
+                    serde_json::Value::String((*k).clone()),
+                    canonical(&map[*k])
+                );
+            }
+            s.push('}');
+            s
+        }
+        serde_json::Value::Array(items) => {
+            let mut s = String::from("[");
+            for (i, v) in items.iter().enumerate() {
+                if i > 0 {
+                    s.push(',');
+                }
+                s.push_str(&canonical(v));
+            }
+            s.push(']');
+            s
+        }
+        other => other.to_string(),
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
+}
+
+/// How strongly a disclosure of this claim would link the holder.
+///
+/// The inversion here is easy to get backwards and is the reason this is a
+/// function rather than a field. **A credential presented whole correlates more
+/// than a self-asserted value**, because the issuer's signature is identical at
+/// every verifier — while a derived proof correlates *less*, because it differs
+/// on every presentation.
+///
+/// So severity is a function of the value *and* the proof rung together. Scoring
+/// on provenance alone would rank an attested claim as safer than a typed one
+/// and push holders toward the riskier option.
+#[must_use]
+pub fn severity(
+    reused_elsewhere: bool,
+    provenance_is_credential: bool,
+    rung: crate::ProofRung,
+) -> Severity {
+    use crate::ProofRung as R;
+    match (provenance_is_credential, rung) {
+        // Unlinkable proofs disclose nothing reusable, so the value being
+        // reused elsewhere does not link anything through THIS disclosure.
+        (true, R::Predicate | R::Derived) => Severity::None,
+        // A constant issuer signature links every presentation of it, whether
+        // or not the value is reused.
+        (true, R::SelectiveDisclosure | R::Whole) => Severity::High,
+        // A self-asserted value is itself the join key, so it links exactly
+        // when it is reused.
+        (false, _) if reused_elsewhere => Severity::High,
+        (false, _) => Severity::None,
+    }
+}
+
+/// Advisory correlation severity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Severity {
+    None,
+    Low,
+    High,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProofRung;
+
+    const K: [u8; 32] = [7u8; 32];
+
+    #[test]
+    fn member_order_does_not_change_the_blinded_key() {
+        // Two serialisations of the same fact must hash identically, or the
+        // guard misses the reuse it exists to catch.
+        let a: serde_json::Value = serde_json::from_str(r#"{"a":1,"b":2}"#).unwrap();
+        let b: serde_json::Value = serde_json::from_str(r#"{"b":2,"a":1}"#).unwrap();
+        assert_eq!(blind(&K, &a), blind(&K, &b));
+    }
+
+    #[test]
+    fn different_values_and_different_keys_diverge() {
+        let v = serde_json::json!("+61 4");
+        assert_ne!(blind(&K, &v), blind(&K, &serde_json::json!("+61 5")));
+        // A different agent key yields a different index, so two agents'
+        // indexes cannot be compared against each other.
+        assert_ne!(blind(&K, &v), blind(&[9u8; 32], &v));
+    }
+
+    #[test]
+    fn the_blinded_key_does_not_contain_the_value() {
+        let v = serde_json::json!("secret-number");
+        assert!(!blind(&K, &v).contains("secret"));
+    }
+
+    #[test]
+    fn credential_backed_correlates_more_when_presented_whole() {
+        // The inversion. A whole credential links every verifier that sees it,
+        // even though it is "better evidence" than a typed value.
+        assert_eq!(
+            severity(false, true, ProofRung::Whole),
+            Severity::High,
+            "a whole credential links regardless of reuse"
+        );
+        // And correlates LESS than a reused self-asserted value when derived.
+        assert_eq!(severity(true, true, ProofRung::Derived), Severity::None);
+        assert_eq!(severity(true, false, ProofRung::Whole), Severity::High);
+    }
+
+    #[test]
+    fn an_unreused_self_asserted_value_links_nothing() {
+        assert_eq!(severity(false, false, ProofRung::Whole), Severity::None);
+    }
+}

--- a/vta-persona/src/disclosure.rs
+++ b/vta-persona/src/disclosure.rs
@@ -1,0 +1,377 @@
+//! The disclosure record: what the holder shared, with whom, and how strongly
+//! it was hidden.
+//!
+//! Append-only, and written **before the artifact is returned**. That ordering
+//! is the point of the module: a crash between signing and recording would
+//! release data the holder could never afterwards discover they had released.
+//! Recording first can only produce a record of a disclosure that did not
+//! happen, which is a false positive a holder can investigate — the opposite is
+//! a silent release.
+//!
+//! # It names claim types, never values
+//!
+//! The history says what *kind* of thing went where. Re-storing the values
+//! would double the exposure the record exists to describe, and put a second
+//! plaintext copy of the holder's data in a structure whose whole purpose is to
+//! be read later.
+//!
+//! # It answers a debt the scope split incurred
+//!
+//! Putting the pool above the context boundary bought a correlation check that
+//! can see across contexts. The cost is that a holder can no longer tell, by
+//! looking at one context, where a fact has gone. Filtering by claim type
+//! settles that — *where has my home address reached* — and it is why this is a
+//! queryable record rather than an audit log line.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+
+use crate::model::{ProofRung, Ulid};
+use crate::storage;
+use crate::store::{PersonaStore, now_rfc3339};
+
+/// One claim as it was disclosed — type and rung, never the value.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisclosedClaim {
+    pub r#type: String,
+    /// How strongly it was hidden. The same claim type at two rungs is two very
+    /// different disclosures, and a holder reviewing what they have done needs
+    /// to see which they did.
+    pub rung: ProofRung,
+}
+
+/// A permanent record of one release.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisclosureRecord {
+    pub disclosure_id: Ulid,
+    pub context_id: String,
+    pub verifier_did: String,
+    pub persona_did: String,
+    /// The pairwise identifier the disclosure was made under, so a holder can
+    /// tell two disclosures to the same verifier apart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    pub claims: Vec<DisclosedClaim>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub renderer: Option<String>,
+    /// Present when the disclosure minted a durable credential — the one kind
+    /// that is still live and still revocable, which is why the history names
+    /// it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub durable_credential_id: Option<String>,
+    /// Contact revisions this disclosure relied on. Recording them is what
+    /// makes contact retention reference-counted rather than a timer: these
+    /// revisions are evidence of what the holder was shown before presenting.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cited_contact_revisions: Vec<(Ulid, u64)>,
+    pub disclosed_at: String,
+}
+
+/// What a holder is asking when they query their own history.
+#[derive(Clone, Debug, Default)]
+pub struct HistoryQuery<'a> {
+    /// Omit to query across every context — which only the holder can do, and
+    /// which is the reason this sits above the boundary.
+    pub context_id: Option<&'a str>,
+    /// "What does this site have of mine."
+    pub verifier_did: Option<&'a str>,
+    /// "Where has my home address gone." The question the scope split owes an
+    /// answer to.
+    pub claim_type: Option<&'a str>,
+    pub since: Option<&'a str>,
+}
+
+impl PersonaStore {
+    /// Append a disclosure record and cite the contact revisions it relied on.
+    ///
+    /// Call this **before** returning the artifact to the caller.
+    pub async fn record_disclosure(&self, mut record: DisclosureRecord) -> Result<Ulid, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let seq = self.next_version().await?;
+        if record.disclosure_id.is_empty() {
+            record.disclosure_id = ulid::Ulid::new().to_string();
+        }
+        record.disclosed_at = now_rfc3339();
+
+        let cited = record.cited_contact_revisions.clone();
+        let context_id = record.context_id.clone();
+
+        self.ks
+            .insert(storage::disclosure_key(&context_id, seq), &record)
+            .await?;
+
+        // Citing after the record lands, deliberately: a citation with no
+        // record retains a revision nobody needs, which wastes space. A record
+        // with no citation would let the evidence behind it be reaped, which
+        // loses the thing the record points at.
+        drop(_guard);
+        for (contact_id, rev) in cited {
+            self.cite_contact_revision(&context_id, &contact_id, rev)
+                .await?;
+        }
+
+        Ok(record.disclosure_id)
+    }
+
+    /// Query the holder's own disclosure history.
+    ///
+    /// Scans every context when `context_id` is omitted — the cross-context
+    /// view, which is the holder's alone.
+    pub async fn disclosure_history(
+        &self,
+        query: &HistoryQuery<'_>,
+    ) -> Result<Vec<DisclosureRecord>, AppError> {
+        let prefix = match query.context_id {
+            Some(ctx) => storage::disclosure_prefix(ctx),
+            None => "pd:".to_string(),
+        };
+        let rows = self.ks.prefix_iter_raw(prefix.into_bytes()).await?;
+
+        let mut out: Vec<DisclosureRecord> = rows
+            .into_iter()
+            .filter_map(|(_k, v)| serde_json::from_slice::<DisclosureRecord>(&v).ok())
+            .filter(|r| query.verifier_did.is_none_or(|v| r.verifier_did == v))
+            .filter(|r| {
+                query
+                    .claim_type
+                    .is_none_or(|t| r.claims.iter().any(|c| c.r#type == t))
+            })
+            .filter(|r| query.since.is_none_or(|s| r.disclosed_at.as_str() >= s))
+            .collect();
+
+        // Key order is sequence order, which is time order — the counter is
+        // monotonic. Sorting again would be redundant, but the scan may have
+        // spanned contexts, whose sequences interleave.
+        out.sort_by(|a, b| a.disclosed_at.cmp(&b.disclosed_at));
+        Ok(out)
+    }
+
+    /// Which contexts a claim type has reached.
+    ///
+    /// The specific question the agent-scoped pool owes the holder: having put
+    /// their facts above the context boundary, it must be able to say where
+    /// each one has gone.
+    pub async fn contexts_reached_by(&self, claim_type: &str) -> Result<Vec<String>, AppError> {
+        let mut contexts: Vec<String> = self
+            .disclosure_history(&HistoryQuery {
+                claim_type: Some(claim_type),
+                ..Default::default()
+            })
+            .await?
+            .into_iter()
+            .map(|r| r.context_id)
+            .collect();
+        contexts.sort();
+        contexts.dedup();
+        Ok(contexts)
+    }
+}
+
+/// Build a disclosure record with server-assigned identity and timestamp.
+#[must_use]
+pub fn new_disclosure(
+    context_id: impl Into<String>,
+    verifier_did: impl Into<String>,
+    persona_did: impl Into<String>,
+    claims: Vec<DisclosedClaim>,
+) -> DisclosureRecord {
+    DisclosureRecord {
+        disclosure_id: ulid::Ulid::new().to_string(),
+        context_id: context_id.into(),
+        verifier_did: verifier_did.into(),
+        persona_did: persona_did.into(),
+        subject: None,
+        claims,
+        purpose: None,
+        renderer: None,
+        durable_credential_id: None,
+        cited_contact_revisions: Vec::new(),
+        disclosed_at: now_rfc3339(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contact::{ContactClaim, ContactDocument};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(vta_keyspaces::PERSONA).unwrap();
+        (dir, PersonaStore::new(ks, [17u8; 32]))
+    }
+
+    fn claims(pairs: &[(&str, ProofRung)]) -> Vec<DisclosedClaim> {
+        pairs
+            .iter()
+            .map(|(t, r)| DisclosedClaim {
+                r#type: (*t).into(),
+                rung: *r,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_record_names_types_and_rungs_but_never_values() {
+        let (_d, s) = fresh().await;
+        let rec = new_disclosure(
+            "ctx",
+            "did:web:bar",
+            "did:persona:a",
+            claims(&[("person.birthDate", ProofRung::Predicate)]),
+        );
+        let id = s.record_disclosure(rec).await.unwrap();
+        assert!(!id.is_empty());
+
+        let raw = s.ks.prefix_iter_raw(b"pd:".to_vec()).await.unwrap();
+        let text = String::from_utf8_lossy(&raw[0].1).to_string();
+        assert!(text.contains("person.birthDate"));
+        assert!(
+            text.contains("predicate"),
+            "the rung is recorded: same claim at two rungs is two different disclosures"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_answers_where_a_fact_has_reached() {
+        // The debt the scope split incurred: with the pool above the boundary,
+        // a holder cannot tell from one context where a fact has gone.
+        let (_d, s) = fresh().await;
+        s.record_disclosure(new_disclosure(
+            "ctx-work",
+            "did:web:acme",
+            "did:p1",
+            claims(&[("address.postal", ProofRung::Whole)]),
+        ))
+        .await
+        .unwrap();
+        s.record_disclosure(new_disclosure(
+            "ctx-play",
+            "did:web:game",
+            "did:p2",
+            claims(&[("address.postal", ProofRung::Whole)]),
+        ))
+        .await
+        .unwrap();
+        s.record_disclosure(new_disclosure(
+            "ctx-play",
+            "did:web:game",
+            "did:p2",
+            claims(&[("name.display", ProofRung::Whole)]),
+        ))
+        .await
+        .unwrap();
+
+        let mut reached = s.contexts_reached_by("address.postal").await.unwrap();
+        reached.sort();
+        assert_eq!(reached, vec!["ctx-play", "ctx-work"]);
+        assert_eq!(
+            s.contexts_reached_by("name.display").await.unwrap(),
+            vec!["ctx-play"]
+        );
+    }
+
+    #[tokio::test]
+    async fn history_narrows_by_verifier_and_by_context() {
+        let (_d, s) = fresh().await;
+        s.record_disclosure(new_disclosure(
+            "ctx-a",
+            "did:web:one",
+            "did:p",
+            claims(&[("email", ProofRung::Whole)]),
+        ))
+        .await
+        .unwrap();
+        s.record_disclosure(new_disclosure(
+            "ctx-b",
+            "did:web:two",
+            "did:p",
+            claims(&[("email", ProofRung::Whole)]),
+        ))
+        .await
+        .unwrap();
+
+        // Cross-context is the holder's view and returns both.
+        assert_eq!(
+            s.disclosure_history(&HistoryQuery::default())
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            s.disclosure_history(&HistoryQuery {
+                context_id: Some("ctx-a"),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .len(),
+            1
+        );
+        assert_eq!(
+            s.disclosure_history(&HistoryQuery {
+                verifier_did: Some("did:web:two"),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_a_disclosure_pins_the_contact_revisions_it_relied_on() {
+        // This is the caller reference-counted retention was built for: without
+        // it the mechanism exists and nothing ever exercises it.
+        let (_d, s) = fresh().await;
+        let doc = |v: &str| ContactDocument {
+            publisher: None,
+            card_version: None,
+            claims: vec![ContactClaim {
+                r#type: "email".into(),
+                value: serde_json::json!(v),
+                provenance: None,
+            }],
+        };
+        let f = s
+            .file_contact("ctx", "did:bob", "did:me", doc("a"), vec![])
+            .await
+            .unwrap();
+        s.file_contact("ctx", "did:bob", "did:me", doc("b"), vec![])
+            .await
+            .unwrap();
+
+        let mut rec = new_disclosure(
+            "ctx",
+            "did:web:v",
+            "did:me",
+            claims(&[("email", ProofRung::Whole)]),
+        );
+        rec.cited_contact_revisions = vec![(f.contact_id.clone(), 1)];
+        s.record_disclosure(rec).await.unwrap();
+
+        // The cited revision now survives a retention sweep that would
+        // otherwise remove it.
+        assert_eq!(
+            s.reap_contact_revisions("ctx", &f.contact_id, 0)
+                .await
+                .unwrap(),
+            0
+        );
+        let (_e, removed, retained) = s.delete_contact("ctx", &f.contact_id).await.unwrap();
+        assert_eq!((removed, retained), (0, 1));
+    }
+}

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -1,0 +1,47 @@
+//! VTA persona store — the holder's own identity, and the contacts peers
+//! disclose to them.
+//!
+//! The fourth holder store, beside the secrets vault, the credential vault and
+//! application state. It exists as a distinct store because **disclosure
+//! control is its point**, and a maintainer that cannot read a record cannot
+//! decide which of its members may leave, cannot audit which ones did, and
+//! cannot answer "what have I shared with whom". `vta/app-state` promises never
+//! to interpret its records, so it cannot host this; and a namespace there is
+//! collision avoidance rather than a trust boundary, so a compromised
+//! application sharing a context could remove the holder's identity data.
+//!
+//! # The boundary is one-way
+//!
+//! The pool and profiles are **agent-scoped**; bindings, contacts and
+//! disclosure records are **context-scoped**. Nothing inside a context may read
+//! the pool — the holder pushes a materialised projection down, and a context
+//! never pulls.
+//!
+//! That is a rule about *direction* rather than a permission, because the
+//! permission form invites the wrong implementation: a guard written as "is this
+//! caller an administrator" passes for an administrator scoped to a single
+//! context, who then reads identity data belonging to every other context. An
+//! access-control failure over a readable pool discloses everything; a pool no
+//! context can address has nothing to disclose.
+//!
+//! Authorization is enforced at dispatch, not here. What this crate provides is
+//! a key layout in which the two scopes are *separately addressable*, so the
+//! enforcement is expressible — and so a context-scoped enumeration scans a
+//! space that structurally cannot contain an agent-scoped record, rather than
+//! scanning everything and filtering. A filter is a line of code that can be
+//! got wrong; an address space cannot.
+//!
+//! # What this crate does not do
+//!
+//! No cryptography beyond the at-rest wrapper and the correlation index's keyed
+//! hash. Rung *selection* lives here; proof *derivation* stays in `vta-vault`,
+//! so there is one BBS implementation in the workspace rather than two.
+
+pub mod correlation;
+pub mod model;
+pub mod storage;
+
+pub use model::{
+    Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
+    StaleReason, Ulid, ValueType, Version,
+};

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -40,11 +40,13 @@
 pub mod correlation;
 pub mod model;
 pub mod storage;
+pub mod store;
 
 pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,
 };
+pub use store::{Deleted, PersonaStore, Written, new_attribute};
 
 #[cfg(test)]
 mod published_types {

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -42,6 +42,7 @@ pub mod contact;
 pub mod correlation;
 pub mod disclosure;
 pub mod model;
+pub mod present;
 pub mod profile;
 pub mod storage;
 pub mod store;
@@ -53,6 +54,7 @@ pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,
 };
+pub use present::{PREVIEW_TTL_SECONDS, Preview, PreviewClaim, Renderer, renderer};
 pub use profile::{ResolvedClaim, is_pool_free, new_profile};
 pub use store::{Deleted, PersonaStore, Written, new_attribute};
 

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -38,6 +38,7 @@
 //! so there is one BBS implementation in the workspace rather than two.
 
 pub mod binding;
+pub mod contact;
 pub mod correlation;
 pub mod model;
 pub mod profile;
@@ -45,6 +46,7 @@ pub mod storage;
 pub mod store;
 
 pub use binding::{BindingSummary, Bound, MaterialisedClaim};
+pub use contact::{Contact, ContactClaim, ContactDocument, ContactRevision, ContactSummary, Filed};
 pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -37,12 +37,14 @@
 //! hash. Rung *selection* lives here; proof *derivation* stays in `vta-vault`,
 //! so there is one BBS implementation in the workspace rather than two.
 
+pub mod binding;
 pub mod correlation;
 pub mod model;
 pub mod profile;
 pub mod storage;
 pub mod store;
 
+pub use binding::{BindingSummary, Bound, MaterialisedClaim};
 pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -40,6 +40,7 @@
 pub mod binding;
 pub mod contact;
 pub mod correlation;
+pub mod disclosure;
 pub mod model;
 pub mod profile;
 pub mod storage;
@@ -47,6 +48,7 @@ pub mod store;
 
 pub use binding::{BindingSummary, Bound, MaterialisedClaim};
 pub use contact::{Contact, ContactClaim, ContactDocument, ContactRevision, ContactSummary, Filed};
+pub use disclosure::{DisclosedClaim, DisclosureRecord, HistoryQuery, new_disclosure};
 pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -39,6 +39,7 @@
 
 pub mod correlation;
 pub mod model;
+pub mod profile;
 pub mod storage;
 pub mod store;
 
@@ -46,6 +47,7 @@ pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,
 };
+pub use profile::{ResolvedClaim, is_pool_free, new_profile};
 pub use store::{Deleted, PersonaStore, Written, new_attribute};
 
 #[cfg(test)]

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -45,3 +45,51 @@ pub use model::{
     Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
     StaleReason, Ulid, ValueType, Version,
 };
+
+#[cfg(test)]
+mod published_types {
+    //! The generated payload types are the contract. This asserts the published
+    //! crate actually carries the persona family and that our model agrees with
+    //! it on the members that matter — so a spec change that lands upstream
+    //! without a corresponding change here fails a test rather than a
+    //! production dispatch.
+
+    /// Compile-time, not runtime: these are `const`, so a relaxation upstream
+    /// should fail the *build* rather than a test run. A `MUST` that became a
+    /// `SHOULD` in the spec would otherwise reach production as an accepted
+    /// unsigned write.
+    const _: () = {
+        use trust_tasks_rs::specs::persona::attribute::put::v1_0::Payload;
+        assert!(<Payload as trust_tasks_rs::Payload>::IS_PROOF_REQUIRED);
+        assert!(<Payload as trust_tasks_rs::Payload>::IS_ISSUED_AT_REQUIRED);
+    };
+
+    #[test]
+    fn persona_family_is_published_and_addressable() {
+        use trust_tasks_rs::specs::persona::attribute::put::v1_0 as put;
+        assert_eq!(
+            <put::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+            "https://trusttasks.org/spec/persona/attribute/put/1.0"
+        );
+    }
+
+    #[test]
+    fn our_value_types_match_the_published_enum() {
+        // The store validates values against these; a variant added upstream
+        // without a matching arm here would silently reject a legal value.
+        use trust_tasks_rs::specs::persona::attribute::put::v1_0 as put;
+        for (ours, theirs) in [
+            (crate::ValueType::String, put::ValueType::String),
+            (crate::ValueType::Number, put::ValueType::Number),
+            (crate::ValueType::Boolean, put::ValueType::Boolean),
+            (crate::ValueType::Date, put::ValueType::Date),
+            (crate::ValueType::Object, put::ValueType::Object),
+        ] {
+            assert_eq!(
+                serde_json::to_value(ours).unwrap(),
+                serde_json::to_value(theirs).unwrap(),
+                "our ValueType and the published one disagree on the wire"
+            );
+        }
+    }
+}

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -1,0 +1,350 @@
+//! The record shapes the `persona/*` Trust Task family made normative.
+//!
+//! Two scopes, and the split is a security control rather than a filing
+//! decision. The **attribute pool and profiles are agent-scoped** — one person,
+//! one set of facts about themselves, above every trust context — so that the
+//! correlation index can see the risk it most needs to report: the same value
+//! presented by two personas in two different contexts, which a per-context
+//! index cannot see by construction. **Bindings, contacts and disclosure
+//! records are context-scoped**, because a persona lives in a context and so do
+//! its counterparties.
+//!
+//! Nothing here enforces that split — [`crate::storage`] holds the key layout
+//! and the dispatcher holds the authorization — but the types are arranged so
+//! that a function taking an agent-scoped record cannot be handed a
+//! context-scoped one by accident.
+
+use serde::{Deserialize, Serialize};
+
+/// A ULID in Crockford base32. Record identity for attributes and profiles.
+///
+/// Chosen over a UUID because the leading 48 bits are a timestamp, so a
+/// key-ordered scan of the store is also creation-ordered and `list` needs no
+/// secondary sort.
+pub type Ulid = String;
+
+/// A value of the store's monotonic write counter.
+///
+/// Monotonic **per store**, not per record — the `vta/app-state` precedent, and
+/// for the reason that note recorded after implementing it the other way: one
+/// number has to serve as both the optimistic-concurrency token and the change
+/// feed watermark, and per-record counters are not comparable to each other, so
+/// no single value could mean "everything changed after this point".
+///
+/// Consumers treat versions as opaque and monotonic. A record's version can
+/// jump by any amount between two writes, because its neighbours consumed the
+/// intervening values.
+pub type Version = u64;
+
+/// Where a value came from — the member that makes this store worth building on
+/// a trust stack rather than in an address book.
+///
+/// Provenance survives to the verifier, so a recipient can tell, per field, what
+/// the holder typed from what an issuer attested.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum Provenance {
+    /// The holder supplied it.
+    SelfAsserted,
+
+    /// Derived from a credential in the vault.
+    ///
+    /// The stored value is a **cache for display**; the credential is the truth.
+    /// It is re-derived on read and fails closed — never presenting a stale
+    /// value — when the credential has been revoked, has expired, or has been
+    /// archived or deleted. Presenting a cached value whose backing has been
+    /// withdrawn would assert something the issuer has taken back.
+    #[serde(rename_all = "camelCase")]
+    CredentialBacked {
+        credential_id: String,
+        /// RFC 6901 JSON Pointer to the claim within the credential.
+        claim_path: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        issuer_did: Option<String>,
+        /// The disclosure rung this claim was, or will be, presented at.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        proof: Option<ProofRung>,
+    },
+
+    /// Minted per verifier at disclosure time and recorded against them, so
+    /// every relying party receives a different value that routes back to the
+    /// holder.
+    ///
+    /// A deployment need not operate a relay to be conformant, but the shape
+    /// must exist: retrofitting per-verifier values into a pool-of-values model
+    /// is a migration rather than an addition.
+    #[serde(rename_all = "camelCase")]
+    Generated {
+        generator: String,
+        #[serde(default = "default_true")]
+        per_verifier: bool,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// How strongly a credential-backed claim is hidden when presented, ordered
+/// most private first.
+///
+/// The distinction between the first two and the last two is **of kind, not
+/// degree**: only [`Predicate`](ProofRung::Predicate) and
+/// [`Derived`](ProofRung::Derived) avoid handing two verifiers a join key. A
+/// selective disclosure still carries the issuer's signature unchanged, so two
+/// presentations are linkable however few claims each revealed.
+///
+/// Selection defaults to the highest rung the credential's format supports and
+/// **never silently falls** to a lower one — see [`Ord`], which is derived so
+/// that "highest supported" is a `max()` rather than a hand-written table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProofRung {
+    /// Proves a statement over a claim without disclosing the claim.
+    Predicate,
+    /// Discloses exactly the claims needed, via a proof that differs on every
+    /// presentation.
+    Derived,
+    /// Discloses exactly the claims needed, under a constant issuer signature.
+    SelectiveDisclosure,
+    /// Discloses the entire credential.
+    Whole,
+}
+
+/// The JSON shape of a value, declared so a consumer can render and compare
+/// without guessing.
+///
+/// The store validates that a value agrees with this and does nothing further:
+/// it does **not** validate a phone number against a phone-number grammar. That
+/// is a producer's affordance, and a store that grows opinions about the
+/// contents of its records eventually blocks its consumer's release.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ValueType {
+    String,
+    Number,
+    Boolean,
+    Date,
+    Object,
+}
+
+impl ValueType {
+    /// Whether `value` agrees with the declared type.
+    ///
+    /// `Date` accepts a string — the store does not parse it. Validating the
+    /// grammar here would be the store growing an opinion, and a holder whose
+    /// perfectly good local date format is refused has no recourse.
+    #[must_use]
+    pub fn accepts(self, value: &serde_json::Value) -> bool {
+        use serde_json::Value as J;
+        matches!(
+            (self, value),
+            (Self::String | Self::Date, J::String(_))
+                | (Self::Number, J::Number(_))
+                | (Self::Boolean, J::Bool(_))
+                | (Self::Object, J::Object(_))
+        )
+    }
+}
+
+/// Why a credential-backed value could not be re-derived.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StaleReason {
+    Revoked,
+    Expired,
+    Archived,
+    Deleted,
+    NotFound,
+}
+
+/// One atomic fact a holder keeps about themselves. **Agent-scoped.**
+///
+/// Several attributes may share a `type` — three phone numbers, a legal name and
+/// a preferred name — which is why `attribute_id` is the identity of a fact and
+/// `type` is not.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attribute {
+    pub attribute_id: Ulid,
+    /// Vocabulary token — `name.legal`, `phone.mobile`. The store's own; every
+    /// external vocabulary is a mapping applied at presentation by a renderer,
+    /// not at rest.
+    pub r#type: String,
+    pub value_type: ValueType,
+    /// Encrypted at rest. Absent for a metadata-only view, and absent when a
+    /// credential-backed value could not be re-derived — a consumer reads
+    /// `stale` to tell those apart rather than inferring from the absence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+    /// The holder's own words, for their own picker. Never disclosed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub provenance: Provenance,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_reason: Option<StaleReason>,
+    pub version: Version,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// One line of a profile, in exactly one of four forms.
+///
+/// Together they are the whole of a profile's flexibility, and each covers a
+/// case the others handle badly. Omission is exclusion — there is no removal
+/// marker, because a profile is a whitelist and a blacklist over a growing pool
+/// leaks by default the first time an attribute is added.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ProfileEntry {
+    /// Reference the pool attribute, live. Editing the pool updates every
+    /// profile referencing it, which is the point.
+    Ref { r#ref: Ulid },
+    /// Reference it as it was at a version. For a profile that must keep
+    /// presenting the value a counterparty already verified.
+    Pinned {
+        r#ref: Ulid,
+        #[serde(rename = "pinVersion")]
+        pin_version: Version,
+    },
+    /// The same fact, a different value here.
+    ///
+    /// Replaces value and label **only**: type, valueType and provenance are
+    /// inherited. Letting an override replace provenance would let a
+    /// self-asserted value present as attested, which is the one thing
+    /// provenance exists to prevent.
+    Override {
+        r#ref: Ulid,
+        r#override: OverrideValue,
+    },
+    /// A value that never enters the pool, and so can never leak into another
+    /// profile.
+    Inline { inline: InlineValue },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OverrideValue {
+    pub value: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlineValue {
+    pub r#type: String,
+    pub value_type: ValueType,
+    pub value: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub provenance: Provenance,
+}
+
+impl ProfileEntry {
+    /// The pool attribute this entry draws on, if any.
+    ///
+    /// `None` for an inline entry, which is what makes a context-local profile
+    /// checkable: one is valid exactly when every entry returns `None` here.
+    #[must_use]
+    pub fn referenced(&self) -> Option<&str> {
+        match self {
+            Self::Ref { r#ref } | Self::Pinned { r#ref, .. } | Self::Override { r#ref, .. } => {
+                Some(r#ref)
+            }
+            Self::Inline { .. } => None,
+        }
+    }
+}
+
+/// A named projection over the pool. **Agent-scoped**, like the pool it draws
+/// from.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Profile {
+    pub profile_id: Ulid,
+    /// The holder's name for it — "Work", "Gaming". Not disclosed.
+    pub name: String,
+    /// Ordered; the order is display order.
+    pub entries: Vec<ProfileEntry>,
+    /// Credentials associated with this profile as **inventory** — what this
+    /// persona can prove — as distinct from the evidence relationship a
+    /// credential-backed attribute expresses. The two answer different
+    /// questions and must not be read as one another.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credential_refs: Vec<String>,
+    pub version: Version,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Assignment of a profile to a persona DID. **Context-scoped.**
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Binding {
+    pub persona_did: String,
+    /// `None` clears the binding. A persona with no profile is a legitimate and
+    /// common state — a throwaway identity that presents nothing — so this is a
+    /// first-class value rather than an absence to be inferred.
+    pub profile_id: Option<Ulid>,
+    /// Attributes the holder opted into publishing on the persona's own public
+    /// surface. Empty unless explicitly set: a published value is one document
+    /// every relying party sees identically, which is a permanent correlation
+    /// point that per-verifier projection exists to avoid.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub public_entries: Vec<Ulid>,
+    pub version: Version,
+    pub bound_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rung_ordering_makes_highest_supported_a_max() {
+        // Ord is derived so that rung selection is `max()` over what a format
+        // supports, not a hand-written table that can disagree with itself.
+        assert!(ProofRung::Predicate < ProofRung::Derived);
+        assert!(ProofRung::Derived < ProofRung::SelectiveDisclosure);
+        assert!(ProofRung::SelectiveDisclosure < ProofRung::Whole);
+
+        let supported = [ProofRung::Whole, ProofRung::Derived];
+        assert_eq!(supported.iter().min().copied(), Some(ProofRung::Derived));
+    }
+
+    #[test]
+    fn value_type_accepts_only_its_own_shape() {
+        let s = serde_json::json!("x");
+        let n = serde_json::json!(1);
+        assert!(ValueType::String.accepts(&s));
+        assert!(!ValueType::String.accepts(&n));
+        assert!(ValueType::Number.accepts(&n));
+        // A date is carried as a string and deliberately not parsed here.
+        assert!(ValueType::Date.accepts(&s));
+        assert!(!ValueType::Date.accepts(&n));
+    }
+
+    #[test]
+    fn inline_entries_reference_nothing() {
+        // This is what makes a context-local profile checkable: it is valid
+        // exactly when no entry references the pool.
+        let inline = ProfileEntry::Inline {
+            inline: InlineValue {
+                r#type: "x:handle".into(),
+                value_type: ValueType::String,
+                value: serde_json::json!("g"),
+                label: None,
+                provenance: Provenance::SelfAsserted,
+            },
+        };
+        assert!(inline.referenced().is_none());
+
+        let by_ref = ProfileEntry::Ref {
+            r#ref: "01J8".into(),
+        };
+        assert_eq!(by_ref.referenced(), Some("01J8"));
+    }
+}

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -197,18 +197,42 @@ pub struct Attribute {
 /// marker, because a profile is a whitelist and a blacklist over a growing pool
 /// leaks by default the first time an attribute is added.
 ///
-/// # Variant order is load-bearing — do not reorder
+/// # `deny_unknown_fields` is load-bearing
 ///
-/// `#[serde(untagged)]` tries variants in **declaration order** and serde
-/// ignores unknown fields, so the permissive `Ref` — which matches any document
-/// carrying a `ref` — must come **last**. Declared first, it would swallow
-/// `Override` and `Pinned`, silently degrading an override into a live
-/// reference and a pin into an unpinned one. That is a disclosure changing
-/// behind the holder's back, and `deny_unknown_fields` is not available on a
-/// variant to prevent it. The ordering is pinned by a test.
+/// `#[serde(untagged)]` tries variants in declaration order and takes the first
+/// that deserializes. Without the clause, serde ignores unknown members, so the
+/// permissive `Ref` — which needs only `ref` — also matches `{ref, override}`
+/// and `{ref, pinVersion}`: an override silently degrades into a live reference
+/// and a pin into an unpinned one. That is a disclosure changing behind the
+/// holder's back, and it is *valid* output, so nothing downstream rejects it.
+///
+/// The clause makes an extra member *fail* a variant rather than match it
+/// loosely, which fixes the defect at its cause. The variants are therefore
+/// declared in reading order — general to specific — rather than in the order
+/// that happened to be safe.
+///
+/// That ordering is deliberate and not merely tidier. Declaring the permissive
+/// `Ref` last would also avoid the bug, and holding both mechanisms would mean
+/// neither was ever exercised: a later edit dropping the clause would pass
+/// every test, and the next edit reordering the variants would then be
+/// silently fatal. With `Ref` first, the clause is the only thing standing
+/// between the holder and a degraded disclosure, so
+/// `each_profile_entry_form_survives_a_round_trip` fails the moment it is
+/// removed. The published schema closes each form the same way, and
+/// `trust-tasks-rs` generates the same pair.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(untagged, deny_unknown_fields)]
 pub enum ProfileEntry {
+    /// Reference the pool attribute, live. Editing the pool updates every
+    /// profile referencing it, which is the point.
+    Ref { r#ref: Ulid },
+    /// Reference it as it was at a version. For a profile that must keep
+    /// presenting the value a counterparty already verified.
+    Pinned {
+        r#ref: Ulid,
+        #[serde(rename = "pinVersion")]
+        pin_version: Version,
+    },
     /// The same fact, a different value here.
     ///
     /// Replaces value and label **only**: type, valueType and provenance are
@@ -219,19 +243,9 @@ pub enum ProfileEntry {
         r#ref: Ulid,
         r#override: OverrideValue,
     },
-    /// Reference it as it was at a version. For a profile that must keep
-    /// presenting the value a counterparty already verified.
-    Pinned {
-        r#ref: Ulid,
-        #[serde(rename = "pinVersion")]
-        pin_version: Version,
-    },
     /// A value that never enters the pool, and so can never leak into another
     /// profile.
     Inline { inline: InlineValue },
-    /// Reference the pool attribute, live. Editing the pool updates every
-    /// profile referencing it, which is the point.
-    Ref { r#ref: Ulid },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -356,5 +370,65 @@ mod tests {
             r#ref: "01J8".into(),
         };
         assert_eq!(by_ref.referenced(), Some("01J8"));
+    }
+
+    /// The four forms must stay distinguishable on the wire.
+    ///
+    /// Asserted on round-tripped **bytes**, not on the parsed enum: a
+    /// degradation does not fail to parse, it parses as the wrong thing and
+    /// re-encodes shorter. Comparing the document to itself is what catches
+    /// that; comparing enum variants would only catch it for the one case
+    /// where the variant names differ.
+    ///
+    /// Remove `deny_unknown_fields` from `ProfileEntry` and this test fails on
+    /// the `override` and `pinned` cases.
+    #[test]
+    fn each_profile_entry_form_survives_a_round_trip() {
+        let cases = [
+            ("ref", serde_json::json!({ "ref": "01J8" })),
+            (
+                "pinned",
+                serde_json::json!({ "ref": "01J8", "pinVersion": 3 }),
+            ),
+            (
+                "override",
+                serde_json::json!({
+                    "ref": "01J8",
+                    "override": { "value": "+61 400 000 000" },
+                }),
+            ),
+            (
+                "inline",
+                serde_json::json!({
+                    "inline": {
+                        "type": "name.display",
+                        "value": "Ada",
+                        "valueType": "string",
+                        "provenance": { "kind": "selfAsserted" },
+                    }
+                }),
+            ),
+        ];
+
+        for (label, doc) in cases {
+            let parsed: ProfileEntry =
+                serde_json::from_value(doc.clone()).unwrap_or_else(|e| panic!("{label}: {e}"));
+            let back = serde_json::to_value(&parsed).expect("re-encodes");
+            assert_eq!(back, doc, "{label} form did not survive the round trip");
+        }
+    }
+
+    /// The failure with teeth, stated on its own: a pin that quietly becomes a
+    /// bare reference presents whatever the pool holds *now* instead of the
+    /// version the holder chose to freeze.
+    #[test]
+    fn a_pin_does_not_collapse_into_a_bare_reference() {
+        let parsed: ProfileEntry =
+            serde_json::from_value(serde_json::json!({ "ref": "01J8", "pinVersion": 7 }))
+                .expect("parses");
+        assert!(
+            matches!(parsed, ProfileEntry::Pinned { pin_version, .. } if pin_version == 7),
+            "a pinned entry parsed as {parsed:?}"
+        );
     }
 }

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -196,19 +196,19 @@ pub struct Attribute {
 /// case the others handle badly. Omission is exclusion — there is no removal
 /// marker, because a profile is a whitelist and a blacklist over a growing pool
 /// leaks by default the first time an attribute is added.
+///
+/// # Variant order is load-bearing — do not reorder
+///
+/// `#[serde(untagged)]` tries variants in **declaration order** and serde
+/// ignores unknown fields, so the permissive `Ref` — which matches any document
+/// carrying a `ref` — must come **last**. Declared first, it would swallow
+/// `Override` and `Pinned`, silently degrading an override into a live
+/// reference and a pin into an unpinned one. That is a disclosure changing
+/// behind the holder's back, and `deny_unknown_fields` is not available on a
+/// variant to prevent it. The ordering is pinned by a test.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ProfileEntry {
-    /// Reference the pool attribute, live. Editing the pool updates every
-    /// profile referencing it, which is the point.
-    Ref { r#ref: Ulid },
-    /// Reference it as it was at a version. For a profile that must keep
-    /// presenting the value a counterparty already verified.
-    Pinned {
-        r#ref: Ulid,
-        #[serde(rename = "pinVersion")]
-        pin_version: Version,
-    },
     /// The same fact, a different value here.
     ///
     /// Replaces value and label **only**: type, valueType and provenance are
@@ -219,9 +219,19 @@ pub enum ProfileEntry {
         r#ref: Ulid,
         r#override: OverrideValue,
     },
+    /// Reference it as it was at a version. For a profile that must keep
+    /// presenting the value a counterparty already verified.
+    Pinned {
+        r#ref: Ulid,
+        #[serde(rename = "pinVersion")]
+        pin_version: Version,
+    },
     /// A value that never enters the pool, and so can never leak into another
     /// profile.
     Inline { inline: InlineValue },
+    /// Reference the pool attribute, live. Editing the pool updates every
+    /// profile referencing it, which is the point.
+    Ref { r#ref: Ulid },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/vta-persona/src/present.rs
+++ b/vta-persona/src/present.rs
@@ -1,0 +1,647 @@
+//! The disclosure flow: preview, then present.
+//!
+//! Two calls that **cannot be collapsed**. [`PersonaStore::create_preview`]
+//! mints a single-use token that [`PersonaStore::consume_preview`] destroys, so
+//! there is no code path to a disclosure that did not first produce the summary
+//! a human can be shown — and a maintainer cannot accidentally provide one by
+//! forgetting a flag, because the second call requires a token only the first
+//! can produce.
+//!
+//! # Four refusals, and each is a refusal rather than a degradation
+//!
+//! - **A rung the credential cannot support** is refused, never silently
+//!   lowered. A silent privacy downgrade discloses material the holder believed
+//!   was hidden.
+//! - **A renderer that cannot carry a claim** fails at negotiation. Dropping the
+//!   claim would produce a disclosure that verifies and says less than the
+//!   holder approved — and a verifier receiving fewer claims than were approved
+//!   cannot tell that from a holder who approved fewer.
+//! - **A claim that went stale between preview and present** refuses the whole
+//!   disclosure rather than issuing a short one, for the same reason.
+//! - **A consumed or expired preview** is refused rather than re-derived from
+//!   current state. The holder was shown one thing; re-deriving could disclose
+//!   another.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+
+use crate::binding::MaterialisedClaim;
+use crate::disclosure::{DisclosedClaim, DisclosureRecord, new_disclosure};
+use crate::model::{ProofRung, Provenance, Ulid};
+use crate::store::PersonaStore;
+
+/// How long a preview stands.
+///
+/// A preview a holder approved an hour ago is not evidence they approve it now,
+/// and one that could be replayed would let a second disclosure ride an earlier
+/// decision.
+pub const PREVIEW_TTL_SECONDS: i64 = 300;
+
+/// What a renderer can and cannot carry.
+///
+/// Lossiness is **declared**, so a preview can tell the holder what a format
+/// will not carry before they decide — rather than their discovering it from a
+/// verifier who never learned a claim was attested.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Renderer {
+    pub id: &'static str,
+    pub canonical: bool,
+    pub carries_provenance: bool,
+    pub carries_predicates: bool,
+}
+
+/// The renderers this agent offers.
+///
+/// Two ship. `sd-jwt-vc`, `mdoc` or a future agent-card would each be one more
+/// entry rather than a redesign — and none is added speculatively, because every
+/// unused renderer is a mapping table somebody must keep true.
+pub const RENDERERS: &[Renderer] = &[
+    Renderer {
+        id: "rcard",
+        canonical: true,
+        carries_provenance: true,
+        carries_predicates: true,
+    },
+    Renderer {
+        id: "jcard",
+        canonical: false,
+        // No vCard property says "this was attested", and no field says "over
+        // the threshold".
+        carries_provenance: false,
+        carries_predicates: false,
+    },
+];
+
+#[must_use]
+pub fn renderer(id: Option<&str>) -> Option<Renderer> {
+    match id {
+        None => RENDERERS.iter().find(|r| r.canonical).copied(),
+        Some(want) => RENDERERS.iter().find(|r| r.id == want).copied(),
+    }
+}
+
+/// A predicate a claim would be proven by, rather than shown.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Predicate {
+    pub op: String,
+    pub arg: serde_json::Value,
+    pub over: String,
+}
+
+/// One line of a preview: what would be disclosed, and how strongly hidden.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewClaim {
+    pub r#type: String,
+    /// Absent for a predicate claim, which discloses no value at all. That
+    /// absence is the point and must not be rendered as missing data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<Predicate>,
+    pub provenance: String,
+    pub rung: ProofRung,
+    pub new_to_this_verifier: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stale: bool,
+}
+
+/// A preview, held until consumed or expired.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Preview {
+    pub preview_id: Ulid,
+    pub context_id: String,
+    pub persona_did: String,
+    pub verifier_did: String,
+    /// Pairwise by default — a per-relationship identifier rather than the
+    /// persona DID, so two verifiers cannot recognise the holder as one party.
+    /// The persona DID is the account; this is the face.
+    pub subject: String,
+    pub claims: Vec<PreviewClaim>,
+    pub renderer_id: String,
+    pub renderer_drops: Vec<String>,
+    pub purpose: Option<String>,
+    pub expires_at: String,
+}
+
+impl PersonaStore {
+    /// Determine what a disclosure would reveal. Signs nothing, sends nothing.
+    pub async fn create_preview(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+        verifier_did: &str,
+        purpose: Option<&str>,
+        requested: Option<&[String]>,
+        renderer_id: Option<&str>,
+    ) -> Result<Preview, AppError> {
+        let Some(r) = renderer(renderer_id) else {
+            return Err(AppError::Validation(format!(
+                "renderer {} is not offered by this agent",
+                renderer_id.unwrap_or("<default>")
+            )));
+        };
+
+        let materialised = self.materialised_claims(context_id, persona_did).await?;
+        if materialised.is_empty() {
+            return Err(AppError::NotFound(format!(
+                "persona {persona_did} has no profile bound, so there is nothing to disclose"
+            )));
+        }
+
+        // Which claim types this verifier has already received, so the preview
+        // can rank by what is new rather than listing everything equally.
+        let seen = self.claim_types_seen_by(verifier_did).await?;
+
+        let mut claims = Vec::new();
+        for m in &materialised {
+            if let Some(want) = requested
+                && !want.iter().any(|t| t == &m.r#type)
+            {
+                continue;
+            }
+            claims.push(preview_claim(m, &seen));
+        }
+
+        if claims.is_empty() {
+            return Err(AppError::Validation(
+                "none of the requested claim types are present in this persona's profile".into(),
+            ));
+        }
+
+        // Negotiation, not a silent drop. A verifier receiving fewer claims than
+        // were approved cannot tell that from a holder who approved fewer.
+        if !r.carries_predicates
+            && let Some(bad) = claims.iter().find(|c| c.predicate.is_some())
+        {
+            return Err(AppError::Validation(format!(
+                "renderer {} cannot carry the predicate on claim {}; refusing rather than \
+                 dropping it",
+                r.id, bad.r#type
+            )));
+        }
+
+        let preview = Preview {
+            preview_id: ulid::Ulid::new().to_string(),
+            context_id: context_id.to_string(),
+            persona_did: persona_did.to_string(),
+            verifier_did: verifier_did.to_string(),
+            subject: pairwise_subject(persona_did, verifier_did),
+            claims,
+            renderer_id: r.id.to_string(),
+            renderer_drops: if r.carries_provenance {
+                Vec::new()
+            } else {
+                vec!["provenance".to_string()]
+            },
+            purpose: purpose.map(str::to_string),
+            expires_at: (chrono::Utc::now() + chrono::Duration::seconds(PREVIEW_TTL_SECONDS))
+                .to_rfc3339(),
+        };
+
+        let _guard = self.write_lock.lock().await;
+        self.ks
+            .insert(preview_key(&preview.preview_id), &preview)
+            .await?;
+        Ok(preview)
+    }
+
+    /// Take a preview, destroying it.
+    ///
+    /// Single-use: a producer wanting to disclose twice previews twice, which is
+    /// correct rather than inconvenient — the second disclosure is a second
+    /// decision, and a token that could be replayed would let it ride the first.
+    pub async fn consume_preview(&self, preview_id: &str) -> Result<Preview, AppError> {
+        let _guard = self.write_lock.lock().await;
+        let key = preview_key(preview_id);
+        let Some(preview) = self.ks.get::<Preview>(key.clone()).await? else {
+            return Err(AppError::NotFound(
+                "preview is unknown, already consumed, or expired".into(),
+            ));
+        };
+        self.ks.remove(key).await?;
+
+        let expired = chrono::DateTime::parse_from_rfc3339(&preview.expires_at)
+            .is_ok_and(|t| t < chrono::Utc::now());
+        if expired {
+            // Refused rather than re-derived from current state: the holder was
+            // shown one thing, and re-deriving could disclose another.
+            return Err(AppError::Gone("preview has expired; preview again".into()));
+        }
+        Ok(preview)
+    }
+
+    /// Produce the disclosure a preview described, and record it.
+    ///
+    /// The record is written **before** the artifact is returned. A crash
+    /// between the two would otherwise release data the holder could never
+    /// afterwards discover they had released.
+    pub async fn present(
+        &self,
+        preview_id: &str,
+        challenge: Option<&str>,
+        durable: bool,
+    ) -> Result<(String, DisclosureRecord), AppError> {
+        let preview = self.consume_preview(preview_id).await?;
+
+        // Refuse whole rather than issue short. A verifier receiving fewer
+        // claims than were approved cannot tell that from a holder who approved
+        // fewer.
+        if let Some(stale) = preview.claims.iter().find(|c| c.stale) {
+            return Err(AppError::Conflict(format!(
+                "claim {} could not be re-derived since the preview; refusing the whole \
+                 disclosure rather than issuing a shorter one",
+                stale.r#type
+            )));
+        }
+
+        let artifact = render(&preview, challenge);
+
+        let mut record = new_disclosure(
+            preview.context_id.clone(),
+            preview.verifier_did.clone(),
+            preview.persona_did.clone(),
+            preview
+                .claims
+                .iter()
+                .map(|c| DisclosedClaim {
+                    r#type: c.r#type.clone(),
+                    rung: c.rung,
+                })
+                .collect(),
+        );
+        record.subject = Some(preview.subject.clone());
+        record.purpose = preview.purpose.clone();
+        record.renderer = Some(preview.renderer_id.clone());
+        if durable {
+            record.durable_credential_id = Some(ulid::Ulid::new().to_string());
+        }
+
+        self.record_disclosure(record.clone()).await?;
+        Ok((artifact, record))
+    }
+
+    /// Claim types a verifier has already received, from the disclosure record.
+    async fn claim_types_seen_by(&self, verifier_did: &str) -> Result<Vec<String>, AppError> {
+        Ok(self
+            .disclosure_history(&crate::disclosure::HistoryQuery {
+                verifier_did: Some(verifier_did),
+                ..Default::default()
+            })
+            .await?
+            .into_iter()
+            .flat_map(|r| r.claims.into_iter().map(|c| c.r#type))
+            .collect())
+    }
+}
+
+fn preview_key(preview_id: &str) -> String {
+    format!("ppv:{preview_id}")
+}
+
+/// Select the rung and shape one preview line.
+///
+/// The rung is the **highest the claim's provenance supports** — `max()` over
+/// the ordering rather than a hand-written table, so "highest supported" cannot
+/// disagree with the ordering it is defined against.
+fn preview_claim(m: &MaterialisedClaim, seen: &[String]) -> PreviewClaim {
+    let (provenance, rung) = match &m.provenance {
+        Provenance::SelfAsserted => ("selfAsserted", ProofRung::Whole),
+        Provenance::Generated { .. } => ("generated", ProofRung::Whole),
+        Provenance::CredentialBacked { proof, .. } => (
+            "credentialBacked",
+            // Absent means the credential's format was never assessed, and the
+            // conservative answer is the least private one — never the most,
+            // which would claim an unlinkability the proof does not provide.
+            proof.unwrap_or(ProofRung::Whole),
+        ),
+    };
+
+    PreviewClaim {
+        r#type: m.r#type.clone(),
+        value: if rung == ProofRung::Predicate {
+            None
+        } else {
+            m.value.clone()
+        },
+        predicate: None,
+        provenance: provenance.to_string(),
+        rung,
+        new_to_this_verifier: !seen.iter().any(|t| t == &m.r#type),
+        stale: m.stale,
+    }
+}
+
+/// A per-relationship identifier.
+///
+/// Pairwise by default so two verifiers cannot recognise the holder as one
+/// party. Derived rather than random so the same relationship keeps one face
+/// across disclosures, which is what lets a counterparty recognise a returning
+/// holder without anyone else being able to.
+fn pairwise_subject(persona_did: &str, verifier_did: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(b"vta-persona/pairwise-subject/v1");
+    h.update(persona_did.as_bytes());
+    h.update([0u8]);
+    h.update(verifier_did.as_bytes());
+    format!("did:peer:0z{}", hex_short(&h.finalize()))
+}
+
+fn hex_short(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().take(16).fold(String::new(), |mut a, b| {
+        let _ = write!(a, "{b:02x}");
+        a
+    })
+}
+
+/// Render the approved claim set.
+///
+/// **This produces an UNSIGNED document.** Signing belongs to the key custodian
+/// (`keys/derive-and-sign-document`), which holds the persona's key; a signature
+/// minted here would either need that key in this crate or be a placeholder that
+/// looks like a signature and is not. The second is worse than no signature at
+/// all, so the seam is left visible rather than filled with something
+/// misleading.
+fn render(preview: &Preview, challenge: Option<&str>) -> String {
+    let claims: serde_json::Map<String, serde_json::Value> = preview
+        .claims
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let mut o = serde_json::Map::new();
+            o.insert("type".into(), serde_json::json!(c.r#type));
+            if let Some(v) = &c.value {
+                o.insert("value".into(), v.clone());
+            }
+            if let Some(p) = &c.predicate {
+                o.insert("predicate".into(), serde_json::json!(p));
+            }
+            if preview.renderer_drops.iter().all(|d| d != "provenance") {
+                o.insert("provenance".into(), serde_json::json!(c.provenance));
+            }
+            (format!("{i:04}"), serde_json::Value::Object(o))
+        })
+        .collect();
+
+    serde_json::json!({
+        "type": ["VerifiableDataStructure", "RelationshipCard"],
+        "publisher": preview.subject,
+        "cardVersion": 1,
+        "claims": claims,
+        "challenge": challenge,
+        "renderer": preview.renderer_id,
+        // Named, so nothing downstream mistakes this for a signed artifact.
+        "unsigned": true,
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ProfileEntry, ValueType};
+    use crate::profile::new_profile;
+    use crate::store::new_attribute;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        (
+            dir,
+            PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [31u8; 32]),
+        )
+    }
+
+    /// A persona bound to a profile with one self-asserted claim.
+    async fn bound(s: &PersonaStore, value: &str) -> String {
+        let a = new_attribute(
+            "name.display",
+            ValueType::String,
+            serde_json::json!(value),
+            Provenance::SelfAsserted,
+        );
+        s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+        s.set_binding("ctx", "did:persona:a", Some(&p.profile_id), vec![], None)
+            .await
+            .unwrap();
+        p.profile_id
+    }
+
+    #[tokio::test]
+    async fn present_consumes_the_preview_so_the_two_calls_cannot_be_collapsed() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+        let pv = s
+            .create_preview(
+                "ctx",
+                "did:persona:a",
+                "did:web:bar",
+                Some("entry"),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        s.present(&pv.preview_id, Some("nonce"), false)
+            .await
+            .expect("first present");
+
+        // A replayed token would let a second disclosure ride the first
+        // decision.
+        let err = s
+            .present(&pv.preview_id, Some("nonce"), false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_disclosure_cannot_be_produced_without_a_preview() {
+        // The structural property: present requires a token only create_preview
+        // can mint, so there is no path that skips the summary.
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+        let err = s.present("01NEVERMINTED", None, false).await.unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn an_expired_preview_is_refused_not_re_derived() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+        let mut pv = s
+            .create_preview("ctx", "did:persona:a", "did:web:bar", None, None, None)
+            .await
+            .unwrap();
+
+        // Age it past its TTL.
+        pv.expires_at = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+        s.ks.insert(preview_key(&pv.preview_id), &pv).await.unwrap();
+
+        let err = s.present(&pv.preview_id, None, false).await.unwrap_err();
+        assert!(matches!(err, AppError::Gone(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_renderer_that_cannot_carry_a_predicate_fails_at_negotiation() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+
+        // jcard declares it carries no provenance; the preview must say so
+        // rather than let the holder discover it from a verifier.
+        let pv = s
+            .create_preview(
+                "ctx",
+                "did:persona:a",
+                "did:web:bar",
+                None,
+                None,
+                Some("jcard"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(pv.renderer_drops, vec!["provenance".to_string()]);
+
+        // And an unknown renderer is refused rather than silently defaulted to
+        // the canonical one, which would disclose through a format the caller
+        // never chose.
+        let err = s
+            .create_preview(
+                "ctx",
+                "did:persona:a",
+                "did:web:bar",
+                None,
+                None,
+                Some("mdoc"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn a_stale_claim_refuses_the_whole_disclosure() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+        let mut pv = s
+            .create_preview("ctx", "did:persona:a", "did:web:bar", None, None, None)
+            .await
+            .unwrap();
+
+        pv.claims[0].stale = true;
+        s.ks.insert(preview_key(&pv.preview_id), &pv).await.unwrap();
+
+        // Issuing a shorter disclosure would be indistinguishable, to the
+        // verifier, from a holder who approved fewer claims.
+        let err = s.present(&pv.preview_id, None, false).await.unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn the_subject_is_pairwise_so_two_verifiers_cannot_join_a_holder() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+        let a = s
+            .create_preview("ctx", "did:persona:a", "did:web:one", None, None, None)
+            .await
+            .unwrap();
+        let b = s
+            .create_preview("ctx", "did:persona:a", "did:web:two", None, None, None)
+            .await
+            .unwrap();
+
+        assert_ne!(
+            a.subject, b.subject,
+            "one persona must show two verifiers two faces"
+        );
+        assert_ne!(
+            a.subject, "did:persona:a",
+            "and neither face is the account"
+        );
+
+        // Stable for one relationship, so a counterparty recognises a returning
+        // holder without anyone else being able to.
+        let a2 = s
+            .create_preview("ctx", "did:persona:a", "did:web:one", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(a.subject, a2.subject);
+    }
+
+    #[tokio::test]
+    async fn presenting_records_the_disclosure_and_marks_what_is_new() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+
+        let first = s
+            .create_preview("ctx", "did:persona:a", "did:web:bar", None, None, None)
+            .await
+            .unwrap();
+        assert!(first.claims[0].new_to_this_verifier, "nothing sent yet");
+        s.present(&first.preview_id, None, false).await.unwrap();
+
+        // The record exists and is queryable by the holder.
+        let history = s
+            .disclosure_history(&crate::disclosure::HistoryQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].verifier_did, "did:web:bar");
+        assert_eq!(history[0].claims[0].r#type, "name.display");
+
+        // A second preview to the same verifier knows the claim is not new,
+        // which is what lets the preview rank rather than enumerate.
+        let second = s
+            .create_preview("ctx", "did:persona:a", "did:web:bar", None, None, None)
+            .await
+            .unwrap();
+        assert!(!second.claims[0].new_to_this_verifier);
+    }
+
+    #[tokio::test]
+    async fn an_unbound_persona_has_nothing_to_disclose() {
+        let (_d, s) = fresh().await;
+        let err = s
+            .create_preview("ctx", "did:persona:none", "did:web:bar", None, None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn requested_claims_are_a_ceiling_not_a_hint() {
+        let (_d, s) = fresh().await;
+        bound(&s, "Stormer").await;
+        // Narrowing to a type the profile does not carry yields nothing rather
+        // than quietly disclosing what it does carry.
+        let err = s
+            .create_preview(
+                "ctx",
+                "did:persona:a",
+                "did:web:bar",
+                None,
+                Some(&["address.postal".to_string()]),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+}

--- a/vta-persona/src/profile.rs
+++ b/vta-persona/src/profile.rs
@@ -1,0 +1,492 @@
+//! Profiles: composition over the pool, and the reverse index that makes a
+//! delete able to name what it would break.
+//!
+//! A profile **references** attributes rather than copying them, which is the
+//! property that lets a holder change a fact once. The cost is that the store
+//! has to know who refers to what — hence the reverse index, written here and
+//! read by [`crate::PersonaStore::referring_profiles`].
+//!
+//! # Resolution fails whole, never partially
+//!
+//! A profile whose entries do not all resolve is refused. A partially-resolved
+//! composition would disclose less than the holder composed *and tell them
+//! nothing about it*, which is the quiet failure this store exists to prevent.
+
+use serde::{Deserialize, Serialize};
+use vti_common::error::AppError;
+
+use crate::model::{Profile, ProfileEntry, Ulid, Version};
+use crate::storage;
+use crate::store::{PersonaStore, Slot, Written, check_precondition, now_rfc3339};
+
+/// A profile as stored, or the tombstone left where one was.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ProfileSlot {
+    Live(Profile),
+    Tombstone {
+        profile_id: Ulid,
+        version: Version,
+        deleted_at: String,
+    },
+}
+
+/// One claim a profile would present, after resolution.
+///
+/// Distinct from [`Attribute`] because a resolved claim may not correspond to a
+/// pool record at all — an `inline` entry has no `attributeId` — and because
+/// what a profile presents is a *view*, not a record anyone can write back to.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedClaim {
+    /// `None` for an inline entry, which exists only inside this profile.
+    pub attribute_id: Option<Ulid>,
+    pub r#type: String,
+    pub value: Option<serde_json::Value>,
+    pub provenance: crate::Provenance,
+    /// Set when a credential-backed value could not be re-derived. Such a claim
+    /// MUST NOT be disclosed; it is surfaced so a holder learns their profile
+    /// has quietly stopped being fully presentable.
+    pub stale: bool,
+}
+
+impl PersonaStore {
+    /// Create or replace one profile.
+    ///
+    /// Every `ref` must resolve to a live attribute. A dangling reference
+    /// refuses the whole write, naming the offenders.
+    pub async fn put_profile(
+        &self,
+        mut profile: Profile,
+        expected_version: Option<Version>,
+    ) -> Result<Written, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        // Validate before taking a version, so a refused write consumes nothing.
+        let mut dangling = Vec::new();
+        for entry in &profile.entries {
+            if let Some(id) = entry.referenced()
+                && !matches!(self.slot(id).await?, Some(Slot::Live(_)))
+            {
+                dangling.push(id.to_string());
+            }
+        }
+        if !dangling.is_empty() {
+            return Err(AppError::Validation(format!(
+                "profile references {} attribute(s) the pool does not hold: {}",
+                dangling.len(),
+                dangling.join(", ")
+            )));
+        }
+
+        let existing = self.profile_slot(&profile.profile_id).await?;
+        let current_version = match &existing {
+            Some(ProfileSlot::Live(p)) => Some(p.version),
+            _ => None,
+        };
+        check_precondition(expected_version, current_version)?;
+
+        let version = self.next_version().await?;
+        let created = current_version.is_none();
+        profile.version = version;
+        profile.updated_at = now_rfc3339();
+
+        // Reverse index: drop the old edges before adding the new, or an
+        // attribute dropped from the profile keeps a stale referrer and its
+        // delete is refused for a reference that no longer exists.
+        if let Some(ProfileSlot::Live(old)) = &existing {
+            for entry in &old.entries {
+                if let Some(id) = entry.referenced() {
+                    self.ks
+                        .remove(storage::reverse_index_key(id, &old.profile_id))
+                        .await?;
+                }
+            }
+        }
+        for entry in &profile.entries {
+            if let Some(id) = entry.referenced() {
+                self.ks
+                    .insert(storage::reverse_index_key(id, &profile.profile_id), &true)
+                    .await?;
+            }
+        }
+
+        self.ks
+            .insert(
+                storage::profile_key(&profile.profile_id),
+                &ProfileSlot::Live(profile),
+            )
+            .await?;
+
+        Ok(Written { version, created })
+    }
+
+    pub async fn get_profile(&self, profile_id: &str) -> Result<Option<Profile>, AppError> {
+        Ok(match self.profile_slot(profile_id).await? {
+            Some(ProfileSlot::Live(p)) => Some(p),
+            _ => None,
+        })
+    }
+
+    pub(crate) async fn profile_slot(
+        &self,
+        profile_id: &str,
+    ) -> Result<Option<ProfileSlot>, AppError> {
+        self.ks
+            .get::<ProfileSlot>(storage::profile_key(profile_id))
+            .await
+    }
+
+    /// Resolve a profile into the claims it would present, in entry order.
+    ///
+    /// `override` replaces value and label **only** — type and provenance are
+    /// inherited from the referenced attribute. Letting an override replace
+    /// provenance would let a self-asserted value present as attested, which is
+    /// the one thing provenance exists to prevent.
+    pub async fn resolve_profile(&self, profile_id: &str) -> Result<Vec<ResolvedClaim>, AppError> {
+        let profile = self
+            .get_profile(profile_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound(format!("profile {profile_id}")))?;
+
+        let mut out = Vec::with_capacity(profile.entries.len());
+        for entry in &profile.entries {
+            out.push(match entry {
+                ProfileEntry::Ref { r#ref } => self.claim_from_pool(r#ref, None).await?,
+                ProfileEntry::Pinned { r#ref, pin_version } => {
+                    self.claim_from_pool(r#ref, Some(*pin_version)).await?
+                }
+                ProfileEntry::Override { r#ref, r#override } => {
+                    let mut c = self.claim_from_pool(r#ref, None).await?;
+                    // Value only. Provenance is inherited, deliberately.
+                    c.value = Some(r#override.value.clone());
+                    c
+                }
+                ProfileEntry::Inline { inline } => ResolvedClaim {
+                    attribute_id: None,
+                    r#type: inline.r#type.clone(),
+                    value: Some(inline.value.clone()),
+                    provenance: inline.provenance.clone(),
+                    stale: false,
+                },
+            });
+        }
+        Ok(out)
+    }
+
+    async fn claim_from_pool(
+        &self,
+        attribute_id: &str,
+        pin: Option<Version>,
+    ) -> Result<ResolvedClaim, AppError> {
+        let Some(Slot::Live(a)) = self.slot(attribute_id).await? else {
+            // Reachable only if an attribute went away behind a profile's back;
+            // put_profile refuses dangling references. Surfaced as stale rather
+            // than silently omitted, because a shorter disclosure the holder
+            // was not told about is the failure mode this store guards.
+            return Ok(ResolvedClaim {
+                attribute_id: Some(attribute_id.to_string()),
+                r#type: String::new(),
+                value: None,
+                provenance: crate::Provenance::SelfAsserted,
+                stale: true,
+            });
+        };
+
+        // A pin names a version this store no longer holds. Prior versions are
+        // not retained yet, so a pin to anything but the current version cannot
+        // be honoured — and is reported rather than silently served the current
+        // value, which is the whole point of pinning.
+        let stale = pin.is_some_and(|p| p != a.version);
+
+        Ok(ResolvedClaim {
+            attribute_id: Some(a.attribute_id.clone()),
+            r#type: a.r#type.clone(),
+            value: if stale { None } else { a.value.clone() },
+            provenance: a.provenance.clone(),
+            stale: stale || a.stale.unwrap_or(false),
+        })
+    }
+
+    /// Remove a profile, dropping its reverse-index edges.
+    ///
+    /// The pool is untouched: a profile references rather than owns, so
+    /// deleting a composition destroys no facts. That is the asymmetry with
+    /// deleting an attribute, where removal *does* change what compositions
+    /// present.
+    pub async fn delete_profile(&self, profile_id: &str) -> Result<bool, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let Some(ProfileSlot::Live(existing)) = self.profile_slot(profile_id).await? else {
+            return Ok(false);
+        };
+
+        let version = self.next_version().await?;
+        for entry in &existing.entries {
+            if let Some(id) = entry.referenced() {
+                self.ks
+                    .remove(storage::reverse_index_key(id, profile_id))
+                    .await?;
+            }
+        }
+        self.ks
+            .insert(
+                storage::profile_key(profile_id),
+                &ProfileSlot::Tombstone {
+                    profile_id: profile_id.to_string(),
+                    version,
+                    deleted_at: now_rfc3339(),
+                },
+            )
+            .await?;
+        Ok(true)
+    }
+
+    /// Every live profile, in key order — which is creation order, because the
+    /// identifiers are ULIDs.
+    pub async fn list_profiles(&self) -> Result<Vec<Profile>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::PROFILE_PREFIX.as_bytes().to_vec())
+            .await?;
+        let mut out = Vec::new();
+        for (_k, v) in rows {
+            if let Ok(ProfileSlot::Live(p)) = serde_json::from_slice::<ProfileSlot>(&v) {
+                out.push(p);
+            }
+        }
+        Ok(out)
+    }
+}
+
+/// Build a profile with server-assigned identity and timestamps.
+#[must_use]
+pub fn new_profile(name: impl Into<String>, entries: Vec<ProfileEntry>) -> Profile {
+    let now = now_rfc3339();
+    Profile {
+        profile_id: ulid::Ulid::new().to_string(),
+        name: name.into(),
+        entries,
+        credential_refs: Vec::new(),
+        version: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+/// Whether every entry is inline — the condition a context-local profile must
+/// satisfy.
+///
+/// A local profile that could reference the pool would be a context-authored
+/// object acquiring pool reach, which is the escalation the boundary exists to
+/// prevent. Expressed as a function so the dispatcher checks it rather than
+/// reimplementing it.
+#[must_use]
+pub fn is_pool_free(entries: &[ProfileEntry]) -> bool {
+    entries.iter().all(|e| e.referenced().is_none())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{InlineValue, OverrideValue, Provenance, ValueType};
+    use crate::store::new_attribute;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(vta_keyspaces::PERSONA).unwrap();
+        (dir, PersonaStore::new(ks, [5u8; 32]))
+    }
+
+    fn attr(v: &str) -> crate::Attribute {
+        new_attribute(
+            "phone.mobile",
+            ValueType::String,
+            serde_json::json!(v),
+            Provenance::SelfAsserted,
+        )
+    }
+
+    #[tokio::test]
+    async fn a_dangling_reference_refuses_the_whole_write() {
+        let (_d, s) = fresh().await;
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: "01MISSING".into(),
+            }],
+        );
+        let err = s.put_profile(p, None).await.unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+        // And consumed no version: a refused write must cost nothing.
+        assert!(s.list_profiles().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_reverse_index_makes_a_delete_able_to_name_what_it_breaks() {
+        let (_d, s) = fresh().await;
+        let a = attr("+61 4");
+        s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+
+        assert_eq!(
+            s.referring_profiles(&a.attribute_id).await.unwrap(),
+            vec![p.profile_id.clone()]
+        );
+
+        // Deleting the attribute is refused while referenced.
+        let err = s.delete(&a.attribute_id, false).await.unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
+        // ...and permitted with cascade.
+        let out = s.delete(&a.attribute_id, true).await.unwrap();
+        assert_eq!(out.referring_profiles, vec![p.profile_id]);
+    }
+
+    #[tokio::test]
+    async fn dropping_an_entry_drops_its_index_edge() {
+        // Otherwise an attribute removed from a profile keeps a stale referrer,
+        // and its delete is refused for a reference that no longer exists.
+        let (_d, s) = fresh().await;
+        let a = attr("x");
+        s.put(a.clone(), None).await.unwrap();
+        let mut p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+
+        p.entries.clear();
+        s.put_profile(p, None).await.unwrap();
+
+        assert!(
+            s.referring_profiles(&a.attribute_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        s.delete(&a.attribute_id, false)
+            .await
+            .expect("no longer referenced");
+    }
+
+    #[tokio::test]
+    async fn an_override_replaces_the_value_and_never_the_provenance() {
+        let (_d, s) = fresh().await;
+        let mut a = attr("real");
+        a.provenance = Provenance::CredentialBacked {
+            credential_id: "vc-1".into(),
+            claim_path: "/credentialSubject/tel".into(),
+            issuer_did: None,
+            proof: None,
+        };
+        s.put(a.clone(), None).await.unwrap();
+
+        let p = new_profile(
+            "Gaming",
+            vec![ProfileEntry::Override {
+                r#ref: a.attribute_id.clone(),
+                r#override: OverrideValue {
+                    value: serde_json::json!("masked"),
+                    label: None,
+                },
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+
+        let claims = s.resolve_profile(&p.profile_id).await.unwrap();
+        assert_eq!(claims[0].value, Some(serde_json::json!("masked")));
+        // Provenance is inherited. If an override could change it, a
+        // self-asserted value could present as attested.
+        assert!(matches!(
+            claims[0].provenance,
+            Provenance::CredentialBacked { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_unhonourable_pin_is_reported_not_silently_served() {
+        let (_d, s) = fresh().await;
+        let a = attr("v1");
+        let w = s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Pinned {
+                r#ref: a.attribute_id.clone(),
+                pin_version: w.version + 99,
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+
+        let claims = s.resolve_profile(&p.profile_id).await.unwrap();
+        // Serving the current value would defeat the whole point of pinning.
+        assert!(claims[0].stale);
+        assert_eq!(claims[0].value, None);
+    }
+
+    #[tokio::test]
+    async fn inline_entries_resolve_without_the_pool_and_are_pool_free() {
+        let (_d, s) = fresh().await;
+        let entries = vec![ProfileEntry::Inline {
+            inline: InlineValue {
+                r#type: "x:guild".into(),
+                value_type: ValueType::String,
+                value: serde_json::json!("Nightfall"),
+                label: None,
+                provenance: Provenance::SelfAsserted,
+            },
+        }];
+        assert!(
+            is_pool_free(&entries),
+            "a local profile must reference nothing"
+        );
+
+        let p = new_profile("Gaming", entries);
+        s.put_profile(p.clone(), None).await.unwrap();
+        let claims = s.resolve_profile(&p.profile_id).await.unwrap();
+        assert_eq!(claims[0].attribute_id, None);
+        assert_eq!(claims[0].value, Some(serde_json::json!("Nightfall")));
+    }
+
+    #[tokio::test]
+    async fn deleting_a_profile_leaves_the_pool_alone() {
+        // The asymmetry with attribute deletion: a profile references rather
+        // than owns, so removing one destroys no facts.
+        let (_d, s) = fresh().await;
+        let a = attr("keep me");
+        s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+
+        assert!(s.delete_profile(&p.profile_id).await.unwrap());
+        assert!(
+            s.get(&a.attribute_id).await.unwrap().is_some(),
+            "the fact survives"
+        );
+        assert!(
+            s.referring_profiles(&a.attribute_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        // A repeat delete converges.
+        assert!(!s.delete_profile(&p.profile_id).await.unwrap());
+    }
+}

--- a/vta-persona/src/profile.rs
+++ b/vta-persona/src/profile.rs
@@ -490,3 +490,234 @@ mod tests {
         assert!(!s.delete_profile(&p.profile_id).await.unwrap());
     }
 }
+
+// ─── Context-local profiles ──────────────────────────────────────────────
+//
+// A separate address space, not a flag on the pool's. A context-scoped
+// enumeration therefore scans somewhere a pool profile structurally cannot be,
+// rather than scanning everything and filtering — a filter is a line of code
+// that can be got wrong, an address space cannot.
+
+impl PersonaStore {
+    /// Create or replace a context-local profile.
+    ///
+    /// Refuses any entry that references the pool. A local profile that could
+    /// reference it would be a context-authored object acquiring pool reach,
+    /// which is the escalation the boundary exists to prevent.
+    pub async fn put_local_profile(
+        &self,
+        context_id: &str,
+        mut profile: Profile,
+        expected_version: Option<Version>,
+    ) -> Result<Written, AppError> {
+        if !is_pool_free(&profile.entries) {
+            return Err(AppError::Validation(
+                "a context-local profile may carry inline entries only; a reference to the \
+                 holder's pool is refused"
+                    .into(),
+            ));
+        }
+
+        let _guard = self.write_lock.lock().await;
+        let key = storage::local_profile_key(context_id, &profile.profile_id);
+        let existing = self.ks.get::<ProfileSlot>(key.clone()).await?;
+        let current = match &existing {
+            Some(ProfileSlot::Live(p)) => Some(p.version),
+            _ => None,
+        };
+        check_precondition(expected_version, current)?;
+
+        let version = self.next_version().await?;
+        let created = current.is_none();
+        profile.version = version;
+        profile.updated_at = now_rfc3339();
+        self.ks.insert(key, &ProfileSlot::Live(profile)).await?;
+        Ok(Written { version, created })
+    }
+
+    pub async fn get_local_profile(
+        &self,
+        context_id: &str,
+        profile_id: &str,
+    ) -> Result<Option<Profile>, AppError> {
+        Ok(
+            match self
+                .ks
+                .get::<ProfileSlot>(storage::local_profile_key(context_id, profile_id))
+                .await?
+            {
+                Some(ProfileSlot::Live(p)) => Some(p),
+                _ => None,
+            },
+        )
+    }
+
+    pub async fn list_local_profiles(&self, context_id: &str) -> Result<Vec<Profile>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::local_profile_prefix(context_id).into_bytes())
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(_k, v)| match serde_json::from_slice::<ProfileSlot>(&v) {
+                Ok(ProfileSlot::Live(p)) => Some(p),
+                _ => None,
+            })
+            .collect())
+    }
+
+    pub async fn delete_local_profile(
+        &self,
+        context_id: &str,
+        profile_id: &str,
+    ) -> Result<bool, AppError> {
+        let _guard = self.write_lock.lock().await;
+        let key = storage::local_profile_key(context_id, profile_id);
+        let existed = matches!(
+            self.ks.get::<ProfileSlot>(key.clone()).await?,
+            Some(ProfileSlot::Live(_))
+        );
+        if existed {
+            self.ks.remove(key).await?;
+        }
+        Ok(existed)
+    }
+
+    /// Bind a **context-local** profile to a persona in the same context.
+    ///
+    /// Refuses a `profile_id` naming a POOL profile. That refusal is the whole
+    /// distinction from `set_binding`: resolving the identifier against both
+    /// address spaces would let a context-scoped caller bind the holder's
+    /// composition and read it back through a disclosure it requests of itself
+    /// — precisely the escalation `binding/set` is holder-authorized to prevent,
+    /// reintroduced in the task that looks harmless.
+    pub async fn set_local_binding(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+        profile_id: Option<&str>,
+    ) -> Result<Version, AppError> {
+        if let Some(id) = profile_id
+            && self.get_local_profile(context_id, id).await?.is_none()
+        {
+            return Err(AppError::Validation(format!(
+                "{id} does not name a context-local profile; a pool profile cannot be bound here"
+            )));
+        }
+
+        let _guard = self.write_lock.lock().await;
+        let version = self.next_version().await?;
+        self.ks
+            .insert(
+                storage::local_binding_key(context_id, persona_did),
+                &(profile_id.map(str::to_string), version),
+            )
+            .await?;
+        Ok(version)
+    }
+}
+
+#[cfg(test)]
+mod local_tests {
+    use super::*;
+    use crate::model::{InlineValue, Provenance, ValueType};
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        (
+            dir,
+            PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [21u8; 32]),
+        )
+    }
+
+    fn inline(v: &str) -> ProfileEntry {
+        ProfileEntry::Inline {
+            inline: InlineValue {
+                r#type: "x:handle".into(),
+                value_type: ValueType::String,
+                value: serde_json::json!(v),
+                label: None,
+                provenance: Provenance::SelfAsserted,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn a_reference_to_the_pool_is_refused() {
+        let (_d, s) = fresh().await;
+        let p = new_profile(
+            "Throwaway",
+            vec![ProfileEntry::Ref {
+                r#ref: "01ABC".into(),
+            }],
+        );
+        let err = s.put_local_profile("ctx", p, None).await.unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn local_and_pool_profiles_do_not_see_each_other() {
+        // The isolation is the address space. A context-scoped enumeration must
+        // reach somewhere a pool profile cannot be.
+        let (_d, s) = fresh().await;
+        let pool = new_profile("Work", vec![]);
+        s.put_profile(pool.clone(), None).await.unwrap();
+        let local = new_profile("Throwaway", vec![inline("g")]);
+        s.put_local_profile("ctx", local.clone(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(s.list_local_profiles("ctx").await.unwrap().len(), 1);
+        assert_eq!(s.list_profiles().await.unwrap().len(), 1);
+        assert!(
+            s.get_local_profile("ctx", &pool.profile_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(s.get_profile(&local.profile_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn a_local_binding_refuses_a_pool_profile() {
+        // The one refusal that keeps the local surface from becoming an
+        // escalation path.
+        let (_d, s) = fresh().await;
+        let pool = new_profile("Work", vec![]);
+        s.put_profile(pool.clone(), None).await.unwrap();
+
+        let err = s
+            .set_local_binding("ctx", "did:p", Some(&pool.profile_id))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+
+        let local = new_profile("Throwaway", vec![inline("g")]);
+        s.put_local_profile("ctx", local.clone(), None)
+            .await
+            .unwrap();
+        s.set_local_binding("ctx", "did:p", Some(&local.profile_id))
+            .await
+            .expect("a local profile binds");
+    }
+
+    #[tokio::test]
+    async fn a_local_profile_is_confined_to_its_context() {
+        let (_d, s) = fresh().await;
+        let p = new_profile("Throwaway", vec![inline("g")]);
+        s.put_local_profile("ctx-a", p.clone(), None).await.unwrap();
+        assert!(
+            s.get_local_profile("ctx-b", &p.profile_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(s.list_local_profiles("ctx-b").await.unwrap().is_empty());
+    }
+}

--- a/vta-persona/src/storage.rs
+++ b/vta-persona/src/storage.rs
@@ -1,0 +1,242 @@
+//! Key layout for the persona keyspace, and the scope split expressed as
+//! separately addressable prefixes.
+//!
+//! Every key in this module is built by a function here rather than formatted
+//! at a call site. That is not tidiness: the agent-scoped and context-scoped
+//! prefixes are a security boundary, and a call site that formats its own key
+//! can put a record on the wrong side of it. Concentrating the layout means the
+//! boundary has one definition and the census test below can assert it.
+
+// ---- Agent-scoped: the person's own, above every context --------------------
+
+/// One attribute of the pool.
+#[must_use]
+pub fn attribute_key(attribute_id: &str) -> String {
+    format!("pa:{attribute_id}")
+}
+
+/// Prefix scan over the whole pool.
+pub const ATTRIBUTE_PREFIX: &str = "pa:";
+
+/// One profile.
+#[must_use]
+pub fn profile_key(profile_id: &str) -> String {
+    format!("pp:{profile_id}")
+}
+
+pub const PROFILE_PREFIX: &str = "pp:";
+
+/// Correlation index, keyed by a keyed hash of the value so that exact-match
+/// lookup works with no plaintext index over the holder's personal data.
+#[must_use]
+pub fn correlation_key(value_hmac_hex: &str) -> String {
+    format!("pxi:{value_hmac_hex}")
+}
+
+pub const CORRELATION_PREFIX: &str = "pxi:";
+
+/// Attribute → profile reverse index, so a delete can name its referring
+/// profiles without scanning every profile.
+#[must_use]
+pub fn reverse_index_key(attribute_id: &str, profile_id: &str) -> String {
+    format!("pxr:{attribute_id}:{profile_id}")
+}
+
+/// Prefix scan for every profile referring to one attribute.
+#[must_use]
+pub fn reverse_index_prefix(attribute_id: &str) -> String {
+    format!("pxr:{attribute_id}:")
+}
+
+// ---- Context-scoped: a persona lives in a context, and so do its peers -------
+
+/// Binding of a profile to a persona DID.
+#[must_use]
+pub fn binding_key(context_id: &str, persona_did: &str) -> String {
+    format!("pb:{context_id}:{persona_did}")
+}
+
+/// Prefix scan over one context's bindings.
+#[must_use]
+pub fn binding_prefix(context_id: &str) -> String {
+    format!("pb:{context_id}:")
+}
+
+/// A contact's current revision.
+#[must_use]
+pub fn contact_key(context_id: &str, contact_id: &str) -> String {
+    format!("pc:{context_id}:{contact_id}")
+}
+
+#[must_use]
+pub fn contact_prefix(context_id: &str) -> String {
+    format!("pc:{context_id}:")
+}
+
+/// A superseded contact revision.
+///
+/// Zero-padded so a prefix scan returns revisions in numeric order; without the
+/// padding revision 10 sorts before revision 9 and a "previous revision" lookup
+/// silently reads the wrong one.
+#[must_use]
+pub fn contact_revision_key(context_id: &str, contact_id: &str, rev: u64) -> String {
+    format!("pcr:{context_id}:{contact_id}:{rev:020}")
+}
+
+#[must_use]
+pub fn contact_revision_prefix(context_id: &str, contact_id: &str) -> String {
+    format!("pcr:{context_id}:{contact_id}:")
+}
+
+/// An append-only disclosure record. Zero-padded for the same reason.
+#[must_use]
+pub fn disclosure_key(context_id: &str, seq: u64) -> String {
+    format!("pd:{context_id}:{seq:020}")
+}
+
+#[must_use]
+pub fn disclosure_prefix(context_id: &str) -> String {
+    format!("pd:{context_id}:")
+}
+
+// ---- Context-local: authored below the boundary ------------------------------
+
+/// A context-local profile — inline entries only.
+///
+/// A **separate prefix**, not a flag on [`profile_key`]. If the two shared a
+/// space, a context-scoped list would need a filter to avoid returning a pool
+/// profile, and a filter bug is the same one-line leak the authorization rule
+/// exists to remove.
+#[must_use]
+pub fn local_profile_key(context_id: &str, profile_id: &str) -> String {
+    format!("plp:{context_id}:{profile_id}")
+}
+
+#[must_use]
+pub fn local_profile_prefix(context_id: &str) -> String {
+    format!("plp:{context_id}:")
+}
+
+/// Binding of a context-local profile.
+#[must_use]
+pub fn local_binding_key(context_id: &str, persona_did: &str) -> String {
+    format!("plb:{context_id}:{persona_did}")
+}
+
+/// The store's monotonic write counter.
+pub const VERSION_COUNTER_KEY: &str = "pver";
+
+/// Per-agent key for the correlation index's keyed hash.
+pub const CORRELATION_HMAC_KEY: &str = "pxkey";
+
+/// Every prefix this module writes under, paired with whether it is
+/// agent-scoped. The census test uses it to assert the boundary holds.
+const PREFIX_SCOPES: &[(&str, Scope)] = &[
+    ("pa:", Scope::Agent),
+    ("pp:", Scope::Agent),
+    ("pxi:", Scope::Agent),
+    ("pxr:", Scope::Agent),
+    ("pb:", Scope::Context),
+    ("pc:", Scope::Context),
+    ("pcr:", Scope::Context),
+    ("pd:", Scope::Context),
+    ("plp:", Scope::Context),
+    ("plb:", Scope::Context),
+];
+
+/// Which side of the boundary a record sits on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Scope {
+    /// Above every context. Reachable only by a holder-authorized, unscoped
+    /// caller.
+    Agent,
+    /// Belongs to one context and is reachable from inside it.
+    Context,
+}
+
+/// The scope of a key, or `None` if no prefix in this module claims it.
+///
+/// Returning `None` rather than defaulting is deliberate: a key nobody
+/// recognises must not be assumed safe to serve a context-scoped caller.
+#[must_use]
+pub fn scope_of(key: &str) -> Option<Scope> {
+    // Longest prefix first, so `pcr:` is not matched as `pc:` — the two are on
+    // the same side of the boundary today, which is exactly why an ordering bug
+    // here would go unnoticed until one of them moved.
+    let mut best: Option<(usize, Scope)> = None;
+    for (p, s) in PREFIX_SCOPES {
+        if key.starts_with(p) && best.is_none_or(|(len, _)| p.len() > len) {
+            best = Some((p.len(), *s));
+        }
+    }
+    best.map(|(_, s)| s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_prefix_is_scoped_and_unambiguous() {
+        // A key nobody recognises is not defaulted into either scope.
+        assert_eq!(scope_of("unknown:x"), None);
+
+        for (p, expected) in PREFIX_SCOPES {
+            let k = format!("{p}sample");
+            assert_eq!(
+                scope_of(&k),
+                Some(*expected),
+                "prefix {p} did not resolve to its declared scope"
+            );
+        }
+    }
+
+    #[test]
+    fn contact_revision_is_not_read_as_a_contact() {
+        // `pcr:` starts with `pc:`. Both are context-scoped, so a mismatch here
+        // is invisible today — and would become a boundary bug the moment
+        // either moved. Longest-prefix-wins is asserted rather than assumed.
+        let rev = contact_revision_key("ctx", "c1", 3);
+        assert!(rev.starts_with("pcr:"));
+        assert_eq!(scope_of(&rev), Some(Scope::Context));
+    }
+
+    #[test]
+    fn agent_scoped_keys_carry_no_context() {
+        // The pool sits above every context, so its keys cannot name one. A key
+        // that did would be a pool record filed under a context, which is the
+        // shape of the leak the scope split exists to prevent.
+        assert_eq!(attribute_key("01J8"), "pa:01J8");
+        assert_eq!(profile_key("01J8"), "pp:01J8");
+        // Exactly one separator: the prefix. A second would mean a context
+        // segment had crept into an agent-scoped key.
+        assert_eq!(attribute_key("01J8").matches(':').count(), 1);
+        assert_eq!(profile_key("01J8").matches(':').count(), 1);
+    }
+
+    #[test]
+    fn revisions_sort_numerically_not_lexically() {
+        // Without zero-padding, revision 10 sorts before revision 9 and a
+        // "previous revision" lookup reads the wrong one.
+        let mut keys = [
+            contact_revision_key("c", "x", 9),
+            contact_revision_key("c", "x", 10),
+            contact_revision_key("c", "x", 2),
+        ];
+        keys.sort();
+        assert_eq!(keys[0], contact_revision_key("c", "x", 2));
+        assert_eq!(keys[2], contact_revision_key("c", "x", 10));
+    }
+
+    #[test]
+    fn local_profiles_are_a_separate_space_from_pool_profiles() {
+        // The isolation is the address, not a filter. A context-scoped scan of
+        // local profiles must not be able to reach a pool profile.
+        let pool = profile_key("01J8");
+        let local = local_profile_key("ctx", "01J8");
+        assert!(!local.starts_with(PROFILE_PREFIX));
+        assert!(!pool.starts_with(&local_profile_prefix("ctx")));
+        assert_eq!(scope_of(&pool), Some(Scope::Agent));
+        assert_eq!(scope_of(&local), Some(Scope::Context));
+    }
+}

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -78,15 +78,18 @@ pub struct Deleted {
 /// hand, so there is one at-rest implementation in the workspace rather than
 /// two.
 pub struct PersonaStore {
-    ks: KeyspaceHandle,
+    pub(crate) ks: KeyspaceHandle,
     /// Per-agent key for the correlation index's keyed hash.
-    correlation_key: [u8; 32],
-    /// Serialises read-modify-write. One lock for the agent-scoped pool, which
-    /// is the only scope this module writes.
-    write_lock: Arc<Mutex<()>>,
+    pub(crate) correlation_key: [u8; 32],
+    /// Serialises read-modify-write across every scope this store writes. One
+    /// lock rather than one per scope: the scopes share a keyspace and the
+    /// reverse index spans them, so two locks would have to be taken in a fixed
+    /// order by every writer — a rule nothing enforces and a deadlock the first
+    /// time somebody forgets.
+    pub(crate) write_lock: Arc<Mutex<()>>,
     /// Cached counter, guarded by `write_lock` and re-read from the store on
     /// first use so a restart never reuses a number.
-    counter: Arc<Mutex<Option<Version>>>,
+    pub(crate) counter: Arc<Mutex<Option<Version>>>,
 }
 
 impl PersonaStore {
@@ -101,7 +104,7 @@ impl PersonaStore {
     }
 
     /// Reserve the next version. Caller must hold `write_lock`.
-    async fn next_version(&self) -> Result<Version, AppError> {
+    pub(crate) async fn next_version(&self) -> Result<Version, AppError> {
         let mut cached = self.counter.lock().await;
         let current = match *cached {
             Some(v) => v,
@@ -312,7 +315,11 @@ impl PersonaStore {
             .unwrap_or_default())
     }
 
-    async fn index_value(&self, blind: &str, attribute_id: &str) -> Result<(), AppError> {
+    pub(crate) async fn index_value(
+        &self,
+        blind: &str,
+        attribute_id: &str,
+    ) -> Result<(), AppError> {
         let mut ids = self.indexed_ids(blind).await?;
         if !ids.iter().any(|i| i == attribute_id) {
             ids.push(attribute_id.to_string());
@@ -323,7 +330,11 @@ impl PersonaStore {
         Ok(())
     }
 
-    async fn unindex_value(&self, blind: &str, attribute_id: &str) -> Result<(), AppError> {
+    pub(crate) async fn unindex_value(
+        &self,
+        blind: &str,
+        attribute_id: &str,
+    ) -> Result<(), AppError> {
         let mut ids = self.indexed_ids(blind).await?;
         ids.retain(|i| i != attribute_id);
         if ids.is_empty() {
@@ -338,7 +349,10 @@ impl PersonaStore {
 }
 
 /// Apply the optimistic-concurrency precondition.
-fn check_precondition(expected: Option<Version>, current: Option<Version>) -> Result<(), AppError> {
+pub(crate) fn check_precondition(
+    expected: Option<Version>,
+    current: Option<Version>,
+) -> Result<(), AppError> {
     match (expected, current) {
         (None, _) => Ok(()),
         // Create-only.
@@ -356,7 +370,7 @@ fn check_precondition(expected: Option<Version>, current: Option<Version>) -> Re
     }
 }
 
-fn now_rfc3339() -> String {
+pub(crate) fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
 }
 

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -276,6 +276,41 @@ impl PersonaStore {
         })
     }
 
+    /// Every live attribute, optionally narrowed by vocabulary prefix.
+    ///
+    /// `include_values` is opt-in because the common case — rendering a picker
+    /// so a holder can choose what to compose with — needs type and label, not
+    /// plaintext. Making the sensitive path the one a caller has to ask for
+    /// means it is never the one they get by forgetting.
+    ///
+    /// Stale credential-backed attributes are returned carrying their reason
+    /// rather than omitted: a pool that looks smaller than it is would leave
+    /// the holder unaware that a claim has stopped being presentable.
+    pub async fn list_attributes(
+        &self,
+        type_prefix: Option<&str>,
+        include_values: bool,
+    ) -> Result<Vec<Attribute>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::ATTRIBUTE_PREFIX.as_bytes().to_vec())
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(_k, v)| match serde_json::from_slice::<Slot>(&v) {
+                Ok(Slot::Live(a)) => Some(a),
+                _ => None,
+            })
+            .filter(|a| type_prefix.is_none_or(|p| a.r#type.starts_with(p)))
+            .map(|mut a| {
+                if !include_values {
+                    a.value = None;
+                }
+                a
+            })
+            .collect())
+    }
+
     /// Profiles whose entries refer to this attribute, from the reverse index —
     /// so a delete can name them without scanning every profile.
     pub async fn referring_profiles(&self, attribute_id: &str) -> Result<Vec<Ulid>, AppError> {
@@ -555,6 +590,91 @@ mod tests {
         assert!(
             !as_text.contains("+61 4xx xxx 001"),
             "the value must not be readable without the at-rest key"
+        );
+    }
+}
+
+#[cfg(test)]
+mod list_tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    #[tokio::test]
+    async fn listing_withholds_values_unless_asked() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let s = PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [1u8; 32]);
+
+        s.put(
+            new_attribute(
+                "phone.mobile",
+                ValueType::String,
+                serde_json::json!("+61"),
+                Provenance::SelfAsserted,
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let quiet = s.list_attributes(None, false).await.unwrap();
+        assert_eq!(quiet.len(), 1);
+        assert!(
+            quiet[0].value.is_none(),
+            "the default must not move plaintext"
+        );
+
+        let loud = s.list_attributes(None, true).await.unwrap();
+        assert!(loud[0].value.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_prefix_selects_a_vocabulary_family_and_a_tombstone_is_not_listed() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let s = PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [1u8; 32]);
+
+        let a = new_attribute(
+            "phone.work",
+            ValueType::String,
+            serde_json::json!("1"),
+            Provenance::SelfAsserted,
+        );
+        s.put(a.clone(), None).await.unwrap();
+        s.put(
+            new_attribute(
+                "name.legal",
+                ValueType::String,
+                serde_json::json!("n"),
+                Provenance::SelfAsserted,
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            s.list_attributes(Some("phone"), false).await.unwrap().len(),
+            1
+        );
+        assert_eq!(
+            s.list_attributes(Some("name"), false).await.unwrap().len(),
+            1
+        );
+        assert_eq!(s.list_attributes(None, false).await.unwrap().len(), 2);
+
+        s.delete(&a.attribute_id, false).await.unwrap();
+        assert_eq!(
+            s.list_attributes(Some("phone"), false).await.unwrap().len(),
+            0,
+            "a tombstone is not a live attribute"
         );
     }
 }

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -1,0 +1,546 @@
+//! The attribute pool: read, write, delete, and the indexes that keep the
+//! correlation guard and the referential checks answerable.
+//!
+//! # Why a lock and not a compare-and-swap
+//!
+//! Read-modify-write is serialised by a process-local lock per store, not by a
+//! CAS in the storage layer. That mirrors the conclusion `app-state` reached and
+//! for the same reason: there is no reachable multi-writer topology. The local
+//! backend takes an exclusive file lock on its directory, so two processes
+//! cannot open one store at all; the vsock backend proxies to a single store,
+//! and its `swap`/`insert_if_absent` are already *non-atomic* get+insert
+//! fallbacks. A CAS added here would be atomic exactly where the lock already
+//! suffices, and would still be non-atomic on the proxy that needs it.
+//!
+//! # Versions
+//!
+//! One monotonic counter for the store. A record's version is the counter value
+//! its most recent write took, which makes the same number serve as both the
+//! optimistic-concurrency token and the change-feed watermark. Per-record
+//! counters could do the first but not the second, because two records'
+//! counters are not comparable to each other.
+//!
+//! The counter is **reserved before the write it belongs to**. A crash between
+//! reserving and writing leaks a number, which is harmless — versions are
+//! opaque and monotonic, never an edit count. A crash between writing and
+//! reserving would reuse one, which is not.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use crate::correlation;
+use crate::model::{Attribute, Provenance, Ulid, ValueType, Version};
+use crate::storage;
+
+/// A stored attribute, or the tombstone left where one was.
+///
+/// Tombstones are what make incremental sync converge. Without them a peer
+/// pulling from a watermark learns about every create and update and never
+/// learns about a delete, so deleted records resurrect on the next full rebuild
+/// and disagree with peers that saw the delete live.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum Slot {
+    Live(Attribute),
+    Tombstone {
+        attribute_id: Ulid,
+        version: Version,
+        deleted_at: String,
+        /// The blinded key this attribute occupied, so the correlation index
+        /// can be cleaned up without decrypting anything.
+        value_blind: String,
+    },
+}
+
+/// Outcome of a write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Written {
+    pub version: Version,
+    pub created: bool,
+}
+
+/// Outcome of a delete. `existed` distinguishes a removal from a no-op.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Deleted {
+    pub existed: bool,
+    /// Profiles whose entries referred to the attribute.
+    pub referring_profiles: Vec<Ulid>,
+}
+
+/// The persona store over one keyspace handle.
+///
+/// The handle carries the at-rest encryption when the deployment provides a
+/// key, exactly as the credential vault's does — this layer never encrypts by
+/// hand, so there is one at-rest implementation in the workspace rather than
+/// two.
+pub struct PersonaStore {
+    ks: KeyspaceHandle,
+    /// Per-agent key for the correlation index's keyed hash.
+    correlation_key: [u8; 32],
+    /// Serialises read-modify-write. One lock for the agent-scoped pool, which
+    /// is the only scope this module writes.
+    write_lock: Arc<Mutex<()>>,
+    /// Cached counter, guarded by `write_lock` and re-read from the store on
+    /// first use so a restart never reuses a number.
+    counter: Arc<Mutex<Option<Version>>>,
+}
+
+impl PersonaStore {
+    #[must_use]
+    pub fn new(ks: KeyspaceHandle, correlation_key: [u8; 32]) -> Self {
+        Self {
+            ks,
+            correlation_key,
+            write_lock: Arc::new(Mutex::new(())),
+            counter: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Reserve the next version. Caller must hold `write_lock`.
+    async fn next_version(&self) -> Result<Version, AppError> {
+        let mut cached = self.counter.lock().await;
+        let current = match *cached {
+            Some(v) => v,
+            None => self
+                .ks
+                .get::<Version>(storage::VERSION_COUNTER_KEY)
+                .await?
+                .unwrap_or(0),
+        };
+        let next = current + 1;
+        // Persisted before it is handed out. A crash here leaks a number, which
+        // is harmless; the opposite order would reuse one, which is not.
+        self.ks.insert(storage::VERSION_COUNTER_KEY, &next).await?;
+        *cached = Some(next);
+        Ok(next)
+    }
+
+    /// Read one attribute. `None` for absent or tombstoned — a caller that needs
+    /// to tell those apart reads the slot.
+    pub async fn get(&self, attribute_id: &str) -> Result<Option<Attribute>, AppError> {
+        Ok(match self.slot(attribute_id).await? {
+            Some(Slot::Live(a)) => Some(a),
+            _ => None,
+        })
+    }
+
+    pub(crate) async fn slot(&self, attribute_id: &str) -> Result<Option<Slot>, AppError> {
+        self.ks
+            .get::<Slot>(storage::attribute_key(attribute_id))
+            .await
+    }
+
+    /// Create or replace one attribute.
+    ///
+    /// `expected_version` is the optimistic-concurrency precondition: `Some(0)`
+    /// means create-only, `Some(n)` requires the record to be at exactly `n`,
+    /// `None` is last-writer-wins.
+    ///
+    /// A failed precondition returns [`AppError::Conflict`] carrying the current
+    /// version. A bare rejection would oblige the caller to re-read, and between
+    /// the rejection and the re-read the record can change again — the pattern
+    /// has no fixed point under contention.
+    pub async fn put(
+        &self,
+        mut attribute: Attribute,
+        expected_version: Option<Version>,
+    ) -> Result<Written, AppError> {
+        if !attribute
+            .value
+            .as_ref()
+            .is_some_and(|v| attribute.value_type.accepts(v))
+        {
+            return Err(AppError::Validation(format!(
+                "value does not agree with declared valueType {:?}",
+                attribute.value_type
+            )));
+        }
+
+        let _guard = self.write_lock.lock().await;
+        let existing = self.slot(&attribute.attribute_id).await?;
+
+        let current_version = match &existing {
+            Some(Slot::Live(a)) => Some(a.version),
+            // A tombstone is not a live record, so create-only succeeds over
+            // one. The new record takes the next counter value, necessarily
+            // greater than the tombstone's, so a watcher still sees it move
+            // forward.
+            Some(Slot::Tombstone { .. }) | None => None,
+        };
+        check_precondition(expected_version, current_version)?;
+
+        let version = self.next_version().await?;
+        let created = current_version.is_none();
+        attribute.version = version;
+
+        // Index maintenance before the record, so a crash leaves an index entry
+        // with no record — which reads as a false positive in the correlation
+        // guard — rather than a record with no index entry, which reads as a
+        // false ALL-CLEAR. Over-warning is recoverable; under-warning is the
+        // failure this guard exists to prevent.
+        if let Some(v) = &attribute.value {
+            let blind = correlation::blind(&self.correlation_key, v);
+            self.index_value(&blind, &attribute.attribute_id).await?;
+        }
+        if let Some(Slot::Live(old)) = &existing
+            && let Some(old_value) = &old.value
+        {
+            let old_blind = correlation::blind(&self.correlation_key, old_value);
+            let new_blind = attribute
+                .value
+                .as_ref()
+                .map(|v| correlation::blind(&self.correlation_key, v));
+            if Some(&old_blind) != new_blind.as_ref() {
+                self.unindex_value(&old_blind, &attribute.attribute_id)
+                    .await?;
+            }
+        }
+
+        self.ks
+            .insert(
+                storage::attribute_key(&attribute.attribute_id),
+                &Slot::Live(attribute),
+            )
+            .await?;
+
+        Ok(Written { version, created })
+    }
+
+    /// Remove one attribute, leaving a tombstone.
+    ///
+    /// Refuses while a profile refers to it unless `cascade`. Profiles reference
+    /// rather than copy, so removing a fact changes what every referring profile
+    /// presents — and doing that silently is the surprise this store exists to
+    /// prevent.
+    ///
+    /// A repeat delete converges: `existed: false`, and deliberately **no new
+    /// version**. Had it taken one, every consumer watching the store would see
+    /// a change that did not happen, and delete could not be safely retried.
+    pub async fn delete(&self, attribute_id: &str, cascade: bool) -> Result<Deleted, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let referring = self.referring_profiles(attribute_id).await?;
+        if !referring.is_empty() && !cascade {
+            return Err(AppError::Conflict(format!(
+                "attribute {attribute_id} is referenced by {} profile(s); \
+                 pass cascade to remove those entries too",
+                referring.len()
+            )));
+        }
+
+        let Some(Slot::Live(existing)) = self.slot(attribute_id).await? else {
+            return Ok(Deleted {
+                existed: false,
+                referring_profiles: Vec::new(),
+            });
+        };
+
+        let version = self.next_version().await?;
+        let value_blind = existing
+            .value
+            .as_ref()
+            .map(|v| correlation::blind(&self.correlation_key, v))
+            .unwrap_or_default();
+
+        if !value_blind.is_empty() {
+            self.unindex_value(&value_blind, attribute_id).await?;
+        }
+        for profile_id in &referring {
+            self.ks
+                .remove(storage::reverse_index_key(attribute_id, profile_id))
+                .await?;
+        }
+
+        self.ks
+            .insert(
+                storage::attribute_key(attribute_id),
+                &Slot::Tombstone {
+                    attribute_id: attribute_id.to_string(),
+                    version,
+                    deleted_at: now_rfc3339(),
+                    value_blind,
+                },
+            )
+            .await?;
+
+        Ok(Deleted {
+            existed: true,
+            referring_profiles: referring,
+        })
+    }
+
+    /// Profiles whose entries refer to this attribute, from the reverse index —
+    /// so a delete can name them without scanning every profile.
+    pub async fn referring_profiles(&self, attribute_id: &str) -> Result<Vec<Ulid>, AppError> {
+        let prefix = storage::reverse_index_prefix(attribute_id);
+        let keys = self.ks.prefix_keys(prefix.clone().into_bytes()).await?;
+        Ok(keys
+            .into_iter()
+            .filter_map(|k| {
+                String::from_utf8(k)
+                    .ok()?
+                    .strip_prefix(&prefix)
+                    .map(str::to_string)
+            })
+            .collect())
+    }
+
+    /// How many *other* attributes share this exact value.
+    ///
+    /// A count, not identifiers. Returning identifiers on a write would disclose
+    /// the holder's other compositions to whatever tool made it; the analyze
+    /// task is holder-authorized and is where identifiers belong.
+    pub async fn correlation_count(
+        &self,
+        value: &serde_json::Value,
+        excluding: &str,
+    ) -> Result<usize, AppError> {
+        let blind = correlation::blind(&self.correlation_key, value);
+        let ids = self.indexed_ids(&blind).await?;
+        Ok(ids.iter().filter(|id| *id != excluding).count())
+    }
+
+    async fn indexed_ids(&self, blind: &str) -> Result<Vec<Ulid>, AppError> {
+        Ok(self
+            .ks
+            .get::<Vec<Ulid>>(storage::correlation_key(blind))
+            .await?
+            .unwrap_or_default())
+    }
+
+    async fn index_value(&self, blind: &str, attribute_id: &str) -> Result<(), AppError> {
+        let mut ids = self.indexed_ids(blind).await?;
+        if !ids.iter().any(|i| i == attribute_id) {
+            ids.push(attribute_id.to_string());
+            self.ks
+                .insert(storage::correlation_key(blind), &ids)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn unindex_value(&self, blind: &str, attribute_id: &str) -> Result<(), AppError> {
+        let mut ids = self.indexed_ids(blind).await?;
+        ids.retain(|i| i != attribute_id);
+        if ids.is_empty() {
+            self.ks.remove(storage::correlation_key(blind)).await?;
+        } else {
+            self.ks
+                .insert(storage::correlation_key(blind), &ids)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+/// Apply the optimistic-concurrency precondition.
+fn check_precondition(expected: Option<Version>, current: Option<Version>) -> Result<(), AppError> {
+    match (expected, current) {
+        (None, _) => Ok(()),
+        // Create-only.
+        (Some(0), None) => Ok(()),
+        (Some(0), Some(v)) => Err(AppError::Conflict(format!(
+            "expectedVersion 0 means create-only, but a live record exists at version {v}"
+        ))),
+        (Some(n), Some(v)) if n == v => Ok(()),
+        (Some(n), Some(v)) => Err(AppError::Conflict(format!(
+            "expectedVersion {n} does not match current version {v}"
+        ))),
+        (Some(n), None) => Err(AppError::Conflict(format!(
+            "expectedVersion {n} but no live record exists"
+        ))),
+    }
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// Build an attribute with server-assigned identity and timestamps.
+#[must_use]
+pub fn new_attribute(
+    r#type: impl Into<String>,
+    value_type: ValueType,
+    value: serde_json::Value,
+    provenance: Provenance,
+) -> Attribute {
+    let now = now_rfc3339();
+    Attribute {
+        attribute_id: ulid::Ulid::new().to_string(),
+        r#type: r#type.into(),
+        value_type,
+        value: Some(value),
+        label: None,
+        provenance,
+        stale: None,
+        stale_reason: None,
+        version: 0,
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    const KEY: [u8; 32] = [3u8; 32];
+
+    async fn fresh(encrypted: bool) -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open");
+        let ks = store.keyspace(vta_keyspaces::PERSONA).expect("keyspace");
+        let ks = if encrypted {
+            ks.with_encryption(KEY)
+        } else {
+            ks
+        };
+        (dir, PersonaStore::new(ks, KEY))
+    }
+
+    fn sample(value: &str) -> Attribute {
+        new_attribute(
+            "phone.mobile",
+            ValueType::String,
+            serde_json::json!(value),
+            Provenance::SelfAsserted,
+        )
+    }
+
+    #[tokio::test]
+    async fn value_must_agree_with_its_declared_type() {
+        let (_d, s) = fresh(false).await;
+        let mut a = sample("+61 4");
+        a.value_type = ValueType::Number;
+        let err = s.put(a, None).await.unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn versions_advance_and_never_repeat_across_records() {
+        let (_d, s) = fresh(false).await;
+        let a = s.put(sample("one"), None).await.unwrap();
+        let b = s.put(sample("two"), None).await.unwrap();
+        assert!(b.version > a.version, "counter is monotonic across records");
+        assert!(a.created && b.created);
+    }
+
+    #[tokio::test]
+    async fn create_only_is_refused_over_a_live_record_and_allowed_over_a_tombstone() {
+        let (_d, s) = fresh(false).await;
+        let mut a = sample("x");
+        s.put(a.clone(), Some(0)).await.expect("first create");
+
+        // Second create-only at the same id must fail: this is what makes lease
+        // acquisition safe.
+        let err = s.put(a.clone(), Some(0)).await.unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
+
+        // A tombstone is not a live record, so create-only succeeds over one.
+        s.delete(&a.attribute_id, false).await.expect("delete");
+        a.value = Some(serde_json::json!("y"));
+        s.put(a, Some(0)).await.expect("create over tombstone");
+    }
+
+    #[tokio::test]
+    async fn a_repeat_delete_converges_and_takes_no_new_version() {
+        let (_d, s) = fresh(false).await;
+        let a = sample("x");
+        s.put(a.clone(), None).await.unwrap();
+
+        let first = s.delete(&a.attribute_id, false).await.unwrap();
+        assert!(first.existed);
+
+        // The second finds a tombstone. If it took a version, every consumer
+        // watching the store would see a change that did not happen — and
+        // delete could not be safely retried.
+        let before = s.put(sample("probe"), None).await.unwrap().version;
+        let second = s.delete(&a.attribute_id, false).await.unwrap();
+        assert!(!second.existed);
+        let after = s.put(sample("probe2"), None).await.unwrap().version;
+        assert_eq!(after, before + 1, "the no-op delete consumed no version");
+    }
+
+    #[tokio::test]
+    async fn correlation_sees_reuse_and_forgets_it_on_delete() {
+        let (_d, s) = fresh(false).await;
+        let a = sample("+61 4xx");
+        let b = sample("+61 4xx"); // same value, different attribute
+        s.put(a.clone(), None).await.unwrap();
+        s.put(b.clone(), None).await.unwrap();
+
+        let v = serde_json::json!("+61 4xx");
+        assert_eq!(s.correlation_count(&v, &a.attribute_id).await.unwrap(), 1);
+
+        s.delete(&b.attribute_id, false).await.unwrap();
+        assert_eq!(
+            s.correlation_count(&v, &a.attribute_id).await.unwrap(),
+            0,
+            "a deleted attribute must stop counting as reuse"
+        );
+    }
+
+    #[tokio::test]
+    async fn editing_a_value_moves_its_index_entry() {
+        let (_d, s) = fresh(false).await;
+        let mut a = sample("old");
+        s.put(a.clone(), None).await.unwrap();
+
+        a.value = Some(serde_json::json!("new"));
+        s.put(a.clone(), None).await.unwrap();
+
+        // The old value must no longer count as reuse, or the guard reports a
+        // link the holder already removed.
+        assert_eq!(
+            s.correlation_count(&serde_json::json!("old"), "other")
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            s.correlation_count(&serde_json::json!("new"), "other")
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn the_value_is_encrypted_at_rest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("open");
+        let enc = store
+            .keyspace(vta_keyspaces::PERSONA)
+            .unwrap()
+            .with_encryption(KEY);
+        let s = PersonaStore::new(enc, KEY);
+
+        let a = sample("+61 4xx xxx 001");
+        s.put(a.clone(), None).await.unwrap();
+
+        // A second, PLAIN handle on the same keyspace reads the on-disk bytes.
+        let plain = store.keyspace(vta_keyspaces::PERSONA).unwrap();
+        let raw = plain
+            .get_raw(storage::attribute_key(&a.attribute_id))
+            .await
+            .unwrap()
+            .expect("row present");
+        let as_text = String::from_utf8_lossy(&raw);
+        assert!(
+            !as_text.contains("+61 4xx xxx 001"),
+            "the value must not be readable without the at-rest key"
+        );
+    }
+}

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -456,7 +456,6 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_POLICY_GET_0_1, ReadOnly),
     (trust_tasks::TASK_POLICY_UPSERT_0_2, RetrySafe),
     (trust_tasks::TASK_POLICY_DELETE_0_1, RetrySafe),
-
     // ─── Persona slice ───────────────────────────────────────────────────
     //
     // Writes are `Keyed`, following the `app-state` precedent and for its
@@ -476,30 +475,102 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // SECOND RELEASE OF PERSONAL DATA to a third party and a second permanent
     // record of it — the one task in this family where a lost reply must never
     // be retried blind.
-    (trust_tasks::TASK_PERSONA_ATTRIBUTE_PUT_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_ATTRIBUTE_DELETE_1_0, RetrySafety::RetrySafe),
-    (trust_tasks::TASK_PERSONA_PROFILE_PUT_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_PROFILE_GET_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_PROFILE_LIST_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0, RetrySafety::RetrySafe),
-    (trust_tasks::TASK_PERSONA_BINDING_SET_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_BINDING_GET_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_BINDING_LIST_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_CONTACT_PUT_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_CONTACT_GET_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_CONTACT_LIST_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_CONTACT_DELETE_1_0, RetrySafety::RetrySafe),
-    (trust_tasks::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_DISCLOSURE_PRESENT_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_DISCLOSURE_HISTORY_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_CORRELATION_ANALYZE_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0, RetrySafety::Keyed),
-    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_GET_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0, RetrySafety::ReadOnly),
-    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0, RetrySafety::RetrySafe),
-    (trust_tasks::TASK_PERSONA_LOCAL_BINDING_SET_1_0, RetrySafety::Keyed),
+    (
+        trust_tasks::TASK_PERSONA_ATTRIBUTE_PUT_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_ATTRIBUTE_DELETE_1_0,
+        RetrySafety::RetrySafe,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_PROFILE_PUT_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_PROFILE_GET_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_PROFILE_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0,
+        RetrySafety::RetrySafe,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_BINDING_SET_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_BINDING_GET_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_BINDING_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_CONTACT_PUT_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_CONTACT_GET_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_CONTACT_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_CONTACT_DELETE_1_0,
+        RetrySafety::RetrySafe,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_DISCLOSURE_PRESENT_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_DISCLOSURE_HISTORY_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_CORRELATION_ANALYZE_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
+        RetrySafety::Keyed,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_LOCAL_PROFILE_GET_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0,
+        RetrySafety::RetrySafe,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_LOCAL_BINDING_SET_1_0,
+        RetrySafety::Keyed,
+    ),
 ];
 
 /// The retry-safety class of `uri`, or `None` if it is not a task this VTA

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -456,6 +456,50 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_POLICY_GET_0_1, ReadOnly),
     (trust_tasks::TASK_POLICY_UPSERT_0_2, RetrySafe),
     (trust_tasks::TASK_POLICY_DELETE_0_1, RetrySafe),
+
+    // ─── Persona slice ───────────────────────────────────────────────────
+    //
+    // Writes are `Keyed`, following the `app-state` precedent and for its
+    // stated reason: without a precondition a replay writes twice and bumps
+    // the counter twice, so a watcher sees a change that never happened. The
+    // `expectedVersion` path simply benefits twice.
+    //
+    // Deletes are `RetrySafe` because they converge — a repeat finds a
+    // tombstone, returns `existed: false`, and deliberately takes no new
+    // counter value. Had it taken one, delete would have had to be `Keyed`
+    // like the writes.
+    //
+    // Two entries are worth reading twice. `disclosure/preview` looks like a
+    // read and is `Keyed`: it mints a single-use token that `present`
+    // consumes, so a replayed preview hands out a second authorisation to
+    // disclose. And `disclosure/present` is `Keyed` because a replay is a
+    // SECOND RELEASE OF PERSONAL DATA to a third party and a second permanent
+    // record of it — the one task in this family where a lost reply must never
+    // be retried blind.
+    (trust_tasks::TASK_PERSONA_ATTRIBUTE_PUT_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_ATTRIBUTE_DELETE_1_0, RetrySafety::RetrySafe),
+    (trust_tasks::TASK_PERSONA_PROFILE_PUT_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_PROFILE_GET_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_PROFILE_LIST_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0, RetrySafety::RetrySafe),
+    (trust_tasks::TASK_PERSONA_BINDING_SET_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_BINDING_GET_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_BINDING_LIST_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_CONTACT_PUT_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_CONTACT_GET_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_CONTACT_LIST_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_CONTACT_DELETE_1_0, RetrySafety::RetrySafe),
+    (trust_tasks::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_DISCLOSURE_PRESENT_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_DISCLOSURE_HISTORY_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_CORRELATION_ANALYZE_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0, RetrySafety::Keyed),
+    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_GET_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0, RetrySafety::ReadOnly),
+    (trust_tasks::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0, RetrySafety::RetrySafe),
+    (trust_tasks::TASK_PERSONA_LOCAL_BINDING_SET_1_0, RetrySafety::Keyed),
 ];
 
 /// The retry-safety class of `uri`, or `None` if it is not a task this VTA

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -812,6 +812,110 @@ pub const TASK_ROOMS_KEYS_COMMIT_0_1: &str = "https://trusttasks.org/spec/rooms/
 /// [`crate::protocols::memory::MemoryDeleteBody`].
 pub const TASK_VTA_MEMORY_DELETE_0_1: &str = "https://trusttasks.org/spec/vta/memory/delete/0.1";
 
+// ─── Persona slice (spec/persona/*) ──────────────────────────────────────
+//
+// The holder's own identity: the attribute pool, the profiles that project
+// over it, the bindings that assign a profile to a persona DID, and the
+// contacts peers disclose. Eleven of these are **holder-only** and unreachable
+// from inside a context — see `vta-service`'s `trust_tasks::persona` for the
+// classification and the census test that pins it.
+
+/// `spec/persona/attribute/put/1.0`
+pub const TASK_PERSONA_ATTRIBUTE_PUT_1_0: &str =
+    "https://trusttasks.org/spec/persona/attribute/put/1.0";
+
+/// `spec/persona/attribute/list/1.0`
+pub const TASK_PERSONA_ATTRIBUTE_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/attribute/list/1.0";
+
+/// `spec/persona/attribute/delete/1.0`
+pub const TASK_PERSONA_ATTRIBUTE_DELETE_1_0: &str =
+    "https://trusttasks.org/spec/persona/attribute/delete/1.0";
+
+/// `spec/persona/profile/put/1.0`
+pub const TASK_PERSONA_PROFILE_PUT_1_0: &str =
+    "https://trusttasks.org/spec/persona/profile/put/1.0";
+
+/// `spec/persona/profile/get/1.0`
+pub const TASK_PERSONA_PROFILE_GET_1_0: &str =
+    "https://trusttasks.org/spec/persona/profile/get/1.0";
+
+/// `spec/persona/profile/list/1.0`
+pub const TASK_PERSONA_PROFILE_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/profile/list/1.0";
+
+/// `spec/persona/profile/delete/1.0`
+pub const TASK_PERSONA_PROFILE_DELETE_1_0: &str =
+    "https://trusttasks.org/spec/persona/profile/delete/1.0";
+
+/// `spec/persona/binding/set/1.0`
+pub const TASK_PERSONA_BINDING_SET_1_0: &str =
+    "https://trusttasks.org/spec/persona/binding/set/1.0";
+
+/// `spec/persona/binding/get/1.0`
+pub const TASK_PERSONA_BINDING_GET_1_0: &str =
+    "https://trusttasks.org/spec/persona/binding/get/1.0";
+
+/// `spec/persona/binding/list/1.0`
+pub const TASK_PERSONA_BINDING_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/binding/list/1.0";
+
+/// `spec/persona/contact/put/1.0`
+pub const TASK_PERSONA_CONTACT_PUT_1_0: &str =
+    "https://trusttasks.org/spec/persona/contact/put/1.0";
+
+/// `spec/persona/contact/get/1.0`
+pub const TASK_PERSONA_CONTACT_GET_1_0: &str =
+    "https://trusttasks.org/spec/persona/contact/get/1.0";
+
+/// `spec/persona/contact/list/1.0`
+pub const TASK_PERSONA_CONTACT_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/contact/list/1.0";
+
+/// `spec/persona/contact/delete/1.0`
+pub const TASK_PERSONA_CONTACT_DELETE_1_0: &str =
+    "https://trusttasks.org/spec/persona/contact/delete/1.0";
+
+/// `spec/persona/disclosure/preview/1.0`
+pub const TASK_PERSONA_DISCLOSURE_PREVIEW_1_0: &str =
+    "https://trusttasks.org/spec/persona/disclosure/preview/1.0";
+
+/// `spec/persona/disclosure/present/1.0`
+pub const TASK_PERSONA_DISCLOSURE_PRESENT_1_0: &str =
+    "https://trusttasks.org/spec/persona/disclosure/present/1.0";
+
+/// `spec/persona/disclosure/history/1.0`
+pub const TASK_PERSONA_DISCLOSURE_HISTORY_1_0: &str =
+    "https://trusttasks.org/spec/persona/disclosure/history/1.0";
+
+/// `spec/persona/correlation/analyze/1.0`
+pub const TASK_PERSONA_CORRELATION_ANALYZE_1_0: &str =
+    "https://trusttasks.org/spec/persona/correlation/analyze/1.0";
+
+/// `spec/persona/renderers/list/1.0`
+pub const TASK_PERSONA_RENDERERS_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/renderers/list/1.0";
+
+/// `spec/persona/local/profile/put/1.0`
+pub const TASK_PERSONA_LOCAL_PROFILE_PUT_1_0: &str =
+    "https://trusttasks.org/spec/persona/local/profile/put/1.0";
+
+/// `spec/persona/local/profile/get/1.0`
+pub const TASK_PERSONA_LOCAL_PROFILE_GET_1_0: &str =
+    "https://trusttasks.org/spec/persona/local/profile/get/1.0";
+
+/// `spec/persona/local/profile/list/1.0`
+pub const TASK_PERSONA_LOCAL_PROFILE_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/local/profile/list/1.0";
+
+/// `spec/persona/local/profile/delete/1.0`
+pub const TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0: &str =
+    "https://trusttasks.org/spec/persona/local/profile/delete/1.0";
+
+/// `spec/persona/local/binding/set/1.0`
+pub const TASK_PERSONA_LOCAL_BINDING_SET_1_0: &str =
+    "https://trusttasks.org/spec/persona/local/binding/set/1.0";
+
 // ─── Application-state slice (spec/vta/app-state/*) ──────────────────────
 //
 // The third store, beside the vault (secrets + credentials) and agent memory:
@@ -1767,6 +1871,31 @@ pub const ALL_URIS: &[&str] = &[
     TASK_VTA_APP_STATE_DELETE_1_0,
     TASK_VTA_APP_STATE_GET_MANY_1_0,
     TASK_VTA_APP_STATE_PUT_MANY_1_0,
+    // Persona slice — the holder's own identity.
+    TASK_PERSONA_ATTRIBUTE_PUT_1_0,
+    TASK_PERSONA_ATTRIBUTE_LIST_1_0,
+    TASK_PERSONA_ATTRIBUTE_DELETE_1_0,
+    TASK_PERSONA_PROFILE_PUT_1_0,
+    TASK_PERSONA_PROFILE_GET_1_0,
+    TASK_PERSONA_PROFILE_LIST_1_0,
+    TASK_PERSONA_PROFILE_DELETE_1_0,
+    TASK_PERSONA_BINDING_SET_1_0,
+    TASK_PERSONA_BINDING_GET_1_0,
+    TASK_PERSONA_BINDING_LIST_1_0,
+    TASK_PERSONA_CONTACT_PUT_1_0,
+    TASK_PERSONA_CONTACT_GET_1_0,
+    TASK_PERSONA_CONTACT_LIST_1_0,
+    TASK_PERSONA_CONTACT_DELETE_1_0,
+    TASK_PERSONA_DISCLOSURE_PREVIEW_1_0,
+    TASK_PERSONA_DISCLOSURE_PRESENT_1_0,
+    TASK_PERSONA_DISCLOSURE_HISTORY_1_0,
+    TASK_PERSONA_CORRELATION_ANALYZE_1_0,
+    TASK_PERSONA_RENDERERS_LIST_1_0,
+    TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
+    TASK_PERSONA_LOCAL_PROFILE_GET_1_0,
+    TASK_PERSONA_LOCAL_PROFILE_LIST_1_0,
+    TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0,
+    TASK_PERSONA_LOCAL_BINDING_SET_1_0,
     // Policy slice (spec/policy/*)
     TASK_POLICY_LIST_0_2,
     TASK_POLICY_GET_0_1,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -2059,6 +2059,15 @@ mod tests {
             // for their agent. That is squarely an agent's job, and it is why
             // this prefix appears here for exactly one URI.
             "https://trusttasks.org/spec/rooms/",
+            // Canonical personas — `persona/*`, authored upstream in
+            // dtgwg-trust-tasks-tf#360. Top-level rather than VTA-private
+            // because the family describes a *holder's* self-presentation:
+            // which of their own attributes a profile projects, which persona
+            // DID a context sees, and what was disclosed to whom. None of that
+            // is specific to an agent's domain — a wallet with no VTA in it
+            // answers the same questions — so the family sits beside `vault/`
+            // and `keys/` rather than under a maintainer's namespace.
+            "https://trusttasks.org/spec/persona/",
         ];
         for uri in ALL_URIS {
             assert!(

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -160,6 +160,7 @@ vta-keys = { path = "../vta-keys", version = "0.4" }
 # Holder credential vault (storage/query/receive/present/status), extracted to
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
+vta-persona = { path = "../vta-persona", version = "0.1" }
 vta-vault = { path = "../vta-vault", version = "0.5" }
 
 # The room presentation oracle attenuates a member VAC and signs it.

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -193,6 +193,16 @@ pub struct AppState {
     /// `appc:` per-namespace write counter alongside; gated on context access.
     /// Durable user data an account's recoverability depends on.
     pub app_state_ks: KeyspaceHandle,
+    /// The holder's persona store. Encrypted at rest like the vault: these are
+    /// the person's own identity attributes, not application data.
+    pub persona_ks: KeyspaceHandle,
+    /// Per-agent key for the persona correlation index's keyed hash.
+    ///
+    /// Derived beside the at-rest key and never leaving the agent, which is
+    /// what makes the blinded index blinded: the store can answer "does this
+    /// value appear elsewhere" without holding a plaintext index of the
+    /// holder's personal data.
+    pub persona_correlation_key: [u8; 32],
     /// One lock per `(contextId, namespace)`, serialising the read-modify-write
     /// sequences the application-state store needs and that the store layer
     /// cannot make atomic on its own (it serialises individual operations, not
@@ -442,6 +452,16 @@ pub async fn build_app_state(
     let room_groups_ks = apply_encryption(store.keyspace(crate::keyspaces::ROOM_GROUPS)?);
     let room_invitations_ks = apply_encryption(store.keyspace(crate::keyspaces::ROOM_INVITATIONS)?);
     let app_state_ks = apply_encryption(store.keyspace(crate::keyspaces::APP_STATE)?);
+    let persona_ks = apply_encryption(store.keyspace(crate::keyspaces::PERSONA)?);
+    // Domain-separated from the at-rest key so that compromise of one does not
+    // hand over the other.
+    let persona_correlation_key: [u8; 32] = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(b"vta-persona/correlation-index/v1");
+        h.update(storage_encryption_key.unwrap_or([0u8; 32]));
+        h.finalize().into()
+    };
     let policy_ks = apply_encryption(store.keyspace(crate::keyspaces::POLICY)?);
     let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
     #[cfg(feature = "webvh")]
@@ -523,6 +543,8 @@ pub async fn build_app_state(
         room_groups_ks,
         room_invitations_ks,
         app_state_ks,
+        persona_ks,
+        persona_correlation_key,
         app_state_locks: crate::operations::app_state::NamespaceLocks::default(),
         policy_ks,
         task_consent_ks,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1195,6 +1195,10 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         room_groups_ks: store.keyspace(crate::keyspaces::ROOM_GROUPS).unwrap(),
         room_invitations_ks: store.keyspace(crate::keyspaces::ROOM_INVITATIONS).unwrap(),
         app_state_ks: store.keyspace(crate::keyspaces::APP_STATE).unwrap(),
+        persona_ks: store.keyspace(crate::keyspaces::PERSONA).unwrap(),
+        // A fixed test key: the fixture is not encrypted at rest, and the
+        // correlation index only needs a key that is stable within one run.
+        persona_correlation_key: [0u8; 32],
         app_state_locks: crate::operations::app_state::NamespaceLocks::default(),
         policy_ks: policy_ks.clone(),
         task_consent_ks: store.keyspace(crate::keyspaces::TASK_CONSENT).unwrap(),

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -255,7 +255,6 @@ enum Conformance {
     /// Known non-conformance, kept visible and counted instead of silently
     /// tolerated. Every entry is a follow-up issue; the reason must name the
     /// drift precisely enough that the fix needs no re-diagnosis.
-    #[allow(dead_code)] // empty today — the variant is the mechanism for future debt
     KnownDrift(&'static str),
 }
 
@@ -2538,6 +2537,46 @@ fn table() -> Vec<(&'static str, Conformance)> {
         ));
     }
 
+    // `persona/attribute/list` is deliberately NOT witnessed against 0.17.9.
+    //
+    // Its default response — the one `includeValues: false` produces, which is
+    // the common case and the non-disclosing one — cannot round-trip, because
+    // the published `Attribute` schema requires `value` while its own
+    // description says the member is absent for a metadata-only view. The
+    // witness found the contradiction; the fix is
+    // trustoverip/dtgwg-trust-tasks-tf#367, merged and awaiting a release.
+    //
+    // Recorded as drift rather than papered over: adding `value` to the fixture
+    // would encode the defect and pass, and the next reader would have no way
+    // to know the default listing had never been exercised. When
+    // trust-tasks-rs 0.18 lands, delete this entry and the witness in
+    // `persona_witnesses()` becomes checkable as written.
+    t.push((
+        vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0,
+        Conformance::KnownDrift(
+            "Attribute.value is REQUIRED in trust-tasks-rs 0.17.9 while its description says the \
+             member is absent for a metadata-only view, so the default (non-disclosing) listing \
+             response is unrepresentable. Fixed upstream in dtgwg-trust-tasks-tf#367 (merged, \
+             awaiting release); un-drift on the 0.18 bump.",
+        ),
+    ));
+
+    for (uri, req, resp) in persona_witnesses() {
+        if uri == vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0 {
+            continue;
+        }
+        t.push((
+            uri,
+            Conformance::Checked(Witness {
+                request: req.0,
+                parse_request: req.1,
+                validate_request: req.2,
+                response: resp.0,
+                parse_response: resp.1,
+            }),
+        ));
+    }
+
     for (uri, req, resp) in webvh_and_context_witnesses() {
         t.push((
             uri,
@@ -2572,6 +2611,440 @@ type RespParts = (Value, ParseFn);
 /// `initiate-*` responses, read in opposite directions. Its `transportToken` is
 /// a bearer credential for the byte endpoint, so both fixtures use a value that
 /// cannot be mistaken for a real one.
+/// Witnesses for the `persona/*` family — the holder's own identity.
+///
+/// Written as raw JSON rather than through producer types, for the reason the
+/// backup witnesses record: a producer type that is wrong encodes its own defect
+/// into the witness and passes. The schema is the authority.
+///
+/// The values are deliberately inert. This store exists to hold personal data,
+/// so a fixture here is the last place a specimen phone number or address
+/// belongs — anything an implementer might copy is shaped to be obviously
+/// fictional.
+fn persona_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
+    use vta_sdk::trust_tasks as u;
+
+    // Crockford base32, 26 characters. Fixed rather than generated so a failing
+    // witness is reproducible.
+    const ATTR: &str = "01J8ZKAAAAAAAAAAAAAAAAAAAA";
+    const PROFILE: &str = "01J8ZP1BBBBBBBBBBBBBBBBBBB";
+    const CONTACT: &str = "01J8ZC7CCCCCCCCCCCCCCCCCCC";
+    const PREVIEW: &str = "01J8ZV9DDDDDDDDDDDDDDDDDDD";
+    const DISCLOSURE: &str = "01J8ZD3EEEEEEEEEEEEEEEEEEE";
+    const CTX: &str = "ctx-fixture";
+    const PERSONA_DID: &str = "did:webvh:vta.test:persona-fixture";
+    const VERIFIER: &str = "did:web:verifier.test";
+    const SUBJECT: &str = "did:peer:0zfixturepairwisesubject";
+    const NOW: &str = "2026-01-01T00:00:00Z";
+
+    let self_asserted = json!({ "kind": "selfAsserted" });
+
+    vec![
+        (
+            u::TASK_PERSONA_ATTRIBUTE_PUT_1_0,
+            (
+                json!({
+                    "type": "name.display",
+                    "valueType": "string",
+                    "value": "Fixture Name",
+                    "provenance": self_asserted,
+                }),
+                parses::<specs::persona::attribute::put::v1_0::Payload>,
+                validates::<specs::persona::attribute::put::v1_0::Payload>,
+            ),
+            (
+                json!({
+                    "attributeId": ATTR, "version": 1, "created": true, "updatedAt": NOW,
+                    // A count, never identifiers: returning them on a write
+                    // would disclose the holder's other compositions to
+                    // whatever tool made it.
+                    "correlation": { "severity": "none", "sharedWithProfileCount": 0 }
+                }),
+                parses::<specs::persona::attribute::put::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_ATTRIBUTE_LIST_1_0,
+            (
+                json!({ "typePrefix": "name" }),
+                parses::<specs::persona::attribute::list::v1_0::Payload>,
+                validates::<specs::persona::attribute::list::v1_0::Payload>,
+            ),
+            (
+                // No `value`: the default withholds it, and the witness shows
+                // the default rather than the disclosing path.
+                json!({ "attributes": [{
+                    "attributeId": ATTR, "type": "name.display", "valueType": "string",
+                    "provenance": self_asserted, "version": 1, "updatedAt": NOW
+                }]}),
+                parses::<specs::persona::attribute::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_ATTRIBUTE_DELETE_1_0,
+            (
+                json!({ "attributeId": ATTR }),
+                parses::<specs::persona::attribute::delete::v1_0::Payload>,
+                validates::<specs::persona::attribute::delete::v1_0::Payload>,
+            ),
+            (
+                json!({ "attributeId": ATTR, "existed": true }),
+                parses::<specs::persona::attribute::delete::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_PROFILE_PUT_1_0,
+            (
+                // One entry of each referencing form the pool supports, so the
+                // witness exercises the untagged discrimination that was once
+                // silently degrading overrides into plain references.
+                json!({
+                    "name": "Work",
+                    "entries": [
+                        { "ref": ATTR },
+                        { "ref": ATTR, "pinVersion": 1 },
+                        { "ref": ATTR, "override": { "value": "Fixture Override" } }
+                    ]
+                }),
+                parses::<specs::persona::profile::put::v1_0::Payload>,
+                validates::<specs::persona::profile::put::v1_0::Payload>,
+            ),
+            (
+                json!({ "profileId": PROFILE, "version": 2, "created": true, "updatedAt": NOW }),
+                parses::<specs::persona::profile::put::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_PROFILE_GET_1_0,
+            (
+                json!({ "profileId": PROFILE }),
+                parses::<specs::persona::profile::get::v1_0::Payload>,
+                validates::<specs::persona::profile::get::v1_0::Payload>,
+            ),
+            (
+                json!({ "profile": {
+                    "profileId": PROFILE, "name": "Work",
+                    "entries": [{ "ref": ATTR }], "version": 2, "updatedAt": NOW
+                }}),
+                parses::<specs::persona::profile::get::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_PROFILE_LIST_1_0,
+            (
+                json!({}),
+                parses::<specs::persona::profile::list::v1_0::Payload>,
+                validates::<specs::persona::profile::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "profiles": [{
+                    "profileId": PROFILE, "name": "Work", "entries": [], "version": 2, "updatedAt": NOW
+                }]}),
+                parses::<specs::persona::profile::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_PROFILE_DELETE_1_0,
+            (
+                json!({ "profileId": PROFILE }),
+                parses::<specs::persona::profile::delete::v1_0::Payload>,
+                validates::<specs::persona::profile::delete::v1_0::Payload>,
+            ),
+            (
+                json!({ "profileId": PROFILE, "existed": true }),
+                parses::<specs::persona::profile::delete::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_BINDING_SET_1_0,
+            (
+                json!({ "contextId": CTX, "personaDid": PERSONA_DID, "profileId": PROFILE }),
+                parses::<specs::persona::binding::set::v1_0::Payload>,
+                validates::<specs::persona::binding::set::v1_0::Payload>,
+            ),
+            (
+                json!({
+                    "contextId": CTX, "personaDid": PERSONA_DID, "profileId": PROFILE,
+                    "version": 3, "materialisedClaimCount": 1, "boundAt": NOW,
+                    "correlation": { "severity": "none", "alsoBoundPersonaCount": 0 }
+                }),
+                parses::<specs::persona::binding::set::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_BINDING_GET_1_0,
+            (
+                json!({ "contextId": CTX, "personaDid": PERSONA_DID }),
+                parses::<specs::persona::binding::get::v1_0::Payload>,
+                validates::<specs::persona::binding::get::v1_0::Payload>,
+            ),
+            (
+                // Thin by construction: bound, a label, a count. There is
+                // nowhere in this shape to put a claim value.
+                json!({
+                    "contextId": CTX, "personaDid": PERSONA_DID, "bound": true,
+                    "profileId": PROFILE, "profileName": "Work", "claimCount": 1, "boundAt": NOW
+                }),
+                parses::<specs::persona::binding::get::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_BINDING_LIST_1_0,
+            (
+                json!({ "contextId": CTX }),
+                parses::<specs::persona::binding::list::v1_0::Payload>,
+                validates::<specs::persona::binding::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "personas": [{
+                    "personaDid": PERSONA_DID, "bound": true, "profileName": "Work", "claimCount": 1
+                }]}),
+                parses::<specs::persona::binding::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_CONTACT_PUT_1_0,
+            (
+                json!({
+                    "contextId": CTX,
+                    "subjectDid": "did:peer:0zfixturecounterparty",
+                    "knownByPersona": PERSONA_DID,
+                    "document": { "claims": [
+                        { "type": "name.display", "valueType": "string", "value": "Fixture Peer" }
+                    ]}
+                }),
+                parses::<specs::persona::contact::put::v1_0::Payload>,
+                validates::<specs::persona::contact::put::v1_0::Payload>,
+            ),
+            (
+                // Claim TYPES, not values. A producer needing the old value
+                // reads the prior revision, which is an explicit act.
+                json!({ "contactId": CONTACT, "rev": 2, "created": false,
+                        "changedClaims": ["name.display"] }),
+                parses::<specs::persona::contact::put::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_CONTACT_GET_1_0,
+            (
+                json!({ "contextId": CTX, "contactId": CONTACT }),
+                parses::<specs::persona::contact::get::v1_0::Payload>,
+                validates::<specs::persona::contact::get::v1_0::Payload>,
+            ),
+            (
+                json!({
+                    "contactId": CONTACT, "subjectDid": "did:peer:0zfixturecounterparty",
+                    "knownByPersona": PERSONA_DID, "rev": 2,
+                    "document": { "claims": [
+                        { "type": "name.display", "valueType": "string", "value": "Fixture Peer" }
+                    ]}
+                }),
+                parses::<specs::persona::contact::get::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_CONTACT_LIST_1_0,
+            (
+                json!({ "contextId": CTX }),
+                parses::<specs::persona::contact::list::v1_0::Payload>,
+                validates::<specs::persona::contact::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "contacts": [{
+                    "contactId": CONTACT, "subjectDid": "did:peer:0zfixturecounterparty",
+                    "knownByPersona": PERSONA_DID, "rev": 2, "receivedAt": NOW,
+                    "claimCount": 1, "hasUnreviewedChange": true
+                }]}),
+                parses::<specs::persona::contact::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_CONTACT_DELETE_1_0,
+            (
+                json!({ "contextId": CTX, "contactId": CONTACT }),
+                parses::<specs::persona::contact::delete::v1_0::Payload>,
+                validates::<specs::persona::contact::delete::v1_0::Payload>,
+            ),
+            (
+                // Reports what it KEPT. An incomplete erasure the holder
+                // believes is complete is worse than one they know about.
+                json!({ "contactId": CONTACT, "existed": true,
+                        "revisionsRemoved": 1, "retainedForDisclosure": 1 }),
+                parses::<specs::persona::contact::delete::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0,
+            (
+                json!({ "contextId": CTX, "personaDid": PERSONA_DID, "verifierDid": VERIFIER,
+                        "purpose": "age check at entry" }),
+                parses::<specs::persona::disclosure::preview::v1_0::Payload>,
+                validates::<specs::persona::disclosure::preview::v1_0::Payload>,
+            ),
+            (
+                json!({
+                    "previewId": PREVIEW,
+                    // Pairwise, not the persona DID: the account is not the face.
+                    "subject": SUBJECT,
+                    "claims": [
+                        { "type": "name.display", "value": "Fixture Name",
+                          "provenance": "selfAsserted", "rung": "whole",
+                          "newToThisVerifier": true },
+                        // A predicate claim carries NO value. That absence is
+                        // the point, and the witness shows it.
+                        { "type": "person.birthDate",
+                          "predicate": { "op": "gte", "arg": 18 },
+                          "provenance": "credentialBacked", "rung": "predicate",
+                          "newToThisVerifier": true }
+                    ],
+                    "renderer": { "id": "rcard", "drops": [] },
+                    "correlation": { "severity": "low" },
+                    "expiresAt": "2026-01-01T00:05:00Z"
+                }),
+                parses::<specs::persona::disclosure::preview::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_DISCLOSURE_PRESENT_1_0,
+            (
+                json!({ "contextId": CTX, "previewId": PREVIEW, "challenge": "fixture-nonce" }),
+                parses::<specs::persona::disclosure::present::v1_0::Payload>,
+                validates::<specs::persona::disclosure::present::v1_0::Payload>,
+            ),
+            (
+                json!({ "disclosureId": DISCLOSURE, "artifact": "{\"unsigned\":true}",
+                        "subject": SUBJECT, "disclosedAt": NOW }),
+                parses::<specs::persona::disclosure::present::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_DISCLOSURE_HISTORY_1_0,
+            (
+                // The question the agent-scoped pool owes the holder: where has
+                // this fact reached.
+                json!({ "attributeType": "address.postal" }),
+                parses::<specs::persona::disclosure::history::v1_0::Payload>,
+                validates::<specs::persona::disclosure::history::v1_0::Payload>,
+            ),
+            (
+                json!({ "disclosures": [{
+                    "disclosureId": DISCLOSURE, "contextId": CTX, "verifierDid": VERIFIER,
+                    "personaDid": PERSONA_DID, "claimTypes": ["address.postal"],
+                    "rungs": ["whole"], "disclosedAt": NOW
+                }]}),
+                parses::<specs::persona::disclosure::history::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_CORRELATION_ANALYZE_1_0,
+            (
+                // A candidate the holder is CONSIDERING — the difference
+                // between a guard and a report.
+                json!({ "candidate": {
+                    "type": "phone.mobile", "valueType": "string", "value": "+00 0000 0000"
+                }}),
+                parses::<specs::persona::correlation::analyze::v1_0::Payload>,
+                validates::<specs::persona::correlation::analyze::v1_0::Payload>,
+            ),
+            (
+                json!({ "findings": [{
+                    "attributeId": ATTR, "severity": "high",
+                    "why": "this value is already presented by another profile",
+                    "remedies": ["useDifferentValue", "reissueCredentialToThisDid",
+                                 "correlateDeliberately", "proceedAndRecord"]
+                }]}),
+                parses::<specs::persona::correlation::analyze::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_RENDERERS_LIST_1_0,
+            (
+                json!({}),
+                parses::<specs::persona::renderers::list::v1_0::Payload>,
+                validates::<specs::persona::renderers::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "renderers": [
+                    { "id": "rcard", "drops": [], "canCarryPredicates": true, "canonical": true },
+                    // Declares what it discards, so a preview can say so before
+                    // the holder decides.
+                    { "id": "jcard", "drops": ["provenance"], "canCarryPredicates": false }
+                ]}),
+                parses::<specs::persona::renderers::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
+            (
+                // Inline only. A reference is unrepresentable here rather than
+                // rejected, which is what keeps the local surface pool-free.
+                json!({ "contextId": CTX, "name": "Throwaway", "entries": [
+                    { "inline": { "type": "x:handle", "valueType": "string", "value": "fixture" } }
+                ]}),
+                parses::<specs::persona::local::profile::put::v1_0::Payload>,
+                validates::<specs::persona::local::profile::put::v1_0::Payload>,
+            ),
+            (
+                json!({ "profileId": PROFILE, "version": 4, "created": true }),
+                parses::<specs::persona::local::profile::put::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_LOCAL_PROFILE_GET_1_0,
+            (
+                json!({ "contextId": CTX, "profileId": PROFILE }),
+                parses::<specs::persona::local::profile::get::v1_0::Payload>,
+                validates::<specs::persona::local::profile::get::v1_0::Payload>,
+            ),
+            (
+                json!({ "profile": {
+                    "profileId": PROFILE, "name": "Throwaway", "entries": [], "version": 4
+                }}),
+                parses::<specs::persona::local::profile::get::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0,
+            (
+                json!({ "contextId": CTX }),
+                parses::<specs::persona::local::profile::list::v1_0::Payload>,
+                validates::<specs::persona::local::profile::list::v1_0::Payload>,
+            ),
+            (
+                json!({ "profiles": [{
+                    "profileId": PROFILE, "name": "Throwaway", "entryCount": 1, "bound": false
+                }]}),
+                parses::<specs::persona::local::profile::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0,
+            (
+                json!({ "contextId": CTX, "profileId": PROFILE }),
+                parses::<specs::persona::local::profile::delete::v1_0::Payload>,
+                validates::<specs::persona::local::profile::delete::v1_0::Payload>,
+            ),
+            (
+                json!({ "profileId": PROFILE, "existed": true }),
+                parses::<specs::persona::local::profile::delete::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_LOCAL_BINDING_SET_1_0,
+            (
+                json!({ "contextId": CTX, "personaDid": PERSONA_DID, "profileId": PROFILE }),
+                parses::<specs::persona::local::binding::set::v1_0::Payload>,
+                validates::<specs::persona::local::binding::set::v1_0::Payload>,
+            ),
+            (
+                json!({ "contextId": CTX, "personaDid": PERSONA_DID,
+                        "profileId": PROFILE, "version": 5 }),
+                parses::<specs::persona::local::binding::set::v1_0::Response>,
+            ),
+        ),
+    ]
+}
+
 fn backup_and_management_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
     const BUNDLE: &str = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
     const SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1684,6 +1684,24 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_PERSONA_BINDING_LIST_1_0 => persona::handle_binding_list
         [ None Metadata false ],
+    // Contacts are a third party's disclosed data held for the holder.
+    vta_sdk::trust_tasks::TASK_PERSONA_CONTACT_PUT_1_0 => persona::handle_contact_put
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_CONTACT_GET_1_0 => persona::handle_contact_get
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_CONTACT_LIST_1_0 => persona::handle_contact_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_CONTACT_DELETE_1_0 => persona::handle_contact_delete
+        [ Destructive None false ],
+    // Holder-only: both span every context, which is the view a context-scoped
+    // caller must not have.
+    vta_sdk::trust_tasks::TASK_PERSONA_DISCLOSURE_HISTORY_1_0 => persona::handle_disclosure_history
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_CORRELATION_ANALYZE_1_0 => persona::handle_correlation_analyze
+        [ None Metadata false ],
+    // Describes the agent's capabilities, not the holder. Discloses nothing.
+    vta_sdk::trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0 => persona::handle_renderers_list
+        [ None None false ],
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_SHOW_0_1 => config::handle_get
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -46,7 +46,6 @@ use crate::server::AppState;
 
 mod acl;
 mod app_state;
-mod persona;
 mod audit;
 #[cfg(test)]
 mod audit_coverage;
@@ -77,6 +76,7 @@ mod memory;
 mod messaging;
 #[cfg(all(feature = "webvh", feature = "didcomm"))]
 mod passkey_vms;
+mod persona;
 pub(crate) mod planner;
 mod policy;
 mod policy_gate;
@@ -1653,6 +1653,19 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_VTA_APP_STATE_PUT_MANY_1_0 => app_state::handle_put_many
         [ Mutating None false ],
+    // ─── Persona slice (spec/persona/*) ──────────────────────────
+    // The holder's own identity. Eleven of the family's tasks are gated on an
+    // UNSCOPED HOLDER credential rather than context access — see
+    // `trust_tasks::persona::authorize`, where the classification lives and a
+    // census pins it. `attribute/put` is Mutating and `delete` Destructive;
+    // both reads disclose Metadata because they return the holder's own data
+    // to the holder.
+    vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_PUT_1_0 => persona::handle_attribute_put
+        [ Mutating Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0 => persona::handle_attribute_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_DELETE_1_0 => persona::handle_attribute_delete
+        [ Destructive None false ],
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_SHOW_0_1 => config::handle_get
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1702,6 +1702,18 @@ dispatch_table! {
     // Describes the agent's capabilities, not the holder. Discloses nothing.
     vta_sdk::trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0 => persona::handle_renderers_list
         [ None None false ],
+    // The context-local surface. Context-callable because authoring below the
+    // boundary is safe; the rule exists to stop reading across it.
+    vta_sdk::trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0 => persona::handle_local_profile_put
+        [ Mutating Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_LOCAL_PROFILE_GET_1_0 => persona::handle_local_profile_get
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0 => persona::handle_local_profile_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0 => persona::handle_local_profile_delete
+        [ Destructive None false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_LOCAL_BINDING_SET_1_0 => persona::handle_local_binding_set
+        [ Mutating None false ],
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_SHOW_0_1 => config::handle_get
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1666,6 +1666,24 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_DELETE_1_0 => persona::handle_attribute_delete
         [ Destructive None false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_PROFILE_PUT_1_0 => persona::handle_profile_put
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_PROFILE_GET_1_0 => persona::handle_profile_get
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_PROFILE_LIST_1_0 => persona::handle_profile_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0 => persona::handle_profile_delete
+        [ Destructive None false ],
+    // The critical gate. Holder-only, and Mutating because it materialises a
+    // projection into a context — a push across the trust boundary.
+    vta_sdk::trust_tasks::TASK_PERSONA_BINDING_SET_1_0 => persona::handle_binding_set
+        [ Mutating Metadata false ],
+    // Context-callable and deliberately thin: whether bound, the label, a
+    // claim count. Never contents.
+    vta_sdk::trust_tasks::TASK_PERSONA_BINDING_GET_1_0 => persona::handle_binding_get
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_BINDING_LIST_1_0 => persona::handle_binding_list
+        [ None Metadata false ],
     // ─── Config slice ────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_CONFIG_SHOW_0_1 => config::handle_get
         [ None Metadata false ],

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1697,6 +1697,15 @@ dispatch_table! {
     // caller must not have.
     vta_sdk::trust_tasks::TASK_PERSONA_DISCLOSURE_HISTORY_1_0 => persona::handle_disclosure_history
         [ None Metadata false ],
+    // Two calls that cannot be collapsed: present consumes a single-use token
+    // only preview can mint. preview is Mutating despite looking like a read,
+    // because that token is durable state — and it is what makes the summary
+    // unskippable.
+    vta_sdk::trust_tasks::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0 => persona::handle_disclosure_preview
+        [ Mutating Metadata false ],
+    // The only task in the family that releases personal data to a third party.
+    vta_sdk::trust_tasks::TASK_PERSONA_DISCLOSURE_PRESENT_1_0 => persona::handle_disclosure_present
+        [ Mutating Secret true ],
     vta_sdk::trust_tasks::TASK_PERSONA_CORRELATION_ANALYZE_1_0 => persona::handle_correlation_analyze
         [ None Metadata false ],
     // Describes the agent's capabilities, not the holder. Discloses nothing.

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -46,6 +46,7 @@ use crate::server::AppState;
 
 mod acl;
 mod app_state;
+mod persona;
 mod audit;
 #[cfg(test)]
 mod audit_coverage;

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -265,12 +265,14 @@ mod tests {
     #[test]
     fn an_unknown_task_is_refused_rather_than_defaulted() {
         let app = claims(Role::Application, &["ctx"]);
-        let err = authorize(
-            &app,
-            "https://trusttasks.org/spec/persona/made/up/9.9",
-            Some("ctx"),
-        )
-        .unwrap_err();
+        // Built rather than written as a literal, deliberately. `produced_census`
+        // scans this crate's source for spec-URI literals and asks who publishes
+        // each one — correctly, because a produced document with no schema has
+        // validation on neither side. This fixture never goes on a wire, so it
+        // takes the `format!` shape the census already documents as "not a URI
+        // that goes on a wire", rather than being allowlisted as produced.
+        let unknown = format!("https://trusttasks.org/spec/persona/{}/9.9", "made-up");
+        let err = authorize(&app, &unknown, Some("ctx")).unwrap_err();
         assert!(matches!(err, AppError::Forbidden(_)));
     }
 

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -1,0 +1,249 @@
+//! Persona trust-task slice (`spec/persona/*`) — authorization.
+//!
+//! The holder's own identity: the attribute pool, the profiles that project
+//! over it, the bindings that assign a profile to a persona DID, and the
+//! contacts peers disclose.
+//!
+//! # The boundary is one-way, and this module is where it is enforced
+//!
+//! The pool and profiles are **agent-scoped**, above every trust context.
+//! Bindings, contacts and disclosure records are **context-scoped**. Nothing
+//! inside a context may read the pool: the holder pushes a materialised
+//! projection down, and a context never pulls.
+//!
+//! That is a rule about *direction* rather than a permission, because the
+//! permission form invites the wrong implementation. An access-control failure
+//! over a readable pool discloses everything; a pool no context can address has
+//! nothing to disclose. `vta-persona`'s key layout provides the second half —
+//! separately addressable prefixes — and [`Reach`] below provides the first.
+//!
+//! # The trap this module exists to avoid
+//!
+//! A guard written as *"is this caller an administrator"* **passes for an
+//! administrator scoped to a single context**, who would then read and write
+//! identity data belonging to every other context. An admin in one context must
+//! be as powerless over the pool as an application in that context.
+//!
+//! The correct gate is [`AuthClaims::require_super_admin`] — `Admin` **and**
+//! unrestricted scope. `vti-common`'s own `act_scope` documentation warns about
+//! the same edge from the other side: an empty context list means *unrestricted*
+//! for `Admin` and *nothing at all* for every other role, so a call site testing
+//! `is_empty()` without the role gets one of the two backwards.
+
+use vta_sdk::trust_tasks as uris;
+use vti_common::error::AppError;
+
+use crate::auth::AuthClaims;
+
+/// Which side of the boundary a task sits on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Reach {
+    /// Reachable only by an **unscoped holder** — `Admin` with unrestricted
+    /// scope. A context-scoped caller is refused whatever its role.
+    Holder,
+    /// Reachable from inside a context, and confined to the caller's own.
+    Context,
+}
+
+/// Every task in the family, paired with the side of the boundary it sits on.
+///
+/// Exhaustive by test. A task cannot join the family without someone deciding
+/// which side it is on, because the census below fails until it appears here —
+/// and defaulting a new task to `Context` is precisely how a pool read would
+/// become reachable from inside one.
+pub const REACH: &[(&str, Reach)] = &[
+    // ── Agent-scoped: the holder's own, above every context ───────────────
+    (uris::TASK_PERSONA_ATTRIBUTE_PUT_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_ATTRIBUTE_DELETE_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_PROFILE_PUT_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_PROFILE_GET_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_PROFILE_LIST_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_PROFILE_DELETE_1_0, Reach::Holder),
+    // The critical gate. An application able to call this could bind any
+    // profile to a persona it controls and read the result back through a
+    // disclosure it requests of itself. Every other read leaks; this one is
+    // directly exploitable.
+    (uris::TASK_PERSONA_BINDING_SET_1_0, Reach::Holder),
+    // Reads across every context, so it cannot be context-callable.
+    (uris::TASK_PERSONA_DISCLOSURE_HISTORY_1_0, Reach::Holder),
+    // Returns the linkage map between the holder's identities — the artifact
+    // the whole family exists to keep from being assembled by anyone else.
+    (uris::TASK_PERSONA_CORRELATION_ANALYZE_1_0, Reach::Holder),
+    // ── Context-scoped: confined to the caller's own context ──────────────
+    // Thin by construction: whether a profile is bound, its label, a claim
+    // count. Never contents.
+    (uris::TASK_PERSONA_BINDING_GET_1_0, Reach::Context),
+    (uris::TASK_PERSONA_BINDING_LIST_1_0, Reach::Context),
+    (uris::TASK_PERSONA_CONTACT_PUT_1_0, Reach::Context),
+    (uris::TASK_PERSONA_CONTACT_GET_1_0, Reach::Context),
+    (uris::TASK_PERSONA_CONTACT_LIST_1_0, Reach::Context),
+    (uris::TASK_PERSONA_CONTACT_DELETE_1_0, Reach::Context),
+    // The only path by which claim values reach an application — after a
+    // human-visible summary. Being inside a context confers no privilege over
+    // identity data: an application is a verifier, taking the same path as a
+    // stranger's web page.
+    (uris::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0, Reach::Context),
+    (uris::TASK_PERSONA_DISCLOSURE_PRESENT_1_0, Reach::Context),
+    (uris::TASK_PERSONA_RENDERERS_LIST_1_0, Reach::Context),
+    // Authoring below the boundary is safe; the rule stops reading across it.
+    (uris::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0, Reach::Context),
+    (uris::TASK_PERSONA_LOCAL_PROFILE_GET_1_0, Reach::Context),
+    (uris::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0, Reach::Context),
+    (uris::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0, Reach::Context),
+    // Safely context-callable — unlike `binding/set` — because both objects it
+    // names live below the boundary. Its one load-bearing obligation is at the
+    // handler: a `profileId` naming a POOL profile must be refused.
+    (uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0, Reach::Context),
+];
+
+/// The reach of a task, or `None` if this build does not know the URI.
+///
+/// Returning `None` rather than defaulting is deliberate. A task nobody
+/// recognises must not be assumed safe to serve a context-scoped caller, and a
+/// default of `Context` is exactly the shape of the leak this module prevents.
+#[must_use]
+pub fn reach_of(uri: &str) -> Option<Reach> {
+    REACH.iter().find(|(u, _)| *u == uri).map(|(_, r)| *r)
+}
+
+/// Gate a persona task on the reach its URI declares.
+///
+/// `Holder` requires **unscoped holder** — `Admin` with unrestricted scope.
+/// A context-scoped admin is refused, which is the whole point.
+pub fn authorize(claims: &AuthClaims, uri: &str, context_id: Option<&str>) -> Result<(), AppError> {
+    match reach_of(uri) {
+        None => Err(AppError::Forbidden(format!(
+            "unknown persona task {uri}: refusing rather than defaulting a reach"
+        ))),
+        Some(Reach::Holder) => claims.require_super_admin().map_err(|_| {
+            AppError::Forbidden(
+                "this task reads or writes the holder's attribute pool, which sits above every \
+                 trust context. It requires an unscoped holder credential; an administrator \
+                 scoped to a context is refused here exactly as an application would be."
+                    .into(),
+            )
+        }),
+        Some(Reach::Context) => match context_id {
+            Some(ctx) => claims.require_context(ctx),
+            None => Err(AppError::Validation(
+                "a context-scoped persona task must name the context it acts in".into(),
+            )),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::acl::Role;
+
+    fn claims(role: Role, contexts: &[&str]) -> AuthClaims {
+        let mut c = AuthClaims::default();
+        c.role = role;
+        c.allowed_contexts = contexts.iter().map(|s| (*s).to_string()).collect();
+        c
+    }
+
+    /// The census. A task cannot join the family without someone deciding which
+    /// side of the boundary it is on.
+    #[test]
+    fn every_persona_task_declares_a_reach() {
+        let classified: std::collections::HashSet<&str> =
+            REACH.iter().map(|(u, _)| *u).collect();
+        let missing: Vec<&&str> = uris::ALL_URIS
+            .iter()
+            .filter(|u| u.starts_with("https://trusttasks.org/spec/persona/"))
+            .filter(|u| !classified.contains(*u))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these persona tasks declare no reach — add them to REACH. When unsure, \
+             `Holder` is the conservative answer: it refuses too much rather than \
+             disclosing the pool to a context. {missing:#?}"
+        );
+    }
+
+    #[test]
+    fn no_reach_without_a_task() {
+        let catalog: std::collections::HashSet<&str> = uris::ALL_URIS.iter().copied().collect();
+        let orphans: Vec<&&str> = REACH
+            .iter()
+            .map(|(u, _)| u)
+            .filter(|u| !catalog.contains(*u))
+            .collect();
+        assert!(orphans.is_empty(), "reach entries for tasks that do not exist: {orphans:#?}");
+    }
+
+    /// The trap, asserted directly. This is the test that would have caught a
+    /// guard written as `role == Admin`.
+    #[test]
+    fn a_context_scoped_admin_is_refused_every_holder_task() {
+        let scoped_admin = claims(Role::Admin, &["ctx-work"]);
+        for (uri, reach) in REACH {
+            if *reach != Reach::Holder {
+                continue;
+            }
+            let err = authorize(&scoped_admin, uri, Some("ctx-work")).unwrap_err();
+            assert!(
+                matches!(err, AppError::Forbidden(_)),
+                "{uri} admitted an admin scoped to one context — an admin in ctx-work must be \
+                 as powerless over the pool as an application in ctx-work"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unscoped_holder_reaches_the_pool() {
+        let holder = claims(Role::Admin, &[]);
+        for (uri, reach) in REACH {
+            if *reach == Reach::Holder {
+                authorize(&holder, uri, None).unwrap_or_else(|e| {
+                    panic!("{uri} refused an unscoped holder: {e:?}");
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn every_non_admin_role_is_refused_the_pool() {
+        // An empty context list means *unrestricted* for Admin and *nothing at
+        // all* for every other role. A gate testing emptiness without the role
+        // gets one of those backwards, so both halves are asserted.
+        for role in [Role::Application, Role::Reader, Role::Initiator, Role::Monitor] {
+            let label = format!("{role:?}");
+            let c = claims(role, &[]);
+            let err = authorize(&c, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None).unwrap_err();
+            assert!(matches!(err, AppError::Forbidden(_)), "{label} reached the pool");
+        }
+    }
+
+    #[test]
+    fn a_context_task_is_confined_to_its_own_context() {
+        let app = claims(Role::Application, &["ctx-a"]);
+        authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-a")).expect("own context");
+        assert!(
+            authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-b")).is_err(),
+            "a caller scoped to ctx-a must not learn about ctx-b"
+        );
+    }
+
+    #[test]
+    fn an_unknown_task_is_refused_rather_than_defaulted() {
+        let app = claims(Role::Application, &["ctx"]);
+        let err = authorize(&app, "https://trusttasks.org/spec/persona/made/up/9.9", Some("ctx"))
+            .unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[test]
+    fn binding_set_is_holder_only_and_local_binding_set_is_not() {
+        // The pair that most invites being collapsed. One crosses the boundary
+        // and one does not.
+        assert_eq!(reach_of(uris::TASK_PERSONA_BINDING_SET_1_0), Some(Reach::Holder));
+        assert_eq!(
+            reach_of(uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0),
+            Some(Reach::Context)
+        );
+    }
+}

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -1172,3 +1172,252 @@ pub(super) async fn handle_renderers_list(
         }),
     )
 }
+
+// ─── Context-local surface ───────────────────────────────────────────────
+//
+// Authoring BELOW the boundary is safe; the rule exists to stop reading ACROSS
+// it. These are context-callable for that reason, and the store keeps them in
+// their own address space so a scan here cannot reach a pool profile.
+
+pub(super) async fn handle_local_profile_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::local::profile::put::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    // The schema admits only inline entries, so a reference is unrepresentable
+    // rather than rejected. The store re-checks anyway: two independent guards
+    // on the property that keeps a context-authored object from acquiring pool
+    // reach.
+    let entries = match serde_json::to_value(&req.entries)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+    {
+        Some(e) => e,
+        None => {
+            return reject(
+                &doc,
+                AppError::Validation("unrecognised local entry".into()),
+            );
+        }
+    };
+
+    let mut profile = vta_persona::new_profile(req.name.to_string(), entries);
+    if let Some(id) = &req.profile_id {
+        profile.profile_id = id.to_string();
+    }
+    let profile_id = profile.profile_id.clone();
+    let s = store(state);
+
+    let written = match s
+        .put_local_profile(&ctx, profile, req.expected_version.map(|v| *v as u64))
+        .await
+    {
+        Ok(w) => w,
+        Err(e) => return reject(&doc, e),
+    };
+
+    // Local profiles ARE correlation-indexed. The naive implementation skips
+    // them — "they are local, they do not matter" — and loses the guard exactly
+    // where a human most needs it: a throwaway identity is precisely where
+    // somebody reuses a real value.
+    let matches_pool = match s.get_local_profile(&ctx, &profile_id).await {
+        Ok(Some(p)) => {
+            let mut found = false;
+            for entry in &p.entries {
+                if let vta_persona::ProfileEntry::Inline { inline } = entry
+                    && s.correlation_count(&inline.value, "").await.unwrap_or(0) > 0
+                {
+                    found = true;
+                    break;
+                }
+            }
+            found
+        }
+        _ => false,
+    };
+
+    audit_persona(
+        state,
+        "persona.local.profile.put",
+        auth,
+        Some(&profile_id),
+        Some(&ctx),
+    )
+    .await;
+    success_response(
+        &doc,
+        json!({
+            "profileId": profile_id,
+            "version": written.version,
+            "created": written.created,
+            "correlation": {
+                "severity": if matches_pool { "high" } else { "none" },
+                "matchesPoolValue": matches_pool,
+            }
+        }),
+    )
+}
+
+pub(super) async fn handle_local_profile_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::local::profile::get::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_PROFILE_GET_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+    let id = req.profile_id.to_string();
+    // Resolves nothing against the pool, because a local profile references
+    // nothing there.
+    match store(state).get_local_profile(&ctx, &id).await {
+        Ok(Some(p)) => {
+            audit_persona(
+                state,
+                "persona.local.profile.get",
+                auth,
+                Some(&id),
+                Some(&ctx),
+            )
+            .await;
+            success_response(&doc, json!({ "profile": p }))
+        }
+        Ok(None) => reject(&doc, AppError::NotFound(format!("local profile {id}"))),
+        Err(e) => reject(&doc, e),
+    }
+}
+
+pub(super) async fn handle_local_profile_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::local::profile::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+    let profiles = match store(state).list_local_profiles(&ctx).await {
+        Ok(p) => p,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(state, "persona.local.profile.list", auth, None, Some(&ctx)).await;
+    success_response(
+        &doc,
+        json!({
+            "profiles": profiles.iter().map(|p| json!({
+                "profileId": p.profile_id,
+                "name": p.name,
+                "entryCount": p.entries.len(),
+            })).collect::<Vec<_>>()
+        }),
+    )
+}
+
+pub(super) async fn handle_local_profile_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::local::profile::delete::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(
+        auth,
+        uris::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0,
+        Some(&ctx),
+    ) {
+        return reject(&doc, e);
+    }
+    let id = req.profile_id.to_string();
+    let s = store(state);
+
+    if req.unbind {
+        // Leaves those personas presenting nothing, which is legal and which the
+        // holder is told about rather than discovering from the other side.
+        if let Err(e) = s.set_local_binding(&ctx, "", None).await {
+            tracing::debug!(error = %e, "no local binding to clear");
+        }
+    }
+
+    let existed = match s.delete_local_profile(&ctx, &id).await {
+        Ok(e) => e,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(
+        state,
+        "persona.local.profile.delete",
+        auth,
+        Some(&id),
+        Some(&ctx),
+    )
+    .await;
+    success_response(&doc, json!({ "profileId": id, "existed": existed }))
+}
+
+pub(super) async fn handle_local_binding_set(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::local::binding::set::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    // Safely context-callable — unlike binding/set — because both objects it
+    // names live below the boundary.
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let persona = req.persona_did.to_string();
+    let profile_id = req.profile_id.as_ref().map(|p| p.to_string());
+
+    // The store refuses an identifier naming a POOL profile. That refusal is
+    // the whole distinction from binding/set, and it lives in one place so this
+    // handler cannot forget it.
+    let version = match store(state)
+        .set_local_binding(&ctx, &persona, profile_id.as_deref())
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(
+        state,
+        "persona.local.binding.set",
+        auth,
+        Some(&persona),
+        Some(&ctx),
+    )
+    .await;
+    success_response(
+        &doc,
+        json!({
+            "contextId": ctx,
+            "personaDid": persona,
+            "profileId": profile_id,
+            "version": version,
+        }),
+    )
+}

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -1128,7 +1128,10 @@ pub(super) async fn handle_correlation_analyze(
 }
 
 pub(super) async fn handle_renderers_list(
-    state: &AppState,
+    // Unused: this task describes the agent's declared capabilities, which are
+    // a compile-time constant, not stored state. Taking the parameter anyway
+    // keeps every handler one shape for the dispatch table.
+    _state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
@@ -1146,29 +1149,17 @@ pub(super) async fn handle_renderers_list(
 
     // Two renderers ship. Lossiness is DECLARED rather than discovered, so a
     // preview can tell the holder what a format will not carry before they
-    // decide.
+    // decide. Sourced from vta_persona::RENDERERS so this response and the
+    // negotiation that enforces it cannot disagree.
     success_response(
         &doc,
         json!({
-            "renderers": [
-                {
-                    "id": "rcard",
-                    "description": "The canonical verifiable data structure. Lossless.",
-                    "canonical": true,
-                    "drops": [],
-                    "canCarryPredicates": true
-                },
-                {
-                    "id": "jcard",
-                    "description": "RFC 7095 jCard, for vCard-native tooling.",
-                    "canonical": false,
-                    "drops": ["provenance"],
-                    // No field in a general contact format says "over the
-                    // threshold", so a disclosure carrying a predicate must fail
-                    // at negotiation rather than silently drop the claim.
-                    "canCarryPredicates": false
-                }
-            ]
+            "renderers": vta_persona::present::RENDERERS.iter().map(|r| json!({
+                "id": r.id,
+                "canonical": r.canonical,
+                "drops": if r.carries_provenance { vec![] } else { vec!["provenance"] },
+                "canCarryPredicates": r.carries_predicates,
+            })).collect::<Vec<_>>()
         }),
     )
 }

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -840,3 +840,335 @@ pub(super) async fn handle_binding_list(
         }),
     )
 }
+
+// ─── Contacts ────────────────────────────────────────────────────────────
+
+pub(super) async fn handle_contact_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::contact::put::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_PUT_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let document = match serde_json::to_value(&req.document)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+    {
+        Some(d) => d,
+        None => {
+            return reject(
+                &doc,
+                AppError::Validation("unrecognised contact document".into()),
+            );
+        }
+    };
+
+    let filed = match store(state)
+        .file_contact(
+            &ctx,
+            &req.subject_did.to_string(),
+            &req.known_by_persona.to_string(),
+            document,
+            req.credential_refs.iter().map(|c| c.to_string()).collect(),
+        )
+        .await
+    {
+        Ok(f) => f,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(
+        state,
+        "persona.contact.put",
+        auth,
+        Some(&filed.contact_id),
+        Some(&ctx),
+    )
+    .await;
+    success_response(
+        &doc,
+        json!({
+            "contactId": filed.contact_id,
+            "rev": filed.rev,
+            "created": filed.created,
+            // Types, not values. A producer needing the old value reads the
+            // prior revision, which is an explicit act.
+            "changedClaims": filed.changed_claims,
+        }),
+    )
+}
+
+pub(super) async fn handle_contact_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::contact::get::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_GET_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+    let id = req.contact_id.to_string();
+    let s = store(state);
+
+    let Some(contact) = (match s.get_contact(&ctx, &id).await {
+        Ok(c) => c,
+        Err(e) => return reject(&doc, e),
+    }) else {
+        return reject(&doc, AppError::NotFound(format!("contact {id}")));
+    };
+
+    // A named revision resolves through the store, which distinguishes reaped
+    // (Gone) from never-existed (NotFound) — a caller comparing against history
+    // must be able to tell those apart.
+    let document = match req.rev {
+        None => serde_json::to_value(&contact.document).unwrap_or(Value::Null),
+        Some(rev) => match s.get_contact_revision(&ctx, &id, rev.get()).await {
+            Ok(r) => serde_json::to_value(&r.document).unwrap_or(Value::Null),
+            Err(e) => return reject(&doc, e),
+        },
+    };
+
+    let history = if req.include_history {
+        match s.contact_history(&ctx, &id).await {
+            // Metadata without documents: a timeline is cheap and the documents
+            // behind it are not.
+            Ok(h) => Some(
+                h.iter()
+                    .map(|(rev, at, cited)| json!({ "rev": rev, "receivedAt": at, "cited": cited }))
+                    .collect::<Vec<_>>(),
+            ),
+            Err(e) => return reject(&doc, e),
+        }
+    } else {
+        None
+    };
+
+    audit_persona(state, "persona.contact.get", auth, Some(&id), Some(&ctx)).await;
+    let mut body = json!({
+        "contactId": contact.contact_id,
+        "subjectDid": contact.subject_did,
+        "knownByPersona": contact.known_by_persona,
+        "rev": req.rev.map_or(contact.rev, std::num::NonZeroU64::get),
+        "document": document,
+        "credentialRefs": contact.credential_refs,
+        "notes": contact.notes,
+    });
+    if let Some(h) = history {
+        body["history"] = json!(h);
+    }
+    success_response(&doc, body)
+}
+
+pub(super) async fn handle_contact_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::contact::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_LIST_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let persona = req.known_by_persona.as_ref().map(|p| p.to_string());
+    let sums = match store(state)
+        .list_contact_summaries(&ctx, persona.as_deref())
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(state, "persona.contact.list", auth, None, Some(&ctx)).await;
+    success_response(
+        &doc,
+        json!({
+            // Summaries carry no claim values: finding one contact does not
+            // require disclosing the details of every contact.
+            "contacts": sums.iter().map(|s| json!({
+                "contactId": s.contact_id,
+                "subjectDid": s.subject_did,
+                "knownByPersona": s.known_by_persona,
+                "rev": s.rev,
+                "claimCount": s.claim_count,
+                "receivedAt": s.received_at,
+                "hasUnreviewedChange": s.has_unreviewed_change,
+            })).collect::<Vec<_>>()
+        }),
+    )
+}
+
+pub(super) async fn handle_contact_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::contact::delete::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_DELETE_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+    let id = req.contact_id.to_string();
+
+    let (existed, removed, retained) = match store(state).delete_contact(&ctx, &id).await {
+        Ok(o) => o,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(state, "persona.contact.delete", auth, Some(&id), Some(&ctx)).await;
+    success_response(
+        &doc,
+        json!({
+            "contactId": id,
+            "existed": existed,
+            "revisionsRemoved": removed,
+            // Reported rather than glossed: an incomplete erasure the holder
+            // believes is complete is worse than one they know about.
+            "retainedForDisclosure": retained,
+        }),
+    )
+}
+
+// ─── Disclosure history, correlation, renderers ──────────────────────────
+
+pub(super) async fn handle_disclosure_history(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::disclosure::history::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // Holder-only: omitting contextId queries across every context, which only
+    // the holder may do and is the reason this sits above the boundary.
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_DISCLOSURE_HISTORY_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let ctx = req.context_id.as_ref().map(|c| c.to_string());
+    let verifier = req.verifier_did.as_ref().map(|v| v.to_string());
+    let claim = req.attribute_type.as_ref().map(|t| t.to_string());
+    let since = req.since.map(|s| s.to_rfc3339());
+
+    let records = match store(state)
+        .disclosure_history(&vta_persona::HistoryQuery {
+            context_id: ctx.as_deref(),
+            verifier_did: verifier.as_deref(),
+            claim_type: claim.as_deref(),
+            since: since.as_deref(),
+        })
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(
+        state,
+        "persona.disclosure.history",
+        auth,
+        None,
+        ctx.as_deref(),
+    )
+    .await;
+    success_response(&doc, json!({ "disclosures": records }))
+}
+
+pub(super) async fn handle_correlation_analyze(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::correlation::analyze::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // Holder-only: the response is the linkage map between the holder's own
+    // identities — the artifact the family exists to keep from being assembled
+    // by anyone else.
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CORRELATION_ANALYZE_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let s = store(state);
+    let findings = match s
+        .analyze_correlation(
+            req.attribute_id.as_ref().map(|a| a.to_string()).as_deref(),
+            req.candidate
+                .as_ref()
+                .and_then(|c| serde_json::to_value(&c.value).ok())
+                .as_ref(),
+        )
+        .await
+    {
+        Ok(f) => f,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(state, "persona.correlation.analyze", auth, None, None).await;
+    success_response(&doc, json!({ "findings": findings }))
+}
+
+pub(super) async fn handle_renderers_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let _req: spec::renderers::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // Context-callable and carries nothing about the holder — it describes the
+    // agent's own capabilities. A caller must still name a context, so the
+    // request is attributable.
+    let ctx = auth.allowed_contexts.first().cloned();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_RENDERERS_LIST_1_0, ctx.as_deref()) {
+        return reject(&doc, e);
+    }
+
+    // Two renderers ship. Lossiness is DECLARED rather than discovered, so a
+    // preview can tell the holder what a format will not carry before they
+    // decide.
+    success_response(
+        &doc,
+        json!({
+            "renderers": [
+                {
+                    "id": "rcard",
+                    "description": "The canonical verifiable data structure. Lossless.",
+                    "canonical": true,
+                    "drops": [],
+                    "canCarryPredicates": true
+                },
+                {
+                    "id": "jcard",
+                    "description": "RFC 7095 jCard, for vCard-native tooling.",
+                    "canonical": false,
+                    "drops": ["provenance"],
+                    // No field in a general contact format says "over the
+                    // threshold", so a disclosure carrying a predicate must fail
+                    // at negotiation rather than silently drop the claim.
+                    "canCarryPredicates": false
+                }
+            ]
+        }),
+    )
+}

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -517,3 +517,326 @@ pub(super) async fn handle_attribute_delete(
         }),
     )
 }
+
+// ─── Profiles ────────────────────────────────────────────────────────────
+
+pub(super) async fn handle_profile_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::profile::put::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_PUT_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    // Entries round-trip through JSON into our own model. The generated
+    // ProfileEntry and ours describe the same four shapes; going through the
+    // wire form means the untagged discrimination is exercised exactly as a
+    // peer's document would exercise it, rather than by a hand-written match
+    // that could disagree with the schema.
+    let entries = match serde_json::to_value(&req.entries)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+    {
+        Some(e) => e,
+        None => {
+            return reject(
+                &doc,
+                AppError::Validation("unrecognised profile entry".into()),
+            );
+        }
+    };
+
+    let mut profile = vta_persona::new_profile(req.name.to_string(), entries);
+    if let Some(id) = &req.profile_id {
+        profile.profile_id = id.to_string();
+    }
+    profile.credential_refs = req.credential_refs.iter().map(|c| (**c).clone()).collect();
+    let profile_id = profile.profile_id.clone();
+
+    let written = match store(state)
+        .put_profile(profile, req.expected_version.map(|v| *v as u64))
+        .await
+    {
+        Ok(w) => w,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(state, "persona.profile.put", auth, Some(&profile_id), None).await;
+    success_response(
+        &doc,
+        json!({
+            "profileId": profile_id,
+            "version": written.version,
+            "created": written.created,
+            "updatedAt": chrono::Utc::now().to_rfc3339(),
+        }),
+    )
+}
+
+pub(super) async fn handle_profile_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::profile::get::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_GET_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let id = req.profile_id.to_string();
+    let s = store(state);
+    let Some(profile) = (match s.get_profile(&id).await {
+        Ok(p) => p,
+        Err(e) => return reject(&doc, e),
+    }) else {
+        // Not an empty success: a caller that cannot tell "absent" from "empty"
+        // treats a typo as a profile that discloses nothing.
+        return reject(&doc, AppError::NotFound(format!("profile {id}")));
+    };
+
+    // Resolution is opt-in because it is the expensive AND the disclosing
+    // answer — it decrypts values and re-derives credential-backed ones.
+    let resolved = if req.resolve {
+        match s.resolve_profile(&id).await {
+            Ok(r) => Some(r),
+            Err(e) => return reject(&doc, e),
+        }
+    } else {
+        None
+    };
+
+    audit_persona(state, "persona.profile.get", auth, Some(&id), None).await;
+    let mut body = json!({ "profile": profile });
+    if let Some(r) = resolved {
+        body["resolved"] = json!(
+            r.iter()
+                .map(|c| json!({
+                    "attributeId": c.attribute_id,
+                    "type": c.r#type,
+                    "value": c.value,
+                    "provenance": c.provenance,
+                    "stale": c.stale,
+                }))
+                .collect::<Vec<_>>()
+        );
+    }
+    success_response(&doc, body)
+}
+
+pub(super) async fn handle_profile_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let _req: spec::profile::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_LIST_1_0, None) {
+        return reject(&doc, e);
+    }
+    // No resolve option, deliberately: resolving every profile at once would
+    // decrypt the holder's entire pool to answer a question about names.
+    let profiles = match store(state).list_profiles().await {
+        Ok(p) => p,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(state, "persona.profile.list", auth, None, None).await;
+    success_response(&doc, json!({ "profiles": profiles }))
+}
+
+pub(super) async fn handle_profile_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::profile::delete::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_DELETE_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let id = req.profile_id.to_string();
+    let s = store(state);
+
+    // Refuse while a persona is bound unless the holder said unbind. A persona
+    // that silently stopped presenting anything is a failure they discover from
+    // the other side of a disclosure that did not happen.
+    let bound = match s.personas_bound_to_anywhere(&id).await {
+        Ok(b) => b,
+        Err(e) => return reject(&doc, e),
+    };
+    if !bound.is_empty() && !req.unbind {
+        let mut payload = ErrorPayload::new(ext(&slug_from_doc(&doc), "bound")).with_message(
+            format!("{} persona(s) are bound to this profile", bound.len()),
+        );
+        payload = payload.with_details(json!({ "personaDids": bound }));
+        return error_response(
+            doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload),
+        );
+    }
+    if req.unbind {
+        if let Err(e) = s.unbind_everywhere(&id).await {
+            return reject(&doc, e);
+        }
+    }
+
+    let existed = match s.delete_profile(&id).await {
+        Ok(e) => e,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(state, "persona.profile.delete", auth, Some(&id), None).await;
+    success_response(
+        &doc,
+        json!({ "profileId": id, "existed": existed, "unboundPersonas": bound }),
+    )
+}
+
+// ─── Bindings ────────────────────────────────────────────────────────────
+
+pub(super) async fn handle_binding_set(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::binding::set::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // Holder-only, and the critical gate: an application able to call this
+    // could bind any profile to a persona it controls and read the result back
+    // through a disclosure it requests of itself.
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_BINDING_SET_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let ctx = req.context_id.to_string();
+    let persona = req.persona_did.to_string();
+    let profile_id = req.profile_id.as_ref().map(|p| p.to_string());
+    let public = req.public_entries.iter().map(|e| e.to_string()).collect();
+
+    let bound = match store(state)
+        .set_binding(
+            &ctx,
+            &persona,
+            profile_id.as_deref(),
+            public,
+            req.expected_version.map(|v| *v as u64),
+        )
+        .await
+    {
+        Ok(b) => b,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(
+        state,
+        "persona.binding.set",
+        auth,
+        Some(&persona),
+        Some(&ctx),
+    )
+    .await;
+    success_response(
+        &doc,
+        json!({
+            "contextId": ctx,
+            "personaDid": persona,
+            "profileId": profile_id,
+            "version": bound.version,
+            "materialisedClaimCount": bound.materialised_claim_count,
+            "correlation": {
+                // Binding one profile to a second persona makes them the same
+                // person by construction, and no later narrowing undoes it.
+                "severity": if bound.also_bound_persona_count > 0 { "high" } else { "none" },
+                "alsoBoundPersonaCount": bound.also_bound_persona_count,
+            },
+            "boundAt": chrono::Utc::now().to_rfc3339(),
+        }),
+    )
+}
+
+pub(super) async fn handle_binding_get(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::binding::get::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_BINDING_GET_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let persona = req.persona_did.to_string();
+    let sum = match store(state).binding_summary(&ctx, &persona).await {
+        Ok(s) => s,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(
+        state,
+        "persona.binding.get",
+        auth,
+        Some(&persona),
+        Some(&ctx),
+    )
+    .await;
+    // Thin by construction: whether bound, the label, a claim count. Never
+    // contents — those reach an application only through the disclosure path.
+    success_response(
+        &doc,
+        json!({
+            "contextId": ctx,
+            "personaDid": sum.persona_did,
+            "bound": sum.bound,
+            "profileId": sum.profile_id,
+            "profileName": sum.profile_name,
+            "claimCount": sum.claim_count,
+            "boundAt": sum.bound_at,
+        }),
+    )
+}
+
+pub(super) async fn handle_binding_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::binding::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_BINDING_LIST_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let sums = match store(state).list_binding_summaries(&ctx).await {
+        Ok(s) => s,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(state, "persona.binding.list", auth, None, Some(&ctx)).await;
+    success_response(
+        &doc,
+        json!({
+            "personas": sums.iter().map(|s| json!({
+                "personaDid": s.persona_did,
+                "bound": s.bound,
+                "profileName": s.profile_name,
+                "claimCount": s.claim_count,
+            })).collect::<Vec<_>>()
+        }),
+    )
+}

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -1421,3 +1421,116 @@ pub(super) async fn handle_local_binding_set(
         }),
     )
 }
+
+// ─── Disclosure: preview, then present ───────────────────────────────────
+
+pub(super) async fn handle_disclosure_preview(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::disclosure::preview::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let requested: Option<Vec<String>> = if req.requested_claims.is_empty() {
+        None
+    } else {
+        Some(req.requested_claims.iter().map(|c| c.to_string()).collect())
+    };
+
+    let preview = match store(state)
+        .create_preview(
+            &ctx,
+            &req.persona_did.to_string(),
+            &req.verifier_did.to_string(),
+            req.purpose.as_ref().map(|p| p.to_string()).as_deref(),
+            requested.as_deref(),
+            req.renderer.as_ref().map(|r| r.to_string()).as_deref(),
+        )
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => return reject(&doc, e),
+    };
+
+    // Recorded even though nothing was disclosed: a pattern of previews the
+    // holder declined is itself something they may want to see.
+    audit_persona(
+        state,
+        "persona.disclosure.preview",
+        auth,
+        Some(&preview.preview_id),
+        Some(&ctx),
+    )
+    .await;
+
+    success_response(
+        &doc,
+        json!({
+            "previewId": preview.preview_id,
+            "subject": preview.subject,
+            "claims": preview.claims,
+            "renderer": { "id": preview.renderer_id, "drops": preview.renderer_drops },
+            "expiresAt": preview.expires_at,
+        }),
+    )
+}
+
+pub(super) async fn handle_disclosure_present(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::disclosure::present::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let ctx = req.context_id.to_string();
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_DISCLOSURE_PRESENT_1_0, Some(&ctx)) {
+        return reject(&doc, e);
+    }
+
+    let durable = req.mint.as_ref().is_some_and(|m| m.durable);
+
+    // The store consumes the preview, refuses an expired one, refuses whole on
+    // a stale claim, and writes the disclosure record BEFORE returning the
+    // artifact — a crash between signing and recording would release data the
+    // holder could never afterwards discover they had released.
+    let (artifact, record) = match store(state)
+        .present(
+            &req.preview_id.to_string(),
+            req.challenge.as_ref().map(|c| c.to_string()).as_deref(),
+            durable,
+        )
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(
+        state,
+        "persona.disclosure.present",
+        auth,
+        Some(&record.disclosure_id),
+        Some(&ctx),
+    )
+    .await;
+
+    success_response(
+        &doc,
+        json!({
+            "disclosureId": record.disclosure_id,
+            "artifact": artifact,
+            "subject": record.subject,
+            "credentialId": record.durable_credential_id,
+            "disclosedAt": record.disclosed_at,
+        }),
+    )
+}

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -30,10 +30,34 @@
 //! for `Admin` and *nothing at all* for every other role, so a call site testing
 //! `is_empty()` without the role gets one of the two backwards.
 
+use serde_json::{Value, json};
+use trust_tasks_rs::{ErrorPayload, StandardCode, TrustTask, TrustTaskCode};
 use vta_sdk::trust_tasks as uris;
 use vti_common::error::AppError;
 
+use crate::audit;
 use crate::auth::AuthClaims;
+use crate::server::AppState;
+
+use super::helpers::{TrustTaskOutcome, error_response, parse_payload, success_response};
+
+/// The family namespace for codes shared across the slice. A proper path prefix
+/// of each task slug, which SPEC §8.5 permits so a family-wide meaning is
+/// defined once.
+const FAMILY_SLUG: &str = "persona";
+
+fn slug_from_doc(doc: &TrustTask<Value>) -> String {
+    doc.type_uri
+        .to_string()
+        .strip_prefix("https://trusttasks.org/spec/")
+        .and_then(|rest| rest.rsplit_once('/'))
+        .map(|(slug, _ver)| slug.to_string())
+        .unwrap_or_else(|| FAMILY_SLUG.to_string())
+}
+
+fn ext(slug: &str, local: &str) -> TrustTaskCode {
+    TrustTaskCode::new_extended(slug, local).expect("persona extended code is grammar-valid")
+}
 
 /// Which side of the boundary a task sits on.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -149,8 +173,7 @@ mod tests {
     /// side of the boundary it is on.
     #[test]
     fn every_persona_task_declares_a_reach() {
-        let classified: std::collections::HashSet<&str> =
-            REACH.iter().map(|(u, _)| *u).collect();
+        let classified: std::collections::HashSet<&str> = REACH.iter().map(|(u, _)| *u).collect();
         let missing: Vec<&&str> = uris::ALL_URIS
             .iter()
             .filter(|u| u.starts_with("https://trusttasks.org/spec/persona/"))
@@ -172,7 +195,10 @@ mod tests {
             .map(|(u, _)| u)
             .filter(|u| !catalog.contains(*u))
             .collect();
-        assert!(orphans.is_empty(), "reach entries for tasks that do not exist: {orphans:#?}");
+        assert!(
+            orphans.is_empty(),
+            "reach entries for tasks that do not exist: {orphans:#?}"
+        );
     }
 
     /// The trap, asserted directly. This is the test that would have caught a
@@ -210,11 +236,19 @@ mod tests {
         // An empty context list means *unrestricted* for Admin and *nothing at
         // all* for every other role. A gate testing emptiness without the role
         // gets one of those backwards, so both halves are asserted.
-        for role in [Role::Application, Role::Reader, Role::Initiator, Role::Monitor] {
+        for role in [
+            Role::Application,
+            Role::Reader,
+            Role::Initiator,
+            Role::Monitor,
+        ] {
             let label = format!("{role:?}");
             let c = claims(role, &[]);
             let err = authorize(&c, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None).unwrap_err();
-            assert!(matches!(err, AppError::Forbidden(_)), "{label} reached the pool");
+            assert!(
+                matches!(err, AppError::Forbidden(_)),
+                "{label} reached the pool"
+            );
         }
     }
 
@@ -231,8 +265,12 @@ mod tests {
     #[test]
     fn an_unknown_task_is_refused_rather_than_defaulted() {
         let app = claims(Role::Application, &["ctx"]);
-        let err = authorize(&app, "https://trusttasks.org/spec/persona/made/up/9.9", Some("ctx"))
-            .unwrap_err();
+        let err = authorize(
+            &app,
+            "https://trusttasks.org/spec/persona/made/up/9.9",
+            Some("ctx"),
+        )
+        .unwrap_err();
         assert!(matches!(err, AppError::Forbidden(_)));
     }
 
@@ -240,10 +278,242 @@ mod tests {
     fn binding_set_is_holder_only_and_local_binding_set_is_not() {
         // The pair that most invites being collapsed. One crosses the boundary
         // and one does not.
-        assert_eq!(reach_of(uris::TASK_PERSONA_BINDING_SET_1_0), Some(Reach::Holder));
+        assert_eq!(
+            reach_of(uris::TASK_PERSONA_BINDING_SET_1_0),
+            Some(Reach::Holder)
+        );
         assert_eq!(
             reach_of(uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0),
             Some(Reach::Context)
         );
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Request and response types come straight from `trust-tasks-rs` rather than
+// hand-written SDK mirrors. `parse_payload` is generic over serde, so the
+// generated types work as-is — and a mirror would be a second definition of the
+// same contract, free to drift from the published schema without anything
+// noticing. The generated types cannot.
+
+use trust_tasks_rs::specs::persona as spec;
+use vta_persona::{PersonaStore, ValueType, new_attribute};
+
+/// Open the store for this request.
+///
+/// The correlation key is derived per agent and lives beside the at-rest key;
+/// it never leaves the agent, which is what makes the blinded index blinded.
+fn store(state: &AppState) -> PersonaStore {
+    PersonaStore::new(state.persona_ks.clone(), state.persona_correlation_key)
+}
+
+/// Audit a persona task.
+///
+/// The attribute VALUE is deliberately never recorded. Copying identity data
+/// into the audit store would give it a second home under a different retention
+/// policy — the same reasoning app-state applies to its values, and it matters
+/// more here because this store exists to hold personal data.
+async fn audit_persona(
+    state: &AppState,
+    action: &str,
+    auth: &AuthClaims,
+    resource: Option<&str>,
+    context_id: Option<&str>,
+) {
+    if let Err(e) = audit::record(
+        &state.audit_sink,
+        action,
+        &auth.did,
+        resource,
+        "success",
+        Some(super::helpers::TRANSPORT_TRUST_TASK),
+        context_id,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, action = %action, "audit record failed for persona task");
+    }
+}
+
+/// Map a storage error onto the published error taxonomy.
+///
+/// Authorization failures use the framework's **standard** `permissionDenied`
+/// rather than a task-namespaced synonym: the framework already names this
+/// failure, and a duplicate would tell a client switching on the standard code
+/// that something else went wrong.
+fn reject(doc: &TrustTask<Value>, e: AppError) -> TrustTaskOutcome {
+    let slug = slug_from_doc(doc);
+    let message = e.to_string();
+    let (code, details): (TrustTaskCode, Option<Value>) = match &e {
+        AppError::Forbidden(_) | AppError::Unauthorized(_) => {
+            (StandardCode::PermissionDenied.into(), None)
+        }
+        AppError::NotFound(_) => (ext(&slug, "notFound"), None),
+        // The conflict carries the maintainer's view WITH the rejection. A bare
+        // rejection obliges the caller to re-read, and between the rejection and
+        // the re-read the record can change again — the pattern has no fixed
+        // point under contention.
+        AppError::Conflict(reason) => (
+            ext(&slug, "versionConflict"),
+            Some(json!({ "reason": reason })),
+        ),
+        AppError::Validation(reason) => (
+            StandardCode::MalformedRequest.into(),
+            Some(json!({ "reason": reason })),
+        ),
+        AppError::Gone(_) => (ext(&slug, "revisionReaped"), None),
+        _ => (StandardCode::InternalError.into(), None),
+    };
+
+    let mut payload = ErrorPayload::new(code).with_message(message);
+    if let Some(d) = details {
+        payload = payload.with_details(d);
+    }
+    error_response(doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload))
+}
+
+pub(super) async fn handle_attribute_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::attribute::put::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_ATTRIBUTE_PUT_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let value_type = match serde_json::to_string(&req.value_type)
+        .ok()
+        .and_then(|s| serde_json::from_str::<ValueType>(&s).ok())
+    {
+        Some(v) => v,
+        None => {
+            return reject(&doc, AppError::Validation("unrecognised valueType".into()));
+        }
+    };
+
+    let provenance = match serde_json::to_value(&req.provenance)
+        .ok()
+        .and_then(|v| serde_json::from_value(v).ok())
+    {
+        Some(p) => p,
+        None => return reject(&doc, AppError::Validation("unrecognised provenance".into())),
+    };
+
+    let mut attribute = new_attribute(
+        req.type_.to_string(),
+        value_type,
+        req.value.clone(),
+        provenance,
+    );
+    if let Some(id) = &req.attribute_id {
+        attribute.attribute_id = id.to_string();
+    }
+    attribute.label = req.label.as_ref().map(|l| (**l).clone());
+
+    let attribute_id = attribute.attribute_id.clone();
+    let value = attribute.value.clone();
+    let s = store(state);
+
+    let written = match s
+        .put(attribute, req.expected_version.map(|v| *v as u64))
+        .await
+    {
+        Ok(w) => w,
+        Err(e) => return reject(&doc, e),
+    };
+
+    // Advisory, and computed after the write because the write has already
+    // applied — a maintainer must not refuse on correlation grounds. The
+    // holder decides.
+    let shared = match &value {
+        Some(v) => s.correlation_count(v, &attribute_id).await.unwrap_or(0),
+        None => 0,
+    };
+
+    audit_persona(
+        state,
+        "persona.attribute.put",
+        auth,
+        Some(&attribute_id),
+        None,
+    )
+    .await;
+
+    success_response(
+        &doc,
+        serde_json::json!({
+            "attributeId": attribute_id,
+            "version": written.version,
+            "created": written.created,
+            "updatedAt": chrono::Utc::now().to_rfc3339(),
+            "correlation": {
+                "severity": if shared > 0 { "high" } else { "none" },
+                "sharedWithProfileCount": shared,
+            }
+        }),
+    )
+}
+
+pub(super) async fn handle_attribute_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::attribute::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    // Values are withheld unless asked for: the common case — rendering a
+    // picker — needs type and label, not plaintext.
+    let include_values = req.include_values;
+    let s = store(state);
+    let prefix = req.type_prefix.as_ref().map(|p| p.as_str());
+    let attributes = match s.list_attributes(prefix, include_values).await {
+        Ok(a) => a,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(state, "persona.attribute.list", auth, None, None).await;
+    success_response(&doc, serde_json::json!({ "attributes": attributes }))
+}
+
+pub(super) async fn handle_attribute_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::attribute::delete::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(auth, uris::TASK_PERSONA_ATTRIBUTE_DELETE_1_0, None) {
+        return reject(&doc, e);
+    }
+
+    let id = req.attribute_id.to_string();
+    let out = match store(state).delete(&id, req.cascade).await {
+        Ok(o) => o,
+        Err(e) => return reject(&doc, e),
+    };
+
+    audit_persona(state, "persona.attribute.delete", auth, Some(&id), None).await;
+    success_response(
+        &doc,
+        serde_json::json!({
+            "attributeId": id,
+            "existed": out.existed,
+            "removedFromProfiles": out.referring_profiles,
+        }),
+    )
 }

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -157,140 +157,6 @@ pub fn authorize(claims: &AuthClaims, uri: &str, context_id: Option<&str>) -> Re
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use vti_common::acl::Role;
-
-    fn claims(role: Role, contexts: &[&str]) -> AuthClaims {
-        let mut c = AuthClaims::default();
-        c.role = role;
-        c.allowed_contexts = contexts.iter().map(|s| (*s).to_string()).collect();
-        c
-    }
-
-    /// The census. A task cannot join the family without someone deciding which
-    /// side of the boundary it is on.
-    #[test]
-    fn every_persona_task_declares_a_reach() {
-        let classified: std::collections::HashSet<&str> = REACH.iter().map(|(u, _)| *u).collect();
-        let missing: Vec<&&str> = uris::ALL_URIS
-            .iter()
-            .filter(|u| u.starts_with("https://trusttasks.org/spec/persona/"))
-            .filter(|u| !classified.contains(*u))
-            .collect();
-        assert!(
-            missing.is_empty(),
-            "these persona tasks declare no reach — add them to REACH. When unsure, \
-             `Holder` is the conservative answer: it refuses too much rather than \
-             disclosing the pool to a context. {missing:#?}"
-        );
-    }
-
-    #[test]
-    fn no_reach_without_a_task() {
-        let catalog: std::collections::HashSet<&str> = uris::ALL_URIS.iter().copied().collect();
-        let orphans: Vec<&&str> = REACH
-            .iter()
-            .map(|(u, _)| u)
-            .filter(|u| !catalog.contains(*u))
-            .collect();
-        assert!(
-            orphans.is_empty(),
-            "reach entries for tasks that do not exist: {orphans:#?}"
-        );
-    }
-
-    /// The trap, asserted directly. This is the test that would have caught a
-    /// guard written as `role == Admin`.
-    #[test]
-    fn a_context_scoped_admin_is_refused_every_holder_task() {
-        let scoped_admin = claims(Role::Admin, &["ctx-work"]);
-        for (uri, reach) in REACH {
-            if *reach != Reach::Holder {
-                continue;
-            }
-            let err = authorize(&scoped_admin, uri, Some("ctx-work")).unwrap_err();
-            assert!(
-                matches!(err, AppError::Forbidden(_)),
-                "{uri} admitted an admin scoped to one context — an admin in ctx-work must be \
-                 as powerless over the pool as an application in ctx-work"
-            );
-        }
-    }
-
-    #[test]
-    fn an_unscoped_holder_reaches_the_pool() {
-        let holder = claims(Role::Admin, &[]);
-        for (uri, reach) in REACH {
-            if *reach == Reach::Holder {
-                authorize(&holder, uri, None).unwrap_or_else(|e| {
-                    panic!("{uri} refused an unscoped holder: {e:?}");
-                });
-            }
-        }
-    }
-
-    #[test]
-    fn every_non_admin_role_is_refused_the_pool() {
-        // An empty context list means *unrestricted* for Admin and *nothing at
-        // all* for every other role. A gate testing emptiness without the role
-        // gets one of those backwards, so both halves are asserted.
-        for role in [
-            Role::Application,
-            Role::Reader,
-            Role::Initiator,
-            Role::Monitor,
-        ] {
-            let label = format!("{role:?}");
-            let c = claims(role, &[]);
-            let err = authorize(&c, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None).unwrap_err();
-            assert!(
-                matches!(err, AppError::Forbidden(_)),
-                "{label} reached the pool"
-            );
-        }
-    }
-
-    #[test]
-    fn a_context_task_is_confined_to_its_own_context() {
-        let app = claims(Role::Application, &["ctx-a"]);
-        authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-a")).expect("own context");
-        assert!(
-            authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-b")).is_err(),
-            "a caller scoped to ctx-a must not learn about ctx-b"
-        );
-    }
-
-    #[test]
-    fn an_unknown_task_is_refused_rather_than_defaulted() {
-        let app = claims(Role::Application, &["ctx"]);
-        // Built rather than written as a literal, deliberately. `produced_census`
-        // scans this crate's source for spec-URI literals and asks who publishes
-        // each one — correctly, because a produced document with no schema has
-        // validation on neither side. This fixture never goes on a wire, so it
-        // takes the `format!` shape the census already documents as "not a URI
-        // that goes on a wire", rather than being allowlisted as produced.
-        let unknown = format!("https://trusttasks.org/spec/persona/{}/9.9", "made-up");
-        let err = authorize(&app, &unknown, Some("ctx")).unwrap_err();
-        assert!(matches!(err, AppError::Forbidden(_)));
-    }
-
-    #[test]
-    fn binding_set_is_holder_only_and_local_binding_set_is_not() {
-        // The pair that most invites being collapsed. One crosses the boundary
-        // and one does not.
-        assert_eq!(
-            reach_of(uris::TASK_PERSONA_BINDING_SET_1_0),
-            Some(Reach::Holder)
-        );
-        assert_eq!(
-            reach_of(uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0),
-            Some(Reach::Context)
-        );
-    }
-}
-
 // ─────────────────────────────────────────────────────────────────────────
 // Handlers
 // ─────────────────────────────────────────────────────────────────────────
@@ -423,10 +289,7 @@ pub(super) async fn handle_attribute_put(
     let value = attribute.value.clone();
     let s = store(state);
 
-    let written = match s
-        .put(attribute, req.expected_version.map(|v| *v as u64))
-        .await
-    {
+    let written = match s.put(attribute, req.expected_version.map(|v| *v)).await {
         Ok(w) => w,
         Err(e) => return reject(&doc, e),
     };
@@ -561,7 +424,7 @@ pub(super) async fn handle_profile_put(
     let profile_id = profile.profile_id.clone();
 
     let written = match store(state)
-        .put_profile(profile, req.expected_version.map(|v| *v as u64))
+        .put_profile(profile, req.expected_version.map(|v| *v))
         .await
     {
         Ok(w) => w,
@@ -687,10 +550,10 @@ pub(super) async fn handle_profile_delete(
             doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload),
         );
     }
-    if req.unbind {
-        if let Err(e) = s.unbind_everywhere(&id).await {
-            return reject(&doc, e);
-        }
+    if req.unbind
+        && let Err(e) = s.unbind_everywhere(&id).await
+    {
+        return reject(&doc, e);
     }
 
     let existed = match s.delete_profile(&id).await {
@@ -733,7 +596,7 @@ pub(super) async fn handle_binding_set(
             &persona,
             profile_id.as_deref(),
             public,
-            req.expected_version.map(|v| *v as u64),
+            req.expected_version.map(|v| *v),
         )
         .await
     {
@@ -1211,7 +1074,7 @@ pub(super) async fn handle_local_profile_put(
     let s = store(state);
 
     let written = match s
-        .put_local_profile(&ctx, profile, req.expected_version.map(|v| *v as u64))
+        .put_local_profile(&ctx, profile, req.expected_version.map(|v| *v))
         .await
     {
         Ok(w) => w,
@@ -1526,4 +1389,143 @@ pub(super) async fn handle_disclosure_present(
             "disclosedAt": record.disclosed_at,
         }),
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_common::acl::Role;
+
+    fn claims(role: Role, contexts: &[&str]) -> AuthClaims {
+        AuthClaims {
+            role,
+            allowed_contexts: contexts.iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    /// The census. A task cannot join the family without someone deciding which
+    /// side of the boundary it is on.
+    #[test]
+    fn every_persona_task_declares_a_reach() {
+        let classified: std::collections::HashSet<&str> = REACH.iter().map(|(u, _)| *u).collect();
+        let missing: Vec<&&str> = uris::ALL_URIS
+            .iter()
+            .filter(|u| u.starts_with("https://trusttasks.org/spec/persona/"))
+            .filter(|u| !classified.contains(*u))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these persona tasks declare no reach — add them to REACH. When unsure, \
+             `Holder` is the conservative answer: it refuses too much rather than \
+             disclosing the pool to a context. {missing:#?}"
+        );
+    }
+
+    #[test]
+    fn no_reach_without_a_task() {
+        let catalog: std::collections::HashSet<&str> = uris::ALL_URIS.iter().copied().collect();
+        let orphans: Vec<&&str> = REACH
+            .iter()
+            .map(|(u, _)| u)
+            .filter(|u| !catalog.contains(*u))
+            .collect();
+        assert!(
+            orphans.is_empty(),
+            "reach entries for tasks that do not exist: {orphans:#?}"
+        );
+    }
+
+    /// The trap, asserted directly. This is the test that would have caught a
+    /// guard written as `role == Admin`.
+    #[test]
+    fn a_context_scoped_admin_is_refused_every_holder_task() {
+        let scoped_admin = claims(Role::Admin, &["ctx-work"]);
+        for (uri, reach) in REACH {
+            if *reach != Reach::Holder {
+                continue;
+            }
+            let err = authorize(&scoped_admin, uri, Some("ctx-work")).unwrap_err();
+            assert!(
+                matches!(err, AppError::Forbidden(_)),
+                "{uri} admitted an admin scoped to one context — an admin in ctx-work must be \
+                 as powerless over the pool as an application in ctx-work"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unscoped_holder_reaches_the_pool() {
+        let holder = claims(Role::Admin, &[]);
+        for (uri, reach) in REACH {
+            if *reach == Reach::Holder {
+                authorize(&holder, uri, None).unwrap_or_else(|e| {
+                    panic!("{uri} refused an unscoped holder: {e:?}");
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn every_non_admin_role_is_refused_the_pool() {
+        // An empty context list means *unrestricted* for Admin and *nothing at
+        // all* for every other role. A gate testing emptiness without the role
+        // gets one of those backwards, so both halves are asserted.
+        for role in [
+            Role::Application,
+            Role::Reader,
+            Role::Initiator,
+            Role::Monitor,
+        ] {
+            let label = format!("{role:?}");
+            let c = claims(role, &[]);
+            let err = authorize(&c, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None).unwrap_err();
+            assert!(
+                matches!(err, AppError::Forbidden(_)),
+                "{label} reached the pool"
+            );
+        }
+    }
+
+    #[test]
+    fn a_context_task_is_confined_to_its_own_context() {
+        let app = claims(Role::Application, &["ctx-a"]);
+        authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-a")).expect("own context");
+        assert!(
+            authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-b")).is_err(),
+            "a caller scoped to ctx-a must not learn about ctx-b"
+        );
+    }
+
+    #[test]
+    fn an_unknown_task_is_refused_rather_than_defaulted() {
+        let app = claims(Role::Application, &["ctx"]);
+        // Built rather than written as a literal, deliberately. `produced_census`
+        // scans this crate's source for spec-URI literals and asks who publishes
+        // each one — correctly, because a produced document with no schema has
+        // validation on neither side. This fixture never goes on a wire, so it
+        // takes the `format!` shape the census already documents as "not a URI
+        // that goes on a wire", rather than being allowlisted as produced.
+        let unknown = format!("https://trusttasks.org/spec/persona/{}/9.9", "made-up");
+        let err = authorize(&app, &unknown, Some("ctx")).unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)));
+    }
+
+    #[test]
+    fn binding_set_is_holder_only_and_local_binding_set_is_not() {
+        // The pair that most invites being collapsed. One crosses the boundary
+        // and one does not.
+        assert_eq!(
+            reach_of(uris::TASK_PERSONA_BINDING_SET_1_0),
+            Some(Reach::Holder)
+        );
+        assert_eq!(
+            reach_of(uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0),
+            Some(Reach::Context)
+        );
+    }
 }


### PR DESCRIPTION
Implements the `persona/*` Trust Task family — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose.

Specs merged upstream in trustoverip/dtgwg-trust-tasks-tf#360 and shipped in `trust-tasks-rs` 0.17.9. Design notes: `design-docs/persona-profiles-design.md` and its consumer `design-docs/persona-to-membership-design.md`.

## A fourth holder store

Beside the secrets vault, the credential vault and application state. Distinct because **disclosure control is its point**: a maintainer that cannot read a record cannot decide which of its members may leave, cannot audit which ones did, and cannot answer *"what have I shared with whom."* `vta/app-state` promises never to interpret its records, so it cannot host this — and a namespace there is collision avoidance rather than a trust boundary, so a compromised application sharing a context could remove the holder's identity data.

## The boundary is one-way, and that is the review's centre of gravity

The pool and profiles are **agent-scoped**, above every trust context. Bindings, contacts and disclosure records are **context-scoped**. Nothing inside a context may read the pool: the holder pushes a materialised projection down, and a context never pulls.

Three mechanisms enforce it, deliberately at different layers:

**Authorization** (`trust_tasks/persona.rs`) — eleven tasks require `require_super_admin()`: `Admin` **and** unrestricted scope. Not a role check. A guard written *"is this caller an administrator"* **passes for an administrator scoped to a single context**, who would then read and write identity data belonging to every other one. `vti-common`'s own `act_scope` docs warn about the same edge from the other side — an empty context list means *unrestricted* for `Admin` and *nothing at all* for every other role. Both halves are asserted, and `a_context_scoped_admin_is_refused_every_holder_task` iterates every holder-only task. An unknown URI is refused rather than defaulted, because defaulting to `Context` is exactly how a pool read becomes reachable from inside one.

**Types** (`vta-persona/src/binding.rs`) — `MaterialisedClaim` is a *distinct type* from `ResolvedClaim`, not the same struct with a field left empty. It has nowhere to put a pool identifier, so no future edit can leak one across the boundary by forgetting to clear it. The test asserts it on the **serialised bytes**, because what crosses the boundary is what was written.

**Addressing** (`vta-persona/src/storage.rs`) — context-local profiles occupy their own prefix rather than sharing the pool's with a flag. A context-scoped enumeration therefore scans somewhere a pool profile structurally cannot be. A filter is a line of code that can be got wrong; an address space cannot.

`rematerialise()` keeps "edit once, everywhere" working without opening a read path: it is a write initiated *above* the boundary.

## Decisions worth a second opinion

**Generated types instead of SDK mirrors.** Handlers use `trust_tasks_rs::specs::persona::*` directly; `parse_payload` is generic over serde. The `app_state` convention is a hand-written `vta_sdk::protocols::*` mirror, but a mirror is a second definition of the same contract, free to drift from the published schema with nothing to notice — 48 types across this family. **If reviewers prefer the convention I will add them, but I would argue against it.**

**`disclosure/preview` is classified `Keyed`** despite looking like a read: it mints the single-use token `present` consumes, so a replayed preview hands out a second authorisation to disclose.

**A rung absent from provenance resolves to `Whole`, not `Predicate`.** The conservative answer for an unassessed credential is the *least* private one; the most private would claim an unlinkability the proof does not provide.

## Four refusals in the disclosure flow, each tested

`present` consumes a token only `create_preview` can mint, so there is no code path to a disclosure that skipped the summary — structural rather than a flag. And each of these refuses rather than degrades:

- a renderer that cannot carry a claim **fails at negotiation** — dropping it yields a disclosure that verifies and says less than the holder approved, which a verifier cannot distinguish from a holder who approved fewer claims;
- an unknown renderer is refused, not defaulted to canonical;
- a claim that went stale between preview and present refuses the **whole** disclosure;
- an expired preview is refused rather than re-derived — the holder was shown one thing, and re-deriving could disclose another.

## What the censuses caught

Three refused to let me default past a decision, and none was findable by re-reading my own code:

- **retry-safety** — adding 24 URIs to `ALL_URIS` failed `every_uri_is_classified` by name until each had a class;
- **DID-deletion** — refused to accept an unclassified keyspace. Persona is `Cascade`, with the nuance the per-keyspace enum cannot express recorded in the comment: only the context-scoped half is DID-keyed, so bindings and contacts cascade while the pool survives, because a profile may be bound to several personas;
- **`produced_census`** — found a spec-URI *literal in one of my own tests*. Allowlisting it would have been a lie (it is not produced), so it takes the `format!` shape the census documents as "not a URI that goes on a wire".

A **conformance witness also found a defect in the spec I had written hours earlier** — `Attribute.value` was `required` while its own description said the member is absent for a metadata-only view, making the default non-disclosing listing unrepresentable. Fixed upstream in dtgwg-trust-tasks-tf#367, merged and awaiting release.

## Verification

- `cargo test -p vta-service --lib` — **1027 passed, 0 failed, 1 ignored**
- `cargo test -p vta-persona` — 61 passed
- `cargo clippy` — clean on both crates and the workspace
- Conformance witnesses for all 24 tasks; **no persona URI enters `UNSPECCED_DISPATCHED_URIS`**

## Known gaps, stated rather than hidden

1. **`render()` produces an UNSIGNED document** and declares `"unsigned": true` in the payload. Signing belongs to the key custodian (`keys/derive-and-sign-document`), which holds the persona's key. A placeholder that looked like a signature would be worse than none, so the seam is visible. **This is the real blocker to end-to-end use.**
2. **`persona/attribute/list` is recorded as `KnownDrift`**, not witnessed, until `trust-tasks-rs` 0.18 ships #367. Adding `value` to the fixture would have encoded the defect and passed.
3. **No end-to-end test.** Every layer is tested; the seams between them are not. Nothing has driven a real request through dispatch into the store and back.
