### PR TITLE
feat(rooms)!: let a community decide whose rooms it hosts

### DIFF
--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -204,9 +204,11 @@
             <td><span class="no">Library only.</span> Nothing serves “issue this member a VMC and a
             VAC” — the owner mints them with <code>dtg-credentials</code> and delivers them out of band</td></tr>
         <tr><td class="hd">Governance (<code>rooms.rego</code>)</td>
-            <td><span class="no">Not implemented.</span> Creation checks that the signer is the
-            owner they name; <em>which</em> members a community lets create rooms on it is still
-            designed rather than built</td></tr>
+            <td><span class="yes">On a VTC.</span> A community decides in Rego who may create a
+            room on it; the shipped default hosts <span class="mono">open</span> /
+            <span class="mono">attributed</span> for its own members and refuses
+            <span class="mono">private</span> until an operator enables it. A standalone room host
+            has no policy engine — T1's governance is its owner</td></tr>
         <tr><td class="hd">Read mirrors, witnessed renewal anchoring</td>
             <td><span class="no">Not implemented.</span> One write-primary; anchoring is the owner's
             job and nothing does it yet</td></tr>
@@ -613,11 +615,11 @@
       <li><strong>Network DID resolution is a decision.</strong> A standalone room host resolves
       <code>did:key</code> only by default; serving <code>did:webvh</code> rooms means turning on
       resolution, and that lets an unauthenticated request make your host fetch.</li>
-      <li><strong>Put it behind a proxy.</strong> The room-host binary carries no TLS and no rate
-      limiter, and while creation now requires the signer to be the owner they name, nothing yet
-      governs <em>which</em> parties may create rooms on your host — so anyone who can reach the
-      endpoint can register one in their own name. Every other verb verifies the document's proof
-      and the authority chain.</li>
+      <li><strong>Put it behind a proxy.</strong> The room-host binary carries no TLS, no rate
+      limiter, and — by design — no policy engine and no roster: T1's governance is its owner, so
+      creation there is open to anyone who can sign as themselves. A VTC governs creation with its
+      <code>rooms</code> policy instead. Every other verb, on both hosts, verifies the document's
+      proof and the authority chain.</li>
       <li><strong>Never log the actor on a private room.</strong> That decision is made once, in
       the crate both hosts share, precisely because every host's logging wants to write the acting
       DID — and on a private room that single line hands you the membership the room was built

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -85,7 +85,7 @@ knowing which half you are standing on saves an afternoon.
 | Succession: nomination, transfer, claim | **Work**, including the "renewing defeats a pending claim" property |
 | **A CLI** | **None.** No `pnm rooms …`. Rooms are driven from `vtc-client` (Rust) or by posting signed Trust Task documents |
 | **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
-| **Governance (`rooms.rego`)** | **Not implemented.** Creation checks that the signer is the owner they name (§8.4); *which* members a community lets create rooms on it is still designed rather than built |
+| **Governance (`rooms.rego`)** | **On a VTC.** A community decides who may create a room on it, in Rego, with the shipped default hosting `open`/`attributed` for its own members. A standalone `room-host` has no policy engine — T1's governance is its owner (§8.4) |
 | **Read mirrors** (T3) | **Not implemented.** One write-primary, and everyone reads from it |
 | **Witnessed renewal anchoring** | **Not implemented.** §9 of the design note makes this the owner's job, not the host's; nothing does it yet |
 
@@ -456,13 +456,25 @@ community's ACL or a session.
   `BACKED_UP`, so `POST /v1/backup/export` captures them.
 - **Audit**: room operations land in the VTC's hash-chained audit keyspace, with
   the same tier rule as above.
-- **Governance** (`rooms.rego` — which tiers a community permits, member counts,
-  hosting axes) is designed but **not implemented**; see §8.4.
+- **Governance**: the `rooms` policy purpose (`vtc.rooms` package) decides who
+  may create a room here. The shipped default hosts `open` and `attributed`
+  rooms for the community's own members and refuses `private` until an operator
+  activates a policy permitting it — §7.4's posture, on the grounds that a
+  community which has not decided should not discover it is hosting rooms whose
+  membership it cannot see. Replace it like any other policy:
+  `POST /v1/policies` then activate. A VTC with **no** active `rooms` policy
+  refuses creation rather than answering 500 — a missing decision is a closed
+  door, not a server fault.
+- **What a policy can see**: the creator (their DID, whether they hold a member
+  row, and their role) and the room's identifier, visibility and owner. It
+  deliberately does *not* carry the design's `didControlledBy` /
+  `contentStoredAt` hosting axes — the published `rooms/create/0.1` schema has
+  no member for either, so no host can know them.
 
 Members of a T2 room do not need to be members of the community. Community
-membership is meant to govern *who may create a room here* — that is what
-`rooms.rego` will decide once it lands — while room membership is, and stays,
-the room's own statement.
+membership governs *who may create a room here*; room membership is, and stays,
+the room's own statement — nothing in the family consults the roster once a room
+exists.
 
 ### 8.3 T3 — cross-community
 
