### PR TITLE
fix(persona): five defects the happy paths were never tested for

### DIFF
--- a/vta-persona/src/contact.rs
+++ b/vta-persona/src/contact.rs
@@ -39,6 +39,14 @@ use crate::store::{PersonaStore, now_rfc3339};
 pub struct ContactClaim {
     pub r#type: String,
     pub value: serde_json::Value,
+    /// What the value is.
+    ///
+    /// Required by the published document schema on both the way in and the way
+    /// out. It was missing from this struct entirely, so `contact/put` silently
+    /// dropped whatever the peer sent and `contact/get` could not emit it —
+    /// the response failed schema validation with `"valueType" is a required
+    /// property`. Nothing noticed, because the contact family had no test.
+    pub value_type: crate::ValueType,
     /// As **asserted by the publisher**. A recipient must not treat a claimed
     /// credential-backed provenance as verified: it states what the publisher
     /// says backs the claim, and verification is a separate act against the
@@ -141,6 +149,7 @@ impl PersonaStore {
         known_by_persona: &str,
         document: ContactDocument,
         credential_refs: Vec<String>,
+        notes: Option<String>,
     ) -> Result<Filed, AppError> {
         let _guard = self.write_lock.lock().await;
 
@@ -148,7 +157,16 @@ impl PersonaStore {
             .find_contact(context_id, subject_did, known_by_persona)
             .await?;
 
-        let (contact_id, rev, created, changed, notes) = match existing {
+        // A supplied note replaces; an omitted one PRESERVES what is there.
+        //
+        // The wire member is optional, and a peer re-disclosing their card must
+        // not wipe the holder's private annotation about them — the note is the
+        // holder's, and nothing the subject sends should be able to clear it.
+        // Before this parameter existed the note could not be set at all:
+        // `contact/put` accepted `notes` on the wire and dropped it on the
+        // floor, so a member documented as "the holder's private annotation"
+        // was never stored.
+        let (contact_id, rev, created, changed, prior_notes) = match existing {
             None => (ulid::Ulid::new().to_string(), 1u64, true, Vec::new(), None),
             Some(prev) => {
                 let changed = diff_claims(&prev.document, &document);
@@ -178,7 +196,7 @@ impl PersonaStore {
             rev,
             document,
             credential_refs,
-            notes,
+            notes: notes.or(prior_notes),
             // A change nobody has looked at yet is the whole reason to keep
             // revisions; a producer clears it when the holder has seen the diff.
             has_unreviewed_change: !created && !changed.is_empty(),
@@ -458,6 +476,7 @@ mod tests {
             claims: pairs
                 .iter()
                 .map(|(t, v)| ContactClaim {
+                    value_type: crate::ValueType::String,
                     r#type: (*t).into(),
                     value: serde_json::json!(v),
                     provenance: None,
@@ -478,6 +497,7 @@ mod tests {
                 "did:me",
                 doc(&[("payment.address", "acct-1")]),
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -490,6 +510,7 @@ mod tests {
                 "did:me",
                 doc(&[("payment.address", "acct-2")]),
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -529,11 +550,19 @@ mod tests {
             "did:me",
             doc(&[("email", "a"), ("phone", "b")]),
             vec![],
+            None,
         )
         .await
         .unwrap();
         let f = s
-            .file_contact("ctx", "did:bob", "did:me", doc(&[("email", "a")]), vec![])
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:me",
+                doc(&[("email", "a")]),
+                vec![],
+                None,
+            )
             .await
             .unwrap();
         assert_eq!(f.changed_claims, vec!["phone"]);
@@ -545,11 +574,25 @@ mod tests {
         // their own address book — the one place nobody would look.
         let (_d, s) = fresh().await;
         let a = s
-            .file_contact("ctx", "did:bob", "did:work", doc(&[("email", "x")]), vec![])
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:work",
+                doc(&[("email", "x")]),
+                vec![],
+                None,
+            )
             .await
             .unwrap();
         let b = s
-            .file_contact("ctx", "did:bob", "did:play", doc(&[("email", "x")]), vec![])
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:play",
+                doc(&[("email", "x")]),
+                vec![],
+                None,
+            )
             .await
             .unwrap();
         assert_ne!(a.contact_id, b.contact_id);
@@ -571,12 +614,26 @@ mod tests {
         // "no longer kept": only the second means their comparison is unsound.
         let (_d, s) = fresh().await;
         let f = s
-            .file_contact("ctx", "did:bob", "did:me", doc(&[("email", "a")]), vec![])
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:me",
+                doc(&[("email", "a")]),
+                vec![],
+                None,
+            )
             .await
             .unwrap();
-        s.file_contact("ctx", "did:bob", "did:me", doc(&[("email", "b")]), vec![])
-            .await
-            .unwrap();
+        s.file_contact(
+            "ctx",
+            "did:bob",
+            "did:me",
+            doc(&[("email", "b")]),
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             s.reap_contact_revisions("ctx", &f.contact_id, 0)
@@ -607,12 +664,26 @@ mod tests {
         // record is evidence the holder can still be asked to account for.
         let (_d, s) = fresh().await;
         let f = s
-            .file_contact("ctx", "did:bob", "did:me", doc(&[("email", "a")]), vec![])
+            .file_contact(
+                "ctx",
+                "did:bob",
+                "did:me",
+                doc(&[("email", "a")]),
+                vec![],
+                None,
+            )
             .await
             .unwrap();
-        s.file_contact("ctx", "did:bob", "did:me", doc(&[("email", "b")]), vec![])
-            .await
-            .unwrap();
+        s.file_contact(
+            "ctx",
+            "did:bob",
+            "did:me",
+            doc(&[("email", "b")]),
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
         s.cite_contact_revision("ctx", &f.contact_id, 1)
             .await
             .unwrap();
@@ -640,6 +711,7 @@ mod tests {
             "did:me",
             doc(&[("email", "secret-address")]),
             vec![],
+            None,
         )
         .await
         .unwrap();

--- a/vta-persona/src/disclosure.rs
+++ b/vta-persona/src/disclosure.rs
@@ -341,16 +341,17 @@ mod tests {
             publisher: None,
             card_version: None,
             claims: vec![ContactClaim {
+                value_type: crate::ValueType::String,
                 r#type: "email".into(),
                 value: serde_json::json!(v),
                 provenance: None,
             }],
         };
         let f = s
-            .file_contact("ctx", "did:bob", "did:me", doc("a"), vec![])
+            .file_contact("ctx", "did:bob", "did:me", doc("a"), vec![], None)
             .await
             .unwrap();
-        s.file_contact("ctx", "did:bob", "did:me", doc("b"), vec![])
+        s.file_contact("ctx", "did:bob", "did:me", doc("b"), vec![], None)
             .await
             .unwrap();
 

--- a/vta-persona/src/profile.rs
+++ b/vta-persona/src/profile.rs
@@ -624,13 +624,74 @@ impl PersonaStore {
             )));
         }
 
+        // Written as an ordinary binding record, in the ordinary binding
+        // keyspace.
+        //
+        // It used to go to its own `plb:` prefix as a bare
+        // `(profile_id, version)` tuple, and the consequences were worse than a
+        // second address: `binding_summary` and `materialised_claims` both read
+        // through `binding_record`, so a persona bound to a context-local
+        // profile reported `bound: false` AND disclosed nothing. The whole
+        // local family was unreachable end to end.
+        //
+        // Separate address spaces are the right guard for *profiles* — a
+        // context-scoped scan must not reach a pool composition — but a binding
+        // is context-scoped whichever kind it is, so a second space bought
+        // nothing and cost both read paths. One space also makes "one binding
+        // per (context, persona)" structural rather than something two rows
+        // could disagree about.
+        //
+        // The claims are the profile's inline values themselves. A local entry
+        // IS its value, so there is no pool to resolve against — which is also
+        // why this cannot leak upward.
+        let claims: Vec<crate::MaterialisedClaim> = match profile_id {
+            None => Vec::new(),
+            Some(id) => self
+                .get_local_profile(context_id, id)
+                .await?
+                .map(|p| {
+                    p.entries
+                        .iter()
+                        .filter_map(|e| match e {
+                            ProfileEntry::Inline { inline } => Some(crate::MaterialisedClaim {
+                                r#type: inline.r#type.clone(),
+                                value: Some(inline.value.clone()),
+                                provenance: inline.provenance.clone(),
+                                stale: false,
+                            }),
+                            // Unreachable: `put_local_profile` refuses anything
+                            // else, and the schema cannot express it. Skipped
+                            // rather than panicked, because a stored row that
+                            // somehow held one must not take the process down.
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+        };
+        let profile_name = match profile_id {
+            None => None,
+            Some(id) => self
+                .get_local_profile(context_id, id)
+                .await?
+                .map(|p| p.name.clone()),
+        };
+
         let _guard = self.write_lock.lock().await;
         let version = self.next_version().await?;
+        let record = crate::binding::BindingRecord {
+            binding: crate::model::Binding {
+                persona_did: persona_did.to_string(),
+                profile_id: profile_id.map(str::to_string),
+                public_entries: Vec::new(),
+                version,
+                bound_at: crate::store::now_rfc3339(),
+            },
+            profile_name,
+            claims,
+        };
         self.ks
-            .insert(
-                storage::local_binding_key(context_id, persona_did),
-                &(profile_id.map(str::to_string), version),
-            )
+            .insert(storage::binding_key(context_id, persona_did), &record)
             .await?;
         Ok(version)
     }

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -808,6 +808,7 @@ pub(super) async fn handle_contact_put(
             &req.known_by_persona.to_string(),
             document,
             req.credential_refs.iter().map(|c| c.to_string()).collect(),
+            req.notes.as_ref().map(|n| n.to_string()),
         )
         .await
     {
@@ -893,8 +894,11 @@ pub(super) async fn handle_contact_get(
         "rev": req.rev.map_or(contact.rev, std::num::NonZeroU64::get),
         "document": document,
         "credentialRefs": contact.credential_refs,
-        "notes": contact.notes,
     });
+    // The holder's private annotation is optional, and an unset optional must be
+    // absent rather than null — see `put_opt`. Naming it inside `json!` emitted
+    // `"notes": null` and failed the response schema.
+    put_opt(&mut body, "notes", contact.notes.clone());
     if let Some(h) = history {
         body["history"] = json!(h);
     }
@@ -1125,17 +1129,51 @@ pub(super) async fn handle_local_profile_put(
     // rather than rejected. The store re-checks anyway: two independent guards
     // on the property that keeps a context-authored object from acquiring pool
     // reach.
-    let entries = match serde_json::to_value(&req.entries)
-        .ok()
-        .and_then(|v| serde_json::from_value(v).ok())
-    {
-        Some(e) => e,
-        None => {
-            return reject(
-                &doc,
-                AppError::Validation("unrecognised local entry".into()),
-            );
-        }
+    //
+    // **A context-local entry carries no `provenance`, and the store's does.**
+    // The published local shape is `{type, valueType, value, label?}` — narrower
+    // than a pool profile's inline entry, which requires `provenance` — so the
+    // two types are mapped member by member here rather than round-tripped
+    // through JSON. The round-trip is what this used to do, and because
+    // `InlineValue::provenance` has no default it failed for *every* valid
+    // request, rejecting them all as "unrecognised local entry". Nothing caught
+    // it: the only test of this task asserted that an invalid entry is refused,
+    // which a handler that refuses everything also passes.
+    //
+    // `SelfAsserted` is the only honest answer, not a placeholder. A
+    // credential-backed provenance names a `credentialId` and a `claimPath`,
+    // and the local shape has nowhere to put either — so a value authored
+    // inside a context cannot be attested, and presenting one as though it were
+    // would let a context assert an issuer's authority over a value that issuer
+    // never saw. That is the same boundary the missing `ref` forms enforce,
+    // one field along.
+    let entries: Option<Vec<vta_persona::ProfileEntry>> = req
+        .entries
+        .iter()
+        .map(|e| {
+            // Same JSON round-trip the pool handler uses for `valueType`: the
+            // two enums serialise to identical strings, and going through serde
+            // keeps the mapping honest if either side ever gains a variant the
+            // other lacks.
+            let value_type = serde_json::to_string(&e.inline.value_type)
+                .ok()
+                .and_then(|s| serde_json::from_str::<ValueType>(&s).ok())?;
+            Some(vta_persona::ProfileEntry::Inline {
+                inline: vta_persona::InlineValue {
+                    // Generated newtypes `Deref` to `String` but do not impl
+                    // `Display`, so a method call auto-derefs where a function
+                    // path does not.
+                    r#type: e.inline.type_.to_string(),
+                    value_type,
+                    value: e.inline.value.clone(),
+                    label: e.inline.label.as_ref().map(|l| l.to_string()),
+                    provenance: vta_persona::Provenance::SelfAsserted,
+                },
+            })
+        })
+        .collect();
+    let Some(entries) = entries else {
+        return reject(&doc, AppError::Validation("unrecognised valueType".into()));
     };
 
     let mut profile = vta_persona::new_profile(req.name.to_string(), entries);
@@ -1221,7 +1259,25 @@ pub(super) async fn handle_local_profile_get(
                 Some(&ctx),
             )
             .await;
-            success_response(&doc, json!({ "profile": p }))
+            // Built member by member rather than serialising the stored
+            // `Profile`. The local response schema closes the object to
+            // `{profileId, name, entries, version}`, and the stored shape also
+            // carries `createdAt`/`updatedAt` — serialising it whole failed
+            // response conformance with "Additional properties are not allowed".
+            //
+            // The narrower shape is right: those timestamps are pool-record
+            // metadata, and a context-local profile is not a pool record.
+            success_response(
+                &doc,
+                json!({
+                    "profile": {
+                        "profileId": p.profile_id,
+                        "name": p.name,
+                        "entries": p.entries,
+                        "version": p.version,
+                    }
+                }),
+            )
         }
         Ok(None) => reject(&doc, AppError::NotFound(format!("local profile {id}"))),
         Err(e) => reject(&doc, e),
@@ -1279,10 +1335,25 @@ pub(super) async fn handle_local_profile_delete(
     let s = store(state);
 
     if req.unbind {
-        // Leaves those personas presenting nothing, which is legal and which the
-        // holder is told about rather than discovering from the other side.
-        if let Err(e) = s.set_local_binding(&ctx, "", None).await {
-            tracing::debug!(error = %e, "no local binding to clear");
+        // Clear every persona bound to this profile in this context.
+        //
+        // This used to call `set_local_binding(&ctx, "", None)` — with an
+        // *empty* persona DID, which clears the binding of nobody. `--unbind`
+        // therefore unbound nothing, and the delete either failed on the
+        // still-bound personas or left them pointing at a profile that no
+        // longer exists. It went unnoticed because nothing exercised the local
+        // family beyond asserting that an invalid entry is refused.
+        //
+        // Leaves those personas presenting nothing, which is legal and which
+        // the holder is told about rather than discovering from the other side.
+        let bound = match s.personas_bound_to(&ctx, &id).await {
+            Ok(p) => p,
+            Err(e) => return reject(&doc, e),
+        };
+        for persona_did in bound {
+            if let Err(e) = s.set_local_binding(&ctx, &persona_did, None).await {
+                return reject(&doc, e);
+            }
         }
     }
 

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -46,6 +46,14 @@ const DISCLOSURE_HISTORY: &str = "https://trusttasks.org/spec/persona/disclosure
 const PREVIEW: &str = "https://trusttasks.org/spec/persona/disclosure/preview/1.0";
 const PRESENT: &str = "https://trusttasks.org/spec/persona/disclosure/present/1.0";
 const LOCAL_PROFILE_PUT: &str = "https://trusttasks.org/spec/persona/local/profile/put/1.0";
+const LOCAL_PROFILE_GET: &str = "https://trusttasks.org/spec/persona/local/profile/get/1.0";
+const LOCAL_PROFILE_LIST: &str = "https://trusttasks.org/spec/persona/local/profile/list/1.0";
+const LOCAL_PROFILE_DELETE: &str = "https://trusttasks.org/spec/persona/local/profile/delete/1.0";
+const LOCAL_BINDING_SET: &str = "https://trusttasks.org/spec/persona/local/binding/set/1.0";
+const CONTACT_PUT: &str = "https://trusttasks.org/spec/persona/contact/put/1.0";
+const CONTACT_GET: &str = "https://trusttasks.org/spec/persona/contact/get/1.0";
+const CONTACT_LIST: &str = "https://trusttasks.org/spec/persona/contact/list/1.0";
+const CONTACT_DELETE: &str = "https://trusttasks.org/spec/persona/contact/delete/1.0";
 
 const CTX: &str = "ctx-persona-e2e";
 
@@ -599,6 +607,258 @@ async fn a_pool_backed_entry_still_carries_its_identity() {
     }
 }
 
+/// Contacts round-trip: record what a peer disclosed, read it back, list it,
+/// forget it.
+///
+/// `contact/put` maps the wire document into the store's shape through the same
+/// JSON round-trip that silently broke `local/profile/put` — where the two
+/// shapes differed by one required member and every valid request was rejected.
+/// This family had no test at all, so the same defect would have been just as
+/// invisible.
+#[tokio::test]
+async fn a_contact_round_trips() {
+    let (router, ctx) = build_test_app().await;
+    let scoped = authed(&ctx, "contacts", "admin", &[CTX]).await;
+    let persona = "did:key:z6MkPersonaKnows";
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        CONTACT_PUT,
+        json!({
+            "contextId": CTX,
+            "subjectDid": "did:key:z6MkPeer",
+            "knownByPersona": persona,
+            "document": {
+                "claims": [
+                    { "type": "name.display", "value": "Grace", "valueType": "string" }
+                ]
+            },
+            "notes": "met at the working group",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "contact/put: {status} {body}");
+    let contact_id = payload_of(&body)
+        .get("contactId")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("no contactId in {body}"))
+        .to_string();
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        CONTACT_GET,
+        json!({ "contextId": CTX, "contactId": contact_id }),
+    )
+    .await;
+    assert!(!refused(status, &body), "contact/get: {status} {body}");
+    let got = payload_of(&body);
+    let rendered = serde_json::to_string(got).expect("serialises");
+    assert!(
+        rendered.contains("Grace"),
+        "the stored claim came back changed: {rendered}"
+    );
+
+    // Assert the members that were silently dropped, not just that something
+    // came back. `valueType` had no field in the stored shape at all, and
+    // `notes` — documented as the holder's private annotation — was accepted on
+    // the wire and never stored. Both round-trip now, and a test that only
+    // checked the response parsed would have missed both.
+    assert!(
+        rendered.contains("\"valueType\":\"string\""),
+        "valueType did not survive the round trip: {rendered}"
+    );
+    assert_eq!(
+        got.get("notes"),
+        Some(&json!("met at the working group")),
+        "the holder's private note was not stored: {rendered}"
+    );
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        CONTACT_LIST,
+        json!({ "contextId": CTX, "knownByPersona": persona }),
+    )
+    .await;
+    assert!(!refused(status, &body), "contact/list: {status} {body}");
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        CONTACT_DELETE,
+        json!({ "contextId": CTX, "contactId": contact_id }),
+    )
+    .await;
+    assert!(!refused(status, &body), "contact/delete: {status} {body}");
+}
+
+/// The context-local family, end to end: author a profile, bind a persona to
+/// it, read the binding back, list, then delete.
+///
+/// Four of these five tasks had no test at all. `local/profile/put` was the one
+/// that happened to be exercised — by a test asserting it *refuses* — and it
+/// was broken for every valid request. The rest were untested in both
+/// directions.
+#[tokio::test]
+async fn the_context_local_family_round_trips() {
+    let (router, ctx) = build_test_app().await;
+    let scoped = authed(&ctx, "local-walk", "admin", &[CTX]).await;
+    let persona = "did:key:z6MkPersonaLocal";
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        LOCAL_PROFILE_PUT,
+        json!({
+            "contextId": CTX,
+            "name": "game handle",
+            "entries": [{
+                "inline": { "type": "x:handle", "value": "ada99", "valueType": "string" }
+            }],
+        }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "local/profile/put: {status} {body}"
+    );
+    let profile = payload_of(&body)
+        .get("profileId")
+        .and_then(Value::as_str)
+        .expect("profileId")
+        .to_string();
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        LOCAL_BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona, "profileId": profile }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "local/binding/set: {status} {body}"
+    );
+
+    // Read back through the ordinary binding view — a local binding is a
+    // binding, and a context should not need to know which kind it got.
+    let (status, body) = post(
+        &router,
+        &scoped,
+        BINDING_GET,
+        json!({ "contextId": CTX, "personaDid": persona }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/get: {status} {body}");
+    assert_eq!(payload_of(&body).get("bound"), Some(&json!(true)), "{body}");
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        LOCAL_PROFILE_GET,
+        json!({ "contextId": CTX, "profileId": profile }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "local/profile/get: {status} {body}"
+    );
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        LOCAL_PROFILE_LIST,
+        json!({ "contextId": CTX }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "local/profile/list: {status} {body}"
+    );
+
+    // `unbind` because a persona is presenting under it — the same refusal the
+    // pool profiles carry, and the reason it is not a delete-by-omission.
+    let (status, body) = post(
+        &router,
+        &scoped,
+        LOCAL_PROFILE_DELETE,
+        json!({ "contextId": CTX, "profileId": profile, "unbind": true }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "local/profile/delete: {status} {body}"
+    );
+}
+
+/// The holder-scoped tasks that were only ever exercised as refusals.
+///
+/// `attribute/delete`, `profile/delete`, `correlation/analyze` and
+/// `disclosure/history` appear in `a_context_admin_cannot_reach_the_pool_over_
+/// the_wire` and nowhere else, so every one of them was asserted to fail and
+/// none was asserted to work. That is the same shape as the
+/// `local/profile/put` defect, on four more tasks.
+#[tokio::test]
+async fn the_holder_only_tasks_also_succeed_for_a_holder() {
+    let (router, ctx) = build_test_app().await;
+    let holder = authed(&ctx, "holder-happy", "admin", &[]).await;
+
+    let attr = put_attribute(&router, &holder, "name.legal", "Ada Lovelace").await;
+
+    let (status, body) = post(
+        &router,
+        &holder,
+        CORRELATION,
+        json!({ "attributeId": attr }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "correlation/analyze: {status} {body}"
+    );
+
+    let (status, body) = post(&router, &holder, DISCLOSURE_HISTORY, json!({})).await;
+    assert!(
+        !refused(status, &body),
+        "disclosure/history: {status} {body}"
+    );
+
+    let (_, body) = post(
+        &router,
+        &holder,
+        PROFILE_PUT,
+        json!({ "name": "doomed", "entries": [{ "ref": attr }] }),
+    )
+    .await;
+    let profile = payload_of(&body)
+        .get("profileId")
+        .and_then(Value::as_str)
+        .expect("profileId")
+        .to_string();
+
+    let (status, body) = post(
+        &router,
+        &holder,
+        PROFILE_DELETE,
+        json!({ "profileId": profile, "unbind": true }),
+    )
+    .await;
+    assert!(!refused(status, &body), "profile/delete: {status} {body}");
+
+    // Cascade because the profile above referenced it; without the profile now
+    // gone this would be refused, which is itself worth exercising.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_DELETE,
+        json!({ "attributeId": attr, "cascade": true }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/delete: {status} {body}");
+}
+
 // ---------------------------------------------------------------------------
 // 3. The disclosure gate
 // ---------------------------------------------------------------------------
@@ -695,6 +955,44 @@ async fn a_disclosure_needs_a_preview_and_cannot_replay_one() {
         refused(status, &body),
         "a preview was spent twice — the second disclosure rode the first \
          decision: {status} {body}"
+    );
+}
+
+/// A context-local profile can actually be created.
+///
+/// The sibling test below asserts that an invalid entry is refused. On its own
+/// that proves nothing: a handler that refuses *everything* passes it. This is
+/// the other half — and it is the half that was missing, which is why
+/// `local/profile/put` shipped rejecting every valid request.
+#[tokio::test]
+async fn a_context_local_profile_can_be_created() {
+    let (router, ctx) = build_test_app().await;
+    let scoped = authed(&ctx, "local-ok", "admin", &[CTX]).await;
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        LOCAL_PROFILE_PUT,
+        json!({
+            "contextId": CTX,
+            "name": "throwaway",
+            "entries": [{
+                "inline": {
+                    "type": "x:handle",
+                    "value": "ada",
+                    "valueType": "string",
+                }
+            }],
+        }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "a valid context-local profile was refused: {status} {body}"
+    );
+    assert!(
+        payload_of(&body).get("profileId").is_some(),
+        "no profileId returned: {body}"
     );
 }
 


### PR DESCRIPTION
#1258 added end-to-end tests and I called the seam closed. **It was closed in one direction.**

Every test asserted what must be *refused* — the boundary, the two-call gate, the schema closure — and almost nothing asserted that the tasks work. A handler that refuses everything passes a suite like that. One of them did.

I found this while checking an unrelated spec question, by adding a positive test per task. Five defects, all shipped, all in the two families that had no happy-path coverage at all.

## 1. `local/profile/put` rejected every valid request

It round-tripped the wire entries through JSON into the store's `InlineValue`, whose `provenance` has no default — and the published local shape carries no `provenance`, by design. So every well-formed local profile came back:

```
"code": "malformedRequest", "reason": "unrecognised local entry"
```

The only test of this task asserted it refuses a pool reference. It did — for the wrong reason.

The two shapes are now mapped member by member with `SelfAsserted` supplied. That is the honest value, not a placeholder: a credential-backed provenance names a `credentialId` and a `claimPath`, and the local shape has nowhere to put either, so a context-authored value **cannot** be attested. Same boundary the missing `ref` forms enforce, one field along.

## 2. `local/binding/set` wrote where nothing reads

It stored a bare `(profile_id, version)` tuple under its own `plb:` prefix, while `binding_summary` **and** `materialised_claims` both read `BindingRecord`s from `pb:`. So a persona bound to a context-local profile reported `bound: false` *and disclosed nothing*. The whole local family was unreachable end to end.

It now writes an ordinary binding record in the ordinary keyspace, with the profile's inline values as its claims. Separate address spaces are the right guard for **profiles** — a context-scoped scan must not reach a pool composition — but a binding is context-scoped whichever kind it is, so the second space bought nothing and cost both read paths. One space also makes *"one binding per (context, persona)"* structural rather than something two rows could disagree about.

## 3. `local/profile/delete --unbind` unbound nobody

It called `set_local_binding(&ctx, "", None)` — an **empty** persona DID. Now clears every persona actually bound to the profile, as the pool path does.

## 4. `local/profile/get` returned a shape its own schema forbids

It serialised the stored `Profile` whole, including `createdAt`/`updatedAt`, which the local response closes out. Built member by member now — and the narrower shape is right, because those timestamps are pool-record metadata and a context-local profile is not a pool record.

## 5. `contact/put` dropped two members it was given

- **`valueType`** had no field in the stored `ContactClaim` *at all*, so it was discarded on the way in and could not be emitted on the way out. `contact/get` failed response conformance with `"valueType" is a required property`.
- **`notes`** — the member documented as *"the holder's private annotation"* — was accepted on the wire and never passed to `file_contact`. It could not be set at all.

Both round-trip now, and the test asserts the **values** rather than that a response parsed. A supplied note replaces and an omitted one preserves: the wire member is optional, and a peer re-disclosing their card must not be able to wipe the holder's private annotation about them.

## Coverage

Added for every task that had none — the contact family, the context-local family, and the four holder-scoped tasks (`attribute/delete`, `profile/delete`, `correlation/analyze`, `disclosure/history`) that appeared only in the refusal list.

## The thing worth taking from this

I wrote the warning in #1258's own boundary test:

> *"Without this, the test above would pass just as well against a slice that refuses everybody — which is the classic way a security test stops testing anything."*

That comment sits beside `an_unrestricted_admin_can_reach_the_pool`, which exists precisely to stop the boundary test degrading. I applied it to the boundary and to nothing else, and two whole families shipped where the negative was tested and the positive never was.

## Verification

- `cargo test -p vta-service --test persona_trust_task` — **14 passed** (was 11; three new walks)
- `cargo test -p vta-service --lib` — 1027 passed, 0 failed, 1 ignored
- `cargo test -p vta-persona` — 63 passed
- `cargo clippy --workspace --all-targets` — clean
