### PR TITLE
ci: run the two package-scoped builds only when the change can affect them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -772,11 +772,42 @@ jobs:
         env:
           VTC_SKIP_ADMIN_UI_BUILD: "1"
 
+  affects:
+    # Which package-scoped builds this change can possibly alter.
+    #
+    # `Mobile build` cross-compiles vta-mobile-core for iOS and Android and takes
+    # ~22 minutes; its workspace dependency closure is TWO crates. `Enclave build`
+    # checks vta-enclave, whose closure contains no vtc-* and no room-host. Most
+    # pull requests here touch neither, and wait for both.
+    #
+    # Deliberately NOT gated on `pull_request`. A job whose `needs` were skipped is
+    # itself skipped, so gating this would stop the builds running on pushes to
+    # main — the opposite of what a filter should do. It runs everywhere and simply
+    # answers `true` when there is no diff to reason about.
+    name: which builds this change can affect
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      mobile: ${{ steps.mobile.outputs.run }}
+      enclave: ${{ steps.enclave.outputs.run }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The diff is the whole input; a shallow clone has no base to diff from.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - id: mobile
+        run: bash scripts/ci-affects.sh vta-mobile-core
+      - id: enclave
+        run: bash scripts/ci-affects.sh vta-enclave
+
   enclave:
     # The Nitro enclave binary uses a TEE-only feature combo that the
     # default `check` job never touches. Linux-only because vsock-store
     # depends on `tokio-vsock` which doesn't build on macOS/Windows.
     name: Enclave build
+    needs: affects
+    if: needs.affects.outputs.enclave != 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -857,6 +888,8 @@ jobs:
     # generates bindings — would land green. macOS runner because iOS needs
     # Xcode; the macOS image also ships the Android NDK.
     name: Mobile build
+    needs: affects
+    if: needs.affects.outputs.mobile != 'false'
     runs-on: macos-latest
     timeout-minutes: 45
     steps:

--- a/scripts/ci-affects.sh
+++ b/scripts/ci-affects.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Decide whether a package-scoped CI job needs to run for the change in hand.
+#
+#   scripts/ci-affects.sh vta-mobile-core
+#
+# Prints a short explanation and, under Actions, writes `run=true|false` to
+# $GITHUB_OUTPUT for the caller to gate its job on.
+#
+# # Why
+#
+# Some jobs build exactly one package. `Mobile build` cross-compiles
+# `vta-mobile-core` for iOS and Android and takes ~22 minutes; its workspace
+# dependency closure is *two crates*, `vta-mobile-core` and `vta-sdk`. Every PR
+# that touches neither waits for it anyway — which on this repo is most of them,
+# including every VTC-only change, since nothing under `vtc-*` is in any of these
+# closures.
+#
+# # The closure is derived, never listed
+#
+# `cargo metadata` knows what a package depends on. A hand-written list of
+# "paths that affect mobile" would be a second description of that, and this repo
+# has now paid three times over for two lists of the same thing drifting apart
+# (#1252, #1256, #1259). So the closure is computed on every run and a crate
+# added to the graph tomorrow is covered with no edit here.
+#
+# # Fail-safe, in the direction that costs minutes rather than correctness
+#
+# A skipped job is a check that did not run, and this repo has already been
+# bitten by checks that silently covered less than they claimed. So every
+# uncertainty resolves to RUN:
+#
+#   - not a pull request (a push to main / nightly) -> run
+#   - the workflow, the toolchain, the lockfile or a root manifest changed -> run
+#   - a changed file cannot be attributed to a workspace crate -> run
+#   - the diff cannot be computed at all -> run
+#
+# Only a change whose every file belongs to a crate demonstrably outside the
+# closure is skipped. The cost of being wrong in that direction is a job that
+# runs unnecessarily; the cost of being wrong the other way is a break that ships.
+set -euo pipefail
+
+PKG="${1:?usage: ci-affects.sh <package> [base-ref]}"
+
+# Resolving the base is where a filter like this quietly stops working. On a
+# pull_request event Actions checks out the MERGE commit, and `origin/main` is
+# often not a named ref in that checkout — so the obvious `git diff origin/main`
+# fails, the fail-safe fires, and every job runs forever while the filter looks
+# installed. Try in order, and say which one was used.
+resolve_base() {
+  if [ -n "${1:-}" ]; then echo "$1"; return; fi
+  if [ -n "${GITHUB_BASE_REF:-}" ] && git rev-parse --verify -q "origin/$GITHUB_BASE_REF" >/dev/null; then
+    echo "origin/$GITHUB_BASE_REF"; return
+  fi
+  # First parent of a merge commit is the base branch tip, which is exactly what
+  # refs/pull/N/merge gives us.
+  if git rev-parse --verify -q "HEAD^2" >/dev/null; then echo "HEAD^1"; return; fi
+  if git rev-parse --verify -q origin/main >/dev/null; then echo "origin/main"; return; fi
+  echo ""
+}
+BASE=$(resolve_base "${2:-}")
+[ -z "$BASE" ] && BASE_NOTE="no base ref could be resolved"
+
+emit() {
+  # $1 = true|false, $2 = why
+  echo "$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && echo "run=$1" >> "$GITHUB_OUTPUT"
+  # Visible in the job list without opening the log.
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "**$PKG**: run=\`$1\` — $2" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+}
+
+# A push builds the branch as a whole; only a pull request has a diff to reason
+# about, and main must never be gated on one.
+if [ "${GITHUB_EVENT_NAME:-pull_request}" != "pull_request" ]; then
+  emit true "not a pull request — always builds"
+fi
+
+if [ -z "$BASE" ]; then
+  emit true "${BASE_NOTE:-no base ref} — running rather than guessing"
+fi
+# Two dots, not three: against a merge commit's first parent the two-dot form is
+# the PR's actual effect on the base. Three dots would ask for the merge base of
+# the merge commit and its own parent, which is the parent — same answer here,
+# but only by accident, and wrong the moment the base ref is a branch tip.
+if ! CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null); then
+  emit true "could not diff against $BASE — running rather than guessing"
+fi
+if [ -z "$CHANGED" ]; then
+  emit true "no files changed against $BASE — running rather than guessing"
+fi
+echo "base: $BASE" >&2
+
+# Files that can change any build regardless of which crate they sit in.
+GLOBAL='^(Cargo\.lock|Cargo\.toml|rust-toolchain(\.toml)?|deny\.toml|\.cargo/|\.github/|scripts/)'
+if global_hit=$(echo "$CHANGED" | grep -E "$GLOBAL" | head -3); then
+  emit true "global file changed: $(echo "$global_hit" | tr '\n' ' ')"
+fi
+
+# Paths that cannot affect any compilation, dropped before attribution. Without
+# this every docs-only change would hit the unattributable fail-safe and rebuild
+# the world — correct, but for no reason. Kept deliberately narrow: prose, and
+# nothing that any build step reads.
+INERT='^(docs/|[^/]*\.md$|LICENSE|\.gitignore$|\.editorconfig$|\.gitattributes$)'
+CHANGED=$(echo "$CHANGED" | grep -Ev "$INERT" || true)
+if [ -z "$CHANGED" ]; then
+  emit false "only prose and non-build files changed"
+fi
+
+# crate directory -> crate name, tagged IN/OUT of $PKG's closure. The graph walk
+# lives in scripts/ci-closure.py; see its docstring for why it is not inline.
+if ! CLOSURE=$(cargo metadata --format-version 1 2>/dev/null | python3 scripts/ci-closure.py "$PKG"); then
+  emit true "could not resolve the closure of $PKG — running rather than guessing"
+fi
+if [ -z "$CLOSURE" ]; then
+  emit true "empty closure for $PKG — running rather than guessing"
+fi
+
+reasons=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  owner=""
+  best=0
+  while IFS=$'\t' read -r dir name state; do
+    case "$f" in
+      "$dir"/*)
+        # Longest matching directory wins, so a nested crate is attributed to
+        # itself rather than to an ancestor.
+        if [ "${#dir}" -gt "$best" ]; then best=${#dir}; owner="$name $state"; fi
+        ;;
+    esac
+  done <<< "$CLOSURE"
+
+  if [ -z "$owner" ]; then
+    emit true "unattributable path '$f' — running rather than guessing"
+  fi
+  set -- $owner
+  if [ "$2" = "IN" ]; then
+    reasons="$1"
+    break
+  fi
+done <<< "$CHANGED"
+
+if [ -n "$reasons" ]; then
+  emit true "$reasons is in $PKG's dependency closure"
+fi
+
+n=$(echo "$CHANGED" | grep -c . || true)
+emit false "none of the $n changed files touch $PKG's dependency closure"

--- a/scripts/ci-closure.py
+++ b/scripts/ci-closure.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Print every workspace crate, tagged by whether it is in a package's closure.
+
+    cargo metadata --format-version 1 | scripts/ci-closure.py vta-mobile-core
+
+emits one `<dir>\t<name>\t<IN|OUT>` row per workspace member, where IN means the
+crate is in the transitive workspace-member dependency closure of the named
+package — i.e. a change to it can change what that package builds.
+
+A separate file rather than a `python3 -c` heredoc inside the shell script,
+because the obvious inline form is quietly broken: the program is wrapped in
+shell single quotes, and every `'.'`, `p['name']` or `'IN'` inside it *ends* that
+quoted string. The result still runs and still exits non-zero, so with a
+fail-safe `|| run-anyway` around it the job silently reverts to running always —
+a filter that looks installed and does nothing. Found by testing it; it does not
+show up in review.
+"""
+
+import json
+import os
+import sys
+
+LIB_KINDS = {"lib", "rlib", "proc-macro", "dylib", "cdylib"}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: ci-closure.py <package>", file=sys.stderr)
+        return 2
+    target = sys.argv[1]
+
+    meta = json.load(sys.stdin)
+    root = meta["workspace_root"] + os.sep
+    members = {p["id"] for p in meta["packages"] if p["manifest_path"].startswith(root)}
+    by_id = {p["id"]: p for p in meta["packages"]}
+
+    resolve = meta.get("resolve")
+    if not resolve:
+        print("no resolve graph — run cargo metadata without --no-deps", file=sys.stderr)
+        return 4
+    nodes = {n["id"]: n for n in resolve["nodes"]}
+
+    start = [i for i in members if by_id[i]["name"] == target]
+    if not start:
+        print(f"{target} is not a workspace member", file=sys.stderr)
+        return 3
+
+    seen: set[str] = set()
+    stack = list(start)
+    while stack:
+        i = stack.pop()
+        if i in seen:
+            continue
+        seen.add(i)
+        for dep in nodes[i]["deps"]:
+            if dep["pkg"] in members:
+                stack.append(dep["pkg"])
+
+    for i in sorted(members, key=lambda x: by_id[x]["name"]):
+        pkg = by_id[i]
+        directory = os.path.dirname(pkg["manifest_path"])[len(root):] or "."
+        print(f"{directory}\t{pkg['name']}\t{'IN' if i in seen else 'OUT'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A VTC-only change currently waits for `Mobile build` (~22 min, closure of **two**
crates) and `Enclave build` — neither of which any `vtc-*` crate is in. This
gates both on whether the change can actually affect them.

## The numbers that motivated it

Last 120 commits on main:

| Shape | Share |
|---|---|
| VTC-only code | 13% |
| No VTC code at all | 53% |
| Touches both | 16% |
| Docs / CI only | 18% |

`vta-mobile-core`'s workspace closure is `{vta-mobile-core, vta-sdk}`.
`vta-enclave`'s is 21 crates, containing **no** `vtc-*` and no `room-host`. So
most changes here pay for at least one build that cannot possibly be affected.

(Worth noting: this is also why I'd argue *against* splitting VTC into its own
repo — more commits cross the boundary (16%) than are confined to VTC (13%), so a
split taxes the larger group. Path filtering helps both directions and touches
nothing about releases.)

## The closure is derived, never listed

`cargo metadata` already knows what a package depends on. A hand-written list of
"paths that affect mobile" would be a second description of the same fact, and
this repo has paid three times over for two lists of one thing drifting apart
(#1252, #1256, #1259). A crate added to the graph tomorrow is covered with no
edit here.

## Every uncertainty resolves to RUN

A skipped job is a check that did not run, and this repo has already shipped
breaks behind checks that silently covered less than they claimed.

- not a pull request → run
- lockfile, root manifest, `.github/`, `scripts/` changed → run
- a changed path owned by no workspace crate → run
- no base ref, or no usable diff → run

The job condition is `!= 'false'`, not `== 'true'`, so a missing output runs the
job rather than skipping it.

## Two traps worth knowing about

**The graph walk is a real file**, `scripts/ci-closure.py`, not a `python3 -c`
heredoc. The inline form is quietly broken: the program sits inside shell single
quotes and every `'.'`, `p['name']` or `'IN'` inside it *ends* that string. It
still runs, still exits non-zero, and with a fail-safe wrapper the filter reverts
to always-running while looking installed. That is exactly what my first draft
did — review would not have caught it; running it did.

**Base resolution** tries `origin/$GITHUB_BASE_REF`, then `HEAD^1`, then
`origin/main`. On a `pull_request` event Actions checks out the *merge* commit,
where `origin/main` is frequently not a named ref — so the obvious `git diff
origin/main` fails and the filter silently degrades to no filter. `HEAD^1` of
that merge commit is the base tip, which is what is wanted.

`affects` is deliberately **not** gated on `pull_request`: a job whose `needs`
were skipped is itself skipped, which would stop both builds running on pushes to
main.

## Verified

Nine cases in a scratch clone:

```
vtc-service source   skip      vta-sdk source        run
room-host source     skip      vta-mobile-core src   run
vti-rooms source     skip      Cargo.lock            run
docs only            skip      unattributable path   run
merge-commit shape, no origin remote → resolves HEAD^1, decides correctly
```

## Next, if this lands well

The Test job is the bigger prize (`vta_service` alone is 906s of 2203s, VTC's 52
integration binaries another 848s), but it is also where a wrong filter is
costly, so I would rather see this pattern proven on the two cheap-to-verify
builds first.