@@ -493,10 +505,13 @@ What that does *not* establish is control of the identifier. Someone can still
 register a `roomId` they do not control while naming themselves owner, and so
 deny that id to its real owner on that host. The row confers nothing — every
 later verb needs credentials the real room issued — so it is a nuisance rather
-than a takeover, and bounding it is quota and access control. Community
-governance of *who may create a room here* (`rooms.rego`) is still designed
-rather than built, so on a public host, creation is open to anyone who can
-authenticate as themselves: put a room host behind a proxy you control.
+than a takeover, and bounding it is quota and access control.
+
+**On a VTC, creation is also governed** by the `rooms` policy (§8.2), which is
+how a community says whose rooms it will host. **A standalone `room-host` has no
+policy engine and no roster**, by design — T1's governance is its owner, and
+that sentence is the whole model — so creation there is open to anyone who can
+sign as themselves: put it behind a proxy you control.
 
 ---
 

--- a/vtc-service/policies/default/rooms.rego
+++ b/vtc-service/policies/default/rooms.rego
@@ -1,0 +1,48 @@
+# Default `rooms` policy — who may create a data room on this community.
+#
+# This governs **creation only**. Once a room exists, every operation on it is
+# authorized by credentials the room itself issued, and this service's roster
+# has no say — that is invariant I5 of the data-rooms design, and it is what
+# lets a room move to another host. What a community decides here is narrower
+# and entirely its own: whether to lend its disk.
+#
+# The shipped posture is §7.4's: members may create `open` and `attributed`
+# rooms; `private` is denied until an operator enables it. Not because a private
+# room is dangerous, but because a community that has not decided should not
+# discover it is hosting rooms whose membership it cannot see. To permit them,
+# upload a policy with the `private` clause removed.
+#
+# The input carries the creator (with their community standing) and the room's
+# identifier, visibility and owner. It deliberately does NOT carry the hosting
+# axes the design sketches (`didControlledBy` / `contentStoredAt`): the
+# published `rooms/create/0.1` schema has no member for either, so no host can
+# know them, and inventing them locally would put this service's rooms out of
+# conformance with the schema every other host reads.
+
+package vtc.rooms
+
+import rego.v1
+
+# Structural totality. A policy that answers nothing is refused by the host
+# rather than read as consent, but saying so here means the common refusal
+# carries a code an operator can act on.
+default decision := {"effect": "deny", "with": {
+	"code": "not-a-member",
+	"reason": "this community hosts rooms for its own members",
+}}
+
+# A private room asks this community to store content it cannot read, for
+# members it cannot enumerate. Permitted only once an operator has said so.
+decision := {"effect": "deny", "with": {
+	"code": "private-tier-not-enabled",
+	"reason": "this community has not enabled private rooms; upload a rooms policy that permits them",
+}} if {
+	input.actor.member == true
+	input.room.visibility == "private"
+}
+
+# The ordinary case: a member creating a room whose tier this community serves.
+else := {"effect": "allow"} if {
+	input.actor.member == true
+	input.room.visibility in {"open", "attributed"}
+}

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -1,6 +1,6 @@
 //! Default policy bundle — spec §7.1 (M2.5).
 //!
-//! The workspace ships nine Rego modules — one per
+//! The workspace ships ten Rego modules — one per
 //! [`PolicyPurpose`] — under `vtc-service/policies/default/`.
 //! They are embedded at compile time via [`include_str!`] so the
 //! binary doesn't read from the filesystem at startup.
@@ -92,13 +92,17 @@ const DEFAULT_SOURCES: &[(PolicyPurpose, &str)] = &[
         PolicyPurpose::RoleChange,
         include_str!("../../policies/default/role_change.rego"),
     ),
+    (
+        PolicyPurpose::Rooms,
+        include_str!("../../policies/default/rooms.rego"),
+    ),
 ];
 
 /// Number of purposes the workspace ships defaults for. Asserted
 /// against [`PolicyPurpose::ALL`] at test time so a missed entry in
 /// `DEFAULT_SOURCES` surfaces as a build-time-ish failure rather
 /// than a silent runtime gap.
-pub const DEFAULT_COUNT: usize = 10;
+pub const DEFAULT_COUNT: usize = 11;
 
 /// Return the embedded default source for `purpose`. Useful to the
 /// admin UX layer that wants to show "reset to default" diffs
