### PR TITLE
feat(vtc): let the console explain the transport advertisement, not hint at it

### DIFF
--- a/docs/03-vtc/trust-registry.md
+++ b/docs/03-vtc/trust-registry.md
@@ -257,8 +257,56 @@ talking to it?":
 "transports": [                        // this VTC's own document
   { "protocol": "tsp",     "advertised": true,  "serviceable": true  },
   { "protocol": "didcomm", "advertised": false, "serviceable": true  }
-]
+],
+"ext": {
+  "org.openvtc": {
+    "transportFindings": [             // what that table *means*
+      {
+        "code": "noDidcommFallback",
+        "severity": "warn",
+        "summary": "the DID document advertises TSP with no DIDComm fallback — …",
+        "message": "this VTC advertises TSP but no DIDComm mediator, so …"
+      },
+      {
+        "code": "servedNotAdvertised",
+        "severity": "info",
+        "protocol": "didcomm",
+        "summary": "this build serves didcomm, but the DID document does not …",
+        "message": "this build serves didcomm but the DID document does not …"
+      }
+    ]
+  }
+}
 ```
+
+`transportFindings` is the same list `vtc status` prints and the daemon
+logs at messaging start, from one function
+(`transport_capability::findings_for_build`) — so no two surfaces can
+tell you a different story about the same document. Four codes, and
+`code` is the stable identity: `message` is prose written for a human
+and will be reworded, so match on the code and never on a substring.
+
+It lives under `ext` rather than at the top level because
+`spec/vtc/registry/diagnostics/0.1#response` is `additionalProperties:
+false`, and the daemon's own response-conformance layer enforces that.
+`ext` is the extension point the spec provides for exactly this (SPEC.md
+§4.5.1, reverse-DNS namespaces); promoting the field to the top level is
+a `trust-tasks-rs` spec release, not a change in this repo.
+
+| `code` | `severity` | What it means |
+|---|---|---|
+| `advertisedNotServable` | `error` | The document promises a transport this build cannot answer. Every conforming client picks it and fails — the more correct the client, the harder. |
+| `noMessagingAdvertised` | `warn` | No `TSPTransport` and no `DIDCommMessaging`: REST-only. Legal (it is what the `vtc-host` template mints by default) but nothing reaches this VTC over a mediator. |
+| `noDidcommFallback` | `warn` | TSP advertised with nothing behind it. A peer that does not speak TSP has no messaging route in. |
+| `servedNotAdvertised` | `info` | The binary serves more than it promises. Normal mid-rollout — ship the capable binary, then add the service entry. Never a fault. |
+
+The first two are statements about the *shape* of the advertised set,
+not about any one protocol, so they cannot be reconstructed from the
+`transports` table above. Read the findings; do not re-derive them.
+
+An empty `transportFindings` with a **non-empty** `transports` means the
+document and the binary agree. Empty *both* means this VTC's DID did not
+resolve — that is "unknown", not "nothing advertised".
 
 `advertised` and `active` are separate on purpose. A registry that
 advertises only TSP while this VTC can answer only DIDComm is
@@ -271,8 +319,16 @@ the half that tells you which side to fix.
 In the admin UI: the **Dashboard** names the live mediator
 protocols on its tile, adds a trust-registry tile (active
 protocol + status), lists the registry DID under Identity, and
-raises a "Transport advertisement" card when the document and the
-build disagree in either direction. The **Recognition** page
+always carries a "Transport advertisement" card — the `transports`
+table, then the findings above, rendered at their own severity.
+
+Read that card against the tiles rather than alongside them. The
+mediator and trust-registry tiles describe **other parties'**
+documents: the mediator this VTC dials, the registry it syncs with.
+The card describes **this community's own**. A registry tile reading
+`advertises TSP, DIDComm` next to a card reading `not advertised:
+DIDComm` is not a contradiction — it is two different DID documents,
+and the card says so on its face. The **Recognition** page
 shows the registry DID, what it advertises, what we are
 connecting over, and the last transport error. The **Audit** page
 carries `RegistryStatusChanged` / `RegistrySyncSucceeded` /

--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -5227,6 +5227,19 @@
           }
         }
       },
+      "DiagnosticsExt": {
+        "type": "object",
+        "description": "The `ext` envelope on the diagnostics response.\n\n`spec/vtc/registry/diagnostics/0.1#response` is `additionalProperties:\nfalse` and `response_conformance` enforces it against every response an\nintegration test provokes, so a new top-level field here is a spec change\nupstream in `trust-tasks-rs` before it is a change in this repo. `ext` is\nthe mechanism the spec provides instead (SPEC.md §4.5.1) — an open object\nwhose immediate keys must each be a reverse-DNS namespace, with the\nstructure beneath one opaque to the framework.\n\nTyped rather than a bare `serde_json::Value` so the shape reaches\n`openapi.json`, and from there the console's generated `wire.ts`. An\nuntyped `ext` would publish the field and un-type exactly the consumer it\nexists for.",
+        "required": [
+          "org.openvtc"
+        ],
+        "properties": {
+          "org.openvtc": {
+            "$ref": "#/components/schemas/OpenVtcDiagnostics",
+            "description": "`org.openvtc`, not `vtc`: §4.5.1 requires at least two segments\n(`^[a-z][a-z0-9-]*(\\.[a-z0-9-]+)+$`), and a bare `vtc` claims a name\nnobody owns — the collision the rule exists to prevent. Same namespace\nthe audit surface already extends under."
+          }
+        }
+      },
       "DiagnosticsResponse": {
         "type": "object",
         "description": "Phase 3 M3.8 — admin-gated diagnostics view.\n\nSurfaces enough of the trust-registry reconciler's internal\nstate to debug \"is sync stuck?\" without shelling onto the\nhost. The fields are picked for *operator action*, not raw\nmetrics dump:\n\n- `registry_status` — does the daemon think the registry\n  is reachable right now? Mirrors the same flag on\n  `GET /v1/community/profile` (M3.2).\n- `queue_depth` — count of pending+InFlight rows. A\n  monotonically rising number means the registry is\n  refusing dispatch.\n- `oldest_pending_age_seconds` — staleness of the\n  longest-waiting job. Drives the \"≥1h behind →\n  degraded\" SLI per spec §8.3.\n- `rtbf_batched_count` — how many jobs are parked behind\n  the RTBF window. Lets operators verify the batch\n  protection is active without inspecting fjall.\n- `failed_count` — terminal-failure rows the syncer gave\n  up on (`attempts > max_attempts` or\n  `RegistryError::Permanent`). These need operator\n  triage; the syncer won't retry them.\n- `last_success_at` / `last_failure_at` / `last_error` —\n  replayed verbatim from the health probe state.\n\nDiagnostics is **admin-gated**, not super-admin: ops staff\nrunning on-call should be able to read this without\nholding the super-admin role.",
@@ -5239,9 +5252,14 @@
           "syncerRunning",
           "syncerRestarts",
           "messagingStatus",
-          "transports"
+          "transports",
+          "ext"
         ],
         "properties": {
+          "ext": {
+            "$ref": "#/components/schemas/DiagnosticsExt",
+            "description": "Vendor-namespaced additions to the published response."
+          },
           "failedCount": {
             "type": "integer",
             "format": "int64",
@@ -5610,6 +5628,50 @@
             "type": "string"
           }
         }
