### PR TITLE
feat(persona): the operator surface, and a preview built to be read

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -2961,7 +2961,10 @@ pub(crate) enum PersonaCommands {
     },
     /// List the output formats this VTA can produce, and what each DISCARDS.
     /// Worth running before a preview: a renderer that drops provenance turns
-    /// "my employer attested this" into an unattributed value. Holder-scoped.
+    /// "my employer attested this" into an unattributed value.
+    ///
+    /// Open to any authenticated caller — it names nothing about you, and a
+    /// context-scoped operator about to request a disclosure needs it.
     Renderers,
 }
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -214,6 +214,18 @@ pub(crate) enum Commands {
         command: CredVaultCommands,
     },
 
+    /// The holder's own identity — the attributes they hold about themselves,
+    /// the profiles that project over them, which persona a context sees, and
+    /// what other people have disclosed.
+    ///
+    /// The pool and profiles sit ABOVE every trust context and need
+    /// unrestricted authority; bindings, contacts and disclosure are
+    /// context-scoped and take `--context`.
+    Persona {
+        #[command(subcommand)]
+        command: PersonaCommands,
+    },
+
     /// Generate auth credentials for applications and services
     AuthCredential {
         #[command(subcommand)]
@@ -2849,4 +2861,552 @@ mod memory_flag_tests {
             assert!(Cli::try_parse_from(["pnm", "memory", alias, "--context", "agent"]).is_ok());
         }
     }
