### PR TITLE
fix(rooms): authorize registering a room, which nothing did

### DIFF
--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -112,15 +112,23 @@ impl HostState {
         &self.rooms
     }
 
+    /// The presenter — proven by the document's own proof, never claimed in its payload.
+    ///
+    /// Split out from [`Self::presenter_and_verifier`] because `rooms/create` needs this half
+    /// and only this half: a room that does not exist yet has issued no credentials, so there
+    /// is no chain to judge and nothing for a verifier to do.
+    async fn presenter(&self, doc: &TrustTask<Value>) -> Result<String, AppError> {
+        vti_common::auth::di_proof::verify_trust_task_proof_with(doc, &self.resolver)
+            .await
+            .map_err(|e| AppError::Forbidden(format!("request proof: {e}")))
+    }
+
     /// The presenter — proven, not claimed — and the verifier to judge their chain with.
     async fn presenter_and_verifier(
         &self,
         doc: &TrustTask<Value>,
     ) -> Result<(String, DtgChainVerifier), AppError> {
-        let presenter =
-            vti_common::auth::di_proof::verify_trust_task_proof_with(doc, &self.resolver)
-                .await
-                .map_err(|e| AppError::Forbidden(format!("request proof: {e}")))?;
+        let presenter = self.presenter(doc).await?;
 
         Ok((
             presenter,
@@ -274,9 +282,25 @@ async fn create(
             );
         }
     };
+    // The one operation no chain can authorize, and therefore the one that needs its own
+    // check: the room has issued nothing yet, so all this host has is who signed the
+    // request. `authorize_create` lives in `vti-rooms` so this host and a VTC cannot come to
+    // different conclusions about who may register a room.
+    let presenter = match state.presenter(doc).await {
+        Ok(p) => p,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let authorized = match authz::authorize_create(&req.room_id, &req.owner_did, &presenter) {
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
+
     let room = Room {
-        room_id: req.room_id.clone(),
-        owner_did: req.owner_did,
+        room_id: authorized.room_id().to_string(),
+        // From the authorization, not the payload. They are equal — that is what was just
+        // checked — and reading it from here is what keeps them equal if this ever grows a
+        // second way to be authorized.
+        owner_did: authorized.owner_did().to_string(),
         visibility: req.visibility,
         epoch: 1,
         next_version: 1,
@@ -896,6 +920,78 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK, "{body}");
+    }
+
+    /// Registration is the one verb no chain can authorize, so the proof on the request
+    /// is the whole of its defence — and `ownerDid` is a payload field until something
+    /// checks it against the signer.
+    #[tokio::test]
+    async fn a_room_cannot_be_registered_in_somebody_elses_name() {
+        let (_d, st) = state();
+        let app = router(st.clone());
+        let f = RoomFixture::new(Visibility::Open).await;
+        let mallory = Party::new();
+
+        let (status, body) = call(
+            &app,
+            ROOMS_CREATE_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "ownerDid": f.room.owner_did,
+                "visibility": f.room.visibility,
+            }),
+            &mallory,
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+
+        // And nothing was stored: a refused registration must not leave the id taken,
+        // or refusing it would still deny the room to its owner.
+        assert!(
+            vti_rooms::storage::get_room(st.rooms(), &f.room.room_id)
+                .await
+                .is_err(),
+            "a refused registration must not create the room"
+        );
+
+        // The owner's own registration still works, which is what makes the check a gate
+        // rather than a wall.
+        register(&app, &f).await;
+    }
+
+    /// A document with no proof has no presenter, and a registration nobody signed
+    /// records an owner nobody proved.
+    #[tokio::test]
+    async fn an_unsigned_registration_is_refused() {
+        let (_d, st) = state();
+        let app = router(st);
+        let f = RoomFixture::new(Visibility::Open).await;
+
+        let doc = serde_json::json!({
+            "id": "urn:uuid:unsigned",
+            "type": ROOMS_CREATE_TYPE,
+            "issuer": f.room.owner_did,
+            "recipient": "did:key:zHost",
+            "payload": {
+                "roomId": f.room.room_id,
+                "ownerDid": f.room.owner_did,
+                "visibility": f.room.visibility,
+            },
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/trust-tasks")
+                    .header("content-type", "application/json")
+                    .body(Body::from(doc.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::OK,
+            "an unsigned registration must not be accepted"
+        );
     }
 
     #[tokio::test]

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -131,9 +131,25 @@ pub(crate) async fn handle_create(state: &AppState, doc: TrustTask<Value>) -> Tr
         Err(resp) => return resp,
     };
 
+    // The one room operation no chain can authorize: the room has issued nothing yet, so all
+    // this service has is the proof on the request. That proof is what makes `ownerDid` a
+    // fact rather than a field — and the decision itself lives in `vti-rooms`, so a room host
+    // and this service cannot disagree about who may register a room.
+    let presenter = match verify_trust_task_proof(state, &doc).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let authorized = match authz::authorize_create(&req.room_id, &req.owner_did, &presenter) {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
     let room = Room {
-        room_id: req.room_id.clone(),
-        owner_did: req.owner_did,
+        room_id: authorized.room_id().to_string(),
+        // Read from the authorization rather than the payload. The two are equal — that is
+        // what was just established — and taking it from here is what keeps them equal if
+        // this ever grows a second way to be authorized.
+        owner_did: authorized.owner_did().to_string(),
         visibility: req.visibility,
         epoch: 1,
         next_version: 1,
@@ -707,6 +723,48 @@ mod tests {
             .await,
         )
         .await
+    }
+
+    /// The community half of the same gate. Registration is the one verb no chain can
+    /// authorize — the room has issued nothing yet — so the request's own proof is what
+    /// makes `ownerDid` a fact rather than a field anyone can fill with anyone.
+    #[tokio::test]
+    async fn a_room_cannot_be_registered_in_somebody_elses_name() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+        let mallory = vti_rooms_dtg::test_support::Party::new();
+
+        let out = handle_create(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_CREATE_TYPE,
+                json!({
+                    "roomId": f.room.room_id,
+                    "visibility": f.room.visibility,
+                    "ownerDid": f.room.owner_did,
+                }),
+                &mallory.did,
+                &mallory.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            !out.status.is_success(),
+            "a signer who is not the named owner must be refused: {}",
+            payload_of(&out)
+        );
+        assert!(
+            vti_rooms::storage::get_room(&state.rooms_ks, &f.room.room_id)
+                .await
+                .is_err(),
+            "a refused registration must not leave the identifier taken"
+        );
+
+        // The owner's own registration still succeeds — a gate, not a wall.
+        assert!(create(state, &f).await.status.is_success());
     }
 
     #[tokio::test]

--- a/vti-rooms/src/authz.rs
+++ b/vti-rooms/src/authz.rs
@@ -209,6 +209,99 @@ impl AuthorizedAction {
     }
 }
 
+/// Proof that [`authorize_create`] ran and allowed a room to be registered.
+///
+/// Separate from [`AuthorizedAction`] because creating a room is the one operation no chain
+/// can authorize: at the moment it runs the room has issued nothing, so there is no
+/// credential in the world that speaks for it. The typestate is the same, though — a handler
+/// takes this rather than a payload, so a create that skipped the check does not compile.
+#[derive(Debug)]
+pub struct AuthorizedCreate {
+    room_id: String,
+    owner_did: String,
+}
+
+impl AuthorizedCreate {
+    /// The room being registered.
+    pub fn room_id(&self) -> &str {
+        &self.room_id
+    }
+    /// Its owner — necessarily also the party that signed the request.
+    pub fn owner_did(&self) -> &str {
+        &self.owner_did
+    }
+}
+
+/// Authorize registering a room: the presenter must be the party they name as owner.
+///
+/// # Why this is the check, and what it deliberately is not
+///
+/// Every other room operation is authorized by a chain the room issued. Create cannot be.
+/// The only signal a host has is the proof on the request document, so the only thing it can
+/// check is that the party signing is the party being recorded as accountable — and it must
+/// check that, because `ownerDid` is otherwise a field anyone can fill with anyone, and a
+/// host that took it on trust would record an owner nobody proved.
+///
+/// What this does **not** establish is control of the identifier. A party can still register
+/// a `roomId` they do not control while naming themselves owner, and so deny that id to its
+/// real owner on this host. That squat is a nuisance rather than a takeover — the row it
+/// creates confers nothing, because every subsequent verb needs credentials the real room
+/// issued and a squatter cannot mint them — and bounding it is quota and access control,
+/// which is the availability row of the trust model and belongs to whoever hosts. Proving
+/// control would mean the *room itself* signing its own registration; that is a stronger
+/// check, deliberately not required here, because it would exclude every owner whose room
+/// key is held somewhere that cannot sign a request document.
+///
+/// Failures are [`AppError::Forbidden`], as everywhere else in this file.
+pub fn authorize_create(
+    room_id: &str,
+    owner_did: &str,
+    presenter: &str,
+) -> Result<AuthorizedCreate, AppError> {
+    if room_id.trim().is_empty() {
+        return Err(AppError::Forbidden(
+            "a room must be registered under an identifier its owner minted".into(),
+        ));
+    }
+    if owner_did.trim().is_empty() {
+        return Err(AppError::Forbidden(
+            "a room must name an owner: it is the accountable party, and a room without one \
+             is a room nobody can be addressed about"
+                .into(),
+        ));
+    }
+    if presenter.trim().is_empty() {
+        return Err(AppError::Forbidden(
+            "no authenticated presenter; a registration nobody signed records an owner \
+             nobody proved"
+                .into(),
+        ));
+    }
+
+    // Compared with any fragment removed from either side. A proof's `verificationMethod`
+    // names a key *within* a DID document (`did:key:z6Mk…#z6Mk…`) while an owner is a DID,
+    // so a literal comparison would refuse correct requests depending on how the signer was
+    // spelled.
+    if did_of(presenter) != did_of(owner_did) {
+        return Err(AppError::Forbidden(format!(
+            "this registration was signed by `{}`, which is not the owner it names; a room \
+             is registered by the party accountable for it",
+            did_of(presenter)
+        )));
+    }
+
+    Ok(AuthorizedCreate {
+        room_id: room_id.trim().to_string(),
+        owner_did: did_of(owner_did).to_string(),
+    })
+}
+
+/// A DID with any verification-method fragment removed.
+fn did_of(did: &str) -> &str {
+    let did = did.trim();
+    did.split('#').next().unwrap_or(did)
+}
+
 /// Authorize `action` on `room` from `presentation`.
 ///
 /// Returns [`AuthorizedAction`] on success. Every failure is [`AppError::Forbidden`], which
@@ -352,6 +445,67 @@ mod tests {
             authority: (0..depth).map(|i| format!("vac-{i}")).collect(),
             subject_binding: binding.then(|| "binding".to_string()),
         }
+    }
+
+    #[test]
+    fn an_owner_registers_their_own_room() {
+        let ok = authorize_create("did:key:zRoom", "did:key:zOwner", "did:key:zOwner")
+            .expect("an owner may register the room they are accountable for");
+        assert_eq!(ok.room_id(), "did:key:zRoom");
+        assert_eq!(ok.owner_did(), "did:key:zOwner");
+    }
+
+    /// The whole of the defect this check exists for: `ownerDid` is a payload field, so a
+    /// host that took it on trust would record an owner who never agreed to be one — and
+    /// would let anyone reachable fill its store with rooms attributed to other people.
+    #[test]
+    fn nobody_registers_a_room_owned_by_somebody_else() {
+        let err = authorize_create("did:key:zRoom", "did:key:zOwner", "did:key:zMallory")
+            .expect_err("a signer who is not the named owner must be refused");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "must be Forbidden, was {err:?}"
+        );
+    }
+
+    /// An unsigned request has no presenter, and the empty string must not match an empty
+    /// owner — which is the shape a caller gets by omitting both.
+    #[test]
+    fn an_unsigned_registration_is_refused() {
+        assert!(authorize_create("did:key:zRoom", "did:key:zOwner", "").is_err());
+        assert!(authorize_create("did:key:zRoom", "", "").is_err());
+        assert!(authorize_create("", "did:key:zOwner", "did:key:zOwner").is_err());
+    }
+
+    /// A proof names a verification method, not a DID, so the fragment must not decide the
+    /// answer — in either direction.
+    #[test]
+    fn a_verification_method_fragment_is_not_a_different_party() {
+        assert!(
+            authorize_create(
+                "did:key:zRoom",
+                "did:key:zOwner",
+                "did:key:zOwner#z6MkKeyOne"
+            )
+            .is_ok()
+        );
+        assert!(
+            authorize_create(
+                "did:key:zRoom",
+                "did:key:zOwner#z6MkKeyOne",
+                "did:key:zOwner"
+            )
+            .is_ok()
+        );
+        assert!(
+            authorize_create(
+                "did:key:zRoom",
+                "did:key:zOwner",
+                "did:key:zOther#z6MkKeyOne"
+            )
+            .is_err(),
+            "a fragment must not make two different DIDs equal"
+        );
     }
 
     /// A verifier that vouches for whatever it is handed.