+      },
+      "Finding": {
+        "type": "object",
+        "description": "One observation about the document-versus-binary relationship.\n\nCarries both a one-line [`summary`](Finding::summary) and the full\n[`message`](Finding::message) because the two consumers need different\nlengths and must not be allowed to drift into different claims: `vtc\nstatus` and the daemon log print the message, the admin console renders the\nsummary as a headline with the message beneath it. Both are written in\n[`findings_against`], once.",
+        "required": [
+          "code",
+          "severity",
+          "summary",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "$ref": "#/components/schemas/FindingCode",
+            "description": "Stable identity — match on this, never on the prose."
+          },
+          "message": {
+            "type": "string",
+            "description": "The full operator-facing explanation: what is wrong, what it causes,\nand every way to fix it (R6.4)."
+          },
+          "protocol": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The transport this is about (`\"tsp\"` / `\"didcomm\"` / `\"rest\"`), when it\nis about one. [`FindingCode::NoMessagingAdvertised`] and\n[`FindingCode::NoDidcommFallback`] are statements about the document as\na whole, so they carry `None`."
+          },
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
+          },
+          "summary": {
+            "type": "string",
+            "description": "One line, no remediation — what state the document and binary are in."
+          }
+        }
+      },
+      "FindingCode": {
+        "type": "string",
+        "description": "Which observation a [`Finding`] is, independent of how it is worded.\n\nThe prose in [`Finding::message`] is written for an operator and will be\nreworded; a console that keys its rendering off substrings of it breaks\nsilently the first time it is. This enum is the stable identity, so a\nconsumer can style, order and link a finding without parsing English.",
+        "enum": [
+          "advertisedNotServable",
+          "noMessagingAdvertised",
+          "noDidcommFallback",
+          "servedNotAdvertised"
+        ]
       },
       "FinishBody": {
         "type": "object",
@@ -6591,6 +6653,22 @@
             ],
             "format": "int32",
             "minimum": 0
+          }
+        }
+      },
+      "OpenVtcDiagnostics": {
+        "type": "object",
+        "description": "What OpenVTC adds to the standard diagnostics payload.",
+        "required": [
+          "transportFindings"
+        ],
+        "properties": {
+          "transportFindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Finding"
+            },
+            "description": "What the document-versus-binary comparison actually *means*, from\n[`transport_capability::findings_for_build`](crate::transport_capability::findings_for_build)\n— the same list `vtc status` prints and the daemon logs at messaging\nstart.\n\nServed rather than re-derived in the console because two of the four\nfindings cannot be reconstructed from\n[`DiagnosticsResponse::transports`] at all. \"advertises TSP with no\nDIDComm fallback\" and \"advertises no messaging at all\" are statements\nabout the *shape* of the advertised set, not about any one protocol's\ntwo booleans, so a console deriving its own view necessarily dropped\nthem — and the first of those is the finding that explains why an\noperator should care about the informational line it *could* render.\nRe-deriving also conflated \"this build cannot serve it\" with \"the\nmediator socket is down\", because `serviceable` is the conjunction,\nwhich turned a transient disconnect into a document-is-broken banner.\n\nAdmin-gated, which is what lets it carry the full remediation prose:\nthat text names build feature flags, and the unauthenticated community\nprofile deliberately excludes it (see\n[`TransportStatus`](crate::transport_capability::TransportStatus)).\n\nEmpty means either \"document and binary agree\" or \"the DID did not\nresolve\" — [`DiagnosticsResponse::transports`] being empty\ndistinguishes them."
           }
         }
       },
@@ -8423,6 +8501,15 @@
             "description": "The DID this session authenticates."
           }
         }
