### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,7 +2677,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -7179,7 +7179,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.14.6"
+version = "0.15.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10304,7 +10304,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "tokio",
@@ -10316,7 +10316,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -10346,7 +10346,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10372,7 +10372,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10405,7 +10405,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10438,7 +10438,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "vti-common",
 ]
@@ -10489,7 +10489,7 @@ dependencies = [
 
 [[package]]
 name = "vta-persona"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -10508,7 +10508,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "hex",
  "multibase",
@@ -10528,7 +10528,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10592,7 +10592,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.23.5"
+version = "0.24.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -10699,7 +10699,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -10719,7 +10719,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "serde_json",
@@ -10735,7 +10735,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes 0.9.3",
  "aes-gcm 0.11.1",
@@ -10770,7 +10770,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10804,7 +10804,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "affinidi-tdk 0.12.0",
  "chrono",
@@ -10825,7 +10825,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10927,7 +10927,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -11002,7 +11002,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11025,7 +11025,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -11048,7 +11048,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.6...cnm-cli-v0.14.0) — 2026-09-07
+
+
+### Added
+
+- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))
+
+#1279 left `acl/grant` refusing a capability narrowing and pointing at
+  `acl update`, because taking one meant a fifteenth positional parameter on
+  `create_acl`. Refusing was honest but it leaves a real window: between the
+  grant and the narrowing the entry holds everything its role implies, and a
+  subject that authenticates inside that window is authorized by what it found
+  there.
+
+  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
+  already had - so the narrowing is one more named field rather than a
+  fourteenth argument nobody can read at the call site. Test call sites state
+  the two or three members they care about and default the rest instead of
+  spelling every one to reach the last.
+
+  The rule is the update path's, applied where the entry is born: a name the
+  role does not carry is refused rather than dropped, an unknown name is
+  refused, and neither leaves a row behind. `pnm acl create --capabilities
+  memory-read,room-present` is now the form to prefer, and the agent runbook
+  says so.
+
+  Also echoes the stored narrowing from `acl create` and `acl show`, so the
+  restriction can be read back from wherever it was set.
+
+- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
+
+
 ## [0.13.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.5...cnm-cli-v0.13.6) — 2026-09-07
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.13.6"
+version = "0.14.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,10 +21,10 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
-vta-cli-common = { path = "../vta-cli-common", version = "0.13", features = [
+vta-cli-common = { path = "../vta-cli-common", version = "0.14", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }
@@ -26,7 +26,7 @@ ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 # SLIP-0010 key derivation (`vti_common::slip10`) — the harness re-derives the
 # same keys the VTA does, from the same seed and paths.
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 
 [lints]
 workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.6...pnm-cli-v0.15.0) — 2026-09-07
+
+
+### Added
+
+- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))
+
+Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
+  building signed Trust Task documents, which is not a surface an operator has.
+  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
+
+  ## Two parties, never confused
+
+  Every command talks to both and keeps them apart: the operator's **VTA** mints
+  a presentation (`rooms/keys/present`) and opens sealed records
+  (`rooms/keys/open`), and the room's **host** stores the bytes. The credentials
+  the presentation is derived from and the group key that opens a record stay
+  inside the VTA - this CLI holds neither at any point.
+
+  That makes the CLI the oracle's first real consumer, and it works: a member
+  who holds less than an action needs is refused by their own VTA, before
+  anything reaches the host, which is the earlier and clearer of the two
+  refusals.
+
+  Each command mints its own presentation for exactly the action it performs -
+  `read` for list/get, `write` for put, `curate` for curate, `admin` for renew.
+  Caching one across commands would mean re-binding it (impossible without the
+  VTA) or sending it unbound, which is a bearer token.
+
+  ## Where the pieces had to live
+
+  `vta-sdk` gains `room_present` / `room_open`, because those are calls to your
+  own VTA. It cannot gain the room *wire types*: `vti-common` re-exports
+  `vta_sdk::acl`, so `vta-sdk -> vti-rooms -> vti-common -> vta-sdk` is a cycle.
+  So `vta-cli-common` takes `vtc-client`, which despite its name is the
+  host-neutral room client - `room-host`'s own example drives itself with it. A
+  second copy of the `rooms/*` wire types in the CLI is exactly the duplication
+  that crate deleted.
+
+  `vtc-client` gains `curate_record`, which nothing had implemented.
+
+  ## What it deliberately cannot do
+
+  **Write to a sealed room**: sealing needs the room's group key, and no task
+  seals on a caller's behalf. **Issue credentials**: minting a VIC, VMC or VAC
+  needs the room's own signing key, which is the owner's - a different party with
+  different custody. Both are refused with the reason rather than half-served,
+  and `get` translates the epoch-mismatch failure into "a commit has not been
+  delivered", which is what it means and not what it reads like.
+
+  Five tests on the two pure decisions: rebuilding a session from what the VTA
+  minted (each missing member refused rather than defaulted, a subject binding
+  surviving, a non-string chain link refused rather than silently shortening the
+  chain), and the pin/unpin tri-state where absence must stay distinct from
+  false.
+
+- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))
+
+#1279 left `acl/grant` refusing a capability narrowing and pointing at
+  `acl update`, because taking one meant a fifteenth positional parameter on
+  `create_acl`. Refusing was honest but it leaves a real window: between the
+  grant and the narrowing the entry holds everything its role implies, and a
+  subject that authenticates inside that window is authorized by what it found
+  there.
+
+  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
+  already had - so the narrowing is one more named field rather than a
+  fourteenth argument nobody can read at the call site. Test call sites state
+  the two or three members they care about and default the rest instead of
+  spelling every one to reach the last.
+
+  The rule is the update path's, applied where the entry is born: a name the
+  role does not carry is refused rather than dropped, an unknown name is
+  refused, and neither leaves a row behind. `pnm acl create --capabilities
+  memory-read,room-present` is now the form to prefer, and the agent runbook
+  says so.
+
+  Also echoes the stored narrowing from `acl create` and `acl show`, so the
+  restriction can be read back from wherever it was set.
+
+- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
+
+
 ## [0.14.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.5...pnm-cli-v0.14.6) — 2026-09-07
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.14.6"
+version = "0.15.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,14 +28,14 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
-vta-cli-common = { path = "../vta-cli-common", version = "0.13", features = [
+vta-cli-common = { path = "../vta-cli-common", version = "0.14", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 # no member lifecycle, no policy engine, no credential issuance, no admin UI.
 vti-rooms = { path = "../vti-rooms", version = "0.1" }
 # The store and AppError. Nothing else internal.
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }
 
 axum = { workspace = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.3...vta-audit-v0.3.4) — 2026-09-07
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.2...vta-audit-v0.3.3) — 2026-09-07
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,8 +20,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17" }
-vta-sdk = { path = "../vta-sdk", version = "0.33" }
+vti-common = { path = "../vti-common", version = "0.18" }
+vta-sdk = { path = "../vta-sdk", version = "0.34" }
 async-trait = "0.1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.3...vta-backup-v0.3.4) — 2026-09-07
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.2...vta-backup-v0.3.3) — 2026-09-07
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,12 +27,12 @@ webvh = ["vta-keyspaces/webvh"]
 tee = ["vta-config/tee", "dep:async-trait"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 # Nonce and bundle-id generation. Was reached through `aes_gcm::aead::OsRng`,
 # a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
 # own and was borrowing one from its cipher.
 rand = { workspace = true }
-vta-sdk = { path = "../vta-sdk", version = "0.33" }
+vta-sdk = { path = "../vta-sdk", version = "0.34" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.4" }
 vta-config = { path = "../vta-config", version = "0.4" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.13.0...vta-cli-common-v0.14.0) — 2026-09-07
+
+
+### Added
+
+- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))
+
+Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
+  building signed Trust Task documents, which is not a surface an operator has.
+  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
+
+  ## Two parties, never confused
+
+  Every command talks to both and keeps them apart: the operator's **VTA** mints
+  a presentation (`rooms/keys/present`) and opens sealed records
+  (`rooms/keys/open`), and the room's **host** stores the bytes. The credentials
+  the presentation is derived from and the group key that opens a record stay
+  inside the VTA - this CLI holds neither at any point.
+
+  That makes the CLI the oracle's first real consumer, and it works: a member
+  who holds less than an action needs is refused by their own VTA, before
+  anything reaches the host, which is the earlier and clearer of the two
+  refusals.
+
+  Each command mints its own presentation for exactly the action it performs -
+  `read` for list/get, `write` for put, `curate` for curate, `admin` for renew.
+  Caching one across commands would mean re-binding it (impossible without the
+  VTA) or sending it unbound, which is a bearer token.
+
+  ## Where the pieces had to live
+
+  `vta-sdk` gains `room_present` / `room_open`, because those are calls to your
+  own VTA. It cannot gain the room *wire types*: `vti-common` re-exports
+  `vta_sdk::acl`, so `vta-sdk -> vti-rooms -> vti-common -> vta-sdk` is a cycle.
+  So `vta-cli-common` takes `vtc-client`, which despite its name is the
+  host-neutral room client - `room-host`'s own example drives itself with it. A
+  second copy of the `rooms/*` wire types in the CLI is exactly the duplication
+  that crate deleted.
+
+  `vtc-client` gains `curate_record`, which nothing had implemented.
+
+  ## What it deliberately cannot do
+
+  **Write to a sealed room**: sealing needs the room's group key, and no task
+  seals on a caller's behalf. **Issue credentials**: minting a VIC, VMC or VAC
+  needs the room's own signing key, which is the owner's - a different party with
+  different custody. Both are refused with the reason rather than half-served,
+  and `get` translates the epoch-mismatch failure into "a commit has not been
+  delivered", which is what it means and not what it reads like.
+
+  Five tests on the two pure decisions: rebuilding a session from what the VTA
+  minted (each missing member refused rather than defaulted, a subject binding
+  surviving, a non-string chain link refused rather than silently shortening the
+  chain), and the pin/unpin tri-state where absence must stay distinct from
+  false.
+
+- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))
+
+#1279 left `acl/grant` refusing a capability narrowing and pointing at
+  `acl update`, because taking one meant a fifteenth positional parameter on
+  `create_acl`. Refusing was honest but it leaves a real window: between the
+  grant and the narrowing the entry holds everything its role implies, and a
+  subject that authenticates inside that window is authorized by what it found
+  there.
+
+  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
+  already had - so the narrowing is one more named field rather than a
+  fourteenth argument nobody can read at the call site. Test call sites state
+  the two or three members they care about and default the rest instead of
+  spelling every one to reach the last.
+
+  The rule is the update path's, applied where the entry is born: a name the
+  role does not carry is refused rather than dropped, an unknown name is
+  refused, and neither leaves a row behind. `pnm acl create --capabilities
+  memory-read,room-present` is now the form to prefer, and the agent runbook
+  says so.
+
+  Also echoes the stored narrowing from `acl create` and `acl show`, so the
+  restriction can be read back from wherever it was set.
+
+- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
+
+
 ## [0.13.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.12.4...vta-cli-common-v0.13.0) — 2026-09-07
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,13 +18,13 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 # The room client. Named for the VTC, but host-neutral by construction: a room's
 # protocol is the same whether a community or a standalone `room-host` serves it,
 # and `room-host`'s own example drives itself with this crate. Taking a second

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.3...vta-config-v0.4.4) — 2026-09-07
+
+
 ## [0.4.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.2...vta-config-v0.4.3) — 2026-09-07
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,11 +26,11 @@ default = []
 tee = []
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.33", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.34", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,8 +34,8 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.23", default-features = false, features = ["tee"] }
-vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
+vta-service = { path = "../vta-service", version = "0.24", default-features = false, features = ["tee"] }
+vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build
 # links no overlay code.

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.3...vta-keys-v0.4.4) — 2026-09-07
+
+
 ## [0.4.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.2...vta-keys-v0.4.3) — 2026-09-07
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -36,9 +36,9 @@ tee = ["vti-secrets/tee"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4" }
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-keyspaces/CHANGELOG.md
+++ b/vta-keyspaces/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.6...vta-keyspaces-v0.2.7) — 2026-09-07
+
+
 ## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.5...vta-keyspaces-v0.2.6) — 2026-09-07
 
 

