### PR TITLE
ci(semver): block a release whose version bump is smaller than its API change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,37 @@ jobs:
       - name: Check published crates for API breaks
         run: bash scripts/semver-report.sh
 
+  release-bump-guard:
+    # The one place the semver signal must BLOCK rather than report.
+    #
+    # Runs only on a release-plz branch, where every manifest already carries the
+    # version about to be published. That is what makes the check meaningful
+    # here and merely informational elsewhere: cargo-semver-checks derives the
+    # release type from the real delta, so a failure means the PROPOSED BUMP IS
+    # TOO SMALL — the release is about to ship a breaking change as a compatible
+    # one, on a version consumers' caret requirements pick up automatically.
+    #
+    # It exists because release-plz's own semver check and this repo's disagreed,
+    # and only release-plz's decided the version. On 2026-09-05 it proposed
+    # `vti-common` 0.16.2 "(✓ API compatible changes)" against a baseline where
+    # the same tool failed `enum_variant_added` on two exhaustive enums, and
+    # `vta-sdk` 0.32.4 where 16 public wire structs had gained a field. Nothing
+    # reconciled the two verdicts. This does.
+    #
+    # NO continue-on-error, unlike the report above. That is the entire point.
+    name: release bump is large enough
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-semver-checks
+      - name: Check the proposed versions cover their API changes
+        env:
+          SEMVER_MODE: enforce
+        run: bash scripts/semver-report.sh
+
   lockfile-self-pins:
     # Sibling guard to release-guards: the version bump can be correct and the
     # release still break if Cargo.lock pins a stale crates.io copy of one of

--- a/scripts/semver-report.sh
+++ b/scripts/semver-report.sh
@@ -44,7 +44,37 @@
 # A crate appearing in (3) is normal exactly once in its life: between merging
 # and its first release. If one sits there across several releases, something is
 # wrong with the release, not with this script.
+#
+# # Two modes
+#
+# `SEMVER_MODE=report` (default) — on an ordinary PR. A break is EXPECTED and
+# allowed; the job reports it so the release can move the compatibility field.
+#
+# `SEMVER_MODE=enforce` — on a release-plz branch, where the manifest already
+# carries the version about to be published. cargo-semver-checks derives the
+# release type from the real delta (0.16.1 -> 0.16.2 is a patch), so a break
+# under that delta means the PROPOSED BUMP IS TOO SMALL and the release is about
+# to ship a breaking change as a compatible one. That is the one place this must
+# block rather than report.
+#
+# Why the guard exists: release-plz runs cargo-semver-checks itself and is meant
+# to raise the bump on its own. On 2026-09-05 it reported `vti-common: next
+# version is 0.16.2 (✓ API compatible changes)` for a release where the same
+# tool, on the same baseline, failed `enum_variant_added` on two exhaustive
+# enums — and `vta-sdk: 0.32.4` where 16 public wire structs had gained a field.
+# Both would have gone out as patch releases that `^0.16` and `^0.32` consumers
+# take automatically. Nothing reconciled release-plz's verdict against the
+# report's; this is that reconciliation.
 set -euo pipefail
+
+MODE="${SEMVER_MODE:-report}"
+case "$MODE" in
+  report | enforce) ;;
+  *)
+    echo "::error::SEMVER_MODE must be 'report' or 'enforce', got '$MODE'"
+    exit 1
+    ;;
+esac
 
 # Excluded for RUNTIME, not because a break there is acceptable. This job builds
 # rustdoc JSON for every crate twice, current and baseline; including these took
@@ -243,10 +273,23 @@ fi
 echo
 echo "coverage: all ${#expected[@]} expected crates were checked"
 
-if [ "$status" -ne 0 ]; then
-  echo "::warning::API breaks reported — expected on a PR marked '!'; the \
-release moves the compatibility field accordingly."
-else
+if [ "$status" -eq 0 ]; then
   echo "all baselines built; no API breaks reported"
+  exit 0
 fi