+      },
+      "Severity": {
+        "type": "string",
+        "description": "How loudly a [`Finding`] should be reported.",
+        "enum": [
+          "error",
+          "warn",
+          "info"
+        ]
       },
       "ShowWhen": {
         "type": "object",

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -16,57 +16,29 @@ export interface HealthResponse {
   vtc_did?: string;
 }
 
-// `GET /v1/health/diagnostics` — admin-gated. Surfaces the
-// trust-registry reconciler state plus the identity/mediator detail
-// that used to live on `/health`. The dashboard only needs the
-// identity fields; the rest are typed for future diagnostics views.
-/** One protocol's state on this VTC's own DID document. */
-export interface TransportStatus {
-  /** "tsp" | "didcomm" | "rest" */
-  protocol: string;
-  /** The DID document advertises it, so a resolving client will find it. */
-  advertised: boolean;
-  /** This build can answer on it right now (compiled in + live mediator). */
-  serviceable: boolean;
-  /** Mediator DID for TSP/DIDComm, base URL for REST. */
-  endpoint?: string;
-}
+// `GET /v1/health/diagnostics` — admin-gated. Surfaces the trust-registry
+// reconciler state plus the identity/mediator detail that used to live on
+// `/health` (P3.7).
+//
+// These three shapes used to be declared here by hand, beside the fetch, in
+// exactly the way #1186 taught us not to: `wire-types.ts` had already aliased
+// the generated schemas, nothing imported them, and the hand-written copies
+// won at the call site. They had drifted before anyone read them — the daemon
+// serialises `messagingStatus` and `transports` unconditionally, the local
+// copy called both optional — and `tsc` could not notice, because the local
+// interface *is* what it checks the console against. Re-export the generated
+// aliases instead, so a response change fails to compile rather than arriving
+// as `undefined`.
+import type { DiagnosticsResponse } from "./wire-types";
 
-/**
- * How the VTC reaches its trust registry.
- *
- * `advertised` is the registry's own claim (read from its DID document);
- * `active` is what the last call actually chose. They are separate because a
- * registry can be configured and unreachable at once — advertising a transport
- * this VTC cannot answer — and one merged field would have to drop half of it.
- */
-export interface RegistryTransport {
-  did?: string;
-  url?: string;
-  advertised: string[];
-  active?: string;
-  error?: string;
-}
-
-export interface DiagnosticsResponse {
-  registryStatus: string;
-  queueDepth: number;
-  rtbfBatchedCount: number;
-  failedCount: number;
-  oldestPendingAgeSeconds?: number;
-  lastSuccessAt?: string;
-  lastFailureAt?: string;
-  lastError?: string;
-  vtaDid?: string;
-  mediatorUrl?: string;
-  mediatorDid?: string;
-  syncerEnabled: boolean;
-  syncerRunning: boolean;
-  syncerRestarts: number;
-  messagingStatus?: string;
-  registryTransport?: RegistryTransport;
-  transports?: TransportStatus[];
-}
+export type {
+  DiagnosticsExt,
+  DiagnosticsResponse,
+  RegistryTransport,
+  TransportFinding,
+  TransportFindingCode,
+  TransportStatus,
+} from "./wire-types";
 
 export interface BuildInfo {
   version: string;

--- a/vtc-service/admin-ui/src/lib/wire-types.ts
+++ b/vtc-service/admin-ui/src/lib/wire-types.ts
@@ -89,4 +89,7 @@ export type GraphEdge = Schemas["GraphEdge"];
 export type GraphHalf = Schemas["GraphHalf"];
 export type DiagnosticsResponse = Schemas["DiagnosticsResponse"];
 export type TransportStatus = Schemas["TransportStatus"];
+export type TransportFinding = Schemas["Finding"];
+export type TransportFindingCode = Schemas["FindingCode"];
+export type DiagnosticsExt = Schemas["DiagnosticsExt"];
 export type RegistryTransport = Schemas["RegistryTransport"];

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -2193,6 +2193,31 @@ export interface components {
             pop?: null | components["schemas"]["Value"];
         };
         /**
+         * @description The `ext` envelope on the diagnostics response.
+         *
+         *     `spec/vtc/registry/diagnostics/0.1#response` is `additionalProperties:
+         *     false` and `response_conformance` enforces it against every response an
+         *     integration test provokes, so a new top-level field here is a spec change
+         *     upstream in `trust-tasks-rs` before it is a change in this repo. `ext` is
+         *     the mechanism the spec provides instead (SPEC.md §4.5.1) — an open object
+         *     whose immediate keys must each be a reverse-DNS namespace, with the
+         *     structure beneath one opaque to the framework.
+         *
+         *     Typed rather than a bare `serde_json::Value` so the shape reaches
+         *     `openapi.json`, and from there the console's generated `wire.ts`. An
+         *     untyped `ext` would publish the field and un-type exactly the consumer it
+         *     exists for.
+         */
+        DiagnosticsExt: {
+            /**
+             * @description `org.openvtc`, not `vtc`: §4.5.1 requires at least two segments
+             *     (`^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$`), and a bare `vtc` claims a name
+             *     nobody owns — the collision the rule exists to prevent. Same namespace
+             *     the audit surface already extends under.
+             */
+            "org.openvtc": components["schemas"]["OpenVtcDiagnostics"];
+        };
+        /**
          * @description Phase 3 M3.8 — admin-gated diagnostics view.
          *
          *     Surfaces enough of the trust-registry reconciler's internal
@@ -2224,6 +2249,8 @@ export interface components {
          *     holding the super-admin role.
          */
         DiagnosticsResponse: {
+            /** @description Vendor-namespaced additions to the published response. */
+            ext: components["schemas"]["DiagnosticsExt"];
             /** Format: int64 */
             failedCount: number;
             lastError?: string | null;
@@ -2428,6 +2455,45 @@ export interface components {
             label: string;
             value: string;
         };
+        /**
+         * @description One observation about the document-versus-binary relationship.
+         *
+         *     Carries both a one-line [`summary`](Finding::summary) and the full
+         *     [`message`](Finding::message) because the two consumers need different
+         *     lengths and must not be allowed to drift into different claims: `vtc
+         *     status` and the daemon log print the message, the admin console renders the
+         *     summary as a headline with the message beneath it. Both are written in
+         *     [`findings_against`], once.
+         */
+        Finding: {
+            /** @description Stable identity — match on this, never on the prose. */
+            code: components["schemas"]["FindingCode"];
+            /**
+             * @description The full operator-facing explanation: what is wrong, what it causes,
+             *     and every way to fix it (R6.4).
+             */
+            message: string;
+            /**
+             * @description The transport this is about (`"tsp"` / `"didcomm"` / `"rest"`), when it
+             *     is about one. [`FindingCode::NoMessagingAdvertised`] and
+             *     [`FindingCode::NoDidcommFallback`] are statements about the document as
+             *     a whole, so they carry `None`.
+             */
+            protocol?: string | null;
+            severity: components["schemas"]["Severity"];
+            /** @description One line, no remediation — what state the document and binary are in. */
+            summary: string;
+        };
+        /**
+         * @description Which observation a [`Finding`] is, independent of how it is worded.
+         *
+         *     The prose in [`Finding::message`] is written for an operator and will be
+         *     reworded; a console that keys its rendering off substrings of it breaks
+         *     silently the first time it is. This enum is the stable identity, so a
+         *     consumer can style, order and link a finding without parsing English.
+         * @enum {string}
+         */
+        FindingCode: "advertisedNotServable" | "noMessagingAdvertised" | "noDidcommFallback" | "servedNotAdvertised";
         FinishBody: {
             newDid: string;
             /** @description Hex-encoded Ed25519 signature by the new DID's key. */
@@ -2977,6 +3043,37 @@ export interface components {
             role: components["schemas"]["VtcRole"];
             /** Format: int32 */
             statusListIndex?: number | null;
+        };
+        /** @description What OpenVTC adds to the standard diagnostics payload. */
+        OpenVtcDiagnostics: {
+            /**
+             * @description What the document-versus-binary comparison actually *means*, from
+             *     [`transport_capability::findings_for_build`](crate::transport_capability::findings_for_build)
+             *     — the same list `vtc status` prints and the daemon logs at messaging
+             *     start.
+             *
+             *     Served rather than re-derived in the console because two of the four
+             *     findings cannot be reconstructed from
+             *     [`DiagnosticsResponse::transports`] at all. "advertises TSP with no
+             *     DIDComm fallback" and "advertises no messaging at all" are statements
+             *     about the *shape* of the advertised set, not about any one protocol's
+             *     two booleans, so a console deriving its own view necessarily dropped
+             *     them — and the first of those is the finding that explains why an
+             *     operator should care about the informational line it *could* render.
+             *     Re-deriving also conflated "this build cannot serve it" with "the
+             *     mediator socket is down", because `serviceable` is the conjunction,
+             *     which turned a transient disconnect into a document-is-broken banner.
+             *
+             *     Admin-gated, which is what lets it carry the full remediation prose:
+             *     that text names build feature flags, and the unauthenticated community
+             *     profile deliberately excludes it (see
+             *     [`TransportStatus`](crate::transport_capability::TransportStatus)).
+             *
+             *     Empty means either "document and binary agree" or "the DID did not
+             *     resolve" — [`DiagnosticsResponse::transports`] being empty
+             *     distinguishes them.
+             */
+            transportFindings: components["schemas"]["Finding"][];
         };
         /**
          * @description Standard response wrapper for list endpoints. Carries the
@@ -4211,6 +4308,11 @@ export interface components {
             /** @description The DID this session authenticates. */
             subject: string;
         };
+        /**
+         * @description How loudly a [`Finding`] should be reported.
+         * @enum {string}
+         */
+        Severity: "error" | "warn" | "info";
         /**
          * @description A `showWhen` predicate, declarative so it crosses the wire: render
          *     the field only when `field`'s value equals `eq` (or its truthiness

--- a/vtc-service/admin-ui/src/plugins/dashboard.tsx
+++ b/vtc-service/admin-ui/src/plugins/dashboard.tsx
@@ -30,11 +30,17 @@ export function Dashboard() {
   // a queue an hour behind is the spec's degraded SLI. Plain depth is not
   // trouble: a burst of joins drains.
   const failed = diagnostics.data?.failedCount ?? 0;
+  // `null` and `undefined` both mean "no dispatchable job is waiting": the
+  // daemon sends `null` when the queue is empty, and the field is absent
+  // before the first diagnostics response lands. `!= null` covers both, which
+  // a `!== undefined` test did not — it read an empty queue as a number and
+  // only got away with it because the hand-written response type here claimed
+  // the field was never null.
   const oldestPending = diagnostics.data?.oldestPendingAgeSeconds;
   const queueTrouble =
     failed > 0
       ? `${failed} sync job${failed === 1 ? "" : "s"} failed`
-      : oldestPending !== undefined && oldestPending >= 3600
+      : oldestPending != null && oldestPending >= 3600
         ? `sync ${formatDuration(oldestPending)} behind`
         : undefined;
 
@@ -42,12 +48,29 @@ export function Dashboard() {
   // transport ready" was true of every deployment and told an operator
   // nothing: a VTC on TSP, or one advertising a transport its build cannot
   // answer, read identically. Name the protocols instead.
-  const messaging = (diagnostics.data?.transports ?? []).filter(
-    (t) => t.protocol !== "rest",
-  );
+  const transports = diagnostics.data?.transports ?? [];
+  const messaging = transports.filter((t) => t.protocol !== "rest");
   const live = messaging.filter((t) => t.advertised && t.serviceable);
-  const advertisedOnly = messaging.filter((t) => t.advertised && !t.serviceable);
-  const servedOnly = messaging.filter((t) => !t.advertised && t.serviceable);
+
+  // Every *interpretation* of the document-versus-binary comparison comes from
+  // the daemon, off `transport_capability::findings_for_build` — the same
+  // function `vtc status` and the boot gate read. The console used to re-derive
+  // its own from the `transports` booleans, which was wrong twice over: two of
+  // the four findings are statements about the shape of the advertised set
+  // ("TSP with no DIDComm fallback", "no messaging advertised at all") and are
+  // not reconstructable from any one protocol's pair of flags, so the console
+  // silently dropped them — including the one that explains why the
+  // informational line it *did* show matters. And `serviceable` is
+  // build-capability AND live-connection, so a transient mediator disconnect
+  // rendered as "a client will choose this and fail", which is a document
+  // defect the operator did not have.
+  //
+  // Under `ext["org.openvtc"]` rather than at the top level because the
+  // published response schema is `additionalProperties: false`: the extension
+  // point is what ships this without waiting on a spec release.
+  const findings =
+    diagnostics.data?.ext?.["org.openvtc"]?.transportFindings ?? [];
+  const hasBrokenAdvertisement = findings.some((f) => f.severity === "error");
 
   const mediatorFoot = !mediatorDid
     ? "REST-only deployment"
@@ -62,7 +85,7 @@ export function Dashboard() {
   // more correct the client, the more certainly it fails.
   const mediatorTone = !mediatorDid
     ? "neutral"
-    : advertisedOnly.length || !live.length
+    : hasBrokenAdvertisement || !live.length
       ? "warn"
       : "ok";
 
@@ -151,30 +174,101 @@ export function Dashboard() {
         )}
       </div>
 
-      {/* Advertised-but-unservable is worth its own line rather than a tone:
-          it is the one state where a *more* conforming client fails harder,
-          and the fix is a document change, not a restart. */}
-      {mediatorDid && (advertisedOnly.length > 0 || servedOnly.length > 0) && (
+      {/* The document-versus-binary comparison, always shown rather than only
+          when something is wrong.
+
+          Two reasons it is a card and not a tile tone. It is about a *document*
+          — the fix is a DID-document change, not a restart — and it is about
+          *this* community's document, where every tile above it describes some
+          other party: the mediator this VTC dials, the registry it syncs with.
+          An operator reading "advertises TSP, DIDComm" on the registry tile and
+          "not advertised" here is looking at two different documents and,
+          before this said so, had no way to tell.
+
+          Always shown because its absence was ambiguous: a silent dashboard
+          meant either "everything agrees" or "we never resolved the DID", and
+          those want opposite reactions. */}
+      {diagnostics.data && (
         <section className="card">
           <h3>Transport advertisement</h3>
-          {advertisedOnly.length > 0 && (
-            <p>
-              Advertised but not servable:{" "}
+          <p className="muted">
+            What <strong>this community&rsquo;s own</strong> DID document
+            advertises, against what this binary serves. The mediator and trust
+            registry tiles above describe other parties&rsquo; documents.
+          </p>
+
+          {transports.length === 0 ? (
+            <p className="finding warn">
               <strong>
-                {advertisedOnly.map((t) => protocolName(t.protocol)).join(", ")}
+                This VTC&rsquo;s DID did not resolve, so there is nothing to
+                compare.
               </strong>
-              . A client resolving this community's DID will choose it and fail.
+              <span className="muted">
+                That is <em>unknown</em>, not <em>nothing advertised</em>.
+                Confirm the DID is published and resolvable before reading
+                anything into the transport tiles above.
+              </span>
             </p>
-          )}
-          {servedOnly.length > 0 && (
-            <p className="muted">
-              Served but not advertised:{" "}
-              <strong>
-                {servedOnly.map((t) => protocolName(t.protocol)).join(", ")}
-              </strong>
-              . No client will choose it — add the service entry to the DID
-              document to start receiving that traffic.
-            </p>
+          ) : (
+            <>
+              <table className="data-table transport-table">
+                <thead>
+                  <tr>
+                    <th>Transport</th>
+                    <th>In the DID document</th>
+                    <th>Serviceable now</th>
+                    <th>Advertised endpoint</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {transports.map((t) => (
+                    <tr key={t.protocol}>
+                      <td>{protocolName(t.protocol)}</td>
+                      <td className={t.advertised ? "yes" : "no"}>
+                        {t.advertised ? "advertised" : "not advertised"}
+                      </td>
+                      <td className={t.serviceable ? "yes" : "no"}>
+                        {t.serviceable ? "yes" : "no"}
+                      </td>
+                      <td>
+                        {t.endpoint ? (
+                          <code>{t.endpoint}</code>
+                        ) : (
+                          <span className="muted">&mdash;</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="muted">
+                A client resolving this DID commits to the highest-preference
+                transport it finds &mdash; TSP, then DIDComm, then REST &mdash;
+                so the topmost advertised row is the one that gets used. For a
+                messaging transport, &ldquo;serviceable&rdquo; means both that
+                this build supports it and that the mediator connection is live
+                right now, so a <em>no</em> there can be a disconnect rather
+                than a document problem; the findings below say which.
+              </p>
+
+              {findings.length === 0 ? (
+                <p className="finding ok">
+                  <strong>Document and binary agree.</strong>
+                </p>
+              ) : (
+                <ul className="finding-list">
+                  {findings.map((f, i) => (
+                    <li
+                      key={`${f.code}:${f.protocol ?? ""}:${i}`}
+                      className={`finding ${f.severity}`}
+                    >
+                      <strong>{f.summary}</strong>
+                      <span className="muted">{f.message}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
           )}
         </section>
       )}

--- a/vtc-service/admin-ui/src/plugins/recognition.tsx
+++ b/vtc-service/admin-ui/src/plugins/recognition.tsx
@@ -149,8 +149,10 @@ export function Recognition() {
               <QueueTile
                 label="Pending"
                 value={diagnostics.data.queueDepth}
+                // `null` (empty queue) and `undefined` (no response yet) both
+                // mean nothing is waiting; `== null` covers both.
                 foot={
-                  oldestPending === undefined
+                  oldestPending == null
                     ? "nothing waiting"
                     : `oldest ${formatDuration(oldestPending)}`
                 }
@@ -158,7 +160,7 @@ export function Recognition() {
                 // depth on its own is normal (a burst of joins drains); depth
                 // that stays *old* is the shape of a stuck reconciler.
                 tone={
-                  oldestPending !== undefined && oldestPending >= 3600
+                  oldestPending != null && oldestPending >= 3600
                     ? "warn"
                     : "neutral"
                 }

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -1203,6 +1203,90 @@ select {
   color: var(--warning);
 }
 
+/* ── Findings ────────────────────────────────────────────────── */
+
+/* One diagnosis: a headline the operator can scan, the remediation beneath
+ * it, and a severity rail so "this is fine" and "this is broken" are told
+ * apart before either is read. Severity is the daemon's own `Severity`, never
+ * inferred from the wording. */
+
+.finding-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.finding {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--border);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: color-mix(in srgb, var(--border) 22%, transparent);
+}
+
+.finding > strong {
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.finding > .muted {
+  line-height: 1.5;
+}
+
+.finding.error {
+  border-left-color: var(--danger);
+  background: var(--danger-tint);
+}
+
+.finding.error > strong {
+  color: var(--danger);
+}
+
+.finding.warn {
+  border-left-color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+}
+
+.finding.warn > strong {
+  color: var(--warning);
+}
+
+.finding.ok {
+  border-left-color: var(--success);
+  background: color-mix(in srgb, var(--success) 9%, transparent);
+}
+
+.finding.ok > strong {
+  color: var(--success);
+}
+
+/* `info` keeps the neutral rail from `.finding` — it is stated so a rollout
+ * is legible, not because anything is wrong, and colouring it would say
+ * otherwise. */
+
+.transport-table td.yes {
+  color: var(--success);
+}
+
+.transport-table td.no {
+  color: var(--text-faint);
+}
+
+/* The endpoint column holds a mediator `did:webvh:…`, which is long enough to
+ * push the table off the card if it is allowed to stay on one line. */
+.transport-table td:last-child {
+  width: 45%;
+}
+
+.transport-table td:last-child code {
+  overflow-wrap: anywhere;
+}
+
 /* ── Chips ───────────────────────────────────────────────────── */
 
 .chip {

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -301,11 +301,16 @@ pub async fn run_didcomm_service(
             // `vtc status` also renders — so an operator who runs `vtc status`
             // to explain a boot message is told the same story, not a second
             // one.
+            //
+            // `code` rides along as a structured field so a log pipeline can
+            // alert on the finding rather than on a substring of prose that
+            // exists to be reworded.
             for finding in crate::transport_capability::findings_for_build(&caps) {
+                let code = format!("{:?}", finding.code);
                 match finding.severity {
-                    Severity::Error => error!("{}", finding.message),
-                    Severity::Warn => warn!("{}", finding.message),
-                    Severity::Info => info!("{}", finding.message),
+                    Severity::Error => error!(finding = %code, "{}", finding.message),
+                    Severity::Warn => warn!(finding = %code, "{}", finding.message),
+                    Severity::Info => info!(finding = %code, "{}", finding.message),
                 }
             }
 

--- a/vtc-service/src/routes/health.rs
+++ b/vtc-service/src/routes/health.rs
@@ -139,6 +139,64 @@ pub struct DiagnosticsResponse {
     /// disagree. Empty when the VTC's DID could not be resolved, which is
     /// "unknown", not "none advertised".
     pub transports: Vec<crate::transport_capability::TransportStatus>,
+    /// Vendor-namespaced additions to the published response.
+    pub ext: DiagnosticsExt,
+}
+
+/// The `ext` envelope on the diagnostics response.
+///
+/// `spec/vtc/registry/diagnostics/0.1#response` is `additionalProperties:
+/// false` and `response_conformance` enforces it against every response an
+/// integration test provokes, so a new top-level field here is a spec change
+/// upstream in `trust-tasks-rs` before it is a change in this repo. `ext` is
+/// the mechanism the spec provides instead (SPEC.md §4.5.1) — an open object
+/// whose immediate keys must each be a reverse-DNS namespace, with the
+/// structure beneath one opaque to the framework.
+///
+/// Typed rather than a bare `serde_json::Value` so the shape reaches
+/// `openapi.json`, and from there the console's generated `wire.ts`. An
+/// untyped `ext` would publish the field and un-type exactly the consumer it
+/// exists for.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct DiagnosticsExt {
+    /// `org.openvtc`, not `vtc`: §4.5.1 requires at least two segments
+    /// (`^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$`), and a bare `vtc` claims a name
+    /// nobody owns — the collision the rule exists to prevent. Same namespace
+    /// the audit surface already extends under.
+    #[serde(rename = "org.openvtc")]
+    pub openvtc: OpenVtcDiagnostics,
+}
+
+/// What OpenVTC adds to the standard diagnostics payload.
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenVtcDiagnostics {
+    /// What the document-versus-binary comparison actually *means*, from
+    /// [`transport_capability::findings_for_build`](crate::transport_capability::findings_for_build)
+    /// — the same list `vtc status` prints and the daemon logs at messaging
+    /// start.
+    ///
+    /// Served rather than re-derived in the console because two of the four
+    /// findings cannot be reconstructed from
+    /// [`DiagnosticsResponse::transports`] at all. "advertises TSP with no
+    /// DIDComm fallback" and "advertises no messaging at all" are statements
+    /// about the *shape* of the advertised set, not about any one protocol's
+    /// two booleans, so a console deriving its own view necessarily dropped
+    /// them — and the first of those is the finding that explains why an
+    /// operator should care about the informational line it *could* render.
+    /// Re-deriving also conflated "this build cannot serve it" with "the
+    /// mediator socket is down", because `serviceable` is the conjunction,
+    /// which turned a transient disconnect into a document-is-broken banner.
+    ///
+    /// Admin-gated, which is what lets it carry the full remediation prose:
+    /// that text names build feature flags, and the unauthenticated community
+    /// profile deliberately excludes it (see
+    /// [`TransportStatus`](crate::transport_capability::TransportStatus)).
+    ///
+    /// Empty means either "document and binary agree" or "the DID did not
+    /// resolve" — [`DiagnosticsResponse::transports`] being empty
+    /// distinguishes them.
+    pub transport_findings: Vec<crate::transport_capability::Finding>,
 }
 
 #[utoipa::path(
@@ -231,18 +289,25 @@ pub async fn diagnostics(
     // Our own advertised-versus-servable view, resolved from the document
     // rather than config: the deployment that motivated this had `#tsp` added
     // to its DID log long after the VTC last wrote its own mirror.
-    let transports = match crate::transport_capability::resolved_capabilities(
+    let caps = crate::transport_capability::resolved_capabilities(
         state.did_resolver.as_ref(),
         config_vtc_did.as_deref().unwrap_or_default(),
     )
-    .await
-    {
+    .await;
+    let transports = match &caps {
         Some(caps) => crate::transport_capability::public_transport_view_for_build(
-            &caps,
+            caps,
             messaging_status == "connected",
         ),
         None => Vec::new(),
     };
+    // The interpretation of that table, off the same function every other
+    // surface reads — so the console cannot tell an operator a different story
+    // than `vtc status` did about the same document.
+    let transport_findings = caps
+        .as_ref()
+        .map(crate::transport_capability::findings_for_build)
+        .unwrap_or_default();
 
     Ok(Json(DiagnosticsResponse {
         registry_status,
@@ -262,5 +327,8 @@ pub async fn diagnostics(
         messaging_status,
         registry_transport,
         transports,
+        ext: DiagnosticsExt {
+            openvtc: OpenVtcDiagnostics { transport_findings },
+        },
     }))
 }

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -403,12 +403,16 @@ fn print_transport_section(caps: Option<&vta_sdk::protocol::matching::ServiceCap
         eprintln!("  {GREEN}✓{RESET} document and binary agree");
         return;
     }
+    // Headline then remediation, rather than one long paragraph per finding.
+    // The operator running this is usually scanning for *which* thing is
+    // wrong; the fix is what they read second, once they have found it.
     for f in findings {
         let (mark, colour) = match f.severity {
             Severity::Error => ("✗", RED),
             Severity::Warn => ("!", YELLOW),
             Severity::Info => ("·", DIM),
         };
-        eprintln!("  {colour}{mark}{RESET} {}", f.message);
+        eprintln!("  {colour}{mark}{RESET} {}", f.summary);
+        eprintln!("    {DIM}{}{RESET}", f.message);
     }
 }

--- a/vtc-service/src/transport_capability.rs
+++ b/vtc-service/src/transport_capability.rs
@@ -226,7 +226,8 @@ pub fn served_not_advertised(served: &[Protocol], caps: &ServiceCapabilities) ->
 }
 
 /// How loudly a [`Finding`] should be reported.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     /// The document promises something this build cannot deliver. Clients that
     /// obey the document will fail.
@@ -238,10 +239,53 @@ pub enum Severity {
     Info,
 }
 
+/// Which observation a [`Finding`] is, independent of how it is worded.
+///
+/// The prose in [`Finding::message`] is written for an operator and will be
+/// reworded; a console that keys its rendering off substrings of it breaks
+/// silently the first time it is. This enum is the stable identity, so a
+/// consumer can style, order and link a finding without parsing English.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum FindingCode {
+    /// The document advertises a messaging transport this build cannot serve.
+    /// The failure this module exists for: every conforming client picks it,
+    /// and the more correct the client, the more certainly it fails.
+    AdvertisedNotServable,
+    /// The document advertises no messaging transport at all — REST only.
+    NoMessagingAdvertised,
+    /// TSP is advertised with no `DIDCommMessaging` behind it, so a peer that
+    /// does not speak TSP has no messaging route in.
+    NoDidcommFallback,
+    /// This build serves a transport the document does not advertise. Normal
+    /// mid-rollout; never a fault.
+    ServedNotAdvertised,
+}
+
 /// One observation about the document-versus-binary relationship.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Carries both a one-line [`summary`](Finding::summary) and the full
+/// [`message`](Finding::message) because the two consumers need different
+/// lengths and must not be allowed to drift into different claims: `vtc
+/// status` and the daemon log print the message, the admin console renders the
+/// summary as a headline with the message beneath it. Both are written in
+/// [`findings_against`], once.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Finding {
+    /// Stable identity — match on this, never on the prose.
+    pub code: FindingCode,
     pub severity: Severity,
+    /// The transport this is about (`"tsp"` / `"didcomm"` / `"rest"`), when it
+    /// is about one. [`FindingCode::NoMessagingAdvertised`] and
+    /// [`FindingCode::NoDidcommFallback`] are statements about the document as
+    /// a whole, so they carry `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    /// One line, no remediation — what state the document and binary are in.
+    pub summary: String,
+    /// The full operator-facing explanation: what is wrong, what it causes,
+    /// and every way to fix it (R6.4).
     pub message: String,
 }
 
@@ -259,7 +303,13 @@ pub fn findings_against(served: &[Protocol], caps: &ServiceCapabilities) -> Vec<
     // 1. Promised but not deliverable. The failure this module exists for.
     for u in unservable_against(served, caps) {
         out.push(Finding {
+            code: FindingCode::AdvertisedNotServable,
             severity: Severity::Error,
+            protocol: Some(u.protocol.as_str().to_string()),
+            summary: format!(
+                "the DID document advertises {} but this build cannot serve it",
+                u.protocol
+            ),
             message: u.remediation(),
         });
     }
@@ -271,7 +321,12 @@ pub fn findings_against(served: &[Protocol], caps: &ServiceCapabilities) -> Vec<
     //    that the document does not say so.
     if !advertises_messaging(caps) {
         out.push(Finding {
+            code: FindingCode::NoMessagingAdvertised,
             severity: Severity::Warn,
+            protocol: None,
+            summary: "the DID document advertises no messaging transport — this community is \
+                      reachable over REST only"
+                .to_string(),
             message: "this VTC's DID document advertises no messaging transport at all (no \
                       `TSPTransport`, no `DIDCommMessaging`) — a client resolving it can reach \
                       this community over REST only, and nothing can be delivered to it over \
@@ -284,7 +339,12 @@ pub fn findings_against(served: &[Protocol], caps: &ServiceCapabilities) -> Vec<
     // 3. TSP with nothing behind it.
     if lacks_didcomm_fallback(caps) {
         out.push(Finding {
+            code: FindingCode::NoDidcommFallback,
             severity: Severity::Warn,
+            protocol: None,
+            summary: "the DID document advertises TSP with no DIDComm fallback — a peer that \
+                      does not speak TSP has no messaging route in"
+                .to_string(),
             message: "this VTC advertises TSP but no DIDComm mediator, so a peer that does not \
                       speak TSP has no messaging transport to fall back to, and a build without \
                       the `tsp` feature would have none at all. tsp-enablement.md §12 Phase A \
@@ -297,7 +357,13 @@ pub fn findings_against(served: &[Protocol], caps: &ServiceCapabilities) -> Vec<
     // 4. Capable of more than it claims. A staged rollout, not a fault.
     for p in served_not_advertised(served, caps) {
         out.push(Finding {
+            code: FindingCode::ServedNotAdvertised,
             severity: Severity::Info,
+            protocol: Some(p.as_str().to_string()),
+            summary: format!(
+                "this build serves {p}, but the DID document does not advertise it, so no \
+                 client will choose it"
+            ),
             message: format!(
                 "this build serves {p} but the DID document does not advertise it, so no client \
                  will choose it. Normal mid-rollout (ship the capable binary, then add the \
@@ -955,5 +1021,111 @@ mod tests {
             Some(Severity::Error),
             "the unservable-transport error must lead: {f:?}"
         );
+    }
+
+    /// The deployed document against the build that actually ships — the state
+    /// an operator sees on a healthy VTC today, and the one the admin console
+    /// used to describe with a single grey line.
+    ///
+    /// Two findings, and the console could reconstruct only the second of them
+    /// from the per-protocol `advertised`/`serviceable` flags. The first is a
+    /// statement about the *shape* of the advertised set, which no pair of
+    /// booleans encodes — so the surface that showed "served but not
+    /// advertised: DIDComm" was structurally unable to also say why that
+    /// mattered.
+    #[test]
+    fn the_shipping_build_against_the_deployed_document_explains_both_halves() {
+        let f = findings_against(TSP_BUILD, &deployed_shape());
+
+        assert!(
+            messages(&f, Severity::Error).is_empty(),
+            "the shipping build serves the TSP this document advertises: {f:?}"
+        );
+
+        let codes: Vec<FindingCode> = f.iter().map(|f| f.code).collect();
+        assert_eq!(
+            codes,
+            vec![
+                FindingCode::NoDidcommFallback,
+                FindingCode::ServedNotAdvertised
+            ],
+            "the warning must come with — and before — the informational line \
+             it explains: {f:?}"
+        );
+
+        assert_eq!(
+            f[1].protocol.as_deref(),
+            Some("didcomm"),
+            "a per-protocol finding names its protocol so a consumer need not \
+             parse the prose: {f:?}"
+        );
+        assert_eq!(
+            f[0].protocol, None,
+            "a finding about the document as a whole names no single protocol: {f:?}"
+        );
+    }
+
+    /// Every finding carries a scannable headline *and* the remediation, and
+    /// they are not the same string.
+    ///
+    /// The two exist because the console renders the summary as a heading with
+    /// the message beneath it; a summary that merely repeated the message
+    /// would render as the paragraph twice, and one that was empty would
+    /// render as a blank heading. Neither fails to compile.
+    #[test]
+    fn every_finding_has_a_headline_distinct_from_its_remediation() {
+        for served in [TSP_BUILD, NON_TSP_BUILD] {
+            for caps in [
+                deployed_shape(),
+                tsp_and_didcomm(),
+                didcomm_only(),
+                rest_only(),
+            ] {
+                for f in findings_against(served, &caps) {
+                    assert!(!f.summary.is_empty(), "empty summary: {f:?}");
+                    assert!(!f.message.is_empty(), "empty message: {f:?}");
+                    assert_ne!(
+                        f.summary, f.message,
+                        "the headline must not restate the remediation: {f:?}"
+                    );
+                    assert!(
+                        f.summary.len() < f.message.len(),
+                        "the headline is the short one: {f:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The console styles, orders and groups on `code` and `severity`, so both
+    /// are part of the wire contract that `openapi.json` publishes. Pin the
+    /// spellings: a `rename_all` slipping off either enum retypes the console
+    /// against strings the daemon never sends, and TypeScript is happy either
+    /// way because it is checking generated types against themselves.
+    #[test]
+    fn finding_wire_shape_is_camel_case() {
+        let f = findings_against(TSP_BUILD, &deployed_shape());
+        let json = serde_json::to_value(&f[1]).expect("a finding serialises");
+
+        assert_eq!(json["code"], "servedNotAdvertised");
+        assert_eq!(json["severity"], "info");
+        assert_eq!(json["protocol"], "didcomm");
+        assert!(json.get("summary").is_some());
+        assert!(json.get("message").is_some());
+
+        // `protocol` is skipped rather than sent as null when the finding is
+        // about the document as a whole.
+        let whole = serde_json::to_value(&f[0]).expect("a finding serialises");
+        assert_eq!(whole["code"], "noDidcommFallback");
+        assert_eq!(whole["severity"], "warn");
+        assert!(
+            whole.get("protocol").is_none(),
+            "an absent protocol is absent, not null: {whole}"
+        );
+
+        let err = findings_against(NON_TSP_BUILD, &deployed_shape());
+        let err = serde_json::to_value(&err[0]).expect("a finding serialises");
+        assert_eq!(err["code"], "advertisedNotServable");
+        assert_eq!(err["severity"], "error");
     }
 }

--- a/vtc-service/tests/diagnostics.rs
+++ b/vtc-service/tests/diagnostics.rs
@@ -200,6 +200,48 @@ async fn diagnostics_surfaces_mediator_detail_to_admin() {
     assert_eq!(v["mediatorDid"], "did:key:z6MkMediator");
 }
 
+/// The transport findings ride in `ext["org.openvtc"]`, and that placement is
+/// the contract — not an implementation detail of the handler.
+///
+/// `spec/vtc/registry/diagnostics/0.1#response` is `additionalProperties:
+/// false`, which the response-conformance layer enforces on every test in this
+/// file, so a well-meant promotion of `transportFindings` to the top level
+/// fails every other test here with a schema violation rather than this one.
+/// This test is the other half: it pins that the field is *present* and where
+/// the console looks for it, so the placement cannot quietly move to some
+/// other namespace and leave the console reading `undefined`.
+#[tokio::test]
+async fn transport_findings_ride_in_the_openvtc_ext_namespace() {
+    let fix = build().await;
+    let token = token_for(&fix, "admin").await;
+
+    let resp = fix
+        .router
+        .clone()
+        .oneshot(get("/v1/health/diagnostics", DIAGNOSTICS_TASK, &token))
+        .await
+        .unwrap();
+    let (status, v) = body_value(resp).await;
+    assert_eq!(status, StatusCode::OK, "{v}");
+
+    // Reverse-DNS, per SPEC.md §4.5.1 — a bare `vtc` key claims a name nobody
+    // owns and would fail the `ext` propertyNames pattern.
+    let findings = v
+        .pointer("/ext/org.openvtc/transportFindings")
+        .unwrap_or_else(|| panic!("transportFindings must live under ext[org.openvtc]: {v}"));
+    assert!(
+        findings.is_array(),
+        "transportFindings is a list even when empty, so a consumer never has \
+         to distinguish absent from none: {v}"
+    );
+
+    assert!(
+        v.get("transportFindings").is_none(),
+        "the field must not also appear at the top level — the published \
+         response schema forbids it: {v}"
+    );
+}
+
 #[tokio::test]
 async fn diagnostics_requires_trust_task_header() {
     let fix = build().await;


### PR DESCRIPTION
## What prompted this

A VTC dashboard showed `TRUST REGISTRY: TSP · active · advertises TSP, DIDComm` beside `TRANSPORT ADVERTISEMENT: Served but not advertised: DIDComm`, on a VTC whose DID document does advertise `#tsp`. The card was correct on both counts and still unreadable: the tile describes the *registry's* document, the card describes *this community's*, and nothing said so.

Digging in, the card was also weaker than the other surfaces reporting on the same thing.

## Root cause

`transport_capability::findings_against` carries this doc comment:

> One function so the boot gate, the messaging listener, and `vtc status` say the *same* thing about the same document — an operator who runs `vtc status` to explain a boot refusal must not be told a different story by the tool they reached for second.

The admin console was the one surface that did not participate. It re-derived its own analysis in TypeScript from the per-protocol `advertised` / `serviceable` booleans on `DiagnosticsResponse.transports`, and that derivation cannot express what the shared function does:

- **Two of the four findings are not reconstructable from those booleans.** `noDidcommFallback` and `noMessagingAdvertised` are statements about the *shape* of the advertised set, not about any one protocol's pair of flags. So a VTC advertising TSP alone got the informational "served but not advertised: DIDComm" line with nothing to say why it mattered — while `vtc status` on the same box printed the warning that explains it.
- **`serviceable` is build-capability AND live-connection**, so `advertised && !serviceable` fired on a transient mediator disconnect and rendered it as "A client resolving this community's DID will choose it and fail" — a document defect the operator did not have.
- **The card rendered only when something looked wrong**, so its absence was ambiguous between "document and binary agree" and "the DID never resolved". Those want opposite reactions.
- **Nothing named the subject document**, which is the confusion above.

## Changes

**`Finding` gains a machine-readable identity.** `code` (`advertisedNotServable` / `noMessagingAdvertised` / `noDidcommFallback` / `servedNotAdvertised`), the `protocol` it concerns when it concerns one, and a one-line `summary` alongside the full remediation `message`. Consumers style and order on `code`; `message` is prose written to be reworded, and keying on substrings of it breaks silently the first time it is.

**The daemon log tags each line** `finding = <code>` so a log pipeline can alert on the finding rather than on English.

**`vtc status`** prints the summary as a headline with the remediation beneath, instead of one long paragraph per finding.

**`/v1/health/diagnostics` serves the findings**, from `findings_for_build` — the same list every other surface reads.

**The console renders them**: the `transports` table, then the findings at their own severity, under a line saying the card describes *this community's own* document and that the tiles above describe other parties'. The TypeScript re-derivation is gone.

### Why the findings ride in `ext`

`spec/vtc/registry/diagnostics/0.1#response` is `additionalProperties: false`, and `test_support/response_conformance` enforces it against every response an integration test provokes — a top-level `transportFindings` failed three tests before this was noticed. `ext` is the extension point the spec provides for exactly this (SPEC.md §4.5.1, reverse-DNS namespaces); the audit surface already extends under the same `org.openvtc`. Promoting the field to the top level is a `trust-tasks-rs` spec release, not a change in this repo.

It is typed (`DiagnosticsExt` / `OpenVtcDiagnostics`) rather than a bare `serde_json::Value`, so the shape reaches `openapi.json` and from there the console's generated `wire.ts`. An untyped `ext` would publish the field and un-type the one consumer it exists for.

## Incidental: a live #1186 seam

`TransportStatus`, `RegistryTransport` and `DiagnosticsResponse` were still hand-written in `api.ts` beside the fetch, duplicating generated aliases that `wire-types.ts` had already exported and nothing imported. That file's own header says why this is a defect:

> **The point is that no shape is written twice.** … A hand-written interface cannot be caught being wrong, because it *is* what `tsc` checks the console against.

They had already drifted. The daemon serialises `messagingStatus` and `transports` unconditionally and `oldestPendingAgeSeconds` as nullable; the local copies called the first two optional and the third never-null. Deleting them in favour of the generated aliases surfaced two null-handling assumptions (`dashboard.tsx` queue-trouble, `recognition.tsx` queue tile) that had only been safe because the hand-written type said so.

## What the reported deployment now shows

| Transport | In the DID document | Serviceable now | Advertised endpoint |
|---|---|---|---|
| TSP | advertised | yes | `did:webvh:QmTS3a…:webvh.storm.ws:mediator` |
| DIDComm | not advertised | yes | — |
| REST | advertised | yes | `https://first.openvtc.net` |

> ⚠ the DID document advertises TSP with no DIDComm fallback — a peer that does not speak TSP has no messaging route in
>
> · this build serves didcomm, but the DID document does not advertise it, so no client will choose it

## Tests

- `the_shipping_build_against_the_deployed_document_explains_both_halves` — the live shape (REST + status-list + TSP) against the shipping build: no error, both findings, in order, with the per-protocol one naming its protocol. This is the case the console was structurally unable to describe.
- `every_finding_has_a_headline_distinct_from_its_remediation` — across both builds and all four documents. A summary that repeated the message would render as the paragraph twice; an empty one as a blank heading. Neither fails to compile.
- `finding_wire_shape_is_camel_case` — pins `code` / `severity` spellings and that an absent `protocol` is absent, not null. A `rename_all` slipping off either enum retypes the console against strings the daemon never sends, and `tsc` stays happy because generated types are self-consistent either way.
- `transport_findings_ride_in_the_openvtc_ext_namespace` — pins the placement the console reads, so it cannot move namespaces and leave the console reading `undefined`.

Green: full `vtc-service` suite (947 lib + every integration binary, admin UI built), `cargo check --workspace --all-targets`, `cargo clippy -p vtc-service --all-targets`, `cargo fmt --check`, and `npm run lint` (which is `wire:check` + `tsc`).

## Docs

`docs/03-vtc/trust-registry.md` — the `ext` payload, the four-code table, why the first two codes cannot be re-derived from `transports`, how to tell "agrees" from "did not resolve", and the note that the registry tile and the transport card describe different documents.
