### PR TITLE
feat(acl)!: create an entry already narrowed, rather than narrowing it after

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1211,6 +1211,9 @@ async fn main() {
                         false,
                         Vec::new(),
                         allowed_keys,
+                        // cnm exposes no capability flags; `None` leaves the
+                        // entry holding everything its role implies.
+                        None,
                     )
                     .await
                 }

--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -514,8 +514,10 @@
       <code>application</code> — what an agent integration is normally granted — along with
       <code>initiator</code> and <code>admin</code> carries both room capabilities, and
       <code>reader</code> and <code>monitor</code> carry neither. To give one agent less than its
-      role allows, narrow its entry:
-      <code>pnm acl update &lt;did&gt; --capabilities room-present</code>, undone with
+      role allows, narrow its entry at creation —
+      <code>pnm acl create … --capabilities room-present</code>, the form to prefer, since it
+      leaves no window where the entry is wider — or afterwards with
+      <code>pnm acl update &lt;did&gt; --capabilities room-present</code>, undone by
       <code>--capabilities-all</code>. A name the role does not carry is refused rather than
       dropped, so the role always describes the entry — and the gate reads the stored entry, so a
       narrowing binds the agent's next call rather than its next token.</p>

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -394,11 +394,13 @@ have become the credential hand-off it exists to replace:
 > capabilities, while `reader` and `monitor` carry neither — minting a
 > credential on a principal's behalf is not a read.
 >
-> Within that ceiling, an entry's own list narrows:
-> `pnm acl update <did> --capabilities room-present` leaves an agent able to
-> present and nothing else, and `--capabilities-all` undoes it. Narrowing binds
-> the agent's next call, not its next token. A name the role does not carry is
-> refused rather than dropped, so the role always describes the entry.
+> Within that ceiling, an entry's own list narrows — at creation
+> (`pnm acl create … --capabilities room-present`, which is the form to prefer,
+> since it leaves no window where the entry is wider) or after
+> (`pnm acl update <did> --capabilities room-present`, undone with
+> `--capabilities-all`). Narrowing binds the agent's next call, not its next
+> token, and a name the role does not carry is refused rather than dropped — so
+> the role always describes the entry.
 
 Withdrawing an agent's access is withdrawing it *at the VTA* — remove the ACL
 entry and no further presentations are minted. That is the whole value of an

--- a/docs/02-vta/personal-ai-agents.md
+++ b/docs/02-vta/personal-ai-agents.md
@@ -110,9 +110,10 @@ above adds it. Set its role/context scope:
 pnm acl create --did <agent-did> --role member --contexts <ctx-id> --expires 30d
 ```
 
-**Capabilities narrow what a role allows**, and `pnm acl update` sets them. They
-can only narrow: every name must be one the role already carries, and one that
-is not is refused rather than dropped. Grant the minimum:
+**Capabilities narrow what a role allows**, and both `pnm acl create` and
+`pnm acl update` set them. They can only narrow: every name must be one the role
+already carries, and one that is not is refused rather than dropped. Grant the
+minimum:
 
 | Capability        | Why an agent needs it                                              |
 |-------------------|-------------------------------------------------------------------|
@@ -128,12 +129,20 @@ both memory capabilities and both room capabilities — usually wider than one
 agent needs. Narrow it to exactly what this agent does:
 
 ```bash
