### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,7 +2677,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -7179,7 +7179,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "tokio",
@@ -10316,7 +10316,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -10346,7 +10346,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10371,7 +10371,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10404,7 +10404,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10437,7 +10437,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "vti-common",
 ]
@@ -10507,7 +10507,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "multibase",
@@ -10527,7 +10527,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.32.4"
+version = "0.33.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10698,7 +10698,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -10718,7 +10718,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "serde_json",
@@ -10769,7 +10769,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10803,7 +10803,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "affinidi-tdk 0.12.0",
  "chrono",
@@ -10824,7 +10824,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10926,7 +10926,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -11001,7 +11001,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -11047,7 +11047,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.5...cnm-cli-v0.13.6) — 2026-09-07
+
+
 ## [0.13.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.4...cnm-cli-v0.13.5) — 2026-09-06
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.13.5"
+version = "0.13.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,10 +21,10 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
-vta-cli-common = { path = "../vta-cli-common", version = "0.12", features = [
+vta-cli-common = { path = "../vta-cli-common", version = "0.13", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }
@@ -26,7 +26,7 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 # SLIP-0010 key derivation (`vti_common::slip10`) — the harness re-derives the
 # same keys the VTA does, from the same seed and paths.
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 
 [lints]
 workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.5...pnm-cli-v0.14.6) — 2026-09-07
+
+
 ## [0.14.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.4...pnm-cli-v0.14.5) — 2026-09-06
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.14.5"
+version = "0.14.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,14 +28,14 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
-vta-cli-common = { path = "../vta-cli-common", version = "0.12", features = [
+vta-cli-common = { path = "../vta-cli-common", version = "0.13", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 # no member lifecycle, no policy engine, no credential issuance, no admin UI.
 vti-rooms = { path = "../vti-rooms", version = "0.1" }
 # The store and AppError. Nothing else internal.
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }
 
 axum = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.2...vta-audit-v0.3.3) — 2026-09-07
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.1...vta-audit-v0.3.2) — 2026-09-06
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,8 +20,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16" }
-vta-sdk = { path = "../vta-sdk", version = "0.32" }
+vti-common = { path = "../vti-common", version = "0.17" }
+vta-sdk = { path = "../vta-sdk", version = "0.33" }
 async-trait = "0.1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.2...vta-backup-v0.3.3) — 2026-09-07
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.1...vta-backup-v0.3.2) — 2026-09-01
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,12 +27,12 @@ webvh = ["vta-keyspaces/webvh"]
 tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 # Nonce and bundle-id generation. Was reached through `aes_gcm::aead::OsRng`,
 # a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
 # own and was borrowing one from its cipher.
 rand = { workspace = true }
