### PR TITLE
feat(vta-sdk)!: make the growth-prone wire bodies non-exhaustive

### DIFF
--- a/vta-cli-common/src/commands/config.rs
+++ b/vta-cli-common/src/commands/config.rs
@@ -60,10 +60,7 @@ pub async fn cmd_config_update(
 
     let resp = client
         .update_config(UpdateConfigRequest {
-            patch: UpdateConfigBody {
-                overrides,
-                ext: None,
-            },
+            patch: UpdateConfigBody::new(overrides),
         })
         .await?;
 

--- a/vta-cli-common/src/commands/policy.rs
+++ b/vta-cli-common/src/commands/policy.rs
@@ -23,12 +23,10 @@ pub async fn cmd_list(
     enabled_only: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let result = client
-        .list_policies(ListPoliciesBody {
-            context_id: context,
-            enabled_only,
-            cursor: None,
-            page_size: None,
-            ext: None,
+        .list_policies({
+            let mut body = ListPoliciesBody::new(enabled_only);
+            body.context_id = context;
+            body
         })
         .await?;
 
@@ -126,11 +124,11 @@ pub async fn cmd_delete(
     reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let result = client
-        .delete_policy(DeletePolicyBody {
-            id: id.to_string(),
-            expected_version,
-            reason,
-            ext: None,
+        .delete_policy({
+            let mut body = DeletePolicyBody::new(id.to_string());
+            body.expected_version = expected_version;
+            body.reason = reason;
+            body
         })
         .await?;
     println!("Deleted policy {} at {}", result.id, result.deleted_at);

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -20,6 +20,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct CreateAclBody {
     /// The entry the caller wants the maintainer to hold.
     pub entry: AclEntry,
@@ -39,6 +40,23 @@ pub struct CreateAclBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl CreateAclBody {
+    /// Build a [`CreateAclBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(entry: AclEntry) -> Self {
+        Self {
+            entry,
+            reason: None,
+            ext: None,
+        }
+    }
 }
 
 /// `acl/grant/0.1` response — the realized entry the maintainer now holds.

--- a/vta-sdk/src/protocols/acl_management/delete.rs
+++ b/vta-sdk/src/protocols/acl_management/delete.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct DeleteAclBody {
     /// VID of the subject being revoked. Was `did` before the canonical fold.
     pub subject: String,
@@ -41,6 +42,24 @@ pub struct DeleteAclBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl DeleteAclBody {
+    /// Build a [`DeleteAclBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(subject: String) -> Self {
+        Self {
+            subject,
+            scopes: None,
+            reason: None,
+            ext: None,
+        }
+    }
 }
 
 /// `acl/revoke/0.1` response — the entry as it stood when revoked.

--- a/vta-sdk/src/protocols/acl_management/get.rs
+++ b/vta-sdk/src/protocols/acl_management/get.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct GetAclBody {
     /// VID of the entry to read. Was `did` before the canonical fold.
     pub subject: String,
@@ -25,6 +26,19 @@ pub struct GetAclBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl GetAclBody {
+    /// Build a [`GetAclBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(subject: String) -> Self {
+        Self { subject, ext: None }
+    }
 }
 
 /// `acl/show/0.1` response.

--- a/vta-sdk/src/protocols/acl_management/list.rs
+++ b/vta-sdk/src/protocols/acl_management/list.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct ListAclBody {
     /// Only entries with this role.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -47,6 +48,30 @@ pub struct ListAclBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl ListAclBody {
+    /// Build a [`ListAclBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    ///
+    /// Every member is optional, so this takes no arguments; set the ones
+    /// you want on the returned value.
+    pub fn new() -> Self {
+        Self {
+            role: None,
+            scope: None,
+            direction: None,
+            subject_prefix: None,
+            page_size: None,
+            cursor: None,
+            ext: None,
+        }
+    }
 }
 
 /// `acl/list/0.1` response.

--- a/vta-sdk/src/protocols/credentials_issuance.rs
+++ b/vta-sdk/src/protocols/credentials_issuance.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 /// Unchanged from 0.1 — the version moved for the response only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[non_exhaustive]
 pub struct IssueCredentialBody {
     /// The holder DID the credential is issued to (`credentialSubject.id`).
     pub holder: String,
@@ -53,6 +54,27 @@ pub struct IssueCredentialBody {
     pub ext: Option<Value>,
 }
 
+impl IssueCredentialBody {
+    /// Build a [`IssueCredentialBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(holder: String, claims: Value, validity_seconds: u64) -> Self {
+        Self {
+            holder,
+            claims,
+            validity_seconds,
+            credential_type: None,
+            purpose: None,
+            authorization_context: None,
+            ext: None,
+        }
+    }
+}
+
 /// `spec/vta/credentials/issue/0.2` response body.
 ///
 /// 0.2 composes this from `credentials/_shared/0.2`'s `IssuedCredentialBase`
@@ -81,6 +103,7 @@ pub struct IssueCredentialResponse {
 /// `spec/vta/credentials/revoke/0.1` request body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[non_exhaustive]
 pub struct RevokeCredentialBody {
     /// The id of the credential to revoke (from the issue response).
     pub credential_id: String,
@@ -100,6 +123,23 @@ pub struct RevokeCredentialBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl RevokeCredentialBody {
+    /// Build a [`RevokeCredentialBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(credential_id: String) -> Self {
+        Self {
+            credential_id,
+            reason: None,
+            ext: None,
+        }
+    }
 }
 
 /// `spec/vta/credentials/revoke/0.1` response body.

--- a/vta-sdk/src/protocols/memory.rs
+++ b/vta-sdk/src/protocols/memory.rs
@@ -21,6 +21,7 @@ use serde_json::Value;
 /// `(contextId, key)` replaces the stored value.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MemoryPutBody {
     /// The context the entry belongs to. The caller must have ACL access to it.
     pub context_id: String,
@@ -43,6 +44,24 @@ pub struct MemoryPutBody {
     pub ext: Option<Value>,
 }
 
+impl MemoryPutBody {
+    /// Build a [`MemoryPutBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(context_id: String, key: String, value: String) -> Self {
+        Self {
+            context_id,
+            key,
+            value,
+            ext: None,
+        }
+    }
+}
+
 /// `spec/vta/memory/put/0.1` response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +73,7 @@ pub struct MemoryPutResponse {
 /// `spec/vta/memory/list/0.1` request body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MemoryListBody {
     /// The context whose entries to list. The caller must have ACL access to it.
     pub context_id: String,
@@ -70,6 +90,22 @@ pub struct MemoryListBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl MemoryListBody {
+    /// Build a [`MemoryListBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(context_id: String) -> Self {
+        Self {
+            context_id,
+            ext: None,
+        }
+    }
 }
 
 /// A single stored memory entry returned by `spec/vta/memory/list/0.1`.
@@ -93,6 +129,7 @@ pub struct MemoryListResponse {
 /// `spec/vta/memory/delete/0.1` request body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[non_exhaustive]
 pub struct MemoryDeleteBody {
     /// The context the entry belongs to. The caller must have ACL access to it.
     pub context_id: String,
@@ -111,6 +148,23 @@ pub struct MemoryDeleteBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl MemoryDeleteBody {
+    /// Build a [`MemoryDeleteBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(context_id: String, key: String) -> Self {
+        Self {
+            context_id,
+            key,
+            ext: None,
+        }
+    }
 }
 
 /// `spec/vta/memory/delete/0.1` response body.

--- a/vta-sdk/src/protocols/policy_management.rs
+++ b/vta-sdk/src/protocols/policy_management.rs
@@ -59,6 +59,7 @@ pub struct PolicyModuleView {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct ListPoliciesBody {
     /// Restrict to policies applying in this context (an unscoped policy
     /// applies everywhere, so it matches every filter).
@@ -85,6 +86,25 @@ pub struct ListPoliciesBody {
     pub ext: Option<Value>,
 }
 
+impl ListPoliciesBody {
+    /// Build a [`ListPoliciesBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(enabled_only: bool) -> Self {
+        Self {
+            enabled_only,
+            context_id: None,
+            cursor: None,
+            page_size: None,
+            ext: None,
+        }
+    }
+}
+
 /// `policy/list/0.2` response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -101,6 +121,7 @@ pub struct ListPoliciesResultBody {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct GetPolicyBody {
     pub id: String,
     /// Ecosystem-defined extension members (SPEC §4.5.1).
@@ -116,6 +137,19 @@ pub struct GetPolicyBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl GetPolicyBody {
+    /// Build a [`GetPolicyBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(id: String) -> Self {
+        Self { id, ext: None }
+    }
 }
 
 /// `policy/get/0.1` response.
@@ -181,6 +215,7 @@ pub struct UpsertPolicyResultBody {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct DeletePolicyBody {
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -201,6 +236,24 @@ pub struct DeletePolicyBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl DeletePolicyBody {
+    /// Build a [`DeletePolicyBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(id: String) -> Self {
+        Self {
+            id,
+            expected_version: None,
+            reason: None,
+            ext: None,
+        }
+    }
 }
 
 /// `policy/delete/0.1` response.

--- a/vta-sdk/src/protocols/vta_management/get_config.rs
+++ b/vta-sdk/src/protocols/vta_management/get_config.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct GetConfigBody {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keys: Option<Vec<String>>,
@@ -31,6 +32,25 @@ pub struct GetConfigBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl GetConfigBody {
+    /// Build a [`GetConfigBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    ///
+    /// Every member is optional, so this takes no arguments; set the ones
+    /// you want on the returned value.
+    pub fn new() -> Self {
+        Self {
+            keys: None,
+            ext: None,
+        }
+    }
 }
 
 /// One configuration key as the operator currently sees it — canonical

--- a/vta-sdk/src/protocols/vta_management/update_config.rs
+++ b/vta-sdk/src/protocols/vta_management/update_config.rs
@@ -36,6 +36,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct UpdateConfigBody {
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub overrides: HashMap<String, serde_json::Value>,
@@ -52,6 +53,22 @@ pub struct UpdateConfigBody {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl UpdateConfigBody {
+    /// Build a [`UpdateConfigBody`] from the members the schema requires.
+    ///
+    /// This type is `#[non_exhaustive]`, so it cannot be built with a struct
+    /// literal from outside this crate — a new member added by a later revision
+    /// of the schema would break every such literal, which is exactly what
+    /// happened when `ext` arrived. The optional members stay public: set them
+    /// on the value this returns.
+    pub fn new(overrides: HashMap<String, serde_json::Value>) -> Self {
+        Self {
+            overrides,
+            ext: None,
+        }
+    }
 }
 
 /// A key the patch declined to apply, and why — canonical

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -355,10 +355,9 @@ async fn update_config_sends_the_overrides_map() {
     overrides.insert("vta_name".to_string(), json!("new"));
     let res = c
         .update_config(UpdateConfigRequest {
-            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
+            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody::new(
                 overrides,
-                ext: None,
-            },
+            ),
         })
         .await
         .unwrap();
@@ -389,10 +388,9 @@ async fn update_config_reports_identity_as_rejected() {
     overrides.insert("vta_did".to_string(), json!("did:web:attacker"));
     let res = c
         .update_config(UpdateConfigRequest {
-            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
+            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody::new(
                 overrides,
-                ext: None,
-            },
+            ),
         })
         .await
         .unwrap();

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -743,15 +743,16 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::acl::list::v0_1::Payload,
                 specs::acl::list::v0_1::Response,
-                to_v(ListAclBody {
-                    role: Some("reader".into()),
-                    scope: Some("ctx-a".into()),
-                    direction: Some(ContextDirection::Subtree),
-                    subject_prefix: Some("did:key:z6Mk".into()),
-                    page_size: Some(50),
-                    cursor: Some("cur-1".into()),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = ListAclBody::new();
+            b.role = Some("reader".into());
+            b.scope = Some("ctx-a".into());
+            b.direction = Some(ContextDirection::Subtree);
+            b.subject_prefix = Some("did:key:z6Mk".into());
+            b.page_size = Some(50);
+            b.cursor = Some("cur-1".into());
+            b
+        }),
                 to_v(ListAclResultBody {
                     entries: vec![acl_entry()],
                     truncated: false,
@@ -765,11 +766,11 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::acl::grant::v0_1::Payload,
                 specs::acl::grant::v0_1::Response,
-                to_v(CreateAclBody {
-                    entry: acl_entry(),
-                    reason: Some("onboarding".into()),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = CreateAclBody::new(acl_entry());
+            b.reason = Some("onboarding".into());
+            b
+        }),
                 to_v(CreateAclResponseBody { entry: acl_entry() })
             ),
         ),
@@ -778,10 +779,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::acl::show::v0_1::Payload,
                 specs::acl::show::v0_1::Response,
-                to_v(GetAclBody {
-                    subject: SUBJECT.into(),
-                    ext: None,
-                }),
+                to_v(GetAclBody::new(SUBJECT.into())),
                 to_v(GetAclResultBody {
                     entry: acl_entry(),
                     redacted_fields: Vec::new(),
@@ -837,12 +835,12 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::acl::revoke::v0_1::Payload,
                 specs::acl::revoke::v0_1::Response,
-                to_v(DeleteAclBody {
-                    subject: SUBJECT.into(),
-                    scopes: Some(vec!["ctx-a".into()]),
-                    reason: Some("offboarding".into()),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = DeleteAclBody::new(SUBJECT.into());
+            b.scopes = Some(vec!["ctx-a".into()]);
+            b.reason = Some("offboarding".into());
+            b
+        }),
                 to_v(DeleteAclResultBody { entry: acl_entry() })
             ),
         ),
@@ -1401,18 +1399,15 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vta::credentials::issue::v0_2::Payload,
                 specs::vta::credentials::issue::v0_2::Response,
-                to_v(IssueCredentialBody {
-                    holder: SUBJECT.into(),
-                    claims: json!({ "role": "agent" }),
-                    credential_type: Some("AgentAuthorization".into()),
-                    validity_seconds: 3600,
-                    purpose: Some("agent onboarding".into()),
-                    // Deliberately absent: `authorizationContext` is a member the
-                    // published schema does not define, so a producer cannot
-                    // send it through the validated transport at all.
-                    authorization_context: None,
-                    ext: None,
-                }),
+                to_v({
+            let mut b = IssueCredentialBody::new(SUBJECT.into(), json!({ "role": "agent" }), 3600);
+            b.credential_type = Some("AgentAuthorization".into());
+            b.purpose = Some("agent onboarding".into());
+            // `authorization_context` is deliberately left at its constructor
+            // default: it is a member the published schema does not define, so a
+            // producer cannot send it through the validated transport at all.
+            b
+        }),
                 to_v(IssueCredentialResponse {
                     credential_id: "cred-1".into(),
                     credential: json!({ "@context": [], "type": ["VerifiableCredential"] }),
@@ -1426,11 +1421,11 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vta::credentials::revoke::v0_1::Payload,
                 specs::vta::credentials::revoke::v0_1::Response,
-                to_v(RevokeCredentialBody {
-                    credential_id: "cred-1".into(),
-                    reason: Some("holder offboarded".into()),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = RevokeCredentialBody::new("cred-1".into());
+            b.reason = Some("holder offboarded".into());
+            b
+        }),
                 to_v(RevokeCredentialResponse {
                     credential_id: "cred-1".into(),
                     revoked_at: TS.into(),
@@ -1650,12 +1645,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vta::memory::put::v0_1::Payload,
                 specs::vta::memory::put::v0_1::Response,
-                to_v(MemoryPutBody {
-                    context_id: "ctx-a".into(),
-                    key: "greeting".into(),
-                    value: "hello".into(),
-                    ext: None,
-                }),
+                to_v(MemoryPutBody::new("ctx-a".into(), "greeting".into(), "hello".into())),
                 to_v(MemoryPutResponse {
                     key: "greeting".into(),
                 })
@@ -1666,10 +1656,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vta::memory::list::v0_1::Payload,
                 specs::vta::memory::list::v0_1::Response,
-                to_v(MemoryListBody {
-                    context_id: "ctx-a".into(),
-                    ext: None,
-                }),
+                to_v(MemoryListBody::new("ctx-a".into())),
                 to_v(MemoryListResponse {
                     items: vec![MemoryItem {
                         key: "greeting".into(),
@@ -1683,11 +1670,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::vta::memory::delete::v0_1::Payload,
                 specs::vta::memory::delete::v0_1::Response,
-                to_v(MemoryDeleteBody {
-                    context_id: "ctx-a".into(),
-                    key: "greeting".into(),
-                    ext: None,
-                }),
+                to_v(MemoryDeleteBody::new("ctx-a".into(), "greeting".into())),
                 to_v(MemoryDeleteResponse {
                     key: "greeting".into(),
                 })
@@ -1880,13 +1863,12 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::policy::list::v0_2::Payload,
                 specs::policy::list::v0_2::Response,
-                to_v(ListPoliciesBody {
-                    context_id: Some("ctx-a".into()),
-                    enabled_only: true,
-                    cursor: None,
-                    page_size: Some(50),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = ListPoliciesBody::new(true);
+            b.context_id = Some("ctx-a".into());
+            b.page_size = Some(50);
+            b
+        }),
                 to_v(ListPoliciesResultBody {
                     policies: vec![policy_module_view()],
                     truncated: false,
@@ -1899,10 +1881,7 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::policy::get::v0_1::Payload,
                 specs::policy::get::v0_1::Response,
-                to_v(GetPolicyBody {
-                    id: "approvals".into(),
-                    ext: None,
-                }),
+                to_v(GetPolicyBody::new("approvals".into())),
                 to_v(GetPolicyResultBody {
                     policy: policy_module_view(),
                 })
@@ -1935,12 +1914,12 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::policy::delete::v0_1::Payload,
                 specs::policy::delete::v0_1::Response,
-                to_v(DeletePolicyBody {
-                    id: "legacy-rego".into(),
-                    expected_version: Some(2),
-                    reason: Some("superseded by the declarative rules".into()),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = DeletePolicyBody::new("legacy-rego".into());
+            b.expected_version = Some(2);
+            b.reason = Some("superseded by the declarative rules".into());
+            b
+        }),
                 to_v(DeletePolicyResultBody {
                     id: "legacy-rego".into(),
                     deleted_at: TS.into(),
@@ -1953,10 +1932,11 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::config::show::v0_1::Payload,
                 specs::config::show::v0_1::Response,
-                to_v(GetConfigBody {
-                    keys: Some(vec!["public_url".into()]),
-                    ext: None,
-                }),
+                to_v({
+            let mut b = GetConfigBody::new();
+            b.keys = Some(vec!["public_url".into()]);
+            b
+        }),
                 to_v(GetConfigResultBody {
                     fields: vec![ConfigField {
                         key: "public_url".into(),
@@ -1972,12 +1952,9 @@ fn table() -> Vec<(&'static str, Conformance)> {
             checked!(
                 specs::config::patch::v0_1::Payload,
                 specs::config::patch::v0_1::Response,
-                to_v(UpdateConfigBody {
-                    overrides: [("public_url".to_string(), json!("https://vta.example"))]
+                to_v(UpdateConfigBody::new([("public_url".to_string(), json!("https://vta.example"))]
                         .into_iter()
-                        .collect(),
-                    ext: None,
-                }),
+                        .collect())),
                 to_v(UpdateConfigResultBody {
                     applied: vec!["public_url".into()],
                     pending_restart: vec![],

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -259,10 +259,9 @@ async fn config_registry_round_trips_and_identity_stays_read_only() {
     overrides.insert("vta_name".to_string(), serde_json::json!("round tripped"));
     let patched = client
         .update_config(vta_sdk::client::UpdateConfigRequest {
-            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
+            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody::new(
                 overrides,
-                ext: None,
-            },
+            ),
         })
         .await
         .expect("config/patch round-trips");
@@ -281,10 +280,9 @@ async fn config_registry_round_trips_and_identity_stays_read_only() {
     );
     let patched = client
         .update_config(vta_sdk::client::UpdateConfigRequest {
-            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody {
+            patch: vta_sdk::protocols::vta_management::update_config::UpdateConfigBody::new(
                 overrides,
-                ext: None,
-            },
+            ),
         })
         .await
         .expect("a rejected key is a reported rejection, not a transport error");


### PR DESCRIPTION
Completes the breaking-change cleanup started in #1262, on the other half of what
the semver report flagged.

Sixteen public request bodies gained an `ext` member in #1231 — under a **`fix:`**
type, which derives the smallest bump there is — and every consumer building one
with a struct literal stopped compiling. `vta-sdk` 0.32.4 shipped that as a patch,
which `^0.32` takes on a routine `cargo update`.

`ext` is the framework's extension member (SPEC §4.5.1), so these bodies gain
members whenever the schema revises. The fix is therefore not to remember the `!`
next time — it is for the addition to stop being breaking at all.

## What changed

Fourteen bodies are now `#[non_exhaustive]` with a `new()` taking the members the
schema requires; optional members stay public and are set on the returned value:

```rust
let mut body = ListPoliciesBody::new(enabled_only);
body.context_id = context;
```

## What is deliberately excluded

`AclEntry` and `AppStateWrite`, which the same report flagged.

`AclEntry` has **68 construction sites**, and its own doc comments record that
`None` and `Some([])` on `allowed_keys` are **opposite** grants — absent means
every key the entry's scopes reach, present-but-empty means no keys at all. A
generated constructor defaulting that to `None`, migrated mechanically across 68
sites, is exactly how the narrowest grant silently becomes the widest. It is the
same class of mistake CLAUDE.md already attributes to #746, #769 and #770 on the
adjacent `allowed_contexts` axis.

That one wants per-site review rather than a script, and it is safer on its own.

## Notes from doing it

The compiler was a better census than grep: I estimated 19 external construction
sites, it found **21**, across five files — including integration tests, which
count as outside the defining crate for `#[non_exhaustive]` purposes.

Two of my own automation passes needed correcting, and the second was nearly
silent: the first brace matcher mis-parsed `//` comments inside the literals, and
the second dropped the comment attached to `authorization_context: None` while
filtering `None`-valued fields. That comment records that `authorizationContext`
is a member the published schema does **not** define, so a producer cannot send it
through the validated transport at all. Restored against the constructor default.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` (the exact CI command) — clean
- `cargo test --workspace --all-features` — 44 test binaries pass

One caveat: the full-workspace run hit `fatal runtime error: stack overflow` in
`vta-service --test mock_vta`. It passes 13/13 in isolation on this branch, and it
did the same on #1262 *before* any of these changes, where CI's Test job then
passed. So it reads as parallel-execution pressure local to this machine rather
than anything here — but it has now happened twice, so I would rather flag it than
keep re-running until green.

## Versioning

Breaking, so this wants the minor slot on `vta-sdk` (0.33.0). #1256's guard will
say so if the release proposes otherwise.
