### PR TITLE
docs(rooms): describe the two gaps as fixed, not as caveats

### DIFF
--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -204,8 +204,9 @@
             <td><span class="no">Library only.</span> Nothing serves “issue this member a VMC and a
             VAC” — the owner mints them with <code>dtg-credentials</code> and delivers them out of band</td></tr>
         <tr><td class="hd">Governance (<code>rooms.rego</code>)</td>
-            <td><span class="no">Not implemented</span> — and <code>rooms/create</code> is ungated
-            on both hosts as a result</td></tr>
+            <td><span class="no">Not implemented.</span> Creation checks that the signer is the
+            owner they name; <em>which</em> members a community lets create rooms on it is still
+            designed rather than built</td></tr>
         <tr><td class="hd">Read mirrors, witnessed renewal anchoring</td>
             <td><span class="no">Not implemented.</span> One write-primary; anchoring is the owner's
             job and nothing does it yet</td></tr>
@@ -386,10 +387,12 @@
       </li>
       <li>
         <h3>Register it with a host</h3>
-        <p>One <code>rooms/create/0.1</code> document. <strong>You bring the roomId</strong> — a
-        room identified by something its host chose could not move. The host sets epoch 1, an
-        expiry one epoch lifetime out, and the retention you asked for; it records the owner DID
-        you gave it.</p>
+        <p>One <code>rooms/create/0.1</code> document, <strong>signed as the owner</strong>: this
+        is the single verb no chain can authorize — the room has issued nothing yet — so the
+        request's own proof is the check, and a signer who is not the owner they name is refused.
+        <strong>You bring the roomId</strong>; a room identified by something its host chose could
+        not move. The host sets epoch 1, an expiry one epoch lifetime out, and the retention you
+        asked for.</p>
       </li>
       <li>
         <h3>Issue yourself membership and authority</h3>
@@ -507,11 +510,12 @@
       this reason: that turns it into “a commit has not been delivered”.</p>
     </div>
     <div class="warn">
-      <p><b>The agent role does not carry the agent capabilities.</b> The oracle gates read the
-      caller's role, and <code>Application</code> — the role agent integrations are normally granted
-      — carries neither <code>roomPresent</code> nor <code>roomOpen</code>. An agent that needs the
-      oracle today must hold a broader role than the design intends. Worth knowing before you scope
-      its entry.</p>
+      <p><b>The grant is the role, not the entry's capability list.</b> The oracle gates read the
+      caller's role: <code>application</code> — what an agent integration is normally granted —
+      along with <code>initiator</code> and <code>admin</code> carries both room capabilities, and
+      <code>reader</code> and <code>monitor</code> carry neither. The per-entry
+      <code>capabilities</code> field is descriptive today, so narrowing it narrows nothing; scope
+      an agent by the role you give it and the context it may act in.</p>
     </div>
   </section>
 
@@ -607,8 +611,9 @@
       <code>did:key</code> only by default; serving <code>did:webvh</code> rooms means turning on
       resolution, and that lets an unauthenticated request make your host fetch.</li>
       <li><strong>Put it behind a proxy.</strong> The room-host binary carries no TLS and no rate
-      limiter, and <code>rooms/create</code> is not authorized on either host yet — anyone who can
-      reach the endpoint can register a room row. Every other verb verifies the document's proof
+      limiter, and while creation now requires the signer to be the owner they name, nothing yet
+      governs <em>which</em> parties may create rooms on your host — so anyone who can reach the
+      endpoint can register one in their own name. Every other verb verifies the document's proof
       and the authority chain.</li>
       <li><strong>Never log the actor on a private room.</strong> That decision is made once, in
       the crate both hosts share, precisely because every host's logging wants to write the acting

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -85,7 +85,7 @@ knowing which half you are standing on saves an afternoon.
 | Succession: nomination, transfer, claim | **Work**, including the "renewing defeats a pending claim" property |
 | **A CLI** | **None.** No `pnm rooms …`. Rooms are driven from `vtc-client` (Rust) or by posting signed Trust Task documents |
 | **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
-| **Governance (`rooms.rego`)** | **Not implemented.** `rooms/create/0.1` is ungated on both hosts — see §8.4 |
+| **Governance (`rooms.rego`)** | **Not implemented.** Creation checks that the signer is the owner they name (§8.4); *which* members a community lets create rooms on it is still designed rather than built |
 | **Read mirrors** (T3) | **Not implemented.** One write-primary, and everyone reads from it |
 | **Witnessed renewal anchoring** | **Not implemented.** §9 of the design note makes this the owner's job, not the host's; nothing does it yet |
 
@@ -221,8 +221,9 @@ a single record there; the `room-host` binary imposes neither.
 
 The host sets what it is entitled to set and nothing else: `epoch = 1`,
 `epochExpiresAt = now + 365 days`, `retentionDays` (default **90**), and the
-version counter. It records the owner DID you gave it. It does not check that
-you are that owner — see §8.4.
+version counter. **Sign this one as the owner**: creation is the single verb no
+chain can authorize, so the request's own proof is the check, and a signer who
+is not the `ownerDid` they name is refused (§8.4).
 
 ### 5.3 Issue the owner's own credentials
 
