### PR TITLE
fix(persona): retire the attribute/list drift, and name what still blocks the other one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9599,9 +9599,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c858ac6e7f0c8b7600bf643312c90ed5ac3c5cb4637d2baacd9fa0ccf64ee688"
+checksum = "85bc5ec5115dcde391d27997c940949f29061bcf38cdf8050a155264c08f1817"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -255,6 +255,20 @@ enum Conformance {
     /// Known non-conformance, kept visible and counted instead of silently
     /// tolerated. Every entry is a follow-up issue; the reason must name the
     /// drift precisely enough that the fix needs no re-diagnosis.
+    ///
+    /// **There are currently none, and that is the goal state rather than
+    /// evidence the variant is surplus.** It is constructed only while a defect
+    /// is outstanding — the last entry was `persona/attribute/list`, whose
+    /// schema contradiction is fixed in trust-tasks-rs 0.17.10 — and the point
+    /// of keeping it is that recording drift stays as easy as papering over it.
+    /// A table with nowhere to say "this one does not round-trip, here is why"
+    /// invites a fixture edited until it passes, which reports a
+    /// non-conformant route as conformant and is the exact failure this whole
+    /// module exists to catch.
+    #[expect(
+        dead_code,
+        reason = "no drift outstanding; kept so the next one can be recorded rather than hidden"
+    )]
     KnownDrift(&'static str),
 }
 
@@ -2537,34 +2551,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
         ));
     }
 
