### PR TITLE
docs(rooms): an operator guide for creating and running a data room

### DIFF
--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="color-scheme" content="light dark" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<title>Data rooms — operator guide</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap">
+<style>
+  :root{
+    --paper:#F7F9F8; --ink:#16211F; --ink-2:#4A5A55; --ink-3:#7C8B86;
+    --line:#D8E0DD; --line-soft:#E6ECEA;
+    --pine:#1F6F62; --pine-soft:#E3EFEC; --pine-ink:#145248;
+    --amber:#A87B24; --amber-soft:#F5EBD8;
+    --card:#FFFFFF; --well:#EFF3F1;
+    --good:#1F6F62; --none:#B04A3A; --none-soft:#F6E7E4;
+  }
+  @media (prefers-color-scheme: dark){
+    :root:not([data-theme="light"]){
+      --paper:#101816; --ink:#E8EDEA; --ink-2:#A7B5B0; --ink-3:#76847F;
+      --line:#2A3733; --line-soft:#222E2A;
+      --pine:#4FA893; --pine-soft:#1A2A26; --pine-ink:#7FC7B5;
+      --amber:#D9A84E; --amber-soft:#2A2318;
+      --card:#161F1C; --well:#1A2421;
+      --good:#4FA893; --none:#D07B6B; --none-soft:#2A1D1A;
+    }
+  }
+  :root[data-theme="dark"]{
+    --paper:#101816; --ink:#E8EDEA; --ink-2:#A7B5B0; --ink-3:#76847F;
+    --line:#2A3733; --line-soft:#222E2A;
+    --pine:#4FA893; --pine-soft:#1A2A26; --pine-ink:#7FC7B5;
+    --amber:#D9A84E; --amber-soft:#2A2318;
+    --card:#161F1C; --well:#1A2421;
+    --good:#4FA893; --none:#D07B6B; --none-soft:#2A1D1A;
+  }
+  *{box-sizing:border-box}
+  body{
+    background:var(--paper); color:var(--ink);
+    font-family:"IBM Plex Sans",-apple-system,"Segoe UI",sans-serif;
+    font-size:16px; line-height:1.65; margin:0;
+  }
+  .page{max-width:1020px; margin:0 auto; padding:56px 28px 96px}
+  .col{max-width:70ch; margin:0 auto}
+  .wide{max-width:960px; margin:0 auto}
+
+  .eyebrow{
+    font-family:"IBM Plex Mono",monospace; font-size:12px; letter-spacing:.14em;
+    text-transform:uppercase; color:var(--pine); font-weight:500; margin:0 0 10px;
+  }
+  h1{
+    font-family:"IBM Plex Serif",Georgia,serif; font-weight:600;
+    font-size:clamp(34px,5.5vw,52px); line-height:1.12; margin:0 0 18px;
+    text-wrap:balance; letter-spacing:-.01em;
+  }
+  h2{
+    font-family:"IBM Plex Serif",Georgia,serif; font-weight:600;
+    font-size:27px; line-height:1.25; margin:0 0 14px; text-wrap:balance;
+  }
+  h3{font-size:17px; font-weight:600; margin:26px 0 8px}
+  p{margin:0 0 16px; color:var(--ink)}
+  .lede{font-size:19px; line-height:1.6; color:var(--ink-2)}
+  a{color:var(--pine-ink); text-decoration-color:var(--line); text-underline-offset:3px}
+  a:focus-visible{outline:2px solid var(--pine); outline-offset:2px; border-radius:2px}
+  strong{font-weight:600}
+  code{font-family:"IBM Plex Mono",monospace; font-size:.86em; background:var(--well); padding:1px 5px; border-radius:4px}
+
+  .meta{display:flex; flex-wrap:wrap; gap:10px 22px; padding:14px 0; margin:26px 0 0;
+    border-top:1px solid var(--line); border-bottom:1px solid var(--line);
+    font-family:"IBM Plex Mono",monospace; font-size:12.5px; color:var(--ink-2)}
+  .meta span b{color:var(--ink); font-weight:500}
+
+  section{margin:64px 0 0}
+  .figure-block{margin:30px 0 34px}
+  figure{margin:0; background:var(--card); border:1px solid var(--line); border-radius:10px; padding:22px 22px 14px; overflow-x:auto}
+  figcaption{font-size:13.5px; color:var(--ink-2); padding:10px 2px 2px; border-top:1px solid var(--line-soft); margin-top:12px}
+  svg{max-width:100%; height:auto; display:block; color:var(--ink)}
+
+  table{border-collapse:collapse; width:100%; font-size:14.5px; background:var(--card);
+    border:1px solid var(--line); border-radius:10px; overflow:hidden}
+  .table-wrap{overflow-x:auto; margin:26px 0 10px; border-radius:10px}
+  th,td{padding:10px 14px; text-align:left; border-bottom:1px solid var(--line-soft); vertical-align:top}
+  thead th{font-family:"IBM Plex Mono",monospace; font-size:11.5px; letter-spacing:.1em;
+    text-transform:uppercase; color:var(--ink-2); font-weight:500; background:var(--well)}
+  tbody tr:last-child td{border-bottom:none}
+  td.yes,span.yes{color:var(--good); font-weight:600}
+  td.no,span.no{color:var(--none); font-weight:600}
+  td.hd,th.hd{font-weight:600; color:var(--ink)}
+  td.mono,.mono{font-family:"IBM Plex Mono",monospace; font-size:13px}
+
+  .cards{display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:16px; margin:28px 0 6px}
+  .card{background:var(--card); border:1px solid var(--line); border-radius:10px; padding:18px 20px}
+  .card h3{margin:0 0 6px; font-size:16.5px}
+  .card p{font-size:14.5px; color:var(--ink-2); margin:8px 0 0}
+  .card .deploy{margin-top:12px; padding-top:10px; border-top:1px solid var(--line-soft);
+    font-family:"IBM Plex Mono",monospace; font-size:12px; color:var(--pine-ink)}
+  .chips{display:flex; gap:6px; flex-wrap:wrap; margin-top:2px}
+  .chip{font-family:"IBM Plex Mono",monospace; font-size:11px; letter-spacing:.05em;
+    padding:2px 8px; border-radius:99px; border:1px solid var(--line); color:var(--ink-2)}
+  .chip.t{background:var(--pine-soft); border-color:transparent; color:var(--pine-ink)}
+  .chip.v{background:var(--amber-soft); border-color:transparent; color:var(--amber)}
+
+  .pull{border-left:3px solid var(--pine); background:var(--pine-soft);
+    padding:16px 20px; border-radius:0 10px 10px 0; margin:26px 0}
+  .pull p{margin:0; color:var(--ink)}
+  .pull p + p{margin-top:10px}
+  .warn{border-left:3px solid var(--none); background:var(--none-soft);
+    padding:16px 20px; border-radius:0 10px 10px 0; margin:26px 0}
+  .warn p{margin:0}
+  .warn p + p{margin-top:10px}
+  .warn b{font-weight:600}
+
+  ol.steps{list-style:none; counter-reset:s; padding:0; margin:26px 0 0}
+  ol.steps > li{counter-increment:s; position:relative; padding:0 0 22px 46px; border-left:1px solid var(--line); margin-left:13px}
+  ol.steps > li:last-child{border-left-color:transparent; padding-bottom:0}
+  ol.steps > li::before{
+    content:counter(s); position:absolute; left:-13px; top:0;
+    width:26px; height:26px; border-radius:99px; background:var(--pine-soft);
+    color:var(--pine-ink); border:1px solid var(--pine);
+    font-family:"IBM Plex Mono",monospace; font-size:12.5px; font-weight:500;
+    display:grid; place-items:center;
+  }
+  ol.steps h3{margin:1px 0 6px}
+  ol.steps p{font-size:15px; color:var(--ink-2); margin:0 0 10px}
+  ol.steps p.code{
+    font-family:"IBM Plex Mono",monospace; font-size:12.5px; color:var(--ink);
+    background:var(--well); border:1px solid var(--line-soft); border-radius:8px;
+    padding:10px 12px; white-space:pre-wrap; line-height:1.5;
+  }
+
+  ul.plain{padding-left:22px; margin:0 0 16px}
+  ul.plain li{margin-bottom:8px}
+
+  .foot{margin-top:80px; padding-top:18px; border-top:1px solid var(--line);
+    font-size:13px; color:var(--ink-3)}
+  .foot p{color:var(--ink-3); margin:0 0 8px}
+  @media (prefers-reduced-motion: no-preference){ html{scroll-behavior:smooth} }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header class="col">
+    <p class="eyebrow">Operator guide · Verifiable Trust Infrastructure</p>
+    <h1>Data rooms: creating one, and keeping it</h1>
+    <p class="lede">A room is a shared space governed entirely by credentials it issues itself —
+    so it can move hosts without reissuing one. This is the working path through that: what you
+    assemble, which of the four topologies you are building, and every verb you use afterwards.</p>
+    <div class="meta">
+      <span>scope <b>operator + integrator</b></span>
+      <span>serves <b>open · attributed</b></span>
+      <span>built on <b>DTG credentials · MLS (RFC&nbsp;9420) · did:webvh</b></span>
+      <span>full text <b>docs/02-vta/data-rooms.md</b></span>
+    </div>
+  </header>
+
+  <section class="col">
+    <p class="eyebrow">Before anything else</p>
+    <h2>The one rule everything follows from</h2>
+    <p>A room operation is authorized by the credential chain <strong>the room issued</strong>,
+    verified against the room's own DID. Never by the host's ACL, never by a session, never by a
+    roster. Every call carries a presentation instead of a token.</p>
+    <p>That is why a host can hold a room it has no member list for — and why re-pointing a
+    service endpoint moves the room, with no credential reissued.</p>
+    <div class="pull">
+      <p>Practical consequence: <strong>a freshly registered room is one nobody can act in,
+      including you.</strong> Registering it with a host and issuing yourself a membership and
+      an authority credential are two separate acts, and the second is the one people forget.</p>
+    </div>
+  </section>
+
+  <section class="col">
+    <p class="eyebrow">Ground truth</p>
+    <h2>What works today</h2>
+    <p>Rooms are implemented across <code>vti-rooms</code>, <code>vti-rooms-dtg</code>,
+    <code>room-host</code>, <code>vtc-service</code> and <code>vta-service</code>. Not everything
+    in the design note is built, and knowing which half you are standing on saves an afternoon.</p>
+  </section>
+
+  <div class="wide table-wrap">
+    <table>
+      <thead><tr><th class="hd">Capability</th><th>State</th></tr></thead>
+      <tbody>
+        <tr><td class="hd"><span class="tiername mono">open</span> and <span class="mono">attributed</span> rooms</td>
+            <td><span class="yes">Serve.</span> Create, records, curate, epoch mint, transfer, claim</td></tr>
+        <tr><td class="hd"><span class="mono">private</span> rooms</td>
+            <td><span class="no">Store, but refuse to serve.</span> The same-subject binding needs a
+            zero-knowledge profile the DTG working group has not settled, and the refusal comes from
+            shared code so a VTC and a room host cannot disagree about what is safe</td></tr>
+        <tr><td class="hd">MLS group layer, record sealing</td>
+            <td>Work — create, add, remove, commit, exporter-derived storage keys</td></tr>
+        <tr><td class="hd">Member-side custody<br><span class="mono">rooms/keys/{key-package,welcome,commit,open}</span></td>
+            <td>Work. A member's VTA holds the group and opens records for their agents</td></tr>
+        <tr><td class="hd">Presentation oracle<br><span class="mono">rooms/keys/present</span></td>
+            <td>Works. Attenuates the member's own authority for an agent — one action, bound
+            audience, four hours</td></tr>
+        <tr><td class="hd">Succession — nomination, transfer, claim</td>
+            <td>Work, including the property that renewing defeats a pending claim</td></tr>
+        <tr><td class="hd">A CLI</td>
+            <td><span class="no">None.</span> No <code>pnm rooms …</code>; drive it from
+            <code>vtc-client</code> or by posting signed Trust Task documents</td></tr>
+        <tr><td class="hd">Credential issuance</td>
+            <td><span class="no">Library only.</span> Nothing serves “issue this member a VMC and a
+            VAC” — the owner mints them with <code>dtg-credentials</code> and delivers them out of band</td></tr>
+        <tr><td class="hd">Governance (<code>rooms.rego</code>)</td>
+            <td><span class="no">Not implemented</span> — and <code>rooms/create</code> is ungated
+            on both hosts as a result</td></tr>
+        <tr><td class="hd">Read mirrors, witnessed renewal anchoring</td>
+            <td><span class="no">Not implemented.</span> One write-primary; anchoring is the owner's
+            job and nothing does it yet</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <section class="col">
+    <p class="eyebrow">Step 1</p>
+    <h2>Pick a topology</h2>
+    <p>The protocol is identical in all four. What differs is where the room lives and who governs
+    creation — never what a room is. Two of them are nearly free: <strong>T3 is T2 plus
+    nothing</strong>, because a membership credential binds a member to <em>the room</em> rather
+    than to a community; <strong>T4 is T1 with the peer relationship as the door</strong>.</p>
+  </section>
+
+  <div class="wide cards">
+    <div class="card">
+      <div class="chips"><span class="chip t">T1</span><span class="chip">personal</span></div>
+      <h3>Your own room host</h3>
+      <p>Members are anyone you invite; you govern, and that sentence is the whole policy model.
+      Your own shareable space, on infrastructure you control, interoperable with every community
+      you belong to.</p>
+      <p class="deploy">deploy: the room-host binary</p>
+    </div>
+    <div class="card">
+      <div class="chips"><span class="chip t">T2</span><span class="chip">community</span></div>
+      <h3>Inside a VTC</h3>
+      <p>A community-wide library whose membership happens to be the roster, or a three-person
+      share — one model. Members of the room need not be members of the community.</p>
+      <p class="deploy">deploy: nothing — a VTC already serves rooms/*</p>
+    </div>
+    <div class="card">
+      <div class="chips"><span class="chip t">T3</span><span class="chip">cross-community</span></div>
+      <h3>One home host, many communities</h3>
+      <p>Members from three communities in one room is the ordinary case, not a bridge. Read
+      mirrors are the optional half, and the half not yet built.</p>
+      <p class="deploy">deploy: nothing beyond T2</p>
+    </div>
+    <div class="card">
+      <div class="chips"><span class="chip t">T4</span><span class="chip">peer</span></div>
+      <h3>Between peers, no community</h3>
+      <p>A room two connected peers both hold membership in, stood up in one action from the
+      edge. Nobody governs it but the owner.</p>
+      <p class="deploy">deploy: the room-host binary</p>
+    </div>
+  </div>
+
+  <div class="wide figure-block">
+    <figure>
+      <svg viewBox="0 0 960 250" role="img" aria-label="Four topologies side by side: a personal room host, a community VTC, one home VTC with a read mirror at a second, and a peer's room host. In each the room is the same entity and the members present credentials issued by the room itself.">
+        <defs>
+          <marker id="a1" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L8,4 L0,8 z" fill="currentColor"/>
+          </marker>
+        </defs>
+        <g font-family="IBM Plex Mono,monospace" font-size="11.5">
+          <g>
+            <text x="112" y="16" text-anchor="middle" fill="var(--pine)" font-weight="500">T1 · PERSONAL</text>
+            <rect x="22" y="28" width="180" height="132" rx="10" fill="none" stroke="currentColor" opacity=".5"/>
+            <text x="112" y="47" text-anchor="middle" fill="currentColor" opacity=".7">my room-host</text>
+            <rect x="52" y="60" width="120" height="66" rx="8" fill="var(--pine-soft)" stroke="var(--pine)" stroke-width="1.5"/>
+            <text x="112" y="88" text-anchor="middle" fill="var(--pine)" font-weight="500">room</text>
+            <text x="112" y="105" text-anchor="middle" fill="var(--pine)" font-size="10">did:webvh</text>
+            <circle cx="112" cy="205" r="7" fill="currentColor" opacity=".8"/>
+            <circle cx="76" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <circle cx="148" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <line x1="112" y1="194" x2="112" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <text x="122" y="170" fill="currentColor" opacity=".7" font-size="10">VMC</text>
+            <line x1="80" y1="195" x2="98" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <line x1="144" y1="195" x2="126" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <text x="112" y="233" text-anchor="middle" fill="currentColor" opacity=".65" font-size="10.5">me + anyone I invite</text>
+          </g>
+          <g transform="translate(238,0)">
+            <text x="112" y="16" text-anchor="middle" fill="var(--pine)" font-weight="500">T2 · COMMUNITY</text>
+            <rect x="22" y="28" width="180" height="132" rx="10" fill="none" stroke="currentColor" opacity=".5"/>
+            <text x="112" y="47" text-anchor="middle" fill="currentColor" opacity=".7">community VTC</text>
+            <rect x="52" y="60" width="120" height="66" rx="8" fill="var(--pine-soft)" stroke="var(--pine)" stroke-width="1.5"/>
+            <text x="112" y="88" text-anchor="middle" fill="var(--pine)" font-weight="500">room</text>
+            <text x="112" y="105" text-anchor="middle" fill="var(--pine)" font-size="10">did:webvh</text>
+            <circle cx="72" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <circle cx="98" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <circle cx="124" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <circle cx="150" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <line x1="112" y1="192" x2="112" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <text x="122" y="170" fill="currentColor" opacity=".7" font-size="10">VMC</text>
+            <text x="112" y="233" text-anchor="middle" fill="currentColor" opacity=".65" font-size="10.5">served in-process, no deploy</text>
+          </g>
+          <g transform="translate(476,0)">
+            <text x="112" y="16" text-anchor="middle" fill="var(--pine)" font-weight="500">T3 · CROSS-COMMUNITY</text>
+            <rect x="8" y="28" width="126" height="132" rx="10" fill="none" stroke="currentColor" opacity=".5"/>
+            <text x="71" y="47" text-anchor="middle" fill="currentColor" opacity=".7">home VTC</text>
+            <rect x="22" y="60" width="98" height="66" rx="8" fill="var(--pine-soft)" stroke="var(--pine)" stroke-width="1.5"/>
+            <text x="71" y="88" text-anchor="middle" fill="var(--pine)" font-weight="500">room</text>
+            <text x="71" y="105" text-anchor="middle" fill="var(--pine)" font-size="10">write-primary</text>
+            <rect x="152" y="28" width="90" height="132" rx="10" fill="none" stroke="currentColor" opacity=".35" stroke-dasharray="4 3"/>
+            <text x="197" y="47" text-anchor="middle" fill="currentColor" opacity=".5">VTC B</text>
+            <rect x="162" y="60" width="70" height="66" rx="8" fill="none" stroke="var(--pine)" stroke-dasharray="4 3" opacity=".6"/>
+            <text x="197" y="90" text-anchor="middle" fill="var(--pine)" font-size="10" opacity=".7">mirror</text>
+            <text x="197" y="106" text-anchor="middle" fill="var(--pine)" font-size="9" opacity=".7">not built</text>
+            <circle cx="46" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <circle cx="96" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <circle cx="197" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <line x1="54" y1="196" x2="64" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <line x1="96" y1="194" x2="88" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <line x1="191" y1="195" x2="106" y2="132" stroke="currentColor" marker-end="url(#a1)"/>
+            <text x="120" y="233" text-anchor="middle" fill="currentColor" opacity=".65" font-size="10.5">members of A and B, one room</text>
+          </g>
+          <g transform="translate(730,0)">
+            <text x="104" y="16" text-anchor="middle" fill="var(--pine)" font-weight="500">T4 · PEERS</text>
+            <rect x="14" y="28" width="180" height="132" rx="10" fill="none" stroke="currentColor" opacity=".5"/>
+            <text x="104" y="47" text-anchor="middle" fill="currentColor" opacity=".7">a peer's room-host</text>
+            <rect x="44" y="60" width="120" height="66" rx="8" fill="var(--pine-soft)" stroke="var(--pine)" stroke-width="1.5"/>
+            <text x="104" y="88" text-anchor="middle" fill="var(--pine)" font-weight="500">room</text>
+            <text x="104" y="105" text-anchor="middle" fill="var(--pine)" font-size="10">did:webvh</text>
+            <circle cx="74" cy="205" r="7" fill="currentColor" opacity=".8"/>
+            <circle cx="134" cy="205" r="7" fill="none" stroke="currentColor"/>
+            <line x1="90" y1="205" x2="118" y2="205" stroke="currentColor" opacity=".8"/>
+            <text x="104" y="197" text-anchor="middle" fill="currentColor" opacity=".7" font-size="9.5">peer link</text>
+            <line x1="79" y1="194" x2="94" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <line x1="129" y1="194" x2="114" y2="134" stroke="currentColor" marker-end="url(#a1)"/>
+            <text x="104" y="233" text-anchor="middle" fill="currentColor" opacity=".65" font-size="10.5">no community at all</text>
+          </g>
+        </g>
+      </svg>
+      <figcaption>The same room in four homes. What changes between panels is who stores the bytes
+      and who governs creation; the arrows are membership credentials held against the
+      <em>room's</em> DID, so no panel's host keeps a member list of its own.</figcaption>
+    </figure>
+  </div>
+
+  <section class="col">
+    <p class="eyebrow">Step 2</p>
+    <h2>Pick a visibility tier</h2>
+    <p>Fixed at creation, for the life of the room. You cannot un-see cleartext, so a downgrade is
+    meaningless and an upgrade would protect only what came after while presenting as though it
+    protected everything.</p>
+  </section>
+
+  <div class="wide table-wrap">
+    <table>
+      <thead><tr><th class="hd">What the host can do</th><th class="mono">open</th><th class="mono">attributed</th><th class="mono">private</th></tr></thead>
+      <tbody>
+        <tr><td class="hd">Read bodies and titles</td><td>yes</td><td>no</td><td>no</td></tr>
+        <tr><td class="hd">See which member is acting</td><td>yes</td><td>yes</td><td>no — unlinkable proof</td></tr>
+        <tr><td class="hd">Search server-side</td><td>yes</td><td>no</td><td>no</td></tr>
+        <tr><td class="hd">Produce a per-member access log</td><td>yes</td><td>yes</td><td>no</td></tr>
+        <tr><td class="hd">Restore the content from its own backup</td><td>yes</td><td>no</td><td>no</td></tr>
+        <tr><td class="hd"><em>Serve it at all, today</em></td><td class="yes">yes</td><td class="yes">yes</td><td class="no">not yet</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <section class="col">
+    <p>The ladder measures <strong>the host, whoever that is</strong>. On a room you host yourself,
+    you-as-host see everything and already know the membership — you issued it — so the ladder
+    largely collapses there. Owner-hosting is not automatically the more private choice; a neutral
+    host that <em>cannot</em> read is a real alternative with a non-obvious answer.</p>
+    <p>On the sealed tiers, <strong>record keys must be opaque</strong>. A key reading
+    <code>decision/acquire-northwind</code> defeats the encryption sitting beside it — structured
+    naming belongs inside the sealed body.</p>
+  </section>
+
+  <section class="col">
+    <p class="eyebrow">Step 3</p>
+    <h2>Create the room</h2>
+    <ol class="steps">
+      <li>
+        <h3>Mint the room's identity</h3>
+        <p>The room's DID <em>is</em> its identifier and its credential issuer, so it exists before
+        anything else does. <code>did:webvh</code> rather than <code>did:peer</code> because a
+        room's controller must be able to change — transferring ownership is a controller change,
+        and <code>did:peer</code> encodes its keys in the identifier. Witness the log for any room
+        whose host you do not fully trust.</p>
+        <p class="code">pnm bootstrap provision-request --template room \
+  --var WEBVH_SERVER=https://dids.example.org \
+  --var MEDIATOR_DID=did:web:mediator.example.org --out room-request.json</p>
+      </li>
+      <li>
+        <h3>Register it with a host</h3>
+        <p>One <code>rooms/create/0.1</code> document. <strong>You bring the roomId</strong> — a
+        room identified by something its host chose could not move. The host sets epoch 1, an
+        expiry one epoch lifetime out, and the retention you asked for; it records the owner DID
+        you gave it.</p>
+      </li>
+      <li>
+        <h3>Issue yourself membership and authority</h3>
+        <p>A membership credential (you are in this room) and an authority credential (what you may
+        do: <code>read</code>, <code>write</code>, <code>curate</code>, <code>admin</code>), both
+        signed by the room's key. Store them in your VTA's credential vault — the oracle finds them
+        by issuer, so a credential filed anywhere else is one it cannot use.</p>
+      </li>
+      <li>
+        <h3>On a sealed tier, form the MLS group</h3>
+        <p>The group's epoch plus one is the room's epoch, so a group you have just created already
+        matches the number the host recorded. Read it rather than computing it: an off-by-one here
+        seals records under an epoch the host rejects, and the failure reads as a key problem.</p>
+      </li>
+    </ol>
+  </section>
+
+  <section class="col">
+    <p class="eyebrow">Step 4</p>
+    <h2>Add a member, and equip their agent</h2>
+    <p>Joining is a <strong>two-party act</strong>. Without an invitation the owner could seal a
+    room key into your VTA and you would simply be <em>in</em>, holding keys to material you never
+    agreed to hold — so the invitation is checked, consumed exactly once, and consumed only
+    <em>after</em> the join succeeds.</p>
+  </section>
+
+  <div class="wide figure-block">
+    <figure>
+      <svg viewBox="0 0 940 300" role="img" aria-label="Who calls what: the owner sends an invitation and a welcome to the member's client, the client drives four tasks against the member's own VTA, the agent asks that VTA for a presentation and for decryption, and only presentations reach the host.">
+        <defs>
+          <marker id="a2" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L8,4 L0,8 z" fill="currentColor"/>
+          </marker>
+        </defs>
+        <g font-family="IBM Plex Mono,monospace" font-size="11.5">
+          <rect x="14" y="34" width="176" height="238" rx="10" fill="none" stroke="currentColor" opacity=".45"/>
+          <text x="102" y="24" text-anchor="middle" fill="var(--pine)" font-weight="500">OWNER</text>
+          <rect x="250" y="34" width="200" height="238" rx="10" fill="none" stroke="currentColor" opacity=".45"/>
+          <text x="350" y="24" text-anchor="middle" fill="var(--pine)" font-weight="500">MEMBER'S VTA</text>
+          <rect x="510" y="34" width="176" height="238" rx="10" fill="none" stroke="currentColor" opacity=".45"/>
+          <text x="598" y="24" text-anchor="middle" fill="var(--pine)" font-weight="500">AGENT</text>
+          <rect x="746" y="34" width="180" height="238" rx="10" fill="none" stroke="currentColor" opacity=".45"/>
+          <text x="836" y="24" text-anchor="middle" fill="var(--pine)" font-weight="500">HOST</text>
+
+          <g fill="currentColor" opacity=".78">
+            <text x="102" y="62" text-anchor="middle">holds the room key</text>
+            <text x="102" y="80" text-anchor="middle">issues VIC / VMC / VAC</text>
+            <text x="102" y="98" text-anchor="middle">commits the MLS group</text>
+            <text x="350" y="62" text-anchor="middle">holds VMC + VAC</text>
+            <text x="350" y="80" text-anchor="middle">holds the MLS leaf</text>
+            <text x="350" y="98" text-anchor="middle">never releases a key</text>
+            <text x="598" y="62" text-anchor="middle">holds nothing</text>
+            <text x="598" y="80" text-anchor="middle">read-only, 4 hours</text>
+            <text x="598" y="98" text-anchor="middle">bound to one host</text>
+            <text x="836" y="62" text-anchor="middle">stores ciphertext</text>
+            <text x="836" y="80" text-anchor="middle">verifies chains</text>
+            <text x="836" y="98" text-anchor="middle">holds no roster</text>
+          </g>
+
+          <g stroke="currentColor" fill="none" opacity=".85">
+            <line x1="190" y1="140" x2="248" y2="140" marker-end="url(#a2)"/>
+            <line x1="190" y1="176" x2="248" y2="176" marker-end="url(#a2)"/>
+            <line x1="510" y1="212" x2="452" y2="212" marker-end="url(#a2)"/>
+            <line x1="510" y1="244" x2="452" y2="244" marker-end="url(#a2)"/>
+            <line x1="686" y1="140" x2="744" y2="140" marker-end="url(#a2)"/>
+          </g>
+          <g fill="currentColor">
+            <text x="219" y="133" text-anchor="middle" font-size="10">VIC</text>
+            <text x="219" y="169" text-anchor="middle" font-size="10">Welcome</text>
+            <text x="481" y="205" text-anchor="middle" font-size="10">present</text>
+            <text x="481" y="237" text-anchor="middle" font-size="10">open</text>
+            <text x="715" y="133" text-anchor="middle" font-size="10">presentation</text>
+          </g>
+
+          <g fill="var(--pine)" font-size="10.5">
+            <text x="350" y="140" text-anchor="middle">rooms/keys/key-package</text>
+            <text x="350" y="158" text-anchor="middle">rooms/keys/welcome</text>
+            <text x="350" y="176" text-anchor="middle">rooms/keys/commit</text>
+          </g>
+          <g fill="var(--amber)" font-size="10.5">
+            <text x="350" y="212" text-anchor="middle">rooms/keys/present</text>
+            <text x="350" y="244" text-anchor="middle">rooms/keys/open</text>
+          </g>
+          <text x="470" y="288" text-anchor="middle" fill="currentColor" opacity=".6" font-size="10.5">
+            green: how a group reaches a VTA — amber: what the VTA does for an agent that holds nothing
+          </text>
+        </g>
+      </svg>
+      <figcaption>Nothing key-shaped crosses to the agent. It asks for a presentation and gets a
+      proof; it sends ciphertext and gets plaintext. Withdrawing its access is removing its entry
+      at the VTA — which is the whole value of an oracle over handing credentials across: there is
+      a place to say no.</figcaption>
+    </figure>
+  </div>
+
+  <div class="wide table-wrap">
+    <table>
+      <thead><tr><th class="hd">Task</th><th>Authorized by</th></tr></thead>
+      <tbody>
+        <tr><td class="mono hd">rooms/keys/key-package</td><td>an invitation — minting retains a private key against a Welcome that may never come</td></tr>
+        <tr><td class="mono hd">rooms/keys/welcome</td><td>that same invitation, consumed after the join succeeds</td></tr>
+        <tr><td class="mono hd">rooms/keys/commit</td><td>the MLS group itself — never an ACL of ours, which has no opinion about who a room's owner is</td></tr>
+        <tr><td class="mono hd">rooms/keys/open</td><td>the <code>roomOpen</code> capability — this one <em>is</em> our own principal's agent asking</td></tr>
+        <tr><td class="mono hd">rooms/keys/present</td><td>the <code>roomPresent</code> capability, plus access to the context holding the principal's key</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <section class="col">
+    <div class="warn">
+      <p><b>Commits are not optional, and their absence is silent.</b> Every membership change
+      produces a commit, and every existing member's VTA must apply it. A member who misses one is
+      stuck at their last epoch and can open nothing sealed after it — the symptom is “this record
+      does not open”, which reads like corruption. The VTA reports which epoch it holds for exactly
+      this reason: that turns it into “a commit has not been delivered”.</p>
+    </div>
+    <div class="warn">
+      <p><b>The agent role does not carry the agent capabilities.</b> The oracle gates read the
+      caller's role, and <code>Application</code> — the role agent integrations are normally granted
+      — carries neither <code>roomPresent</code> nor <code>roomOpen</code>. An agent that needs the
+      oracle today must hold a broader role than the design intends. Worth knowing before you scope
+      its entry.</p>
+    </div>
+  </section>
+
+  <section class="col">
+    <p class="eyebrow">Step 5</p>
+    <h2>Keep it alive</h2>
+    <p>No host can promise to hold every room forever, and on a sealed room the host is the
+    worst-placed party to judge value: it cannot read the content, and inactivity is not
+    worthlessness. <strong>So the host never decides.</strong> Every state below is computed from
+    two numbers the room already carries, and every one of them is undone by a single renewal
+    until the last.</p>
+  </section>
+
+  <div class="wide figure-block">
+    <figure>
+      <svg viewBox="-10 0 970 190" role="img" aria-label="Lifecycle timeline: live for one epoch lifetime, then lapsed and read-only, then dormant after a grace window, then reclaimable after the retention period. A single renewal returns the room to live from any state before reclaimable.">
+        <defs>
+          <marker id="a3" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L8,4 L0,8 z" fill="currentColor"/>
+          </marker>
+        </defs>
+        <g font-family="IBM Plex Mono,monospace" font-size="11.5">
+          <line x1="60" y1="70" x2="860" y2="70" stroke="currentColor" opacity=".35"/>
+          <g>
+            <circle cx="80" cy="70" r="9" fill="var(--pine)"/>
+            <text x="80" y="46" text-anchor="middle" fill="var(--pine)" font-weight="500">LIVE</text>
+            <text x="80" y="98" text-anchor="middle" fill="currentColor" opacity=".7" font-size="10.5">reads + writes</text>
+          </g>
+          <g>
+            <circle cx="330" cy="70" r="9" fill="var(--amber)"/>
+            <text x="330" y="46" text-anchor="middle" fill="var(--amber)" font-weight="500">LAPSED</text>
+            <text x="330" y="98" text-anchor="middle" fill="currentColor" opacity=".7" font-size="10.5">read-only · nothing destroyed</text>
+          </g>
+          <g>
+            <circle cx="580" cy="70" r="9" fill="var(--amber)"/>
+            <text x="580" y="46" text-anchor="middle" fill="var(--amber)" font-weight="500">DORMANT</text>
+            <text x="580" y="98" text-anchor="middle" fill="currentColor" opacity=".7" font-size="10.5">owner notified · claimable</text>
+          </g>
+          <g>
+            <circle cx="830" cy="70" r="9" fill="none" stroke="currentColor" stroke-dasharray="3 2"/>
+            <text x="830" y="46" text-anchor="middle" fill="currentColor" opacity=".8" font-weight="500">RECLAIMABLE</text>
+            <text x="830" y="98" text-anchor="middle" fill="currentColor" opacity=".7" font-size="10.5">reported, never automatic</text>
+          </g>
+          <g fill="currentColor" opacity=".65" font-size="10">
+            <text x="205" y="64" text-anchor="middle">epoch expires · 365d</text>
+            <text x="455" y="64" text-anchor="middle">grace · 30d</text>
+            <text x="705" y="64" text-anchor="middle">retention · you set it</text>
+          </g>
+          <path d="M830,132 C640,168 260,168 84,132" fill="none" stroke="var(--pine)" stroke-width="1.6" marker-end="url(#a3)" opacity=".9"/>
+          <text x="457" y="180" text-anchor="middle" fill="var(--pine)" font-size="11">a single renewal — minting an epoch, which is ordinary use</text>
+        </g>
+      </svg>
+      <figcaption>Reads deliberately do not extend the clock: a host counting reads would make a
+      sealed room's lifecycle depend on the one signal the host can see, which is exactly the
+      correlation the tiers exist to deny. Liveness is expressed by renewing, and a room being read
+      is a room whose members are in a position to renew it.</figcaption>
+    </figure>
+  </div>
+
+  <section class="col">
+    <p class="eyebrow">Step 6</p>
+    <h2>Hand it on</h2>
+    <p><strong>Transfer</strong> is the owner acting while present, gated on <code>admin</code> —
+    the same grant that mints epochs, because handing over the room is the more consequential of
+    the two. The host does not check that the incoming owner is a member: it holds no roster and
+    no group state, and a host that refused what it cannot verify would fail every correct
+    transfer. That obligation is the outgoing owner's, who can see the group.</p>
+    <p><strong>Claim</strong> is what happens when they are not there, and it needs three things at
+    once — a nomination the room issued naming this claimant, the room actually dormant, and the
+    claimant's own membership. Each closes a different route to a takeover: a nomination alone does
+    nothing while the owner renews, dormancy alone does nothing without a nomination, and neither
+    helps someone who could not commit once they had it.</p>
+    <div class="pull">
+      <p><strong>Renewing is the whole defence, and it is the same act as ordinary use.</strong> An
+      owner who was merely away defeats every pending claim by minting an epoch — which is what
+      they would have done anyway. Nothing has to be revoked and no dispute has to be raised.
+      Security that requires no vigilance is the only kind that survives contact with people on
+      holiday.</p>
+    </div>
+    <p>A claim hands over a dormant room and <em>leaves it dormant</em>. The new owner's first act
+    should be the renewal that proves they can perform it; if they cannot, the next nominee can
+    claim in turn — the succession chain working rather than failing.</p>
+  </section>
+
+  <section class="col">
+    <p class="eyebrow">Running a host</p>
+    <h2>What an operator owes the room</h2>
+    <ul class="plain">
+      <li><strong>Availability, and nothing else.</strong> Confidentiality, content integrity and
+      membership integrity need no trust in you. Availability and non-destruction irreducibly do —
+      which is why the lifecycle rules above are the ones a host must not shortcut.</li>
+      <li><strong>Network DID resolution is a decision.</strong> A standalone room host resolves
+      <code>did:key</code> only by default; serving <code>did:webvh</code> rooms means turning on
+      resolution, and that lets an unauthenticated request make your host fetch.</li>
+      <li><strong>Put it behind a proxy.</strong> The room-host binary carries no TLS and no rate
+      limiter, and <code>rooms/create</code> is not authorized on either host yet — anyone who can
+      reach the endpoint can register a room row. Every other verb verifies the document's proof
+      and the authority chain.</li>
+      <li><strong>Never log the actor on a private room.</strong> That decision is made once, in
+      the crate both hosts share, precisely because every host's logging wants to write the acting
+      DID — and on a private room that single line hands you the membership the room was built
+      never to disclose, assembled one entry at a time, with nothing breaking.</li>
+      <li><strong>Back up what only you hold.</strong> A VTC captures the room keyspaces in its
+      export; a standalone host's data directory is yours to back up. And a member's VTA backup
+      must carry their room groups — restore one without them and every sealed room they belong to
+      is unreadable, with no recovery but a fresh invitation from every owner.</li>
+    </ul>
+  </section>
+
+  <section class="col">
+    <p class="eyebrow">Reference</p>
+    <h2>Numbers worth knowing</h2>
+  </section>
+
+  <div class="wide table-wrap">
+    <table>
+      <thead><tr><th class="hd">Constant</th><th>Value</th><th>Why it is that</th></tr></thead>
+      <tbody>
+        <tr><td class="hd">Epoch lifetime</td><td class="mono">365 days</td><td>Long enough that renewal is not busywork, short enough that a room nobody has touched says something</td></tr>
+        <tr><td class="hd">Lapsed → dormant</td><td class="mono">30 days</td><td>A grace window, because “lapsed” is frequently somebody on holiday</td></tr>
+        <tr><td class="hd">Default retention</td><td class="mono">90 days</td><td>Counted from the lapse, never sooner than the dormancy window</td></tr>
+        <tr><td class="hd">Max authority-chain depth</td><td class="mono">8</td><td>Verification is linear in chain length and runs on every operation</td></tr>
+        <tr><td class="hd">Minted presentation lifetime</td><td class="mono">4 hours</td><td>A constant, not a request parameter — a caller that could ask for a year would be asking for the standing credential the oracle exists not to hand over</td></tr>
+        <tr><td class="hd">Unused key-package lifetime</td><td class="mono">7 days</td><td>The private half is retained key material; a caller that minted and never joined left a key behind</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <footer class="foot col">
+    <p>The full guide — commands, wire shapes, the refusal-to-cause table — is
+    <code>docs/02-vta/data-rooms.md</code>. The design and its rationale are
+    <code>docs/05-design-notes/data-rooms.md</code>, with two adversarial security reviews beside
+    it. A runnable end-to-end walkthrough ships as
+    <code>cargo run -p room-host --example data_room</code>: a real host on a real port, real
+    credentials, four acts.</p>
+    <p>Written against the implementation, not the design note — where the two differ, this page
+    follows the code.</p>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -1,0 +1,735 @@
+# Data rooms — creating one, and keeping it
+
+A **data room** is a shared space — a set of records — readable and writable by
+exactly the parties its credentials admit, for the humans in it and for their AI
+agents. It is not a row in some service's table: a room has its own DID, issues
+its own credentials, and can move from one host to another without a single
+credential being reissued.
+
+This guide is the operator's path through that: what you assemble, which of the
+four topologies you are building, and every verb you will use afterwards.
+
+> **Design and rationale** live in
+> [`../05-design-notes/data-rooms.md`](../05-design-notes/data-rooms.md) — the
+> four topologies, the visibility ladder, why MLS, why the host never decides.
+> The security reviews are
+> [v2](../05-design-notes/data-rooms-security-review-v2.md) (current) and
+> [v1](../05-design-notes/data-rooms-security-review-v1.md). This guide does not
+> repeat the arguments; it tells you which commands and calls make them true.
+>
+> **A running walkthrough** ships as an example:
+> `cargo run -p room-host --example data_room`. It starts a real host on a real
+> port, signs real credentials, and drives four acts against it. Read it beside
+> this guide — every mechanic below appears there, executable.
+
+---
+
+## 1. What a room is made of
+
+Five pieces. Getting them straight up front saves most of the confusion later,
+because three of them are commonly assumed to be one thing.
+
+| Piece | What it is | Who holds it |
+|---|---|---|
+| **The room** | A DID (`did:webvh`, ideally witnessed). Its identifier **is** the `roomId`. It issues every credential in the room. | Controlled by the **owner** |
+| **The host** | Stores records and answers `rooms/*` Trust Tasks. Holds no member list and could not consult one. | A VTC, or the `room-host` binary |
+| **The member's VTA** | Holds the member's room credentials, their MLS group state, and acts as an oracle for their agents. | Each member, separately |
+| **The credentials** | VIC to enter once, VMC to prove membership, VAC for what you may do. All issued **by the room**. | Each member's VTA |
+| **The MLS group** | The group-key layer on the sealed tiers. One leaf per member — the member's VTA, not their devices. | Each member's VTA |
+
+```mermaid
+graph TB
+    room["The room<br/>did:webvh:…<br/><i>issues every credential</i>"]
+    host["Host<br/>VTC or room-host<br/><i>stores ciphertext</i>"]
+    vta1["Alice's VTA<br/><i>credentials + MLS leaf</i>"]
+    vta2["Bob's VTA"]
+    agent["Alice's agent<br/><i>read-only, 4h</i>"]
+
+    room -->|"VMC + VAC"| vta1
+    room -->|"VMC + VAC"| vta2
+    room -.->|"service endpoint"| host
+    vta1 -->|"presentation, no session"| host
+    vta2 -->|"presentation, no session"| host
+    agent -->|"rooms/keys/present<br/>rooms/keys/open"| vta1
+    agent -->|"attenuated presentation"| host
+
+    classDef r fill:#e9d7f7,stroke:#7e3fa6,color:#3a0a5a
+    classDef h fill:#e8f5e9,stroke:#3e8e41,color:#1b3a1f
+    classDef v fill:#d4e6f9,stroke:#3a6fb0,color:#08305f
+    class room r
+    class host h
+    class vta1,vta2,agent v
+```
+
+**The one rule everything else follows from:** a room operation is authorized by
+the credential chain the room issued, verified against the room's own DID. Never
+by the host's ACL, never by a session, never by a roster. That is what lets a
+room change hosts by re-pointing a service endpoint — and it is why every call
+below carries a presentation rather than a bearer token.
+
+---
+
+## 2. What works today
+
+Rooms are implemented across `vti-rooms`, `vti-rooms-dtg`, `room-host`,
+`vtc-service` and `vta-service`. Not everything in the design note is built, and
+knowing which half you are standing on saves an afternoon.
+
+| | State |
+|---|---|
+| `open` and `attributed` rooms | **Serve.** Create, records, curate, epoch mint, transfer, claim |
+| `private` rooms | **Store but refuse to serve.** The same-subject binding needs a ZK profile the DTG working group has not settled; `vti-rooms-dtg` refuses rather than guessing, so a VTC and a room host cannot disagree about it |
+| MLS group layer, record sealing | **Work** (`vti-rooms` `mls` feature) — create, add/remove, commit, exporter-derived storage keys |
+| VTA custody: `rooms/keys/{key-package,welcome,commit,open}` | **Work.** A member's VTA holds the group and opens records for their agents |
+| The presentation oracle: `rooms/keys/present` | **Works.** Attenuates the member's own VAC for an agent |
+| Succession: nomination, transfer, claim | **Work**, including the "renewing defeats a pending claim" property |
+| **A CLI** | **None.** No `pnm rooms …`. Rooms are driven from `vtc-client` (Rust) or by posting signed Trust Task documents |
+| **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
+| **Governance (`rooms.rego`)** | **Not implemented.** `rooms/create/0.1` is ungated on both hosts — see §8.4 |
+| **Read mirrors** (T3) | **Not implemented.** One write-primary, and everyone reads from it |
+| **Witnessed renewal anchoring** | **Not implemented.** §9 of the design note makes this the owner's job, not the host's; nothing does it yet |
+
+---
+
+## 3. Choose a topology
+
+The room protocol is identical in all four. What differs is **where the room
+lives and who governs creation** — never what a room is.
+
+| | Room lives on | Members come from | Governed by | You deploy |
+|---|---|---|---|---|
+| **T1 Personal** | your own `room-host` | anyone you invite | you | the `room-host` binary (§8.1) |
+| **T2 Community** | a VTC | that community, typically | the community | nothing — a VTC already serves `rooms/*` (§8.2) |
+| **T3 Cross-community** | one home host | any communities' members | the home host | nothing beyond T2 (§8.3) |
+| **T4 Peer** | a peer's `room-host` | VRC-connected peers | the owner | the `room-host` binary (§8.4) |
+
+Two of these are nearly free. **T3 is T2 plus nothing** — a VMC binds a member
+to *the room*, so members from three communities in one room is the ordinary
+case rather than a bridge. **T4 is T1 with the VRC as the door.**
+
+Pick by asking two questions, in this order:
+
+1. **Who must not be able to read it?** If the answer includes the host, you are
+   on `attributed` (§4), and the room's DID should be owner-controlled.
+2. **Who is accountable for it existing?** That party is the owner. If it is a
+   community, use T2. If it is a person, use T1 — a personal host is governed by
+   its owner, and that sentence is the whole policy model.
+
+---
+
+## 4. Choose a visibility tier
+
+Fixed at creation, for the life of the room. You cannot un-see cleartext, so a
+downgrade is meaningless and an upgrade would protect only what came after while
+presenting as though it protected everything.
+
+| | `open` | `attributed` | `private` |
+|---|---|---|---|
+| Record bodies, titles | cleartext | encrypted | encrypted |
+| Which member is acting | visible to the host | visible to the host | unlinkable proof |
+| Server-side search | ✅ | ❌ | ❌ |
+| Per-member access log at the host | ✅ | ✅ | ❌ |
+| Recoverable from the host's backup alone | ✅ | ❌ | ❌ |
+| **Serves today** | ✅ | ✅ | ❌ (§2) |
+
+The ladder measures **the host, whoever that is**. On a room you host yourself,
+you-as-host see everything and already know the membership — you issued it — so
+the ladder largely collapses. Owner-hosting is not automatically the more
+private choice; a neutral host that *cannot* read is a real alternative.
+
+On the sealed tiers, **record keys must be opaque**. A key reading
+`decision/acquire-northwind` defeats the encryption sitting beside it — use
+`SealedRoom::opaque_key()` and put structured naming inside the sealed body.
+
+---
+
+## 5. Create a room
+
+Four steps. Steps 1 and 3 are the owner's own work; only step 2 touches a host.
+
+### 5.1 Mint the room's identity
+
+The room's DID is its identifier and its credential issuer, so it must be
+minted before anything else exists.
+
+**Production shape — `did:webvh` via the `room` DID template:**
+
+```bash
+pnm bootstrap provision-request \
+  --template room \
+  --var WEBVH_SERVER=https://dids.example.org \
+  --var MEDIATOR_DID=did:web:mediator.example.org \
+  --var 'LABEL=Northwind deal room' \
+  --out room-request.json
+
+pnm bootstrap provision-integration \
+  --request room-request.json \
+  --context personal \
+  --out room-bundle.asc
+
+pnm bootstrap open --bundle room-bundle.asc --expect-digest <sha256-from-producer>
+```
+
+`did:webvh` rather than `did:peer` on purpose: a `did:peer` encodes its keys in
+the identifier, so its controller can never change — and transferring a room is
+a controller change. Set `WITNESSES` for any room whose host you do not fully
+trust; witnessing is what makes a host serving a stale log *evident* rather than
+merely possible.
+
+> **Gap to know about:** no installer consumes a `room` bundle yet. `pnm
+> bootstrap open` prints the payload summary; extracting the room's signing key
+> to issue credentials with means opening the sealed payload yourself via
+> `vta_sdk::sealed_transfer`. Until that lands, most non-production rooms use a
+> locally-minted `did:key` (below), which also means the host needs no network
+> DID resolution at all.
+
+**Evaluation shape — a local `did:key`:** mint an Ed25519 key, form
+`did:key:z6Mk…`, and use that as both the room's identifier and its issuing key.
+`vti_rooms_dtg::test_support::RoomFixture` does exactly this, and it is what the
+`data_room` example runs on.
+
+### 5.2 Register the room with its host
+
+```rust
+use vtc_client::{VtcClient, rooms::Visibility};
+
+// A room host mounts at the origin; a VTC's base_url includes its mount (…/v1).
+let client = VtcClient::anonymous("https://rooms.example.org", host_did);
+
+client.create_room(
+    room_did,              // roomId — the room's own DID
+    owner_did,             // the accountable party (invariant I1)
+    Visibility::Attributed,
+    Some(365),             // retentionDays after the room goes dormant
+    signer_did,            // signs the Trust Task document
+    signer_key_multibase,
+).await?;
+```
+
+Over the wire that is one `rooms/create/0.1` document
+(`vta_sdk::trust_task_sign::build_signed` builds and signs it) posted to
+`/trust-tasks`. **The caller brings the `roomId`** — a room identified by
+something its host chose could not move to another host without changing
+identity.
+
+Two things bite anyone hand-building these documents rather than using the
+client. On a VTC the document's **`recipient` must be the VTC's own DID** — that
+binding is the framework's replay defence, and a document addressed elsewhere is
+rejected before it reaches a room handler. And a VTC's Trust Task endpoint rides
+its governed chain, with a **64 KiB body cap**, which is the practical ceiling on
+a single record there; the `room-host` binary imposes neither.
+
+The host sets what it is entitled to set and nothing else: `epoch = 1`,
+`epochExpiresAt = now + 365 days`, `retentionDays` (default **90**), and the
+version counter. It records the owner DID you gave it. It does not check that
+you are that owner — see §8.4.
+
+### 5.3 Issue the owner's own credentials
+
+The room is now registered and **nobody can do anything in it**, including you.
+Authority comes from credentials the room issued, so mint two with the room's
+key:
+
+- a **VMC** — the room's statement that this DID is a member;
+- a **VAC** granting `read`, `write`, `curate`, `admin`.
+
+```rust
+use dtg_credentials::DTGCredential;
+
+let mut vac = DTGCredential::new_vac(
+    room_did.to_string(),      // issuer: the room
+    owner_did.to_string(),     // subject: the member
+    room_did.to_string(),      // scope: the room governs itself
+    vec!["read".into(), "write".into(), "curate".into(), "admin".into()],
+    now - Duration::minutes(1),
+    Some(now + Duration::days(30)),
+)?;
+vac.sign(&room_secret, None).await?;
+```
+
+Then store both in the member's VTA credential vault:
+
+```bash
+pnm cred-vault receive --credential-file ./vmc.json
+pnm cred-vault receive --credential-file ./vac.json
+```
+
+This matters for more than tidiness: the presentation oracle (§7) finds a
+member's room credentials **by issuer** — `issuer == roomId`, type
+`MembershipCredential` / `AuthorityCredential` — and refuses if it holds none,
+or if it holds two of the same kind for one room.
+
+The four actions are a ladder with one deliberate break: **`curate` is not
+implied by `write`.** Deciding what a room's shared knowledge is worth is a
+different grant from being able to add to it. `admin` mints epochs and transfers
+ownership.
+
+### 5.4 On a sealed tier, form the MLS group
+
+```rust
+use vti_rooms::mls::RoomGroup;
+use vti_rooms::sealed::SealedRoom;
+
+let group = RoomGroup::create(owner_did)?;      // one leaf: the owner's VTA
+let room  = SealedRoom::new(room_did, group);
+```
+
+**The room's epoch is the MLS epoch plus one** — MLS counts from 0, a room from
+1 — so a group you have just created is already at the epoch the host recorded
+when it registered the room, and nothing needs minting yet. Read it from
+`SealedRoom::room_epoch()` rather than computing it; an off-by-one here seals
+records under an epoch the host rejects, and the failure reads as a key problem
+rather than an arithmetic one.
+
+After that, every membership change moves the group and the number has to follow
+(§6, §10.1). The host never learns the key — minting an epoch is an `admin`
+chain saying a number, not a key exchange.
+
+---
+
+## 6. Add a member
+
+Joining is a **two-party act**. Without an invitation step the owner could seal a
+room key into your VTA and you would simply be *in*, holding keys to material
+you never agreed to hold. The VIC is that second party's half, and it is
+enforced, not ceremonial.
+
+```mermaid
+sequenceDiagram
+    participant O as Owner
+    participant M as Member's client
+    participant V as Member's VTA
+    participant H as Host
+
+    O->>M: VIC (invitation, issued by the room)
+    M->>V: rooms/keys/key-package + invitation
+    V-->>M: KeyPackage (private half retained, 7 days)
+    M->>O: KeyPackage
+    O->>O: group.add_member(kp) → Welcome + Commit
+    O->>M: Welcome
+    M->>V: rooms/keys/welcome + invitation
+    V-->>M: epoch (invitation now consumed)
+    O->>H: rooms/epoch/mint (admin)
+    O->>M: VMC + VAC for the new member
+```
+
+Step by step:
+
+1. **The owner issues a VIC** naming the joiner, from the room's key, and
+   delivers it — DIDComm on a sealed room, because a server-side invitation
+   store would hand the host the membership at invite time.
+2. **The joiner's VTA mints a KeyPackage** (`rooms/keys/key-package/0.1`,
+   invitation required). Minting retains a private key against a Welcome that
+   may never come, which is why it is not offered unconditionally; unused
+   packages expire after 7 days.
+3. **The owner adds the leaf** — `RoomGroup::add_member(key_package)` produces a
+   Welcome and a Commit — and sends the Welcome to the joiner.
+4. **The joiner's VTA processes it** (`rooms/keys/welcome/0.1`, same invitation).
+   The invitation is consumed **after** the join succeeds, so a Welcome that
+   failed to process does not strand the member with a spent invitation and no
+   membership. Single use means single use, and the consumed record outlives
+   leaving the room.
+5. **The owner mints the new epoch** on the host and **issues the member's VMC +
+   VAC**, which the member stores in their own VTA (§5.3).
+
+Five checks stand behind the invitation, and none is optional: it parses as a
+DTG credential and is an invitation; its proof verifies; the issuer is *this*
+room; the subject is *us*; it is in its window and unconsumed.
+
+### Commits are not optional, and their absence is silent
+
+Every membership change after the first produces a Commit, and **every existing
+member's VTA must apply it** (`rooms/keys/commit/0.1`). A member who misses one
+is stuck at their last epoch and can open nothing sealed after it. The symptom
+is "this record does not open", which reads like corruption — so
+`rooms/keys/open` reports *which epoch the VTA holds* when a record is sealed
+under a later one. If you see that, deliver the missing commit.
+
+Commits are authorized **inside the group** by MLS, not by any ACL of the
+receiving VTA. A VTA has no opinion about who a room's owner is, and should not
+acquire one.
+
+---
+
+## 7. Give an agent access
+
+The case rooms were designed for: a member holds `read`/`write`, and their agent
+runs on a chain one link longer whose leaf confers only `read`, expires in
+hours, and is bound to the agent. The agent never holds the member's
+credentials, and never holds a key at all.
+
+The member's VTA does both halves:
+
+| Task | What it does | Gate |
+|---|---|---|
+| `rooms/keys/present/0.1` | Attenuates the principal's VAC into a one-action, audience-bound leaf and returns a presentation | `roomPresent` capability + context access |
+| `rooms/keys/open/0.1` | Takes ciphertext, returns plaintext | `roomOpen` capability |
+
+```jsonc
+// rooms/keys/present/0.1 payload
+{
+  "roomId":  "did:webvh:…",
+  "action":  "read",              // exactly one; required
+  "audience": "did:web:rooms.example.org",   // bind it to the host you will call
+  "nonce":   "…"                   // optional
+}
+```
+
+Four things a caller **cannot** obtain by asking, each closing a way this could
+have become the credential hand-off it exists to replace:
+
+- **More than the principal holds** — `attenuate` refuses to widen, in the
+  credential library, not at a policy check somebody could forget to write.
+- **A presentation covering everything** — `action` is required and exactly one
+  action is conferred.
+- **A presentation made out to somebody else** — the leaf grants to the DID the
+  *transport* authenticated, never one named in the payload. Minted for A, it is
+  worthless to B.
+- **A long-lived leaf** — the lifetime is a constant (4 hours), not a request
+  parameter.
+
+> **Operational catch.** These gates read the caller's **role**, and
+> `Role::Application` — the role `vta-agent-memory` grants its agents — does
+> **not** carry `roomPresent` or `roomOpen`. Today an agent that needs the
+> oracle must hold `initiator` (or `admin`), which is broader than the design
+> intends. Worth knowing before you scope an agent's ACL entry.
+
+Withdrawing an agent's access is withdrawing it *at the VTA* — remove the ACL
+entry and no further presentations are minted. That is the whole value of an
+oracle over handing credentials across: there is a place to say no.
+
+---
+
+## 8. Run the host
+
+### 8.1 T1 — your own room host
+
+```bash
+cargo build --release -p room-host
+
+room-host \
+  --data-dir /var/lib/room-host \
+  --listen 127.0.0.1:8300 \
+  --resolve-dids           # required for did:webvh rooms; see below
+```
+
+- **`--resolve-dids` is off by default and is a real decision.** A room's
+  credentials are normally issued by a `did:webvh` room, so a host without it
+  serves almost nothing — but turning it on means an *unauthenticated* request
+  can make this host fetch. `did:key`-only is the conservative construction and
+  is what the example and the tests run on.
+- **The binary is deliberately thin.** No TLS, no rate limiter, no admin
+  surface, no roster, and no body cap of its own beyond axum's 2 MB default. Put
+  it behind a reverse proxy that provides the first two. The absence of the
+  roster is the portability guarantee: there is nothing in the binary that could
+  consult one.
+- **It is not part of the VTA, on purpose.** The process guarding a master seed
+  should not also terminate presentations from arbitrary DIDs. If you want the
+  host to have its own identity for addressing, provision it with the
+  `room-host` DID template (`WEBVH_SERVER`, `URL`, `MEDIATOR_DID`) — though
+  nothing in the binary consumes that bundle yet, since it verifies presentations
+  and signs nothing.
+- **Storage** is a plain fjall store under `--data-dir`, unencrypted at rest. On
+  `attributed`/`private` the records are already sealed; on `open` they are
+  cleartext, so the data directory deserves the same care as any content store.
+  Back it up yourself — there is no export task.
+- **Audit** goes to `tracing`. Which actor may be recorded is decided in
+  `vti_rooms::audit`, shared with the VTC, so a `private` room logs that *a
+  member* acted and never who. Do not add the DID back in your own log pipeline;
+  that single line reassembles the membership one entry at a time.
+
+### 8.2 T2 — a community (VTC)
+
+Nothing to deploy. A `vtc-service` serves the whole `rooms/*` family in-process
+at `POST /v1/trust-tasks`, on the unauthenticated chain — which is correct here,
+because on every verb but `create` (§8.4) the caller is authenticated by the
+document's own proof and authorized by the room's chain, never by the
+community's ACL or a session.
+
+- **Keyspaces**: `rooms` (one row per room) and `room_records`. Both are in
+  `BACKED_UP`, so `POST /v1/backup/export` captures them.
+- **Audit**: room operations land in the VTC's hash-chained audit keyspace, with
+  the same tier rule as above.
+- **Governance** (`rooms.rego` — which tiers a community permits, member counts,
+  hosting axes) is designed but **not implemented**; see §8.4.
+
+Members of a T2 room do not need to be members of the community. Community
+membership is meant to govern *who may create a room here* — that is what
+`rooms.rego` will decide once it lands — while room membership is, and stays,
+the room's own statement.
+
+### 8.3 T3 — cross-community
+
+T3 is T2 with members from anywhere: a VMC binds a member to **the room**, so a
+room whose members come from three communities needs no bridging and no special
+configuration. Register the room on whichever host is the home, and every
+member's VTA presents to that one.
+
+What is *not* built is the optional half: **read mirrors** — other hosts holding
+ciphertext copies fed by `sinceVersion` pulls. Until they exist, T3 means one
+write-primary that everyone also reads from. Multi-primary replication is a
+non-goal, not a gap: replicated multi-writer room state needs state-resolution
+machinery whose failure modes took Matrix years to shake out.
+
+### 8.4 T4 — peers, and the caveat that applies to every topology
+
+T4 runs the same binary as T1; what differs is the door — a VRC-linked peer
+rather than an invitation you originated — and that nobody governs creation but
+the owner.
+
+**The caveat, stated once for all four:** `rooms/create/0.1` is **not
+authorized** on either host today. The document's proof is not checked on that
+verb, the signer is not compared to `ownerDid`, and no policy consults anything.
+Anyone who can reach the endpoint can register a room row — squatting a `roomId`
+or filling storage. Every *other* verb verifies the document proof and the
+authority chain. Until governance lands, treat a room host's endpoint as
+something to put behind a proxy you control, and do not expose a personal room
+host to the open internet.
+
+---
+
+## 9. Use the room
+
+All record verbs carry a presentation and no token. `RoomSession` holds the
+credentials — build one per room per identity; a member's and their agent's are
+different sessions against the same room, differing only in the chain.
+
+```rust
+use vtc_client::rooms::{RoomSession, CleartextContent, SealedContent};
+
+let alice = RoomSession::new(room_did, membership_vmc, chain_leaf_first)?;
+```
+
+The chain travels **leaf first**, whole, on every call. A host never fetches a
+link it was not given: resolving one over the network would make verification
+depend on availability, turn an identifier into a request the host can be
+induced to make against an address the *caller* chooses, and signal credential
+use to whoever hosts it. Depth is capped at `MAX_CHAIN_DEPTH` (8).
+
+| Verb | Task URI | Needs |
+|---|---|---|
+| Write | `rooms/records/put/0.1` | `write` |
+| Read | `rooms/records/get/0.1` | `read` |
+| List | `rooms/records/list/0.1` | `read` |
+| Curate | `rooms/records/curate/0.1` | `curate` |
+| Mint an epoch | `rooms/epoch/mint/0.1` | `admin` |
+| Transfer ownership | `rooms/owner/transfer/0.1` | `admin` |
+| Claim ownership | `rooms/owner/claim/0.1` | a nomination (§10) |
+
+**Writing on an `open` room** carries `cleartext` (`title`, `description`,
+`body`, `tags`); on a sealed room it carries `sealed` (`ciphertext`, `nonce`,
+`epoch`). Exactly one — the host refuses the wrong shape for the tier.
+
+**`expectedVersion` is the concurrency control.** `Some(0)` is create-only;
+`Some(n)` requires the stored record to be at version `n`, and a mismatch comes
+back carrying the current version so you do not have to re-read to learn what
+you lost to. Versions are assigned by the host, monotonic per **room**, which is
+what `sinceVersion` watermarks compare.
+
+**Sealing binds a record to its location.** The AEAD associated data commits to
+`roomId | key | version | epoch`, so a host that relocates a record — to another
+key, version, epoch, or room — produces an authentication failure rather than a
+readable record. It holds every byte and cannot move one.
+
+That binding has a consequence worth planning for: **the version is committed
+before the host assigns it.** `seal_record` takes the version you *intend*, so
+the shapes that work are create-only writes (`expectedVersion: 0`) or a read of
+the current version before a rewrite.
+
+**Listing returns metadata, never bodies.** On sealed tiers clients fetch and
+decrypt to rank, which is affordable because rooms are small — and is one
+concrete reason `open` continues to exist.
+
+**Curation** (`status` → `active` / `deprecated` / `retracted`, plus `pinned`) is
+separate from writing because a record's *standing* is not its content: on a
+sealed tier "same body, marked deprecated" would otherwise make a member re-seal
+and re-upload bytes the host already holds. A curation assigns a new version —
+a change others must converge on is a change like any other. `retracted` is a
+tombstone: the body goes, the key/version/epoch stay, so incremental sync
+converges instead of resurrecting deletions.
+
+**Bodies are human-readable markdown**, written for the human and recalled by
+the agent — and treated as **untrusted input in both directions**. A room is a
+writable channel into every member's agent context, and a phishing channel into
+every member's eyes. Render inert; fence recalled content as data, never
+instructions.
+
+---
+
+## 10. Keep it alive, and hand it on
+
+### 10.1 The lifecycle clock
+
+```text
+  Live  ──epoch expires──▶  Lapsed  ──30 days──▶  Dormant  ──retention──▶  Reclaimable
+   ▲                          │                      │                        │
+   └──────────────────────────┴──────────────────────┴─── a single renewal ───┘
+```
+
+- **Live** — normal. A new room is live for one epoch lifetime: **365 days**.
+- **Lapsed** — read-only. Nothing destroyed, nothing hidden.
+- **Dormant** — 30 days past lapse. The owner should have been told, and this is
+  the state a successor can claim in (§10.2).
+- **Reclaimable** — the `retentionDays` you stated at creation has run out,
+  counted from the lapse and never sooner than the dormancy window, so a short
+  retention cannot reclaim a room before its owner has had the notice. Even
+  here the code only reports; deleting is a separate deliberate act.
+
+The state is **computed, never stored** — a stored state is a decision somebody
+made and can get wrong. Renewal is minting an epoch, and it undoes every earlier
+state up to the last. **Reads do not extend anything**, deliberately: a host
+counting reads would make a sealed room's lifecycle depend on the one signal the
+host can see, which is exactly the correlation the tiers exist to deny.
+
+```rust
+client.mint_epoch(&alice, next_epoch, Some("added a member"), signer, key).await?;
+```
+
+The design also wants each renewal **anchored in the room's witnessed DID log**
+(the MLS epoch authenticator plus the version watermark), which is what makes a
+host claiming a live room lapsed, a forked group, and a rolled-back mirror all
+detectable. That is the owner's job, not the host's, and it is not implemented —
+`RoomGroup::epoch_authenticator()` gives you the value if you want to anchor it
+yourself.
+
+### 10.2 Ownership: transfer and claim
+
+Two verbs, the same storage effect, entirely different routes.
+
+**Transfer** is the owner acting while present, gated on `admin` — the same
+grant that mints epochs, because handing over the room is the more consequential
+of the two.
+
+```rust
+client.transfer_owner(&alice, new_owner_did, Some("stepping back"), signer, key).await?;
+```
+
+The host does **not** check that the incoming owner is a member of the group. It
+cannot — it holds no roster and no group state. Refusing what it cannot verify
+would fail every correct transfer, and treating its own ignorance as evidence
+would convert "I don't know" into "no". That obligation is the outgoing owner's,
+who can see the group.
+
+**Claim** is what happens when the owner is not there, and it needs three things
+at once:
+
+1. a **nomination** the room issued, naming this claimant, in its window;
+2. the room **dormant** — not merely lapsed;
+3. the claimant's **own membership**, presented as every other room task does.
+
+A nomination is a VAC granting `succeed` — a word no room task accepts, so it
+confers nothing at all while the owner is present, and is redeemable through
+exactly one path. Issue it like any other room credential, from the room's key:
+
+```rust
+let mut nomination = DTGCredential::new_vac(
+    room_did.to_string(),        // issuer: the room
+    successor_did.to_string(),   // subject: who may claim
+    room_did.to_string(),
+    vec![vti_rooms::authz::ACTION_SUCCEED.into()],
+    now - Duration::minutes(1),
+    Some(now + Duration::days(365)),   // give it a real window
+)?;
+nomination.sign(&room_secret, None).await?;
+```
+
+Give it to the nominee and to nobody else; a claim presents it alongside their
+own membership.
+
+**Renewing is the whole defence, and it is the same act as ordinary use.** An
+owner who was merely away defeats every pending claim by minting an epoch —
+which is what they would have done anyway. Nothing has to be revoked and no
+dispute has to be raised. That is why the gate is dormancy rather than lapse: a
+window that opened the moment an epoch expired would make every holiday one.
+
+**A claim does not renew the room.** It hands over a dormant room and leaves it
+dormant; the new owner's first act should be the epoch mint that proves they can
+perform it. If they cannot, the next nominee can claim in turn — the succession
+chain working rather than failing.
+
+### 10.3 Losing a member, and losing everyone
+
+A member who loses their VTA lost their MLS leaf. The design's answer is
+**k-of-n re-admission** — some members attest the returning party and the owner
+commits an add for their new leaf; not secret sharing, because what needs
+distributing is the *authority to re-admit*, not shards of a key. No quorum
+machinery is implemented, so today this is the owner adding a fresh leaf on
+whatever assurance they are willing to act on, which is the same human judgement
+the quorum would formalise.
+
+If every member's VTA is gone, **the room is gone.** The host holds ciphertext
+and cannot help. Say this at creation, not in a footnote.
+
+Which is why `room_groups` and `room_invitations` are in the VTA's `BACKED_UP`
+set — that is a decision, not a default. A member who restores a VTA without
+their room groups has lost every sealed room they belong to, with no way to
+recover but a fresh invitation from every owner.
+
+---
+
+## 11. When something is refused
+
+| Refusal | What it usually means |
+|---|---|
+| `a private room must not be served without a ZK profile` | The tier is not servable yet (§2). Use `attributed` |
+| the chain "does not confer this on room …" | Wrong action for the chain (agent with `read` writing), or a chain rooted somewhere other than this room |
+| a valid-looking presentation refused on a *different* signer | Presentations are bound to the presenter. A captured one is worthless — this is working as intended |
+| `this VTA holds no AuthorityCredential issued by room …` | The member's VMC/VAC are not in the credential vault (§5.3) |
+| `this VTA holds N AuthorityCredentials issued by room …` | Two credentials of one kind for one room; the oracle will not guess which to attenuate |
+| record "does not open", VTA reports an older epoch | A missed commit (§6). Deliver it |
+| `no invitation presented for room …` | `key-package`/`welcome` without the VIC, or the VIC names someone else |
+| `invitation … has already been used` | Single use. Issue a fresh one |
+| a room "is live" / "not claimable" | The owner renewed. The claim is correctly dead |
+| `unsupportedType` | The host does not implement that task — check you are talking to a room host and not something else on the same port |
+| Every call fails on `missing field 'id'` | You are posting a bare JSON body. Room calls are Trust Task **documents** — build them with `vta_sdk::trust_task_sign::build_signed` |
+
+---
+
+## 12. Reference
+
+**Host tasks** (`https://trusttasks.org/spec/rooms/…`), served by `room-host`
+and `vtc-service`:
+
+| URI | Action required |
+|---|---|
+| `rooms/create/0.1` | *(ungated — §8.4)* |
+| `rooms/records/put/0.1` | `write` |
+| `rooms/records/get/0.1` | `read` |
+| `rooms/records/list/0.1` | `read` |
+| `rooms/records/curate/0.1` | `curate` |
+| `rooms/epoch/mint/0.1` | `admin` |
+| `rooms/owner/transfer/0.1` | `admin` |
+| `rooms/owner/claim/0.1` | nomination + membership + dormancy |
+
+**Member-VTA tasks** (`https://trusttasks.org/spec/rooms/keys/…`), served by
+`vta-service`:
+
+| URI | Authorized by |
+|---|---|
+| `rooms/keys/key-package/0.1` | an invitation |
+| `rooms/keys/welcome/0.1` | that invitation, consumed |
+| `rooms/keys/commit/0.1` | the MLS group itself |
+| `rooms/keys/open/0.1` | `roomOpen` capability |
+| `rooms/keys/present/0.1` | `roomPresent` capability + context access |
+
+**Constants**
+
+| | Value | Where |
+|---|---|---|
+| Epoch lifetime | 365 days | `vti_rooms::lifecycle::DEFAULT_EPOCH_LIFETIME_DAYS` |
+| Lapsed → dormant | 30 days | `DORMANT_AFTER_LAPSE_DAYS` |
+| Default retention | 90 days | host-side default for `retentionDays` |
+| Max chain depth | 8 | `vti_rooms::authz::MAX_CHAIN_DEPTH` |
+| Minted presentation lifetime | 4 hours | `room_oracle::PRESENTATION_LIFETIME` |
+| Unused KeyPackage lifetime | 7 days | `room_group::KEY_PACKAGE_LIFETIME_SECS` |
+
+**Crates**
+
+| | |
+|---|---|
+| `vti-rooms` | Storage, wire types, authorization, lifecycle, audit-actor rule; `mls` + sealing behind the `mls` feature |
+| `vti-rooms-dtg` | The credential half — chain verification, invitation and nomination checking, `RoomFixture` test support |
+| `room-host` | The standalone host binary (T1/T4) and the `data_room` example |
+| `vtc-service` | The same family in-process (T2/T3) |
+| `vta-service` | Member-side custody and the oracle (`operations::{room_oracle,room_groups,room_invitation}`) |
+| `vtc-client` | `RoomSession` and the client methods, with `mls` for the group layer |

--- a/docs/05-design-notes/data-rooms-concept.html
+++ b/docs/05-design-notes/data-rooms-concept.html
@@ -569,14 +569,18 @@
   <section class="col">
     <p class="eyebrow">Status</p>
     <h2>Where this stands</h2>
-    <p>Design revision 3, on the <code>design/community-data-rooms</code> branch of
+    <p>Design revision 3 in
     <a href="https://github.com/OpenVTC/verifiable-trust-infrastructure">verifiable-trust-infrastructure</a>
     (<code>docs/05-design-notes/data-rooms.md</code>), with two adversarial security reviews —
-    the first reshaped the design; the second examined what emerged. Nothing is implemented.
-    The path runs: one question to the DTG working group (do VMC/VIC bind to node
-    <em>kinds</em> or to deployed services?), the VAC specification, a host-neutral
-    <code>rooms/*</code> task family, then the tiers in order — <span class="tiername">open</span>
-    first, cryptography on top of a settled model.</p>
+    the first reshaped the design; the second examined what emerged. <strong>Most of it is now
+    built:</strong> the host-neutral <code>rooms/*</code> family serves from both a community
+    service and a standalone room host, member-side key custody and the presentation oracle run in
+    the agent, and succession works end to end. Still open: the
+    <span class="tiername">private</span> tier's zero-knowledge profile — which turns on the one
+    question still with the DTG working group (do VMC/VIC bind to node <em>kinds</em> or to
+    deployed services?) — plus community governance of room creation, read mirrors, and anchoring
+    renewals in the room's witnessed log. The operator guide is
+    <code>docs/02-vta/data-rooms.md</code>.</p>
     <p>Feedback most wanted on: the VAC (§ above), the witness-selection policy for room logs,
     and whether the four topologies match how your community would actually use this.</p>
   </section>

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -1,7 +1,15 @@
 # Data rooms
 
-Status: **design, revision 3.** Nothing is implemented. The upstream spec work
-has not started.
+Status: **revision 3, largely implemented.** The `rooms/*` family is served by
+`vtc-service` and by the standalone `room-host` binary, with member-side key
+custody and the presentation oracle in `vta-service` (#1237–#1251). Still open:
+the `private` tier's zero-knowledge profile, `rooms.rego` governance, read
+mirrors, and witnessed renewal anchoring — §2 of the operator guide is the
+current line between built and designed.
+
+Operator guide: [`../02-vta/data-rooms.md`](../02-vta/data-rooms.md) — how to
+create a room, run each topology, add members, equip an agent, renew, and hand
+ownership on.
 
 A **data room** is a shared, credential-governed, end-to-end-encryptable space —
 a set of records held somewhere, readable and writable by exactly the parties

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ VTA via the `vtc-host` DID template.
 | Provision a mediator / webvh-host / custom integration | [Provision-integration](02-vta/provision-integration.md) |
 | Require a second person to approve an operation | [Approvals](02-vta/approvals.md) |
 | Understand the consent ceremony (DTTE) end to end | [Task consent](02-vta/task-consent.md) |
+| Create or run a data room | [Data rooms](02-vta/data-rooms.md) |
 | Configure community membership policy | [VTC community lifecycle](03-vtc/community-lifecycle.md) |
 | Host a public community website | [VTC website + admin UX](03-vtc/website-and-admin.md) |
 | Deploy a trust registry and wire a VTC to it | [Trust-registry deployment](03-vtc/trust-registry-deployment.md) |
@@ -118,6 +119,10 @@ How to operate, deploy, and integrate against a VTA.
   format, rotation, hosting.
 - **[Personal AI agents](02-vta/personal-ai-agents.md)** — provisioning
   an agent its own identity, context, capabilities and kill switch.
+- **[Data rooms](02-vta/data-rooms.md)** — creating a room and
+  keeping it: the four topologies, the visibility tiers, inviting
+  members, equipping an agent through the oracle, renewal and
+  succession, and running a host.
 - **[vta-mcp](02-vta/vta-mcp.md)** — using a VTA from an MCP host
   (Claude Code, Claude Desktop, an agent framework): what it exposes,
   the security model, hardening flags, and how to see what it is doing.
@@ -186,7 +191,8 @@ are implementer-facing rather than operator-facing.
   topologies (personal VTA, in a VTC, cross-community, VRC peers), a
   three-tier visibility ladder (`open`/`attributed`/`private` with
   unlinkable BBS+ presentations), MLS (RFC 9420) as the group-key layer,
-  witnessed room DID logs, and renew-not-reap lifecycle. Design only.
+  witnessed room DID logs, and renew-not-reap lifecycle. The operator
+  path through it is [Data rooms](02-vta/data-rooms.md).
 - **[Data rooms — concept document](05-design-notes/data-rooms-concept.html)** —
   shareable, non-technical-audience write-up of the idea, benefits, design
   and the case for the VAC, with diagrams of the four topologies, the


### PR DESCRIPTION
Data rooms shipped across nine PRs (#1237–#1251) with no operator documentation. The doc set was a design note, two security reviews and a concept page — none of which tells anyone how to create a room or run a host. This adds the missing guide, **written against the implementation rather than the design note**.

### What's here

- **`docs/02-vta/data-rooms.md`** — the guide, covering all four topologies end to end: the pieces a room is made of, choosing a topology and a visibility tier, creating the room (identity → registration → the owner's own credentials → the MLS group), adding a member, equipping an agent through the oracle, using records, renewal, transfer and claim, running each kind of host, a refusal-to-cause table, and a reference of task URIs, gates and constants.
- **`docs/02-vta/data-rooms-guide.html`** — the same path as a readable page, in the concept document's design language, with diagrams of the four topologies, who calls what, and the lifecycle clock.
- **`docs/README.md`** — a Part II entry, an "If you're trying to…" row, and the design-note entry now points at the guide.

### Four things verification turned up

Checking every claim against the code found four worth stating rather than smoothing over. The guide names all of them:

| | |
|---|---|
| `rooms/create/0.1` is authorized by nothing | On both hosts: the document's proof is not checked on that verb, the signer is not compared to `ownerDid`, and no policy consults anything. Anyone who can reach the endpoint can register a room row. Every *other* verb verifies properly |
| `Role::Application` carries neither `roomPresent` nor `roomOpen` | The role agent integrations run as cannot use the oracle built for agents; today that needs `initiator` or `admin`, which is broader than the design intends |
| No installer consumes a `room` or `room-host` bundle | The templates mint the DID shape, but extracting the room's signing key to issue credentials with means opening the sealed payload by hand |
| The room epoch is the MLS epoch plus one | The off-by-one that seals records under an epoch the host rejects — and the failure reads as a key problem, not an arithmetic one |

### Stale status corrected

`docs/05-design-notes/data-rooms.md` still opened with *"Nothing is implemented. The upstream spec work has not started"* while its own §10 described succession as implemented; the concept HTML said the same and named a branch that no longer exists. Both now say what is built and what is not.

Docs only — no code, no version edits.