--- a/vta-keyspaces/Cargo.toml
+++ b/vta-keyspaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keyspaces"
 description = "VTA keyspace-name registry — the shared storage vocabulary for the VTA subsystem crates"
 readme = "README.md"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -26,4 +26,4 @@ webvh = []
 
 [dependencies]
 # For `KeyspaceHandle` in the shared `Keyspaces` handle bundle.
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-persona/CHANGELOG.md
+++ b/vta-persona/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.1.0...vta-persona-v0.2.0) — 2026-09-07
+
+
+### Fixed
+
+- **persona**: The audit trail says what changed, and correlation/analyze conforms ([#1283](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1283))
+
+* fix(persona): the audit trail says what changed
+
+  Every persona write recorded action, actor, resource and outcome and
+  nothing else. `audit_persona` called `audit::record(...)`, which has no
+  `detail` parameter, so a console audit pane showed twenty rows of
+  `persona.attribute.put` against opaque ULIDs with no way to tell a
+  create from an update, a cascade delete from a no-op against a typo'd
+  id, or a binding that materialised forty claims from one that cleared
+  them.
+
+  The console side was never the problem: `AuditEnvelope` already renders
+  `detail` in full as `detail.reason`. There was simply nothing to render.
+
+  So the write handlers now go through `audit::record_with_detail` and
+  supply one: attribute put/delete, profile put/delete, binding/set, and
+  the three context-local writes each say what changed — created or
+  updated, the claim type, the value type, the provenance kind, entry and
+  claim counts, whether the record existed, how many profiles or personas
+  were affected, and the resulting version. Reads still pass `None`; a
+  read changes nothing, and a sentence restating the request would be
+  noise in an append-only store.
+
+  The attribute VALUE stays out, and `audit_persona` now explains why at
+  length, because the reason is not the one people assume. It is NOT an
+  access-control reason. Persona rows are recorded with `context_id:
+  None`, and `operations::audit::authorize` already refuses every entry
+  not confined to a named context to anyone but an unrestricted admin —
+  exactly the caller `Reach::Holder` admits to `attribute/list`, which
+  returns the plaintext outright. Nobody gains a read by us writing one.
+
+  The reason is lifetime. The audit keyspace is append-only and pruned on
+  its own retention schedule; the pool is deleted when the holder deletes
+  an attribute. Copy a value across and `attribute/delete` quietly stops
+  being a delete — the value outlives the record it came from, in a store
+  the holder's delete does not reach. Stating that distinction matters,
+  because "don't log values" as a bare prohibition is the rule somebody
+  relaxes the first time an operator asks for a better trail, and the
+  access-control argument does not survive that conversation.
+
+  The new test asserts both halves together. A test that only checks the
+  value is absent passes against a handler that records no detail at all,
+  which is precisely the state being fixed.
+
+- **persona**: "edit once, everywhere" reached nothing ([#1281](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1281))
+
+A holder edited their name and the verifier was still shown the old
+  one. `rematerialise` — the function whose docstring explains that a
+  context holds a materialised copy and can only be updated by a write
+  from above the boundary — was **called from no handler in the
+  codebase**. The only reference outside its own file was a comment in a
+  test.
+
+  A context may never read the pool, so its copy changes only if
+  something pushes. Nothing did. `attribute/put`, `attribute/delete
+  --cascade` and `profile/put` all changed what a profile projects and
+  left every bound context presenting the state from before the edit,
+  which `disclosure/preview` and `disclosure/present` then handed to a
+  verifier.
+
+  **The push now belongs to the write, not to the call site.** `put`,
+  `delete` and `put_profile` push before returning, from inside the lock
+  they already hold. Leaving it to handlers is the same decision taken
+  once per call site and forgetting it is silent — the pool shows the new
+  value, the console shows the pool, and only the verifier sees the old
+  one.
+
+
+
 ## [0.1.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/releases/tag/vta-persona-v0.1.0) — 2026-09-06
 
 

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-persona"
 description = "VTA persona store — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose"
 readme = "README.md"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 # Published for the same reason vta-vault is: `vta-service` is published, and a
 # crate cannot go to crates.io without its whole dependency closure. Nothing
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
+vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.3...vta-policy-v0.3.4) — 2026-09-07
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.2...vta-policy-v0.3.3) — 2026-09-07
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,12 +20,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 vta-config = { path = "../vta-config", version = "0.4" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.33", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.34", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,89 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.34.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.33.0...vta-sdk-v0.34.0) — 2026-09-07
+
+
+### Added
+
+- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))
+
+Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
+  building signed Trust Task documents, which is not a surface an operator has.
+  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
+
+  ## Two parties, never confused
+
+  Every command talks to both and keeps them apart: the operator's **VTA** mints
+  a presentation (`rooms/keys/present`) and opens sealed records
+  (`rooms/keys/open`), and the room's **host** stores the bytes. The credentials
+  the presentation is derived from and the group key that opens a record stay
+  inside the VTA - this CLI holds neither at any point.
+
+  That makes the CLI the oracle's first real consumer, and it works: a member
+  who holds less than an action needs is refused by their own VTA, before
+  anything reaches the host, which is the earlier and clearer of the two
+  refusals.
+
+  Each command mints its own presentation for exactly the action it performs -
+  `read` for list/get, `write` for put, `curate` for curate, `admin` for renew.
+  Caching one across commands would mean re-binding it (impossible without the
+  VTA) or sending it unbound, which is a bearer token.
+
+  ## Where the pieces had to live
+
+  `vta-sdk` gains `room_present` / `room_open`, because those are calls to your
+  own VTA. It cannot gain the room *wire types*: `vti-common` re-exports
+  `vta_sdk::acl`, so `vta-sdk -> vti-rooms -> vti-common -> vta-sdk` is a cycle.
+  So `vta-cli-common` takes `vtc-client`, which despite its name is the
+  host-neutral room client - `room-host`'s own example drives itself with it. A
+  second copy of the `rooms/*` wire types in the CLI is exactly the duplication
+  that crate deleted.
+
+  `vtc-client` gains `curate_record`, which nothing had implemented.
+
+  ## What it deliberately cannot do
+
+  **Write to a sealed room**: sealing needs the room's group key, and no task
+  seals on a caller's behalf. **Issue credentials**: minting a VIC, VMC or VAC
+  needs the room's own signing key, which is the owner's - a different party with
+  different custody. Both are refused with the reason rather than half-served,
+  and `get` translates the epoch-mismatch failure into "a commit has not been
+  delivered", which is what it means and not what it reads like.
+
+  Five tests on the two pure decisions: rebuilding a session from what the VTA
+  minted (each missing member refused rather than defaulted, a subject binding
+  surviving, a non-string chain link refused rather than silently shortening the
+  chain), and the pin/unpin tri-state where absence must stay distinct from
+  false.
+
+- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))
+
+#1279 left `acl/grant` refusing a capability narrowing and pointing at
+  `acl update`, because taking one meant a fifteenth positional parameter on
+  `create_acl`. Refusing was honest but it leaves a real window: between the
+  grant and the narrowing the entry holds everything its role implies, and a
+  subject that authenticates inside that window is authorized by what it found
+  there.
+
+  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
+  already had - so the narrowing is one more named field rather than a
+  fourteenth argument nobody can read at the call site. Test call sites state
+  the two or three members they care about and default the rest instead of
+  spelling every one to reach the last.
+
+  The rule is the update path's, applied where the entry is born: a name the
+  role does not carry is refused rather than dropped, an unknown name is
+  refused, and neither leaves a row behind. `pnm acl create --capabilities
+  memory-read,room-present` is now the form to prefer, and the agent runbook
+  says so.
+
+  Also echoes the stored narrowing from `acl create` and `acl show`, so the
+  restriction can be read back from wherever it was set.
+
+- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
+
+
 ## [0.33.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.32.4...vta-sdk-v0.33.0) — 2026-09-07
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.33.0"
+version = "0.34.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,110 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.24.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.5...vta-service-v0.24.0) — 2026-09-07
+
+
+### Added
+
+- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))
+
+#1279 left `acl/grant` refusing a capability narrowing and pointing at
+  `acl update`, because taking one meant a fifteenth positional parameter on
+  `create_acl`. Refusing was honest but it leaves a real window: between the
+  grant and the narrowing the entry holds everything its role implies, and a
+  subject that authenticates inside that window is authorized by what it found
+  there.
+
+  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
+  already had - so the narrowing is one more named field rather than a
+  fourteenth argument nobody can read at the call site. Test call sites state
+  the two or three members they care about and default the rest instead of
+  spelling every one to reach the last.
+
+  The rule is the update path's, applied where the entry is born: a name the
+  role does not carry is refused rather than dropped, an unknown name is
+  refused, and neither leaves a row behind. `pnm acl create --capabilities
+  memory-read,room-present` is now the form to prefer, and the agent runbook
+  says so.
+
+  Also echoes the stored narrowing from `acl create` and `acl show`, so the
+  restriction can be read back from wherever it was set.
+
+- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
+
+
+### Fixed
+
+- **persona**: The audit trail says what changed, and correlation/analyze conforms ([#1283](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1283))
+
+* fix(persona): the audit trail says what changed
+
+  Every persona write recorded action, actor, resource and outcome and
+  nothing else. `audit_persona` called `audit::record(...)`, which has no
+  `detail` parameter, so a console audit pane showed twenty rows of
+  `persona.attribute.put` against opaque ULIDs with no way to tell a
+  create from an update, a cascade delete from a no-op against a typo'd
+  id, or a binding that materialised forty claims from one that cleared
+  them.
+
+  The console side was never the problem: `AuditEnvelope` already renders
+  `detail` in full as `detail.reason`. There was simply nothing to render.
+
+  So the write handlers now go through `audit::record_with_detail` and
+  supply one: attribute put/delete, profile put/delete, binding/set, and
+  the three context-local writes each say what changed — created or
+  updated, the claim type, the value type, the provenance kind, entry and
+  claim counts, whether the record existed, how many profiles or personas
+  were affected, and the resulting version. Reads still pass `None`; a
+  read changes nothing, and a sentence restating the request would be
+  noise in an append-only store.
+
+  The attribute VALUE stays out, and `audit_persona` now explains why at
+  length, because the reason is not the one people assume. It is NOT an
+  access-control reason. Persona rows are recorded with `context_id:
+  None`, and `operations::audit::authorize` already refuses every entry
+  not confined to a named context to anyone but an unrestricted admin —
+  exactly the caller `Reach::Holder` admits to `attribute/list`, which
+  returns the plaintext outright. Nobody gains a read by us writing one.
+
+  The reason is lifetime. The audit keyspace is append-only and pruned on
+  its own retention schedule; the pool is deleted when the holder deletes
+  an attribute. Copy a value across and `attribute/delete` quietly stops
+  being a delete — the value outlives the record it came from, in a store
+  the holder's delete does not reach. Stating that distinction matters,
+  because "don't log values" as a bare prohibition is the rule somebody
+  relaxes the first time an operator asks for a better trail, and the
+  access-control argument does not survive that conversation.
+
+  The new test asserts both halves together. A test that only checks the
+  value is absent passes against a handler that records no detail at all,
+  which is precisely the state being fixed.
+
+- **persona**: "edit once, everywhere" reached nothing ([#1281](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1281))
+
+A holder edited their name and the verifier was still shown the old
+  one. `rematerialise` — the function whose docstring explains that a
+  context holds a materialised copy and can only be updated by a write
+  from above the boundary — was **called from no handler in the
+  codebase**. The only reference outside its own file was a comment in a
+  test.
+
+  A context may never read the pool, so its copy changes only if
+  something pushes. Nothing did. `attribute/put`, `attribute/delete
+  --cascade` and `profile/put` all changed what a profile projects and
+  left every bound context presenting the state from before the edit,
+  which `disclosure/preview` and `disclosure/present` then handed to a
+  verifier.
+
+  **The push now belongs to the write, not to the call site.** `put`,
+  `delete` and `put_profile` push before returning, from inside the lock
+  they already hold. Leaving it to handlers is the same decision taken
+  once per call site and forgetting it is silent — the pool shows the new
+  value, the console shows the pool, and only the verifier sees the old
+  one.
+
+
+
 ## [0.23.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.4...vta-service-v0.23.5) — 2026-09-06
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.23.5"
+version = "0.24.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -139,7 +139,7 @@ path = "src/main.rs"
 required-features = ["cli-synthesis"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17", features = ["encryption", "passkey", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.18", features = ["encryption", "passkey", "openapi"] }
 # Seed-store backends + `create_seed_store` factory + `SecretsConfig` (lifted
 # from this crate into a shared crate so external integrations can reuse them).
 # Per-backend features are activated by this crate's matching features below.
@@ -160,7 +160,7 @@ vta-keys = { path = "../vta-keys", version = "0.4" }
 # Holder credential vault (storage/query/receive/present/status), extracted to
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
-vta-persona = { path = "../vta-persona", version = "0.1" }
+vta-persona = { path = "../vta-persona", version = "0.2" }
 vta-vault = { path = "../vta-vault", version = "0.5" }
 
 # The room presentation oracle attenuates a member VAC and signs it.
@@ -188,7 +188,7 @@ vta-policy = { path = "../vta-policy", version = "0.3" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.2", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -209,7 +209,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.13" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.14" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made
@@ -384,7 +384,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.2...vta-support-v0.3.3) — 2026-09-07
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.1...vta-support-v0.3.2) — 2026-09-07
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -29,8 +29,8 @@ vta-config = { path = "../vta-config", version = "0.4" }
 # verifies each crate in isolation, where nothing enables it, so the method
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
-vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-sweepers/CHANGELOG.md
+++ b/vta-sweepers/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.3...vta-sweepers-v0.3.4) — 2026-09-07
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.2...vta-sweepers-v0.3.3) — 2026-09-07
 
 

--- a/vta-sweepers/Cargo.toml
+++ b/vta-sweepers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sweepers"
 description = "Background TTL sweepers for the VTA's core keyspaces — ACL grant expiry, pending-consent expiry, and soft-deleted-vault purge"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -20,7 +20,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 vta-audit = { path = "../vta-audit", version = "0.3" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-vault = { path = "../vta-vault", version = "0.5" }

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.3...vta-tee-v0.2.4) — 2026-09-07
+
+
 ## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.2...vta-tee-v0.2.3) — 2026-09-06
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -27,7 +27,7 @@ repository.workspace = true
 tenant-overlay = ["dep:tokio-vsock"]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17", features = ["encryption", "openapi"] }
+vti-common = { path = "../vti-common", version = "0.18", features = ["encryption", "openapi"] }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4", features = ["tee"] }
 vta-keys = { path = "../vta-keys", version = "0.4" }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.3...vta-vault-v0.5.4) — 2026-09-07