@@ -199,6 +203,7 @@ pub async fn install_defaults(
 /// `decision` rule is a pre-migration boolean leftover.
 const CEREMONY_DECISION_PACKAGES: &[(PolicyPurpose, &str)] = &[
     (PolicyPurpose::Directory, "vtc.directory"),
+    (PolicyPurpose::Rooms, "vtc.rooms"),
     (PolicyPurpose::Join, "vtc.join"),
     (PolicyPurpose::Removal, "vtc.removal"),
     (PolicyPurpose::RoleChange, "vtc.role_change"),

--- a/vtc-service/src/policy/model.rs
+++ b/vtc-service/src/policy/model.rs
@@ -105,14 +105,15 @@ pub const POLICY_SOURCE_MAX_BYTES: usize = 64 * 1024;
 /// `crossCommunityRoles`) — operators wire purposes into REST
 /// payloads + the policies CLI verbs.
 ///
-/// Per spec §7.1, the workspace ships nine purposes. They split
-/// into three groups:
+/// Per spec §7.1, the workspace ships ten purposes. They split
+/// into four groups:
 /// - **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],
 ///   [`Self::Personhood`].
 /// - **Discoverability**: [`Self::Registry`], [`Self::Directory`].
 /// - **Authorization**: [`Self::RoleDefinitions`],
 ///   [`Self::CrossCommunityRoles`],
 ///   [`Self::CrossCommunityRelationships`], [`Self::Relationships`].
+/// - **Hosting**: [`Self::Rooms`].
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
@@ -131,6 +132,14 @@ pub enum PolicyPurpose {
     /// may grant `admin`, gated by a verified step-up. Distinct from
     /// [`Self::RoleDefinitions`] (the role→permission matrix).
     RoleChange,
+    /// Who may **create a data room** on this community (`vtc.rooms`).
+    ///
+    /// Creation only. Once a room exists, every operation on it is authorized
+    /// by credentials the room itself issued and this community's roster has
+    /// no say — invariant I5 of the data-rooms design, and what lets a room
+    /// change hosts. This purpose decides the narrower question a host is
+    /// unambiguously entitled to decide: whether to lend its disk.
+    Rooms,
 }
 
 impl PolicyPurpose {
@@ -138,7 +147,7 @@ impl PolicyPurpose {
     /// boot-time default-policy loader (M2.5) so missing rows can
     /// be filled from the bundled defaults without listing each
     /// purpose explicitly at the call site.
-    pub const ALL: [PolicyPurpose; 10] = [
+    pub const ALL: [PolicyPurpose; 11] = [
         PolicyPurpose::Join,
         PolicyPurpose::Removal,
         PolicyPurpose::Personhood,
@@ -149,6 +158,7 @@ impl PolicyPurpose {
         PolicyPurpose::CrossCommunityRelationships,
         PolicyPurpose::Relationships,
         PolicyPurpose::RoleChange,
+        PolicyPurpose::Rooms,
     ];
 
     /// Lowercase camelCase wire form of this purpose. Stable wire
@@ -166,6 +176,7 @@ impl PolicyPurpose {
             PolicyPurpose::CrossCommunityRelationships => "crossCommunityRelationships",
             PolicyPurpose::Relationships => "relationships",
             PolicyPurpose::RoleChange => "roleChange",
+            PolicyPurpose::Rooms => "rooms",
         }
     }
 
@@ -187,6 +198,11 @@ impl PolicyPurpose {
             PolicyPurpose::Removal => Some("vtc.removal"),
             PolicyPurpose::RoleChange => Some("vtc.role_change"),
             PolicyPurpose::Directory => Some("vtc.directory"),
+            // Probed by a fixed package like the ceremony purposes: a rooms
+            // policy compiled into the wrong one evaluates to `undefined`,
+            // which this service refuses rather than reads as consent — but an
+            // operator would see every registration denied with no clue why.
+            PolicyPurpose::Rooms => Some("vtc.rooms"),
             _ => None,
         }
     }
@@ -286,7 +302,7 @@ mod tests {
         // the bundled default would silently never load. Drive the
         // count + exhaustiveness assertion off the same constant
         // so a missed entry surfaces at test time.
-        assert_eq!(PolicyPurpose::ALL.len(), 10);
+        assert_eq!(PolicyPurpose::ALL.len(), 11);
         for purpose in PolicyPurpose::ALL {
             // Compiles iff the match is total — `as_str` exhaustively
             // matches every variant; this exists so the assertion

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -22,6 +22,7 @@
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 
+use super::policy as room_policy;
 use crate::server::AppState;
 use crate::trust_tasks::helpers::{
     TrustTaskOutcome, app_error_to_reject, parse_payload, success_response, verify_trust_task_proof,
@@ -120,6 +121,77 @@ const DEFAULT_RETENTION_DAYS: u32 = 90;
 const EPOCH_LIFETIME_DAYS_SECS: u64 =
     vti_rooms::lifecycle::DEFAULT_EPOCH_LIFETIME_DAYS as u64 * 24 * 60 * 60;
 
+/// Ask the active `rooms` policy whether this community will host this room.
+///
+/// Reads the creator's member row — the only place in this file that touches the
+/// roster, and legitimate because the question is "will we lend our disk", not
+/// "who belongs to this room". A DID with no member row reaches the policy as
+/// `member: false` rather than being refused here, so an operator whose policy
+/// admits strangers gets what they wrote.
+async fn govern_creation(
+    state: &AppState,
+    authorized: &authz::AuthorizedCreate,
+    visibility: vti_rooms::Visibility,
+    retention_days: Option<u32>,
+) -> Result<(), vti_common::error::AppError> {
+    // Membership is the member row; the role is the ACL entry beside it — the
+    // same split `ceremony::assemble` uses, so a rooms policy branches on the
+    // same two facts every other purpose does.
+    let member = crate::members::storage::get_member(&state.members_ks, authorized.owner_did())
+        .await
+        .unwrap_or(None);
+    let role = crate::ceremony::assemble::load_actor_role(state, authorized.owner_did())
+        .await
+        .unwrap_or(None);
+
+    let verified = room_policy::VerifiedRoomCreation::assemble(room_policy::RoomCreationFacts {
+        now: chrono::Utc::now(),
+        actor: room_policy::Actor {
+            did: authorized.owner_did().to_string(),
+            role,
+            member: member.is_some(),
+        },
+        room: room_policy::RoomRequest {
+            room_id: authorized.room_id().to_string(),
+            visibility,
+            owner_did: authorized.owner_did().to_string(),
+            retention_days,
+        },
+    })?;
+
+    // A VTC with no active rooms policy **refuses**, rather than answering 500
+    // and inviting a retry. `install_defaults` fills the row at boot, so the
+    // gap means either a first boot that has not reached it or an operator who
+    // deleted the row — and in both cases "we are not currently deciding this"
+    // is a closed door, not a server fault. The message says which, because a
+    // bare 403 on a fresh upgrade would send an operator hunting their
+    // credentials instead of their policy list.
+    let policy = match crate::policy::load_active_compiled(
+        &state.active_policies_ks,
+        &state.policies_ks,
+        crate::policy::model::PolicyPurpose::Rooms,
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                room = %authorized.room_id(),
+                "no active rooms policy; refusing the registration"
+            );
+            return Err(vti_common::error::AppError::Forbidden(
+                "room creation denied (no-policy): this community has no active `rooms` \
+                 policy, so it is not currently deciding whether to host rooms. The shipped \
+                 default installs at boot; check `GET /v1/policies`."
+                    .into(),
+            ));
+        }
+    };
+
+    room_policy::decide_room_creation(&verified, &policy)
+}
+
 /// `rooms/create/0.1`.
 ///
 /// The creator brings the room's identifier; this service does not assign one. A room
@@ -143,6 +215,14 @@ pub(crate) async fn handle_create(state: &AppState, doc: TrustTask<Value>) -> Tr
         Ok(a) => a,
         Err(e) => return app_error_to_reject(&doc, &e),
     };
+
+    // …and the one room operation this community governs. Registering a room is
+    // asking a host for its disk, which is the host's to refuse; every operation
+    // *within* the room stays authorized by the room's own credentials, and the
+    // handlers below never consult the roster. See `super::policy`.
+    if let Err(e) = govern_creation(state, &authorized, req.visibility, req.retention_days).await {
+        return app_error_to_reject(&doc, &e);
+    }
 
     let room = Room {
         room_id: authorized.room_id().to_string(),
@@ -705,8 +785,68 @@ mod tests {
         d.get("payload").cloned().unwrap_or(Value::Null)
     }
 
+    /// Make the fixture's room owner a member of this community.
+    ///
+    /// Needed because registering a room is now governed (`super::policy`): the
+    /// shipped default hosts rooms for its own members, and every fixture owner
+    /// is a fresh `did:key` this VTC has never met. Seeding the row is what the
+    /// tests below were implicitly assuming before creation was governed at all.
+    async fn seed_creator(state: &AppState, f: &RoomFixture) {
+        // The shipped defaults, which a real VTC installs at boot. Without them
+        // there is no active rooms policy and every registration is refused —
+        // correctly, and unhelpfully for a test about something else.
+        crate::policy::default::install_defaults(&state.policies_ks, &state.active_policies_ks)
+            .await
+            .expect("install the shipped default policies");
+
+        crate::members::storage::store_member(
+            &state.members_ks,
+            &crate::members::Member::fresh(f.room.owner_did.clone()),
+        )
+        .await
+        .expect("seed the creator's member row");
+    }
+
+    /// Enable `private` rooms, the way an operator would: by activating a rooms
+    /// policy that permits the tier.
+    ///
+    /// The shipped default denies it (§7.4), so a test about *serving* a private
+    /// room has to say the community decided to host them — which is also the
+    /// working example of how an operator turns the tier on.
+    async fn permit_private(state: &AppState) {
+        let source = "package vtc.rooms\n\n\
+             import rego.v1\n\n\
+             default decision := {\"effect\": \"deny\", \"with\": {\"code\": \"not-a-member\"}}\n\n\
+             decision := {\"effect\": \"allow\"} if input.actor.member == true\n";
+        let id = uuid::Uuid::new_v4();
+        let compiled =
+            crate::policy::engine::compile(source, id).expect("the permissive policy compiles");
+        let mut policy = crate::policy::storage::new_policy(
+            crate::policy::model::PolicyPurpose::Rooms,
+            source.to_string(),
+            *compiled.source_sha256(),
+            "did:key:zOperator".to_string(),
+            2,
+        );
+        policy.id = id;
+        crate::policy::storage::store_policy(&state.policies_ks, &policy)
+            .await
+            .expect("store");
+        crate::policy::storage::set_active_policy_id(
+            &state.active_policies_ks,
+            crate::policy::model::PolicyPurpose::Rooms,
+            id,
+        )
+        .await
+        .expect("activate");
+    }
+
     /// Register the fixture's room with this VTC.
     async fn create(state: &AppState, f: &RoomFixture) -> TrustTaskOutcome {
+        seed_creator(state, f).await;
+        if matches!(f.room.visibility, Visibility::Private) {
+            permit_private(state).await;
+        }
         handle_create(
             state,
             doc(
@@ -723,6 +863,105 @@ mod tests {
             .await,
         )
         .await
+    }
+
+    /// The gap this closes: before the policy gate, anyone who could reach the
+    /// endpoint could register a room here in their own name. A stranger signs a
+    /// perfectly valid registration and is refused by the community, not by the
+    /// proof — and no room row is left behind.
+    #[tokio::test]
+    async fn a_stranger_cannot_register_a_room_on_this_community() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Open).await;
+
+        // The defaults, but no member row for the creator.
+        crate::policy::default::install_defaults(&state.policies_ks, &state.active_policies_ks)
+            .await
+            .expect("install defaults");
+
+        let out = handle_create(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_CREATE_TYPE,
+                json!({
+                    "roomId": f.room.room_id,
+                    "visibility": f.room.visibility,
+                    "ownerDid": f.room.owner_did,
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+
+        assert!(
+            !out.status.is_success(),
+            "a non-member must not register a room here: {}",
+            payload_of(&out)
+        );
+        assert!(
+            String::from_utf8_lossy(&out.body).contains("not-a-member"),
+            "the refusal carries the policy's own code: {}",
+            payload_of(&out)
+        );
+        assert!(
+            vti_rooms::storage::get_room(&state.rooms_ks, &f.room.room_id)
+                .await
+                .is_err(),
+            "a refused registration must not leave the identifier taken"
+        );
+    }
+
+    /// The community's own posture, over the wire: a member may create the tiers
+    /// this community serves, and `private` is refused until an operator says
+    /// otherwise (§7.4).
+    #[tokio::test]
+    async fn a_member_is_refused_a_private_room_until_the_community_enables_it() {
+        let tv = build_test_vtc().await;
+        let state = &tv.state;
+        let f = RoomFixture::new(Visibility::Private).await;
+
+        crate::policy::default::install_defaults(&state.policies_ks, &state.active_policies_ks)
+            .await
+            .expect("install defaults");
+        crate::members::storage::store_member(
+            &state.members_ks,
+            &crate::members::Member::fresh(f.room.owner_did.clone()),
+        )
+        .await
+        .expect("seed the member row");
+
+        let out = handle_create(
+            state,
+            doc(
+                state,
+                vti_rooms::wire::ROOMS_CREATE_TYPE,
+                json!({
+                    "roomId": f.room.room_id,
+                    "visibility": f.room.visibility,
+                    "ownerDid": f.room.owner_did,
+                }),
+                &f.owner.did,
+                &f.owner.secret_multibase,
+            )
+            .await,
+        )
+        .await;
+        assert!(
+            String::from_utf8_lossy(&out.body).contains("private-tier-not-enabled"),
+            "a member is still refused the tier the community has not enabled: {}",
+            payload_of(&out)
+        );
+
+        // …and enabling it is a policy upload, not a code change.
+        permit_private(state).await;
+        assert!(
+            create(state, &f).await.status.is_success(),
+            "once the community permits private rooms, the same request succeeds"
+        );
     }
 
     /// The community half of the same gate. Registration is the one verb no chain can
@@ -772,7 +1011,8 @@ mod tests {
         let tv = build_test_vtc().await;
         let state = &tv.state;
         let f = RoomFixture::new(Visibility::Open).await;
-        assert!(create(state, &f).await.status.is_success());
+        let out = create(state, &f).await;
+        assert!(out.status.is_success(), "create: {}", payload_of(&out));
 
         let out = handle_put_record(
             state,

--- a/vtc-service/src/rooms/mod.rs
+++ b/vtc-service/src/rooms/mod.rs
@@ -10,6 +10,7 @@
 //! module had to move when the subsystem did.
 
 pub mod handlers;
+pub mod policy;
 
 pub use vti_rooms::{
     ROOM_RECORDS_KEYSPACE, ROOMS_KEYSPACE, Record, RecordStatus, Room, Visibility, authz, storage,

--- a/vtc-service/src/rooms/policy.rs
+++ b/vtc-service/src/rooms/policy.rs
@@ -1,0 +1,355 @@
+//! Who may create a room **on this community** — §7.4 of the data-rooms design.
+//!
+//! # Why this is not a violation of invariant I5
+//!
+//! Every *operation* on a room is authorized by credentials the room itself
+//! issued, and [`super::handlers`] never consults this service's roster to
+//! decide one. That is I5, and it is what makes a room portable.
+//!
+//! Creation is the exception the design names, and it is not the same question.
+//! A host that refuses to store a room is not deciding who belongs to it — the
+//! room does not exist yet and has issued nothing. It is deciding whether to
+//! lend its disk, which is the one thing a host is unambiguously entitled to
+//! decide: *"A VTC governs what its members may create on it"*. Nothing here
+//! reaches an existing room, and a room created elsewhere is unaffected.
+//!
+//! # What a policy can see, and what it cannot
+//!
+//! The design sketches an input contract carrying `didControlledBy` and
+//! `contentStoredAt` — which of the two hosting axes the creator is asking for.
+//! **The published `rooms/create/0.1` schema carries neither**, so a host cannot
+//! know them and this input does not pretend to: it offers the creator (with
+//! their community standing), and the room's identifier, visibility and owner.
+//! Inventing the missing members locally would put this service's rooms out of
+//! conformance with the schema every other host reads.
+//!
+//! # The verification gate
+//!
+//! [`VerifiedRoomCreation`] has no public constructor: it is reachable only
+//! through [`VerifiedRoomCreation::assemble`], which takes the DID a *proof*
+//! established. The convention `ceremony::verify` sets — policy input is always
+//! the output of a verification gate, never a caller's payload — holds here for
+//! the same reason: a policy that branched on an unproven actor would be
+//! deciding about somebody who had not been shown to be there.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::policy::engine::{CompiledPolicy, evaluate};
+use vti_common::error::AppError;
+use vti_rooms::Visibility;
+
+/// The `input` document a `rooms` policy evaluates over.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomCreationFacts {
+    /// Evaluation timestamp, so a policy compares against this rather than
+    /// reading a wall clock — the same reason the ceremony facts carry one.
+    pub now: DateTime<Utc>,
+    pub actor: Actor,
+    pub room: RoomRequest,
+}
+
+/// The party asking to create the room.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Actor {
+    /// The DID the request's own proof established — never a payload field.
+    pub did: String,
+    /// Their community role, when this service holds a member row for them.
+    /// `None` for a stranger, which is the case the default policy denies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Whether this service holds a member row for the actor at all. Surfaced
+    /// separately from `role` so a policy can say "any member" without
+    /// enumerating roles, and so an absent role is unambiguous.
+    pub member: bool,
+}
+
+/// The room being asked for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomRequest {
+    /// The room's own identifier, which the creator minted.
+    pub room_id: String,
+    /// `open` | `attributed` | `private`.
+    pub visibility: Visibility,
+    /// The accountable party. Equal to `actor.did` — a registration is signed
+    /// by the owner it names — and carried anyway so a policy reads what it
+    /// governs rather than inferring it.
+    pub owner_did: String,
+    /// How long the host is asked to hold the room after it lapses. A policy
+    /// may cap it; nothing here does by default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention_days: Option<u32>,
+}
+
+/// Facts that passed the verification gate.
+///
+/// No public constructor and no public fields: the only way to obtain one is
+/// [`Self::assemble`], so a policy can never be evaluated over an actor nobody
+/// authenticated.
+#[derive(Debug, Clone)]
+pub struct VerifiedRoomCreation(RoomCreationFacts);
+
+impl VerifiedRoomCreation {
+    /// Seal the facts for evaluation.
+    ///
+    /// `presenter` is the DID the request document's own `eddsa-jcs-2022` proof
+    /// established. Everything else describes the room being asked for.
+    pub fn assemble(facts: RoomCreationFacts) -> Result<Self, AppError> {
+        if facts.actor.did.trim().is_empty() {
+            // Belt and braces: the caller reaches this with a proof-verified
+            // DID, and an empty one would mean the proof layer returned
+            // something impossible. Denying beats evaluating a policy about
+            // nobody.
+            return Err(AppError::Forbidden(
+                "a room registration must name the party that signed it".into(),
+            ));
+        }
+        Ok(Self(facts))
+    }
+
+    /// The JSON `input` the policy sees.
+    pub fn to_input(&self) -> Result<JsonValue, AppError> {
+        serde_json::to_value(&self.0).map_err(AppError::from)
+    }
+
+    /// The facts, for the audit trail and the refusal message.
+    pub fn facts(&self) -> &RoomCreationFacts {
+        &self.0
+    }
+}
+
+/// The decision shape a `rooms` policy returns — the same `{effect, with}`
+/// object every other purpose in this service uses, so one authoring style
+/// serves them all.
+#[derive(Debug, Clone, Deserialize)]
+struct Decision {
+    effect: String,
+    #[serde(default)]
+    with: DecisionWith,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct DecisionWith {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// Query the default bundle answers.
+const DECISION_QUERY: &str = "data.vtc.rooms.decision";
+
+/// Decide whether this creation may proceed.
+///
+/// `Ok(())` is an allow. Everything else is [`AppError::Forbidden`] carrying the
+/// policy's own code, so an operator reading a refusal sees which rule produced
+/// it rather than a bare 403.
+///
+/// **A policy that answers nothing is a deny.** Rego is permissive about a
+/// missing rule — an empty result set is not an error — and reading that as
+/// "no objection" would turn a typo in a policy name into an open host. The
+/// default bundle is total (it carries a `default decision`), and this treats a
+/// non-total operator policy the same way it treats an explicit deny.
+pub fn decide_room_creation(
+    verified: &VerifiedRoomCreation,
+    policy: &CompiledPolicy,
+) -> Result<(), AppError> {
+    let results = evaluate(policy, DECISION_QUERY, verified.to_input()?)?;
+
+    // regorus returns `{"result": [{"expressions": [{"value": …}]}]}`.
+    let value = results
+        .get("result")
+        .and_then(|r| r.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("expressions"))
+        .and_then(|e| e.as_array())
+        .and_then(|exprs| exprs.first())
+        .and_then(|expr| expr.get("value"));
+
+    let Some(value) = value else {
+        tracing::warn!(
+            room = %verified.facts().room.room_id,
+            "the active rooms policy produced no decision; refusing the registration"
+        );
+        return Err(AppError::Forbidden(
+            "room creation denied (no-decision): the active rooms policy answered nothing, \
+             which is refused rather than read as consent"
+                .into(),
+        ));
+    };
+
+    let decision: Decision = serde_json::from_value(value.clone()).map_err(|e| {
+        AppError::Internal(format!(
+            "the active rooms policy returned a decision this service cannot read: {e}"
+        ))
+    })?;
+
+    match decision.effect.as_str() {
+        "allow" => Ok(()),
+        "deny" => {
+            let code = decision.with.code.unwrap_or_else(|| "denied".to_string());
+            let reason = decision
+                .with
+                .reason
+                .map(|r| format!(": {r}"))
+                .unwrap_or_default();
+            Err(AppError::Forbidden(format!(
+                "room creation denied ({code}){reason}"
+            )))
+        }
+        // `refer` and `request-more` are the threaded ceremony verdicts. A
+        // registration is one synchronous call with no thread to resume, so a
+        // policy returning one is misconfigured — and the safe reading of a
+        // verdict this surface cannot honour is refusal.
+        other => {
+            tracing::warn!(
+                effect = other,
+                room = %verified.facts().room.room_id,
+                "the active rooms policy returned a verdict room creation cannot honour"
+            );
+            Err(AppError::Forbidden(format!(
+                "room creation denied (unsupported-verdict): the active rooms policy \
+                 answered `{other}`, which this synchronous surface cannot carry out"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::default::default_source;
+    use crate::policy::engine::compile;
+    use crate::policy::model::PolicyPurpose;
+
+    fn facts(role: Option<&str>, member: bool, visibility: Visibility) -> VerifiedRoomCreation {
+        VerifiedRoomCreation::assemble(RoomCreationFacts {
+            now: "2026-09-07T12:00:00Z".parse().unwrap(),
+            actor: Actor {
+                did: "did:key:zCreator".into(),
+                role: role.map(str::to_string),
+                member,
+            },
+            room: RoomRequest {
+                room_id: "did:webvh:room.example".into(),
+                visibility,
+                owner_did: "did:key:zCreator".into(),
+                retention_days: Some(90),
+            },
+        })
+        .expect("a signed registration assembles")
+    }
+
+    fn default_policy() -> CompiledPolicy {
+        compile(default_source(PolicyPurpose::Rooms), uuid::Uuid::nil())
+            .expect("the bundled rooms policy compiles")
+    }
+
+    #[test]
+    fn a_member_may_create_an_open_room() {
+        decide_room_creation(
+            &facts(Some("member"), true, Visibility::Open),
+            &default_policy(),
+        )
+        .expect("the shipped default permits open rooms for members");
+    }
+
+    #[test]
+    fn a_member_may_create_an_attributed_room() {
+        decide_room_creation(
+            &facts(Some("member"), true, Visibility::Attributed),
+            &default_policy(),
+        )
+        .expect("attributed is permitted by default too — the host cannot read it either way");
+    }
+
+    /// §7.4's default posture: `private` is denied until an operator enables it.
+    /// Not because it is dangerous, but because a community that has not decided
+    /// should not discover it is hosting rooms whose membership it cannot see.
+    #[test]
+    fn private_is_denied_until_an_operator_enables_it() {
+        let err = decide_room_creation(
+            &facts(Some("member"), true, Visibility::Private),
+            &default_policy(),
+        )
+        .expect_err("the shipped default denies private");
+        assert!(
+            matches!(err, AppError::Forbidden(ref m) if m.contains("private")),
+            "the refusal must name the tier it refused: {err:?}"
+        );
+    }
+
+    /// The gap this whole change closes: before it, anyone who could reach the
+    /// endpoint could register a room in their own name on somebody else's host.
+    #[test]
+    fn a_stranger_may_not_create_a_room_here() {
+        let err = decide_room_creation(&facts(None, false, Visibility::Open), &default_policy())
+            .expect_err("a non-member is refused by the shipped default");
+        assert!(
+            matches!(err, AppError::Forbidden(ref m) if m.contains("not-a-member")),
+            "the refusal must carry the policy's own code: {err:?}"
+        );
+    }
+
+    /// A policy naming no `decision` rule answers with an empty set, which Rego
+    /// does not treat as an error. Reading that as consent would turn a typo
+    /// into an open host.
+    #[test]
+    fn a_policy_that_decides_nothing_refuses() {
+        let silent = compile(
+            "package vtc.rooms\n\nimport rego.v1\n\nunrelated := true\n",
+            uuid::Uuid::nil(),
+        )
+        .expect("a policy with no decision rule still compiles");
+
+        let err = decide_room_creation(&facts(Some("member"), true, Visibility::Open), &silent)
+            .expect_err("no decision is a refusal");
+        assert!(
+            matches!(err, AppError::Forbidden(ref m) if m.contains("no-decision")),
+            "got {err:?}"
+        );
+    }
+
+    /// A verdict the synchronous surface cannot carry out is refused rather
+    /// than approximated.
+    #[test]
+    fn a_threaded_verdict_is_refused() {
+        let refers = compile(
+            "package vtc.rooms\n\nimport rego.v1\n\n\
+             decision := {\"effect\": \"refer\", \"with\": {\"code\": \"ask-an-admin\"}}\n",
+            uuid::Uuid::nil(),
+        )
+        .expect("compiles");
+
+        let err = decide_room_creation(&facts(Some("member"), true, Visibility::Open), &refers)
+            .expect_err("refer cannot be honoured here");
+        assert!(
+            matches!(err, AppError::Forbidden(ref m) if m.contains("unsupported-verdict")),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unsigned_registration_never_reaches_a_policy() {
+        let err = VerifiedRoomCreation::assemble(RoomCreationFacts {
+            now: Utc::now(),
+            actor: Actor {
+                did: "  ".into(),
+                role: None,
+                member: false,
+            },
+            room: RoomRequest {
+                room_id: "did:webvh:room.example".into(),
+                visibility: Visibility::Open,
+                owner_did: "did:key:zCreator".into(),
+                retention_days: None,
+            },
+        })
+        .expect_err("an empty actor is refused at the gate");
+        assert!(matches!(err, AppError::Forbidden(_)), "got {err:?}");
+    }
+}


### PR DESCRIPTION
The first of the data-room gaps the guide had to warn about. #1274 made a registration prove who its owner is — which stops anyone registering a room in *somebody else's* name, but nothing stopped a stranger registering one in their own, on a community that had never met them. §7.4 says a VTC governs what its members may create on it; this is that, in the policy engine the service already has.

### A new policy purpose, not a new mechanism

`rooms` joins the ten existing purposes — bundled default, active-policy row, `POST /v1/policies` to replace it. `handle_create` assembles facts, loads the active policy, and refuses on a deny **with the policy's own code**, so a refusal names the rule that produced it.

The shipped default hosts `open` and `attributed` for the community's own members and refuses `private` until an operator activates a policy permitting it. Not because a private room is dangerous, but because a community that has not decided should not discover it is hosting rooms whose membership it cannot see.

### Why this does not break invariant I5

I5 — room authorization never touches a host's ACL — is what makes a room portable, and it holds. Creation is the exception the design names, and it is a different question: a host refusing to store a room is not deciding who belongs to it (the room does not exist yet and has issued nothing), it is deciding whether to lend its disk.

`govern_creation` is the only place in the rooms handlers that reads the roster, it runs **before** the room exists, and no operation on an existing room consults it. A standalone `room-host` has no policy engine and no roster at all — T1's governance is its owner, which is the whole model.

### Three refusals, all closed rather than open

| | |
|---|---|
| A policy that answers **nothing** | Deny. Rego is permissive about a missing rule; reading an empty result as "no objection" would turn a typo in a package name into an open host |
| A **threaded** verdict (`refer` / `request-more`) | Deny. Registration is one synchronous call with no thread to resume, so a verdict this surface cannot carry out is refused rather than approximated |
| **No active `rooms` policy** | Deny — *not* a 500. `install_defaults` fills the row at boot, so the gap means a first boot that has not reached it or a deleted row; both are a closed door, and the message says which, so an operator checks their policy list rather than their credentials |

### What a policy can see

The creator (DID, whether a member row exists, their ACL role) and the room's identifier, visibility and owner. **Not** the design's `didControlledBy` / `contentStoredAt` hosting axes: the published `rooms/create/0.1` schema has no member for either, so no host can know them, and inventing them locally would put this service's rooms out of conformance with the schema every other host reads. Worth a look in review — if those axes matter, they need to go upstream first.

### Tests

Seven unit tests on the decision (each default-policy branch, the no-decision refusal, the threaded-verdict refusal, the verification gate) and two at the wire: a stranger's perfectly-valid registration is refused **and leaves no room row**; a member is refused `private` until the community enables it, after which the same request succeeds.

Existing room tests now seed a member row for the fixture owner — they were creating rooms as strangers, which is exactly what this refuses — and the private-tier tests activate a permissive policy, which doubles as the worked example of enabling the tier.

`cargo test -p vtc-service --no-fail-fast`: 952 lib + every integration suite green; the only failures are the four known `VTC_SKIP_ADMIN_UI_BUILD=1` artefacts. `clippy --all-targets` and `fmt --check` clean.

### Breaking

`PolicyPurpose` gains a variant (its `ALL` array goes 10 → 11), so an exhaustive downstream `match` needs an arm. A VTC that upgrades installs the new default at boot; one that somehow has no `rooms` row refuses room creation until it does, rather than serving it ungoverned.