### PR TITLE
docs(releasing): say what actually counts as a breaking change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -941,6 +941,12 @@ subject, so the title is the entry — CI lints it.
 
 - **Title**: `<type>(<scope>): <subject>`, `!` for a breaking change. Types:
   `feat` `fix` `docs` `test` `ci` `build` `perf` `refactor` `chore` `security`.
+- **A new enum variant or struct field in a published crate IS breaking** unless
+  the type is `#[non_exhaustive]`, and it is the case people forget — release-plz
+  reads the bump off the `!`, so an unmarked one ships as a patch that consumers
+  take automatically. It has happened five times here (#1231, #1234, #1244,
+  #1247, #1250). For a type designed to grow, `#[non_exhaustive]` beats
+  remembering the marker. RELEASING.md has the full list.
 - **Body**: included in the changelog verbatim. Write the explanation there.
 - **Never** edit `version = ` in a `Cargo.toml`.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,36 @@ feat(sdk)!: rename the transport selector      <- ! marks a breaking change
 Types: `feat` `fix` `docs` `test` `ci` `build` `perf` `refactor` `chore`
 `security`.
 
+**What actually counts as breaking**, because the `!` is easy to leave off a
+change that does not feel like one. release-plz derives the bump from the type
+and the `!`, so an unmarked break ships as a patch — and a caret requirement
+picks that up on a routine `cargo update`. In a published crate, all of these
+are breaking even though none of them removes or renames anything:
+
+- **A new variant on a public enum** that is not `#[non_exhaustive]`. Any
+  downstream exhaustive `match` stops compiling.
+- **A new field on a public struct** a consumer can build with a literal. Their
+  literal is now missing a field.
+- **A new required argument, or a new trait method with no default.**
+- **A stricter bound, or a narrowed return type.**
+
+This is not a hypothetical list. Every entry on it happened here between
+2026-08-29 and 2026-09-06, and none was marked: `Capability` gained four
+variants across #1234, #1247 and #1250, `AuditEvent` gained one in #1244, and
+sixteen `vta-sdk` wire structs gained an `ext` field in #1231 — under `fix:`,
+which derives the smallest bump there is. `vti-common` 0.16.2 and `vta-sdk`
+0.32.4 went out as patches carrying all of it.
+
+**The better fix is usually not the `!`.** If a type is *designed* to grow —
+a capability list, an event vocabulary — mark it `#[non_exhaustive]` once and
+the additions stop being breaking at all. That is what #1262 did for
+`Capability` and `AuditEvent`. Reach for the marker when the break is real and
+intended; reach for `#[non_exhaustive]` when the type will keep growing.
+
+Neither replaces the mechanical check: `release bump is large enough` runs
+cargo-semver-checks against the versions a Release PR actually proposes and
+blocks when the bump is too small. It does not depend on anyone noticing.
+
 **Write a real commit body.** It is included in the changelog verbatim, so the
 explanation you write for reviewers is the same text an external consumer reads
 on crates.io. This is the whole changelog process now — there are no fragment

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -118,8 +118,19 @@ pub enum ServiceKind {
 /// produces a sensible default from the existing role (Admin gets
 /// everything, Reader gets only `vault-read`, etc.) so existing ACL
 /// behaviour is preserved bit-for-bit.
+/// **Non-exhaustive on purpose.** This list grows every time the agent gains a
+/// power worth gating separately, and each addition used to be a breaking change
+/// for anyone matching on it — which is exactly what happened: `MemoryRead`,
+/// `MemoryWrite`, `RoomPresent` and `RoomOpen` went out in `vti-common` 0.16.2, a
+/// patch release, and any downstream exhaustive `match` stopped compiling on a
+/// routine `cargo update`.
+///
+/// Downstream code must carry a `_ =>` arm. That is the point: a capability this
+/// consumer has never heard of is precisely the one it must not silently treat as
+/// granted, and a wildcard arm forces that decision to be written down.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum Capability {
     VaultRead,
     VaultWrite,

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -43,8 +43,17 @@ pub const REDACTED_MARKER: &str = "<redacted>";
 /// Audit-event payload. Tagged on `type` with the variant name and
 /// the variant's data under `data`. Phase-0 vocabulary only;
 /// Phase-1+ adds variants alongside the features that emit them.
+/// **Non-exhaustive on purpose**, and for the reason the doc comment above already
+/// states: variants arrive alongside the features that emit them, so the set is
+/// designed to grow. `RoomOperation` shipped in `vti-common` 0.16.2 — a patch — and
+/// broke every downstream exhaustive `match`.
+///
+/// A consumer that cannot name an event still has to record it; a `_ =>` arm is the
+/// honest shape for that, and dropping an unrecognised event on the floor is the
+/// failure this prevents being silent.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", content = "data")]
+#[non_exhaustive]
 pub enum AuditEvent {
     /// Bootstrap completed — the first admin DID was written into the
     /// ACL and the install carve-out was permanently closed.


### PR DESCRIPTION
`RELEASING.md` and `CLAUDE.md` both tell an author to put `!` on "a breaking
change", then leave the term undefined — as though it were self-evident. It
isn't. The cases that get missed are the ones that *add* rather than remove, and
they don't feel like breaks while you're writing them.

Five went out unmarked here between 2026-08-29 and 2026-09-06:

| Change | PR | Type used |
|---|---|---|
| `Capability::{MemoryRead, MemoryWrite}` | #1234 | `feat` |
| `Capability::RoomPresent` | #1247 | `feat` |
| `Capability::RoomOpen` | #1250 | `feat` |
| `AuditEvent::RoomOperation` | #1244 | `feat` |
| 16 `vta-sdk` wire structs gained `ext` | #1231 | **`fix`** — the smallest bump there is |

Neither enum was `#[non_exhaustive]`, so each variant broke every downstream
exhaustive `match`; the struct fields broke every literal. release-plz derives
the bump from the type and the `!`, so all of it shipped as patches —
`vti-common` 0.16.2 and `vta-sdk` 0.32.4 — which a caret requirement picks up on
a routine `cargo update`.

**Three of those five are mine.** That is the reason to write this down rather
than file it under carelessness: I diagnosed this problem for several hours
without noticing I had caused most of it, because adding a variant genuinely
does not register as an API break at the time.

## What changed

`RELEASING.md` gains the additive cases explicitly — new enum variant, new
struct field, new required argument, new trait method without a default,
stricter bound — with the note that this list is not hypothetical and where each
one happened.

It also says the better answer is usually **not** the marker: a type designed to
grow (a capability list, an event vocabulary) should be `#[non_exhaustive]` once,
as #1262 did, rather than depending on every future author remembering. Reach for
`!` when the break is real and intended; reach for `#[non_exhaustive]` when the
type will keep growing.

`CLAUDE.md` gets the short form beside the existing title rule, since that is
where the convention is actually read.

## Why this doesn't replace the guard

Both notes point at `release bump is large enough` (#1256), which compares the
versions a Release PR actually proposes against cargo-semver-checks and blocks
when the bump is too small. Documentation improves the odds an author notices;
the check does not depend on anyone noticing. This PR is the first half, not a
substitute for the second.
