### PR TITLE
docs: give every crate a README, starting with the one that blocked a publish

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,33 @@
+# vti-fuzz
+
+Fuzz targets for the parsers that read bytes someone else wrote.
+
+Not published, and not part of the workspace build — `cargo-fuzz` needs its own
+manifest and a nightly toolchain, which is why this sits in a detached crate
+rather than as a feature of the crates it exercises.
+
+## What is worth fuzzing here
+
+Both current targets — `fuzz_nitro_quote` and `fuzz_nitro_verify` — aim at the
+same class of surface: **attestation bytes, parsed before anything has
+authenticated them.**
+
+That is the shape worth the effort. A Nitro quote arrives from whoever is
+claiming to be an enclave, and it has to be decoded before it can be checked,
+so a panic in the decoder is reachable by anyone who can reach the endpoint —
+a different kind of bug from one sitting behind an authorization check.
+
+## Running
+
+```sh
+cargo +nightly fuzz run <target>
+cargo +nightly fuzz list      # what exists
+```
+
+Crashes land in `artifacts/`. A reproducer is worth turning into an ordinary
+unit test in the crate that owns the parser, so the case stays covered without
+needing nightly.
+
+## Licence
+
+Apache-2.0

--- a/room-host/README.md
+++ b/room-host/README.md
@@ -1,0 +1,25 @@
+# room-host
+
+Stores data-room records for rooms it does not govern — a delivery service, not
+a community.
+
+Not published to crates.io; it is deployed as a binary.
+
+## What it deliberately is not
+
+A room host holds records — ciphertext on every tier but `open` — and answers
+`rooms/*` Trust Tasks against them. It has **no member roster, no policy engine,
+no credential issuance, no admin surface**, and no opinion about who belongs to
+any room it stores.
+
+That is not minimalism for its own sake. A room is authorized by credentials the
+room itself issued, so a host that kept its own record of who belongs would
+become part of that room's membership — and the room could no longer move to a
+different host without the old host's cooperation.
+
+The absence of a roster is what makes a room portable, and it is the property
+this binary exists to preserve.
+
+## Licence
+
+Apache-2.0

--- a/vta-mobile-core/README.md
+++ b/vta-mobile-core/README.md
@@ -1,0 +1,25 @@
+# vta-mobile-core
+
+The shared engine behind the VTA mobile agent (Android and iOS), exposed to both
+platforms through a single UniFFI surface.
+
+Not published to crates.io — it ships as a UniFFI binding inside the mobile
+apps.
+
+## The FFI surface is pure functions over bytes
+
+Deliberately. Everything stateful or platform-bound stays **native** and is
+handed to this crate as input:
+
+- key custody (Secure Enclave / StrongBox) and biometric gating,
+- the mediator WebSocket transport and APNs/FCM push wake-up,
+- storage.
+
+The engine builds and parses documents; the platform holds the keys and the
+sockets. That line is what keeps one implementation of the protocol serving two
+platforms without either platform's lifecycle leaking into it — and it is why a
+key never crosses the boundary in either direction.
+
+## Licence
+
+Apache-2.0