+
+
 ## [0.5.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.2...vta-vault-v0.5.3) — 2026-09-07
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -33,8 +33,8 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.17", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm", "sealed-transfer"] }
+vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.4...vta-webvh-v0.2.5) — 2026-09-07
+
+
 ## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.3...vta-webvh-v0.2.4) — 2026-09-07
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,8 +21,8 @@ repository.workspace = true
 
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
-vti-common = { path = "../vti-common", version = "0.17" }
-vta-sdk = { path = "../vta-sdk", version = "0.33" }
+vti-common = { path = "../vti-common", version = "0.18" }
+vta-sdk = { path = "../vta-sdk", version = "0.34" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.3...vtc-client-v0.5.4) — 2026-09-07
+
+
+### Added
+
+- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))
+
+Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
+  building signed Trust Task documents, which is not a surface an operator has.
+  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
+
+  ## Two parties, never confused
+
+  Every command talks to both and keeps them apart: the operator's **VTA** mints
+  a presentation (`rooms/keys/present`) and opens sealed records
+  (`rooms/keys/open`), and the room's **host** stores the bytes. The credentials
+  the presentation is derived from and the group key that opens a record stay
+  inside the VTA - this CLI holds neither at any point.
+
+  That makes the CLI the oracle's first real consumer, and it works: a member
+  who holds less than an action needs is refused by their own VTA, before
+  anything reaches the host, which is the earlier and clearer of the two
+  refusals.
+
+  Each command mints its own presentation for exactly the action it performs -
+  `read` for list/get, `write` for put, `curate` for curate, `admin` for renew.
+  Caching one across commands would mean re-binding it (impossible without the
+  VTA) or sending it unbound, which is a bearer token.
+
+  ## Where the pieces had to live
+
+  `vta-sdk` gains `room_present` / `room_open`, because those are calls to your
+  own VTA. It cannot gain the room *wire types*: `vti-common` re-exports
+  `vta_sdk::acl`, so `vta-sdk -> vti-rooms -> vti-common -> vta-sdk` is a cycle.
+  So `vta-cli-common` takes `vtc-client`, which despite its name is the
+  host-neutral room client - `room-host`'s own example drives itself with it. A
+  second copy of the `rooms/*` wire types in the CLI is exactly the duplication
+  that crate deleted.
+
+  `vtc-client` gains `curate_record`, which nothing had implemented.
+
+  ## What it deliberately cannot do
+
+  **Write to a sealed room**: sealing needs the room's group key, and no task
+  seals on a caller's behalf. **Issue credentials**: minting a VIC, VMC or VAC
+  needs the room's own signing key, which is the owner's - a different party with
+  different custody. Both are refused with the reason rather than half-served,
+  and `get` translates the epoch-mismatch failure into "a commit has not been
+  delivered", which is what it means and not what it reads like.
+
+  Five tests on the two pure decisions: rebuilding a session from what the VTA
+  minted (each missing member refused rather than defaulted, a subject binding
+  surviving, a non-string chain link refused rather than silently shortening the
+  chain), and the pin/unpin tri-state where absence must stay distinct from
+  false.
+
+
+
 ## [0.5.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.2...vtc-client-v0.5.3) — 2026-09-07
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ mls = ["vti-rooms/mls"]
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["session"] }
 
 # The room's wire types, and — under the `mls` feature — its group-key and
 # sealing layers, which this crate re-exports rather than owning. A VTA needs

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -119,7 +119,7 @@ path = "src/main.rs"
 [dependencies]
 vti-rooms = { path = "../vti-rooms", version = "0.1" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }
