### PR TITLE
fix(persona): "edit once, everywhere" reached nothing

### DIFF
--- a/vta-persona/src/binding.rs
+++ b/vta-persona/src/binding.rs
@@ -334,8 +334,29 @@ impl PersonaStore {
     /// the direction rule forbids.
     ///
     /// Returns how many projections were refreshed.
+    ///
+    /// **This is the maintenance entry point, not the mechanism.** Every write
+    /// that changes what a profile projects pushes for itself, from inside its
+    /// own lock — see [`Self::push_profile_locked`]. Calling this afterwards is
+    /// a no-op that costs a scan.
     pub async fn rematerialise(&self, profile_id: &str) -> Result<usize, AppError> {
         let _guard = self.write_lock.lock().await;
+        self.push_profile_locked(profile_id).await
+    }
+
+    /// The push itself. **Caller must hold `write_lock`.**
+    ///
+    /// Split out because the writes that need it already hold the lock, and
+    /// `tokio::sync::Mutex` is not reentrant — `put` calling `rematerialise`
+    /// would deadlock rather than fail, which is the worst way to find out.
+    ///
+    /// Holding the lock across both is not merely convenient, it is the
+    /// property that matters: the write and the push land together. A crash
+    /// between them would leave every bound context holding a projection of a
+    /// pool state that no longer exists, with nothing to notice or repair it —
+    /// and the holder would have no way to tell, because the console reads the
+    /// pool while the verifier is shown the copy.
+    pub(crate) async fn push_profile_locked(&self, profile_id: &str) -> Result<usize, AppError> {
         let claims = self.materialise(profile_id).await?;
 
         let mut refreshed = 0usize;
@@ -350,6 +371,23 @@ impl PersonaStore {
             record.claims = claims.clone();
             self.ks.insert(k, &record).await?;
             refreshed += 1;
+        }
+        Ok(refreshed)
+    }
+
+    /// Push every profile that references one attribute.
+    ///
+    /// The attribute-side entry point: a pool edit changes what every profile
+    /// referencing it projects, and the reverse index is what makes that
+    /// answerable without scanning every profile. **Caller must hold
+    /// `write_lock`.**
+    pub(crate) async fn push_attribute_locked(
+        &self,
+        attribute_id: &str,
+    ) -> Result<usize, AppError> {
+        let mut refreshed = 0usize;
+        for profile_id in self.referring_profiles(attribute_id).await? {
+            refreshed += self.push_profile_locked(&profile_id).await?;
         }
         Ok(refreshed)
     }

--- a/vta-persona/src/profile.rs
+++ b/vta-persona/src/profile.rs
@@ -120,12 +120,18 @@ impl PersonaStore {
             }
         }
 
+        let profile_id = profile.profile_id.clone();
         self.ks
             .insert(
-                storage::profile_key(&profile.profile_id),
+                storage::profile_key(&profile_id),
                 &ProfileSlot::Live(profile),
             )
             .await?;
+
+        // Changing what a profile projects changes what every persona bound to
+        // it presents. Same reasoning as the attribute path in `store.rs`: the
+        // push belongs to the write, because a context cannot pull.
+        self.push_profile_locked(&profile_id).await?;
 
         Ok(Written { version, created })
     }

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -203,12 +203,27 @@ impl PersonaStore {
             }
         }
 
+        let attribute_id = attribute.attribute_id.clone();
         self.ks
             .insert(
-                storage::attribute_key(&attribute.attribute_id),
+                storage::attribute_key(&attribute_id),
                 &Slot::Live(attribute),
             )
             .await?;
+
+        // Edit once, everywhere — and it happens HERE, inside the write, not at
+        // the call site.
+        //
+        // A context holds a materialised copy and may never read the pool, so
+        // the copy only changes if a write above the boundary pushes it. Leaving
+        // that to handlers is the same decision taken once per call site, and
+        // forgetting it is silent: the pool shows the new value, the console
+        // shows the pool, and the verifier is handed the old one. That is
+        // exactly what shipped — nothing called `rematerialise` at all.
+        //
+        // On a create this is a no-op: nothing references a brand-new attribute
+        // yet, so the reverse index is empty and the scan does not run.
+        self.push_attribute_locked(&attribute_id).await?;
 
         Ok(Written { version, created })
     }
