### PR TITLE
feat(vta-sdk)!: make AclEntry and AppStateWrite non-exhaustive

### DIFF
--- a/vta-sdk/src/protocols/acl_management/entry.rs
+++ b/vta-sdk/src/protocols/acl_management/entry.rs
@@ -108,6 +108,7 @@ impl Approve {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct AclEntry {
     /// VID of the party in the ACL.
     pub subject: String,
@@ -162,6 +163,42 @@ pub struct AclEntry {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl AclEntry {
+    /// Build an entry from the three members that carry its authorization.
+    ///
+    /// `#[non_exhaustive]`, so it cannot be built with a struct literal from
+    /// outside this crate — the `ext` member added in #1231 broke every such
+    /// literal, and the next schema revision would do it again.
+    ///
+    /// **`scopes` is an argument rather than a default, and `allowed_keys` is
+    /// not one at all.** Both encode a grant whose empty case is not its
+    /// neutral case: empty `scopes` means *unrestricted* for an admin role and
+    /// *authorized nowhere* for every other, and on `allowed_keys` `None` and
+    /// `Some(vec![])` are opposite grants — absent reaches every key the scopes
+    /// reach, present-but-empty reaches none. A constructor that defaulted
+    /// either would be picking a grant on the caller's behalf, and picking the
+    /// wrong one silently. So the caller states `scopes`, and `allowed_keys`
+    /// starts absent — the same thing an entry predating the member means — and
+    /// must be set deliberately to narrow it.
+    pub fn new(subject: String, role: String, scopes: Vec<String>) -> Self {
+        Self {
+            subject,
+            role,
+            scopes,
+            allowed_keys: None,
+            label: None,
+            created_at: None,
+            created_by: None,
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+            step_up: None,
+            approve: None,
+            ext: None,
+        }
+    }
 }
 
 /// Unix epoch seconds → RFC 3339, for the wire.

--- a/vta-sdk/src/protocols/app_state.rs
+++ b/vta-sdk/src/protocols/app_state.rs
@@ -458,6 +458,7 @@ pub enum PutManyMode {
 /// supplies.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[non_exhaustive]
 pub struct AppStateWrite {
     /// The record key.
     pub key: String,
@@ -490,6 +491,25 @@ pub struct AppStateWrite {
     /// The VTA does not interpret the contents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ext: Option<Value>,
+}
+
+impl AppStateWrite {
+    /// Build a write against `key`.
+    ///
+    /// `#[non_exhaustive]`: set the rest on the returned value. `value` and
+    /// `merge_patch` are mutually exclusive and both start absent, so the
+    /// constructor cannot pick between them — a write that sets neither is a
+    /// caller error the service reports, not something a default should paper
+    /// over by guessing which was meant.
+    pub fn new(key: String) -> Self {
+        Self {
+            key,
+            value: None,
+            merge_patch: None,
+            expected_version: None,
+            ext: None,
+        }
+    }
 }
 
 /// `spec/vta/app-state/put-many/1.0` request body.

--- a/vta-sdk/tests/trust_task_decode.rs
+++ b/vta-sdk/tests/trust_task_decode.rs
@@ -97,21 +97,24 @@ fn ts() -> chrono::DateTime<Utc> {
 /// `None` and `Some(∅)` are opposite grants on this type, and the empty vec is
 /// the one that must survive as `"allowedKeys": []`.
 fn agent_acl_entry() -> AclEntry {
-    AclEntry {
-        subject: "did:key:z6MkSubject".into(),
-        role: "admin".into(),
-        scopes: vec!["personal".into()],
-        allowed_keys: Some(vec![]),
-        label: Some("laptop".into()),
-        created_at: Some(ts()),
-        created_by: Some("did:key:z6MkAdmin".into()),
-        updated_at: Some(ts()),
-        updated_by: Some("did:key:z6MkAdmin".into()),
-        expires_at: Some(ts()),
-        step_up: None,
-        approve: None,
-        ext: None,
-    }
+    let mut entry = AclEntry::new(
+        "did:key:z6MkSubject".into(),
+        "admin".into(),
+        vec!["personal".into()],
+    );
+    // `Some(vec![])` rather than the constructor's `None`, and the distinction is
+    // the whole point of this fixture: they are opposite grants, and the empty vec
+    // is the one that must survive the wire as `"allowedKeys": []`.
+    entry.allowed_keys = Some(vec![]);
+    entry.label = Some("laptop".into());
+    entry.created_at = Some(ts());
+    entry.created_by = Some("did:key:z6MkAdmin".into());
+    entry.updated_at = Some(ts());
+    entry.updated_by = Some("did:key:z6MkAdmin".into());
+    entry.expires_at = Some(ts());
+    // `step_up`, `approve` and `ext` stay at the constructor's `None`, as they
+    // were here before.
+    entry
 }
 
 /// `pnm acl show` / `grant` / `update` / `change-role`.

--- a/vta-service/src/operations/app_state.rs
+++ b/vta-service/src/operations/app_state.rs
@@ -2559,27 +2559,24 @@ mod tests {
         put_value(&ks, &locks, "ctx", "openvtc", "b", json!(1)).await;
 
         let writes = vec![
-            AppStateWrite {
-                key: "a".into(),
-                value: Some(json!(2)),
-                merge_patch: None,
-                expected_version: Some(a.version),
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("a".into());
+                w.value = Some(json!(2));
+                w.expected_version = Some(a.version);
+                w
             },
-            AppStateWrite {
-                key: "b".into(),
-                value: Some(json!(2)),
-                merge_patch: None,
+            {
+                let mut w = AppStateWrite::new("b".into());
+                w.value = Some(json!(2));
                 // Stale on purpose.
-                expected_version: Some(999),
-                ext: None,
+                w.expected_version = Some(999);
+                w
             },
-            AppStateWrite {
-                key: "c".into(),
-                value: Some(json!(1)),
-                merge_patch: None,
-                expected_version: Some(0),
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("c".into());
+                w.value = Some(json!(1));
+                w.expected_version = Some(0);
+                w
             },
         ];
         let (results, high) = put_many(
@@ -2617,19 +2614,17 @@ mod tests {
         let counter_before = read_counter(&ks, "ctx", "openvtc").await.unwrap();
 
         let writes = vec![
-            AppStateWrite {
-                key: "member".into(),
-                value: Some(json!({"label": "Cyprus"})),
-                merge_patch: None,
-                expected_version: Some(0),
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("member".into());
+                w.value = Some(json!({"label": "Cyprus"}));
+                w.expected_version = Some(0);
+                w
             },
-            AppStateWrite {
-                key: "index".into(),
-                value: Some(json!({"ids": ["cyprus"]})),
-                merge_patch: None,
-                expected_version: Some(999), // stale
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("index".into());
+                w.value = Some(json!({"ids": ["cyprus"]}));
+                w.expected_version = Some(999); // stale
+                w
             },
         ];
         let err = put_many(&ks, &locks, "ctx", "openvtc", &writes, PutManyMode::Atomic)
@@ -2665,19 +2660,17 @@ mod tests {
         let (_d, ks, locks) = open().await;
         let idx = put_value(&ks, &locks, "ctx", "openvtc", "index", json!({"ids": []})).await;
         let writes = vec![
-            AppStateWrite {
-                key: "member".into(),
-                value: Some(json!({"label": "Cyprus"})),
-                merge_patch: None,
-                expected_version: Some(0),
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("member".into());
+                w.value = Some(json!({"label": "Cyprus"}));
+                w.expected_version = Some(0);
+                w
             },
-            AppStateWrite {
-                key: "index".into(),
-                value: Some(json!({"ids": ["cyprus"]})),
-                merge_patch: None,
-                expected_version: Some(idx.version),
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("index".into());
+                w.value = Some(json!({"ids": ["cyprus"]}));
+                w.expected_version = Some(idx.version);
+                w
             },
         ];
         let (results, _) = put_many(&ks, &locks, "ctx", "openvtc", &writes, PutManyMode::Atomic)
@@ -2690,19 +2683,15 @@ mod tests {
     async fn duplicate_keys_in_a_batch_are_refused() {
         let (_d, ks, locks) = open().await;
         let writes = vec![
-            AppStateWrite {
-                key: "k".into(),
-                value: Some(json!(1)),
-                merge_patch: None,
-                expected_version: None,
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("k".into());
+                w.value = Some(json!(1));
+                w
             },
-            AppStateWrite {
-                key: "k".into(),
-                value: Some(json!(2)),
-                merge_patch: None,
-                expected_version: None,
-                ext: None,
+            {
+                let mut w = AppStateWrite::new("k".into());
+                w.value = Some(json!(2));
+                w
             },
         ];
         let err = put_many(

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -407,33 +407,29 @@ fn key_result() -> CreateKeyResultBody {
 
 /// A fully-populated canonical `AclEntry` (the family's shared component).
 fn acl_entry() -> AclEntry {
-    AclEntry {
-        subject: SUBJECT.into(),
-        role: "reader".into(),
+    let mut entry = AclEntry::new(SUBJECT.into(), "reader".into(), vec!["ctx-a".into()]);
+    entry.label = Some("build agent".into());
+    entry.created_at = Some(dt());
+    entry.created_by = Some("did:key:z6MkAdmin".into());
+    entry.updated_at = Some(dt());
+    entry.updated_by = Some("did:key:z6MkAdmin".into());
+    entry.expires_at = Some(dt());
+    entry.step_up = Some(StepUp {
+        approver: Some("did:key:z6MkApprover".into()),
+        require: Some("delegated".into()),
+    });
+    entry.approve = Some(Approve {
+        all: false,
         scopes: vec!["ctx-a".into()],
-        label: Some("build agent".into()),
-        created_at: Some(dt()),
-        created_by: Some("did:key:z6MkAdmin".into()),
-        updated_at: Some(dt()),
-        updated_by: Some("did:key:z6MkAdmin".into()),
-        expires_at: Some(dt()),
-        step_up: Some(StepUp {
-            approver: Some("did:key:z6MkApprover".into()),
-            require: Some("delegated".into()),
-        }),
-        approve: Some(Approve {
-            all: false,
-            scopes: vec!["ctx-a".into()],
-        }),
-        // `allowedKeys` (#818) reached the published
-        // `acl/_shared/0.1/acl-entry` component in `trust-tasks-rs` 0.2.51,
-        // so the entry every ACL response embeds now carries it. Populated
-        // rather than `None` deliberately: `None` and `Some(∅)` are opposite
-        // grants and only a present value proves the member survives the
-        // wire under its canonical `allowedKeys` spelling.
-        allowed_keys: Some(vec!["tenant-key-a".into()]),
-        ext: None,
-    }
+    });
+    // `allowedKeys` (#818) reached the published
+    // `acl/_shared/0.1/acl-entry` component in `trust-tasks-rs` 0.2.51,
+    // so the entry every ACL response embeds now carries it. Populated
+    // rather than the constructor's `None` deliberately: `None` and `Some(∅)`
+    // are opposite grants and only a present value proves the member survives
+    // the wire under its canonical `allowedKeys` spelling.
+    entry.allowed_keys = Some(vec!["tenant-key-a".into()]);
+    entry
 }
 
 fn to_v<T: serde::Serialize>(t: T) -> Value {
@@ -1802,19 +1798,19 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     namespace: "openvtc".into(),
                     mode: Some(PutManyMode::Independent),
                     writes: vec![
-                        AppStateWrite {
-                            key: "community/acme".into(),
-                            value: None,
-                            merge_patch: Some(serde_json::json!({ "role": "owner" })),
-                            expected_version: Some(52),
-                            ext: None,
+                        {
+                            let mut w = AppStateWrite::new("community/acme".into());
+                            w.merge_patch =
+                                Some(serde_json::json!({ "role": "owner" }));
+                            w.expected_version = Some(52);
+                            w
                         },
-                        AppStateWrite {
-                            key: "profile/labels".into(),
-                            value: Some(serde_json::json!({ "colours": { "acme": "blue" } })),
-                            merge_patch: None,
-                            expected_version: Some(0),
-                            ext: None,
+                        {
+                            let mut w = AppStateWrite::new("profile/labels".into());
+                            w.value =
+                                Some(serde_json::json!({ "colours": { "acme": "blue" } }));
+                            w.expected_version = Some(0);
+                            w
                         },
                     ],
                     ext: None,


### PR DESCRIPTION
The last two types the semver report flagged, deferred out of #1270 because
`AclEntry` looked like a 68-site migration through security-sensitive semantics.

## It was one site, not 68 — and I should correct that

The compiler finds **one** construction site outside `vta-sdk`. My 68 came from a
grep that conflated three different types — this wire `AclEntry`, the unrelated
`vti_common::acl::AclEntry`, and `vtc-service`'s own `VtcAclEntry` — and counted
every `fn … -> AclEntry {` body as a literal. The caution was right; the
arithmetic behind it was not.

## What the review did earn: the constructor's shape

Both real fixtures set `allowed_keys` deliberately, and both say why in a comment:

- `trust_task_decode.rs` — `Some(vec![])` **on purpose**, because the empty vec
  must survive the wire as `"allowedKeys": []`
- `conformance.rs` — a populated vec, because "only a present value proves the
  member survives under its canonical `allowedKeys` spelling"

On this type `None` and `Some(∅)` are **opposite grants**: absent reaches every
key the entry's scopes reach; present-but-empty reaches none.

So `AclEntry::new(subject, role, scopes)` leaves `allowed_keys` absent — the
meaning an entry predating the member already has — and defaults no grant whose
empty case is not its neutral case. `scopes` is an argument for the same reason:
empty means *unrestricted* for an admin role and *authorized nowhere* for every
other.

Had I scripted this without reading those two comments, a constructor defaulting
`allowed_keys` to `None` would have looked correct and quietly widened the
narrowest grant — in the fixture that exists to prove that exact distinction
survives the wire.

`AppStateWrite::new(key)` leaves `value` and `merge_patch` absent: they are
mutually exclusive, and a write setting neither is a caller error the service
reports rather than something a default should paper over by guessing.

## Notes from doing it

**Twelve** `AppStateWrite` sites across two files — the second file only surfaced
after the first one's compile error cleared. Worth knowing about
compiler-as-census: it reports one crate at a time, so "0 errors" mid-migration
does not mean done.

**One transformer bug.** A field written `expected_version: Some(999), // stale`
does not end in a comma, so my line-based parser merged it with the next field and
emitted `ext: None;` as a statement. `-D warnings` caught it, and I then audited
every rewritten site field-by-field to confirm no non-default value was silently
dropped.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` (exact CI command) — clean
- `cargo test --workspace --all-features` — 44 binaries pass

`vta-service --test mock_vta` hit `fatal runtime error: stack overflow` again. That
is now the **third** occurrence, across three unrelated branches (#1262, #1270,
this one), always passing in isolation and always green in CI. It predates all of
these changes and none of them can cause a runtime stack overflow. I have stopped
treating it as noise — it deserves its own investigation, and I would rather raise
it separately than keep footnoting it.

## Versioning

Breaking; wants the minor slot on `vta-sdk` alongside #1270.