### PR DESCRIPTION
Found while writing the data-rooms operator guide (#1273): `rooms/create/0.1` was the one verb **neither host authorized**. The document's proof was never verified on that path, and the signer was never compared to `ownerDid`.

So anyone able to reach a room host or a VTC's Trust-Task endpoint could register a room row naming **any** party as its owner — filling the store with rooms attributed to people who never agreed to own them, and taking identifiers from under their real owners. Every other verb verifies the proof *and* the authority chain; this one fell through precisely because it is the one operation no chain can authorize, and the check it needed instead was never written.

### The check

Create cannot be authorized by a chain: at the moment it runs the room has issued nothing, so no credential in the world speaks for it. What a host does have is the proof on the request — and that is what turns `ownerDid` from a field anyone can fill into a fact. The presenter must be the party they name as owner, and the room is then written **from the authorization, not from the payload**.

The decision lives in `vti_rooms::authz::authorize_create`, beside the chain authorization it complements, because a room host and a VTC disagreeing about who may register a room is exactly the drift that crate exists to prevent. It returns an `AuthorizedCreate` with no public constructor, so a handler that skips the check does not compile — the same typestate as `AuthorizedAction`.

### What it deliberately does not do

It does not prove control of the identifier. A party can still register a `roomId` they do not control while naming themselves owner, denying that id to its real owner on that host. That row confers nothing — every later verb needs credentials the real room issued, and a squatter cannot mint them — so it is a nuisance rather than a takeover, and bounding it is quota and access control, which is the availability row of the trust model (I2). Proving control would mean the *room* signing its own registration; that would exclude every owner whose room key is held somewhere that cannot sign a request document.

### Tests

| | |
|---|---|
| `vti-rooms` | owner accepted; non-owner refused; unsigned/empty refused; a `#fragment` on either side is not a different party |
| `room-host` | a registration in somebody else's name is `403` **and leaves the identifier free**; an unsigned one is refused; the owner's own still succeeds |
| `vtc-service` | the same pair against the community host |

`cargo test -p vti-rooms -p room-host` and the `vtc-service` rooms suite pass, `cargo check --workspace --all-targets` is clean, and `cargo run -p room-host --example data_room` still runs end to end.

### Compatibility

A behaviour change for any caller that relayed a registration on an owner's behalf. There were none: both hosts, their tests, and the example all already signed as the owner. Public API is additive (`authorize_create`, `AuthorizedCreate`).