-# This agent reads memory and presents in rooms. Nothing else.
+# Narrow at creation — the entry is never briefly wider than intended.
+pnm acl create --did <agent-did> --role application --contexts <ctx-id> \
+  --capabilities memory-read,room-present
+
+# Or narrow one that already exists.
 pnm acl update <agent-did> --capabilities memory-read,room-present
 
 # Undo the narrowing — the entry holds everything its role implies again.
 pnm acl update <agent-did> --capabilities-all
 ```
+
+**Prefer the first form.** Granting and then narrowing leaves a window in which
+the entry holds everything its role implies, and an agent that authenticates
+inside that window is authorized by what it found there.
 
 The gate reads the stored entry on every call, so a narrowing binds the agent's
 **next request** rather than waiting for its token to expire. Pick the role
@@ -314,7 +323,7 @@ Lower priority unless your agents do credential work.
 | Capability vocabulary                  | Exists (`vti_common::acl::Capability`) |
 | `pnm device …` / `pnm vault …` CLI     | **Added** (this change) — `VtaClient::{device_*,vault_*}` + `pnm` commands, both transports |
 | Sealed vault upsert/release            | **Added** — `seal_vault_secret` / `open_sealed_secret` on the DIDComm session |
-| `pnm acl update --capabilities` flag   | **Added** — an entry narrows within its role, enforced on every gated call |
+| `pnm acl \{create,update\} --capabilities` | **Added** — an entry narrows within its role, at creation or after, enforced on every gated call |
 | Agent memory Trust Tasks               | Exists (`trust_tasks/memory.rs`, `VtaClient::memory_*`) — capability- and context-gated, audited |
 | `pnm memory …` CLI                     | **Added** — `plant` / `recall` / `forget` / `wipe` over the same three tasks |
 | Agent-side connect ladder              | Exists (`vta_sdk::agent_connect::AgentConnect`) — one way in for every agent bridge |

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1950,6 +1950,15 @@ pub(crate) enum AclCommands {
         /// string is not an id and is rejected.
         #[arg(long, value_delimiter = ',')]
         allowed_keys: Option<Vec<String>>,
+        /// Narrow the new entry to exactly these capabilities (comma-separated,
+        /// kebab-case: `vault-read`, `memory-read`, `room-present`, …).
+        ///
+        /// Set at creation so the entry is never briefly wider than intended —
+        /// the window a grant-then-narrow pair leaves open. Every name must be
+        /// one the role already carries; one that is not is refused. Omit for
+        /// everything the role implies.
+        #[arg(long, value_delimiter = ',')]
+        capabilities: Option<Vec<String>>,
     },
     /// Update an ACL entry
     /// Change a subject's role, guarded by a compare-and-swap.

--- a/pnm-cli/src/commands/acl.rs
+++ b/pnm-cli/src/commands/acl.rs
@@ -25,6 +25,7 @@ pub(crate) async fn run(
             approve_all,
             approve_contexts,
             allowed_keys,
+            capabilities,
         } => match resolve_expires_at(expires.as_deref()) {
             Ok(expires_at) => {
                 acl::cmd_acl_create(
@@ -39,6 +40,7 @@ pub(crate) async fn run(
                     approve_all,
                     approve_contexts,
                     allowed_keys,
+                    capabilities,
                 )
                 .await
             }

--- a/vta-cli-common/src/commands/acl.rs
+++ b/vta-cli-common/src/commands/acl.rs
@@ -329,6 +329,10 @@ pub async fn cmd_acl_get(client: &VtaClient, did: &str) -> Result<(), Box<dyn st
     if let Some(keys) = format_allowed_keys(entry.allowed_keys.as_deref()) {
         println!("Allowed keys:     {keys}");
     }
+    let held = entry.capabilities();
+    if !held.is_empty() {
+        println!("Capabilities:     {}", held.join(", "));
+    }
     if let Some(scope) =
         format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts())
     {
@@ -352,9 +356,13 @@ pub async fn cmd_acl_create(
     approve_all: bool,
     approve_contexts: Vec<String>,
     allowed_keys: Option<Vec<String>>,
+    capabilities: Option<Vec<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     validate_role(&role)?;
     let mut req = CreateAclRequest::new(did, role).contexts(contexts);
+    if let Some(ref caps) = capabilities {
+        req = req.capabilities(caps.clone());
+    }
     if let Some(keys) = allowed_keys {
         req = req.allowed_keys(keys);
     }
@@ -391,6 +399,12 @@ pub async fn cmd_acl_create(
     );
     if let Some(keys) = format_allowed_keys(entry.allowed_keys.as_deref()) {
         println!("  Allowed keys: {keys}");
+    }
+    // Echoed from the entry the VTA stored, so an operator sees the narrowing
+    // that actually took effect rather than the one they asked for.
+    let held = entry.capabilities();
+    if !held.is_empty() {
+        println!("  Capabilities: {}", held.join(", "));
     }
     if let Some(scope) =
         format_approve_scope(entry.approve_all_contexts(), entry.approve_contexts())

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2752,6 +2752,7 @@ mod tests {
             approve_all_contexts: false,
             approve_contexts: vec![],
             allowed_keys: None,
+            capabilities: Vec::new(),
         };
         let json = serde_json::to_value(&req).unwrap();
         // The builder API is unchanged; only what it serialises moved. The wire

--- a/vta-sdk/src/client/types.rs
+++ b/vta-sdk/src/client/types.rs
@@ -554,6 +554,13 @@ pub struct CreateAclRequest {
     /// entry's contexts); `Some(∅)` = **no** keys at all — the two are
     /// opposite grants and are serialized distinctly.
     pub allowed_keys: Option<Vec<String>>,
+    /// Narrow the entry to exactly these capabilities at creation, within what
+    /// its role allows. Empty leaves it holding everything the role implies.
+    ///
+    /// Set here rather than by a follow-up update so the entry is never briefly
+    /// wider than intended — a window during which the subject may already be
+    /// authenticating.
+    pub capabilities: Vec<String>,
 }
 
 impl serde::Serialize for CreateAclRequest {
@@ -590,7 +597,13 @@ impl serde::Serialize for CreateAclRequest {
                 }),
                 step_up: has_step_up.then_some(step_up),
                 approve: has_approve.then_some(approve),
-                ext: None,
+                // The narrowing is ecosystem-local, so it rides the entry's
+                // `ext` slot — the same member the update path and the
+                // response use, so one spelling serves all three.
+                ext: crate::protocols::acl_management::entry::capabilities_into_ext(
+                    None,
+                    &self.capabilities,
+                ),
             },
             reason: None,
             ext: None,
@@ -612,6 +625,7 @@ impl CreateAclRequest {
             approve_all_contexts: false,
             approve_contexts: Vec::new(),
             allowed_keys: None,
+            capabilities: Vec::new(),
         }
     }
     pub fn label(mut self, label: impl Into<String>) -> Self {
@@ -654,6 +668,14 @@ impl CreateAclRequest {
     /// subject unfiltered (every key its contexts reach).
     pub fn allowed_keys(mut self, keys: Vec<String>) -> Self {
         self.allowed_keys = Some(keys);
+        self
+    }
+
+    /// Narrow the new entry to exactly these capabilities (kebab-case names),
+    /// within what its role allows. A name the role does not carry is refused
+    /// by the VTA rather than dropped.
+    pub fn capabilities(mut self, capabilities: Vec<String>) -> Self {
+        self.capabilities = capabilities;
         self
     }
 }

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -300,23 +300,64 @@ fn validate_allowed_keys(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Everything a new ACL entry can carry, beside the four arguments every ACL
+/// operation takes (store, audit, contexts, caller).
+///
+/// A struct rather than a positional list because this grew to fourteen
+/// arguments, and the fifteenth — the capability narrowing — was the one that
+/// tipped it: a caller reading `create_acl(.., None, None, None, scope, None,
+/// caps, "rest")` cannot tell which `None` is the label. Named fields also mean
+/// a test states the two or three members it cares about and defaults the rest,
+/// instead of spelling every one to reach the last.
+///
+/// Mirrors [`UpdateAclParams`] on the other side of the pair.
+#[derive(Debug, Default, Clone)]
+pub struct CreateAclParams {
+    /// VID the entry is for.
+    pub did: String,
+    pub role: Role,
+    pub label: Option<String>,
+    /// **Empty is not neutral.** It means *unrestricted* for `Role::Admin` and
+    /// *authorized nowhere* for every other role, which is why this is a stated
+    /// field rather than something a builder defaults quietly.
+    pub allowed_contexts: Vec<String>,
+    /// Unix epoch seconds; `None` is permanent.
+    pub expires_at: Option<u64>,
+    pub step_up_approver: Option<String>,
+    /// `"self"` | `"delegated"`; `None` leaves the system floor.
+    pub step_up_require: Option<String>,
+    pub approve_scope: ApproveScope,
+    /// Signing-oracle key filter. `None` = no filter; `Some(∅)` = **no keys** —
+    /// opposite grants, so this stays an `Option` rather than a plain set.
+    pub allowed_keys: Option<std::collections::BTreeSet<String>>,
+    /// Capability narrowing, applied at creation so the entry is never briefly
+    /// wider than intended. Empty = whatever the role implies; a name the role
+    /// does not carry is refused, never dropped ([`capabilities_beyond_role`]).
+    pub capabilities: Vec<Capability>,
+}
+
 pub async fn create_acl(
     acl_ks: &KeyspaceHandle,
     audit: &vta_audit::SharedAuditSink,
     contexts_ks: &KeyspaceHandle,
     auth: &AuthClaims,
-    did: &str,
-    role: Role,
-    label: Option<String>,
-    allowed_contexts: Vec<String>,
-    expires_at: Option<u64>,
-    step_up_approver: Option<String>,
-    step_up_require: Option<String>,
-    approve_scope: ApproveScope,
-    allowed_keys: Option<std::collections::BTreeSet<String>>,
+    params: CreateAclParams,
     channel: &str,
 ) -> Result<CreateAclResultBody, AppError> {
+    let CreateAclParams {
+        did,
+        role,
+        label,
+        allowed_contexts,
+        expires_at,
+        step_up_approver,
+        step_up_require,
+        approve_scope,
+        allowed_keys,
+        capabilities,
+    } = params;
+    let did = did.as_str();
+
     auth.require_manage()?;
     validate_role_assignment(auth, &role)?;
     validate_acl_modification(auth, &role, &allowed_contexts)?;
@@ -324,6 +365,16 @@ pub async fn create_acl(
     // `sign_payload` gate 4), so granting it needs no privilege check beyond
     // the ones above — only a shape check.
     validate_allowed_keys(allowed_keys.as_ref())?;
+    // Same rule the update path applies, for the same reason: a narrowing that
+    // named something the role never had would be silently dropped, and the
+    // operator would believe the entry held less than it does.
+    let beyond = capabilities_beyond_role(&role, &capabilities);
+    if !beyond.is_empty() {
+        return Err(AppError::Validation(format!(
+            "role {role} does not carry {beyond:?}; an entry's capabilities can only \
+             narrow what its role allows, never widen it"
+        )));
+    }
     // Granting approve-authority is its own privilege check: `all` is
     // super-admin-only, a scoped grant requires the caller to hold each context.
     validate_approve_scope_grant(auth, &approve_scope)?;
@@ -346,7 +397,8 @@ pub async fn create_acl(
         .with_step_up_approver(step_up_approver)
         .with_step_up_require(step_up_require)
         .with_approve_scope(approve_scope)
-        .with_allowed_keys(allowed_keys);
+        .with_allowed_keys(allowed_keys)
+        .with_capabilities(capabilities);
 
     store_acl_entry(acl_ks, &entry).await?;
 
@@ -913,39 +965,39 @@ pub async fn grant_from_entry(
     let role = Role::parse(&entry.role)
         .map_err(|_| AppError::Validation(format!("invalid role: {}", entry.role)))?;
 
-    // Grant does not carry a capability narrowing yet, and **refuses** one
-    // rather than ignoring it. Accepting the member and dropping it would hand
-    // the operator an entry they believe is narrowed and is not — the precise
-    // failure the narrowing exists to prevent, arriving through the surface
-    // that introduced it. The refusal names the command that does work, per the
-    // workspace rule that an operator error should carry its own fix.
-    if let Ok(Some(_)) =
-        vta_sdk::protocols::acl_management::entry::capabilities_from_ext(entry.ext.as_ref())
-    {
-        return Err(AppError::Validation(format!(
-            "`acl/grant` does not set a capability narrowing. Grant the entry, then narrow it:\n\
-             \n  pnm acl update {} --capabilities <name,name>\n",
-            entry.subject
-        )));
-    }
+    // A narrowing may arrive with the grant, so an entry is never briefly wider
+    // than the operator intended — the window a grant-then-narrow pair leaves
+    // open, during which the subject holds everything its role implies and may
+    // already be authenticating. An unrecognised name is refused here, exactly
+    // as on the update path.
+    let capabilities = match vta_sdk::protocols::acl_management::entry::capabilities_from_ext(
+        entry.ext.as_ref(),
+    ) {
+        Ok(Some(names)) => parse_capability_names(&names)?,
+        Ok(None) => Vec::new(),
+        Err(reason) => return Err(AppError::Validation(reason)),
+    };
 
     let stored = create_acl(
         acl_ks,
         audit,
         contexts_ks,
         auth,
-        &entry.subject,
-        role,
-        entry.label.clone(),
-        entry.scopes.clone(),
-        entry.expires_at.map(to_epoch),
-        entry.step_up_approver(),
-        entry.step_up_require(),
-        entry.approve_scope(),
-        entry
-            .allowed_keys
-            .clone()
-            .map(|keys| keys.into_iter().collect()),
+        CreateAclParams {
+            did: entry.subject.clone(),
+            role,
+            label: entry.label.clone(),
+            allowed_contexts: entry.scopes.clone(),
+            expires_at: entry.expires_at.map(to_epoch),
+            step_up_approver: entry.step_up_approver(),
+            step_up_require: entry.step_up_require(),
+            approve_scope: entry.approve_scope(),
+            allowed_keys: entry
+                .allowed_keys
+                .clone()
+                .map(|keys| keys.into_iter().collect()),
+            capabilities,
+        },
         channel,
     )
     .await?;
@@ -1501,12 +1553,11 @@ mod tests {
     /// #744: before this, `approve_scope` was settable only at create time,
     /// so narrowing or revoking an approver meant delete-and-recreate — and a
     /// failed recreate leaves the DID with no ACL entry at all.
-    /// Grant does not carry a narrowing, and says so instead of dropping it.
-    /// An ignored capability member would hand back an entry the operator
-    /// believes is narrowed and is not — through the very surface the narrowing
-    /// was added for.
+    /// A grant carries the narrowing, so the entry is never briefly wider than
+    /// intended. Doing it in two steps leaves a window in which the subject
+    /// holds everything its role implies and may already be authenticating.
     #[tokio::test]
-    async fn grant_refuses_a_capability_narrowing_rather_than_ignoring_it() {
+    async fn a_grant_creates_the_entry_already_narrowed() {
         let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
         seed_contexts(&contexts_ks, &["ctx-a"]).await;
 
@@ -1516,7 +1567,54 @@ mod tests {
             vec!["ctx-a".into()],
         );
         wire.ext = Some(serde_json::json!({
-            "org.openvtc.capabilities": ["memory-read"],
+            "org.openvtc.capabilities": ["memory-read", "room-present"],
+        }));
+
+        let body = grant_from_entry(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &super_admin("did:key:zRoot"),
+            wire,
+            "test",
+        )
+        .await
+        .expect("an application entry may be created narrowed");
+        // The response echoes the narrowing through the entry's `ext`, which is
+        // where every other surface reads it from.
+        let echoed = vta_sdk::protocols::acl_management::entry::capabilities_from_ext(
+            body.entry.ext.as_ref(),
+        )
+        .expect("the echoed ext parses");
+        assert_eq!(
+            echoed,
+            Some(vec!["memory-read".to_string(), "room-present".to_string()])
+        );
+
+        // Narrowed from the first request, not from a follow-up.
+        let stored = get_acl_entry(&acl_ks, "did:key:zNew")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(entry_has_capability(&stored, Capability::MemoryRead));
+        assert!(
+            !entry_has_capability(&stored, Capability::MemoryWrite),
+            "the capability it did not name must be gone from the moment it existed"
+        );
+    }
+
+    /// The same ceiling rule as update, applied where the entry is born: a name
+    /// the role never had is refused rather than dropped, and no row is left
+    /// behind holding more than the operator asked for.
+    #[tokio::test]
+    async fn a_grant_refuses_a_capability_the_role_lacks() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+
+        let mut wire =
+            WireAclEntry::new("did:key:zNew".into(), "reader".into(), vec!["ctx-a".into()]);
+        wire.ext = Some(serde_json::json!({
+            "org.openvtc.capabilities": ["room-present"],
         }));
 
         let err = grant_from_entry(
@@ -1528,17 +1626,50 @@ mod tests {
             "test",
         )
         .await
-        .expect_err("a narrowing on grant must be refused, not dropped");
+        .expect_err("a reader cannot be created holding room-present");
         assert!(
-            matches!(err, AppError::Validation(ref m) if m.contains("acl update")),
-            "the refusal must name the command that works: {err:?}"
+            matches!(err, AppError::Validation(ref m) if m.contains("RoomPresent")),
+            "the refusal must name what it refused: {err:?}"
         );
         assert!(
             get_acl_entry(&acl_ks, "did:key:zNew")
                 .await
                 .unwrap()
                 .is_none(),
-            "and must not have created the entry it refused to narrow"
+            "a refused grant must not leave an entry behind"
+        );
+    }
+
+    /// An unknown name is refused too — the operator asked for a narrowing this
+    /// build cannot enforce, and creating the entry anyway would hand them one
+    /// that holds more than they believe.
+    #[tokio::test]
+    async fn a_grant_refuses_an_unknown_capability_name() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-a"]).await;
+
+        let mut wire = WireAclEntry::new(
+            "did:key:zNew".into(),
+            "application".into(),
+            vec!["ctx-a".into()],
+        );
+        wire.ext = Some(serde_json::json!({
+            "org.openvtc.capabilities": ["memory-read", "teleport"],
+        }));
+
+        let err = grant_from_entry(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &super_admin("did:key:zRoot"),
+            wire,
+            "test",
+        )
+        .await
+        .expect_err("an unknown capability name must be refused");
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("teleport")),
+            "the refusal must name the word it did not recognise: {err:?}"
         );
     }
 
@@ -2135,15 +2266,12 @@ mod tests {
             &audit,
             &contexts_ks,
             &caller,
-            "did:key:zNewAdmin",
-            Role::Admin,
-            None,
-            vec!["ctx-typo".into()],
-            None,
-            None,
-            None,
-            ApproveScope::None,
-            None,
+            CreateAclParams {
+                did: "did:key:zNewAdmin".into(),
+                role: Role::Admin,
+                allowed_contexts: vec!["ctx-typo".into()],
+                ..Default::default()
+            },
             "test",
         )
         .await
@@ -2172,15 +2300,12 @@ mod tests {
             &audit,
             &contexts_ks,
             &caller,
-            "did:key:zNewAdmin",
-            Role::Admin,
-            None,
-            vec!["ctx-real".into()],
-            None,
-            None,
-            None,
-            ApproveScope::None,
-            None,
+            CreateAclParams {
+                did: "did:key:zNewAdmin".into(),
+                role: Role::Admin,
+                allowed_contexts: vec!["ctx-real".into()],
+                ..Default::default()
+            },
             "test",
         )
         .await
@@ -2204,15 +2329,13 @@ mod tests {
             &audit,
             &contexts_ks,
             &caller,
-            "did:key:zApprover",
-            Role::Reader,
-            None,
-            Vec::new(), // acts nowhere
-            None,
-            None,
-            None,
-            ApproveScope::Contexts(vec!["ctx-a".into()]),
-            None,
+            CreateAclParams {
+                did: "did:key:zApprover".into(),
+                role: Role::Reader,
+                allowed_contexts: Vec::new(), // acts nowhere
+                approve_scope: ApproveScope::Contexts(vec!["ctx-a".into()]),
+                ..Default::default()
+            },
             "test",
         )
         .await
@@ -2237,15 +2360,13 @@ mod tests {
             &audit,
             &contexts_ks,
             &caller,
-            "did:key:zApprover",
-            Role::Reader,
-            None,
-            Vec::new(),
-            None,
-            None,
-            None,
-            ApproveScope::Contexts(vec!["ctx-b".into()]),
-            None,
+            CreateAclParams {
+                did: "did:key:zApprover".into(),
+                role: Role::Reader,
+                allowed_contexts: Vec::new(),
+                approve_scope: ApproveScope::Contexts(vec!["ctx-b".into()]),
+                ..Default::default()
+            },
             "test",
         )
         .await
@@ -2266,15 +2387,12 @@ mod tests {
             &audit,
             &contexts_ks,
             &caller,
-            "did:key:zWouldBeSuper",
-            Role::Admin,
-            None,
-            Vec::new(), // admin + empty = super-admin
-            None,
-            None,
-            None,
-            ApproveScope::None,
-            None,
+            CreateAclParams {
+                did: "did:key:zWouldBeSuper".into(),
+                role: Role::Admin,
+                allowed_contexts: Vec::new(), // admin + empty = super-admin
+                ..Default::default()
+            },
             "test",
         )
         .await

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -634,15 +634,13 @@ pub async fn provision_integration(
         &state.audit,
         &state.contexts_ks,
         auth,
-        &admin_did,
-        Role::Admin,
-        request.label().map(str::to_string),
-        vec![context.clone()],
-        None,
-        None,
-        None,
-        crate::acl::ApproveScope::None,
-        None,
+        super::acl::CreateAclParams {
+            did: admin_did.clone(),
+            role: Role::Admin,
+            label: request.label().map(str::to_string),
+            allowed_contexts: vec![context.clone()],
+            ..Default::default()
+        },
         "provision-integration",
     )
     .await
@@ -911,15 +909,13 @@ async fn provision_admin_rotation(
         &state.audit,
         &state.contexts_ks,
         auth,
-        &admin_did,
-        Role::Admin,
-        request.label().map(str::to_string),
-        vec![context.to_string()],
-        None,
-        None,
-        None,
-        crate::acl::ApproveScope::None,
-        None,
+        super::acl::CreateAclParams {
+            did: admin_did.clone(),
+            role: Role::Admin,
+            label: request.label().map(str::to_string),
+            allowed_contexts: vec![context.to_string()],
+            ..Default::default()
+        },
         "provision-integration",
     )
     .await


### PR DESCRIPTION
The follow-up #1279 named. It left `acl/grant` **refusing** a capability narrowing and pointing at `acl update`, because accepting one meant a fifteenth positional parameter on `create_acl`. Refusing was honest, but it leaves a real window: between the grant and the narrowing the entry holds everything its role implies, and a subject that authenticates inside that window is authorized by what it found there.

### `CreateAclParams`, not a fifteenth argument

`create_acl` now takes an options struct — the shape `update_acl` already had. The narrowing is one more named field rather than an argument nobody can read at the call site, and test sites state the two or three members they care about with `..Default::default()` instead of spelling every one to reach the last:

```rust
create_acl(&acl_ks, &audit, &contexts_ks, &caller, CreateAclParams {
    did: "did:key:zApprover".into(),
    role: Role::Reader,
    allowed_contexts: Vec::new(),          // acts nowhere
    approve_scope: ApproveScope::Contexts(vec!["ctx-a".into()]),
    ..Default::default()
}, "test")
```

### Same rule, applied where the entry is born

A name the role does not carry is refused rather than dropped; an unknown name is refused; neither leaves a row behind. That is the update path's rule, and it now holds at creation too, so there is no surface where a narrowing is silently weaker than what was asked for.

```bash
pnm acl create --did <agent-did> --role application --contexts <ctx> \
  --capabilities memory-read,room-present     # narrowed from the first request
```

The agent runbook now recommends this form over grant-then-narrow and says why. `acl create` and `acl show` echo the stored narrowing, so it can be read back from wherever it was set.

### Tests

Three new, all through `grant_from_entry`: an entry is created already narrowed and the capability it did not name is gone *from the moment it existed*; a `reader` created with `room-present` is refused naming what it refused, leaving no row; an unrecognised name is refused naming the word.

`cargo test --workspace` green (spot-checked the affected suites plus a full run), `clippy --all-targets` clean, `fmt --check` clean.

### Breaking

`create_acl`'s signature — 14 positional parameters become one `CreateAclParams`, and `CreateAclRequest` (SDK) gains a `capabilities` field. Every in-tree call site is migrated; behaviour is unchanged for a request that names no capabilities.