### PR TITLE
feat(acl)!: enforce an entry's capabilities, and give an operator a way to set them

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1238,6 +1238,9 @@ async fn main() {
                     None,
                     None,
                     allowed_keys,
+                    // cnm exposes no capability flags either; `None` leaves
+                    // any narrowing exactly as it is.
+                    None,
                 )
                 .await
             }

--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -509,13 +509,16 @@
       does not open”, which reads like corruption. The VTA reports which epoch it holds for exactly
       this reason: that turns it into “a commit has not been delivered”.</p>
     </div>
-    <div class="warn">
-      <p><b>The grant is the role, not the entry's capability list.</b> The oracle gates read the
-      caller's role: <code>application</code> — what an agent integration is normally granted —
-      along with <code>initiator</code> and <code>admin</code> carries both room capabilities, and
-      <code>reader</code> and <code>monitor</code> carry neither. The per-entry
-      <code>capabilities</code> field is descriptive today, so narrowing it narrows nothing; scope
-      an agent by the role you give it and the context it may act in.</p>
+    <div class="pull">
+      <p><b>The role is the ceiling; the entry narrows within it.</b>
+      <code>application</code> — what an agent integration is normally granted — along with
+      <code>initiator</code> and <code>admin</code> carries both room capabilities, and
+      <code>reader</code> and <code>monitor</code> carry neither. To give one agent less than its
+      role allows, narrow its entry:
+      <code>pnm acl update &lt;did&gt; --capabilities room-present</code>, undone with
+      <code>--capabilities-all</code>. A name the role does not carry is refused rather than
+      dropped, so the role always describes the entry — and the gate reads the stored entry, so a
+      narrowing binds the agent's next call rather than its next token.</p>
     </div>
   </section>
 

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -389,12 +389,16 @@ have become the credential hand-off it exists to replace:
 - **A long-lived leaf** — the lifetime is a constant (4 hours), not a request
   parameter.
 
-> **How to grant it.** These gates read the caller's **role**, not the
-> capability list on its ACL entry — that field is descriptive today, and
-> narrowing it narrows nothing. `application` (what an agent integration is
-> normally granted), `initiator` and `admin` carry both room capabilities;
-> `reader` and `monitor` carry neither, deliberately, because minting a
+> **How to grant it.** The role is the ceiling: `application` (what an agent
+> integration is normally granted), `initiator` and `admin` carry both room
+> capabilities, while `reader` and `monitor` carry neither — minting a
 > credential on a principal's behalf is not a read.
+>
+> Within that ceiling, an entry's own list narrows:
+> `pnm acl update <did> --capabilities room-present` leaves an agent able to
+> present and nothing else, and `--capabilities-all` undoes it. Narrowing binds
+> the agent's next call, not its next token. A name the role does not carry is
+> refused rather than dropped, so the role always describes the entry.
 
 Withdrawing an agent's access is withdrawing it *at the VTA* — remove the ACL
 entry and no further presentations are minted. That is the whole value of an