-vti-common = { path = "../vti-common", version = "0.17", features = [
+vti-common = { path = "../vti-common", version = "0.18", features = [
   "passkey",
   # `setup` gates the shared dialoguer-driven secrets-prompt helper
   # the wizard calls into.
@@ -136,7 +136,7 @@ vti-common = { path = "../vti-common", version = "0.17", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.18.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.17.0...vti-common-v0.18.0) — 2026-09-07
+
+
+### Added
+
+- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
+
+
+### Fixed
+
+- **acl**: Let the role an agent runs as reach the room oracle ([#1275](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1275))
+
+The room presentation oracle exists for one consumer: an agent holding
+  strictly less than its human, asking its principal's VTA to mint a scoped
+  presentation and to open what it cannot decrypt. `application` is the role
+  such an agent runs as - `vta-agent-memory` grants exactly it - and it held
+  neither `RoomPresent` nor `RoomOpen`, so the one consumer the oracle was
+  built for could not call it.
+
+  The gates are role-derived (`role_has_capability` reads the role and nothing
+  else), so there was no way to grant the capability to a particular entry
+  either. The workaround an operator reaches for is worse than the grant:
+  running the agent as `initiator`, which carries `KeyMint` and `DeviceAdmin`
+  besides.
+
+  Neither capability widens what this role can do. `RoomPresent` mints a leaf
+  attenuated from the principal's own room authority - one action, one room,
+  four hours, bound to the caller - and the role already holds `Sign`, which is
+  the principal's key over arbitrary bytes and therefore strictly more.
+  `RoomOpen` decrypts a room record under a group key the VTA already holds,
+  and the same role can already read the credential vault. `Reader` and
+  `Monitor` get neither, and a test pins that: minting a credential on a
+  principal's behalf is not a read.
+
+  Also corrects two doc comments that described enforcement that does not
+  exist. `AclEntry::capabilities` said the auth layer falls back to the
+  role-derived set when it is empty, which reads as "and uses this set when it
+  is not" - but no gate consults the field, the authenticated claims carry no
+  capability set, and nothing over the wire can set it. It is read in exactly
+  one place, to describe a registered device's authority in a binding listing.
+  A reader who believed otherwise would think an entry was least-privileged
+  when it holds everything its role does, so the field and
+  `role_has_capability` now say what is true. Making it real means carrying the
+  set in the claims and giving the ACL surface a way to set it - a separate
+  change with its own design question about whether an entry's set may widen
+  beyond its role or only narrow within it.
+
+
+
 ## [0.17.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.16.2...vti-common-v0.17.0) — 2026-09-07
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.33", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.34", default-features = false }
 async-trait = "0.1"
 # Durable OutboxStore backend (`outbox_store::VtiOutboxStore`) for the D1
 # delivery layer — the Guaranteed-send outbox, persisted via `store::Store`.

--- a/vti-rooms-dtg/CHANGELOG.md
+++ b/vti-rooms-dtg/CHANGELOG.md
@@ -2,5 +2,8 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.1...vti-rooms-dtg-v0.1.2) — 2026-09-07
+
+
 ## [0.1.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.0...vti-rooms-dtg-v0.1.1) — 2026-09-07
 

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms-dtg"
 description = "The DTG-credential chain verifier for data rooms"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -25,7 +25,7 @@ test-support = ["dep:ed25519-dalek", "dep:getrandom", "dep:multibase", "dep:vta-
 
 [dependencies]
 vti-rooms = { path = "../vti-rooms", version = "0.1" }
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 
 # `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
 # 0.6.0 sat merged and unreleased; released 2026-09-03.
@@ -45,7 +45,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { version = "0.3", optional = true }
 multibase = { workspace = true, optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = ["didcomm"], optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm"], optional = true }
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/vti-rooms/CHANGELOG.md
+++ b/vti-rooms/CHANGELOG.md
@@ -2,5 +2,50 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.1...vti-rooms-v0.1.2) — 2026-09-07
+
+
+### Fixed
+
+- **rooms**: Authorize registering a room, which nothing did ([#1274](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1274))
+
+`rooms/create/0.1` was the one verb neither host authorized. The document's
+  proof was never verified on that path and the signer was never compared to
+  `ownerDid`, so anyone who could reach the endpoint could register a room row
+  naming any party as its owner - filling a host's store with rooms attributed
+  to people who never agreed to own them, and taking identifiers from under
+  their real owners. Every other verb verifies the proof and the authority
+  chain; this one fell through because it is the one operation no chain can
+  authorize, and the check it needed instead was never written.
+
+  Create cannot be authorized by a chain: at the moment it runs the room has
+  issued nothing, so no credential in the world speaks for it. What a host does
+  have is the proof on the request, and that is what makes `ownerDid` a fact
+  rather than a field anyone can fill with anyone. So the presenter must be the
+  party they name as owner, and the room is then written from the authorization
+  rather than from the payload.
+
+  The decision lives in `vti_rooms::authz::authorize_create`, beside the chain
+  authorization it complements, because a room host and a VTC disagreeing about
+  who may register a room is exactly the class of drift that crate exists to
+  prevent. It returns an `AuthorizedCreate` with no public constructor, so a
+  handler that skips the check does not compile - the same typestate the rest
+  of the family uses.
+
+  What this deliberately does not do is prove control of the identifier. A
+  party can still register a `roomId` they do not control while naming
+  themselves owner, denying that id to its real owner on that host. The row
+  confers nothing - every later verb needs credentials the real room issued -
+  so it is a nuisance rather than a takeover, and bounding it is quota and
+  access control, which is the availability row of the trust model. Proving
+  control would mean the room signing its own registration, which would exclude
+  every owner whose room key cannot sign a request document.
+
+  Behaviour change for any caller that relayed a registration on an owner's
+  behalf: there were none in the workspace, and the two hosts, their tests and
+  the `data_room` example all already signed as the owner.
+
+
+
 ## [0.1.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.0...vti-rooms-v0.1.1) — 2026-09-07
 

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -29,7 +29,7 @@ mls = [
 # The store abstraction and AppError. This crate's only internal dependency:
 # a room's storage and authorization need nothing from a community service,
 # which is the whole reason they are extractable.
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.2...vti-secrets-v0.3.3) — 2026-09-07
+
+
 ## [0.3.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.1...vti-secrets-v0.3.2) — 2026-09-07
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -47,14 +47,14 @@ onboarding = [
 ]
 
 [dependencies]
-vti-common = { path = "../vti-common", version = "0.17" }
+vti-common = { path = "../vti-common", version = "0.18" }
 serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.33.0 -> 0.34.0 (✓ API compatible changes)
* `vti-common`: 0.17.0 -> 0.18.0 (✓ API compatible changes)
* `vti-rooms`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `vtc-client`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `vta-cli-common`: 0.13.0 -> 0.14.0 (✓ API compatible changes)
* `cnm-cli`: 0.13.6 -> 0.14.0
* `pnm-cli`: 0.14.6 -> 0.15.0
* `vta-persona`: 0.1.0 -> 0.2.0 (✓ API compatible changes)
* `vta-service`: 0.23.5 -> 0.24.0 (✓ API compatible changes)
* `vti-rooms-dtg`: 0.1.1 -> 0.1.2
* `vta-audit`: 0.3.3 -> 0.3.4
* `vti-secrets`: 0.3.2 -> 0.3.3
* `vta-config`: 0.4.3 -> 0.4.4
* `vta-keyspaces`: 0.2.6 -> 0.2.7
* `vta-keys`: 0.4.3 -> 0.4.4
* `vta-support`: 0.3.2 -> 0.3.3
* `vta-backup`: 0.3.3 -> 0.3.4
* `vta-policy`: 0.3.3 -> 0.3.4
* `vta-vault`: 0.5.3 -> 0.5.4
* `vta-sweepers`: 0.3.3 -> 0.3.4
* `vta-tee`: 0.2.3 -> 0.2.4
* `vta-webvh`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.34.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.33.0...vta-sdk-v0.34.0) — 2026-09-07

### Added

- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))

Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
  building signed Trust Task documents, which is not a surface an operator has.
  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
</blockquote>

## `vti-common`

<blockquote>

## [0.18.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.17.0...vti-common-v0.18.0) — 2026-09-07

### Added

- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))


### Fixed

- **acl**: Let the role an agent runs as reach the room oracle ([#1275](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1275))

The room presentation oracle exists for one consumer: an agent holding
  strictly less than its human, asking its principal's VTA to mint a scoped
  presentation and to open what it cannot decrypt. `application` is the role
  such an agent runs as - `vta-agent-memory` grants exactly it - and it held
  neither `RoomPresent` nor `RoomOpen`, so the one consumer the oracle was
  built for could not call it.

  The gates are role-derived (`role_has_capability` reads the role and nothing
  else), so there was no way to grant the capability to a particular entry
  either. The workaround an operator reaches for is worse than the grant:
  running the agent as `initiator`, which carries `KeyMint` and `DeviceAdmin`
  besides.

  Neither capability widens what this role can do. `RoomPresent` mints a leaf
  attenuated from the principal's own room authority - one action, one room,
  four hours, bound to the caller - and the role already holds `Sign`, which is
  the principal's key over arbitrary bytes and therefore strictly more.
  `RoomOpen` decrypts a room record under a group key the VTA already holds,
  and the same role can already read the credential vault. `Reader` and
  `Monitor` get neither, and a test pins that: minting a credential on a
  principal's behalf is not a read.

  Also corrects two doc comments that described enforcement that does not
  exist. `AclEntry::capabilities` said the auth layer falls back to the
  role-derived set when it is empty, which reads as "and uses this set when it
  is not" - but no gate consults the field, the authenticated claims carry no
  capability set, and nothing over the wire can set it. It is read in exactly
  one place, to describe a registered device's authority in a binding listing.
  A reader who believed otherwise would think an entry was least-privileged
  when it holds everything its role does, so the field and
  `role_has_capability` now say what is true. Making it real means carrying the
  set in the claims and giving the ACL surface a way to set it - a separate
  change with its own design question about whether an entry's set may widen
  beyond its role or only narrow within it.
</blockquote>

## `vti-rooms`

<blockquote>

## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.1...vti-rooms-v0.1.2) — 2026-09-07

### Fixed

- **rooms**: Authorize registering a room, which nothing did ([#1274](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1274))

`rooms/create/0.1` was the one verb neither host authorized. The document's
  proof was never verified on that path and the signer was never compared to
  `ownerDid`, so anyone who could reach the endpoint could register a room row
  naming any party as its owner - filling a host's store with rooms attributed
  to people who never agreed to own them, and taking identifiers from under
  their real owners. Every other verb verifies the proof and the authority
  chain; this one fell through because it is the one operation no chain can
  authorize, and the check it needed instead was never written.

  Create cannot be authorized by a chain: at the moment it runs the room has
  issued nothing, so no credential in the world speaks for it. What a host does
  have is the proof on the request, and that is what makes `ownerDid` a fact
  rather than a field anyone can fill with anyone. So the presenter must be the
  party they name as owner, and the room is then written from the authorization
  rather than from the payload.

  The decision lives in `vti_rooms::authz::authorize_create`, beside the chain
  authorization it complements, because a room host and a VTC disagreeing about
  who may register a room is exactly the class of drift that crate exists to
  prevent. It returns an `AuthorizedCreate` with no public constructor, so a
  handler that skips the check does not compile - the same typestate the rest
  of the family uses.

  What this deliberately does not do is prove control of the identifier. A
  party can still register a `roomId` they do not control while naming
  themselves owner, denying that id to its real owner on that host. The row
  confers nothing - every later verb needs credentials the real room issued -
  so it is a nuisance rather than a takeover, and bounding it is quota and
  access control, which is the availability row of the trust model. Proving
  control would mean the room signing its own registration, which would exclude
  every owner whose room key cannot sign a request document.

  Behaviour change for any caller that relayed a registration on an owner's
  behalf: there were none in the workspace, and the two hosts, their tests and
  the `data_room` example all already signed as the owner.
</blockquote>

## `vtc-client`

<blockquote>

## [0.5.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.3...vtc-client-v0.5.4) — 2026-09-07

### Added

- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))

Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
  building signed Trust Task documents, which is not a surface an operator has.
  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
</blockquote>

## `vta-cli-common`

<blockquote>

## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.13.0...vta-cli-common-v0.14.0) — 2026-09-07

### Added

- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))

Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
  building signed Trust Task documents, which is not a surface an operator has.
  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
</blockquote>

## `cnm-cli`

<blockquote>

## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.6...cnm-cli-v0.14.0) — 2026-09-07

### Added

- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))