+}
+
+/// How a value should be typed on the wire.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ValueTypeOpt {
+    /// Taken literally. `--value` is used as-is, not parsed as JSON.
+    String,
+    Number,
+    Boolean,
+    /// An ISO-8601 date, carried as a string.
+    Date,
+    /// A JSON object. `--value` is parsed.
+    Object,
+}
+
+/// Where a value came from — which decides how it may be presented.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ProvenanceOpt {
+    /// The holder typed it. True of most of an address book.
+    #[default]
+    SelfAsserted,
+    /// Backed by a held credential. Requires `--credential-id` and
+    /// `--claim-path`.
+    CredentialBacked,
+    /// Minted by the agent — a relay address, a per-verifier alias. Requires
+    /// `--generator`.
+    Generated,
+}
+
+/// How strongly a credential-backed claim is hidden when presented, most
+/// private first.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ProofRungOpt {
+    /// Proves a statement over the claim without disclosing it.
+    Predicate,
+    /// Discloses only what is needed, unlinkably — two presentations cannot be
+    /// joined.
+    Derived,
+    /// Discloses only what is needed, but carries the issuer's signature
+    /// unchanged, so two presentations ARE linkable.
+    SelectiveDisclosure,
+    /// Discloses the whole credential.
+    Whole,
+}
+
+/// `pnm persona …` — the holder's own identity.
+#[derive(Subcommand)]
+pub(crate) enum PersonaCommands {
+    /// The attribute pool: the facts the holder holds about themselves.
+    /// Holder-scoped — needs unrestricted authority, not a context admin.
+    Attribute {
+        #[command(subcommand)]
+        command: PersonaAttributeCommands,
+    },
+    /// Profiles: named projections over the pool. Holder-scoped.
+    Profile {
+        #[command(subcommand)]
+        command: PersonaProfileCommands,
+    },
+    /// Bindings: which profile a persona DID presents in a given context.
+    Binding {
+        #[command(subcommand)]
+        command: PersonaBindingCommands,
+    },
+    /// Contacts: what other people have disclosed to the holder.
+    Contact {
+        #[command(subcommand)]
+        command: PersonaContactCommands,
+    },
+    /// Disclosure: preview what would be revealed, then present it.
+    Disclosure {
+        #[command(subcommand)]
+        command: PersonaDisclosureCommands,
+    },
+    /// Profiles and bindings that live INSIDE one context, built only from
+    /// inline values — they cannot reference the holder's pool.
+    Local {
+        #[command(subcommand)]
+        command: PersonaLocalCommands,
+    },
+    /// Report how linkable a value, attribute or profile would make the
+    /// holder. Reads the pool; writes nothing. Holder-scoped.
+    ///
+    /// Note the inversion: a credential presented WHOLE correlates more than a
+    /// self-asserted value, because the issuer's signature is identical at
+    /// every verifier — while a derived proof correlates less.
+    Correlate {
+        /// Analyse one stored attribute.
+        #[arg(long = "attribute-id")]
+        attribute_id: Option<String>,
+        /// Analyse an entire profile.
+        #[arg(long = "profile-id")]
+        profile_id: Option<String>,
+        /// Analyse a value that is NOT stored — "what would happen if I gave
+        /// them this". Path to a JSON document, or `-` for stdin.
+        #[arg(long = "candidate-file")]
+        candidate_file: Option<String>,
+    },
+    /// List the output formats this VTA can produce, and what each DISCARDS.
+    /// Worth running before a preview: a renderer that drops provenance turns
+    /// "my employer attested this" into an unattributed value. Holder-scoped.
+    Renderers,
+}
+
+/// `pnm persona attribute …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaAttributeCommands {
+    /// Store one fact about the holder. Omit `--attribute-id` to create.
+    Put {
+        /// Vocabulary token naming what this is — `name.legal`,
+        /// `phone.mobile`, `address.postal`. Dotted, most-general first;
+        /// `x:` opens an extension namespace.
+        #[arg(long = "type")]
+        claim_type: String,
+        /// The value. Taken literally for `--value-type string` and `date`;
+        /// parsed as JSON otherwise.
+        #[arg(long)]
+        value: String,
+        /// What the value is.
+        #[arg(long = "value-type", value_enum, default_value = "string")]
+        value_type: ValueTypeOpt,
+        /// The holder's own name for it — "work mobile", "the flat".
+        #[arg(long)]
+        label: Option<String>,
+        /// Where the value came from.
+        #[arg(long, value_enum, default_value = "self-asserted")]
+        provenance: ProvenanceOpt,
+        /// Vault id of the backing credential. Required for
+        /// `--provenance credential-backed`.
+        #[arg(long = "credential-id")]
+        credential_id: Option<String>,
+        /// RFC 6901 JSON Pointer to the claim inside that credential, e.g.
+        /// `/credentialSubject/familyName`. Required for
+        /// `--provenance credential-backed`.
+        #[arg(long = "claim-path")]
+        claim_path: Option<String>,
+        /// Issuer of the backing credential. Advisory — a consumer verifies
+        /// the credential rather than trusting this.
+        #[arg(long = "issuer-did")]
+        issuer_did: Option<String>,
+        /// The rung this claim should be presented at.
+        #[arg(long, value_enum)]
+        proof: Option<ProofRungOpt>,
+        /// Names the minting scheme, e.g. `relayEmail`. Required for
+        /// `--provenance generated`.
+        #[arg(long)]
+        generator: Option<String>,
+        /// Mint a distinct value per verifier. Defaults to true server-side,
+        /// and there is rarely a reason to turn it off.
+        #[arg(long = "per-verifier")]
+        per_verifier: Option<bool>,
+        /// Update an existing attribute, or make a create idempotent.
+        #[arg(long = "attribute-id")]
+        attribute_id: Option<String>,
+        /// Require the attribute to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
+    /// Enumerate the pool. Metadata only unless `--values` is given.
+    List {
+        /// Match a dotted prefix — `phone` returns `phone.mobile` and
+        /// `phone.work`.
+        #[arg(long = "type-prefix")]
+        type_prefix: Option<String>,
+        /// Include the values themselves. This turns a listing into a read of
+        /// the holder's identity, so it is opt-in.
+        #[arg(long)]
+        values: bool,
+        /// Include attributes whose backing credential can no longer be
+        /// re-derived. On by default — a holder deciding what to present needs
+        /// to see what went stale, not have it quietly omitted.
+        #[arg(long = "include-stale")]
+        include_stale: Option<bool>,
+        /// Page size.
+        #[arg(long)]
+        limit: Option<std::num::NonZeroU64>,
+        /// Continuation token from a previous page.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+    /// Remove an attribute. Refused while a profile still references it
+    /// unless `--cascade` is given.
+    Delete {
+        /// The attribute id.
+        #[arg(long = "attribute-id")]
+        attribute_id: String,
+        /// Also drop every profile entry referencing it.
+        #[arg(long)]
+        cascade: bool,
+        /// Require the attribute to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
+}
+
+/// `pnm persona profile …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaProfileCommands {
+    /// Create or update a profile. Supply entries with `--ref` (repeatable,
+    /// for the simple "just show these attributes" case) or `--entries-file`
+    /// for the full shape.
+    Put {
+        /// The holder's name for this projection — "work", "gaming".
+        #[arg(long)]
+        name: String,
+        /// Reference a pool attribute, live. Repeatable.
+        #[arg(long = "ref")]
+        refs: Vec<String>,
+        /// Path to a JSON array of profile entries (or `-` for stdin). Each
+        /// is one of `{"ref":…}`, `{"ref":…,"pinVersion":n}`,
+        /// `{"ref":…,"override":{…}}` or `{"inline":{…}}`.
+        #[arg(long = "entries-file", conflicts_with = "refs")]
+        entries_file: Option<String>,
+        /// Tag a credential as belonging with this profile. Repeatable.
+        #[arg(long = "credential-ref")]
+        credential_refs: Vec<String>,
+        /// Update an existing profile, or make a create idempotent.
+        #[arg(long = "profile-id")]
+        profile_id: Option<String>,
+        /// Require the profile to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
+    /// Read one profile.
+    Get {
+        /// The profile id.
+        #[arg(long = "profile-id")]
+        profile_id: String,
+        /// Resolve entries against the pool and show what the profile would
+        /// actually present, rather than how it is built.
+        #[arg(long)]
+        resolve: bool,
+    },
+    /// Enumerate profiles.
+    List {
+        /// Page size.
+        #[arg(long)]
+        limit: Option<std::num::NonZeroU64>,
+        /// Continuation token.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+    /// Remove a profile. Refused while a persona still presents under it
+    /// unless `--unbind` is given.
+    Delete {
+        /// The profile id.
+        #[arg(long = "profile-id")]
+        profile_id: String,
+        /// Also clear every binding pointing at it. Those personas will
+        /// present nothing until rebound.
+        #[arg(long)]
+        unbind: bool,
+        /// Require the profile to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
+}
+
+/// `pnm persona binding …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaBindingCommands {
+    /// Decide what a context sees. The profile is resolved above the context
+    /// and a COPY of its values is written in — the context never reads back
+    /// into the pool. Omit `--profile-id` to clear the binding.
+    Set {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The persona DID presenting in it.
+        #[arg(long = "persona-did")]
+        persona_did: String,
+        /// The profile to project. Omit to clear.
+        #[arg(long = "profile-id")]
+        profile_id: Option<String>,
+        /// Attribute ids disclosed in this context without asking.
+        /// Repeatable.
+        #[arg(long = "public")]
+        public_entries: Vec<String>,
+        /// Require the binding to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
+    /// What one persona presents in one context.
+    Get {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The persona DID.
+        #[arg(long = "persona-did")]
+        persona_did: String,
+    },
+    /// Every persona bound in one context.
+    List {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// Page size.
+        #[arg(long)]
+        limit: Option<std::num::NonZeroU64>,
+        /// Continuation token.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+}
+
+/// `pnm persona contact …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaContactCommands {
+    /// Record what a peer disclosed. Writes a new revision rather than
+    /// overwriting, so what they told you in March survives them changing it
+    /// in April.
+    Put {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The DID the disclosure came from.
+        #[arg(long = "subject-did")]
+        subject_did: String,
+        /// Which of the holder's own personas knows this contact. Required —
+        /// a contact filed against no persona is one you cannot later reason
+        /// about disclosing to.
+        #[arg(long = "known-by")]
+        known_by_persona: String,
+        /// Path to the disclosed document JSON (or `-` for stdin):
+        /// `{"claims":[…]}`.
+        #[arg(long = "document-file")]
+        document_file: String,
+        /// A credential received alongside it. Repeatable.
+        #[arg(long = "credential-ref")]
+        credential_refs: Vec<String>,
+        /// The holder's private annotation. Never disclosed.
+        #[arg(long)]
+        notes: Option<String>,
+    },
+    /// Read one contact.
+    Get {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The contact id.
+        #[arg(long = "contact-id")]
+        contact_id: String,
+        /// Read one specific revision instead of the current one.
+        #[arg(long)]
+        rev: Option<std::num::NonZeroU64>,
+        /// Return every retained revision.
+        #[arg(long = "history")]
+        include_history: bool,
+    },
+    /// Enumerate contacts in one context.
+    List {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// Only contacts filed against this persona.
+        #[arg(long = "known-by")]
+        known_by_persona: Option<String>,
+        /// Only contacts whose current revision is newer than this
+        /// (RFC 3339).
+        #[arg(long = "changed-since")]
+        changed_since: Option<String>,
+        /// Page size.
+        #[arg(long)]
+        limit: Option<std::num::NonZeroU64>,
+        /// Continuation token.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+    /// Forget a contact.
+    Delete {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The contact id.
+        #[arg(long = "contact-id")]
+        contact_id: String,
+    },
+}
+
+/// `pnm persona disclosure …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaDisclosureCommands {
+    /// Show exactly what would be revealed, and to whom. Signs nothing and
+    /// sends nothing.
+    ///
+    /// This is the only screen between a request and the holder's identity
+    /// leaving the machine, and the `previewId` it returns is the ONLY way to
+    /// reach `present` — there is no single-call form.
+    Preview {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The persona that would present. Its binding supplies the profile.
+        #[arg(long = "persona-did")]
+        persona_did: String,
+        /// Who would receive it.
+        #[arg(long = "verifier-did")]
+        verifier_did: String,
+        /// A claim type the verifier asked for. Repeatable. Omit to preview
+        /// everything the bound profile would present.
+        #[arg(long = "claim")]
+        requested_claims: Vec<String>,
+        /// The verifier's stated reason, carried into the preview and the
+        /// disclosure record.
+        #[arg(long)]
+        purpose: Option<String>,
+        /// Which output format to prepare for. Omit for the canonical one.
+        /// See `persona renderers` for what each one discards.
+        #[arg(long)]
+        renderer: Option<String>,
+    },
+    /// Hand over what the preview showed. Consumes the preview — a replay is
+    /// refused rather than riding the earlier decision.
+    Present {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The preview being acted on.
+        #[arg(long = "preview-id")]
+        preview_id: String,
+        /// Verifier-supplied nonce binding the disclosure to this exchange.
+        #[arg(long)]
+        challenge: Option<String>,
+        /// Path to a JSON object (or `-` for stdin) asking for the disclosure
+        /// as a self-issued credential rather than a bare document.
+        #[arg(long = "mint-file")]
+        mint_file: Option<String>,
+    },
+    /// What was disclosed, to whom, when. Omit `--context` to read across
+    /// every context — which is a holder-scoped read and gated as one.
+    History {
+        /// Narrow to one trust context.
+        #[arg(long)]
+        context: Option<String>,
+        /// Narrow to one verifier.
+        #[arg(long = "verifier-did")]
+        verifier_did: Option<String>,
+        /// Narrow to one claim type.
+        #[arg(long = "type")]
+        attribute_type: Option<String>,
+        /// Only disclosures after this instant (RFC 3339).
+        #[arg(long)]
+        since: Option<String>,
+        /// Page size.
+        #[arg(long)]
+        limit: Option<std::num::NonZeroU64>,
+        /// Continuation token.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+}
+
+/// `pnm persona local …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaLocalCommands {
+    /// Profiles that live inside one context.
+    Profile {
+        #[command(subcommand)]
+        command: PersonaLocalProfileCommands,
+    },
+    /// Bind a persona DID to a context-local profile.
+    Binding {
+        #[command(subcommand)]
+        command: PersonaLocalBindingCommands,
+    },
+}
+
+/// `pnm persona local profile …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaLocalProfileCommands {
+    /// Create or update a context-local profile.
+    ///
+    /// Entries are inline values only. A profile built inside a context
+    /// cannot reference, pin or override an attribute in the holder's pool —
+    /// that is the boundary, and it is enforced by the schema rather than by
+    /// this command.
+    Put {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The holder's name for it.
+        #[arg(long)]
+        name: String,
+        /// Path to a JSON array of entries (or `-` for stdin). Each is
+        /// `{"inline":{"type":…,"value":…,"valueType":…,"provenance":{…}}}`.
+        #[arg(long = "entries-file")]
+        entries_file: String,
+        /// Update an existing local profile, or make a create idempotent.
+        #[arg(long = "profile-id")]
+        profile_id: Option<String>,
+        /// Require the profile to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
+    /// Read one context-local profile.
+    Get {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The profile id.
+        #[arg(long = "profile-id")]
+        profile_id: String,
+    },
+    /// Enumerate a context's own profiles.
+    List {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// Page size.
+        #[arg(long)]
+        limit: Option<std::num::NonZeroU64>,
+        /// Continuation token.
+        #[arg(long)]
+        cursor: Option<String>,
+    },
+    /// Remove a context-local profile.
+    Delete {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The profile id.
+        #[arg(long = "profile-id")]
+        profile_id: String,
+        /// Also clear any local binding pointing at it.
+        #[arg(long)]
+        unbind: bool,
+    },
+}
+
+/// `pnm persona local binding …`
+#[derive(Subcommand)]
+pub(crate) enum PersonaLocalBindingCommands {
+    /// Bind a persona DID to a context-local profile. Omit `--profile-id` to
+    /// clear.
+    Set {
+        /// The trust context.
+        #[arg(long)]
+        context: String,
+        /// The persona DID.
+        #[arg(long = "persona-did")]
+        persona_did: String,
+        /// The context-local profile. Omit to clear.
+        #[arg(long = "profile-id")]
+        profile_id: Option<String>,
+        /// Require the binding to be at exactly this version.
+        #[arg(long = "expected-version")]
+        expected_version: Option<u64>,
+    },
 }

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod did_templates;
 pub(crate) mod health;
 pub(crate) mod keys;
 pub(crate) mod memory;
+pub(crate) mod persona;
 pub(crate) mod policy;
 pub(crate) mod services;
 pub(crate) mod setup;

--- a/pnm-cli/src/commands/persona.rs
+++ b/pnm-cli/src/commands/persona.rs
@@ -1,0 +1,653 @@
+//! `pnm persona …` dispatch — thin shim over the shared persona commands,
+//! plus the three places a flat CLI has to reconstruct a structured payload:
+//! provenance, typed values, and profile entries.
+//!
+//! Each of those validates here rather than letting the VTA reject the
+//! request, so the operator is told which flag is missing instead of reading a
+//! schema-validation failure.
+
+use std::io::Read;
+
+use vta_cli_common::commands::persona as p;
+use vta_sdk::prelude::*;
+use vta_sdk::protocols::persona::{
+    ContactDocument, LocalProfileEntry, ProfileEntry, ProofRung, Provenance, ValueType,
+};
+
+use crate::cli::{
+    PersonaAttributeCommands, PersonaBindingCommands, PersonaCommands, PersonaContactCommands,
+    PersonaDisclosureCommands, PersonaLocalBindingCommands, PersonaLocalCommands,
+    PersonaLocalProfileCommands, PersonaProfileCommands, ProofRungOpt, ProvenanceOpt, ValueTypeOpt,
+};
+
+type CmdResult = Result<(), Box<dyn std::error::Error>>;
+
+pub(crate) async fn run(client: &VtaClient, command: PersonaCommands) -> CmdResult {
+    match command {
+        PersonaCommands::Attribute { command } => attribute(client, command).await,
+        PersonaCommands::Profile { command } => profile(client, command).await,
+        PersonaCommands::Binding { command } => binding(client, command).await,
+        PersonaCommands::Contact { command } => contact(client, command).await,
+        PersonaCommands::Disclosure { command } => disclosure(client, command).await,
+        PersonaCommands::Local { command } => local(client, command).await,
+        PersonaCommands::Correlate {
+            attribute_id,
+            profile_id,
+            candidate_file,
+        } => {
+            let candidate = candidate_file.as_deref().map(read_json).transpose()?;
+            if attribute_id.is_none() && profile_id.is_none() && candidate.is_none() {
+                return Err(
+                    "nothing to analyse — pass one of --attribute-id, --profile-id or \
+                            --candidate-file"
+                        .into(),
+                );
+            }
+            p::cmd_correlate(client, attribute_id, profile_id, candidate).await
+        }
+        PersonaCommands::Renderers => p::cmd_renderers(client).await,
+    }
+}
+
+async fn attribute(client: &VtaClient, command: PersonaAttributeCommands) -> CmdResult {
+    match command {
+        PersonaAttributeCommands::Put {
+            claim_type,
+            value,
+            value_type,
+            label,
+            provenance,
+            credential_id,
+            claim_path,
+            issuer_did,
+            proof,
+            generator,
+            per_verifier,
+            attribute_id,
+            expected_version,
+        } => {
+            let vt = value_type_of(value_type);
+            let parsed = parse_value(&value, vt)?;
+            let prov = build_provenance(
+                provenance,
+                credential_id,
+                claim_path,
+                issuer_did,
+                proof,
+                generator,
+                per_verifier,
+            )?;
+            p::cmd_attribute_put(
+                client,
+                claim_type,
+                parsed,
+                vt,
+                prov,
+                label,
+                attribute_id,
+                expected_version,
+            )
+            .await
+        }
+        PersonaAttributeCommands::List {
+            type_prefix,
+            values,
+            include_stale,
+            limit,
+            cursor,
+        } => p::cmd_attribute_list(client, type_prefix, values, include_stale, limit, cursor).await,
+        PersonaAttributeCommands::Delete {
+            attribute_id,
+            cascade,
+            expected_version,
+        } => p::cmd_attribute_delete(client, attribute_id, cascade, expected_version).await,
+    }
+}
+
+async fn profile(client: &VtaClient, command: PersonaProfileCommands) -> CmdResult {
+    match command {
+        PersonaProfileCommands::Put {
+            name,
+            refs,
+            entries_file,
+            credential_refs,
+            profile_id,
+            expected_version,
+        } => {
+            let entries = profile_entries(refs, entries_file)?;
+            p::cmd_profile_put(
+                client,
+                name,
+                entries,
+                credential_refs,
+                profile_id,
+                expected_version,
+            )
+            .await
+        }
+        PersonaProfileCommands::Get {
+            profile_id,
+            resolve,
+        } => p::cmd_profile_get(client, profile_id, resolve).await,
+        PersonaProfileCommands::List { limit, cursor } => {
+            p::cmd_profile_list(client, limit, cursor).await
+        }
+        PersonaProfileCommands::Delete {
+            profile_id,
+            unbind,
+            expected_version,
+        } => p::cmd_profile_delete(client, profile_id, unbind, expected_version).await,
+    }
+}
+
+async fn binding(client: &VtaClient, command: PersonaBindingCommands) -> CmdResult {
+    match command {
+        PersonaBindingCommands::Set {
+            context,
+            persona_did,
+            profile_id,
+            public_entries,
+            expected_version,
+        } => {
+            p::cmd_binding_set(
+                client,
+                context,
+                persona_did,
+                profile_id,
+                public_entries,
+                expected_version,
+            )
+            .await
+        }
+        PersonaBindingCommands::Get {
+            context,
+            persona_did,
+        } => p::cmd_binding_get(client, context, persona_did).await,
+        PersonaBindingCommands::List {
+            context,
+            limit,
+            cursor,
+        } => p::cmd_binding_list(client, context, limit, cursor).await,
+    }
+}
+
+async fn contact(client: &VtaClient, command: PersonaContactCommands) -> CmdResult {
+    match command {
+        PersonaContactCommands::Put {
+            context,
+            subject_did,
+            known_by_persona,
+            document_file,
+            credential_refs,
+            notes,
+        } => {
+            let raw = read_json(&document_file)?;
+            let document: ContactDocument = serde_json::from_value(raw).map_err(|e| {
+                format!(
+                    "{document_file}: not a contact document ({e}) — expected an object with a \
+                         `claims` array, each entry carrying at least `type` and `value`"
+                )
+            })?;
+            p::cmd_contact_put(
+                client,
+                context,
+                subject_did,
+                known_by_persona,
+                document,
+                credential_refs,
+                notes,
+            )
+            .await
+        }
+        PersonaContactCommands::Get {
+            context,
+            contact_id,
+            rev,
+            include_history,
+        } => p::cmd_contact_get(client, context, contact_id, rev, include_history).await,
+        PersonaContactCommands::List {
+            context,
+            known_by_persona,
+            changed_since,
+            limit,
+            cursor,
+        } => {
+            p::cmd_contact_list(
+                client,
+                context,
+                known_by_persona,
+                changed_since,
+                limit,
+                cursor,
+            )
+            .await
+        }
+        PersonaContactCommands::Delete {
+            context,
+            contact_id,
+        } => p::cmd_contact_delete(client, context, contact_id).await,
+    }
+}
+
+async fn disclosure(client: &VtaClient, command: PersonaDisclosureCommands) -> CmdResult {
+    match command {
+        PersonaDisclosureCommands::Preview {
+            context,
+            persona_did,
+            verifier_did,
+            requested_claims,
+            purpose,
+            renderer,
+        } => {
+            p::cmd_disclosure_preview(
+                client,
+                context,
+                persona_did,
+                verifier_did,
+                requested_claims,
+                purpose,
+                renderer,
+            )
+            .await
+        }
+        PersonaDisclosureCommands::Present {
+            context,
+            preview_id,
+            challenge,
+            mint_file,
+        } => {
+            let mint = mint_file.as_deref().map(read_json).transpose()?;
+            p::cmd_disclosure_present(client, context, preview_id, challenge, mint).await
+        }
+        PersonaDisclosureCommands::History {
+            context,
+            verifier_did,
+            attribute_type,
+            since,
+            limit,
+            cursor,
+        } => {
+            p::cmd_disclosure_history(
+                client,
+                context,
+                verifier_did,
+                attribute_type,
+                since,
+                limit,
+                cursor,
+            )
+            .await
+        }
+    }
+}
+
+async fn local(client: &VtaClient, command: PersonaLocalCommands) -> CmdResult {
+    match command {
+        PersonaLocalCommands::Profile { command } => match command {
+            PersonaLocalProfileCommands::Put {
+                context,
+                name,
+                entries_file,
+                profile_id,
+                expected_version,
+            } => {
+                let entries = local_entries(&entries_file)?;
+                p::cmd_local_profile_put(
+                    client,
+                    context,
+                    name,
+                    entries,
+                    profile_id,
+                    expected_version,
+                )
+                .await
+            }
+            PersonaLocalProfileCommands::Get {
+                context,
+                profile_id,
+            } => p::cmd_local_profile_get(client, context, profile_id).await,
+            PersonaLocalProfileCommands::List {
+                context,
+                limit,
+                cursor,
+            } => p::cmd_local_profile_list(client, context, limit, cursor).await,
+            PersonaLocalProfileCommands::Delete {
+                context,
+                profile_id,
+                unbind,
+            } => p::cmd_local_profile_delete(client, context, profile_id, unbind).await,
+        },
+        PersonaLocalCommands::Binding { command } => match command {
+            PersonaLocalBindingCommands::Set {
+                context,
+                persona_did,
+                profile_id,
+                expected_version,
+            } => {
+                p::cmd_local_binding_set(client, context, persona_did, profile_id, expected_version)
+                    .await
+            }
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reconstructing structure from flags
+// ---------------------------------------------------------------------------
+
+fn value_type_of(v: ValueTypeOpt) -> ValueType {
+    match v {
+        ValueTypeOpt::String => ValueType::String,
+        ValueTypeOpt::Number => ValueType::Number,
+        ValueTypeOpt::Boolean => ValueType::Boolean,
+        ValueTypeOpt::Date => ValueType::Date,
+        ValueTypeOpt::Object => ValueType::Object,
+    }
+}
+
+/// Interpret `--value` according to `--value-type`.
+///
+/// Strings and dates are taken literally: parsing them as JSON would turn the
+/// perfectly ordinary name `null`, or a house number typed as `7`, into
+/// something other than what the operator wrote. Everything else is parsed,
+/// and a parse failure names the type that was asked for rather than reporting
+/// a syntax error against a document the operator did not think they were
+/// writing.
+fn parse_value(raw: &str, value_type: ValueType) -> Result<serde_json::Value, String> {
+    match value_type {
+        ValueType::String | ValueType::Date => Ok(serde_json::Value::String(raw.to_string())),
+        ValueType::Number | ValueType::Boolean | ValueType::Object => serde_json::from_str(raw)
+            .map_err(|e| {
+                format!(
+                    "--value is not a valid {}: {e}. Pass `--value-type string` to store it \
+                     literally.",
+                    match value_type {
+                        ValueType::Number => "number",
+                        ValueType::Boolean => "boolean",
+                        _ => "JSON object",
+                    }
+                )
+            }),
+    }
+}
+
+/// Build a [`Provenance`] from the flat flags, refusing an incomplete one.
+///
+/// A `credentialBacked` claim missing its credential is not a claim with a
+/// gap — it is a self-asserted value wearing a credential's authority, which
+/// is the one thing provenance exists to prevent. So the incomplete
+/// combination is an error here rather than a silent downgrade anywhere.
+fn build_provenance(
+    kind: ProvenanceOpt,
+    credential_id: Option<String>,
+    claim_path: Option<String>,
+    issuer_did: Option<String>,
+    proof: Option<ProofRungOpt>,
+    generator: Option<String>,
+    per_verifier: Option<bool>,
+) -> Result<Provenance, String> {
+    let unused = |flags: &[(&str, bool)]| -> Result<(), String> {
+        let set: Vec<&str> = flags
+            .iter()
+            .filter(|(_, on)| *on)
+            .map(|(n, _)| *n)
+            .collect();
+        if set.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "{} ignored by --provenance {}; remove them or change the provenance",
+                set.join(", "),
+                match kind {
+                    ProvenanceOpt::SelfAsserted => "self-asserted",
+                    ProvenanceOpt::CredentialBacked => "credential-backed",
+                    ProvenanceOpt::Generated => "generated",
+                }
+            ))
+        }
+    };
+
+    match kind {
+        ProvenanceOpt::SelfAsserted => {
+            unused(&[
+                ("--credential-id", credential_id.is_some()),
+                ("--claim-path", claim_path.is_some()),
+                ("--issuer-did", issuer_did.is_some()),
+                ("--proof", proof.is_some()),
+                ("--generator", generator.is_some()),
+                ("--per-verifier", per_verifier.is_some()),
+            ])?;
+            Ok(Provenance::SelfAsserted)
+        }
+        ProvenanceOpt::CredentialBacked => {
+            unused(&[
+                ("--generator", generator.is_some()),
+                ("--per-verifier", per_verifier.is_some()),
+            ])?;
+            let credential_id =
+                credential_id.ok_or("--provenance credential-backed requires --credential-id")?;
+            let claim_path = claim_path.ok_or(
+                "--provenance credential-backed requires --claim-path, e.g. \
+                 /credentialSubject/familyName",
+            )?;
+            Ok(Provenance::CredentialBacked {
+                credential_id,
+                claim_path,
+                issuer_did,
+                proof: proof.map(|r| match r {
+                    ProofRungOpt::Predicate => ProofRung::Predicate,
+                    ProofRungOpt::Derived => ProofRung::Derived,
+                    ProofRungOpt::SelectiveDisclosure => ProofRung::SelectiveDisclosure,
+                    ProofRungOpt::Whole => ProofRung::Whole,
+                }),
+            })
+        }
+        ProvenanceOpt::Generated => {
+            unused(&[
+                ("--credential-id", credential_id.is_some()),
+                ("--claim-path", claim_path.is_some()),
+                ("--issuer-did", issuer_did.is_some()),
+                ("--proof", proof.is_some()),
+            ])?;
+            let generator =
+                generator.ok_or("--provenance generated requires --generator, e.g. relayEmail")?;
+            Ok(Provenance::Generated {
+                generator,
+                per_verifier,
+            })
+        }
+    }
+}
+
+/// Profile entries from either the `--ref` shorthand or a JSON file.
+fn profile_entries(
+    refs: Vec<String>,
+    entries_file: Option<String>,
+) -> Result<Vec<ProfileEntry>, String> {
+    if let Some(path) = entries_file {
+        let raw = read_json(&path)?;
+        return serde_json::from_value(raw).map_err(|e| {
+            format!(
+                "{path}: not a profile-entry array ({e}) — each entry is one of \
+                 {{\"ref\":\"…\"}}, {{\"ref\":\"…\",\"pinVersion\":n}}, \
+                 {{\"ref\":\"…\",\"override\":{{\"value\":…}}}} or {{\"inline\":{{…}}}}"
+            )
+        });
+    }
+    if refs.is_empty() {
+        return Err(
+            "a profile needs entries — pass --ref <attribute-id> (repeatable) or --entries-file"
+                .into(),
+        );
+    }
+    Ok(refs
+        .into_iter()
+        .map(|attribute_id| ProfileEntry::Ref { attribute_id })
+        .collect())
+}
+
+/// Entries for a context-local profile: inline values only.
+///
+/// The error path is the interesting one. A `{"ref": …}` entry fails to parse,
+/// and serde's own message ("unknown field `ref`") describes the symptom
+/// rather than the rule, so it is replaced with the rule: a profile inside a
+/// context cannot reach into the holder's pool, and the way to get a pool
+/// value in here is to bind an agent-scoped profile instead.
+fn local_entries(path: &str) -> Result<Vec<LocalProfileEntry>, String> {
+    let raw = read_json(path)?;
+    let mentions_ref = raw
+        .as_array()
+        .is_some_and(|a| a.iter().any(|e| e.get("ref").is_some()));
+    serde_json::from_value(raw).map_err(|e| {
+        if mentions_ref {
+            format!(
+                "{path}: a context-local profile cannot reference the holder's attribute pool. \
+                 Its entries are inline values only — {{\"inline\":{{\"type\":…,\"value\":…, \
+                 \"valueType\":…,\"provenance\":{{\"kind\":\"selfAsserted\"}}}}}}. To present a \
+                 pool attribute in this context, build an agent-scoped profile with \
+                 `persona profile put` and bind it with `persona binding set`."
+            )
+        } else {
+            format!("{path}: not a local-profile-entry array ({e})")
+        }
+    })
+}
+
+/// Read a JSON document from a file path, or stdin when `path` is `-`.
+fn read_json(path: &str) -> Result<serde_json::Value, String> {
+    let contents = if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| format!("stdin: {e}"))?;
+        buf
+    } else {
+        std::fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?
+    };
+    serde_json::from_str(&contents).map_err(|e| format!("{path}: invalid JSON: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A name that happens to read as JSON is still a name.
+    ///
+    /// `null`, `7` and `true` are all things a person legitimately types into
+    /// a string field — a house number, a nickname, a nom de plume. Parsing
+    /// `--value` as JSON regardless of `--value-type` would store something
+    /// other than what was written, and the holder would find out when a
+    /// verifier saw it.
+    #[test]
+    fn a_string_value_is_taken_literally() {
+        for raw in ["null", "7", "true", "{\"not\": \"an object\"}"] {
+            let v = parse_value(raw, ValueType::String).expect("string values always parse");
+            assert_eq!(v, serde_json::Value::String(raw.to_string()));
+        }
+    }
+
+    /// A typed value that is not of its type fails here, naming the escape
+    /// hatch, rather than at the VTA's schema validator.
+    #[test]
+    fn a_mistyped_value_names_the_way_out() {
+        let err = parse_value("not-a-number", ValueType::Number).expect_err("must not parse");
+        assert!(
+            err.contains("--value-type string"),
+            "the error should name the escape hatch, got: {err}"
+        );
+    }
+
+    /// An incomplete `credentialBacked` claim is refused rather than
+    /// downgraded.
+    ///
+    /// The alternative — dropping the missing members and sending it anyway —
+    /// produces a self-asserted value wearing a credential's authority, which
+    /// is the single thing provenance exists to prevent.
+    #[test]
+    fn credential_backed_provenance_refuses_to_be_incomplete() {
+        let err = build_provenance(
+            ProvenanceOpt::CredentialBacked,
+            None,
+            Some("/credentialSubject/familyName".into()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect_err("must refuse without a credential id");
+        assert!(err.contains("--credential-id"), "got: {err}");
+
+        let err = build_provenance(
+            ProvenanceOpt::CredentialBacked,
+            Some("cred-1".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect_err("must refuse without a claim path");
+        assert!(err.contains("--claim-path"), "got: {err}");
+    }
+
+    /// A flag that the chosen provenance would ignore is an error, not a
+    /// no-op.
+    ///
+    /// Silently dropping `--credential-id` from a self-asserted attribute
+    /// leaves the operator believing they stored something attested.
+    #[test]
+    fn a_flag_the_provenance_ignores_is_refused() {
+        let err = build_provenance(
+            ProvenanceOpt::SelfAsserted,
+            Some("cred-1".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect_err("must refuse a flag it would ignore");
+        assert!(err.contains("--credential-id"), "got: {err}");
+    }
+
+    #[test]
+    fn a_complete_generated_provenance_builds() {
+        let p = build_provenance(
+            ProvenanceOpt::Generated,
+            None,
+            None,
+            None,
+            None,
+            Some("relayEmail".into()),
+            Some(true),
+        )
+        .expect("builds");
+        assert!(matches!(
+            p,
+            Provenance::Generated {
+                ref generator,
+                per_verifier: Some(true)
+            } if generator == "relayEmail"
+        ));
+    }
+
+    /// `--ref` shorthand produces live references, not pins.
+    #[test]
+    fn the_ref_shorthand_produces_live_references() {
+        let entries = profile_entries(vec!["01J8".into(), "01J9".into()], None).expect("builds");
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .all(|e| matches!(e, ProfileEntry::Ref { .. }))
+        );
+    }
+
+    /// A profile with no entries is a mistake worth catching before the round
+    /// trip: it would discloses nothing, which is never what was meant.
+    #[test]
+    fn a_profile_with_no_entries_is_refused() {
+        let err = profile_entries(Vec::new(), None).expect_err("must refuse");
+        assert!(err.contains("--ref"), "got: {err}");
+    }
+}

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -288,6 +288,7 @@ async fn main() {
         Commands::Device { command } => commands::device::run(&client, command).await,
         Commands::Vault { command } => commands::vault::run(&client, command).await,
         Commands::CredVault { command } => commands::cred_vault::run(&client, command).await,
+        Commands::Persona { command } => commands::persona::run(&client, command).await,
         Commands::AuthCredential { command } => {
             commands::auth_credential::run(&client, command).await
         }

--- a/vta-cli-common/src/commands/mod.rs
+++ b/vta-cli-common/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod did_templates;
 pub mod keys;
 pub mod memory;
 /// Raw Rego policy management over the canonical `policy/*` family.
+pub mod persona;
 pub mod policy;
 pub mod services;
 pub mod vault;

--- a/vta-cli-common/src/commands/persona.rs
+++ b/vta-cli-common/src/commands/persona.rs
@@ -8,12 +8,17 @@
 //!
 //! ## Scope, and the error an operator will actually hit
 //!
-//! Eleven of these are holder-scoped — the attribute pool, profiles,
-//! correlation, renderers — and the VTA requires *unrestricted* authority for
-//! them. An operator whose credential is scoped to one trust context gets
-//! `e.p.msg.forbidden`, and that is the boundary working: the pool sits above
-//! every context and is not any one context's to read. The context-scoped
-//! commands all take `--context`.
+//! Ten of these are holder-scoped — the attribute pool, profiles, correlation,
+//! and cross-context disclosure history — and the VTA requires *unrestricted*
+//! authority for them. An operator whose credential is scoped to one trust
+//! context gets `e.p.msg.forbidden`, and that is the boundary working: the pool
+//! sits above every context and is not any one context's to read. The
+//! context-scoped commands all take `--context`.
+//!
+//! `persona renderers` is on neither side. It lists the output formats this
+//! VTA ships and what each discards, which names nothing about the holder —
+//! and a context-scoped operator about to request a disclosure needs it, since
+//! `persona disclosure preview` takes a renderer by name.
 
 use serde_json::Value;
 use vta_sdk::client::VtaClient;

--- a/vta-cli-common/src/commands/persona.rs
+++ b/vta-cli-common/src/commands/persona.rs
@@ -1,0 +1,660 @@
+//! `persona …` operator commands — the holder's own identity.
+//!
+//! Thin wrappers over the `VtaClient::persona_*` methods, with one exception
+//! worth knowing about before reading further: [`cmd_disclosure_preview`]
+//! renders its response rather than dumping it, because that response is the
+//! only thing standing between an automated request and the holder's name
+//! leaving the machine. Everything else prints the payload.
+//!
+//! ## Scope, and the error an operator will actually hit
+//!
+//! Eleven of these are holder-scoped — the attribute pool, profiles,
+//! correlation, renderers — and the VTA requires *unrestricted* authority for
+//! them. An operator whose credential is scoped to one trust context gets
+//! `e.p.msg.forbidden`, and that is the boundary working: the pool sits above
+//! every context and is not any one context's to read. The context-scoped
+//! commands all take `--context`.
+
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::persona::{
+    ContactDocument, LocalProfileEntry, ProfileEntry, Provenance, ValueType,
+};
+
+use crate::render::{BOLD, CYAN, DIM, RED, RESET, YELLOW, is_json_output, print_json};
+
+type CmdResult = Result<(), Box<dyn std::error::Error>>;
+
+fn print_result(label: &str, value: &Value) -> CmdResult {
+    if is_json_output() {
+        print_json(value)?;
+    } else {
+        println!("{label}");
+        println!("{}", serde_json::to_string_pretty(value)?);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The pool
+// ---------------------------------------------------------------------------
+
+/// `persona attribute put` — store one fact about the holder.
+#[allow(clippy::too_many_arguments)]
+pub async fn cmd_attribute_put(
+    client: &VtaClient,
+    claim_type: String,
+    value: Value,
+    value_type: ValueType,
+    provenance: Provenance,
+    label: Option<String>,
+    attribute_id: Option<String>,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let result = client
+        .persona_attribute_put(
+            &claim_type,
+            value,
+            value_type,
+            provenance,
+            label.as_deref(),
+            attribute_id.as_deref(),
+            expected_version,
+        )
+        .await?;
+    print_result("Attribute:", &result)
+}
+
+/// `persona attribute list` — enumerate the pool.
+///
+/// Metadata-only unless `--values` is given. The default is not timidity: a
+/// listing that returns values is a read of the holder's identity, and the
+/// command that does it should be the one the operator typed on purpose.
+pub async fn cmd_attribute_list(
+    client: &VtaClient,
+    type_prefix: Option<String>,
+    include_values: bool,
+    include_stale: Option<bool>,
+    limit: Option<std::num::NonZeroU64>,
+    cursor: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_attribute_list(
+            type_prefix.as_deref(),
+            include_values,
+            include_stale,
+            limit,
+            cursor.as_deref(),
+        )
+        .await?;
+    if !is_json_output() && !include_values {
+        println!("{DIM}Metadata only — add --values to include the values themselves.{RESET}");
+    }
+    print_result("Attributes:", &result)
+}
+
+/// `persona attribute delete` — remove one attribute.
+pub async fn cmd_attribute_delete(
+    client: &VtaClient,
+    attribute_id: String,
+    cascade: bool,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let result = client
+        .persona_attribute_delete(&attribute_id, cascade, expected_version)
+        .await?;
+    if !is_json_output() && cascade {
+        println!("{DIM}Cascaded: profile entries referencing {attribute_id} were removed.{RESET}");
+    }
+    print_result("Result:", &result)
+}
+
+// ---------------------------------------------------------------------------
+// Profiles
+// ---------------------------------------------------------------------------
+
+/// `persona profile put` — create or update a projection over the pool.
+pub async fn cmd_profile_put(
+    client: &VtaClient,
+    name: String,
+    entries: Vec<ProfileEntry>,
+    credential_refs: Vec<String>,
+    profile_id: Option<String>,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let result = client
+        .persona_profile_put(
+            &name,
+            entries,
+            credential_refs,
+            profile_id.as_deref(),
+            expected_version,
+        )
+        .await?;
+    print_result("Profile:", &result)
+}
+
+/// `persona profile get` — read one profile.
+pub async fn cmd_profile_get(client: &VtaClient, profile_id: String, resolve: bool) -> CmdResult {
+    let result = client.persona_profile_get(&profile_id, resolve).await?;
+    if !is_json_output() && !resolve {
+        println!(
+            "{DIM}Showing how the profile is built — add --resolve to see what it would present.{RESET}"
+        );
+    }
+    print_result("Profile:", &result)
+}
+
+/// `persona profile list` — enumerate profiles.
+pub async fn cmd_profile_list(
+    client: &VtaClient,
+    limit: Option<std::num::NonZeroU64>,
+    cursor: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_profile_list(limit, cursor.as_deref())
+        .await?;
+    print_result("Profiles:", &result)
+}
+
+/// `persona profile delete` — remove a profile.
+pub async fn cmd_profile_delete(
+    client: &VtaClient,
+    profile_id: String,
+    unbind: bool,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let result = client
+        .persona_profile_delete(&profile_id, unbind, expected_version)
+        .await?;
+    if !is_json_output() && unbind {
+        println!(
+            "{YELLOW}Unbound: every persona presenting under {profile_id} now presents nothing until rebound.{RESET}"
+        );
+    }
+    print_result("Result:", &result)
+}
+
+// ---------------------------------------------------------------------------
+// Bindings
+// ---------------------------------------------------------------------------
+
+/// `persona binding set` — decide what a context sees.
+pub async fn cmd_binding_set(
+    client: &VtaClient,
+    context_id: String,
+    persona_did: String,
+    profile_id: Option<String>,
+    public_entries: Vec<String>,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let clearing = profile_id.is_none();
+    let result = client
+        .persona_binding_set(
+            &context_id,
+            &persona_did,
+            profile_id.as_deref(),
+            public_entries,
+            expected_version,
+        )
+        .await?;
+    if !is_json_output() {
+        if clearing {
+            println!(
+                "{DIM}Binding cleared — {persona_did} now presents nothing in {context_id}.{RESET}"
+            );
+        } else {
+            println!(
+                "{DIM}A copy of the profile's values was written into {context_id}. Editing the \
+                 pool refreshes it; nothing inside the context can read back the other way.{RESET}"
+            );
+        }
+    }
+    print_result("Binding:", &result)
+}
+
+/// `persona binding get` — what one persona presents in one context.
+pub async fn cmd_binding_get(
+    client: &VtaClient,
+    context_id: String,
+    persona_did: String,
+) -> CmdResult {
+    let result = client
+        .persona_binding_get(&context_id, &persona_did)
+        .await?;
+    print_result("Binding:", &result)
+}
+
+/// `persona binding list` — every persona bound in one context.
+pub async fn cmd_binding_list(
+    client: &VtaClient,
+    context_id: String,
+    limit: Option<std::num::NonZeroU64>,
+    cursor: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_binding_list(&context_id, limit, cursor.as_deref())
+        .await?;
+    print_result("Bindings:", &result)
+}
+
+// ---------------------------------------------------------------------------
+// Contacts
+// ---------------------------------------------------------------------------
+
+/// `persona contact put` — record what someone disclosed.
+pub async fn cmd_contact_put(
+    client: &VtaClient,
+    context_id: String,
+    subject_did: String,
+    known_by_persona: String,
+    document: ContactDocument,
+    credential_refs: Vec<String>,
+    notes: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_contact_put(
+            &context_id,
+            &subject_did,
+            &known_by_persona,
+            document,
+            credential_refs,
+            notes.as_deref(),
+        )
+        .await?;
+    print_result("Contact:", &result)
+}
+
+/// `persona contact get` — read one contact.
+pub async fn cmd_contact_get(
+    client: &VtaClient,
+    context_id: String,
+    contact_id: String,
+    rev: Option<std::num::NonZeroU64>,
+    include_history: bool,
+) -> CmdResult {
+    let result = client
+        .persona_contact_get(&context_id, &contact_id, rev, include_history)
+        .await?;
+    print_result("Contact:", &result)
+}
+
+/// `persona contact list` — enumerate contacts.
+pub async fn cmd_contact_list(
+    client: &VtaClient,
+    context_id: String,
+    known_by_persona: Option<String>,
+    changed_since: Option<String>,
+    limit: Option<std::num::NonZeroU64>,
+    cursor: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_contact_list(
+            &context_id,
+            known_by_persona.as_deref(),
+            changed_since.as_deref(),
+            limit,
+            cursor.as_deref(),
+        )
+        .await?;
+    print_result("Contacts:", &result)
+}
+
+/// `persona contact delete` — forget a contact.
+pub async fn cmd_contact_delete(
+    client: &VtaClient,
+    context_id: String,
+    contact_id: String,
+) -> CmdResult {
+    let result = client
+        .persona_contact_delete(&context_id, &contact_id)
+        .await?;
+    print_result("Result:", &result)
+}
+
+// ---------------------------------------------------------------------------
+// Disclosure
+// ---------------------------------------------------------------------------
+
+/// `persona disclosure preview` — what would this reveal, and to whom?
+///
+/// Signs nothing and sends nothing. This is the only place the holder sees
+/// what is about to leave, so the response is rendered rather than dumped —
+/// and rendered by *rank*, not as a flat list. A preview that shows fourteen
+/// fields with fourteen equal weights is a notice-and-consent dialog, which is
+/// the pattern that teaches people to click through.
+pub async fn cmd_disclosure_preview(
+    client: &VtaClient,
+    context_id: String,
+    persona_did: String,
+    verifier_did: String,
+    requested_claims: Vec<String>,
+    purpose: Option<String>,
+    renderer: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_disclosure_preview(
+            &context_id,
+            &persona_did,
+            &verifier_did,
+            requested_claims,
+            purpose.as_deref(),
+            renderer.as_deref(),
+        )
+        .await?;
+
+    if is_json_output() {
+        print_json(&result)?;
+        return Ok(());
+    }
+    render_preview(&result, &context_id, &verifier_did, purpose.as_deref());
+    Ok(())
+}
+
+/// Render a preview for a human, falling back to the raw payload if the
+/// response is not the shape this function knows how to read.
+///
+/// The fallback is the point. A renderer that quietly showed an empty claim
+/// table on an unfamiliar response would tell the holder "nothing will be
+/// disclosed" about a disclosure that is about to happen — the one lie this
+/// screen must not tell. Better an ugly payload than a confident wrong
+/// summary.
+fn render_preview(result: &Value, context_id: &str, verifier_did: &str, purpose: Option<&str>) {
+    let (Some(preview_id), Some(claims)) = (
+        result.get("previewId").and_then(Value::as_str),
+        result.get("claims").and_then(Value::as_array),
+    ) else {
+        println!(
+            "{YELLOW}Preview response was not in the expected shape; showing it as received.{RESET}"
+        );
+        println!(
+            "{}",
+            serde_json::to_string_pretty(result).unwrap_or_else(|_| format!("{result:?}"))
+        );
+        return;
+    };
+
+    println!();
+    println!("{BOLD}Disclosure preview{RESET} — nothing has been sent.");
+    println!();
+    println!("  {DIM}To{RESET}         {verifier_did}");
+    println!("  {DIM}Context{RESET}    {context_id}");
+    if let Some(p) = purpose {
+        println!("  {DIM}Purpose{RESET}    {p}");
+    }
+    if let Some(subject) = result.get("subject").and_then(Value::as_str) {
+        println!("  {DIM}As{RESET}         {subject}");
+    }
+
+    // What the chosen renderer cannot carry. Declared, not discovered.
+    if let Some(r) = result.get("renderer") {
+        let id = r.get("id").and_then(Value::as_str).unwrap_or("?");
+        let drops: Vec<&str> = r
+            .get("drops")
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        if drops.is_empty() {
+            println!("  {DIM}Format{RESET}     {id} {DIM}(carries everything){RESET}");
+        } else {
+            println!(
+                "  {DIM}Format{RESET}     {id} {YELLOW}— discards: {}{RESET}",
+                drops.join(", ")
+            );
+        }
+    }
+
+    // Correlation. The inversion is easy to get backwards, so the reason the
+    // VTA supplies is printed rather than re-derived here.
+    if let Some(c) = result.get("correlation") {
+        let severity = c.get("severity").and_then(Value::as_str).unwrap_or("none");
+        let colour = match severity {
+            "high" => RED,
+            "low" => YELLOW,
+            _ => DIM,
+        };
+        let reason = c.get("reason").and_then(Value::as_str).unwrap_or("");
+        println!(
+            "  {DIM}Linkable{RESET}   {colour}{}{RESET} {reason}",
+            severity.to_uppercase()
+        );
+    }
+
+    let anomalous: Vec<&str> = result
+        .get("anomalous")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    println!();
+    if claims.is_empty() {
+        println!("  {DIM}No claims would be disclosed.{RESET}");
+    }
+    for claim in claims {
+        let ty = claim.get("type").and_then(Value::as_str).unwrap_or("?");
+        let provenance = claim
+            .get("provenance")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let rung = claim.get("rung").and_then(Value::as_str).unwrap_or("");
+        let stale = claim.get("stale").and_then(Value::as_bool).unwrap_or(false);
+        let fresh = claim
+            .get("newToThisVerifier")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let odd = anomalous.contains(&ty);
+
+        // A predicate claim carries no value, and that absence is the whole
+        // point of the rung — never render it as missing data.
+        let shown = if let Some(p) = claim.get("predicate") {
+            let op = p.get("op").and_then(Value::as_str).unwrap_or("?");
+            let arg = p.get("arg").map(render_scalar).unwrap_or_default();
+            format!("{DIM}proves {op} {arg} — the value itself is not sent{RESET}")
+        } else if stale {
+            format!("{YELLOW}stale — will NOT be sent{RESET}")
+        } else {
+            claim.get("value").map(render_scalar).unwrap_or_default()
+        };
+
+        let mark = if odd || fresh {
+            format!("{RED}!{RESET}")
+        } else {
+            " ".into()
+        };
+        println!("  {mark} {CYAN}{ty}{RESET}");
+        println!("      {shown}");
+        let mut notes: Vec<String> = Vec::new();
+        if !provenance.is_empty() {
+            notes.push(provenance.to_string());
+        }
+        if !rung.is_empty() {
+            notes.push(rung.to_string());
+        }
+        if fresh {
+            notes.push("new to this verifier".into());
+        }
+        if odd {
+            notes.push("unusual for the stated purpose".into());
+        }
+        if !notes.is_empty() {
+            println!("      {DIM}{}{RESET}", notes.join(" · "));
+        }
+    }
+
+    println!();
+    if let Some(expiry) = result.get("expiresAt").and_then(Value::as_str) {
+        println!("  {DIM}This preview expires at {expiry} and can be used once.{RESET}");
+    }
+    println!(
+        "  Disclose with: {BOLD}persona disclosure present --context {context_id} \
+         --preview-id {preview_id}{RESET}"
+    );
+    println!();
+}
+
+/// Render a JSON scalar the way a person reads it — a string without its
+/// quotes, anything else as compact JSON.
+fn render_scalar(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// `persona disclosure present` — hand over what the preview showed.
+pub async fn cmd_disclosure_present(
+    client: &VtaClient,
+    context_id: String,
+    preview_id: String,
+    challenge: Option<String>,
+    mint: Option<Value>,
+) -> CmdResult {
+    let result = client
+        .persona_disclosure_present(&context_id, &preview_id, challenge.as_deref(), mint)
+        .await?;
+
+    // The document the VTA returns is unsigned; signing belongs to the key
+    // custodian. Say so, rather than letting an operator hand a verifier
+    // something that looks presentable and is not.
+    if !is_json_output()
+        && result
+            .get("document")
+            .and_then(|d| d.get("unsigned"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    {
+        println!(
+            "{YELLOW}This document is UNSIGNED. Sign it with the persona's key \
+             (`keys derive-and-sign-document`) before sending it to a verifier.{RESET}"
+        );
+    }
+    print_result("Disclosure:", &result)
+}
+
+/// `persona disclosure history` — what was disclosed, to whom, when.
+pub async fn cmd_disclosure_history(
+    client: &VtaClient,
+    context_id: Option<String>,
+    verifier_did: Option<String>,
+    attribute_type: Option<String>,
+    since: Option<String>,
+    limit: Option<std::num::NonZeroU64>,
+    cursor: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_disclosure_history(
+            context_id.as_deref(),
+            verifier_did.as_deref(),
+            attribute_type.as_deref(),
+            since.as_deref(),
+            limit,
+            cursor.as_deref(),
+        )
+        .await?;
+    print_result("Disclosures:", &result)
+}
+
+// ---------------------------------------------------------------------------
+// Correlation and renderers
+// ---------------------------------------------------------------------------
+
+/// `persona correlate` — how linkable would this make the holder?
+pub async fn cmd_correlate(
+    client: &VtaClient,
+    attribute_id: Option<String>,
+    profile_id: Option<String>,
+    candidate: Option<Value>,
+) -> CmdResult {
+    let result = client
+        .persona_correlation_analyze(attribute_id.as_deref(), profile_id.as_deref(), candidate)
+        .await?;
+    print_result("Correlation:", &result)
+}
+
+/// `persona renderers` — the output formats, and what each one discards.
+pub async fn cmd_renderers(client: &VtaClient) -> CmdResult {
+    let result = client.persona_renderers_list().await?;
+    print_result("Renderers:", &result)
+}
+
+// ---------------------------------------------------------------------------
+// Context-local profiles and bindings
+// ---------------------------------------------------------------------------
+
+/// `persona local profile put` — a profile that lives inside one context.
+pub async fn cmd_local_profile_put(
+    client: &VtaClient,
+    context_id: String,
+    name: String,
+    entries: Vec<LocalProfileEntry>,
+    profile_id: Option<String>,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let result = client
+        .persona_local_profile_put(
+            &context_id,
+            &name,
+            entries,
+            profile_id.as_deref(),
+            expected_version,
+        )
+        .await?;
+    print_result("Local profile:", &result)
+}
+
+/// `persona local profile get` — read one context-local profile.
+pub async fn cmd_local_profile_get(
+    client: &VtaClient,
+    context_id: String,
+    profile_id: String,
+) -> CmdResult {
+    let result = client
+        .persona_local_profile_get(&context_id, &profile_id)
+        .await?;
+    print_result("Local profile:", &result)
+}
+
+/// `persona local profile list` — enumerate a context's own profiles.
+pub async fn cmd_local_profile_list(
+    client: &VtaClient,
+    context_id: String,
+    limit: Option<std::num::NonZeroU64>,
+    cursor: Option<String>,
+) -> CmdResult {
+    let result = client
+        .persona_local_profile_list(&context_id, limit, cursor.as_deref())
+        .await?;
+    print_result("Local profiles:", &result)
+}
+
+/// `persona local profile delete` — remove a context-local profile.
+pub async fn cmd_local_profile_delete(
+    client: &VtaClient,
+    context_id: String,
+    profile_id: String,
+    unbind: bool,
+) -> CmdResult {
+    let result = client
+        .persona_local_profile_delete(&context_id, &profile_id, unbind)
+        .await?;
+    print_result("Result:", &result)
+}
+
+/// `persona local binding set` — bind a persona to a context-local profile.
+pub async fn cmd_local_binding_set(
+    client: &VtaClient,
+    context_id: String,
+    persona_did: String,
+    profile_id: Option<String>,
+    expected_version: Option<u64>,
+) -> CmdResult {
+    let result = client
+        .persona_local_binding_set(
+            &context_id,
+            &persona_did,
+            profile_id.as_deref(),
+            expected_version,
+        )
+        .await?;
+    print_result("Local binding:", &result)
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -315,6 +315,7 @@ mod app_state;
 #[cfg(feature = "test-loopback")]
 pub mod loopback;
 mod memory;
+mod persona;
 mod policy;
 mod secrets;
 mod vault;

--- a/vta-sdk/src/client/persona.rs
+++ b/vta-sdk/src/client/persona.rs
@@ -9,15 +9,24 @@
 //!
 //! ## Two scopes, and callers should know which they are in
 //!
-//! Eleven of these tasks are **holder-scoped**: the attribute pool, the
-//! profiles built over it, correlation analysis, the renderer registry. The
-//! VTA gates them on *unrestricted* authority — an administrator scoped to a
-//! single trust context is refused, because the pool is not any context's to
-//! read. A client holding a context-scoped credential will get
-//! `e.p.msg.forbidden` from every one of them, and that is the boundary
-//! working rather than a misconfiguration.
+//! Ten of these tasks are **holder-scoped**: the attribute pool, the profiles
+//! built over it, correlation analysis, and disclosure history read across
+//! every context. The VTA gates them on *unrestricted* authority — an
+//! administrator scoped to a single trust context is refused, because the pool
+//! is not any context's to read. A client holding a context-scoped credential
+//! will get `e.p.msg.forbidden` from every one of them, and that is the
+//! boundary working rather than a misconfiguration.
 //!
-//! The rest are context-scoped and take a `context_id`.
+//! Thirteen are **context-scoped** and take a `context_id`.
+//!
+//! [`persona_renderers_list`](VtaClient::persona_renderers_list) is neither,
+//! and deliberately so: it returns the renderer ids this VTA ships and what
+//! each one discards, which names nothing about the holder or any context. Any
+//! authenticated caller may ask. Gating it as holder-scoped would refuse the
+//! callers who most need it — `persona_disclosure_preview` is context-scoped
+//! and takes a renderer name, so an application that cannot list renderers
+//! cannot choose one, and choosing blind is how a holder discloses through a
+//! format that silently drops provenance.
 //!
 //! ## Disclosure is two calls, on purpose
 //!

--- a/vta-sdk/src/client/persona.rs
+++ b/vta-sdk/src/client/persona.rs
@@ -1,0 +1,703 @@
+//! Persona Trust Task client methods (`spec/persona/*`).
+//!
+//! Drives the family through the generic trust-task dispatcher
+//! ([`VtaClient::dispatch_trust_task`]) — there are no dedicated REST routes.
+//!
+//! Bodies are built from the typed [`protocols::persona`] structs rather than
+//! `json!` literals, so a schema change surfaces here as a compile error
+//! rather than as a payload the VTA rejects at run time.
+//!
+//! ## Two scopes, and callers should know which they are in
+//!
+//! Eleven of these tasks are **holder-scoped**: the attribute pool, the
+//! profiles built over it, correlation analysis, the renderer registry. The
+//! VTA gates them on *unrestricted* authority — an administrator scoped to a
+//! single trust context is refused, because the pool is not any context's to
+//! read. A client holding a context-scoped credential will get
+//! `e.p.msg.forbidden` from every one of them, and that is the boundary
+//! working rather than a misconfiguration.
+//!
+//! The rest are context-scoped and take a `context_id`.
+//!
+//! ## Disclosure is two calls, on purpose
+//!
+//! [`persona_disclosure_preview`](VtaClient::persona_disclosure_preview) signs
+//! nothing and sends nothing; it returns a `previewId` that
+//! [`persona_disclosure_present`](VtaClient::persona_disclosure_present)
+//! consumes. There is no single-call form, and adding one would remove the
+//! only point at which a human can see what is about to be handed over.
+
+use serde_json::Value;
+
+use super::VtaClient;
+use crate::error::VtaError;
+use crate::protocols::persona::{
+    ContactDocument, LocalProfileEntry, PersonaAttributeDeleteBody, PersonaAttributeListBody,
+    PersonaAttributePutBody, PersonaBindingGetBody, PersonaBindingListBody, PersonaBindingSetBody,
+    PersonaContactDeleteBody, PersonaContactGetBody, PersonaContactListBody, PersonaContactPutBody,
+    PersonaCorrelationAnalyzeBody, PersonaDisclosureHistoryBody, PersonaDisclosurePresentBody,
+    PersonaDisclosurePreviewBody, PersonaLocalBindingSetBody, PersonaLocalProfileDeleteBody,
+    PersonaLocalProfileGetBody, PersonaLocalProfileListBody, PersonaLocalProfilePutBody,
+    PersonaProfileDeleteBody, PersonaProfileGetBody, PersonaProfileListBody, PersonaProfilePutBody,
+    PersonaRenderersListBody, ProfileEntry, Provenance, ValueType,
+};
+use crate::trust_tasks;
+
+/// Round-trip timeout (seconds) for persona trust tasks. Matches the
+/// application-state and memory slices: these are local store operations, and
+/// the two that are not — preview and present — are bounded by the VTA's own
+/// credential work rather than by anything a client can wait longer for.
+const PERSONA_TT_TIMEOUT: u64 = 30;
+
+/// Serialize a typed body, mapping the (unreachable in practice) failure into
+/// a typed SDK error rather than panicking inside a client call.
+fn body(value: impl serde::Serialize) -> Result<Value, VtaError> {
+    serde_json::to_value(value)
+        .map_err(|e| VtaError::Validation(format!("encode persona payload: {e}")))
+}
+
+impl VtaClient {
+    // -----------------------------------------------------------------------
+    // The pool — holder-scoped
+    // -----------------------------------------------------------------------
+
+    /// `persona/attribute/put/1.0` — create or update one attribute in the
+    /// holder's pool.
+    ///
+    /// Omit `attribute_id` to create. Supplying one makes a create idempotent;
+    /// supplying one that exists is an update, and `expected_version` is the
+    /// precondition that keeps two editors from silently overwriting each
+    /// other.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn persona_attribute_put(
+        &self,
+        claim_type: &str,
+        value: Value,
+        value_type: ValueType,
+        provenance: Provenance,
+        label: Option<&str>,
+        attribute_id: Option<&str>,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaAttributePutBody {
+            claim_type: claim_type.to_string(),
+            value,
+            value_type,
+            provenance,
+            label: label.map(str::to_string),
+            attribute_id: attribute_id.map(str::to_string),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_ATTRIBUTE_PUT_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/attribute/list/1.0` — enumerate the pool.
+    ///
+    /// Metadata-only unless `include_values` is set. That default is the
+    /// difference between "how many phone numbers do I hold" and a read of the
+    /// holder's identity, so it is opt-in rather than something a caller has
+    /// to remember to narrow.
+    pub async fn persona_attribute_list(
+        &self,
+        type_prefix: Option<&str>,
+        include_values: bool,
+        include_stale: Option<bool>,
+        limit: Option<std::num::NonZeroU64>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaAttributeListBody {
+            type_prefix: type_prefix.map(str::to_string),
+            include_values: include_values.then_some(true),
+            include_stale,
+            limit,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/attribute/delete/1.0` — remove an attribute.
+    ///
+    /// Refused while a profile still references it unless `cascade` is set;
+    /// the alternative would be profiles quietly presenting a dangling
+    /// reference.
+    pub async fn persona_attribute_delete(
+        &self,
+        attribute_id: &str,
+        cascade: bool,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaAttributeDeleteBody {
+            attribute_id: attribute_id.to_string(),
+            cascade: cascade.then_some(true),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_ATTRIBUTE_DELETE_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Profiles — holder-scoped
+    // -----------------------------------------------------------------------
+
+    /// `persona/profile/put/1.0` — create or update an agent-scoped profile.
+    pub async fn persona_profile_put(
+        &self,
+        name: &str,
+        entries: Vec<ProfileEntry>,
+        credential_refs: Vec<String>,
+        profile_id: Option<&str>,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaProfilePutBody {
+            name: name.to_string(),
+            entries,
+            credential_refs,
+            profile_id: profile_id.map(str::to_string),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_PROFILE_PUT_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/profile/get/1.0` — read one profile.
+    ///
+    /// `resolve` returns the values the profile would present rather than the
+    /// references it is built from — which is what a holder needs to answer
+    /// "what does this actually show", and what a diff against the pool needs
+    /// to answer "has it drifted".
+    pub async fn persona_profile_get(
+        &self,
+        profile_id: &str,
+        resolve: bool,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaProfileGetBody {
+            profile_id: profile_id.to_string(),
+            resolve: resolve.then_some(true),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_PROFILE_GET_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/profile/list/1.0` — enumerate agent-scoped profiles.
+    pub async fn persona_profile_list(
+        &self,
+        limit: Option<std::num::NonZeroU64>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaProfileListBody {
+            limit,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_PROFILE_LIST_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/profile/delete/1.0` — remove an agent-scoped profile.
+    ///
+    /// Refused while a persona still presents under it unless `unbind` is set.
+    /// A context losing its identity mid-relationship is not something to do
+    /// by omission.
+    pub async fn persona_profile_delete(
+        &self,
+        profile_id: &str,
+        unbind: bool,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaProfileDeleteBody {
+            profile_id: profile_id.to_string(),
+            unbind: unbind.then_some(true),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Bindings — context-scoped
+    // -----------------------------------------------------------------------
+
+    /// `persona/binding/set/1.0` — assign a profile to a persona DID in one
+    /// context.
+    ///
+    /// The push across the boundary. The profile is resolved above the context
+    /// and a *materialised* projection is written into it — the context
+    /// receives values, never pool identifiers, so nothing inside it can walk
+    /// back to the holder's other faces. Pass `profile_id: None` to clear.
+    pub async fn persona_binding_set(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+        profile_id: Option<&str>,
+        public_entries: Vec<String>,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaBindingSetBody {
+            context_id: context_id.to_string(),
+            persona_did: persona_did.to_string(),
+            profile_id: profile_id.map(str::to_string),
+            public_entries,
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_BINDING_SET_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/binding/get/1.0` — what one persona DID presents in one
+    /// context.
+    pub async fn persona_binding_get(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaBindingGetBody {
+            context_id: context_id.to_string(),
+            persona_did: persona_did.to_string(),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_BINDING_GET_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/binding/list/1.0` — every persona bound in one context.
+    pub async fn persona_binding_list(
+        &self,
+        context_id: &str,
+        limit: Option<std::num::NonZeroU64>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaBindingListBody {
+            context_id: context_id.to_string(),
+            limit,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_BINDING_LIST_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Contacts — context-scoped
+    // -----------------------------------------------------------------------
+
+    /// `persona/contact/put/1.0` — record what a peer disclosed.
+    ///
+    /// Writes a new revision rather than overwriting: the previous one is
+    /// retained while anything still references it, so "what did they tell me
+    /// in March" survives them changing their mind in April.
+    pub async fn persona_contact_put(
+        &self,
+        context_id: &str,
+        subject_did: &str,
+        known_by_persona: &str,
+        document: ContactDocument,
+        credential_refs: Vec<String>,
+        notes: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaContactPutBody {
+            context_id: context_id.to_string(),
+            subject_did: subject_did.to_string(),
+            known_by_persona: known_by_persona.to_string(),
+            document,
+            credential_refs,
+            notes: notes.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_CONTACT_PUT_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/contact/get/1.0` — read one contact, optionally at an older
+    /// revision or with its full history.
+    pub async fn persona_contact_get(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+        rev: Option<std::num::NonZeroU64>,
+        include_history: bool,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaContactGetBody {
+            context_id: context_id.to_string(),
+            contact_id: contact_id.to_string(),
+            rev,
+            include_history: include_history.then_some(true),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_CONTACT_GET_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/contact/list/1.0` — enumerate contacts in one context.
+    pub async fn persona_contact_list(
+        &self,
+        context_id: &str,
+        known_by_persona: Option<&str>,
+        changed_since: Option<&str>,
+        limit: Option<std::num::NonZeroU64>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaContactListBody {
+            context_id: context_id.to_string(),
+            known_by_persona: known_by_persona.map(str::to_string),
+            changed_since: changed_since.map(str::to_string),
+            limit,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_CONTACT_LIST_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/contact/delete/1.0` — forget a contact.
+    pub async fn persona_contact_delete(
+        &self,
+        context_id: &str,
+        contact_id: &str,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaContactDeleteBody {
+            context_id: context_id.to_string(),
+            contact_id: contact_id.to_string(),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_CONTACT_DELETE_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Disclosure — context-scoped, and deliberately two calls
+    // -----------------------------------------------------------------------
+
+    /// `persona/disclosure/preview/1.0` — what would this disclosure reveal?
+    ///
+    /// Signs nothing, sends nothing, and is the **only** way to obtain the
+    /// `previewId` that
+    /// [`persona_disclosure_present`](Self::persona_disclosure_present)
+    /// consumes. The response carries what would be disclosed, what the chosen
+    /// renderer would *drop*, how much the disclosure would correlate the
+    /// holder, and which claims are unusual for the verifier's stated purpose
+    /// — the last so a holder reads the line worth reading rather than
+    /// clicking through fourteen equal-weighted fields.
+    ///
+    /// The preview is single-use and short-lived. One approved an hour ago is
+    /// not evidence of approval now.
+    pub async fn persona_disclosure_preview(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+        verifier_did: &str,
+        requested_claims: Vec<String>,
+        purpose: Option<&str>,
+        renderer: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaDisclosurePreviewBody {
+            context_id: context_id.to_string(),
+            persona_did: persona_did.to_string(),
+            verifier_did: verifier_did.to_string(),
+            requested_claims,
+            purpose: purpose.map(str::to_string),
+            renderer: renderer.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/disclosure/present/1.0` — hand over what the preview showed.
+    ///
+    /// Consumes `preview_id`. A replay is refused rather than riding the
+    /// earlier decision, and a claim that went stale between the two calls
+    /// refuses the *whole* disclosure rather than quietly presenting a shorter
+    /// one than the holder approved.
+    pub async fn persona_disclosure_present(
+        &self,
+        context_id: &str,
+        preview_id: &str,
+        challenge: Option<&str>,
+        mint: Option<Value>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaDisclosurePresentBody {
+            context_id: context_id.to_string(),
+            preview_id: preview_id.to_string(),
+            challenge: challenge.map(str::to_string),
+            mint,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_DISCLOSURE_PRESENT_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/disclosure/history/1.0` — what was disclosed, to whom, when.
+    ///
+    /// Omitting `context_id` reads across every context, which is a
+    /// holder-scoped read and gated as one.
+    pub async fn persona_disclosure_history(
+        &self,
+        context_id: Option<&str>,
+        verifier_did: Option<&str>,
+        attribute_type: Option<&str>,
+        since: Option<&str>,
+        limit: Option<std::num::NonZeroU64>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaDisclosureHistoryBody {
+            context_id: context_id.map(str::to_string),
+            verifier_did: verifier_did.map(str::to_string),
+            attribute_type: attribute_type.map(str::to_string),
+            since: since.map(str::to_string),
+            limit,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_DISCLOSURE_HISTORY_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Correlation and renderers — holder-scoped
+    // -----------------------------------------------------------------------
+
+    /// `persona/correlation/analyze/1.0` — how linkable would this make me?
+    ///
+    /// Pass a `candidate` to ask before disclosing rather than after — the
+    /// answer is worth more then. Note the inversion the response encodes: a
+    /// credential presented **whole** correlates *more* than a self-asserted
+    /// value, because the issuer's signature is byte-identical at every
+    /// verifier, while a derived proof correlates *less* because it differs on
+    /// every presentation.
+    pub async fn persona_correlation_analyze(
+        &self,
+        attribute_id: Option<&str>,
+        profile_id: Option<&str>,
+        candidate: Option<Value>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaCorrelationAnalyzeBody {
+            attribute_id: attribute_id.map(str::to_string),
+            profile_id: profile_id.map(str::to_string),
+            candidate,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_CORRELATION_ANALYZE_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/renderers/list/1.0` — the output formats this VTA can produce,
+    /// and what each one cannot carry.
+    ///
+    /// Worth calling before a preview: a renderer that drops provenance turns
+    /// "my employer attested this number" into "this number", and a holder is
+    /// owed that before choosing, not after.
+    pub async fn persona_renderers_list(&self) -> Result<Value, VtaError> {
+        let payload = body(PersonaRenderersListBody { ext: None })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    // -----------------------------------------------------------------------
+    // Context-local profiles and bindings
+    // -----------------------------------------------------------------------
+
+    /// `persona/local/profile/put/1.0` — a profile that lives inside one
+    /// context.
+    ///
+    /// Entries are [`LocalProfileEntry`] — inline only. A context-local
+    /// profile cannot reference, pin or override a pool attribute, because
+    /// there is nowhere in the type to name one.
+    pub async fn persona_local_profile_put(
+        &self,
+        context_id: &str,
+        name: &str,
+        entries: Vec<LocalProfileEntry>,
+        profile_id: Option<&str>,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaLocalProfilePutBody {
+            context_id: context_id.to_string(),
+            name: name.to_string(),
+            entries,
+            profile_id: profile_id.map(str::to_string),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/local/profile/get/1.0` — read one context-local profile.
+    pub async fn persona_local_profile_get(
+        &self,
+        context_id: &str,
+        profile_id: &str,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaLocalProfileGetBody {
+            context_id: context_id.to_string(),
+            profile_id: profile_id.to_string(),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_LOCAL_PROFILE_GET_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/local/profile/list/1.0` — enumerate one context's own
+    /// profiles.
+    pub async fn persona_local_profile_list(
+        &self,
+        context_id: &str,
+        limit: Option<std::num::NonZeroU64>,
+        cursor: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaLocalProfileListBody {
+            context_id: context_id.to_string(),
+            limit,
+            cursor: cursor.map(str::to_string),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/local/profile/delete/1.0` — remove a context-local profile.
+    pub async fn persona_local_profile_delete(
+        &self,
+        context_id: &str,
+        profile_id: &str,
+        unbind: bool,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaLocalProfileDeleteBody {
+            context_id: context_id.to_string(),
+            profile_id: profile_id.to_string(),
+            unbind: unbind.then_some(true),
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `persona/local/binding/set/1.0` — bind a persona DID to a
+    /// context-local profile.
+    ///
+    /// The counterpart to [`persona_binding_set`](Self::persona_binding_set)
+    /// for an identity that never existed above the context. There is no pool
+    /// read on this path at all.
+    pub async fn persona_local_binding_set(
+        &self,
+        context_id: &str,
+        persona_did: &str,
+        profile_id: Option<&str>,
+        expected_version: Option<u64>,
+    ) -> Result<Value, VtaError> {
+        let payload = body(PersonaLocalBindingSetBody {
+            context_id: context_id.to_string(),
+            persona_did: persona_did.to_string(),
+            profile_id: profile_id.map(str::to_string),
+            expected_version,
+            ext: None,
+        })?;
+        self.dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_LOCAL_BINDING_SET_1_0,
+            payload,
+            PERSONA_TT_TIMEOUT,
+        )
+        .await
+    }
+}

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -30,6 +30,7 @@ pub mod memory;
 pub mod app_state;
 /// Passkey-based login flow (`vta/auth/passkey-login-{start,finish}/1.0`).
 pub mod passkey_login;
+pub mod persona;
 /// Runtime Policy Decision Point management (`policy/*`) — where the
 /// declarative approvals model is read and written.
 pub mod policy_management;

--- a/vta-sdk/src/protocols/persona.rs
+++ b/vta-sdk/src/protocols/persona.rs
@@ -1,0 +1,921 @@
+//! Wire payloads for the persona Trust Tasks (`spec/persona/*`).
+//!
+//! A fourth holder store beside the secrets vault, the credential vault and
+//! [`crate::protocols::app_state`]: the holder's **own** identity — the
+//! attributes they hold about themselves, the profiles that project over
+//! those attributes, the persona DID a given context presents under, and the
+//! contacts other people have disclosed to them.
+//!
+//! ## The boundary these types are shaped around
+//!
+//! Two scopes, and the split is not an access-control list — it is the
+//! addressing:
+//!
+//! * **Agent-scoped**, above every trust context: the attribute pool
+//!   (`attribute/*`), the profiles built over it (`profile/*`), correlation
+//!   analysis, and the renderer registry. A caller reaching these must be
+//!   *unrestricted* — an administrator scoped to a single context is refused,
+//!   because the pool is not any context's to read.
+//! * **Context-scoped**: bindings (`binding/*`), contacts (`contact/*`),
+//!   disclosure (`disclosure/*`) and the context's own local profiles
+//!   (`local/*`).
+//!
+//! Nothing inside a context may read the pool. The holder *pushes* a
+//! materialised projection down; a context never pulls. That is why
+//! [`LocalProfileEntry`] is a separate type from [`ProfileEntry`] rather than
+//! the same type with some variants unused: a context-local profile can only
+//! be built from [`inline`](LocalProfileEntry::inline) values, so there is
+//! nowhere in the type to put a pool identifier. The published schema says the
+//! same thing, and this mirror keeps saying it in Rust.
+//!
+//! ## Request bodies only
+//!
+//! Responses come back as [`Value`], as they do for `app-state`. These are the
+//! shapes a caller must get right to be understood; a response is read by
+//! whatever is rendering it.
+//!
+//! ## Why hand-written here and generated in the service
+//!
+//! `vta-service` builds these payloads from `trust-tasks-rs` directly, because
+//! a mirror is a second definition of one contract and free to drift. This
+//! crate cannot: `trust-tasks-rs` is an **optional** dependency here and the
+//! `client` feature does not enable it, so a types-only consumer must not be
+//! made to pull the generated tree in. Two source-level censuses cover the gap
+//! the generated types would otherwise have closed — `payload_ext_census`
+//! (every `deny_unknown_fields` body carries `ext`) and `payload_null_census`
+//! (no optional member may serialize as `null`).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Shared vocabulary
+// ---------------------------------------------------------------------------
+
+/// What a stored value *is*, as opposed to what it means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValueType {
+    String,
+    Number,
+    Boolean,
+    Date,
+    Object,
+}
+
+/// How strongly a credential-backed claim is hidden when presented, ordered
+/// **most private first**.
+///
+/// The distinction between the first two and the last two is of kind, not
+/// degree: only `Predicate` and `Derived` avoid handing two verifiers a join
+/// key. A request that cannot be met at the rung asked for is refused rather
+/// than quietly served at a lower one — a silent privacy downgrade discloses
+/// material the holder believed was hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ProofRung {
+    /// Proves a statement over a claim without disclosing the claim.
+    Predicate,
+    /// Discloses exactly the claims needed, via a proof that differs on every
+    /// presentation, so two disclosures cannot be joined.
+    Derived,
+    /// Discloses exactly the claims needed, but carries the issuer's signature
+    /// unchanged — so two disclosures **are** linkable.
+    SelectiveDisclosure,
+    /// Discloses the entire credential.
+    Whole,
+}
+
+/// Where a value came from, which is what decides how it may be presented.
+///
+/// Tagged on `kind` rather than inferred from which members are present, so a
+/// `credentialBacked` claim missing its `credentialId` is a parse failure
+/// rather than a claim that silently degrades to self-asserted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum Provenance {
+    /// The holder typed it. True of most of an address book.
+    SelfAsserted,
+    /// Backed by a credential the holder holds.
+    #[serde(rename_all = "camelCase")]
+    CredentialBacked {
+        /// Vault identifier of the backing credential.
+        credential_id: String,
+        /// RFC 6901 JSON Pointer to the claim within it, e.g.
+        /// `/credentialSubject/familyName`.
+        claim_path: String,
+        /// Advisory only. A consumer verifies the credential rather than
+        /// trusting this member.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        issuer_did: Option<String>,
+        /// The rung this claim was, or will be, presented at.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        proof: Option<ProofRung>,
+    },
+    /// Minted by the agent — a relay address, a per-verifier alias.
+    #[serde(rename_all = "camelCase")]
+    Generated {
+        /// Names the minting scheme, e.g. `relayEmail`. Maintainer-defined.
+        generator: String,
+        /// When true — the default, and the only useful setting — a distinct
+        /// value is minted for each verifier.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        per_verifier: Option<bool>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Profile entries
+// ---------------------------------------------------------------------------
+
+/// The value an [`ProfileEntry::Override`] substitutes for the pool's.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct OverrideValue {
+    /// Replaces the pool attribute's value for this profile only.
+    pub value: Value,
+    /// Replaces its label too, when given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// A value that lives in a profile and nowhere else.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InlineValue {
+    /// The vocabulary token naming what this value is — `name.legal`,
+    /// `phone.mobile`. Dotted, most-general segment first; `x:` opens an
+    /// extension namespace.
+    #[serde(rename = "type")]
+    pub claim_type: String,
+    /// The value itself.
+    pub value: Value,
+    /// What the value is.
+    pub value_type: ValueType,
+    /// Where it came from.
+    pub provenance: Provenance,
+    /// The holder's own name for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// One line of an **agent-scoped** profile: how this profile takes a value.
+///
+/// Four forms, and the difference between them is the difference between "show
+/// my current mobile" and "show the mobile I gave this employer in March":
+///
+/// * [`Ref`](Self::Ref) — track the pool. Editing the attribute changes what
+///   this profile presents.
+/// * [`Pinned`](Self::Pinned) — track one *version*. Later edits do not reach
+///   it.
+/// * [`Override`](Self::Override) — present something else entirely, without
+///   putting that something in the pool.
+/// * [`Inline`](Self::Inline) — a value that exists only here.
+///
+/// # `deny_unknown_fields` is load-bearing
+///
+/// This is an untagged union, so serde tries the variants in order and takes
+/// the first that deserializes. Without `deny_unknown_fields` the `Ref` form —
+/// which needs only `ref` — matches an `{ref, override}` document too, and the
+/// override is dropped: the holder's substituted value silently becomes a live
+/// reference to the pool, and a pin silently becomes unpinned. That is a
+/// disclosure changing behind the holder's back, and it is the exact bug this
+/// crate's counterpart hit before the schema's own `deny_unknown_fields` was
+/// mirrored here. With the clause, an extra member makes a variant *fail*
+/// rather than match loosely, so the forms stay distinguishable no matter what
+/// order they are declared in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum ProfileEntry {
+    /// Track the pool attribute at whatever version it currently holds.
+    Ref {
+        #[serde(rename = "ref")]
+        attribute_id: String,
+    },
+    /// Track one specific version of the pool attribute.
+    #[serde(rename_all = "camelCase")]
+    Pinned {
+        #[serde(rename = "ref")]
+        attribute_id: String,
+        pin_version: ::std::num::NonZeroU64,
+    },
+    /// Take the pool attribute's identity but present a different value.
+    Override {
+        #[serde(rename = "ref")]
+        attribute_id: String,
+        #[serde(rename = "override")]
+        override_value: OverrideValue,
+    },
+    /// A value that exists only in this profile.
+    Inline { inline: InlineValue },
+}
+
+/// One line of a **context-local** profile.
+///
+/// Inline only — and that is the one-way boundary, expressed as a type rather
+/// than as a check. A profile built inside a trust context cannot reference,
+/// pin or override an attribute in the agent-scoped pool, because there is
+/// nowhere in this struct to name one. A context that wants the holder's real
+/// mobile number gets it because the holder pushed it down, never because
+/// something inside the context reached up for it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LocalProfileEntry {
+    /// The value, carried in full. There is no other form.
+    pub inline: InlineValue,
+}
+
+// ---------------------------------------------------------------------------
+// The pool — agent-scoped. `persona/attribute/*`
+// ---------------------------------------------------------------------------
+
+/// `spec/persona/attribute/put/1.0` — create or update one pool attribute.
+///
+/// Omit [`attribute_id`](Self::attribute_id) to create. Supplying one makes a
+/// create idempotent; supplying one that already exists is an update, and the
+/// VTA refuses rather than silently overwriting when the version precondition
+/// says otherwise.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaAttributePutBody {
+    /// The vocabulary token naming what this value is.
+    #[serde(rename = "type")]
+    pub claim_type: String,
+    /// The value.
+    pub value: Value,
+    /// What the value is.
+    pub value_type: ValueType,
+    /// Where it came from.
+    pub provenance: Provenance,
+    /// The holder's own name for it — "work mobile", "the flat".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Address an existing attribute, or make a create idempotent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribute_id: Option<String>,
+    /// Optimistic-concurrency precondition: the attribute must be at exactly
+    /// this version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1). Carried explicitly
+    /// so `deny_unknown_fields` still refuses a *typo* while letting through
+    /// the one member the spec says a conforming producer may always send.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/attribute/list/1.0` — enumerate the pool.
+///
+/// Metadata-only by default. [`include_values`](Self::include_values) is what
+/// turns a listing into a read of the holder's identity, which is why it is
+/// opt-in rather than the default a caller forgets to narrow.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaAttributeListBody {
+    /// Match on a dotted prefix — `phone` returns `phone.mobile` and
+    /// `phone.work`. The vocabulary is prefix-groupable precisely so a
+    /// consumer that has never heard of a token can still file it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_prefix: Option<String>,
+    /// Return values, not just metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_values: Option<bool>,
+    /// Include attributes whose backing credential could no longer be
+    /// re-derived. Defaults to true: a holder deciding what to present needs
+    /// to see that something went stale, not to have it quietly omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_stale: Option<bool>,
+    /// Page size. Absent takes the maintainer's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<::std::num::NonZeroU64>,
+    /// Continuation token from a previous page.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/attribute/delete/1.0` — remove one pool attribute.
+///
+/// Without [`cascade`](Self::cascade) the delete is refused while any profile
+/// still references the attribute, rather than leaving those profiles
+/// presenting a dangling reference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaAttributeDeleteBody {
+    /// The attribute to remove.
+    pub attribute_id: String,
+    /// Also drop every profile entry that references it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cascade: Option<bool>,
+    /// Optimistic-concurrency precondition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Profiles — agent-scoped. `persona/profile/*`
+// ---------------------------------------------------------------------------
+
+/// `spec/persona/profile/put/1.0` — create or update an agent-scoped profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaProfilePutBody {
+    /// The holder's name for this projection — "work", "gaming", "the one my
+    /// family sees".
+    pub name: String,
+    /// How this profile takes each of its values. See [`ProfileEntry`].
+    pub entries: Vec<ProfileEntry>,
+    /// Credentials tagged as belonging with this profile.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credential_refs: Vec<String>,
+    /// Address an existing profile, or make a create idempotent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Optimistic-concurrency precondition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/profile/get/1.0` — read one profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaProfileGetBody {
+    /// The profile to read.
+    pub profile_id: String,
+    /// Resolve every entry against the pool and return the values this profile
+    /// would actually present, rather than the references it is built from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolve: Option<bool>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/profile/list/1.0` — enumerate agent-scoped profiles.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaProfileListBody {
+    /// Page size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<::std::num::NonZeroU64>,
+    /// Continuation token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/profile/delete/1.0` — remove an agent-scoped profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaProfileDeleteBody {
+    /// The profile to remove.
+    pub profile_id: String,
+    /// Also clear every binding that points at it. Without this the delete is
+    /// refused while a persona still presents under the profile — a context
+    /// losing its identity mid-relationship is not something to do by
+    /// omission.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unbind: Option<bool>,
+    /// Optimistic-concurrency precondition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Bindings — context-scoped. `persona/binding/*`
+// ---------------------------------------------------------------------------
+
+/// `spec/persona/binding/set/1.0` — assign a profile to a persona DID within
+/// one context.
+///
+/// This is the push across the boundary: the profile is resolved
+/// agent-side and a *materialised* projection is written into the context.
+/// The context receives values, never pool identifiers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaBindingSetBody {
+    /// The context the binding lives in.
+    pub context_id: String,
+    /// The persona DID this binding is for.
+    pub persona_did: String,
+    /// The agent-scoped profile to project. Omit to clear the binding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Attributes disclosed without asking — the subset a verifier in this
+    /// context receives with no per-disclosure decision.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub public_entries: Vec<String>,
+    /// Optimistic-concurrency precondition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/binding/get/1.0` — what one persona DID presents in one
+/// context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaBindingGetBody {
+    /// The context.
+    pub context_id: String,
+    /// The persona DID.
+    pub persona_did: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/binding/list/1.0` — every persona bound in one context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaBindingListBody {
+    /// The context.
+    pub context_id: String,
+    /// Page size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<::std::num::NonZeroU64>,
+    /// Continuation token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Contacts — context-scoped. `persona/contact/*`
+// ---------------------------------------------------------------------------
+
+/// One claim inside a contact document, as the *other* party published it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactClaim {
+    /// The vocabulary token.
+    #[serde(rename = "type")]
+    pub claim_type: String,
+    /// The value.
+    pub value: Value,
+    /// What the value is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_type: Option<ValueType>,
+    /// The publisher's own label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// What the publisher claimed about where the value came from. Advisory
+    /// until the backing credential is verified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<Provenance>,
+}
+
+/// What someone disclosed about themselves.
+///
+/// Stored as received. The holder does not merge it into their own pool, and
+/// that separation is the point: a contact is somebody else's account of
+/// themselves, not a fact the holder is asserting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContactDocument {
+    /// The claims the publisher disclosed.
+    pub claims: Vec<ContactClaim>,
+    /// The publisher's own version counter, if they carried one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub card_version: Option<::std::num::NonZeroU64>,
+    /// Who published it, as they named themselves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<Value>,
+}
+
+/// `spec/persona/contact/put/1.0` — record what a peer disclosed.
+///
+/// A new revision rather than an overwrite: the previous one is retained while
+/// anything still references it, so "what did they tell me in March" survives
+/// them changing their mind in April.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaContactPutBody {
+    /// The context this contact belongs to.
+    pub context_id: String,
+    /// The DID the disclosure came from.
+    pub subject_did: String,
+    /// Which of the holder's own personas knows this contact. Required, not
+    /// optional: a contact filed against no persona is a contact the holder
+    /// cannot later reason about disclosing to.
+    pub known_by_persona: String,
+    /// What they disclosed.
+    pub document: ContactDocument,
+    /// Credentials received alongside it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credential_refs: Vec<String>,
+    /// The holder's private annotation. Never disclosed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/contact/get/1.0` — read one contact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaContactGetBody {
+    /// The context.
+    pub context_id: String,
+    /// The contact.
+    pub contact_id: String,
+    /// Read one specific revision instead of the current one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rev: Option<::std::num::NonZeroU64>,
+    /// Return every retained revision, so a holder can see what changed and
+    /// when.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_history: Option<bool>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/contact/list/1.0` — enumerate contacts in one context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaContactListBody {
+    /// The context.
+    pub context_id: String,
+    /// Only contacts filed against this persona.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub known_by_persona: Option<String>,
+    /// Only contacts whose current revision is newer than this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub changed_since: Option<String>,
+    /// Page size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<::std::num::NonZeroU64>,
+    /// Continuation token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/contact/delete/1.0` — forget a contact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaContactDeleteBody {
+    /// The context.
+    pub context_id: String,
+    /// The contact.
+    pub contact_id: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Disclosure — context-scoped. `persona/disclosure/*`
+// ---------------------------------------------------------------------------
+
+/// `spec/persona/disclosure/preview/1.0` — what would this disclosure reveal?
+///
+/// Signs nothing and sends nothing. The first of two calls that cannot be
+/// collapsed: the `previewId` it returns is what
+/// [`PersonaDisclosurePresentBody`] consumes, so there is no code path to a
+/// disclosure that skipped the summary. Single-use and short-lived — a preview
+/// approved an hour ago is not evidence of approval now.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaDisclosurePreviewBody {
+    /// The context.
+    pub context_id: String,
+    /// The persona that would present. Its binding supplies the profile.
+    pub persona_did: String,
+    /// Who would receive it. Required rather than optional, because half of
+    /// what a preview says is who is asking — one that could not name the
+    /// recipient would be a list of fields rather than a decision.
+    pub verifier_did: String,
+    /// Claim types the verifier asked for. Omit to preview everything the
+    /// bound profile would present; when present, nothing outside it is
+    /// returned.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requested_claims: Vec<String>,
+    /// The verifier's stated reason, carried into the preview and the
+    /// disclosure record so a holder deciding later has the context a holder
+    /// deciding now had.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    /// Which output format to prepare for. Omit for the canonical form. It
+    /// matters to the *preview* because renderers differ in what they can
+    /// carry, and a holder is owed that before deciding rather than after.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub renderer: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/disclosure/present/1.0` — hand over what the preview showed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaDisclosurePresentBody {
+    /// The context.
+    pub context_id: String,
+    /// The preview being acted on. Consumed — a second `present` on the same
+    /// id is refused rather than riding the earlier decision.
+    pub preview_id: String,
+    /// Verifier-supplied nonce to bind the disclosure to this exchange.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub challenge: Option<String>,
+    /// Ask for the disclosure as a self-issued credential rather than a bare
+    /// document.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mint: Option<Value>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/disclosure/history/1.0` — what was disclosed, to whom, when.
+///
+/// The record the holder needs to answer "what does this verifier already
+/// know", which is also what makes a later preview rankable.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaDisclosureHistoryBody {
+    /// Narrow to one context. Omit to read across all of them — which is a
+    /// holder-scoped read, and gated as one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    /// Narrow to one verifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verifier_did: Option<String>,
+    /// Narrow to one claim type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribute_type: Option<String>,
+    /// Only disclosures after this instant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since: Option<String>,
+    /// Page size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<::std::num::NonZeroU64>,
+    /// Continuation token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Correlation and renderers — agent-scoped.
+// ---------------------------------------------------------------------------
+
+/// `spec/persona/correlation/analyze/1.0` — how linkable would this make me?
+///
+/// Reads the pool and writes nothing. Note the inversion that is easy to get
+/// backwards: a credential presented **whole** correlates *more* than a
+/// self-asserted value, because the issuer's signature is byte-identical at
+/// every verifier — while a derived proof correlates *less*, because it
+/// differs on every presentation. Severity is a function of value and rung
+/// together, never of provenance alone.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaCorrelationAnalyzeBody {
+    /// Analyse one existing attribute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribute_id: Option<String>,
+    /// Analyse an entire profile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Analyse a value the holder has not stored — "what would happen if I
+    /// gave them this". The answer is worth more before the disclosure than
+    /// after it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate: Option<Value>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/renderers/list/1.0` — the output formats this VTA can
+/// produce, and what each one **cannot carry**.
+///
+/// Lossiness is declared rather than discovered. A holder is owed "this
+/// verifier will see your work number but not that your employer attested it"
+/// before deciding, not after.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaRenderersListBody {
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Context-local profiles and bindings. `persona/local/*`
+// ---------------------------------------------------------------------------
+
+/// `spec/persona/local/profile/put/1.0` — a profile that lives inside one
+/// context.
+///
+/// For an identity the holder keeps *only* here, with no pool attribute behind
+/// it. Its entries are [`LocalProfileEntry`] — inline only — so a context
+/// cannot build a profile that reaches into the agent-scoped pool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaLocalProfilePutBody {
+    /// The context this profile belongs to.
+    pub context_id: String,
+    /// The holder's name for it.
+    pub name: String,
+    /// Its values, carried in full.
+    pub entries: Vec<LocalProfileEntry>,
+    /// Address an existing local profile, or make a create idempotent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Optimistic-concurrency precondition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/local/profile/get/1.0` — read one context-local profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaLocalProfileGetBody {
+    /// The context.
+    pub context_id: String,
+    /// The profile.
+    pub profile_id: String,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/local/profile/list/1.0` — enumerate one context's own
+/// profiles.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaLocalProfileListBody {
+    /// The context.
+    pub context_id: String,
+    /// Page size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<::std::num::NonZeroU64>,
+    /// Continuation token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/local/profile/delete/1.0` — remove a context-local profile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaLocalProfileDeleteBody {
+    /// The context.
+    pub context_id: String,
+    /// The profile.
+    pub profile_id: String,
+    /// Also clear any local binding pointing at it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unbind: Option<bool>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `spec/persona/local/binding/set/1.0` — bind a persona DID to a
+/// **context-local** profile.
+///
+/// The counterpart to [`PersonaBindingSetBody`] for an identity that never
+/// existed above the context. There is no pool read on this path at all.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PersonaLocalBindingSetBody {
+    /// The context.
+    pub context_id: String,
+    /// The persona DID.
+    pub persona_did: String,
+    /// The context-local profile to bind. Omit to clear.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Optimistic-concurrency precondition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The four profile-entry forms must stay distinguishable.
+    ///
+    /// This is an untagged union: serde tries the variants and takes the first
+    /// that deserializes. `Ref` needs only `ref`, so without
+    /// `deny_unknown_fields` it matches every one of these documents — and an
+    /// override becomes a live reference, a pin becomes unpinned, and the
+    /// holder's disclosure changes without them touching it. The assertion is
+    /// on round-tripped *bytes* rather than on the enum, because what reaches
+    /// the VTA is the document, not the value that produced it.
+    #[test]
+    fn each_profile_entry_form_survives_a_round_trip() {
+        let cases = [
+            (
+                "ref",
+                serde_json::json!({ "ref": "01J0000000000000000000000A" }),
+            ),
+            (
+                "pinned",
+                serde_json::json!({
+                    "ref": "01J0000000000000000000000A",
+                    "pinVersion": 3,
+                }),
+            ),
+            (
+                "override",
+                serde_json::json!({
+                    "ref": "01J0000000000000000000000A",
+                    "override": { "value": "+61 400 000 000" },
+                }),
+            ),
+            (
+                "inline",
+                serde_json::json!({
+                    "inline": {
+                        "type": "name.display",
+                        "value": "Ada",
+                        "valueType": "string",
+                        "provenance": { "kind": "selfAsserted" },
+                    }
+                }),
+            ),
+        ];
+
+        for (label, doc) in cases {
+            let parsed: ProfileEntry =
+                serde_json::from_value(doc.clone()).unwrap_or_else(|e| panic!("{label}: {e}"));
+            let back = serde_json::to_value(&parsed).expect("re-encodes");
+            assert_eq!(back, doc, "{label} form did not survive the round trip");
+        }
+    }
+
+    /// A pinned entry must not degrade into an unpinned one.
+    ///
+    /// Stated separately from the round-trip above because this is the failure
+    /// with teeth: the degraded document is still *valid*, so nothing rejects
+    /// it — the VTA simply presents whatever the pool holds now instead of the
+    /// version the holder pinned.
+    #[test]
+    fn a_pin_does_not_collapse_into_a_bare_reference() {
+        let doc = serde_json::json!({
+            "ref": "01J0000000000000000000000A",
+            "pinVersion": 7,
+        });
+        let parsed: ProfileEntry = serde_json::from_value(doc).expect("parses");
+        assert!(
+            matches!(parsed, ProfileEntry::Pinned { pin_version, .. } if pin_version.get() == 7),
+            "a pinned entry parsed as {parsed:?}"
+        );
+    }
+
+    /// A context-local profile entry has nowhere to name a pool attribute.
+    ///
+    /// The one-way boundary, checked as a parse failure rather than as a
+    /// convention: a document that tries to reference the agent-scoped pool
+    /// from inside a context is refused by the type, not by a handler that
+    /// might forget.
+    #[test]
+    fn a_local_entry_cannot_reference_the_pool() {
+        let doc = serde_json::json!({ "ref": "01J0000000000000000000000A" });
+        serde_json::from_value::<LocalProfileEntry>(doc)
+            .expect_err("a local entry must not accept a pool reference");
+    }
+
+    /// Provenance is tagged, so an incomplete `credentialBacked` claim is a
+    /// parse failure rather than a claim that quietly becomes self-asserted.
+    #[test]
+    fn credential_backed_provenance_needs_its_credential() {
+        serde_json::from_value::<Provenance>(serde_json::json!({ "kind": "credentialBacked" }))
+            .expect_err("credentialBacked without a credentialId must not parse");
+    }
+}

--- a/vta-sdk/tests/payload_ext_census.rs
+++ b/vta-sdk/tests/payload_ext_census.rs
@@ -59,9 +59,10 @@ use syn::{Fields, Item, ItemStruct, Meta};
 /// for this type — not that adding the field is inconvenient. A type whose
 /// schema has one, listed here, re-opens the defect this file exists to
 /// prevent.
-const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[(
-    "IssuedCredentialSummary",
-    "`vault`-style list row, not a payload root. \
+const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[
+    (
+        "IssuedCredentialSummary",
+        "`vault`-style list row, not a payload root. \
      `vta/credentials/list/0.1`'s published schema closes \
      `IssuedCredentialSummary` with `additionalProperties: false` and declares \
      no `ext` slot on it — SPEC §4.5.1 gives the slot to the payload, which \
@@ -69,7 +70,35 @@ const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[(
      send one here, and adding the field would let this crate emit a document \
      the schema rejects: the opposite of the defect this census exists to \
      prevent. Revisit only if that schema gains the slot.",
-)];
+    ),
+    (
+        "OverrideValue",
+        "The `override` member of a `persona/profile/put/1.0` profile entry, \
+         not a payload root. The published schema closes the object with \
+         `additionalProperties: false` and declares only `value` and `label`; \
+         the generated `ProfileEntryVariant2Override` in `trust-tasks-rs` \
+         carries `deny_unknown_fields` and no `ext` for the same reason. \
+         Adding one here would make this crate emit a document the VTA's own \
+         `validate_payload` rejects.",
+    ),
+    (
+        "InlineValue",
+        "The `inline` member of a profile entry — `persona/profile/put/1.0` \
+         and `persona/local/profile/put/1.0` both nest it, and both close it \
+         with `additionalProperties: false` and no `ext` slot. A member of a \
+         payload rather than a payload, exactly as \
+         `IssuedCredentialSummary` above.",
+    ),
+    (
+        "LocalProfileEntry",
+        "One item of `persona/local/profile/put/1.0`'s `entries` array. The \
+         schema closes it to the single `inline` member — that closure is \
+         load-bearing rather than incidental, because it is what makes a \
+         context-local profile structurally unable to name a pool attribute. \
+         An `ext` slot the schema does not declare would be the first crack \
+         in it.",
+    ),
+];
 
 /// One `deny_unknown_fields` type that would reject a conforming `ext`.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Follow-on to #1255, which built the store and the handlers. This is what an operator touches: `pnm persona …` over all twenty-four persona Trust Tasks, plus the SDK wire types and client methods underneath.

## The preview is rendered, not dumped

Every other command prints its payload. `persona disclosure preview` is the only screen between a request and the holder's identity leaving the machine, so it is laid out for a person — what the verifier gets, what the chosen renderer **discards**, how linkable the disclosure would make the holder, and which claims are unusual for the stated purpose, marked.

That marking is the point rather than decoration. A preview listing fourteen fields with fourteen equal weights is a notice-and-consent dialog, and that is the pattern that teaches people to click through; ranking by what is out of place is what makes the surfaced line the one worth reading.

Two details in the renderer are load-bearing:

- **A predicate claim renders as `proves gte 18 — the value itself is not sent`, not as a blank.** The absence of a value is the whole point of that rung; a blank reads as missing data.
- **An unrecognised response falls back to the raw payload, not an empty table.** A confident summary saying "nothing will be disclosed" about a disclosure that is about to happen is the one lie this screen must not tell.

`present` warns when the returned document carries `unsigned: true`, so an operator does not hand a verifier something that looks presentable and is not. (That flag is #1255's known gap — signing belongs to the key custodian.)

## Three places a flat CLI has to rebuild structure

Each validates in the shim rather than letting the VTA's schema validator answer, so the operator is told which flag is missing instead of reading a validation failure about a document they did not think they were writing.

**`--value` is taken literally for `string` and `date`.** Parsing it as JSON regardless would turn the perfectly ordinary name `null`, or a house number typed as `7`, into something other than what was written — and the holder would find out when a verifier saw it. A genuinely mistyped `--value-type number` fails naming the escape hatch.

**Provenance refuses to be incomplete.** A `credentialBacked` claim missing its `--credential-id` is not a claim with a gap; it is a self-asserted value wearing a credential's authority, which is the single thing provenance exists to prevent. A flag the chosen provenance would *ignore* is likewise an error rather than a no-op — silently dropping `--credential-id` from a self-asserted attribute leaves the operator believing they stored something attested.

**`persona local profile put` replaces serde's "unknown field `ref`" with the rule it is a symptom of.** A profile inside a context cannot reach into the holder's pool; the error says that, and names the way to get a pool value in there (bind an agent-scoped profile).

## The SDK layer, and why it departs from #1255

#1255 argued for using `trust-tasks-rs` types directly in `vta-service`, because a mirror is a second definition of one contract and free to drift. This crate cannot do the same: **`trust-tasks-rs` is an optional dependency of `vta-sdk` and the `client` feature does not enable it**, so a types-only consumer must not be made to pull the generated tree in. So `protocols::persona` is hand-written, and two source-level censuses cover the gap the generated types would otherwise have closed.

**The boundary is in the types.** `LocalProfileEntry` is a separate type from `ProfileEntry` rather than the same type with variants unused, because the published schema for `persona/local/profile/put/1.0` closes its entries to a single `inline` member. A profile built inside a trust context has nowhere to name an attribute in the agent-scoped pool. That closure is what makes the one-way boundary structural, so it is mirrored as a distinct type rather than a shared one used carefully.

**Three census exemptions, and why they are not the easy way out.** `OverrideValue`, `InlineValue` and `LocalProfileEntry` deny unknown fields and carry no `ext`, which `payload_ext_census` flags. Adding one would be *wrong*: the published schemas close all three with `additionalProperties: false` and declare no `ext` slot, and `trust-tasks-rs` generates them with `deny_unknown_fields` and no `ext` for the same reason — so the field would make this crate emit documents the VTA's own `validate_payload` rejects, which is the opposite of the defect that census exists to prevent. They join `IssuedCredentialSummary` in `NO_EXT_BY_DESIGN`, which exists for exactly this case: a member of a payload rather than a payload.

## Verification

- `cargo clippy --workspace --all-targets` and `--all-features --all-targets` — clean
- `cargo test -p pnm-cli -p vta-cli-common -p vta-sdk` — **935 passed, 0 failed**
- `payload_ext_census`, `payload_null_census`, `inert_alias_census` — pass
- Seven new tests over the flag-reconstruction rules, and four over the profile-entry forms; the latter fail if `deny_unknown_fields` is removed, which is how I know they are checking something

## Gaps

1. **Nothing has driven a real request end to end.** Every layer is tested; the seams are not. This is the same gap #1255 carried, and it is now one layer wider.
2. **The renderer is exercised by reading it, not by a test.** `render_preview` has a fallback for unrecognised responses precisely because I could not assert its output against a live preview — worth a fixture test once an end-to-end path exists.
3. **openvtc TUI and the browser plugin are untouched.** Separate lanes.