+
+if [ "$MODE" = "enforce" ]; then
+  echo "::error::THE PROPOSED RELEASE UNDER-BUMPS A BREAKING CHANGE. Each version above \
+is the one about to be published, so cargo-semver-checks derived the release type from the \
+real delta — and a failure means that delta is too small, not that breaking is forbidden. \
+Shipping this would hand consumers a compile break on a version their caret requirement \
+picks up automatically. Raise each failing crate to its breaking slot: for a 0.x crate that \
+is the MINOR field (0.16.1 -> 0.17.0), not the patch. Alternatively make the change \
+non-breaking (\`#[non_exhaustive]\` on a struct or enum that should never have been \
+exhaustively constructible) and re-run."
+  exit "$status"
+fi
+
+echo "::warning::API breaks reported — expected on a PR marked '!'; the \
+release moves the compatibility field accordingly."
 exit "$status"


### PR DESCRIPTION
release-plz runs cargo-semver-checks itself and is meant to raise the bump when a
crate actually broke. On 2026-09-05 it did not, and nothing caught it:

```
vti-common: next version is 0.16.2 (✓ API compatible changes)
vta-sdk:    next version is 0.32.4 (✓ API compatible changes)
```

Run directly against the same baseline, the same tool disagrees:

| Crate | Lint | Detail |
|---|---|---|
| `vti-common` | `enum_variant_added` | `Capability` gained `MemoryRead`, `MemoryWrite`, `RoomPresent`, `RoomOpen`; `AuditEvent` gained `RoomOperation`. Neither is `#[non_exhaustive]`, so a downstream exhaustive `match` stops compiling. |
| `vta-sdk` | `constructible_struct_adds_field` ×16 | `CreateAclBody`, `AclEntry`, `IssueCredentialBody`, `MemoryPut/List/DeleteBody`, `UpdateConfigBody` and others gained a public `ext` field, breaking struct-literal construction — the expected usage for an SDK's wire types. |

Both were about to ship as **patch** releases, which `^0.16` and `^0.32`
consumers take automatically: a compile break delivered by a routine update.
RELEASING.md's rule is the opposite — the release moves the compatibility field
instead of shipping a break as a patch.

## Why the existing report cannot catch this

It runs on ordinary PRs, where the manifest still carries the **published**
version. cargo-semver-checks compares 0.16.1 against 0.16.1 and can only answer
*"a break exists"* — never *"the chosen bump is too small"*, because no bump has
been chosen yet.

A release-plz branch is the one place the question is answerable: every manifest
already holds the version about to be published, so cargo-semver-checks derives
the release type from the real delta and a failure means precisely that the delta
is insufficient.

So this is **not** new logic or a reimplementation of semver arithmetic. It is the
same check, the same script, the same exclusion list and coverage assertion — run
at the one point where it can answer the right question, and enforced instead of
reported. `SEMVER_MODE=enforce` selects it; the default stays `report`.

## Verified both directions, against the real release branch

```
0.16.2 / 0.32.4  ->  "(minor change)"  ->  fails, exit 100
0.17.0 / 0.33.0  ->  "(major change)"  ->  passes, exit 0
```

The second run bumped both crates to their breaking slot and moved all 26
internal requirements, as release-plz would. It blocks an under-bump and permits
a properly declared breaking release — rather than being red on every release
and therefore ignored, which is the failure mode this job family has already had
twice (#1252, #1253).

## Scope

- Runs only when `github.head_ref` starts with `release-plz-`; ordinary PRs are
  unaffected and still get the informational report.
- **No `continue-on-error`.** That is the entire point.
- To make it binding, add "release bump is large enough" to the branch
  protection required checks — it only ever runs on release branches, so it
  cannot block anything else.

## Not fixed here

Release PR #1232 still proposes the under-bumped versions. The correct values
are `vti-common` 0.17.0 and `vta-sdk` 0.33.0. Why release-plz reports these as
compatible is still unexplained: I ruled out the unpublished-crate abort (a
rerun with both crates published gave the same answer), baseline mismatch (the
git tag and the crates.io artifact agree, and neither has the variants), feature
gating, and workspace-vs-package mode. The only invocation that yields
release-plz's verdict is `--release-type major`, under which the tool runs zero
checks and skips all 254 — i.e. "breaking is permitted", not "nothing broke".
release-plz does not log its invocation, so that remains a hypothesis. Worth
raising upstream separately; this guard makes the disagreement harmless either
way.