#1279 left `acl/grant` refusing a capability narrowing and pointing at
  `acl update`, because taking one meant a fifteenth positional parameter on
  `create_acl`. Refusing was honest but it leaves a real window: between the
  grant and the narrowing the entry holds everything its role implies, and a
  subject that authenticates inside that window is authorized by what it found
  there.

  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
  already had - so the narrowing is one more named field rather than a
  fourteenth argument nobody can read at the call site. Test call sites state
  the two or three members they care about and default the rest instead of
  spelling every one to reach the last.

  The rule is the update path's, applied where the entry is born: a name the
  role does not carry is refused rather than dropped, an unknown name is
  refused, and neither leaves a row behind. `pnm acl create --capabilities
  memory-read,room-present` is now the form to prefer, and the agent runbook
  says so.

  Also echoes the stored narrowing from `acl create` and `acl show`, so the
  restriction can be read back from wherever it was set.

- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))
</blockquote>

## `pnm-cli`

<blockquote>

## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.6...pnm-cli-v0.15.0) — 2026-09-07

### Added

- **rooms**: A member's CLI surface, driven through the oracle ([#1285](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1285))

Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-
  building signed Trust Task documents, which is not a surface an operator has.
  `pnm rooms {create,list,get,put,curate,renew}` is that surface for a member.