@@ -269,6 +284,15 @@ impl PersonaStore {
                 },
             )
             .await?;
+
+        // A cascade leaves the profile's `ref` in place and the attribute
+        // tombstoned, so resolution reports the claim stale rather than
+        // dropping it — which is the honest answer, and one the bound contexts
+        // must be given too. Without this push they would go on presenting the
+        // deleted value as though it were current.
+        for profile_id in &referring {
+            self.push_profile_locked(profile_id).await?;
+        }
 
         Ok(Deleted {
             existed: true,

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -371,14 +371,22 @@ async fn an_attribute_reaches_a_context_only_as_a_count() {
     );
 }
 
-/// Editing the pool changes what a bound context presents — without the
-/// context reading anything.
+/// Editing the pool changes what the HOLDER sees resolved.
 ///
-/// "Edit once, everywhere" and the one-way boundary are in tension: the
-/// obvious way to keep a projection current is to let it resolve on read,
-/// which is a read *upward*. Instead the write above the boundary pushes.
-/// This is the test that the push actually happens; the store-level test can
-/// only show that `rematerialise` works when called.
+/// **This test does not show that anything was pushed, and it used to say it
+/// did.** Its docstring read "this is the test that the push actually happens";
+/// it asserts through `profile/get?resolve=true`, which resolves live from the
+/// pool on every call, so it passed with nothing pushed anywhere — and did,
+/// for the whole time `rematerialise` was called from no handler at all. A
+/// verifier was being handed the value from before the edit.
+///
+/// Kept, because the holder-side resolution is worth pinning on its own. The
+/// push is asserted by `a_pool_edit_reaches_the_copy_a_verifier_is_shown`,
+/// through the materialised copy, which is the only place the two differ.
+///
+/// The general lesson, and it is the same one VTI#1268 taught this family:
+/// a test that reads through the path it is trying to prove exists cannot
+/// fail. Assert through the *other* side.
 #[tokio::test]
 async fn editing_the_pool_updates_an_already_bound_context() {
     let (router, ctx) = build_test_app().await;
@@ -1046,5 +1054,89 @@ async fn a_context_local_profile_cannot_reference_the_pool() {
         refused(status, &body),
         "a context-local profile was allowed to reference the holder's pool: \
          {status} {body}"
+    );
+}
+
+/// **What a bound context actually holds after the pool is edited.**
+///
+/// `editing_the_pool_updates_an_already_bound_context` above claims to cover
+/// this and does not. It asserts through `profile/get?resolve=true`, which
+/// resolves live from the pool on every call — so it passes whether or not
+/// anything was ever pushed down, and would pass with `rematerialise` deleted
+/// outright. Its own docstring says it is "the test that the push actually
+/// happens", which is the reading that let the gap ship.
+///
+/// This asserts through `disclosure/preview`, which reads the **materialised**
+/// claims the binding holds. That is the copy a verifier is shown, and it is
+/// the only place the difference between "the profile projects X" and "the
+/// context holds X" is observable.
+#[tokio::test]
+async fn a_pool_edit_reaches_the_copy_a_verifier_is_shown() {
+    let (router, ctx) = build_test_app().await;
+    let holder = authed(&ctx, "push", "admin", &[]).await;
+    let scoped = authed(&ctx, "push-scoped", "admin", &[CTX]).await;
+
+    let attr = put_attribute(&router, &holder, "name.display", "Ada").await;
+    let (_, body) = post(
+        &router,
+        &holder,
+        PROFILE_PUT,
+        json!({ "name": "pushed", "entries": [{ "ref": attr }] }),
+    )
+    .await;
+    let profile = payload_of(&body)
+        .get("profileId")
+        .and_then(Value::as_str)
+        .expect("profileId")
+        .to_string();
+
+    let persona = "did:key:z6MkPersonaPushed";
+    let (status, body) = post(
+        &router,
+        &holder,
+        BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona, "profileId": profile }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/set: {status} {body}");
+
+    // The edit the holder makes once, expecting it everywhere.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_PUT,
+        json!({
+            "attributeId": attr,
+            "type": "name.display",
+            "value": "Ada Lovelace",
+            "valueType": "string",
+            "provenance": { "kind": "selfAsserted" },
+        }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "attribute/put (edit): {status} {body}"
+    );
+
+    let (status, body) = post(
+        &router,
+        &scoped,
+        PREVIEW,
+        json!({
+            "contextId": CTX,
+            "personaDid": persona,
+            "verifierDid": "did:key:z6MkVerifierPushed",
+            "purpose": "who are you",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "preview: {status} {body}");
+
+    let rendered = serde_json::to_string(payload_of(&body)).expect("serialises");
+    assert!(
+        rendered.contains("Ada Lovelace"),
+        "the verifier would be shown the value from before the edit — \"edit once, \
+         everywhere\" did not reach the materialised copy: {rendered}"
     );
 }


### PR DESCRIPTION
A holder edits their name; the verifier is still shown the old one.

```
the verifier would be shown the value from before the edit —
"edit once, everywhere" did not reach the materialised copy:
{"claims":[{"type":"name.display","value":"Ada", ...}]}
```

That is `disclosure/preview` after `attribute/put` changed the value to `Ada Lovelace`.

## What was wrong

`rematerialise` — whose own docstring explains that a context holds a *materialised copy* and that keeping it current has to be a **write initiated above the boundary**, never a read from below — was **called from no handler in the codebase**. `grep` finds one reference outside `binding.rs`, and it is a comment in a test.

A context may never read the pool, so its copy changes only if something pushes it. Nothing did. `attribute/put`, `attribute/delete --cascade` and `profile/put` each change what a profile projects, and each left every bound context presenting the state from before the edit — which `disclosure/preview` and `disclosure/present` then handed to a verifier.

The holder had no way to see it: the console reads the pool, and the pool was correct.

## The fix

**The push belongs to the write, not to the call site.** `store::put`, `store::delete` and `profile::put_profile` now push before returning, from inside the lock they already hold.

Leaving it to handlers is the same decision taken once per call site, and forgetting it is silent in exactly the way that shipped. On a create the push is a no-op — nothing references a brand-new attribute, so the reverse index is empty and the scan does not run.

`tokio::sync::Mutex` is not reentrant, so `put` calling `rematerialise` would **deadlock rather than fail**, which is the worst way to find out. Hence `push_profile_locked` / `push_attribute_locked`, which assume the lock; `rematerialise` keeps its signature as the public wrapper and is re-documented as a maintenance entry point rather than the mechanism.

Holding the lock across write-and-push is the property that matters, not the convenience. A crash between them would leave every bound context projecting a pool state that no longer exists, with nothing to notice or repair it.

The cascade case is worth naming: a cascade delete leaves the profile's `ref` in place and tombstones the attribute, so resolution reports the claim *stale* rather than dropping it. That is the honest answer, and the bound contexts have to be given it too — without the push they go on presenting the deleted value as current.

## The test that was meant to catch this

`editing_the_pool_updates_an_already_bound_context` says, in its own docstring:

> This is the test that the push actually happens; the store-level test can only show that `rematerialise` works when called.

It asserts through `profile/get?resolve=true`, which resolves **live from the pool** on every call. So it passed with nothing pushed anywhere, and would pass with `rematerialise` deleted outright.

It is kept — the holder-side resolution is worth pinning on its own — with a docstring that says what it does and does not cover. `a_pool_edit_reaches_the_copy_a_verifier_is_shown` asserts through the materialised claims instead, which is the only place the two answers differ. **It fails on the code before this commit** (verified).

Same lesson VTI#1268 taught this family, from a new angle: a test that reads through the path it is trying to prove exists cannot fail. Assert through the other side.

## Verification

- `cargo test -p vta-persona` — 63 passed
- `cargo test -p vta-service --test persona_trust_task` — 15 passed, including the new one
- `cargo fmt --all --check`, `cargo clippy -p vta-persona --all-targets` clean

## Not covered

`rematerialise` does not bump a binding's `version`, and this change does not make it. A change-feed consumer watching bindings will not see the projection move. That is the behaviour the function already had; changing it would inflate the store counter on every pool edit and could invalidate an `expectedVersion` a client is mid-edit against. Worth deciding separately.