### PR TITLE
feat(vti-common)!: make Capability and AuditEvent non-exhaustive

### DIFF
--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -118,8 +118,19 @@ pub enum ServiceKind {
 /// produces a sensible default from the existing role (Admin gets
 /// everything, Reader gets only `vault-read`, etc.) so existing ACL
 /// behaviour is preserved bit-for-bit.
+/// **Non-exhaustive on purpose.** This list grows every time the agent gains a
+/// power worth gating separately, and each addition used to be a breaking change
+/// for anyone matching on it — which is exactly what happened: `MemoryRead`,
+/// `MemoryWrite`, `RoomPresent` and `RoomOpen` went out in `vti-common` 0.16.2, a
+/// patch release, and any downstream exhaustive `match` stopped compiling on a
+/// routine `cargo update`.
+///
+/// Downstream code must carry a `_ =>` arm. That is the point: a capability this
+/// consumer has never heard of is precisely the one it must not silently treat as
+/// granted, and a wildcard arm forces that decision to be written down.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum Capability {
     VaultRead,
     VaultWrite,

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -43,8 +43,17 @@ pub const REDACTED_MARKER: &str = "<redacted>";
 /// Audit-event payload. Tagged on `type` with the variant name and
 /// the variant's data under `data`. Phase-0 vocabulary only;
 /// Phase-1+ adds variants alongside the features that emit them.
+/// **Non-exhaustive on purpose**, and for the reason the doc comment above already
+/// states: variants arrive alongside the features that emit them, so the set is
+/// designed to grow. `RoomOperation` shipped in `vti-common` 0.16.2 — a patch — and
+/// broke every downstream exhaustive `match`.
+///
+/// A consumer that cannot name an event still has to record it; a `_ =>` arm is the
+/// honest shape for that, and dropping an unrecognised event on the floor is the
+/// failure this prevents being silent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", content = "data")]
+#[non_exhaustive]
 pub enum AuditEvent {
     /// Bootstrap completed — the first admin DID was written into the
     /// ACL and the install carve-out was permanently closed.


### PR DESCRIPTION
Both enums are designed to grow. `Capability` gains an entry whenever the agent
gains a power worth gating separately; `AuditEvent`'s own doc comment says
variants arrive alongside the features that emit them. Neither was
`#[non_exhaustive]`, so every one of those additions was a breaking change for
anyone matching on them.

Not hypothetical — it is what happened this week. `MemoryRead`, `MemoryWrite`,
`RoomPresent`, `RoomOpen` and `AuditEvent::RoomOperation` shipped in `vti-common`
**0.16.2, a patch release**, so a downstream exhaustive `match` stopped compiling
on a routine `cargo update`.

## Cost inside the workspace: zero

Nothing here matches exhaustively on either type. Every reference constructs a
variant as a value, and the only `match self` is inside `vti-common` itself,
where the attribute has no effect. I checked that before writing the change
rather than discovering it from a build; `cargo build/clippy --workspace
--all-targets --all-features` then confirmed it.

## Why the `_ =>` arm is the point, not the price

A capability a consumer has never heard of is precisely the one it must not
silently treat as granted. An audit event it cannot name still has to be
recorded. A wildcard arm forces both decisions to be written down, instead of
being made accidentally by a compile error at whatever moment the next variant
lands.

## Deliberately not applied to the `vta-sdk` wire structs

The sixteen structs that broke the same way when they gained `ext` are left
alone. `#[non_exhaustive]` on a *struct* removes literal construction from
outside the crate entirely — including functional update with
`..Default::default()`, which is the part people assume still works — so all
sixteen would need constructors or builders. That is a redesign of the public SDK
surface rather than cleanup.

The safety half is covered regardless: adding a field forces a breaking bump, and
#1256's guard makes that stick. Worth doing deliberately, in its own change, with
the ergonomics thought through.

## Versioning

Breaking for external consumers, so this wants the minor slot — `vti-common`
0.17.0, not a patch. #1256's guard will say so if the Release PR proposes
otherwise, which makes this the first live exercise of that guard's failure path;
CI has so far only seen it pass.

## Note on the test suite

One full-workspace run hit `fatal runtime error: stack overflow` in
`vta-service --test mock_vta`. It passes 13/13 in isolation, and a compile-time
attribute cannot cause a runtime stack overflow, so this reads as parallel
execution pressure rather than a consequence of the change — but flagging it
rather than quietly re-running until green. Worth a look at CI's Test job.