--- a/docs/02-vta/personal-ai-agents.md
+++ b/docs/02-vta/personal-ai-agents.md
@@ -110,9 +110,9 @@ above adds it. Set its role/context scope:
 pnm acl create --did <agent-did> --role member --contexts <ctx-id> --expires 30d
 ```
 
-**Capabilities are not a `pnm acl` flag.** For a Service consumer they live on
-the `DeviceBinding` and are set when the agent runtime calls `device/register`
-(`operations/device.rs`). Grant the minimum:
+**Capabilities narrow what a role allows**, and `pnm acl update` sets them. They
+can only narrow: every name must be one the role already carries, and one that
+is not is refused rather than dropped. Grant the minimum:
 
 | Capability        | Why an agent needs it                                              |
 |-------------------|-------------------------------------------------------------------|
@@ -122,12 +122,22 @@ the `DeviceBinding` and are set when the agent runtime calls `device/register`
 | `ProxyLogin`      | *Only if* the agent must act **as the user** (mints a session).   |
 | `Sign` / `KeyMint`| *Only if* the agent needs the generic signing oracle / to mint keys. |
 
-Avoid `PolicyAdmin` / `DeviceAdmin` for an agent. The capability set an agent
-derives from its **role** at provision time is usually sufficient — an
-`application`-role consumer derives `VaultRead` + `ProxyLogin` + `FillRelease` +
-`Sign` + `SignTrustTask`. Explicit *per-entry* capability overrides are a
-deferred Phase-3 item (`CreateAclRequest` carries no `capabilities` field yet),
-so pick the role whose derived set matches the least privilege you want.
+Avoid `PolicyAdmin` / `DeviceAdmin` for an agent. An `application`-role consumer
+derives `VaultRead` + `ProxyLogin` + `FillRelease` + `Sign` + `SignTrustTask`,
+both memory capabilities and both room capabilities — usually wider than one
+agent needs. Narrow it to exactly what this agent does:
+
+```bash
+# This agent reads memory and presents in rooms. Nothing else.
+pnm acl update <agent-did> --capabilities memory-read,room-present
+
+# Undo the narrowing — the entry holds everything its role implies again.
+pnm acl update <agent-did> --capabilities-all
+```
+
+The gate reads the stored entry on every call, so a narrowing binds the agent's
+**next request** rather than waiting for its token to expire. Pick the role
+whose derived set is the ceiling you want, then narrow within it.
 
 ### Driving device + vault from the CLI
 
@@ -304,7 +314,7 @@ Lower priority unless your agents do credential work.
 | Capability vocabulary                  | Exists (`vti_common::acl::Capability`) |
 | `pnm device …` / `pnm vault …` CLI     | **Added** (this change) — `VtaClient::{device_*,vault_*}` + `pnm` commands, both transports |
 | Sealed vault upsert/release            | **Added** — `seal_vault_secret` / `open_sealed_secret` on the DIDComm session |
-| `pnm acl --capabilities` flag          | **Gap** (deferred Phase 3) — capabilities derive from role / are set at `device/register` |
+| `pnm acl update --capabilities` flag   | **Added** — an entry narrows within its role, enforced on every gated call |
 | Agent memory Trust Tasks               | Exists (`trust_tasks/memory.rs`, `VtaClient::memory_*`) — capability- and context-gated, audited |
 | `pnm memory …` CLI                     | **Added** — `plant` / `recall` / `forget` / `wipe` over the same three tasks |
 | Agent-side connect ladder              | Exists (`vta_sdk::agent_connect::AgentConnect`) — one way in for every agent bridge |

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -2026,6 +2026,21 @@ pub(crate) enum AclCommands {
         /// "no keys at all" and "no filter".
         #[arg(long)]
         allowed_keys_unrestricted: bool,
+        /// Narrow this entry to exactly these capabilities (comma-separated,
+        /// kebab-case: `vault-read`, `memory-read`, `room-present`, …).
+        ///
+        /// It can only narrow: every name must be one the entry's role already
+        /// carries, and one that is not is refused rather than dropped. Omit to
+        /// leave the narrowing unchanged.
+        #[arg(long, value_delimiter = ',', conflicts_with = "capabilities_all")]
+        capabilities: Option<Vec<String>>,
+        /// Remove the narrowing — the entry holds everything its role implies.
+        ///
+        /// A privilege increase, and its own flag for the same reason
+        /// `--allowed-keys-unrestricted` is: an empty `--capabilities` cannot
+        /// mean both "narrowed to nothing" and "not narrowed at all".
+        #[arg(long)]
+        capabilities_all: bool,
     },
     /// Delete an ACL entry
     Delete {

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -56,11 +56,14 @@ pub(crate) async fn run(
             approve_none,
             allowed_keys,
             allowed_keys_unrestricted,
+            capabilities,
+            capabilities_all,
         } => {
             let approve_scope =
                 acl::approve_scope_from_flags(approve_all, approve_contexts, approve_none);
             let allowed_keys =
                 acl::allowed_keys_from_flags(allowed_keys, allowed_keys_unrestricted);
+            let capabilities = acl::capabilities_from_flags(capabilities, capabilities_all);
             acl::cmd_acl_update(
                 client,
                 &did,
@@ -71,6 +74,7 @@ pub(crate) async fn run(
                 step_up_require,
                 approve_scope,
                 allowed_keys,
+                capabilities,
             )
             .await
         }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -690,6 +690,7 @@ async fn update_acl_via_didcomm_carries_every_member() {
         step_up_require: Some("delegated".into()),
         approve_scope: Some(vta_sdk::acl::ApproveScope::Contexts(vec!["ctx-b".into()])),
         allowed_keys: Some(Some(vec!["tenant-key-a".into()])),
+        capabilities: None,
     };
     client.update_acl("did:key:zAdmin", req).await.unwrap();
 

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -87,6 +87,25 @@ pub fn allowed_keys_from_flags(
     }
 }
 
+/// Resolve the two mutually-exclusive capability flags into the wire value.
+///
+/// `None` leaves the narrowing unchanged; `Some(vec![])` clears it
+/// (`--capabilities-all`, a privilege increase); `Some(names)` narrows to
+/// exactly those. Clearing needs its own flag because an empty
+/// `--capabilities` cannot mean both "narrowed to nothing" and "not narrowed" —
+/// and of those two readings, the one an operator would get by accident is the
+/// one that hands the entry back everything.
+pub fn capabilities_from_flags(
+    capabilities: Option<Vec<String>>,
+    capabilities_all: bool,
+) -> Option<Vec<String>> {
+    if capabilities_all {
+        Some(Vec::new())
+    } else {
+        capabilities
+    }
+}
+
 pub fn validate_role(role: &str) -> Result<(), Box<dyn std::error::Error>> {
     match role {
         "admin" | "initiator" | "application" | "reader" => Ok(()),
@@ -458,6 +477,7 @@ pub async fn cmd_acl_update(
     step_up_require: Option<String>,
     approve_scope: Option<ApproveScope>,
     allowed_keys: Option<Option<Vec<String>>>,
+    capabilities: Option<Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Role transitions moved to `acl change-role`, which carries the
     // compare-and-swap that makes a concurrent edit an error instead of a
@@ -488,6 +508,7 @@ pub async fn cmd_acl_update(
         step_up_require: step_up_require.clone(),
         approve_scope,
         allowed_keys,
+        capabilities: capabilities.clone(),
     };
     let entry = client.update_acl(did, req).await?;
     println!("ACL entry updated:");
@@ -537,6 +558,18 @@ pub async fn cmd_acl_update(
             ApproveScope::Contexts(cs) => format!("contexts [{}]", cs.join(", ")),
         };
         println!("  Approve:  {rendered}");
+    }
+    // Echoed from the entry the VTA returned, not from the flags: a narrowing
+    // an operator cannot read back is one they cannot verify, and the whole
+    // point of the field is that somebody later trusts what it says.
+    if capabilities.is_some() {
+        let held = entry.capabilities();
+        let rendered = if held.is_empty() {
+            "(cleared — everything the role allows)".to_string()
+        } else {
+            held.join(", ")
+        };
+        println!("  Capabilities: {rendered}");
     }
     Ok(())
 }

--- a/vta-sdk/src/client/acl.rs
+++ b/vta-sdk/src/client/acl.rs
@@ -121,6 +121,13 @@ impl VtaClient {
                 .as_ref()
                 .map(acl_management::entry::Approve::from_scope),
             allowed_keys: req.allowed_keys.clone(),
+            // The capability narrowing is ecosystem-local, so it rides `ext`
+            // rather than a member the published schema does not declare.
+            ext: req.capabilities.as_ref().map(|caps| {
+                serde_json::json!({
+                    acl_management::entry::CAPABILITIES_EXT_MEMBER: caps,
+                })
+            }),
         };
         let wrapped: AclEntryEnvelope = self
             .rpc_tt(

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2784,6 +2784,7 @@ mod tests {
             step_up_require: None,
             approve_scope: None,
             allowed_keys: None,
+            capabilities: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         let obj = json.as_object().unwrap();
@@ -2802,6 +2803,7 @@ mod tests {
             step_up_require: None,
             approve_scope: None,
             allowed_keys: None,
+            capabilities: None,
         };
 
         let set = UpdateAclRequest {

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -409,6 +409,26 @@ pub struct AclEntryResponse {
     /// Flattened out of the canonical `approve` object.
     #[serde(default)]
     approve: Option<ApproveWire>,
+    /// Ecosystem extension members. Carries the entry's capability narrowing
+    /// under `org.openvtc.capabilities`; read it through
+    /// [`AclEntryResponse::capabilities`] rather than indexing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ext: Option<serde_json::Value>,
+}
+
+impl AclEntryResponse {
+    /// The entry's capability narrowing, as kebab-case names.
+    ///
+    /// Empty means the entry is not narrowed and holds everything its role
+    /// implies — which is what an entry that has never been narrowed looks
+    /// like, and is deliberately not distinguished from "narrowed to nothing"
+    /// because narrowing to nothing is spelled by clearing the set.
+    pub fn capabilities(&self) -> Vec<String> {
+        crate::protocols::acl_management::entry::capabilities_from_ext(self.ext.as_ref())
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -681,6 +701,16 @@ pub struct UpdateAclRequest {
     /// pinned to the canonical `allowedKeys`.
     #[serde(rename = "allowedKeys", skip_serializing_if = "Option::is_none")]
     pub allowed_keys: Option<Option<Vec<String>>>,
+    /// Narrow what the entry may do, within what its role allows:
+    /// `None` leaves the narrowing unchanged, `Some(vec![])` clears it (the
+    /// entry regains everything its role implies — a privilege increase), and
+    /// `Some(names)` narrows to exactly those kebab-case capability names.
+    ///
+    /// Over the Trust-Task and DIDComm transports this travels in the body's
+    /// `ext` under `org.openvtc.capabilities`; the REST route takes it as a
+    /// member. Both spellings reach the same stored field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
 }
 
 // ── WebVH server types ──────────────────────────────────────────────

--- a/vta-sdk/src/protocols/acl_management/create.rs
+++ b/vta-sdk/src/protocols/acl_management/create.rs
@@ -134,6 +134,14 @@ pub struct CreateAclResultBody {
         alias = "allowed_keys"
     )]
     pub allowed_keys: Option<Vec<String>>,
+    /// The entry's capability narrowing, as kebab-case capability names.
+    ///
+    /// Empty means the entry holds everything its role implies — the shape of
+    /// every entry that has never been narrowed. Echoed so an operator can see
+    /// what a narrowing actually stored: a restriction nobody can read back is
+    /// one nobody can verify.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
 }
 
 #[cfg(test)]

--- a/vta-sdk/src/protocols/acl_management/entry.rs
+++ b/vta-sdk/src/protocols/acl_management/entry.rs
@@ -25,6 +25,73 @@ use crate::acl::ApproveScope;
 use super::create::CreateAclResultBody;
 use serde_json::Value;
 
+/// Where an entry's capability narrowing travels: the `ext` member
+/// `org.openvtc.capabilities`, holding the kebab-case capability names.
+///
+/// It rides `ext` rather than a member of its own because the published
+/// `acl/*` schemas are `additionalProperties: false` and declare an extension
+/// slot for exactly this — an ecosystem-local concept the framework has no
+/// vocabulary for. Same convention as `org.openvtc.vault-session` and the
+/// device binding's local capability list.
+pub const CAPABILITIES_EXT_MEMBER: &str = "org.openvtc.capabilities";
+
+/// Read a capability narrowing out of an `ext` object.
+///
+/// `None` means the member is absent — leave whatever is stored alone. An empty
+/// vec means it was present and empty, which is the spelling for "clear the
+/// narrowing": the two are different intentions and a caller that conflated
+/// them would silently widen an entry it meant to leave untouched.
+///
+/// Unknown names are an error rather than a skip. A capability this build has
+/// never heard of is precisely the one that must not be quietly dropped: the
+/// operator would be told the narrowing succeeded while the entry kept an
+/// authority they had just tried to remove.
+pub fn capabilities_from_ext(ext: Option<&Value>) -> Result<Option<Vec<String>>, String> {
+    let Some(member) = ext.and_then(|e| e.get(CAPABILITIES_EXT_MEMBER)) else {
+        return Ok(None);
+    };
+    let Some(items) = member.as_array() else {
+        return Err(format!(
+            "`{CAPABILITIES_EXT_MEMBER}` must be an array of capability names"
+        ));
+    };
+    items
+        .iter()
+        .map(|v| {
+            v.as_str().map(str::to_string).ok_or_else(|| {
+                format!("`{CAPABILITIES_EXT_MEMBER}` must contain strings, found {v}")
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+/// Put a capability narrowing into an `ext` object, preserving anything else
+/// already there.
+pub fn capabilities_into_ext(ext: Option<Value>, capabilities: &[String]) -> Option<Value> {
+    if capabilities.is_empty() {
+        // Nothing to say: an entry with no narrowing holds what its role
+        // implies, and an empty array here would read as "narrowed to nothing".
+        return ext;
+    }
+    let mut base = match ext {
+        Some(Value::Object(map)) => map,
+        // A non-object `ext` is not something to merge into — replace it rather
+        // than dropping the narrowing on the floor.
+        _ => serde_json::Map::new(),
+    };
+    base.insert(
+        CAPABILITIES_EXT_MEMBER.to_string(),
+        Value::Array(
+            capabilities
+                .iter()
+                .map(|c| Value::String(c.clone()))
+                .collect(),
+        ),
+    );
+    Some(Value::Object(base))
+}
+
 /// Per-entry step-up configuration — canonical `AclEntry.stepUp`.
 ///
 /// **Additive only.** A per-entry setting may raise the assurance required of
@@ -239,10 +306,10 @@ impl AclEntry {
             expires_at: r.expires_at.and_then(to_rfc3339),
             step_up: (!step_up.is_empty()).then_some(step_up),
             approve: (!approve.is_empty()).then_some(approve),
-            // The VTA does not author extension members; it only carries a
-            // producer's through. Nothing to put here when building the wire
-            // form from our own row.
-            ext: None,
+            // One extension member the VTA does author: the capability
+            // narrowing. The framework has no vocabulary for it, and an
+            // operator who cannot read a restriction back cannot verify it.
+            ext: capabilities_into_ext(None, &r.capabilities),
         }
     }
 

--- a/vta-sdk/src/protocols/acl_management/update.rs
+++ b/vta-sdk/src/protocols/acl_management/update.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::acl::ApproveScope;
 
 use super::create::CreateAclResultBody;
-use super::entry::{Approve, StepUp};
+use super::entry::{Approve, StepUp, capabilities_from_ext};
+use serde_json::Value;
 
 /// Request payload for canonical `acl/update/0.1`.
 ///
@@ -92,6 +93,18 @@ pub struct UpdateAclBody {
         skip_serializing_if = "Option::is_none"
     )]
     pub allowed_keys: Option<Option<Vec<String>>>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1), which the published
+    /// `acl/update/0.1` schema declares.
+    ///
+    /// One member is interpreted: `org.openvtc.capabilities`, the entry's
+    /// capability narrowing (see
+    /// [`super::entry::CAPABILITIES_EXT_MEMBER`]). It travels here rather than
+    /// as a member of its own because the schema is
+    /// `additionalProperties: false` and a capability set is an
+    /// ecosystem-local concept — the same slot the vault session and the
+    /// device binding's local capabilities use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
 }
 
 /// Deserialize a member where **absent** and **explicit `null`** mean
@@ -124,6 +137,16 @@ impl UpdateAclBody {
     pub fn approve_scope(&self) -> Option<ApproveScope> {
         self.approve.as_ref().map(Approve::to_scope)
     }
+
+    /// The capability narrowing this request asks for, as raw wire names.
+    ///
+    /// `None` leaves the stored narrowing alone; `Some(vec![])` clears it, so
+    /// the entry holds everything its role implies. Names are not parsed here —
+    /// the consumer maps them, and rejects one it does not recognise rather
+    /// than dropping it.
+    pub fn capabilities(&self) -> Result<Option<Vec<String>>, String> {
+        capabilities_from_ext(self.ext.as_ref())
+    }
 }
 
 pub type UpdateAclResultBody = CreateAclResultBody;
@@ -151,6 +174,7 @@ mod tests {
             step_up: None,
             approve: None,
             allowed_keys: Some(Some(vec!["key-1".into(), "key-2".into()])),
+            ext: None,
         };
         let v = serde_json::to_value(&b).unwrap();
         assert!(v.get("allowedKeys").is_some(), "{v}");
@@ -170,6 +194,49 @@ mod tests {
             "subject": "did:key:zA", "allowed_keys": ["key-1"]
         }));
         assert_eq!(b.allowed_keys, None);
+    }
+
+    /// The capability narrowing's three intentions, which a `Vec` alone could
+    /// not carry: absent leaves the stored set alone, an empty array clears it,
+    /// and a populated one narrows. Confusing the first two is a silent
+    /// privilege increase, so each is pinned.
+    #[test]
+    fn a_capability_narrowing_carries_three_intentions() {
+        let unchanged = body(serde_json::json!({ "subject": "did:key:zA" }));
+        assert_eq!(unchanged.capabilities().unwrap(), None);
+
+        let cleared = body(serde_json::json!({
+            "subject": "did:key:zA",
+            "ext": { "org.openvtc.capabilities": [] },
+        }));
+        assert_eq!(cleared.capabilities().unwrap(), Some(Vec::new()));
+
+        let narrowed = body(serde_json::json!({
+            "subject": "did:key:zA",
+            "ext": { "org.openvtc.capabilities": ["memory-read", "room-present"] },
+        }));
+        assert_eq!(
+            narrowed.capabilities().unwrap(),
+            Some(vec!["memory-read".to_string(), "room-present".to_string()])
+        );
+    }
+
+    /// A malformed narrowing is an error, not an empty read. Treating
+    /// `"capabilities": "memory-read"` as "nothing named" would silently leave
+    /// an entry holding everything.
+    #[test]
+    fn a_malformed_narrowing_is_refused() {
+        let bad = body(serde_json::json!({
+            "subject": "did:key:zA",
+            "ext": { "org.openvtc.capabilities": "memory-read" },
+        }));
+        assert!(bad.capabilities().is_err());
+
+        let worse = body(serde_json::json!({
+            "subject": "did:key:zA",
+            "ext": { "org.openvtc.capabilities": [7] },
+        }));
+        assert!(worse.capabilities().is_err());
     }
 
     /// The three intentions decode to three different values: omitted =
@@ -203,6 +270,7 @@ mod tests {
             step_up: None,
             approve: None,
             allowed_keys: Some(None),
+            ext: None,
         };
         let v = serde_json::to_value(&b).unwrap();
         assert!(v.get("allowedKeys").is_some_and(|k| k.is_null()), "{v}");

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -946,6 +946,7 @@ async fn update_acl_patches() {
         step_up_require: None,
         approve_scope: None,
         allowed_keys: None,
+        capabilities: None,
     };
     let resp = c.update_acl("did:key:zAdmin", req).await.unwrap();
     assert_eq!(resp.did, "did:key:zAdmin");

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -823,6 +823,13 @@ didcomm_handler!(
         // No `role` here: role transitions are `acl/change-role`, which
         // carries the compare-and-swap this path cannot express.
         let role = None;
+        // Same `ext` narrowing the REST and Trust-Task paths accept; an
+        // unrecognised name is refused rather than dropped.
+        let capabilities = match body.capabilities() {
+            Ok(Some(names)) => Some(operations::acl::parse_capability_names(&names)?),
+            Ok(None) => None,
+            Err(reason) => return Err(crate::error::AppError::Validation(reason)),
+        };
         operations::acl::update_from_params(
             &s.acl_ks,
             &s.audit_sink,
@@ -831,6 +838,7 @@ didcomm_handler!(
             &body.did,
             operations::acl::UpdateAclParams {
                 role,
+                capabilities,
                 label: body.label.clone(),
                 allowed_contexts: body.allowed_contexts.clone(),
                 step_up_approver: body.step_up_approver(),

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -11,10 +11,10 @@ use vta_sdk::protocols::acl_management::{
 };
 
 use crate::acl::{
-    AclEntry, ApproveScope, ContextDirection, Role, acl_entry_matches_context, delete_acl_entry,
-    get_acl_entry, is_acl_entry_auditable, is_acl_entry_visible, list_acl_entries, store_acl_entry,
-    update_acl_entry_versioned, validate_acl_modification, validate_approve_scope_grant,
-    validate_role_assignment,
+    AclEntry, ApproveScope, Capability, ContextDirection, Role, acl_entry_matches_context,
+    capabilities_beyond_role, delete_acl_entry, get_acl_entry, is_acl_entry_auditable,
+    is_acl_entry_visible, list_acl_entries, store_acl_entry, update_acl_entry_versioned,
+    validate_acl_modification, validate_approve_scope_grant, validate_role_assignment,
 };
 use crate::auth::AuthClaims;
 use crate::auth::session::now_epoch;
@@ -48,6 +48,21 @@ pub struct UpdateAclParams {
     pub expires_at: Option<u64>,
     /// Optional human-readable rationale, recorded with the audit entry.
     pub reason: Option<String>,
+    /// Replace this entry's capability narrowing.
+    ///
+    /// Three intentions, and the middle one is the reason this is a nested
+    /// option rather than a `Vec`:
+    ///
+    /// - `None` — leave the narrowing unchanged;
+    /// - `Some(vec![])` — **clear** it, so the entry holds everything its role
+    ///   implies. A privilege *increase*, and the only way to undo a narrowing;
+    /// - `Some(caps)` — narrow to exactly these, which must be a subset of what
+    ///   the role carries.
+    ///
+    /// A `Vec` alone would make "clear it" and "leave it alone" the same wire
+    /// value, and the one an operator reaches for in a hurry is the one they
+    /// would silently not get.
+    pub capabilities: Option<Vec<Capability>>,
     /// Replace the signing-oracle key filter (#818). `None` leaves it
     /// unchanged; `Some(None)` clears it (back to every key in the entry's
     /// contexts — a privilege *increase*); `Some(Some(keys))` sets it to
@@ -205,6 +220,29 @@ fn not_manageable(auth: &AuthClaims, entry: &AclEntry, did: &str, verb: &str) ->
     }
 }
 
+/// Parse wire capability names into the enum, refusing any it does not know.
+///
+/// Every transport goes through this, so a name is spelled one way and refused
+/// the same way everywhere. An unknown name is an error rather than a skip: the
+/// caller is narrowing an entry, and dropping a name they meant to include
+/// would leave the entry holding an authority they had just tried to remove —
+/// while telling them it worked.
+pub fn parse_capability_names(names: &[String]) -> Result<Vec<Capability>, AppError> {
+    names
+        .iter()
+        .map(|n| {
+            serde_json::from_value::<Capability>(serde_json::Value::String(n.clone())).map_err(
+                |_| {
+                    AppError::Validation(format!(
+                        "unknown capability `{n}`; this VTA does not recognise it, and narrowing \
+                     an entry to a capability nobody enforces would grant more than intended"
+                    ))
+                },
+            )
+        })
+        .collect()
+}
+
 fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
     let (approve_all_contexts, approve_contexts) = match &e.approve_scope {
         ApproveScope::All => (true, Vec::new()),
@@ -229,6 +267,15 @@ fn to_result_body(e: &AclEntry) -> CreateAclResultBody {
             .allowed_keys
             .as_ref()
             .map(|keys| keys.iter().cloned().collect()),
+        // Serialized through serde so the names on the wire are the canonical
+        // kebab-case ones a caller sends back, rather than a second spelling
+        // invented here.
+        capabilities: e
+            .capabilities
+            .iter()
+            .filter_map(|c| serde_json::to_value(c).ok())
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
     }
 }
 
@@ -440,6 +487,24 @@ async fn update_acl(
     }
     if let Some(label) = params.label {
         entry.label = Some(label);
+    }
+    if let Some(capabilities) = params.capabilities {
+        // Checked against the *post-patch* role, so narrowing and a role change
+        // in one request are judged against the role the entry ends up with —
+        // not the one it happened to start from.
+        let beyond = capabilities_beyond_role(&entry.role, &capabilities);
+        if !beyond.is_empty() {
+            // Refused rather than intersected. Silently dropping what the role
+            // cannot carry would store a narrower grant than the operator asked
+            // for and report success, and they would only find out by reading
+            // the entry back.
+            return Err(AppError::Validation(format!(
+                "role {} does not carry {beyond:?}; an entry's capabilities can only \
+                 narrow what its role allows, never widen it",
+                entry.role
+            )));
+        }
+        entry.capabilities = capabilities;
     }
     if let Some(approver) = params.step_up_approver {
         entry.step_up_approver = Some(approver);
@@ -847,6 +912,23 @@ pub async fn grant_from_entry(
 ) -> Result<CreateAclResponseBody, AppError> {
     let role = Role::parse(&entry.role)
         .map_err(|_| AppError::Validation(format!("invalid role: {}", entry.role)))?;
+
+    // Grant does not carry a capability narrowing yet, and **refuses** one
+    // rather than ignoring it. Accepting the member and dropping it would hand
+    // the operator an entry they believe is narrowed and is not — the precise
+    // failure the narrowing exists to prevent, arriving through the surface
+    // that introduced it. The refusal names the command that does work, per the
+    // workspace rule that an operator error should carry its own fix.
+    if let Ok(Some(_)) =
+        vta_sdk::protocols::acl_management::entry::capabilities_from_ext(entry.ext.as_ref())
+    {
+        return Err(AppError::Validation(format!(
+            "`acl/grant` does not set a capability narrowing. Grant the entry, then narrow it:\n\
+             \n  pnm acl update {} --capabilities <name,name>\n",
+            entry.subject
+        )));
+    }
+
     let stored = create_acl(
         acl_ks,
         audit,
@@ -989,7 +1071,7 @@ pub async fn revoke_by_subject(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acl::{AclEntry, store_acl_entry};
+    use crate::acl::{AclEntry, entry_has_capability, store_acl_entry};
     use crate::store::Store;
     use vti_common::config::StoreConfig;
 
@@ -1419,6 +1501,170 @@ mod tests {
     /// #744: before this, `approve_scope` was settable only at create time,
     /// so narrowing or revoking an approver meant delete-and-recreate — and a
     /// failed recreate leaves the DID with no ACL entry at all.
+    /// Grant does not carry a narrowing, and says so instead of dropping it.
+    /// An ignored capability member would hand back an entry the operator
+    /// believes is narrowed and is not — through the very surface the narrowing
+    /// was added for.
+    #[tokio::test]
+    async fn grant_refuses_a_capability_narrowing_rather_than_ignoring_it() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+
+        let mut wire = WireAclEntry::new(
+            "did:key:zNew".into(),
+            "application".into(),
+            vec!["ctx-a".into()],
+        );
+        wire.ext = Some(serde_json::json!({
+            "org.openvtc.capabilities": ["memory-read"],
+        }));
+
+        let err = grant_from_entry(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &super_admin("did:key:zRoot"),
+            wire,
+            "test",
+        )
+        .await
+        .expect_err("a narrowing on grant must be refused, not dropped");
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("acl update")),
+            "the refusal must name the command that works: {err:?}"
+        );
+        assert!(
+            get_acl_entry(&acl_ks, "did:key:zNew")
+                .await
+                .unwrap()
+                .is_none(),
+            "and must not have created the entry it refused to narrow"
+        );
+    }
+
+    /// Narrow, read back, clear. The read-back is half the point: a
+    /// restriction an operator cannot see stored is one they cannot verify.
+    #[tokio::test]
+    async fn update_acl_narrows_and_clears_capabilities() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+        let target = "did:key:zAgent";
+        seed_target(&acl_ks, target, &["ctx-a"]).await;
+        let admin = super_admin("did:key:zRoot");
+
+        let set = |caps: Option<Vec<Capability>>| UpdateAclParams {
+            allowed_keys: None,
+            role: None,
+            label: None,
+            allowed_contexts: None,
+            step_up_approver: None,
+            step_up_require: None,
+            approve_scope: None,
+            expires_at: None,
+            reason: None,
+            capabilities: caps,
+        };
+
+        let narrowed = update_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &admin,
+            target,
+            set(Some(vec![Capability::MemoryRead])),
+            "test",
+        )
+        .await
+        .expect("narrowing within the role is allowed");
+        assert_eq!(narrowed.capabilities, vec!["memory-read".to_string()]);
+
+        let stored = get_acl_entry(&acl_ks, target).await.unwrap().unwrap();
+        assert!(entry_has_capability(&stored, Capability::MemoryRead));
+        assert!(
+            !entry_has_capability(&stored, Capability::MemoryWrite),
+            "an admin narrowed to memory-read must lose memory-write"
+        );
+
+        // Absent leaves it alone — the intention a `Vec` alone could not carry.
+        let untouched = update_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &admin,
+            target,
+            set(None),
+            "test",
+        )
+        .await
+        .expect("an update that says nothing about capabilities");
+        assert_eq!(untouched.capabilities, vec!["memory-read".to_string()]);
+
+        // Empty clears, and the entry is back to what its role implies.
+        let cleared = update_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &admin,
+            target,
+            set(Some(Vec::new())),
+            "test",
+        )
+        .await
+        .expect("clearing is allowed");
+        assert!(cleared.capabilities.is_empty());
+        let stored = get_acl_entry(&acl_ks, target).await.unwrap().unwrap();
+        assert!(entry_has_capability(&stored, Capability::MemoryWrite));
+    }
+
+    /// Refused, not silently intersected: storing less than the operator asked
+    /// for and reporting success is how an entry ends up holding something
+    /// nobody believes it holds.
+    #[tokio::test]
+    async fn update_acl_refuses_a_capability_the_role_lacks() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+        let target = "did:key:zReader";
+        store_acl_entry(
+            &acl_ks,
+            &AclEntry::new(target, Role::Reader, "seed").with_contexts(vec!["ctx-a".into()]),
+        )
+        .await
+        .unwrap();
+
+        let err = update_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &super_admin("did:key:zRoot"),
+            target,
+            UpdateAclParams {
+                allowed_keys: None,
+                role: None,
+                label: None,
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: None,
+                expires_at: None,
+                reason: None,
+                capabilities: Some(vec![Capability::RoomPresent]),
+            },
+            "test",
+        )
+        .await
+        .expect_err("a reader cannot be narrowed to a capability it never had");
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("RoomPresent")),
+            "the refusal must name what it refused: {err:?}"
+        );
+
+        let stored = get_acl_entry(&acl_ks, target).await.unwrap().unwrap();
+        assert!(
+            stored.capabilities.is_empty(),
+            "a refused update must store nothing"
+        );
+    }
+
     #[tokio::test]
     async fn update_acl_sets_and_revokes_approve_scope() {
         let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
@@ -1437,6 +1683,7 @@ mod tests {
             approve_scope: Some(scope),
             expires_at: None,
             reason: None,
+            capabilities: None,
         };
 
         // Narrow: All -> a single context, without touching the entry.
@@ -1526,6 +1773,7 @@ mod tests {
             expires_at: None,
             reason: None,
             allowed_keys: replacement,
+            capabilities: None,
         };
         let stored_filter = |acl_ks: &KeyspaceHandle| {
             let acl_ks = acl_ks.clone();
@@ -1645,6 +1893,7 @@ mod tests {
                 approve_scope: Some(ApproveScope::All),
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -1668,6 +1917,7 @@ mod tests {
                 approve_scope: None,
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -1709,6 +1959,7 @@ mod tests {
                 approve_scope: Some(ApproveScope::All),
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -1735,6 +1986,7 @@ mod tests {
                 approve_scope: Some(ApproveScope::Contexts(vec!["ctx-b".into()])),
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -1770,6 +2022,7 @@ mod tests {
                 approve_scope: None,
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -1809,6 +2062,7 @@ mod tests {
                 approve_scope: None,
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -1845,6 +2099,7 @@ mod tests {
                 approve_scope: None,
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )
@@ -2125,6 +2380,7 @@ mod tests {
                 approve_scope: None,
                 expires_at: None,
                 reason: None,
+                capabilities: None,
             },
             "test",
         )

--- a/vta-service/src/routes/acl.rs
+++ b/vta-service/src/routes/acl.rs
@@ -169,6 +169,15 @@ pub struct UpdateAclRequest {
     /// `allowedKeys` (the SDK's `UpdateAclRequest` serializes the same).
     #[serde(rename = "allowedKeys", default, deserialize_with = "double_option")]
     pub allowed_keys: Option<Option<Vec<String>>>,
+    /// Narrow what this entry may do, within what its role allows. Omitted
+    /// leaves the narrowing unchanged; an **empty array clears it**, so the
+    /// entry holds everything its role implies (a privilege increase).
+    ///
+    /// Kebab-case capability names. A name this VTA does not recognise is
+    /// refused rather than dropped — a narrowing that silently kept a
+    /// capability is worse than one that failed loudly.
+    #[serde(default)]
+    pub capabilities: Option<Vec<String>>,
 }
 
 /// Absent vs explicit-null, distinguishably: absent → `None` (leave alone),
@@ -240,6 +249,10 @@ pub async fn update_acl(
         &did,
         operations::acl::UpdateAclParams {
             role: None,
+            capabilities: match req.capabilities.as_deref() {
+                Some(names) => Some(operations::acl::parse_capability_names(names)?),
+                None => None,
+            },
             label: req.label,
             allowed_contexts: req.allowed_contexts,
             step_up_approver: req.step_up_approver,

--- a/vta-service/src/trust_tasks/acl.rs
+++ b/vta-service/src/trust_tasks/acl.rs
@@ -122,6 +122,20 @@ pub(super) async fn handle_update(
     };
     // Role transitions live in `acl/change-role`, not here.
     let role = None;
+    // The capability narrowing rides `ext`; an unrecognised name is refused
+    // here rather than dropped, because a narrowing that silently kept a
+    // capability is the failure this whole surface exists to prevent.
+    let capabilities = match req.capabilities() {
+        Ok(Some(names)) => match operations::acl::parse_capability_names(&names) {
+            Ok(caps) => Some(caps),
+            Err(e) => return app_error_to_reject(&doc, e),
+        },
+        Ok(None) => None,
+        Err(reason) => {
+            return app_error_to_reject(&doc, crate::error::AppError::Validation(reason));
+        }
+    };
+
     match operations::acl::update_from_params(
         &state.acl_ks,
         &state.audit_sink,
@@ -130,6 +144,7 @@ pub(super) async fn handle_update(
         &req.did,
         operations::acl::UpdateAclParams {
             role,
+            capabilities,
             label: req.label.clone(),
             allowed_contexts: req.allowed_contexts.clone(),
             step_up_approver: req.step_up_approver(),
@@ -397,6 +412,11 @@ mod tests {
             // clear (`Some(None)` → explicit `null`) and leave-unchanged
             // (`None` → omitted) arms are pinned in `update.rs`'s own tests.
             allowed_keys: Some(Some(vec!["tenant-key-a".into()])),
+            // The narrowing rides `ext`; a fully-populated sample carries one
+            // so the round-trip pins its member name too.
+            ext: Some(serde_json::json!({
+                "org.openvtc.capabilities": ["memory-read"],
+            })),
         }
     }
 

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -808,6 +808,13 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     // an explicit `null` (clear) and `None` emits nothing,
                     // and `update.rs`'s own tests pin all three.
                     allowed_keys: Some(Some(vec!["tenant-key-a".into()])),
+                    // The capability narrowing rides the schema's `ext` slot,
+                    // so the sample carries one — this is what proves the
+                    // namespaced member validates against the published
+                    // schema rather than merely round-tripping through serde.
+                    ext: Some(serde_json::json!({
+                        "org.openvtc.capabilities": ["memory-read", "room-present"],
+                    })),
                 }),
                 to_v(CreateAclResponseBody { entry: acl_entry() })
             ),

--- a/vta-service/src/trust_tasks/cred_vault.rs
+++ b/vta-service/src/trust_tasks/cred_vault.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use trust_tasks_rs::{RejectReason, TrustTask};
 use uuid::Uuid;
-use vti_common::acl::{Capability, role_has_capability};
+use vti_common::acl::Capability;
 use vti_common::vault::{LifecycleError, VaultStatus};
 
 use crate::auth::AuthClaims;
@@ -47,25 +47,15 @@ use super::helpers::{
 /// Capability gate, mirroring [`super::vault::require_capability`] for the
 /// credential-vault surface (kept local so the two vault slices stay
 /// independent).
-fn require_cap(
+async fn require_cap(
+    state: &AppState,
     auth: &AuthClaims,
     doc: &TrustTask<Value>,
     cap: Capability,
     action: &str,
 ) -> Result<(), TrustTaskOutcome> {
-    if role_has_capability(&auth.role, cap) {
-        Ok(())
-    } else {
-        Err(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "credential-vault {action} denied: role {} does not carry {cap:?}",
-                    auth.role
-                ),
-            },
-        ))
-    }
+    super::helpers::require_capability(state, auth, doc, cap, &format!("credential-vault {action}"))
+        .await
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -138,7 +128,7 @@ pub(super) async fn handle_receive(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::VaultWrite, "receive") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::VaultWrite, "receive").await {
         return r;
     }
     let req: ReceiveBody = match parse_payload(&doc) {
@@ -372,7 +362,7 @@ pub(super) async fn handle_query(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::VaultRead, "query") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::VaultRead, "query").await {
         return r;
     }
     let query: CredentialQuery = match parse_payload(&doc) {
@@ -432,7 +422,7 @@ pub(super) async fn handle_get(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::VaultRead, "get") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::VaultRead, "get").await {
         return r;
     }
     let req: GetBody = match parse_payload(&doc) {
@@ -601,7 +591,7 @@ async fn cred_transition(
     verb: &str,
     transition: impl FnOnce(&mut crate::vault::model::StoredCredential) -> Result<(), LifecycleError>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, verb) {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::CredentialWrite, verb).await {
         return r;
     }
     let req: CredLifecycleBody = match parse_payload(&doc) {
@@ -640,7 +630,7 @@ pub(super) async fn handle_delete(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, "delete") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::CredentialWrite, "delete").await {
         return r;
     }
     let req: CredDeleteBody = match parse_payload(&doc) {
@@ -713,7 +703,7 @@ pub(super) async fn handle_purge(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::CredentialWrite, "purge") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::CredentialWrite, "purge").await {
         return r;
     }
     let req: CredLifecycleBody = match parse_payload(&doc) {

--- a/vta-service/src/trust_tasks/helpers.rs
+++ b/vta-service/src/trust_tasks/helpers.rs
@@ -31,7 +31,10 @@ use trust_tasks_rs::{
 use uuid::Uuid;
 use vta_sdk::protocols::trust_task_reject_reasons as reasons;
 
+use crate::auth::AuthClaims;
 use crate::error::AppError;
+use crate::server::AppState;
+use vti_common::acl::Capability;
 // The SDK owns the spelling of every `details` member both sides touch,
 // so the service cannot drift from the client that reads it.
 use vta_sdk::protocols::trust_task_reject_details as details;
@@ -229,6 +232,67 @@ fn bound_details(details: Option<Value>) -> Option<Value> {
         return None;
     }
     Some(details)
+}
+
+/// The capability gate every gated task goes through.
+///
+/// # Why this reads the ACL rather than the token
+///
+/// A caller's role rides in their access token; their *narrowing* does not. It is
+/// read from the entry, per call, on purpose:
+///
+/// - A capability set is a **restriction**, and a restriction that takes effect
+///   at the subject's next token mint is a restriction with a fifteen-minute hole
+///   in it. Narrowing an entry stops the next call, not the next login.
+/// - The alternative — a `capabilities` claim in the JWT — would put the set in
+///   `AuthClaims`, a published struct built by literal in 130 places, and would
+///   still leave every unexpired token holding what it held before.
+///
+/// The read is one keyspace hit on the tasks that are capability-gated, which are
+/// already reading vault or memory keyspaces to do their work.
+///
+/// # An entry that is not there
+///
+/// Falls back to the role's own set. The offline CLI synthesizes claims under a
+/// `cli:<channel>` DID that is deliberately in no ACL, and DIDs authenticated
+/// before an entry existed behave as they always did. This gate narrows what an
+/// entry says to narrow; it is not an authorization check of its own, and the
+/// authenticated role is what it defers to.
+pub(super) async fn require_capability(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    cap: Capability,
+    what: &str,
+) -> Result<(), TrustTaskOutcome> {
+    let allowed = match vti_common::acl::get_acl_entry(&state.acl_ks, &auth.did).await {
+        Ok(Some(entry)) => vti_common::acl::entry_has_capability(&entry, cap),
+        // No entry: the role decides, exactly as before this gate existed.
+        Ok(None) => vti_common::acl::role_has_capability(&auth.role, cap),
+        // A store error must not become a grant. It also must not leak: the
+        // caller is told the capability is missing, and the operator gets the
+        // real reason in the log.
+        Err(e) => {
+            tracing::error!(
+                error = %e, did = %auth.did,
+                "could not read the ACL entry for a capability check; refusing"
+            );
+            false
+        }
+    };
+
+    if allowed {
+        return Ok(());
+    }
+    Err(reject_with(
+        doc,
+        RejectReason::PermissionDenied {
+            reason: format!(
+                "{what} denied: {} does not carry the {cap:?} capability",
+                auth.did
+            ),
+        },
+    ))
 }
 
 pub(super) fn reject_with(doc: &TrustTask<Value>, reason: RejectReason) -> TrustTaskOutcome {

--- a/vta-service/src/trust_tasks/memory.rs
+++ b/vta-service/src/trust_tasks/memory.rs
@@ -34,17 +34,14 @@ use vta_sdk::protocols::memory::{
     MemoryPutResponse,
 };
 
-use trust_tasks_rs::RejectReason;
-use vti_common::acl::{Capability, role_has_capability};
+use vti_common::acl::Capability;
 
 use crate::audit;
 use crate::auth::AuthClaims;
 use crate::operations::memory;
 use crate::server::AppState;
 
-use super::helpers::{
-    TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, reject_with, success_response,
-};
+use super::helpers::{TRANSPORT_TRUST_TASK, app_error_to_reject, parse_payload, success_response};
 
 /// Capability gate for the memory surface, mirroring the vault slices'
 /// [`super::vault::require_capability`].
@@ -52,25 +49,14 @@ use super::helpers::{
 /// Checked **before** the context gate so a caller who holds neither learns
 /// only that the capability is missing — the narrower fact, and the one that
 /// does not reveal whether a given context exists.
-fn require_cap(
+async fn require_cap(
+    state: &AppState,
     auth: &AuthClaims,
     doc: &TrustTask<Value>,
     cap: Capability,
     action: &str,
 ) -> Result<(), super::helpers::TrustTaskOutcome> {
-    if role_has_capability(&auth.role, cap) {
-        Ok(())
-    } else {
-        Err(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "memory {action} denied: role {} does not carry {cap:?} capability",
-                    auth.role
-                ),
-            },
-        ))
-    }
+    super::helpers::require_capability(state, auth, doc, cap, &format!("memory {action}")).await
 }
 
 /// Handler for `spec/vta/memory/put/0.1`.
@@ -79,7 +65,7 @@ pub(super) async fn handle_put(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> super::helpers::TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::MemoryWrite, "put") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::MemoryWrite, "put").await {
         return r;
     }
     let req: MemoryPutBody = match parse_payload(&doc) {
@@ -104,7 +90,7 @@ pub(super) async fn handle_list(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> super::helpers::TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::MemoryRead, "list") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::MemoryRead, "list").await {
         return r;
     }
     let req: MemoryListBody = match parse_payload(&doc) {
@@ -128,7 +114,7 @@ pub(super) async fn handle_delete(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> super::helpers::TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::MemoryWrite, "delete") {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::MemoryWrite, "delete").await {
         return r;
     }
     let req: MemoryDeleteBody = match parse_payload(&doc) {
@@ -270,6 +256,79 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].get("key").and_then(Value::as_str), Some("name"));
         assert_eq!(items[0].get("value").and_then(Value::as_str), Some("Ada"));
+    }
+
+    /// The point of the whole capability field: an entry narrowed to read
+    /// cannot write, even though its role can — and the check reads the stored
+    /// entry, so the narrowing binds the caller's *next* request rather than
+    /// waiting for their token to expire.
+    #[tokio::test]
+    async fn a_narrowed_entry_loses_what_its_role_still_carries() {
+        use vti_common::acl::{AclEntry, Capability, store_acl_entry};
+
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = admin_of("acme");
+
+        // Un-narrowed first: the write works, so the refusal below is the
+        // narrowing and not some other gate.
+        assert!(
+            handle_put(&state, &auth, put_doc("acme", "before", "ok"))
+                .await
+                .status
+                .is_success()
+        );
+
+        let narrowed = AclEntry::new(&auth.did, auth.role.clone(), "did:key:zAdmin")
+            .with_contexts(vec!["acme".to_string()])
+            .with_capabilities(vec![Capability::MemoryRead]);
+        store_acl_entry(&state.acl_ks, &narrowed)
+            .await
+            .expect("store the narrowed entry");
+
+        let refused = handle_put(&state, &auth, put_doc("acme", "after", "no")).await;
+        assert!(
+            !refused.status.is_success(),
+            "a memory-read-only entry must not write"
+        );
+        assert!(
+            handle_list(&state, &auth, list_doc("acme"))
+                .await
+                .status
+                .is_success(),
+            "…and must still read: narrowing removes one capability, not the entry"
+        );
+    }
+
+    /// A capability the role does not carry cannot be recovered by naming it,
+    /// which is what keeps the role an upper bound rather than a suggestion.
+    #[tokio::test]
+    async fn naming_a_capability_the_role_lacks_does_not_grant_it() {
+        use vti_common::acl::{AclEntry, Capability, store_acl_entry};
+
+        let (state, _dir) = build_signing_test_app_state().await;
+        let auth = claims_for(Role::Reader, "acme");
+
+        let entry = AclEntry::new(&auth.did, Role::Reader, "did:key:zAdmin")
+            .with_contexts(vec!["acme".to_string()])
+            .with_capabilities(vec![Capability::MemoryRead, Capability::MemoryWrite]);
+        store_acl_entry(&state.acl_ks, &entry)
+            .await
+            .expect("store the entry");
+
+        assert!(
+            !handle_put(&state, &auth, put_doc("acme", "k", "v"))
+                .await
+                .status
+                .is_success(),
+            "a reader naming memory-write must still not write"
+        );
+        assert!(
+            handle_list(&state, &auth, list_doc("acme"))
+                .await
+                .status
+                .is_success(),
+            "the capability the role does carry is unaffected"
+        );
     }
 
     #[tokio::test]

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -28,8 +28,8 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use trust_tasks_rs::{RejectReason, TrustTask};
-use vti_common::acl::{Capability, role_has_capability};
+use trust_tasks_rs::TrustTask;
+use vti_common::acl::Capability;
 
 use crate::audit;
 use crate::auth::AuthClaims;
@@ -37,8 +37,7 @@ use crate::operations::{room_groups, room_invitation};
 use crate::server::AppState;
 
 use super::helpers::{
-    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, reject_with,
-    success_response,
+    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, success_response,
 };
 
 /// How long an unused KeyPackage's private half is retained.
@@ -215,16 +214,16 @@ pub(super) async fn handle_open(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if !role_has_capability(&auth.role, Capability::RoomOpen) {
-        return reject_with(
-            &doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "opening a room record denied: role {} does not carry RoomOpen",
-                    auth.role
-                ),
-            },
-        );
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::RoomOpen,
+        "opening a room record",
+    )
+    .await
+    {
+        return r;
     }
 
     let req: trust_tasks_rs::specs::rooms::keys::open::v0_1::Payload = match parse_payload(&doc) {

--- a/vta-service/src/trust_tasks/room_keys.rs
+++ b/vta-service/src/trust_tasks/room_keys.rs
@@ -25,8 +25,8 @@
 //! request, so a presentation minted for A is worthless to B even if B obtains it.
 
 use serde_json::Value;
-use trust_tasks_rs::{RejectReason, TrustTask};
-use vti_common::acl::{Capability, role_has_capability};
+use trust_tasks_rs::TrustTask;
+use vti_common::acl::Capability;
 
 use crate::audit;
 use crate::auth::AuthClaims;
@@ -34,29 +34,18 @@ use crate::operations::room_oracle;
 use crate::server::AppState;
 
 use super::helpers::{
-    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, reject_with,
-    success_response,
+    TRANSPORT_TRUST_TASK, TrustTaskOutcome, app_error_to_reject, parse_payload, success_response,
 };
 
-/// Refuse unless the caller's role carries `cap`.
-fn require_cap(
+/// Refuse unless the caller holds `cap` — by role, and by whatever their ACL
+/// entry narrowed that to.
+async fn require_cap(
+    state: &AppState,
     auth: &AuthClaims,
     doc: &TrustTask<Value>,
     cap: Capability,
 ) -> Result<(), TrustTaskOutcome> {
-    if role_has_capability(&auth.role, cap) {
-        Ok(())
-    } else {
-        Err(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "minting a room presentation denied: role {} does not carry {cap:?}",
-                    auth.role
-                ),
-            },
-        ))
-    }
+    super::helpers::require_capability(state, auth, doc, cap, "minting a room presentation").await
 }
 
 /// `rooms/keys/present/0.1`.
@@ -65,7 +54,7 @@ pub(super) async fn handle_present(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_cap(auth, &doc, Capability::RoomPresent) {
+    if let Err(r) = require_cap(state, auth, &doc, Capability::RoomPresent).await {
         return r;
     }
 

--- a/vta-service/src/trust_tasks/vault.rs
+++ b/vta-service/src/trust_tasks/vault.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
-use vti_common::acl::{Capability, role_has_capability};
+use vti_common::acl::Capability;
 use vti_common::vault::{
     LifecycleError, SecretKind, SiteTarget, StoredVaultEntry, VaultEntry, VaultListFilter,
     VaultSecret, VaultStatus, delete_vault_entry, get_stored_vault_entry, get_vault_entry,
@@ -418,39 +418,25 @@ struct VaultSessionExt {
     expires_at: String,
 }
 
-/// Reject the request unless the caller's role implies `cap`. `action` names
-/// the operation for the rejection message (`"read"`, `"write"`, `"release"`,
-/// `"proxy-login"`, `"sign-trust-task"`); the `{cap:?}` Debug repr renders the
-/// canonical capability name. When AclEntry-level explicit capabilities arrive
-/// (M4), this upgrades to consult the entry's `capabilities` Vec instead of
-/// deriving from role.
+/// Reject the request unless the caller holds `cap` — by role, and by whatever
+/// their ACL entry narrowed that to. `action` names the operation for the
+/// rejection message (`"read"`, `"write"`, `"release"`, `"proxy-login"`,
+/// `"sign-trust-task"`).
 ///
-/// Capability semantics (role→capability fallback in
-/// [`role_has_capability`]): `VaultRead` (list/get), `VaultWrite` (upsert/
-/// delete — Admin + Initiator), `FillRelease` (release — + Application),
-/// `ProxyLogin` (the VTA performs the login; same roles as FillRelease but the
-/// consumer never sees the long-term secret), `SignTrustTask` (per-envelope
-/// signing on the entry's principal DID — split from ProxyLogin so operators
-/// can limit blast radius on Service consumers).
-fn require_capability(
+/// Capability semantics: `VaultRead` (list/get), `VaultWrite` (upsert/delete —
+/// Admin + Initiator), `FillRelease` (release — + Application), `ProxyLogin`
+/// (the VTA performs the login; same roles as FillRelease but the consumer
+/// never sees the long-term secret), `SignTrustTask` (per-envelope signing on
+/// the entry's principal DID — split from ProxyLogin so operators can limit
+/// blast radius on Service consumers).
+async fn require_capability(
+    state: &AppState,
     auth: &AuthClaims,
     doc: &TrustTask<Value>,
     cap: Capability,
     action: &str,
 ) -> Result<(), TrustTaskOutcome> {
-    if role_has_capability(&auth.role, cap) {
-        Ok(())
-    } else {
-        Err(reject_with(
-            doc,
-            RejectReason::PermissionDenied {
-                reason: format!(
-                    "vault {action} denied: role {} does not carry {cap:?} capability",
-                    auth.role
-                ),
-            },
-        ))
-    }
+    super::helpers::require_capability(state, auth, doc, cap, &format!("vault {action}")).await
 }
 
 /// Reject if the caller may not act in `context_id` (when one is supplied).
@@ -599,7 +585,7 @@ pub(super) async fn handle_list(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::VaultRead, "read") {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::VaultRead, "read").await {
         return r;
     }
 
@@ -689,7 +675,7 @@ pub(super) async fn handle_get(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::VaultRead, "read") {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::VaultRead, "read").await {
         return r;
     }
     let req: VaultGetBody = match parse_payload(&doc) {
@@ -735,7 +721,7 @@ pub(super) async fn handle_upsert(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, "write") {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::VaultWrite, "write").await {
         return r;
     }
 
@@ -1180,7 +1166,7 @@ pub(super) async fn handle_delete(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, "write") {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::VaultWrite, "write").await {
         return r;
     }
 
@@ -1299,7 +1285,7 @@ async fn handle_lifecycle_transition(
     verb: &str,
     transition: impl Fn(&mut VaultEntry, &str, Option<&str>) -> Result<(), LifecycleError>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, verb) {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::VaultWrite, verb).await {
         return r;
     }
     let req: VaultLifecycleBody = match parse_payload(&doc) {
@@ -1338,7 +1324,7 @@ pub(super) async fn handle_purge(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::VaultWrite, "purge") {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::VaultWrite, "purge").await {
         return r;
     }
     let req: VaultLifecycleBody = match parse_payload(&doc) {
@@ -1403,7 +1389,8 @@ pub(super) async fn handle_release(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::FillRelease, "release") {
+    if let Err(r) = require_capability(state, auth, &doc, Capability::FillRelease, "release").await
+    {
         return r;
     }
 
@@ -1548,7 +1535,9 @@ pub(super) async fn handle_proxy_login(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::ProxyLogin, "proxy-login") {
+    if let Err(r) =
+        require_capability(state, auth, &doc, Capability::ProxyLogin, "proxy-login").await
+    {
         return r;
     }
 
@@ -1752,7 +1741,15 @@ pub(super) async fn handle_sign_trust_task(
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
-    if let Err(r) = require_capability(auth, &doc, Capability::SignTrustTask, "sign-trust-task") {
+    if let Err(r) = require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::SignTrustTask,
+        "sign-trust-task",
+    )
+    .await
+    {
         return r;
     }
     let req: VaultSignTrustTaskBody = match parse_payload(&doc) {

--- a/vta-service/tests/client_round_trip.rs
+++ b/vta-service/tests/client_round_trip.rs
@@ -111,6 +111,7 @@ async fn acl_lifecycle_round_trips_through_the_real_client() {
                 step_up_require: None,
                 approve_scope: None,
                 allowed_keys: None,
+                capabilities: None,
             },
         )
         .await
@@ -716,6 +717,7 @@ async fn acl_change_role_compare_and_swaps() {
                 step_up_require: None,
                 approve_scope: None,
                 allowed_keys: None,
+                capabilities: None,
             },
         )
         .await

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -191,14 +191,58 @@ pub enum Capability {
 
 /// Returns true if `role` is granted `cap` by the default capability mapping.
 ///
-/// **This is what every capability gate in the workspace actually calls**, and it
-/// answers from the role alone — [`AclEntry::capabilities`] is not consulted here
-/// or anywhere else, because the authenticated claims a gate holds carry a role
-/// and no capability set. An entry's explicit capabilities are therefore
-/// descriptive today, not enforced; see the note on that field before writing a
-/// gate that assumes otherwise.
+/// The role's set is the **ceiling**, and this answers about the ceiling alone.
+/// A gate wants [`effective_capabilities`] (or, on the request path,
+/// `AuthClaims::has_capability`), which also honours an entry's own narrowing.
 pub fn role_has_capability(role: &Role, cap: Capability) -> bool {
     derived_capabilities_for_role(role).contains(&cap)
+}
+
+/// What an entry may actually do: its own set, bounded by its role's.
+///
+/// **An explicit set only ever narrows.** Empty means "whatever the role
+/// implies" — the shape every entry written before this had — and a non-empty
+/// one is intersected with the role's, never unioned. So `role` stays a true
+/// upper bound: an operator reading `role: reader` knows the entry holds no more
+/// than a reader, whatever else its capability list says, and a capability
+/// removed from a role's derived set is removed from every entry at once rather
+/// than surviving in the rows that happened to name it.
+///
+/// The alternative — letting the list replace the role's — was considered and
+/// declined. It buys targeted grants ("this one agent may present, nothing
+/// else") at the price of making the role no longer describe the entry, which is
+/// the property the ACL's own display, audit trail and role-assignment checks
+/// all lean on.
+pub fn effective_capabilities(role: &Role, explicit: &[Capability]) -> Vec<Capability> {
+    let derived = derived_capabilities_for_role(role);
+    if explicit.is_empty() {
+        return derived;
+    }
+    derived
+        .into_iter()
+        .filter(|c| explicit.contains(c))
+        .collect()
+}
+
+/// Whether `entry` may exercise `cap`, honouring both its role and its own
+/// narrowing. The storage-side counterpart of `AuthClaims::has_capability`.
+pub fn entry_has_capability(entry: &AclEntry, cap: Capability) -> bool {
+    effective_capabilities(&entry.role, &entry.capabilities).contains(&cap)
+}
+
+/// Capabilities named in `requested` that `role` does not carry.
+///
+/// A grant path calls this to refuse loudly rather than silently dropping what
+/// it cannot honour. Silently intersecting at write time would store a set the
+/// operator did not ask for and report success; the operator would then read the
+/// entry back and find a capability they granted simply absent.
+pub fn capabilities_beyond_role(role: &Role, requested: &[Capability]) -> Vec<Capability> {
+    let derived = derived_capabilities_for_role(role);
+    requested
+        .iter()
+        .filter(|c| !derived.contains(c))
+        .copied()
+        .collect()
 }
 
 /// Default capability set inferred from a role for entries that pre-date
@@ -499,20 +543,19 @@ pub struct AclEntry {
     /// rows deserialise as `Service { Daemon }`.
     #[serde(default)]
     pub kind: ConsumerKind,
-    /// Fine-grained capability set. Empty Vec on legacy rows.
+    /// Fine-grained capability set — what this entry may do **within** what its
+    /// role allows. Empty means "everything the role implies", which is what
+    /// every entry written before this field meant.
     ///
-    /// **Not enforced.** Every gate in the workspace asks
-    /// [`role_has_capability`], which answers from the role alone — the claims a
-    /// gate holds carry no capability set — and nothing over the wire can set
-    /// this field, so today it is only read to describe a registered device's
-    /// authority in a binding listing. Narrowing it narrows nothing and widening
-    /// it grants nothing.
+    /// Enforced through [`effective_capabilities`]: the set is intersected with
+    /// the role's, never unioned, so it can only narrow. A grant naming a
+    /// capability the role does not carry is refused at the ACL surface rather
+    /// than quietly dropped ([`capabilities_beyond_role`]), because storing less
+    /// than the operator asked for and reporting success is how an entry ends up
+    /// holding something nobody believes it holds.
     ///
-    /// Stated plainly because the shape invites the opposite assumption, and a
-    /// reader who assumed the auth layer consulted it would believe an entry was
-    /// least-privileged when it holds everything its role does. Making it real
-    /// means carrying the set in the authenticated claims and giving the ACL
-    /// surface a way to set it; until then, the role is the grant.
+    /// The set travels in the access token, so a change takes effect at the
+    /// subject's next token mint — the same latency a role change already has.
     #[serde(default)]
     pub capabilities: Vec<Capability>,
     /// Optional Companion/Service device-binding metadata. Populated by
@@ -1354,6 +1397,75 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ── Capability narrowing ────────────────────────────────────────
+
+    /// The shape every entry written before this feature has, and the one that
+    /// must keep behaving exactly as it did: no narrowing is not "narrowed to
+    /// nothing".
+    #[test]
+    fn an_entry_that_names_no_capabilities_holds_what_its_role_holds() {
+        let role = Role::Application;
+        assert_eq!(
+            effective_capabilities(&role, &[]),
+            derived_capabilities_for_role(&role)
+        );
+    }
+
+    #[test]
+    fn an_explicit_set_narrows_to_the_intersection() {
+        let held = effective_capabilities(
+            &Role::Application,
+            &[Capability::RoomPresent, Capability::MemoryRead],
+        );
+        assert_eq!(held.len(), 2, "{held:?}");
+        assert!(held.contains(&Capability::RoomPresent));
+        assert!(held.contains(&Capability::MemoryRead));
+        assert!(
+            !held.contains(&Capability::Sign),
+            "a capability the entry did not name must be gone: {held:?}"
+        );
+    }
+
+    /// The decision this feature turns on: the role is the ceiling. An entry
+    /// naming something its role never had gains nothing, so a stored row
+    /// cannot out-grant the role an operator reads beside it.
+    #[test]
+    fn an_explicit_set_cannot_widen_beyond_the_role() {
+        let held = effective_capabilities(&Role::Reader, &[Capability::RoomPresent]);
+        assert!(
+            held.is_empty(),
+            "a reader naming room-present must hold nothing: {held:?}"
+        );
+        assert_eq!(
+            capabilities_beyond_role(&Role::Reader, &[Capability::RoomPresent]),
+            vec![Capability::RoomPresent],
+            "and the grant path must be able to say which name it refused"
+        );
+    }
+
+    #[test]
+    fn narrowing_within_the_role_is_not_beyond_it() {
+        assert!(
+            capabilities_beyond_role(&Role::Application, &[Capability::RoomPresent]).is_empty()
+        );
+    }
+
+    #[test]
+    fn entry_has_capability_reads_both_the_role_and_the_narrowing() {
+        let mut entry = AclEntry::new("did:key:zAgent", Role::Application, "did:key:zAdmin");
+        assert!(
+            entry_has_capability(&entry, Capability::MemoryWrite),
+            "un-narrowed, the role decides"
+        );
+
+        entry.capabilities = vec![Capability::RoomPresent];
+        assert!(entry_has_capability(&entry, Capability::RoomPresent));
+        assert!(
+            !entry_has_capability(&entry, Capability::MemoryWrite),
+            "narrowed, what the entry did not name is gone even though the role has it"
+        );
     }
 
     // ── Test fixtures ───────────────────────────────────────────────


### PR DESCRIPTION
Closes the third finding from the data-rooms review (#1273 → #1274 / #1275): `AclEntry::capabilities` was stored, echoed in a device-binding listing, and **enforced nowhere**. Every gate called `role_has_capability`, which reads the role and nothing else; the authenticated claims carried no capability set; nothing over the wire could set the field. Narrowing it narrowed nothing.

Worse than a missing feature, because the shape invites the opposite assumption: an operator reading an entry whose `capabilities` list one thing would believe it held one thing, while it held everything its role did.

### Semantics: narrow within the role, never widen beyond it

`effective_capabilities(role, explicit)` **intersects**. Empty means "whatever the role implies" — what every entry written before this means — and a non-empty set only subtracts.

| | |
|---|---|
| `application` + `[room-present, room-open]` | holds exactly those two |
| `reader` + `[room-present]` | holds **nothing** — and the grant path refuses it rather than storing it |
| any role + `[]` | holds everything the role implies |

So `role` stays a true upper bound: an operator reading `role: reader` knows the entry holds no more than a reader whatever else its list says, and a capability removed from a role's derived set is removed from every entry at once rather than surviving in the rows that happened to name it. Letting the list *replace* the role's set was the alternative, and it buys targeted grants at the price of the role no longer describing the entry — which the ACL's display, its audit trail and `validate_role_assignment` all lean on.

### The check reads the entry, not the token

A capability set is a **restriction**, and a restriction that takes effect at the subject's next token mint has a fifteen-minute hole in it. `helpers::require_capability` reads the ACL entry per gated call, so **a narrowing binds the caller's next request**. Ten gates route through it — vault (read / write / release / proxy-login / sign-trust-task), the credential vault, agent memory, and the two room tasks; the one that was inline in `room_group` now uses the same funnel.

A DID with no entry falls back to the role's set — what the offline CLI's synthesized `cli:<channel>` claims need, and what every caller already did. A store error denies rather than grants.

> Putting the set in the JWT was tried and abandoned: `AuthClaims` is built by struct literal in **130** places, so it would have buried the fix in mechanical churn, and every unexpired token would still have held what it held before.

### Setting it

```bash
pnm acl update <did> --capabilities memory-read,room-present   # narrow
pnm acl update <did> --capabilities-all                        # clear
```

Absent leaves the narrowing alone, empty clears it, populated narrows — three intentions kept distinct, because conflating the first two is a silent privilege increase. It rides `ext` as `org.openvtc.capabilities`, since the published `acl/*` schemas are `additionalProperties: false` and declare that slot; **the conformance witness now carries one**, so the schema check proves the member validates rather than merely round-trips. All three transports (Trust Task / DIDComm / REST) parse it through one function, and `acl show` / `list` echo the stored set — a restriction nobody can read back is one nobody can verify.

**Two refusals rather than silent drops:** a capability the role does not carry is rejected naming what it refused; and `acl/grant`, which does not take a narrowing yet, refuses one and prints the `acl update` command instead. A grant that accepted the member and dropped it would hand back an entry the operator believes is narrowed — through the very surface the narrowing was added for.

### Tests

11 new: the intersection and its ceiling (5), the wire's three intentions plus malformed input (2), narrow/clear/refuse at the operations layer (3), the grant refusal (1) — plus two end-to-end gate tests proving a narrowed entry loses a capability its role still carries, and that naming one the role lacks grants nothing.

`cargo test --workspace` green, `cargo clippy --all-targets` clean on every touched crate, `cargo fmt --check` clean.

### Breaking, and what is not here

`UpdateAclParams`, `UpdateAclBody`, `UpdateAclRequest` and `CreateAclResultBody` each gain a member, so struct literals need updating. Behaviour is unchanged for every entry that names no capabilities — all of them today.

Creating an entry **pre-narrowed** is deliberately out: `create_acl` has fourteen positional parameters across twenty-eight call sites and threading a fifteenth would double this diff. The refusal above makes that gap loud rather than silent, and it is the obvious follow-up.

Docs: `personal-ai-agents.md` claimed capabilities were a deferred Phase-3 item set at `device/register` — wrong on both counts even before this — and the data-rooms guide said the field was descriptive. Both now describe what happens.