-vta-sdk = { path = "../vta-sdk", version = "0.32" }
+vta-sdk = { path = "../vta-sdk", version = "0.33" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.4" }
 vta-config = { path = "../vta-config", version = "0.4" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.4...vta-cli-common-v0.13.0) — 2026-09-07
+
+
+### Added
+
+- **vta-sdk**: Make the growth-prone wire bodies non-exhaustive ([#1270](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1270))
+
+Sixteen public request bodies gained an `ext` member in #1231 — under a `fix:`
+  type, which derives the smallest bump there is — and every consumer building one
+  with a struct literal stopped compiling. `vta-sdk` 0.32.4 shipped that as a patch
+  release, which a caret requirement takes on a routine `cargo update`.
+
+  `ext` is the framework's extension member (SPEC §4.5.1); these bodies gain
+  members whenever the schema revises. So the fix is not to remember the `!` next
+  time, it is for the addition to stop being breaking: fourteen of them are now
+  `#[non_exhaustive]` with a `new()` taking the members the schema requires. The
+  optional members stay public — set them on the returned value.
+
+  Deliberately NOT applied to `AclEntry` or `AppStateWrite`, which the same report
+  flagged. `AclEntry` has 68 construction sites, and its own doc comments record
+  that `None` and `Some([])` on `allowed_keys` are OPPOSITE grants: absent means
+  every key the entry's scopes reach, present-but-empty means no keys at all. A
+  generated constructor defaulting that to `None`, migrated mechanically across 68
+  sites, is precisely how the narrowest grant becomes the widest — the same class
+  of mistake CLAUDE.md already attributes to #746, #769 and #770 on the adjacent
+  `allowed_contexts` axis. That one wants per-site review, not a script, and it is
+  better done on its own.
+
+  The compiler was a better census than grep: I estimated 19 external construction
+  sites and it found 21, across five files including integration tests, which count
+  as outside the defining crate for this purpose.
+
+  Two of my own automation passes needed correcting on the way, both worth naming
+  because the second was nearly silent: the first brace matcher mis-parsed `//`
+  comments sitting inside the literals, and the second dropped the comment attached
+  to `authorization_context: None` while filtering out `None`-valued fields. That
+  comment records that `authorizationContext` is a member the published schema does
+  not define, so a producer cannot send it through the validated transport at all.
+  It is restored against the constructor default.
+
+  Breaking, so this wants the minor slot on vta-sdk. #1256's guard will say so if
+  the release proposes otherwise.
+
+
+
 ## [0.12.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.3...vta-cli-common-v0.12.4) — 2026-09-06
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.12.4"
+version = "0.13.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,13 +18,13 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.2...vta-config-v0.4.3) — 2026-09-07
+
+
 ## [0.4.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.1...vta-config-v0.4.2) — 2026-09-06
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,11 +26,11 @@ default = []
 tee = []
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.32", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.33", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -35,7 +35,7 @@ tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
 vta-service = { path = "../vta-service", version = "0.23", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build
 # links no overlay code.

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.2...vta-keys-v0.4.3) — 2026-09-07
+
+
 ## [0.4.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.1...vta-keys-v0.4.2) — 2026-09-01
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -36,9 +36,9 @@ tee = ["vti-secrets/tee"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4" }
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.5...vta-keyspaces-v0.2.6) — 2026-09-07
+
+
 ## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.4...vta-keyspaces-v0.2.5) — 2026-09-06
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,4 +26,4 @@ webvh = []
 
 [dependencies]
 # For `KeyspaceHandle` in the shared `Keyspaces` handle bundle.
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.2...vta-policy-v0.3.3) — 2026-09-07
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.1...vta-policy-v0.3.2) — 2026-09-01
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,12 +20,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 vta-config = { path = "../vta-config", version = "0.4" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.32", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.33", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.33.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.4...vta-sdk-v0.33.0) — 2026-09-07
+
+
+### Added
+
+- **vta-sdk**: Make AclEntry and AppStateWrite non-exhaustive ([#1271](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1271))
+
+The last two types the semver report flagged, deferred out of #1270 because
+  AclEntry looked like a 68-site migration through security-sensitive semantics.
+
+  It was not. The compiler finds ONE construction site outside vta-sdk. The 68 came
+  from a grep that conflated three different types — this wire `AclEntry`, the
+  unrelated `vti_common::acl::AclEntry`, and vtc-service's own `VtcAclEntry` — and
+  counted every `fn ... -> AclEntry {` body as a literal. The caution was right; the
+  arithmetic behind it was not, and the compiler was the census that settled it.
+
+  What the review did earn is the shape of the constructor. Both real fixtures set
+  `allowed_keys` deliberately and say why in a comment: `trust_task_decode.rs` uses
+  `Some(vec![])` because the empty vec must survive the wire as `"allowedKeys": []`,
+  and `conformance.rs` uses a populated vec because only a present value proves the
+  member survives under its canonical spelling. On this type `None` and `Some(∅)`
+  are OPPOSITE grants — absent reaches every key the entry's scopes reach,
+  present-but-empty reaches none.
+
+  So `AclEntry::new` takes subject, role and scopes, and leaves `allowed_keys`
+  absent — the meaning an entry predating the member already has. It defaults no
+  grant whose empty case is not its neutral case, and the doc comment says so.
+  Empty `scopes` has the same shape of hazard (unrestricted for an admin role,
+  authorized nowhere for every other), which is why it is an argument rather than a
+  default.
+
+- **vta-sdk**: Make the growth-prone wire bodies non-exhaustive ([#1270](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1270))
+
+Sixteen public request bodies gained an `ext` member in #1231 — under a `fix:`
+  type, which derives the smallest bump there is — and every consumer building one
+  with a struct literal stopped compiling. `vta-sdk` 0.32.4 shipped that as a patch
+  release, which a caret requirement takes on a routine `cargo update`.
+
+  `ext` is the framework's extension member (SPEC §4.5.1); these bodies gain
+  members whenever the schema revises. So the fix is not to remember the `!` next
+  time, it is for the addition to stop being breaking: fourteen of them are now
+  `#[non_exhaustive]` with a `new()` taking the members the schema requires. The
+  optional members stay public — set them on the returned value.
+
+  Deliberately NOT applied to `AclEntry` or `AppStateWrite`, which the same report
+  flagged. `AclEntry` has 68 construction sites, and its own doc comments record
+  that `None` and `Some([])` on `allowed_keys` are OPPOSITE grants: absent means
+  every key the entry's scopes reach, present-but-empty means no keys at all. A
+  generated constructor defaulting that to `None`, migrated mechanically across 68
+  sites, is precisely how the narrowest grant becomes the widest — the same class
+  of mistake CLAUDE.md already attributes to #746, #769 and #770 on the adjacent
+  `allowed_contexts` axis. That one wants per-site review, not a script, and it is
+  better done on its own.
+
+  The compiler was a better census than grep: I estimated 19 external construction
+  sites and it found 21, across five files including integration tests, which count
+  as outside the defining crate for this purpose.
+
+  Two of my own automation passes needed correcting on the way, both worth naming
+  because the second was nearly silent: the first brace matcher mis-parsed `//`
+  comments sitting inside the literals, and the second dropped the comment attached
+  to `authorization_context: None` while filtering out `None`-valued fields. That
+  comment records that `authorizationContext` is a member the published schema does
+  not define, so a producer cannot send it through the validated transport at all.
+  It is restored against the constructor default.
+
+  Breaking, so this wants the minor slot on vta-sdk. #1256's guard will say so if
+  the release proposes otherwise.
+
+- **persona**: Move to trust-tasks-rs 0.18 and resolve inline entries ([#1266](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1266))
+
+
 ## [0.32.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.3...vta-sdk-v0.32.4) — 2026-09-06
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.32.4"
+version = "0.33.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -139,7 +139,7 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.17", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
@@ -188,7 +188,7 @@ vta-policy = { path = "../vta-policy", version = "0.3" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.2", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -209,7 +209,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.12" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.13" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made
@@ -384,7 +384,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.1...vta-support-v0.3.2) — 2026-09-07
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.0...vta-support-v0.3.1) — 2026-08-29
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -29,8 +29,8 @@ vta-config = { path = "../vta-config", version = "0.4" }
 # verifies each crate in isolation, where nothing enables it, so the method
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
-vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.2...vta-sweepers-v0.3.3) — 2026-09-07
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.1...vta-sweepers-v0.3.2) — 2026-08-29
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 vta-audit = { path = "../vta-audit", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-vault = { path = "../vta-vault", version = "0.5" }

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -27,7 +27,7 @@ repository.workspace = true
 tenant-overlay = ["dep:tokio-vsock"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16", features = ["encryption", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.17", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4", features = ["tee"] }
 vta-keys = { path = "../vta-keys", version = "0.4" }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.2...vta-vault-v0.5.3) — 2026-09-07
+
+
 ## [0.5.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.1...vta-vault-v0.5.2) — 2026-09-01
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -33,8 +33,8 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.16", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm", "sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.3...vta-webvh-v0.2.4) — 2026-09-07
+
+
 ## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.2...vta-webvh-v0.2.3) — 2026-09-01
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,8 +21,8 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.16" }
-vta-sdk = { path = "../vta-sdk", version = "0.32" }
+vti-common = { path = "../vti-common", version = "0.17" }
+vta-sdk = { path = "../vta-sdk", version = "0.33" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.2...vtc-client-v0.5.3) — 2026-09-07
+
+
 ## [0.5.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.1...vtc-client-v0.5.2) — 2026-09-06
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ mls = ["vti-rooms/mls"]
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["session"] }
 
 # The room's wire types, and — under the `mls` feature — its group-key and
 # sealing layers, which this crate re-exports rather than owning. A VTA needs

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -119,7 +119,7 @@ path = "src/main.rs"
 [dependencies]
 vti-rooms = { path = "../vti-rooms", version = "0.1" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }
-vti-common = { path = "../vti-common", version = "0.16", features = [
+vti-common = { path = "../vti-common", version = "0.17", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
@@ -136,7 +136,7 @@ vti-common = { path = "../vti-common", version = "0.16", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.16.2...vti-common-v0.17.0) — 2026-09-07
+
+
+### Added
+
+- **vti-common**: Make Capability and AuditEvent non-exhaustive ([#1262](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1262))
+
+Both enums are designed to grow — `Capability` gains an entry whenever the agent
+  gains a power worth gating separately, and `AuditEvent`'s own doc comment says
+  variants arrive alongside the features that emit them. Neither was
+  `#[non_exhaustive]`, so every one of those additions was a breaking change for
+  anyone matching on them.
+
+  That is not hypothetical. `MemoryRead`, `MemoryWrite`, `RoomPresent`, `RoomOpen`
+  and `AuditEvent::RoomOperation` went out in vti-common 0.16.2 — a PATCH release —
+  so a downstream exhaustive `match` stopped compiling on a routine `cargo update`,
+  with the caret requirement picking it up automatically.
+
+  The cost inside this workspace is zero: nothing here matches exhaustively on
+  either type. Every reference constructs a variant as a value, and the only
+  `match self` sits in `vti-common` itself, where the attribute has no effect.
+  Checked before writing it, not after.
+
+  Downstream code now needs a `_ =>` arm, and that is the point rather than the
+  price. A capability a consumer has never heard of is precisely the one it must
+  not silently treat as granted, and an audit event it cannot name still has to be
+  recorded; a wildcard arm forces both decisions to be written down instead of
+  being decided by a compile error at the wrong moment.
+
+  Deliberately NOT applied to the sixteen `vta-sdk` wire structs that broke the
+  same way when they gained `ext`. `#[non_exhaustive]` on a struct removes literal
+  construction from outside the crate entirely — functional update with
+  `..Default::default()` included, which is the part people assume still works — so
+  all sixteen would need constructors or builders. That is a redesign of the public
+  SDK surface, not cleanup, and the safety half is now covered anyway: a new field
+  forces a breaking bump and #1256's guard makes that stick. Worth doing
+  deliberately, in its own change.
+
+  Breaking for external consumers, so this needs the minor slot (0.17.0) rather
+  than a patch. The guard added in #1256 will now say so if the release proposes
+  otherwise — which makes this its first live exercise of the failure path.
+
+
+
 ## [0.16.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.16.1...vti-common-v0.16.2) — 2026-09-06
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.16.2"
+version = "0.17.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.32", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.33", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-rooms-dtg/CHANGELOG.md
+++ b/vti-rooms-dtg/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.0...vti-rooms-dtg-v0.1.1) — 2026-09-07
+

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms-dtg"
 description = "The DTG-credential chain verifier for data rooms"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -25,7 +25,7 @@ test-support = ["dep:ed25519-dalek", "dep:getrandom", "dep:multibase", "dep:vta-
 
 [dependencies]
 vti-rooms = { path = "../vti-rooms", version = "0.1" }
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 
 # `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
 # 0.6.0 sat merged and unreleased; released 2026-09-03.
@@ -45,7 +45,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { version = "0.3", optional = true }
 multibase = { workspace = true, optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = ["didcomm"], optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm"], optional = true }
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/vti-rooms/CHANGELOG.md
+++ b/vti-rooms/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+Notable changes to the published crates. Generated from conventional commits by
+[git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.0...vti-rooms-v0.1.1) — 2026-09-07
+

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -29,7 +29,7 @@ mls = [
 # The store abstraction and AppError. This crate's only internal dependency:
 # a room's storage and authorization need nothing from a community service,
 # which is the whole reason they are extractable.
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.1...vti-secrets-v0.3.2) — 2026-09-07
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.0...vti-secrets-v0.3.1) — 2026-08-29
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,14 +47,14 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.16" }
+vti-common = { path = "../vti-common", version = "0.17" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.32", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.32.4 -> 0.33.0 (✓ API compatible changes)
* `vti-common`: 0.16.2 -> 0.17.0 (✓ API compatible changes)
* `vta-cli-common`: 0.12.4 -> 0.13.0 (✓ API compatible changes)
* `cnm-cli`: 0.13.5 -> 0.13.6
* `pnm-cli`: 0.14.5 -> 0.14.6
* `vti-rooms`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `vti-rooms-dtg`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `vtc-client`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `vta-keys`: 0.4.2 -> 0.4.3
* `vta-persona`: 0.1.0
* `vta-tee`: 0.2.2 -> 0.2.3
* `vta-webvh`: 0.2.3 -> 0.2.4
* `vta-service`: 0.23.4 -> 0.23.5
* `vta-audit`: 0.3.2 -> 0.3.3
* `vti-secrets`: 0.3.1 -> 0.3.2
* `vta-config`: 0.4.2 -> 0.4.3
* `vta-keyspaces`: 0.2.5 -> 0.2.6
* `vta-support`: 0.3.1 -> 0.3.2
* `vta-backup`: 0.3.2 -> 0.3.3
* `vta-policy`: 0.3.2 -> 0.3.3
* `vta-vault`: 0.5.2 -> 0.5.3
* `vta-sweepers`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.33.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.4...vta-sdk-v0.33.0) — 2026-09-07

### Added

- **vta-sdk**: Make AclEntry and AppStateWrite non-exhaustive ([#1271](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1271))

The last two types the semver report flagged, deferred out of #1270 because
  AclEntry looked like a 68-site migration through security-sensitive semantics.

  It was not. The compiler finds ONE construction site outside vta-sdk. The 68 came
  from a grep that conflated three different types — this wire `AclEntry`, the
  unrelated `vti_common::acl::AclEntry`, and vtc-service's own `VtcAclEntry` — and
  counted every `fn ... -> AclEntry {` body as a literal. The caution was right; the
  arithmetic behind it was not, and the compiler was the census that settled it.

  What the review did earn is the shape of the constructor. Both real fixtures set
  `allowed_keys` deliberately and say why in a comment: `trust_task_decode.rs` uses
  `Some(vec![])` because the empty vec must survive the wire as `"allowedKeys": []`,
  and `conformance.rs` uses a populated vec because only a present value proves the
  member survives under its canonical spelling. On this type `None` and `Some(∅)`
  are OPPOSITE grants — absent reaches every key the entry's scopes reach,
  present-but-empty reaches none.

  So `AclEntry::new` takes subject, role and scopes, and leaves `allowed_keys`
  absent — the meaning an entry predating the member already has. It defaults no
  grant whose empty case is not its neutral case, and the doc comment says so.
  Empty `scopes` has the same shape of hazard (unrestricted for an admin role,
  authorized nowhere for every other), which is why it is an argument rather than a
  default.

- **vta-sdk**: Make the growth-prone wire bodies non-exhaustive ([#1270](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1270))

Sixteen public request bodies gained an `ext` member in #1231 — under a `fix:`
  type, which derives the smallest bump there is — and every consumer building one
  with a struct literal stopped compiling. `vta-sdk` 0.32.4 shipped that as a patch
  release, which a caret requirement takes on a routine `cargo update`.

  `ext` is the framework's extension member (SPEC §4.5.1); these bodies gain
  members whenever the schema revises. So the fix is not to remember the `!` next
  time, it is for the addition to stop being breaking: fourteen of them are now
  `#[non_exhaustive]` with a `new()` taking the members the schema requires. The
  optional members stay public — set them on the returned value.

  Deliberately NOT applied to `AclEntry` or `AppStateWrite`, which the same report
  flagged. `AclEntry` has 68 construction sites, and its own doc comments record
  that `None` and `Some([])` on `allowed_keys` are OPPOSITE grants: absent means
  every key the entry's scopes reach, present-but-empty means no keys at all. A
  generated constructor defaulting that to `None`, migrated mechanically across 68
  sites, is precisely how the narrowest grant becomes the widest — the same class
  of mistake CLAUDE.md already attributes to #746, #769 and #770 on the adjacent
  `allowed_contexts` axis. That one wants per-site review, not a script, and it is
  better done on its own.

  The compiler was a better census than grep: I estimated 19 external construction
  sites and it found 21, across five files including integration tests, which count
  as outside the defining crate for this purpose.

  Two of my own automation passes needed correcting on the way, both worth naming
  because the second was nearly silent: the first brace matcher mis-parsed `//`
  comments sitting inside the literals, and the second dropped the comment attached
  to `authorization_context: None` while filtering out `None`-valued fields. That
  comment records that `authorizationContext` is a member the published schema does
  not define, so a producer cannot send it through the validated transport at all.
  It is restored against the constructor default.

  Breaking, so this wants the minor slot on vta-sdk. #1256's guard will say so if
  the release proposes otherwise.

- **persona**: Move to trust-tasks-rs 0.18 and resolve inline entries ([#1266](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1266))
</blockquote>

## `vti-common`

<blockquote>

## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.16.2...vti-common-v0.17.0) — 2026-09-07

### Added

- **vti-common**: Make Capability and AuditEvent non-exhaustive ([#1262](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1262))

Both enums are designed to grow — `Capability` gains an entry whenever the agent
  gains a power worth gating separately, and `AuditEvent`'s own doc comment says
  variants arrive alongside the features that emit them. Neither was
  `#[non_exhaustive]`, so every one of those additions was a breaking change for
  anyone matching on them.

  That is not hypothetical. `MemoryRead`, `MemoryWrite`, `RoomPresent`, `RoomOpen`
  and `AuditEvent::RoomOperation` went out in vti-common 0.16.2 — a PATCH release —
  so a downstream exhaustive `match` stopped compiling on a routine `cargo update`,
  with the caret requirement picking it up automatically.

  The cost inside this workspace is zero: nothing here matches exhaustively on
  either type. Every reference constructs a variant as a value, and the only
  `match self` sits in `vti-common` itself, where the attribute has no effect.
  Checked before writing it, not after.

  Downstream code now needs a `_ =>` arm, and that is the point rather than the
  price. A capability a consumer has never heard of is precisely the one it must
  not silently treat as granted, and an audit event it cannot name still has to be
  recorded; a wildcard arm forces both decisions to be written down instead of
  being decided by a compile error at the wrong moment.

  Deliberately NOT applied to the sixteen `vta-sdk` wire structs that broke the
  same way when they gained `ext`. `#[non_exhaustive]` on a struct removes literal
  construction from outside the crate entirely — functional update with
  `..Default::default()` included, which is the part people assume still works — so
  all sixteen would need constructors or builders. That is a redesign of the public
  SDK surface, not cleanup, and the safety half is now covered anyway: a new field
  forces a breaking bump and #1256's guard makes that stick. Worth doing
  deliberately, in its own change.

  Breaking for external consumers, so this needs the minor slot (0.17.0) rather
  than a patch. The guard added in #1256 will now say so if the release proposes
  otherwise — which makes this its first live exercise of the failure path.
</blockquote>

## `vta-cli-common`

<blockquote>

## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.4...vta-cli-common-v0.13.0) — 2026-09-07

### Added

- **vta-sdk**: Make the growth-prone wire bodies non-exhaustive ([#1270](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1270))

Sixteen public request bodies gained an `ext` member in #1231 — under a `fix:`
  type, which derives the smallest bump there is — and every consumer building one
  with a struct literal stopped compiling. `vta-sdk` 0.32.4 shipped that as a patch
  release, which a caret requirement takes on a routine `cargo update`.

  `ext` is the framework's extension member (SPEC §4.5.1); these bodies gain
  members whenever the schema revises. So the fix is not to remember the `!` next
  time, it is for the addition to stop being breaking: fourteen of them are now
  `#[non_exhaustive]` with a `new()` taking the members the schema requires. The
  optional members stay public — set them on the returned value.

  Deliberately NOT applied to `AclEntry` or `AppStateWrite`, which the same report
  flagged. `AclEntry` has 68 construction sites, and its own doc comments record
  that `None` and `Some([])` on `allowed_keys` are OPPOSITE grants: absent means
  every key the entry's scopes reach, present-but-empty means no keys at all. A
  generated constructor defaulting that to `None`, migrated mechanically across 68
  sites, is precisely how the narrowest grant becomes the widest — the same class
  of mistake CLAUDE.md already attributes to #746, #769 and #770 on the adjacent
  `allowed_contexts` axis. That one wants per-site review, not a script, and it is
  better done on its own.

  The compiler was a better census than grep: I estimated 19 external construction
  sites and it found 21, across five files including integration tests, which count
  as outside the defining crate for this purpose.

  Two of my own automation passes needed correcting on the way, both worth naming
  because the second was nearly silent: the first brace matcher mis-parsed `//`
  comments sitting inside the literals, and the second dropped the comment attached
  to `authorization_context: None` while filtering out `None`-valued fields. That
  comment records that `authorizationContext` is a member the published schema does
  not define, so a producer cannot send it through the validated transport at all.
  It is restored against the constructor default.

  Breaking, so this wants the minor slot on vta-sdk. #1256's guard will say so if
  the release proposes otherwise.
</blockquote>







## `vta-persona`

<blockquote>

## [0.1.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/releases/tag/vta-persona-v0.1.0) — 2026-09-06

### Added

- **persona**: The holder's own identity, and a boundary a context cannot read across ([#1255](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1255))

* feat(persona): register the persona keyspace

  Fourth holder store, beside the vault, agent memory and application state.
  It is distinct because disclosure control is its point, and app-state
  promises never to interpret its records — so it cannot host something whose
  whole job is deciding which members may leave.

  Two scopes share the keyspace and the split is a control, not filing: the
  pool and profiles are agent-scoped so the correlation index can see the same
  value presented by two personas in two contexts, which a per-context index
  cannot see by construction.

  BACKED_UP, because a restore without the holder's identity returns an agent
  that no longer knows who its holder is.

  Cascade on DID deletion, with the nuance the per-keyspace enum cannot
  express: only the context-scoped half is DID-keyed. Bindings and contacts
  cascade; the pool survives, because a profile may be bound to several
  personas and deleting one must not destroy facts presented through another.

  * feat(persona): vta-persona crate — models, key layout, correlation index

  The fourth holder store. Distinct from app-state because disclosure control
  is its point, and a store that promises never to interpret its records cannot
  gate what leaves them.

  model.rs carries the shapes the specs made normative. Two choices are
  load-bearing. ProofRung derives Ord so that 'the highest rung this format
  supports' is a max() rather than a hand-written table that can disagree with
  itself. And ProfileEntry::referenced() returns None only for inline entries,
  which is what makes a context-local profile checkable: one is valid exactly
  when no entry references the pool.

  storage.rs builds every key in one place, because the agent-scoped and
  context-scoped prefixes are a security boundary and a call site that formats
  its own key can put a record on the wrong side of it. scope_of() returns
  Option rather than defaulting — a key nobody recognises must not be assumed
  safe to serve a context-scoped caller. Local profiles get their own prefix
  rather than a flag, so a context-scoped scan reaches a space that
  structurally cannot hold a pool profile; a filter is a line of code that can
  be got wrong, an address space cannot.

  correlation.rs is keyed by HMAC over a canonicalised value, so exact-match
  lookup works with no plaintext index over the holder's PII — and prefix and
  substring search are out of scope by construction, which is the trade.
  Canonicalisation sorts object members, or two serialisations of one fact
  would hash differently and the guard would miss the reuse it exists to catch.
  Comparison is constant-time, or an attacker submitting candidates could use
  timing to learn what the holder holds.

  severity() encodes the inversion that is easy to get backwards: a credential
  presented WHOLE correlates more than a self-asserted value, because the
  issuer signature is identical at every verifier, while a derived proof
  correlates less because it differs every presentation. Scoring on provenance
  alone would rank an attested claim safer than a typed one and push holders
  toward the riskier option.

  * feat(persona): pin trust-tasks-rs 0.17.9 and assert the contract in tests

  The persona family is published, so the generated payload types are now the
  contract this crate stores against. Taken as a dev-dependency rather than a
  real one: storage needs none of it, and depending on it only in tests means a
  spec change that lands upstream without a matching change here fails a test
  instead of a production dispatch.

  Two assertions earn their place. The proof and issuedAt constants are how a
  dispatcher learns those were declared REQUIRED, so a relaxation upstream
  surfaces as a failing test rather than as an accepted unsigned write. And our
  ValueType is compared to the published enum on the wire, because a variant
  added upstream without a matching arm here would silently reject a value the
  spec calls legal.

  * feat(persona): attribute store — versions, preconditions, tombstones, indexes

  Read-modify-write is serialised by a process-local lock rather than a CAS,
  following the conclusion app-state reached: there is no reachable multi-writer
  topology, and a CAS would be atomic exactly where the lock already suffices
  while staying non-atomic on the vsock proxy that would need it.

  The version counter is reserved BEFORE the write it belongs to. A crash
  between reserving and writing leaks a number, which is harmless because
  versions are opaque and monotonic and never an edit count. The opposite order
  would reuse one, which is not.

  Index maintenance runs before the record write, deliberately. A crash then
  leaves an index entry with no record — a false positive in the correlation
  guard — rather than a record with no index entry, which would read as a false
  ALL-CLEAR. Over-warning is recoverable; under-warning is the failure the
  guard exists to prevent.

  A tombstone is not a live record, so expectedVersion 0 succeeds over one and
  the new record takes a later counter value. A repeat delete returns
  existed: false and takes NO version: had it taken one, every consumer
  watching the store would see a change that did not happen and delete could
  not be safely retried — asserted by a test that measures the counter either
  side.

  correlation_count returns a count and never identifiers, because returning
  them on a write would disclose the holder's other compositions to whatever
  tool made it.

  * feat(persona): profiles, resolution, and the reverse index

  put_profile validates every reference before taking a version, so a refused
  write consumes nothing, and refuses the whole composition on a dangling
  reference — a partially-resolved profile would disclose less than the holder
  composed and tell them nothing about it.

  The reverse index drops its old edges before adding new ones. Without that an
  attribute removed from a profile keeps a stale referrer, and its delete is
  refused for a reference that no longer exists.

  An override replaces value and label only; provenance is inherited. A pin
  naming a version the store no longer holds resolves stale with no value
  rather than silently serving the current one, which would defeat the entire
  point of pinning.

  Deleting a profile leaves the pool untouched. A profile references rather
  than owns, so removing a composition destroys no facts — the asymmetry with
  attribute deletion, where removal does change what compositions present.

  **Fixes a real serde defect the tests caught.** ProfileEntry is untagged, and
  untagged tries variants in declaration order while serde ignores unknown
  fields — so the permissive Ref variant was matching {ref, override} and
  {ref, pinVersion}, silently degrading an override into a live reference and a
  pin into an unpinned one. A disclosure changing behind the holder's back.
  deny_unknown_fields is not available on a variant, so the fix is declaration
  order with Ref last, documented at the enum and pinned by a test.

  * feat(persona): bindings — the push across the context boundary

  Setting a binding is the moment a composition crosses from agent scope into a
  context, and the crossing has a direction: the holder pushes a materialised
  projection down, and a context never pulls.

  MaterialisedClaim is a distinct type from ResolvedClaim rather than the same
  one with a field left empty. The difference IS the security property — a
  function handed a MaterialisedClaim cannot obtain a pool identifier, so no
  future edit leaks one across the boundary by forgetting to clear it. The
  compiler enforces what a reviewer would otherwise have to notice. Asserted on
  the serialised bytes, because what crosses the boundary is what was written.

  rematerialise() keeps 'edit once, everywhere' working without opening a read
  path: it is a write initiated ABOVE the boundary, never a pull from below.

  Binding to a missing profile is refused rather than written — a binding that
  appears configured and presents nothing is a failure the holder discovers
  from the other side. Clearing is a first-class state, not an absence: a
  persona with no profile is legitimate and common.

  A second persona on one profile is counted and returned, because that act
  makes them the same person by construction and no later narrowing undoes it.
  A count, not identifiers — the association between the holder's personas is
  exactly what an attacker wants.

  BindingSummary is what a context-scoped caller may learn: whether bound, the
  label, a claim count. It has nowhere to put a value, which is the point.

  * feat(persona): contacts — revisions, diffs, and reference-counted retention

  A contact is what a peer disclosed, appended as a revision and never
  overwritten. An address book that silently replaces a payment address is a
  phishing surface; one that reports what changed and when is a defence — which
  is what changed_claims and has_unreviewed_change exist for. A revision
  history nobody is shown is an archive, not a defence.

  Keyed on (context, subject, knownByPersona): the same peer met through two
  personas is two contacts. Collapsing them would correlate the holder's own
  personas inside their own address book, which is the one place nobody would
  think to look for that linkage.

  The diff counts a claim that VANISHED as changed. A diff reporting only
  mutations stays quiet when a peer stops disclosing their payment address,
  which is exactly when it should speak up.

  A reaped revision returns Gone, never NotFound. A caller comparing a current
  value against history must tell 'never existed' from 'no longer kept' —
  only the second means their comparison is unsound rather than mistaken, and
  collapsing them lets a producer conclude 'nothing changed' from an absence
  that means the opposite.

  Retention counts references rather than days. A revision cited by a
  disclosure record is evidence of what the holder was shown before they
  presented; a flat TTL would delete it precisely when it mattered. Deletion
  reports what it retained, because an incomplete erasure the holder believes
  is complete is worse than one they know about.

  The outgoing revision is archived BEFORE the new one lands, so a crash leaves
  a duplicate rather than a gap — and a gap in a history that exists to prove
  what changed is worse than a repeat.

  * feat(persona): the disclosure record, and the caller retention was built for

  Append-only, and written BEFORE the artifact is returned. A crash between
  signing and recording would release data the holder could never afterwards
  discover they had released; recording first can only produce a record of a
  disclosure that did not happen, which is a false positive they can
  investigate. One of those is recoverable.

  Records name claim TYPES and rungs, never values. Re-storing the values would
  double the exposure the record exists to describe, and put a second plaintext
  copy of the holder's data in a structure whose whole purpose is to be read
  later. The rung is recorded because the same claim type at two rungs is two
  very different disclosures.

  contexts_reached_by() pays the debt the scope split incurred. Putting the
  pool above the context boundary bought a correlation check that sees across
  contexts; the cost is that a holder can no longer tell from one context where
  a fact has gone. This answers it directly.

  record_disclosure cites the contact revisions a disclosure relied on — the
  caller reference-counted retention was built for, and until now had none.
  Citation happens after the record lands: a citation with no record retains a
  revision nobody needs, while a record with no citation would let the evidence
  behind it be reaped. Only one of those loses something.

  * feat(persona): task URIs and retry-safety classification

  Adding the 24 URIs to ALL_URIS made every_uri_is_classified fail until each
  was classified, which is the census working: a task cannot join the catalogue
  without someone deciding what a lost reply costs it.

  Writes are Keyed following the app-state precedent — without a precondition a
  replay writes twice and bumps the counter twice, so a watcher sees a change
  that never happened. Deletes are RetrySafe because they converge: a repeat
  finds a tombstone, returns existed: false, and takes no counter value.

  Two entries are worth reading twice. disclosure/preview looks like a read and
  is Keyed, because it mints the single-use token present consumes — a replayed
  preview hands out a second authorisation to disclose. And disclosure/present
  is Keyed because a replay is a second release of personal data to a third
  party and a second permanent record of it: the one task in this family where
  a lost reply must never be retried blind.

  * feat(persona): the authorization boundary, enforced and pinned by census

  The pool and profiles are agent-scoped; bindings, contacts and disclosure
  records are context-scoped. Nothing inside a context may read the pool. That
  is a rule about direction rather than a permission — an access-control failure
  over a readable pool discloses everything, while a pool no context can address
  has nothing to disclose.

  The gate is require_super_admin (Admin AND unrestricted scope), not a role
  check. A guard written as 'is this caller an administrator' PASSES for an
  administrator scoped to a single context, who would then read and write
  identity data belonging to every other one. vti-common's own act_scope docs
  warn about the same edge from the other side: an empty context list means
  unrestricted for Admin and nothing at all for every other role, so a call site
  testing is_empty() without the role gets one of the two backwards. Both halves
  are asserted.

  REACH classifies all 24 tasks and is exhaustive by test, so a task cannot join
  the family without someone deciding which side it is on — and an unknown URI
  is refused rather than defaulted, because defaulting to Context is exactly how
  a pool read becomes reachable from inside one.

  The test that matters is a_context_scoped_admin_is_refused_every_holder_task:
  it iterates every holder-only task and asserts an admin scoped to ctx-work is
  turned away. That is the conformance witness the design asked for, and the
  test that would have caught the trap.



### Fixed

- **persona**: Drive the slice end to end, and fix the four things that found ([#1258](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1258))

Every layer of the persona slice was tested and none of the seams between
  them were. The unit tests assert that `authorize` refuses a context-scoped
  caller; they cannot say whether the dispatcher ever calls `authorize`. The
  store tests assert that a materialised claim carries no pool identifier;
  they cannot say what a context receives on the wire. Those are different
  claims and only one of them is about the system.

  `vta-service/tests/persona_trust_task.rs` posts real Trust Task documents
  through the real dispatch spine into the real store. It failed on four
  counts the first time it ran.

  **`renderers/list` refused the most privileged caller.** The handler
  supplied a context from `auth.allowed_contexts.first()`, reasoning that a
  caller should name one so the request is attributable. That was wrong
  twice: the context did not come from the request, so it attributed
  nothing; and reading the caller's own list inverted the gate — an `Admin`
  with an unrestricted (empty) list is the most privileged caller there is,
  and was the only one refused, while every scoped caller was admitted.
  This is the `allowed_contexts.is_empty()` family CLAUDE.md warns about,
  reached by a route the warning does not name.

  The fix is a third reach rather than a different one of the two, because
  both are wrong for this task in opposite directions. `Context` refuses the
  unscoped holder — the payload schema has no `contextId`, so there is no
  context to name. `Holder` would refuse the callers who most need it:
  `disclosure/preview` is context-scoped and takes a renderer name, so an
  application that cannot list renderers cannot choose one, and choosing
  blind is how a holder discloses through a format that silently drops
  provenance. `Reach::Any` says what is true — the response is a
  compile-time constant naming nothing about anybody.

  **Two responses emitted `null` where the schema types a string.**
  `disclosure/present` for an unminted `credentialId`, and `binding/get` for
  `profileId` / `profileName` / `boundAt` when nothing is bound. `json!`
  renders a `None` as `null`; an unset optional must be *absent*. This is
  the response-side twin of the rule `payload_null_census` pins on requests
  in `vta-sdk`, and it has no census — the response-conformance layer caught
  it at run time, which is the only reason either was noticed. Both now go
  through `put_opt`.

  Note which case failed: `binding/get` conformed while bound and did not
  while unbound. That is the wrong way round — "nobody is bound here" is
  exactly the reading a caller needs to be able to trust.

  **`profile/get --resolve` omitted three required members**, because
  `ResolvedClaim` never carried them. It now carries `valueType`, `version`
  and `updatedAt`, which are also the members that make a resolved read
  useful: a holder can see that an entry is pinned to v3 while the pool is
  at v5.

  **And a spec defect the same test surfaced.** That response types each
  resolved entry as the pool `Attribute` shape, requiring `attributeId`,
  `updatedAt` and `version`. An inline entry has none of them — it has no
  pool record behind it, which is the reason inline exists. So `resolved` is
  a projection that may contain non-pool values and the pool record's shape
  cannot describe them.

  Until that is fixed upstream the handler refuses, naming the reason. The
  two alternatives are both dishonest: a synthesised `attributeId` lies
  about where a value lives, and omitting the entry returns a profile that
  appears to present less than it does — the failure this store exists to
  prevent. `an_inline_entry_is_refused_until_the_schema_allows_one` pins the
  interim behaviour so it expires rather than settles; when the schema takes
  the three members as optional, that test fails and the refusal goes with
  it.
</blockquote>

## `vta-tee`

<blockquote>

## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.2...vta-tee-v0.2.3) — 2026-09-06

### Fixed

- **tee**: Make allow_kms_reinit explicit authorization for reinit regardless of KMS failure type ([#1249](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1249))

* fix(tee): make allow_kms_reinit explicit authorization for reinit regardless of KMS failure type
</blockquote>


## `vta-service`

<blockquote>

## [0.23.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.4...vta-service-v0.23.5) — 2026-09-06

### Added

- **persona**: The holder's own identity, and a boundary a context cannot read across ([#1255](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1255))

* feat(persona): register the persona keyspace

  Fourth holder store, beside the vault, agent memory and application state.
  It is distinct because disclosure control is its point, and app-state
  promises never to interpret its records — so it cannot host something whose
  whole job is deciding which members may leave.

  Two scopes share the keyspace and the split is a control, not filing: the
  pool and profiles are agent-scoped so the correlation index can see the same
  value presented by two personas in two contexts, which a per-context index
  cannot see by construction.

  BACKED_UP, because a restore without the holder's identity returns an agent
  that no longer knows who its holder is.

  Cascade on DID deletion, with the nuance the per-keyspace enum cannot
  express: only the context-scoped half is DID-keyed. Bindings and contacts
  cascade; the pool survives, because a profile may be bound to several
  personas and deleting one must not destroy facts presented through another.

  * feat(persona): vta-persona crate — models, key layout, correlation index

  The fourth holder store. Distinct from app-state because disclosure control
  is its point, and a store that promises never to interpret its records cannot
  gate what leaves them.

  model.rs carries the shapes the specs made normative. Two choices are
  load-bearing. ProofRung derives Ord so that 'the highest rung this format
  supports' is a max() rather than a hand-written table that can disagree with
  itself. And ProfileEntry::referenced() returns None only for inline entries,
  which is what makes a context-local profile checkable: one is valid exactly
  when no entry references the pool.

  storage.rs builds every key in one place, because the agent-scoped and
  context-scoped prefixes are a security boundary and a call site that formats
  its own key can put a record on the wrong side of it. scope_of() returns
  Option rather than defaulting — a key nobody recognises must not be assumed
  safe to serve a context-scoped caller. Local profiles get their own prefix
  rather than a flag, so a context-scoped scan reaches a space that
  structurally cannot hold a pool profile; a filter is a line of code that can
  be got wrong, an address space cannot.

  correlation.rs is keyed by HMAC over a canonicalised value, so exact-match
  lookup works with no plaintext index over the holder's PII — and prefix and
  substring search are out of scope by construction, which is the trade.
  Canonicalisation sorts object members, or two serialisations of one fact
  would hash differently and the guard would miss the reuse it exists to catch.
  Comparison is constant-time, or an attacker submitting candidates could use
  timing to learn what the holder holds.

  severity() encodes the inversion that is easy to get backwards: a credential
  presented WHOLE correlates more than a self-asserted value, because the
  issuer signature is identical at every verifier, while a derived proof
  correlates less because it differs every presentation. Scoring on provenance
  alone would rank an attested claim safer than a typed one and push holders
  toward the riskier option.

  * feat(persona): pin trust-tasks-rs 0.17.9 and assert the contract in tests

  The persona family is published, so the generated payload types are now the
  contract this crate stores against. Taken as a dev-dependency rather than a
  real one: storage needs none of it, and depending on it only in tests means a
  spec change that lands upstream without a matching change here fails a test
  instead of a production dispatch.

  Two assertions earn their place. The proof and issuedAt constants are how a
  dispatcher learns those were declared REQUIRED, so a relaxation upstream
  surfaces as a failing test rather than as an accepted unsigned write. And our
  ValueType is compared to the published enum on the wire, because a variant
  added upstream without a matching arm here would silently reject a value the
  spec calls legal.

  * feat(persona): attribute store — versions, preconditions, tombstones, indexes

  Read-modify-write is serialised by a process-local lock rather than a CAS,
  following the conclusion app-state reached: there is no reachable multi-writer
  topology, and a CAS would be atomic exactly where the lock already suffices
  while staying non-atomic on the vsock proxy that would need it.

  The version counter is reserved BEFORE the write it belongs to. A crash
  between reserving and writing leaks a number, which is harmless because
  versions are opaque and monotonic and never an edit count. The opposite order
  would reuse one, which is not.

  Index maintenance runs before the record write, deliberately. A crash then
  leaves an index entry with no record — a false positive in the correlation
  guard — rather than a record with no index entry, which would read as a false
  ALL-CLEAR. Over-warning is recoverable; under-warning is the failure the
  guard exists to prevent.

  A tombstone is not a live record, so expectedVersion 0 succeeds over one and
  the new record takes a later counter value. A repeat delete returns
  existed: false and takes NO version: had it taken one, every consumer
  watching the store would see a change that did not happen and delete could
  not be safely retried — asserted by a test that measures the counter either
  side.

  correlation_count returns a count and never identifiers, because returning
  them on a write would disclose the holder's other compositions to whatever
  tool made it.

  * feat(persona): profiles, resolution, and the reverse index

  put_profile validates every reference before taking a version, so a refused
  write consumes nothing, and refuses the whole composition on a dangling
  reference — a partially-resolved profile would disclose less than the holder
  composed and tell them nothing about it.

  The reverse index drops its old edges before adding new ones. Without that an
  attribute removed from a profile keeps a stale referrer, and its delete is
  refused for a reference that no longer exists.

  An override replaces value and label only; provenance is inherited. A pin
  naming a version the store no longer holds resolves stale with no value
  rather than silently serving the current one, which would defeat the entire
  point of pinning.

  Deleting a profile leaves the pool untouched. A profile references rather
  than owns, so removing a composition destroys no facts — the asymmetry with
  attribute deletion, where removal does change what compositions present.

  **Fixes a real serde defect the tests caught.** ProfileEntry is untagged, and
  untagged tries variants in declaration order while serde ignores unknown
  fields — so the permissive Ref variant was matching {ref, override} and
  {ref, pinVersion}, silently degrading an override into a live reference and a
  pin into an unpinned one. A disclosure changing behind the holder's back.
  deny_unknown_fields is not available on a variant, so the fix is declaration
  order with Ref last, documented at the enum and pinned by a test.

  * feat(persona): bindings — the push across the context boundary

  Setting a binding is the moment a composition crosses from agent scope into a
  context, and the crossing has a direction: the holder pushes a materialised
  projection down, and a context never pulls.

  MaterialisedClaim is a distinct type from ResolvedClaim rather than the same
  one with a field left empty. The difference IS the security property — a
  function handed a MaterialisedClaim cannot obtain a pool identifier, so no
  future edit leaks one across the boundary by forgetting to clear it. The
  compiler enforces what a reviewer would otherwise have to notice. Asserted on
  the serialised bytes, because what crosses the boundary is what was written.

  rematerialise() keeps 'edit once, everywhere' working without opening a read
  path: it is a write initiated ABOVE the boundary, never a pull from below.

  Binding to a missing profile is refused rather than written — a binding that
  appears configured and presents nothing is a failure the holder discovers
  from the other side. Clearing is a first-class state, not an absence: a
  persona with no profile is legitimate and common.

  A second persona on one profile is counted and returned, because that act
  makes them the same person by construction and no later narrowing undoes it.
  A count, not identifiers — the association between the holder's personas is
  exactly what an attacker wants.

  BindingSummary is what a context-scoped caller may learn: whether bound, the
  label, a claim count. It has nowhere to put a value, which is the point.

  * feat(persona): contacts — revisions, diffs, and reference-counted retention

  A contact is what a peer disclosed, appended as a revision and never
  overwritten. An address book that silently replaces a payment address is a
  phishing surface; one that reports what changed and when is a defence — which
  is what changed_claims and has_unreviewed_change exist for. A revision
  history nobody is shown is an archive, not a defence.

  Keyed on (context, subject, knownByPersona): the same peer met through two
  personas is two contacts. Collapsing them would correlate the holder's own
  personas inside their own address book, which is the one place nobody would
  think to look for that linkage.

  The diff counts a claim that VANISHED as changed. A diff reporting only
  mutations stays quiet when a peer stops disclosing their payment address,
  which is exactly when it should speak up.

  A reaped revision returns Gone, never NotFound. A caller comparing a current
  value against history must tell 'never existed' from 'no longer kept' —
  only the second means their comparison is unsound rather than mistaken, and
  collapsing them lets a producer conclude 'nothing changed' from an absence
  that means the opposite.

  Retention counts references rather than days. A revision cited by a
  disclosure record is evidence of what the holder was shown before they
  presented; a flat TTL would delete it precisely when it mattered. Deletion
  reports what it retained, because an incomplete erasure the holder believes
  is complete is worse than one they know about.

  The outgoing revision is archived BEFORE the new one lands, so a crash leaves
  a duplicate rather than a gap — and a gap in a history that exists to prove
  what changed is worse than a repeat.

  * feat(persona): the disclosure record, and the caller retention was built for

  Append-only, and written BEFORE the artifact is returned. A crash between
  signing and recording would release data the holder could never afterwards
  discover they had released; recording first can only produce a record of a
  disclosure that did not happen, which is a false positive they can
  investigate. One of those is recoverable.

  Records name claim TYPES and rungs, never values. Re-storing the values would
  double the exposure the record exists to describe, and put a second plaintext
  copy of the holder's data in a structure whose whole purpose is to be read
  later. The rung is recorded because the same claim type at two rungs is two
  very different disclosures.

  contexts_reached_by() pays the debt the scope split incurred. Putting the
  pool above the context boundary bought a correlation check that sees across
  contexts; the cost is that a holder can no longer tell from one context where
  a fact has gone. This answers it directly.

  record_disclosure cites the contact revisions a disclosure relied on — the
  caller reference-counted retention was built for, and until now had none.
  Citation happens after the record lands: a citation with no record retains a
  revision nobody needs, while a record with no citation would let the evidence
  behind it be reaped. Only one of those loses something.

  * feat(persona): task URIs and retry-safety classification

  Adding the 24 URIs to ALL_URIS made every_uri_is_classified fail until each
  was classified, which is the census working: a task cannot join the catalogue
  without someone deciding what a lost reply costs it.

  Writes are Keyed following the app-state precedent — without a precondition a
  replay writes twice and bumps the counter twice, so a watcher sees a change
  that never happened. Deletes are RetrySafe because they converge: a repeat
  finds a tombstone, returns existed: false, and takes no counter value.

  Two entries are worth reading twice. disclosure/preview looks like a read and
  is Keyed, because it mints the single-use token present consumes — a replayed
  preview hands out a second authorisation to disclose. And disclosure/present
  is Keyed because a replay is a second release of personal data to a third
  party and a second permanent record of it: the one task in this family where
  a lost reply must never be retried blind.

  * feat(persona): the authorization boundary, enforced and pinned by census

  The pool and profiles are agent-scoped; bindings, contacts and disclosure
  records are context-scoped. Nothing inside a context may read the pool. That
  is a rule about direction rather than a permission — an access-control failure
  over a readable pool discloses everything, while a pool no context can address
  has nothing to disclose.

  The gate is require_super_admin (Admin AND unrestricted scope), not a role
  check. A guard written as 'is this caller an administrator' PASSES for an
  administrator scoped to a single context, who would then read and write
  identity data belonging to every other one. vti-common's own act_scope docs
  warn about the same edge from the other side: an empty context list means
  unrestricted for Admin and nothing at all for every other role, so a call site
  testing is_empty() without the role gets one of the two backwards. Both halves
  are asserted.

  REACH classifies all 24 tasks and is exhaustive by test, so a task cannot join
  the family without someone deciding which side it is on — and an unknown URI
  is refused rather than defaulted, because defaulting to Context is exactly how
  a pool read becomes reachable from inside one.

  The test that matters is a_context_scoped_admin_is_refused_every_holder_task:
  it iterates every holder-only task and asserts an admin scoped to ctx-work is
  turned away. That is the conformance witness the design asked for, and the
  test that would have caught the trap.

- **rooms**: A VTA joins a room, keeps up, and opens what it holds ([#1250](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1250))

Implements rooms/keys/{key-package,welcome,commit,open} - the delivery
  flow specified in dtgwg-trust-tasks-tf#355 and the decryption oracle from
  #349, on the custody layer from #1248. This is the piece that makes a
  data room readable by an agent that never holds a key.

  Four tasks, four different gates, and only one is a capability. The
  delivery three are inbound - a room's owner reaching this VTA - and an
  ACL of ours has no opinion about who a room's owner is. commit in
  particular is authorized INSIDE the group: MLS authenticates the
  committer as a member of the group we already hold, and a list we kept
  would be this service deciding who may commit to a room it is not part
  of. Only open is our own principal's agent asking us to decrypt, which is
  what a capability is for - RoomOpen, registered upstream in #351.

  The invitation is what makes a Welcome acceptable. A Welcome carries a
  group's secrets, so anyone able to reach a VTA could otherwise push group
  state into it. Joining a room is already a two-party act and the VIC is
  already the consent artefact; this is where that stops being ceremonial.
  Five checks, none optional - it parses as an invitation, its proof
  verifies, the issuer is the room, the subject is us, and it is live and
  unspent - and dropping any one leaves a way in. VerifiedInvitation is
  constructible only by the verifier, so a caller cannot reach consumption
  with something nobody checked.

  The invitation is consumed only AFTER the join succeeds. Burning it on a
  Welcome that then failed to process would strand the member: invitation
  spent, not in the room.

  Joining twice is refused rather than merged. Two group states for one
  room is a condition nothing downstream can resolve - open has no way to
  choose, and choosing wrong returns 'did not open' for a record the member
  can plainly see.

  open reports which epoch the VTA holds when a record is sealed under a
  later one. A member who missed a commit is stuck at their last epoch, and
  the raw symptom is 'this record does not open', which reads like
  corruption; naming the epoch turns it into 'a commit has not been
  delivered', which an operator can act on.

  Two keyspaces, both Cascade on DID deletion: room_groups holds group
  secrets and belongs at the same protection level as the key store, and
  room_invitations outlives the groups it admitted - while the member
  exists, a consumed invitation MUST survive leaving a room, or the same
  invitation would work twice.

  Four censuses had something to say. The MCP guard, where open and welcome
  are Sensitive (plaintext out, key material in) while key-package and
  commit are ordinary mutations. Retry safety, which produced four
  different answers and is the better for it: open is ReadOnly, commit is
  RetrySafe because the spec made replay a no-op precisely so delivery
  could retry, and key-package and welcome are Keyed - one leaves a second
  private half behind, the other cannot tell a lost reply from a completed
  join. Then the conformance witnesses and the namespace list.

  trust-tasks-rs 0.17.8 landed mid-build carrying #351, #354 and #355, so
  all four request types are generated rather than hand-written.

- **rooms**: The presentation oracle, so an agent never holds its human's credentials ([#1247](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1247))

Implements rooms/keys/present/0.1. The data-rooms design turns on a member
  equipping their agent with strictly less than they hold - a chain one link
  longer, conferring read for four hours, bound to one host - and nothing
  minted one. A member wanting to give an agent access had two options: hand
  over their own credentials, which is the outcome attenuation exists to
  prevent, or mint an attenuation by hand, which nobody does.

  So the agent asks, and the VTA mints. The VTA already holds the member's
  keys and is already in their trusted computing base; a host is not, which
  is why the host only ever sees the result.

  Four things a caller cannot obtain by asking, and each closes a way this
  could have quietly become the credential hand-off it replaces:

    More than the principal holds fails in attenuate, which refuses to
    widen - not at a policy check somebody could forget to write.

    A presentation covering everything is unreachable: action is required
    and exactly one action is conferred.

    A presentation made out to somebody else is unreachable: the leaf grants
    to the DID the transport authenticated, never one named in the payload.
    One minted for A is worthless to B even if B obtains it, because the
    presenter binding refuses it on the far side.

    A long-lived leaf is unreachable: the lifetime is a constant, not a
    request parameter. A caller that could ask for a year would be asking
    for the standing credential the oracle exists not to hand over.

  Gated on Capability::RoomPresent - registered upstream as roomPresent in
  dtgwg-trust-tasks-tf#351 - and deliberately not on Sign. An agent that may
  ask for a scoped, audience-bound presentation is not thereby an agent that
  may sign anything at all with its principal's key, and gating an oracle on
  the generic signing oracle grants strictly more than the task needs.

  The credentials are found by issuer, because a room issues its own - the
  same property the host verifies against, so a credential that would not
  verify there is not one this will present. Two authority credentials from
  one room is refused rather than resolved: picking the broader one hands
  out more than necessary, picking the narrower produces a presentation that
  fails at the host for reasons the caller cannot see.

  Five censuses had something to say, and all five were right. The
  conformance witness. The retry-safety classification - RetrySafe, because
  the oracle stores nothing and a retry mints a second leaf conferring
  exactly what the first did, on the same expiry; keying it would buy a
  dedup record against a harmless duplicate at the price of failing a retry
  the caller needs. The MCP guard, where it joins 'authority, moved' beside
  vta/credentials/issue: an MCP host approves a tool, so a blanket vta_call
  approval must not silently cover minting a presentation over its
  principal's standing. And the canonical-namespace list, which gains
  spec/rooms/ for exactly one URI - most of that family is a host's surface,
  and this is the one member a VTA serves.

- **vta**: Discharge the backup family's spec debt, and audit what it was hiding ([#1239](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1239))

* feat(vta): discharge the backup family's spec debt, and audit what it was hiding

  trust-tasks-rs 0.17.7 carries the six specs from
  trustoverip/dtgwg-trust-tasks-tf#347, so `vta/backup/*` and
  `vta/management/reload-services` come off `UNSPECCED_DISPATCHED_URIS` and
  gain conformance witnesses. The reduction plan's §D suggestion of a
  top-level `backup/*` was not taken: the family is agent lifecycle, and
  `vta/` is where the rest of it lives.

  That was meant to be bookkeeping. It was not.
</blockquote>











</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).