### PR TITLE
fix(ci): the release-bump guard was missing the system deps its check needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,43 +497,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install system dependencies
-        run: |
-          # `apt-get update` is the operation that hangs here — three runs
-          # stalled on it, and once each attempt was bounded the timings showed
-          # every failure landing on the 90s `update` ceiling, never on the
-          # install. The mirror is unresponsive; retrying it harder does not
-          # help.
-          #
-          # So don't run it unless it is actually needed. The runner image ships
-          # a usable package index, and pkg-config is already present on
-          # ubuntu-24.04, so the fast path is to check what is missing and
-          # install straight from the shipped index. Refreshing the index is the
-          # fallback, still bounded and retried, for the case where the package
-          # genuinely is not in it.
-          pkgs=""
-          for p in libdbus-1-dev pkg-config; do
-            dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
-          done
-          if [ -z "$pkgs" ]; then
-            echo "libdbus-1-dev and pkg-config already present; nothing to do"
-            exit 0
-          fi
-          echo "missing:$pkgs"
-          if sudo timeout 120 apt-get install -y $pkgs; then
-            exit 0
-          fi
-          echo "::warning::install from the shipped index failed; refreshing"
-          for attempt in 1 2 3; do
-            if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
-              && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
-              exit 0
-            fi
-            echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
-            sleep 10
-          done
-          echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
-          exit 1
-
+        run: bash scripts/install-semver-deps.sh
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-semver-checks
 
@@ -576,6 +540,13 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+      # Same system packages as the report job, from the same script. Omitting
+      # this is what broke the guard's first real run: rustdoc could not build
+      # `vta-cli-common` (libdbus-sys -> pkg_config), and a failed baseline build
+      # is reported as a broken PUBLISHED crate — which looked like a finding
+      # rather than a missing build dependency on the runner.
+      - name: Install system dependencies
+        run: bash scripts/install-semver-deps.sh
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-semver-checks
       - name: Check the proposed versions cover their API changes

--- a/scripts/install-semver-deps.sh
+++ b/scripts/install-semver-deps.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# System packages cargo-semver-checks needs to build rustdoc for this workspace.
+#
+# `vta-cli-common` pulls `libdbus-sys`, whose build script shells out to
+# pkg-config. Without the dbus headers rustdoc fails to build, and the semver
+# script reads a failed baseline build as "a PUBLISHED CRATE DOES NOT BUILD" —
+# a deliberately loud error, because that genuinely is a production defect when
+# it is real. A missing build dependency on the runner produces the identical
+# message, so the two must not be allowed to look alike.
+#
+# They already did once: the release-bump guard shipped without this step and
+# failed its first real run on `libdbus-sys ... pkg_config failed`, reported as
+# a broken published artifact. The fix is not a second copy of the apt logic in
+# the second job — that is how two lists of the same thing drift — so it lives
+# here and both jobs call it.
+#
+# # Why this is not just `apt-get update && apt-get install`
+#
+# `apt-get update` is the operation that hangs. Three runs stalled on it, and
+# once each attempt was bounded the timings showed every failure landing on the
+# 90s `update` ceiling, never on the install. The mirror is unresponsive;
+# retrying it harder does not help.
+#
+# So it is not run unless actually needed. The runner image ships a usable
+# package index, and pkg-config is already present on ubuntu-24.04, so the fast
+# path checks what is missing and installs straight from the shipped index.
+# Refreshing the index is the fallback — still bounded, still retried — for the
+# case where the package genuinely is not in it.
+set -euo pipefail
+
+pkgs=""
+for p in libdbus-1-dev pkg-config; do
+  dpkg -s "$p" >/dev/null 2>&1 || pkgs="$pkgs $p"
+done
+
+if [ -z "$pkgs" ]; then
+  echo "libdbus-1-dev and pkg-config already present; nothing to do"
+  exit 0
+fi
+
+echo "missing:$pkgs"
+if sudo timeout 120 apt-get install -y $pkgs; then
+  exit 0
+fi
+
+echo "::warning::install from the shipped index failed; refreshing"
+for attempt in 1 2 3; do
+  if sudo timeout 120 apt-get -o Acquire::Retries=3 update \
+    && sudo timeout 120 apt-get -o Acquire::Retries=3 install -y $pkgs; then
+    exit 0
+  fi
+  echo "::warning::apt attempt $attempt failed or timed out; retrying in 10s"
+  sleep 10
+done
+
+echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
+exit 1


### PR DESCRIPTION
The guard added in #1256 shipped without the **Install system dependencies**
step the report job beside it has. Its first real run — against Release PR
#1232, the exact under-bump it was built to catch — failed on this instead:

```
error: failed to run custom build command for `libdbus-sys v0.2.7`
  pkg_config failed
error: failed to build rustdoc for crate vta-cli-common v0.12.4
```

`vta-cli-common` pulls `libdbus-sys`, whose build script shells out to
pkg-config. Without the dbus headers rustdoc cannot build, and
`semver-report.sh` reads a failed baseline build as **"a PUBLISHED CRATE DOES
NOT BUILD"** — deliberately loud, because that is a genuine production defect
when it is real. A missing build dependency on the runner produces the
identical message.

So the guard was red for a reason unrelated to version bumps, wearing the
wording of a far more serious finding. That is the same conflation this job
family has now had three times (#1252 twice over, and this). It matters more
here than anywhere else: the guard's entire value is being believed when it
goes red, and its first appearance on a real Release PR was a false positive.

## The fix

The apt logic moves to `scripts/install-semver-deps.sh`; both jobs call it.

A second copy of the block inside the guard job would have been the shorter
diff and the wrong one — two lists of the same thing agree right up until
someone edits one, which is exactly the defect #1252 exists to fix. Same
reasoning that put the exclusion list and coverage assertion in one script
rather than two.

Verified both jobs now resolve to identical step lists:

```
semver-checks:       [checkout, Install system dependencies, toolchain, install-action, Check published crates for API breaks]
release-bump-guard:  [checkout, Install system dependencies, toolchain, install-action, Check the proposed versions cover their API changes]
```

## What this does not yet prove

The guard still has not had a clean run against a real under-bump. #1232
remains the test case: once this merges and release-plz refreshes that branch,
the guard should fail with `THE PROPOSED RELEASE UNDER-BUMPS A BREAKING CHANGE`
and exit 100, naming `vti-common` 0.16.2 and `vta-sdk` 0.32.4. Locally, against
a checkout of that same branch, it does exactly that — and passes at 0.17.0 /
0.33.0 — but that is my reconstruction, not the job.