-    // `persona/attribute/list` is deliberately NOT witnessed against 0.17.9.
-    //
-    // Its default response — the one `includeValues: false` produces, which is
-    // the common case and the non-disclosing one — cannot round-trip, because
-    // the published `Attribute` schema requires `value` while its own
-    // description says the member is absent for a metadata-only view. The
-    // witness found the contradiction; the fix is
-    // trustoverip/dtgwg-trust-tasks-tf#367, merged and awaiting a release.
-    //
-    // Recorded as drift rather than papered over: adding `value` to the fixture
-    // would encode the defect and pass, and the next reader would have no way
-    // to know the default listing had never been exercised. When
-    // trust-tasks-rs 0.18 lands, delete this entry and the witness in
-    // `persona_witnesses()` becomes checkable as written.
-    t.push((
-        vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0,
-        Conformance::KnownDrift(
-            "Attribute.value is REQUIRED in trust-tasks-rs 0.17.9 while its description says the \
-             member is absent for a metadata-only view, so the default (non-disclosing) listing \
-             response is unrepresentable. Fixed upstream in dtgwg-trust-tasks-tf#367 (merged, \
-             awaiting release); un-drift on the 0.18 bump.",
-        ),
-    ));
-
     for (uri, req, resp) in persona_witnesses() {
-        if uri == vta_sdk::trust_tasks::TASK_PERSONA_ATTRIBUTE_LIST_1_0 {
-            continue;
-        }
         t.push((
             uri,
             Conformance::Checked(Witness {

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -536,8 +536,17 @@ pub(super) async fn handle_profile_get(
         // present less than it does, which is the failure mode this whole
         // store is built to prevent.
         //
+        // Fixed upstream in dtgwg-trust-tasks-tf#370 and released in
+        // trust-tasks-rs **0.18.0**, which this workspace cannot yet reach.
+        // `affinidi-messaging-sdk` 0.21.1 — the newest there is — still
+        // requires `trust-tasks-rs ^0.17`, and `vta-sdk` hands it a
+        // `messaging::account::update::MediatorAcl` in `acl_setup.rs`. Two
+        // versions in one graph make that "expected `MediatorAcl`, found a
+        // different `MediatorAcl`", so the bump waits on a messaging SDK built
+        // against 0.18 rather than on anything in this repository.
+        //
         // Pinned by `an_inline_entry_is_refused_until_the_schema_allows_one`,
-        // so this stops being interim behaviour the moment the spec lands.
+        // so this stops being interim behaviour the moment that lands.
         if r.iter().any(|c| c.attribute_id.is_none()) {
             return reject(
                 &doc,

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -480,9 +480,17 @@ async fn an_unbound_persona_reads_back_cleanly() {
 /// an `attributeId` (a lie about where the value lives) or omitting the entry
 /// (a profile that appears to present less than it does).
 ///
-/// **This test exists to expire.** When the schema takes optional
-/// `attributeId`/`updatedAt`/`version`, this fails, and the refusal in
-/// `handle_profile_get` goes with it.
+/// **This test exists to expire**, and the fix already exists: the schema
+/// takes those three as optional from `trust-tasks-rs` 0.18.0
+/// (dtgwg-trust-tasks-tf#370).
+///
+/// What it waits on is not this repository. `affinidi-messaging-sdk` 0.21.1
+/// still requires `trust-tasks-rs ^0.17`, and `vta-sdk::acl_setup` passes it a
+/// generated `MediatorAcl`; with two versions in one graph that is a type
+/// mismatch, not a warning. When a messaging SDK built against 0.18 ships,
+/// bump, and this test fails — at which point delete it and the refusal in
+/// `handle_profile_get` together, and assert instead that an inline entry
+/// resolves like any other.
 #[tokio::test]
 async fn an_inline_entry_is_refused_until_the_schema_allows_one() {
     let (router, ctx) = build_test_app().await;


### PR DESCRIPTION
Two interim measures in the persona slice were written with expiry conditions. **One has expired. The other has not, and the reason is not the one I recorded.**

## `persona/attribute/list` is witnessed again

Its default response — `includeValues: false`, which is both the common case and the non-disclosing one — could not round-trip, because the published `Attribute` schema required `value` while its own description said the member is absent for a metadata-only view. #1255 recorded that as `KnownDrift` rather than editing the fixture to pass, on the grounds that a fixture edited until it passes reports a non-conformant route as conformant.

Fixed upstream in [dtgwg-trust-tasks-tf#367](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/367) — which shipped in **trust-tasks-rs 0.17.10, not 0.18 as my drift entry claimed.** So it has been un-drift-able since that release and the comment was pointing at the wrong one. The bump here is a patch inside the existing `^0.17` range.

The `KnownDrift` entry is gone, and the witness written alongside it in #1255 now checks as it was written.

## `KnownDrift` has no constructors left, and is kept

That is the goal state, not evidence the variant is surplus. It is constructed only while a defect is outstanding, and a table with nowhere to say *"this one does not round-trip, here is why"* invites the fixture edit — which is the exact failure this module exists to catch. Kept with `#[expect(dead_code, reason = ...)]` and the reasoning written on it, so the next person finds the mechanism rather than reinventing it.

## The inline-entry refusal stays, and not for the reason I wrote

`profile/get --resolve` still refuses a profile containing an inline entry, because the response schema typed each resolved entry as the pool `Attribute` and an inline value has no `attributeId`, `version` or `updatedAt`. That is also fixed — [dtgwg-trust-tasks-tf#370](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/370), released in trust-tasks-rs **0.18.0** — and this workspace cannot reach it.

**`affinidi-messaging-sdk` 0.21.1, the newest published, still requires `trust-tasks-rs ^0.17`**, and `vta-sdk::acl_setup` hands it a generated `messaging::account::update::MediatorAcl`. With two versions in one graph that is:

```
error[E0308]: mismatched types
   --> vta-sdk/src/acl_setup.rs:147:18
    |
147 |             Some(acl),
    |                  ^^^ expected `MediatorAcl`, found a different `MediatorAcl`
    |
note: there are multiple different versions of crate `trust_tasks_rs` in the dependency graph
```

A hard compile error, not a warning — and the shape CLAUDE.md's note describes, where a re-exported type makes another crate's version part of your own public API. I confirmed it by attempting the bump rather than reasoning about it, then reverted; publishing the six trust-tasks companion crates at 0.18 (dtgwg#373) does not help, because the requirement comes from Affinidi's crate, not from those.

**So the blocker is external: a messaging SDK built against trust-tasks-rs 0.18.** Both the handler comment and the pinning test now name it with the file and symbol, so the next person to try does not repeat the investigation.

## Verification

- `cargo test -p vta-service --lib` — **1027 passed**, 0 failed, 1 ignored
- `cargo test -p vta-service --test persona_trust_task` — 9 passed
- `cargo test -p vta-persona` — 63 passed
- `cargo clippy --workspace --all-targets` — clean
- `trust-tasks-rs` resolves to a **single** version (0.17.10); the only `0.18.0` left in the lockfile is `fancy-regex`