@@ -388,11 +389,12 @@ have become the credential hand-off it exists to replace:
 - **A long-lived leaf** — the lifetime is a constant (4 hours), not a request
   parameter.
 
-> **Operational catch.** These gates read the caller's **role**, and
-> `Role::Application` — the role `vta-agent-memory` grants its agents — does
-> **not** carry `roomPresent` or `roomOpen`. Today an agent that needs the
-> oracle must hold `initiator` (or `admin`), which is broader than the design
-> intends. Worth knowing before you scope an agent's ACL entry.
+> **How to grant it.** These gates read the caller's **role**, not the
+> capability list on its ACL entry — that field is descriptive today, and
+> narrowing it narrows nothing. `application` (what an agent integration is
+> normally granted), `initiator` and `admin` carry both room capabilities;
+> `reader` and `monitor` carry neither, deliberately, because minting a
+> credential on a principal's behalf is not a read.
 
 Withdrawing an agent's access is withdrawing it *at the VTA* — remove the ACL
 entry and no further presentations are minted. That is the whole value of an
@@ -471,20 +473,26 @@ write-primary that everyone also reads from. Multi-primary replication is a
 non-goal, not a gap: replicated multi-writer room state needs state-resolution
 machinery whose failure modes took Matrix years to shake out.
 
-### 8.4 T4 — peers, and the caveat that applies to every topology
+### 8.4 T4 — peers, and what still governs creation
 
 T4 runs the same binary as T1; what differs is the door — a VRC-linked peer
 rather than an invitation you originated — and that nobody governs creation but
 the owner.
 
-**The caveat, stated once for all four:** `rooms/create/0.1` is **not
-authorized** on either host today. The document's proof is not checked on that
-verb, the signer is not compared to `ownerDid`, and no policy consults anything.
-Anyone who can reach the endpoint can register a room row — squatting a `roomId`
-or filling storage. Every *other* verb verifies the document proof and the
-authority chain. Until governance lands, treat a room host's endpoint as
-something to put behind a proxy you control, and do not expose a personal room
-host to the open internet.
+**What creation checks, stated once for all four.** `rooms/create/0.1` is the
+one verb no chain can authorize: at the moment it runs the room has issued
+nothing. So the check is the request's own proof — **the signer must be the
+party they name as owner** — and the room is written from that, not from the
+payload. Without it `ownerDid` is a field anyone can fill with anyone.
+
+What that does *not* establish is control of the identifier. Someone can still
+register a `roomId` they do not control while naming themselves owner, and so
+deny that id to its real owner on that host. The row confers nothing — every
+later verb needs credentials the real room issued — so it is a nuisance rather
+than a takeover, and bounding it is quota and access control. Community
+governance of *who may create a room here* (`rooms.rego`) is still designed
+rather than built, so on a public host, creation is open to anyone who can
+authenticate as themselves: put a room host behind a proxy you control.
 
 ---
 
@@ -681,6 +689,7 @@ recover but a fresh invitation from every owner.
 | `invitation … has already been used` | Single use. Issue a fresh one |
 | a room "is live" / "not claimable" | The owner renewed. The claim is correctly dead |
 | `unsupportedType` | The host does not implement that task — check you are talking to a room host and not something else on the same port |
+| `this registration was signed by …, which is not the owner it names` | `rooms/create` signed by anyone but the `ownerDid` in the payload. Sign as the owner (§5.2) |
 | Every call fails on `missing field 'id'` | You are posting a bare JSON body. Room calls are Trust Task **documents** — build them with `vta_sdk::trust_task_sign::build_signed` |
 
 ---
@@ -692,7 +701,7 @@ and `vtc-service`:
 
 | URI | Action required |
 |---|---|
-| `rooms/create/0.1` | *(ungated — §8.4)* |
+| `rooms/create/0.1` | no chain — the signer must be the `ownerDid` (§8.4) |
 | `rooms/records/put/0.1` | `write` |
 | `rooms/records/get/0.1` | `read` |
 | `rooms/records/list/0.1` | `read` |


### PR DESCRIPTION
Follow-up to #1273, which merged while the two defects it surfaced were being fixed.

The guide describes both as live gaps, so it goes stale the moment either of #1274 / #1275 lands. This corrects both, in the markdown and in the HTML page:

- **Room creation** — the caveat ("`rooms/create/0.1` is not authorized on either host; anyone who can reach the endpoint can register a room row") becomes what creation now checks, and what it still does not: the request's own proof establishes that the signer is the owner it names, while *which* parties may create a room on a given host remains ungoverned until `rooms.rego` lands. Step 3 of the walkthrough now says to sign that one call as the owner, since that is a thing a caller has to get right.
- **The room oracle's gate** — the catch ("`Role::Application` carries neither `roomPresent` nor `roomOpen`") becomes how to grant it: by role, with `application` / `initiator` / `admin` carrying both and `reader` / `monitor` carrying neither. It also says the per-entry `capabilities` field is descriptive rather than enforced, which is worth stating exactly where an operator would otherwise reach for it.

Plus a refusal-table row for the registration error an operator will now meet.

**Merge after #1274 and #1275** — this describes their behaviour. If either is rejected, say so and I will put the caveat back rather than the fix.