</blockquote>

## `vta-persona`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.1.0...vta-persona-v0.2.0) — 2026-09-07

### Fixed

- **persona**: The audit trail says what changed, and correlation/analyze conforms ([#1283](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1283))

* fix(persona): the audit trail says what changed

  Every persona write recorded action, actor, resource and outcome and
  nothing else. `audit_persona` called `audit::record(...)`, which has no
  `detail` parameter, so a console audit pane showed twenty rows of
  `persona.attribute.put` against opaque ULIDs with no way to tell a
  create from an update, a cascade delete from a no-op against a typo'd
  id, or a binding that materialised forty claims from one that cleared
  them.

  The console side was never the problem: `AuditEnvelope` already renders
  `detail` in full as `detail.reason`. There was simply nothing to render.

  So the write handlers now go through `audit::record_with_detail` and
  supply one: attribute put/delete, profile put/delete, binding/set, and
  the three context-local writes each say what changed — created or
  updated, the claim type, the value type, the provenance kind, entry and
  claim counts, whether the record existed, how many profiles or personas
  were affected, and the resulting version. Reads still pass `None`; a
  read changes nothing, and a sentence restating the request would be
  noise in an append-only store.

  The attribute VALUE stays out, and `audit_persona` now explains why at
  length, because the reason is not the one people assume. It is NOT an
  access-control reason. Persona rows are recorded with `context_id:
  None`, and `operations::audit::authorize` already refuses every entry
  not confined to a named context to anyone but an unrestricted admin —
  exactly the caller `Reach::Holder` admits to `attribute/list`, which
  returns the plaintext outright. Nobody gains a read by us writing one.

  The reason is lifetime. The audit keyspace is append-only and pruned on
  its own retention schedule; the pool is deleted when the holder deletes
  an attribute. Copy a value across and `attribute/delete` quietly stops
  being a delete — the value outlives the record it came from, in a store
  the holder's delete does not reach. Stating that distinction matters,
  because "don't log values" as a bare prohibition is the rule somebody
  relaxes the first time an operator asks for a better trail, and the
  access-control argument does not survive that conversation.

  The new test asserts both halves together. A test that only checks the
  value is absent passes against a handler that records no detail at all,
  which is precisely the state being fixed.

- **persona**: "edit once, everywhere" reached nothing ([#1281](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1281))

A holder edited their name and the verifier was still shown the old
  one. `rematerialise` — the function whose docstring explains that a
  context holds a materialised copy and can only be updated by a write
  from above the boundary — was **called from no handler in the
  codebase**. The only reference outside its own file was a comment in a
  test.

  A context may never read the pool, so its copy changes only if
  something pushes. Nothing did. `attribute/put`, `attribute/delete
  --cascade` and `profile/put` all changed what a profile projects and
  left every bound context presenting the state from before the edit,
  which `disclosure/preview` and `disclosure/present` then handed to a
  verifier.

  **The push now belongs to the write, not to the call site.** `put`,
  `delete` and `put_profile` push before returning, from inside the lock
  they already hold. Leaving it to handlers is the same decision taken
  once per call site and forgetting it is silent — the pool shows the new
  value, the console shows the pool, and only the verifier sees the old
  one.
</blockquote>

## `vta-service`

<blockquote>

## [0.24.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.5...vta-service-v0.24.0) — 2026-09-07

### Added

- **acl**: Create an entry already narrowed, rather than narrowing it after ([#1280](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1280))

#1279 left `acl/grant` refusing a capability narrowing and pointing at
  `acl update`, because taking one meant a fifteenth positional parameter on
  `create_acl`. Refusing was honest but it leaves a real window: between the
  grant and the narrowing the entry holds everything its role implies, and a
  subject that authenticates inside that window is authorized by what it found
  there.

  `create_acl` now takes a `CreateAclParams` struct - the shape `update_acl`
  already had - so the narrowing is one more named field rather than a
  fourteenth argument nobody can read at the call site. Test call sites state
  the two or three members they care about and default the rest instead of
  spelling every one to reach the last.

  The rule is the update path's, applied where the entry is born: a name the
  role does not carry is refused rather than dropped, an unknown name is
  refused, and neither leaves a row behind. `pnm acl create --capabilities
  memory-read,room-present` is now the form to prefer, and the agent runbook
  says so.

  Also echoes the stored narrowing from `acl create` and `acl show`, so the
  restriction can be read back from wherever it was set.

- **acl**: Enforce an entry's capabilities, and give an operator a way to set them ([#1279](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1279))


### Fixed

- **persona**: The audit trail says what changed, and correlation/analyze conforms ([#1283](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1283))

* fix(persona): the audit trail says what changed

  Every persona write recorded action, actor, resource and outcome and
  nothing else. `audit_persona` called `audit::record(...)`, which has no
  `detail` parameter, so a console audit pane showed twenty rows of
  `persona.attribute.put` against opaque ULIDs with no way to tell a
  create from an update, a cascade delete from a no-op against a typo'd
  id, or a binding that materialised forty claims from one that cleared
  them.

  The console side was never the problem: `AuditEnvelope` already renders
  `detail` in full as `detail.reason`. There was simply nothing to render.

  So the write handlers now go through `audit::record_with_detail` and
  supply one: attribute put/delete, profile put/delete, binding/set, and
  the three context-local writes each say what changed — created or
  updated, the claim type, the value type, the provenance kind, entry and
  claim counts, whether the record existed, how many profiles or personas
  were affected, and the resulting version. Reads still pass `None`; a
  read changes nothing, and a sentence restating the request would be
  noise in an append-only store.

  The attribute VALUE stays out, and `audit_persona` now explains why at
  length, because the reason is not the one people assume. It is NOT an
  access-control reason. Persona rows are recorded with `context_id:
  None`, and `operations::audit::authorize` already refuses every entry
  not confined to a named context to anyone but an unrestricted admin —
  exactly the caller `Reach::Holder` admits to `attribute/list`, which
  returns the plaintext outright. Nobody gains a read by us writing one.

  The reason is lifetime. The audit keyspace is append-only and pruned on
  its own retention schedule; the pool is deleted when the holder deletes
  an attribute. Copy a value across and `attribute/delete` quietly stops
  being a delete — the value outlives the record it came from, in a store
  the holder's delete does not reach. Stating that distinction matters,
  because "don't log values" as a bare prohibition is the rule somebody
  relaxes the first time an operator asks for a better trail, and the
  access-control argument does not survive that conversation.

  The new test asserts both halves together. A test that only checks the
  value is absent passes against a handler that records no detail at all,
  which is precisely the state being fixed.

- **persona**: "edit once, everywhere" reached nothing ([#1281](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1281))

A holder edited their name and the verifier was still shown the old
  one. `rematerialise` — the function whose docstring explains that a
  context holds a materialised copy and can only be updated by a write
  from above the boundary — was **called from no handler in the
  codebase**. The only reference outside its own file was a comment in a
  test.

  A context may never read the pool, so its copy changes only if
  something pushes. Nothing did. `attribute/put`, `attribute/delete
  --cascade` and `profile/put` all changed what a profile projects and
  left every bound context presenting the state from before the edit,
  which `disclosure/preview` and `disclosure/present` then handed to a
  verifier.

  **The push now belongs to the write, not to the call site.** `put`,
  `delete` and `put_profile` push before returning, from inside the lock
  they already hold. Leaving it to handlers is the same decision taken
  once per call site and forgetting it is silent — the pool shows the new
  value, the console shows the pool, and only the verifier sees the old
  one.
</blockquote>















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).