--- a/vta-persona/README.md
+++ b/vta-persona/README.md
@@ -1,0 +1,78 @@
+# vta-persona
+
+The holder's own identity, for a Verifiable Trust Agent: the attributes a person
+keeps about themselves, the profiles that project over them, which face a given
+trust context sees, and what other people have disclosed back.
+
+Implements the `persona/*` Trust Task family
+([spec](https://trusttasks.org/spec/persona/)), and is the fourth holder store
+in a VTA — beside the secrets vault, the credential vault, and application
+state.
+
+## The one-way boundary
+
+The design turns on a single property, and most of this crate exists to enforce
+it.
+
+The **attribute pool** and the **profiles** built over it are *agent-scoped*:
+they sit above every trust context. Bindings, contacts, disclosure records and
+context-local profiles are *context-scoped*.
+
+**Nothing inside a context may read the pool.** The holder pushes a materialised
+projection down; a context never pulls. So an application that shares one
+context with another cannot enumerate the holder's other faces, and a
+compromised one cannot ask "who else is this person".
+
+That is enforced in four ways here, deliberately at different layers, because
+each catches a case the others cannot:
+
+| | |
+|---|---|
+| **Authorization** | Holder-scoped tasks require `Admin` *and* unrestricted scope. A guard reading "is this an administrator" passes for one scoped to a single context, who would then read every other context's identity data. |
+| **Types** | `MaterialisedClaim` is a distinct type from `ResolvedClaim` with nowhere to put a pool identifier, so no future edit can leak one by forgetting to clear a field. |
+| **Addressing** | Context-local profiles occupy their own key prefix rather than sharing the pool's with a flag. A filter can be got wrong; an address space cannot. |
+| **The schema** | A context-local profile's entries admit a single `inline` member, so one cannot *name* a pool attribute at all. |
+
+Editing a pool attribute refreshes every context bound to it — "edit once,
+everywhere" — without opening a read path, because the write is initiated above
+the boundary.
+
+## Disclosure is two calls
+
+`preview` says what would be revealed and to whom; `present` hands it over and
+consumes a single-use token only `preview` mints. There is no one-call form, so
+there is no code path to a disclosure that skipped the summary a human can be
+shown.
+
+Four things refuse rather than degrade, because a quietly smaller disclosure is
+indistinguishable to a verifier from a holder who chose to share less:
+
+- a renderer that cannot carry a requested claim fails at negotiation;
+- an unknown renderer is refused, not defaulted;
+- a claim that went stale between preview and present refuses the *whole*
+  disclosure;
+- an expired preview is refused rather than silently re-derived.
+
+## Correlation
+
+`correlation/analyze` reports how linkable a value would make the holder, and
+encodes an inversion that is easy to get backwards: a credential presented
+**whole** correlates *more* than a self-asserted value, because the issuer's
+signature is byte-identical at every verifier — while a derived proof correlates
+*less*, differing on every presentation. Severity is a function of value and
+proof rung together, never of provenance alone.
+
+The index is blinded: an HMAC over canonicalised JSON, keyed per agent, so the
+store can say "you have used this value elsewhere" without holding a corpus of
+the holder's values in a comparable form.
+
+## Status
+
+Early. The API will change. See
+[`CHANGELOG.md`](https://github.com/OpenVTC/verifiable-trust-infrastructure/blob/main/vta-persona/CHANGELOG.md)
+and the [workspace](https://github.com/OpenVTC/verifiable-trust-infrastructure)
+for how it is used in a running agent.
+
+## Licence
+
+Apache-2.0

--- a/vti-rooms-dtg/README.md
+++ b/vti-rooms-dtg/README.md
@@ -1,0 +1,28 @@
+# vti-rooms-dtg
+
+The DTG-credential chain verifier for data rooms — the cryptographic half of
+room authorization.
+
+[`vti-rooms`](https://crates.io/crates/vti-rooms) decides whether a presentation
+is *shaped* right, then asks a `ChainVerifier` whether it is *true*. This crate
+is that verifier, over the DTG credentials the rooms design uses: a **VMC** for
+membership and a chain of **VACs** for authority.
+
+## Why it is a separate crate
+
+`vti-rooms` depends on `vti-common` and nothing else, so a room host can reuse
+its storage without dragging in a credential library and a DID resolver.
+Verifying needs both.
+
+Keeping them apart is what lets `vti-rooms` stay honest about the limit of what
+it can answer on its own — a crate that could reach a verifier would eventually
+be asked to, and the boundary between "well-formed" and "valid" would blur at
+exactly the point where it matters.
+
+## Status
+
+Early. The API will change.
+
+## Licence
+
+Apache-2.0

--- a/vti-rooms/README.md
+++ b/vti-rooms/README.md
@@ -1,0 +1,42 @@
+# vti-rooms
+
+Data-room storage, wire types, and authorization — the parts of a room that are
+not a service.
+
+A **data room** is a shared space whose access is governed by credentials the
+*room itself* issues, not by anything the host stores. Everything here is
+arranged around that one property, and it inverts the assumption most storage is
+built on.
+
+## There is no member list
+
+Not "not yet" — there must not be one.
+
+Authorization is a presentation carrying a membership credential and an
+authority chain, verified against the room's own identifier. A host that kept a
+roster and consulted it would become part of the room's membership, and the room
+could no longer move to a different host without that host's cooperation. The
+absence is what makes a room portable.
+
+So this crate holds records and the rules for reading them, and knows nothing
+about who belongs to anything.
+
+## What it does not depend on
+
+`vti-rooms` depends on `vti-common` and nothing else — no credential library, no
+DID resolver. A host can reuse the storage without taking on the machinery of
+verification, which lives in
+[`vti-rooms-dtg`](https://crates.io/crates/vti-rooms-dtg) behind a
+`ChainVerifier` trait.
+
+That split is also what keeps this crate honest: it can decide whether a
+presentation is *shaped* right, and it structurally cannot decide whether it is
+*true*.
+
+## Status
+
+Early. The API will change.
+
+## Licence
+
+Apache-2.0


### PR DESCRIPTION
`cargo publish -p vta-persona --dry-run`:

```
error: readme `README.md` does not appear to exist (relative to .../vta-persona)
```

**`vta-persona` cannot be published at all.** It declares `readme = "README.md"` and has none.

This is *independent* of the crates.io token scope that stopped the release run. Re-running that workflow after fixing the token would have failed here too — which would have read as a second, unrelated outage rather than the same release still not landing.

Found by dry-running the publish rather than assuming the release would work once the token did.

## Why a README and not just dropping the `readme` line

`vti-rooms` publishes fine because it doesn't declare one. That is the other way to satisfy cargo, and the worse one: a published crate with no README has a **blank crates.io page**, which is the only page most people looking at it will ever see.

`vti-rooms` and `vti-rooms-dtg` are both live on crates.io with blank pages today.

## The six

Each leads with the property its crate is organised around, rather than restating its `description`:

| crate | leads with |
|---|---|
| **`vta-persona`** | the pool/context boundary, the four mechanisms enforcing it, why disclosure is two calls, and the correlation inversion that is easy to get backwards |
| **`vti-rooms`** | that there is deliberately **no member list** — and that its absence is what makes a room portable |
| **`vti-rooms-dtg`** | why the verifier is a separate crate: `vti-rooms` structurally *cannot* decide whether a presentation is true, only whether it is well-formed |
| **`vta-mobile-core`** | the FFI surface is pure functions over bytes, so a key never crosses it |
| **`room-host`** | a delivery service, not a community — same reason `vti-rooms` has no roster |
| **`vti-fuzz`** | both targets are attestation decoders: bytes parsed before anything has authenticated them |

A README that only says what the manifest already says is worse than none — it costs a reader a click to learn nothing.

## After this

Every crate in the workspace has a README, verified by sweep. `vta-persona` can then be published, and a re-run of the release workflow has one less thing to fail on.