### PR TITLE
fix(persona): the audit trail says what changed, and correlation/analyze conforms

### DIFF
--- a/vta-persona/src/binding.rs
+++ b/vta-persona/src/binding.rs
@@ -301,6 +301,52 @@ impl PersonaStore {
             .collect())
     }
 
+    /// Every persona bound to a profile **and the context each is bound in**,
+    /// across every context.
+    ///
+    /// The sibling above answers "who would stop presenting if this profile
+    /// went away", which is a question about personas alone — so it discards
+    /// the key and loses the context. `correlation/analyze` asks a different
+    /// question: *where has this value actually gone*, and a persona DID with
+    /// no context attached does not answer it. A holder shown
+    /// `did:peer:0z6Mk…` and nothing else cannot act; shown that DID in
+    /// `ctx-employer` they can.
+    ///
+    /// Holder-only for the same reason as its sibling — it spans contexts,
+    /// which is precisely the view a context-scoped caller must not have.
+    ///
+    /// # Parsing the context out of the key
+    ///
+    /// The key is `pb:{context_id}:{persona_did}` and **a persona DID contains
+    /// colons** — `did:peer:2.Ez6…` has two before the method-specific id even
+    /// begins. So the key cannot be split on `':'` and indexed: `split(':')`
+    /// over that key yields `["pb", ctx, "did", "peer", …]`, and any call site
+    /// that takes a fixed element is reading a DID fragment as a context id.
+    /// Strip the `pb:` prefix, then `split_once(':')` — it consumes exactly the
+    /// **first** separator and hands back the whole remainder untouched, so the
+    /// colons inside the DID cannot be mistaken for structure. The persona DID
+    /// itself is read from the deserialised record rather than from that
+    /// remainder, so nothing is ever reassembled and there is nothing to
+    /// mangle.
+    pub async fn bindings_to_anywhere(
+        &self,
+        profile_id: &str,
+    ) -> Result<Vec<(String, String)>, AppError> {
+        let rows = self.ks.prefix_iter_raw(b"pb:".to_vec()).await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let record = serde_json::from_slice::<BindingRecord>(&v).ok()?;
+                if record.binding.profile_id.as_deref() != Some(profile_id) {
+                    return None;
+                }
+                let key = String::from_utf8(k).ok()?;
+                let (context_id, _persona) = key.strip_prefix("pb:")?.split_once(':')?;
+                Some((context_id.to_string(), record.binding.persona_did))
+            })
+            .collect())
+    }
+
     /// Clear every binding to a profile, across every context.
     ///
     /// The deliberate half of profile deletion: it leaves those personas
@@ -428,6 +474,44 @@ mod tests {
         );
         s.put_profile(p.clone(), None).await.unwrap();
         (a.attribute_id, p.profile_id)
+    }
+
+    /// A binding is reported with the context it lives in — and the context id
+    /// survives a persona DID full of colons.
+    ///
+    /// `personas_bound_to_anywhere` discards the storage key, so the context is
+    /// simply not available to it. `bindings_to_anywhere` recovers it from the
+    /// key, and the key is `pb:{context_id}:{persona_did}` — where the persona
+    /// DID has colons of its own. The `did:peer:2.…` below is the shape that
+    /// breaks a naive `split(':')`: an implementation taking a fixed element
+    /// returns `"did"` as the context id, which is not obviously wrong when
+    /// read and is completely wrong when acted on.
+    #[tokio::test]
+    async fn a_binding_is_reported_with_the_context_it_lives_in() {
+        let (_d, s) = fresh().await;
+        let (_a, profile) = pool_profile(&s, "+61 400 000 000").await;
+        let persona = "did:peer:2.Ez6LSbXq3.Vz6MkfR9c";
+
+        s.set_binding("ctx-employer", persona, Some(&profile), vec![], None)
+            .await
+            .unwrap();
+
+        let found = s.bindings_to_anywhere(&profile).await.unwrap();
+        assert_eq!(
+            found,
+            vec![("ctx-employer".to_string(), persona.to_string())],
+            "the context id was lost or mangled parsing a key whose persona DID \
+             contains colons"
+        );
+
+        // And a profile nothing is bound to reports nothing, rather than every
+        // binding in the store.
+        assert!(
+            s.bindings_to_anywhere("01J0000000000000000000000A")
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/vta-persona/src/correlation.rs
+++ b/vta-persona/src/correlation.rs
@@ -196,7 +196,59 @@ mod tests {
 
 // ─── Findings ────────────────────────────────────────────────────────────
 
+use std::collections::{BTreeSet, HashMap};
+
 use serde::Serialize;
+
+/// The published cap on `findings[].sharedWith` (`maxItems: 128`).
+///
+/// Enforced here rather than left to the response layer to catch. A finding
+/// truncated to the cap still names 128 places the value has reached, which is
+/// far past the point a holder is reading the list one row at a time; a
+/// finding that overflows the cap is *dropped whole* by schema validation, and
+/// the holder is told nothing at all about the value that has spread furthest.
+const MAX_SHARED_WITH: usize = 128;
+
+/// The published cap on `sharedWith[].disclosedTo` (`maxItems: 64`), for the
+/// same reason.
+const MAX_DISCLOSED_TO: usize = 64;
+
+/// One place a shared value has actually reached.
+///
+/// Every member is optional and every one is **absent rather than null** when
+/// it is unknown: the response schema types them `string` / `array`, neither
+/// of which accepts `null`, so a `None` serialised as `null` fails validation
+/// and takes the whole response with it.
+///
+/// The shape answers three widths of question with one type. A value sitting
+/// in a profile that is bound nowhere carries only `profileId` — it is one
+/// `binding/set` away from a disclosure and worth reporting, but there is no
+/// context to name. A bound one adds `contextId` and `personaDid`, which is
+/// what makes the finding actionable: a DID with no context beside it tells a
+/// holder nothing they can act on. `disclosedTo` is the strongest reading —
+/// not "this could link you" but "this already went to these verifiers".
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedWith {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persona_did: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub disclosed_to: Vec<String>,
+}
+
+/// Verifier DIDs a claim type has actually been presented to, keyed by the
+/// binding that presented it: `(context_id, persona_did, claim_type)`.
+///
+/// Built once per analysis from a single pass over the disclosure log, rather
+/// than queried per finding. The per-finding shape is the obvious one and is
+/// quadratic: `analyze_correlation` with no `attributeId` walks the whole
+/// pool, and each finding would re-scan every disclosure record in every
+/// context to answer a question about one claim type.
+type DisclosureIndex = HashMap<(String, String, String), BTreeSet<String>>;
 
 /// One place the holder's identities link, and what can be done about it.
 #[derive(Clone, Debug, Serialize)]
@@ -206,8 +258,27 @@ pub struct Finding {
     pub severity: &'static str,
     /// Plain-language cause. A severity with no explanation is a warning a
     /// holder learns to dismiss.
+    ///
+    /// Carries the count of other attributes holding the value, which is the
+    /// one fact [`Finding::shared_with`] does not restate: that list is keyed
+    /// on the *profiles and bindings* the value reaches, and two attributes
+    /// referenced by one profile collapse to a single entry there.
     pub why: String,
-    pub shared_with_profile_count: usize,
+    /// Where the value has actually gone.
+    ///
+    /// Identifiers, not a count — and that asymmetry with the write tasks is
+    /// deliberate on both sides. `correlation_count` returns a bare number
+    /// because it answers a *write*, where naming the holder's other
+    /// compositions would disclose them to whatever tool made the write. This
+    /// task is holder-authorized and exists so the holder can act, and nobody
+    /// can act on a number: "this value appears in 3 other places" leaves them
+    /// with no way to find those places short of reading every profile.
+    ///
+    /// Empty is a legitimate answer (a value shared with an attribute that no
+    /// profile references), and it serialises as an absent member rather than
+    /// an empty array, matching the schema's `default`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub shared_with: Vec<SharedWith>,
     /// What the holder can actually do.
     ///
     /// `reissueCredentialToThisDid` matters more than it looks: without it, a
@@ -219,6 +290,110 @@ pub struct Finding {
 }
 
 impl crate::PersonaStore {
+    /// Every verifier each (context, persona, claim type) has presented to.
+    ///
+    /// One pass over the whole disclosure log, across every context — which is
+    /// exactly why this is reachable only from a holder-authorized task. The
+    /// same scan `disclosure/history` performs, and it sits behind the same
+    /// gate.
+    async fn disclosure_index(&self) -> Result<DisclosureIndex, vti_common::error::AppError> {
+        let mut index = DisclosureIndex::new();
+        for record in self
+            .disclosure_history(&crate::HistoryQuery::default())
+            .await?
+        {
+            for claim in &record.claims {
+                index
+                    .entry((
+                        record.context_id.clone(),
+                        record.persona_did.clone(),
+                        claim.r#type.clone(),
+                    ))
+                    .or_default()
+                    .insert(record.verifier_did.clone());
+            }
+        }
+        Ok(index)
+    }
+
+    /// Where a value has reached: the profiles carrying it, the bindings
+    /// pushing those profiles into a context, and — when the claim type is
+    /// known — the verifiers each binding has actually presented it to.
+    ///
+    /// `claim_type` is `None` for a **candidate**, and that omission is
+    /// correct rather than a gap. A candidate is a value the holder has not
+    /// written, so there is no attribute and no claim type; the disclosures
+    /// this scan could reach belong to the *other* attributes already holding
+    /// the value, whose own findings report them under their own types.
+    /// Attributing those disclosures to the candidate would tell the holder
+    /// their unwritten value had already been presented somewhere, which is
+    /// false. So `disclosedTo` is left **absent** — never null, never an empty
+    /// array standing in for "unknown".
+    async fn shared_with(
+        &self,
+        value: &serde_json::Value,
+        excluding_attribute_id: &str,
+        claim_type: Option<&str>,
+        disclosures: &DisclosureIndex,
+    ) -> Result<Vec<SharedWith>, vti_common::error::AppError> {
+        let blind = blind(&self.correlation_key, value);
+        let others: Vec<String> = self
+            .indexed_ids(&blind)
+            .await?
+            .into_iter()
+            .filter(|id| id != excluding_attribute_id)
+            .collect();
+
+        // Deduplicated, and sorted by construction. One profile commonly
+        // references several of the attributes sharing a value, and naming it
+        // once per attribute would spend the schema's 128-entry budget saying
+        // the same thing repeatedly — pushing the entries that name a
+        // *different* place off the end.
+        let mut profiles: BTreeSet<String> = BTreeSet::new();
+        for id in &others {
+            profiles.extend(self.referring_profiles(id).await?);
+        }
+
+        let mut out: Vec<SharedWith> = Vec::new();
+        for profile_id in profiles {
+            let bindings = self.bindings_to_anywhere(&profile_id).await?;
+            if bindings.is_empty() {
+                // A composition that carries the value but is bound nowhere.
+                // Still worth naming — it is one `binding/set` away from being
+                // a disclosure — but there is no context and no persona, and
+                // those members stay absent rather than null.
+                out.push(SharedWith {
+                    profile_id: Some(profile_id),
+                    ..Default::default()
+                });
+                continue;
+            }
+            for (context_id, persona_did) in bindings {
+                let disclosed_to = claim_type
+                    .and_then(|t| {
+                        disclosures.get(&(context_id.clone(), persona_did.clone(), t.to_string()))
+                    })
+                    .map(|verifiers| {
+                        verifiers
+                            .iter()
+                            .take(MAX_DISCLOSED_TO)
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                out.push(SharedWith {
+                    profile_id: Some(profile_id.clone()),
+                    context_id: Some(context_id),
+                    persona_did: Some(persona_did),
+                    disclosed_to,
+                });
+            }
+        }
+
+        out.truncate(MAX_SHARED_WITH);
+        Ok(out)
+    }
+
     /// Report where the holder's identities link.
     ///
     /// Accepts a **candidate** the holder is considering but has not written,
@@ -230,6 +405,7 @@ impl crate::PersonaStore {
         candidate: Option<&serde_json::Value>,
     ) -> Result<Vec<Finding>, vti_common::error::AppError> {
         let mut findings = Vec::new();
+        let disclosures = self.disclosure_index().await?;
 
         if let Some(value) = candidate {
             let count = self.correlation_count(value, "").await?;
@@ -242,7 +418,7 @@ impl crate::PersonaStore {
                          both links the personas that carry them, permanently, to anyone who \
                          sees both"
                     ),
-                    shared_with_profile_count: count,
+                    shared_with: self.shared_with(value, "", None, &disclosures).await?,
                     remedies: vec![
                         "useDifferentValue",
                         "reissueCredentialToThisDid",
@@ -275,21 +451,38 @@ impl crate::PersonaStore {
             let sev = severity(true, credential_backed, rung);
             findings.push(Finding {
                 attribute_id: Some(a.attribute_id.clone()),
+                // The published enum is `{low, high}` — a finding has no
+                // "none" rung, and emitting one was the second way this
+                // response failed its own schema. The mapping is not a
+                // workaround for that: `severity()` answers a narrower
+                // question than a finding asks. `None` from it means *this
+                // disclosure* links nothing, which is true of a credential
+                // presented at the Derived or Predicate rung. A finding says
+                // something wider — the value is reused, and the first time it
+                // is presented at a linking rung it links — so the weakest
+                // true thing a finding can say is `low`, never nothing at all.
                 severity: match sev {
                     Severity::High => "high",
-                    Severity::Low => "low",
-                    Severity::None => "none",
+                    Severity::Low | Severity::None => "low",
                 },
+                // Both branches state the count, because `shared_with` below
+                // does not: it is keyed on the profiles and bindings the value
+                // reaches, so two attributes referenced by one profile appear
+                // as one entry there. The count and the list answer different
+                // questions and neither substitutes for the other.
                 why: if credential_backed {
                     format!(
                         "credential-backed and presented at the {rung:?} rung. A credential \
                          presented whole carries the same issuer signature to every verifier, \
-                         so it links them however few claims each received"
+                         so it links them however few claims each received; the same value is \
+                         held by {count} other attribute(s)"
                     )
                 } else {
                     format!("the same value is held by {count} other attribute(s)")
                 },
-                shared_with_profile_count: count,
+                shared_with: self
+                    .shared_with(value, &a.attribute_id, Some(&a.r#type), &disclosures)
+                    .await?,
                 remedies: if credential_backed {
                     vec![
                         "reissueCredentialToThisDid",

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -366,7 +366,15 @@ impl PersonaStore {
         Ok(ids.iter().filter(|id| *id != excluding).count())
     }
 
-    async fn indexed_ids(&self, blind: &str) -> Result<Vec<Ulid>, AppError> {
+    /// The attribute ids occupying one blinded index slot — every attribute
+    /// holding this exact value.
+    ///
+    /// `pub(crate)` rather than private because `correlation::analyze` needs
+    /// the identifiers themselves, not the count [`Self::correlation_count`]
+    /// derives from them. Deliberately not `pub`: outside this crate the only
+    /// supported way to ask about a value's reach is the holder-authorized
+    /// analyze task, which decides what it is safe to say.
+    pub(crate) async fn indexed_ids(&self, blind: &str) -> Result<Vec<Ulid>, AppError> {
         Ok(self
             .ks
             .get::<Vec<Ulid>>(storage::correlation_key(blind))

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -220,18 +220,57 @@ fn put_opt<T: serde::Serialize>(body: &mut Value, key: &str, value: Option<T>) {
 
 /// Audit a persona task.
 ///
-/// The attribute VALUE is deliberately never recorded. Copying identity data
-/// into the audit store would give it a second home under a different retention
-/// policy — the same reasoning app-state applies to its values, and it matters
-/// more here because this store exists to hold personal data.
+/// `detail` is a short human-readable sentence saying what the operation
+/// *changed*, and it exists because the trail without one is unreadable. Every
+/// write in this family used to record action, actor, resource and outcome and
+/// nothing else, so an entire console audit pane read `persona.attribute.put`
+/// against an opaque ULID, twenty rows deep, with no way to tell a created
+/// attribute from an updated one or a cascade delete from a refused one. The
+/// console was never the problem: `AuditEnvelope` renders `detail` in full as
+/// `detail.reason`, and there was simply nothing to render.
+///
+/// # The attribute VALUE is never recorded — and the reason is LIFETIME
+///
+/// The obvious reading of that rule is an access-control one: that whoever
+/// reads the audit log is less trusted than whoever reads the pool. That
+/// reading is false here, and believing it leads to the wrong conclusion in
+/// both directions.
+///
+/// Persona rows are recorded with `context_id: None`, and
+/// [`crate::operations::audit`]'s `authorize` already refuses every entry not
+/// confined to a named context to anyone but an **unrestricted (super) admin**
+/// — precisely the caller [`Reach::Holder`] admits to `attribute/list`, which
+/// hands back the plaintext values on request. So a value written here would
+/// disclose nothing to anyone who could not already ask for it directly.
+/// Nobody gains a read.
+///
+/// What they gain is a **second copy with a different lifetime**. The audit
+/// keyspace is append-only and pruned on its own retention schedule
+/// (`vta_audit::cleanup_expired_logs`); the pool is deleted when the holder
+/// deletes an attribute. Copy a value across and `attribute/delete` quietly
+/// stops being a delete: the value outlives the record it came from, in a
+/// store the holder's delete does not reach and whose whole point is that it
+/// is not rewritten afterwards.
+///
+/// The distinction is spelled out because "don't log values", stated as a bare
+/// prohibition, is exactly the rule someone relaxes the first time an operator
+/// asks for a more useful trail — and the access-control argument, being
+/// false, does not survive that conversation. The lifetime argument does.
+///
+/// What `detail` may therefore carry: claim **types**, value *types*,
+/// provenance kinds, counts, versions, and identifiers. Each of those
+/// describes the shape of a change without being the personal data, and each
+/// is already reconstructible from the live record — so none of them acquires
+/// a life the record does not have.
 async fn audit_persona(
     state: &AppState,
     action: &str,
     auth: &AuthClaims,
     resource: Option<&str>,
     context_id: Option<&str>,
+    detail: Option<&str>,
 ) {
-    if let Err(e) = audit::record(
+    if let Err(e) = audit::record_with_detail(
         &state.audit_sink,
         action,
         &auth.did,
@@ -239,11 +278,38 @@ async fn audit_persona(
         "success",
         Some(super::helpers::TRANSPORT_TRUST_TASK),
         context_id,
+        detail,
     )
     .await
     {
         tracing::warn!(error = %e, action = %action, "audit record failed for persona task");
     }
+}
+
+/// The `kind` discriminant of a provenance, as the wire spells it.
+///
+/// Matched rather than serialised because only the tag is wanted: serialising
+/// a `CredentialBacked` provenance would carry `credentialId`, `claimPath` and
+/// `issuerDid` into the audit row alongside it, and a claim path is a
+/// description of what an issuer attested about the holder — a fact with the
+/// same lifetime problem as the value itself.
+fn provenance_kind(p: &vta_persona::Provenance) -> &'static str {
+    match p {
+        vta_persona::Provenance::SelfAsserted => "selfAsserted",
+        vta_persona::Provenance::CredentialBacked { .. } => "credentialBacked",
+        vta_persona::Provenance::Generated { .. } => "generated",
+    }
+}
+
+/// The wire spelling of a value type — `string`, `number`, `date`, …
+///
+/// Via serde rather than a second `match`, so a variant added to `ValueType`
+/// cannot end up spelled one way in a response and another in the audit row.
+fn value_type_name(v: ValueType) -> String {
+    serde_json::to_value(v)
+        .ok()
+        .and_then(|j| j.as_str().map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Map a storage error onto the published error taxonomy.
@@ -306,13 +372,18 @@ pub(super) async fn handle_attribute_put(
         }
     };
 
-    let provenance = match serde_json::to_value(&req.provenance)
+    let provenance: vta_persona::Provenance = match serde_json::to_value(&req.provenance)
         .ok()
         .and_then(|v| serde_json::from_value(v).ok())
     {
         Some(p) => p,
         None => return reject(&doc, AppError::Validation("unrecognised provenance".into())),
     };
+
+    // Read the discriminant before the value moves into the attribute. Only the
+    // tag survives into the audit row; `provenance_kind` says why the rest of a
+    // `CredentialBacked` provenance must not.
+    let provenance_kind = provenance_kind(&provenance);
 
     let mut attribute = new_attribute(
         req.type_.to_string(),
@@ -342,12 +413,29 @@ pub(super) async fn handle_attribute_put(
         None => 0,
     };
 
+    // Type, value TYPE, provenance kind and version — never `value`. See
+    // `audit_persona` for why that line is drawn on lifetime rather than on
+    // who may read the row.
+    let detail = format!(
+        "{} attribute {attribute_id}: claim type {}, valueType {}, provenance {}, now at \
+         version {}",
+        if written.created {
+            "created"
+        } else {
+            "updated"
+        },
+        req.type_.as_str(),
+        value_type_name(value_type),
+        provenance_kind,
+        written.version,
+    );
     audit_persona(
         state,
         "persona.attribute.put",
         auth,
         Some(&attribute_id),
         None,
+        Some(&detail),
     )
     .await;
 
@@ -389,7 +477,7 @@ pub(super) async fn handle_attribute_list(
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.attribute.list", auth, None, None).await;
+    audit_persona(state, "persona.attribute.list", auth, None, None, None).await;
     success_response(&doc, serde_json::json!({ "attributes": attributes }))
 }
 
@@ -412,7 +500,28 @@ pub(super) async fn handle_attribute_delete(
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.attribute.delete", auth, Some(&id), None).await;
+    // `existed` is the half a reader cannot reconstruct afterwards: the record
+    // is gone either way, so a row that only says "delete" cannot distinguish a
+    // removal from a no-op against a typo'd id.
+    let detail = format!(
+        "attribute {id} {}; cascade {}; removed from {} profile(s)",
+        if out.existed {
+            "deleted"
+        } else {
+            "did not exist"
+        },
+        req.cascade,
+        out.referring_profiles.len(),
+    );
+    audit_persona(
+        state,
+        "persona.attribute.delete",
+        auth,
+        Some(&id),
+        None,
+        Some(&detail),
+    )
+    .await;
     success_response(
         &doc,
         serde_json::json!({
@@ -462,6 +571,7 @@ pub(super) async fn handle_profile_put(
     }
     profile.credential_refs = req.credential_refs.iter().map(|c| (**c).clone()).collect();
     let profile_id = profile.profile_id.clone();
+    let entry_count = profile.entries.len();
 
     let written = match store(state)
         .put_profile(profile, req.expected_version.map(|v| *v))
@@ -471,7 +581,29 @@ pub(super) async fn handle_profile_put(
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.profile.put", auth, Some(&profile_id), None).await;
+    // The entry COUNT, not the entries. An entry is either a pool reference —
+    // an identifier, safe — or an inline value, which is a claim value under
+    // another name and carries the whole lifetime problem with it.
+    let detail = format!(
+        "{} profile {profile_id} with {} entr{}, now at version {}",
+        if written.created {
+            "created"
+        } else {
+            "updated"
+        },
+        entry_count,
+        if entry_count == 1 { "y" } else { "ies" },
+        written.version,
+    );
+    audit_persona(
+        state,
+        "persona.profile.put",
+        auth,
+        Some(&profile_id),
+        None,
+        Some(&detail),
+    )
+    .await;
     success_response(
         &doc,
         json!({
@@ -518,7 +650,7 @@ pub(super) async fn handle_profile_get(
         None
     };
 
-    audit_persona(state, "persona.profile.get", auth, Some(&id), None).await;
+    audit_persona(state, "persona.profile.get", auth, Some(&id), None, None).await;
     let mut body = json!({ "profile": profile });
     if let Some(r) = resolved {
         // A resolved entry is a `ResolvedClaim`, not the pool `Attribute`, so an
@@ -572,7 +704,7 @@ pub(super) async fn handle_profile_list(
         Ok(p) => p,
         Err(e) => return reject(&doc, e),
     };
-    audit_persona(state, "persona.profile.list", auth, None, None).await;
+    audit_persona(state, "persona.profile.list", auth, None, None, None).await;
     success_response(&doc, json!({ "profiles": profiles }))
 }
 
@@ -618,7 +750,28 @@ pub(super) async fn handle_profile_delete(
         Ok(e) => e,
         Err(e) => return reject(&doc, e),
     };
-    audit_persona(state, "persona.profile.delete", auth, Some(&id), None).await;
+    // How many personas were left presenting nothing is the consequence a
+    // holder most needs to find later, and it is the one fact that survives
+    // nowhere else: the bindings it describes have already been cleared.
+    let detail = format!(
+        "profile {id} {}; {}; {} persona(s) unbound",
+        if existed { "deleted" } else { "did not exist" },
+        if req.unbind {
+            "unbind requested"
+        } else {
+            "no unbind requested"
+        },
+        bound.len(),
+    );
+    audit_persona(
+        state,
+        "persona.profile.delete",
+        auth,
+        Some(&id),
+        None,
+        Some(&detail),
+    )
+    .await;
     success_response(
         &doc,
         json!({ "profileId": id, "existed": existed, "unboundPersonas": bound }),
@@ -662,12 +815,27 @@ pub(super) async fn handle_binding_set(
         Err(e) => return reject(&doc, e),
     };
 
+    // The materialised claim count is what changed on the far side of the
+    // boundary: this write is a PUSH into a context, and the count is how much
+    // that context can now present. "unbound" is spelled out rather than left
+    // as an absent profileId, because a binding cleared and a binding never
+    // made read identically otherwise.
+    let detail = format!(
+        "persona {persona} in context {ctx} bound to {}; {} claim(s) materialised, now at \
+         version {}",
+        profile_id
+            .as_deref()
+            .map_or_else(|| "unbound".to_string(), |p| format!("profile {p}")),
+        bound.materialised_claim_count,
+        bound.version,
+    );
     audit_persona(
         state,
         "persona.binding.set",
         auth,
         Some(&persona),
         Some(&ctx),
+        Some(&detail),
     )
     .await;
     success_response(
@@ -714,6 +882,7 @@ pub(super) async fn handle_binding_get(
         auth,
         Some(&persona),
         Some(&ctx),
+        None,
     )
     .await;
     // Thin by construction: whether bound, the label, a claim count. Never
@@ -756,7 +925,7 @@ pub(super) async fn handle_binding_list(
         Ok(s) => s,
         Err(e) => return reject(&doc, e),
     };
-    audit_persona(state, "persona.binding.list", auth, None, Some(&ctx)).await;
+    audit_persona(state, "persona.binding.list", auth, None, Some(&ctx), None).await;
     let personas: Vec<Value> = sums
         .iter()
         .map(|s| {
@@ -822,6 +991,7 @@ pub(super) async fn handle_contact_put(
         auth,
         Some(&filed.contact_id),
         Some(&ctx),
+        None,
     )
     .await;
     success_response(
@@ -886,7 +1056,15 @@ pub(super) async fn handle_contact_get(
         None
     };
 
-    audit_persona(state, "persona.contact.get", auth, Some(&id), Some(&ctx)).await;
+    audit_persona(
+        state,
+        "persona.contact.get",
+        auth,
+        Some(&id),
+        Some(&ctx),
+        None,
+    )
+    .await;
     let mut body = json!({
         "contactId": contact.contact_id,
         "subjectDid": contact.subject_did,
@@ -928,7 +1106,7 @@ pub(super) async fn handle_contact_list(
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.contact.list", auth, None, Some(&ctx)).await;
+    audit_persona(state, "persona.contact.list", auth, None, Some(&ctx), None).await;
     success_response(
         &doc,
         json!({
@@ -967,7 +1145,15 @@ pub(super) async fn handle_contact_delete(
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.contact.delete", auth, Some(&id), Some(&ctx)).await;
+    audit_persona(
+        state,
+        "persona.contact.delete",
+        auth,
+        Some(&id),
+        Some(&ctx),
+        None,
+    )
+    .await;
     success_response(
         &doc,
         json!({
@@ -1022,6 +1208,7 @@ pub(super) async fn handle_disclosure_history(
         auth,
         None,
         ctx.as_deref(),
+        None,
     )
     .await;
     success_response(&doc, json!({ "disclosures": records }))
@@ -1058,7 +1245,7 @@ pub(super) async fn handle_correlation_analyze(
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.correlation.analyze", auth, None, None).await;
+    audit_persona(state, "persona.correlation.analyze", auth, None, None, None).await;
     success_response(&doc, json!({ "findings": findings }))
 }
 
@@ -1181,6 +1368,7 @@ pub(super) async fn handle_local_profile_put(
         profile.profile_id = id.to_string();
     }
     let profile_id = profile.profile_id.clone();
+    let entry_count = profile.entries.len();
     let s = store(state);
 
     let written = match s
@@ -1211,12 +1399,30 @@ pub(super) async fn handle_local_profile_put(
         _ => false,
     };
 
+    // `matchesPoolValue` is carried because it is the reason this task is
+    // correlation-indexed at all: a throwaway identity is precisely where
+    // somebody reuses a real value, and a holder auditing that later needs to
+    // see WHICH local write raised the flag, not merely that one did. The flag
+    // is a boolean about a value, never the value.
+    let detail = format!(
+        "{} context-local profile {profile_id} in context {ctx} with {} entr{}, now at version \
+         {}; matches a pool value: {matches_pool}",
+        if written.created {
+            "created"
+        } else {
+            "updated"
+        },
+        entry_count,
+        if entry_count == 1 { "y" } else { "ies" },
+        written.version,
+    );
     audit_persona(
         state,
         "persona.local.profile.put",
         auth,
         Some(&profile_id),
         Some(&ctx),
+        Some(&detail),
     )
     .await;
     success_response(
@@ -1257,6 +1463,7 @@ pub(super) async fn handle_local_profile_get(
                 auth,
                 Some(&id),
                 Some(&ctx),
+                None,
             )
             .await;
             // Built member by member rather than serialising the stored
@@ -1301,7 +1508,15 @@ pub(super) async fn handle_local_profile_list(
         Ok(p) => p,
         Err(e) => return reject(&doc, e),
     };
-    audit_persona(state, "persona.local.profile.list", auth, None, Some(&ctx)).await;
+    audit_persona(
+        state,
+        "persona.local.profile.list",
+        auth,
+        None,
+        Some(&ctx),
+        None,
+    )
+    .await;
     success_response(
         &doc,
         json!({
@@ -1334,6 +1549,7 @@ pub(super) async fn handle_local_profile_delete(
     let id = req.profile_id.to_string();
     let s = store(state);
 
+    let mut unbound = 0usize;
     if req.unbind {
         // Clear every persona bound to this profile in this context.
         //
@@ -1350,6 +1566,7 @@ pub(super) async fn handle_local_profile_delete(
             Ok(p) => p,
             Err(e) => return reject(&doc, e),
         };
+        unbound = bound.len();
         for persona_did in bound {
             if let Err(e) = s.set_local_binding(&ctx, &persona_did, None).await {
                 return reject(&doc, e);
@@ -1361,12 +1578,21 @@ pub(super) async fn handle_local_profile_delete(
         Ok(e) => e,
         Err(e) => return reject(&doc, e),
     };
+    // The unbind count is the only surviving trace of the silent-unbind bug
+    // this handler used to have: `--unbind` cleared nobody, and nothing said
+    // so. A row reading "0 persona(s) unbound" against a profile that had
+    // bindings is now visible after the fact rather than only reproducible.
+    let detail = format!(
+        "context-local profile {id} in context {ctx} {}; {unbound} persona(s) unbound",
+        if existed { "deleted" } else { "did not exist" },
+    );
     audit_persona(
         state,
         "persona.local.profile.delete",
         auth,
         Some(&id),
         Some(&ctx),
+        Some(&detail),
     )
     .await;
     success_response(&doc, json!({ "profileId": id, "existed": existed }))
@@ -1402,12 +1628,25 @@ pub(super) async fn handle_local_binding_set(
         Err(e) => return reject(&doc, e),
     };
 
+    // No materialised count here, unlike `binding/set`: a context-local entry
+    // IS its own value, so there is no pool projection to count — the store
+    // takes the profile's inline entries as the claims directly. Saying so is
+    // better than reporting a count that would mean something different from
+    // the one on the pool task with the same name.
+    let detail = format!(
+        "persona {persona} in context {ctx} bound to {}, now at version {version}",
+        profile_id.as_deref().map_or_else(
+            || "unbound".to_string(),
+            |p| format!("context-local profile {p}")
+        ),
+    );
     audit_persona(
         state,
         "persona.local.binding.set",
         auth,
         Some(&persona),
         Some(&ctx),
+        Some(&detail),
     )
     .await;
     success_response(
@@ -1466,6 +1705,7 @@ pub(super) async fn handle_disclosure_preview(
         auth,
         Some(&preview.preview_id),
         Some(&ctx),
+        None,
     )
     .await;
 
@@ -1519,6 +1759,7 @@ pub(super) async fn handle_disclosure_present(
         auth,
         Some(&record.disclosure_id),
         Some(&ctx),
+        None,
     )
     .await;
 

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -1140,3 +1140,135 @@ async fn a_pool_edit_reaches_the_copy_a_verifier_is_shown() {
          everywhere\" did not reach the materialised copy: {rendered}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 5. The audit trail says what changed
+// ---------------------------------------------------------------------------
+
+/// Every row the audit keyspace holds, oldest first.
+///
+/// Read straight from the keyspace rather than through `audit/list`, because
+/// that task's own authorization is a separate subject and a test that had to
+/// satisfy it would be asserting two things at once. The storage key is
+/// `log:{timestamp:020}:{uuid}`, so a lexicographic scan is chronological.
+async fn audit_rows(
+    ctx: &TestAppContext,
+) -> Vec<vta_sdk::protocols::audit_management::list::AuditLogEntry> {
+    let mut pairs = ctx
+        .state
+        .audit_ks
+        .prefix_iter_raw("log:")
+        .await
+        .expect("audit prefix scan");
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    pairs
+        .into_iter()
+        .filter_map(|(_k, v)| serde_json::from_slice(&v).ok())
+        .collect()
+}
+
+/// A persona write leaves an audit row that says **what changed** — and that
+/// row does not contain the value.
+///
+/// Both halves are needed and neither is sufficient. The positive half is the
+/// defect this exists for: `audit_persona` recorded action, actor, resource
+/// and outcome and nothing else, so a console audit pane showed
+/// `persona.attribute.put` against an opaque ULID with no way to tell a create
+/// from an update or a cascade delete from a no-op. The console renders
+/// `detail` in full; there was simply nothing to render.
+///
+/// The negative half is the rule `audit_persona` documents at length: the
+/// attribute VALUE is never recorded, because the audit log outlives the
+/// record it describes and a value copied into it would survive the holder's
+/// delete under a retention policy that delete does not reach.
+///
+/// **Asserted together, deliberately.** A test that only checks the value is
+/// absent passes against a handler that records no detail at all — which is
+/// exactly the state this pair of assertions replaces, and exactly the way a
+/// regression would look if `detail` were quietly dropped again.
+#[tokio::test]
+async fn a_persona_write_is_audited_with_what_changed_and_not_the_value() {
+    let (router, ctx) = build_test_app().await;
+    let holder = authed(&ctx, "audit-detail", "admin", &[]).await;
+
+    // A value distinctive enough that finding it anywhere in the log is
+    // unambiguous — a substring like "Ada" could appear by coincidence in a
+    // claim type or an identifier, and the assertion would then be about the
+    // wrong thing.
+    const SECRET_VALUE: &str = "+61 400 999 777 zzq";
+
+    let attr = put_attribute(&router, &holder, "phone.mobile", SECRET_VALUE).await;
+
+    let rows = audit_rows(&ctx).await;
+    let put_row = rows
+        .iter()
+        .rev()
+        .find(|r| r.action == "persona.attribute.put")
+        .unwrap_or_else(|| panic!("no persona.attribute.put audit row in {rows:#?}"));
+
+    let detail = put_row
+        .detail
+        .as_deref()
+        .unwrap_or_else(|| panic!("the audit row carries no detail: {put_row:#?}"));
+
+    // What CHANGED, not merely that something did.
+    assert!(
+        detail.contains("created"),
+        "the detail does not say the attribute was created: {detail}"
+    );
+    assert!(
+        detail.contains("phone.mobile"),
+        "the detail does not name the claim type — the one fact that makes the row \
+         legible without resolving the id: {detail}"
+    );
+    assert!(
+        detail.contains("selfAsserted"),
+        "the detail does not name the provenance kind: {detail}"
+    );
+    assert!(
+        detail.contains(&attr),
+        "the detail does not name the attribute it describes: {detail}"
+    );
+
+    // And not the value — anywhere in the row, not merely in `detail`.
+    let whole_row = serde_json::to_string(put_row).expect("audit row serialises");
+    assert!(
+        !whole_row.contains(SECRET_VALUE),
+        "the attribute's VALUE reached the audit log. The log outlives the record, \
+         so this value would survive the holder deleting the attribute it came \
+         from: {whole_row}"
+    );
+
+    // The same pair on a delete, because that is the operation the lifetime
+    // argument is actually about: after it, the pool no longer holds the value
+    // and the audit row is the only place a copy could persist.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_DELETE,
+        json!({ "attributeId": attr, "cascade": false }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/delete: {status} {body}");
+
+    let rows = audit_rows(&ctx).await;
+    let delete_row = rows
+        .iter()
+        .rev()
+        .find(|r| r.action == "persona.attribute.delete")
+        .unwrap_or_else(|| panic!("no persona.attribute.delete audit row in {rows:#?}"));
+    let detail = delete_row
+        .detail
+        .as_deref()
+        .unwrap_or_else(|| panic!("the delete audit row carries no detail: {delete_row:#?}"));
+    assert!(
+        detail.contains("deleted"),
+        "the delete detail does not distinguish a removal from a no-op: {detail}"
+    );
+
+    let whole_log = serde_json::to_string(&rows).expect("audit log serialises");
+    assert!(
+        !whole_log.contains(SECRET_VALUE),
+        "the deleted attribute's value is still in the audit log: {whole_log}"
+    );
+}

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -1272,3 +1272,130 @@ async fn a_persona_write_is_audited_with_what_changed_and_not_the_value() {
         "the deleted attribute's value is still in the audit log: {whole_log}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 6. `correlation/analyze` names where a value went
+// ---------------------------------------------------------------------------
+
+/// A finding names the profile, context and persona a shared value reaches —
+/// and the response validates against the published schema.
+///
+/// Two defects in one, and they are the same defect. `Finding` carried
+/// `sharedWithProfileCount`, which the response schema for
+/// `persona/correlation/analyze/1.0` does not define; the object is
+/// `additionalProperties: false`, so every response carrying a non-empty
+/// `findings` array was non-conformant. It went unnoticed because the only
+/// test of this task analysed a pool holding one attribute, which produces no
+/// findings at all — an empty array conforms to anything.
+///
+/// The schema instead defines `sharedWith`, an array of
+/// `{profileId?, contextId?, personaDid?, disclosedTo?}`. `PersonaStore::
+/// correlation_count` states the design's own reasoning for that: a count is
+/// what a *write* may return, because naming identifiers there would disclose
+/// the holder's other compositions to whatever tool made the write; this task
+/// is holder-authorized and is where identifiers belong. So the count was both
+/// the non-conformant answer and the weaker one, and the implementation is the
+/// side that had to move.
+///
+/// The assertion is therefore not "a member called sharedWith exists" but that
+/// it names the place the value actually reached. A `sharedWith` populated
+/// with empty objects would conform to the schema and tell the holder nothing.
+#[tokio::test]
+async fn a_correlation_finding_names_where_the_shared_value_went() {
+    let (router, ctx) = build_test_app().await;
+    let holder = authed(&ctx, "correlate", "admin", &[]).await;
+    let persona = "did:peer:2.Ez6LSpersonaCorrelate.Vz6MkpersonaCorrelate";
+
+    // The same value under two claim types. `subject` is the one being
+    // analysed; `reused` is the one that has been composed into a profile and
+    // pushed into a context, which is what the finding must be able to name.
+    const SHARED: &str = "+61 400 111 222";
+    let subject = put_attribute(&router, &holder, "phone.mobile", SHARED).await;
+    let reused = put_attribute(&router, &holder, "phone.work", SHARED).await;
+
+    let (status, body) = post(
+        &router,
+        &holder,
+        PROFILE_PUT,
+        json!({ "name": "work", "entries": [{ "ref": reused }] }),
+    )
+    .await;
+    assert!(!refused(status, &body), "profile/put: {status} {body}");
+    let profile = payload_of(&body)
+        .get("profileId")
+        .and_then(Value::as_str)
+        .expect("profileId")
+        .to_string();
+
+    let (status, body) = post(
+        &router,
+        &holder,
+        BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona, "profileId": profile }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/set: {status} {body}");
+
+    let (status, body) = post(
+        &router,
+        &holder,
+        CORRELATION,
+        json!({ "attributeId": subject }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "correlation/analyze: {status} {body}"
+    );
+
+    // Conformance, asserted twice over and deliberately. The dispatch spine's
+    // response-conformance layer already replaced a violating body with an
+    // error document, so `refused` above covers it — but that check is silent
+    // when it passes, and this one names the contract. The generated type is
+    // `deny_unknown_fields`, so a member the schema does not define (which is
+    // exactly what `sharedWithProfileCount` was) fails here with the offending
+    // name in the message.
+    let payload = payload_of(&body).clone();
+    let typed: trust_tasks_rs::specs::persona::correlation::analyze::v1_0::Response =
+        serde_json::from_value(payload.clone()).unwrap_or_else(|e| {
+            panic!("the response does not match the published schema: {e}\n{payload:#}")
+        });
+
+    let finding = typed
+        .findings
+        .iter()
+        .find(|f| f.attribute_id.as_deref().map(|s| &**s) == Some(subject.as_str()))
+        .unwrap_or_else(|| panic!("no finding for the analysed attribute: {payload:#}"));
+
+    // The count has not been lost — it moved into the prose, which is where a
+    // holder reads it. `sharedWith` is keyed on profiles and bindings, so it
+    // cannot restate a count of attributes.
+    assert!(
+        finding.why.contains("1 other attribute"),
+        "the finding no longer says how many other attributes hold the value: {}",
+        finding.why.as_str()
+    );
+
+    let reached = finding
+        .shared_with
+        .iter()
+        .find(|s| s.profile_id.as_deref().map(|p| &**p) == Some(profile.as_str()))
+        .unwrap_or_else(|| {
+            panic!(
+                "the finding does not name the profile the shared value reaches — a holder \
+                 told \"this links your personas\" and given no identifier has nothing to \
+                 act on: {payload:#}"
+            )
+        });
+    assert_eq!(
+        reached.context_id.as_deref(),
+        Some(CTX),
+        "the profile is named without the context it is bound in, which is the half that \
+         makes the finding actionable: {payload:#}"
+    );
+    assert_eq!(
+        reached.persona_did.as_deref(),
+        Some(persona),
+        "the binding is named without the persona presenting it: {payload:#}"
+    );
+}


### PR DESCRIPTION
Two fixes to the `persona/*` trust-task slice. They are separate commits and read independently, but they share a shape: in both cases the slice was producing an answer that was technically a response and practically not usable.

## 1. The audit trail says what changed

A user looked at the console's audit pane and could not tell what a persona operation had done. `audit_persona` called `audit::record(...)` — which has no `detail` parameter — so every persona row was an action name, an actor, an opaque ULID and `success`. Twenty rows of `persona.attribute.put` against twenty identifiers, with no way to distinguish a create from an update, a cascade delete from a no-op against a typo'd id, or a `binding/set` that materialised forty claims from one that cleared them.

The console side was never the defect. `impl From<&AuditLogEntry> for AuditEnvelope` already surfaces `detail` as `detail.reason` and the audit pane renders it in full. There was nothing to render.

The write handlers now go through `audit::record_with_detail` and say what changed:

| task | detail |
|---|---|
| `attribute/put` | created-or-updated, claim type, valueType, provenance kind, resulting version |
| `attribute/delete` | whether it existed, cascade or not, how many profiles it was removed from |
| `profile/put` | created-or-updated, entry count, resulting version |
| `profile/delete` | whether it existed, whether unbind was asked for, how many personas were unbound |
| `binding/set` | the profile bound or "unbound", materialised claim count, version |
| `local/profile/put` | created-or-updated, entry count, version, whether it matches a pool value |
| `local/profile/delete` | whether it existed, how many personas were unbound |
| `local/binding/set` | the local profile bound or "unbound", version |

Reads still pass `None`. A read changes nothing, and a sentence restating the request is noise in an append-only store.

### Why the value stays out — and why the usual reason is the wrong one

The rule that the attribute VALUE is never recorded is not new. What is new is that `audit_persona` now explains it, at length, because the reason people reach for first is false here and does not survive contact with an operator asking for a better trail.

The reason is **not** access control. Persona rows are recorded with `context_id: None`, and `operations::audit::authorize` already refuses any entry not confined to a named context to anyone but an unrestricted (super) admin — precisely the caller `Reach::Holder` admits to `attribute/list`, which hands back the plaintext values on request. Nobody gains a read by us writing one into the log.

The reason is **lifetime**. The audit keyspace is append-only and pruned on its own retention schedule (`vta_audit::cleanup_expired_logs`); the pool is deleted when the holder deletes an attribute. Copy a value across and `attribute/delete` quietly stops being a delete — the value outlives the record it came from, in a store the holder's delete does not reach and which is not rewritten afterwards.

Stating that distinction is the point of the comment. "Don't log values", as a bare prohibition with no reason attached, is exactly the rule someone relaxes the first time an operator asks for a more useful trail. The access-control argument loses that conversation because it is not true. The lifetime argument wins it. What the comment then permits is explicit: claim types, value types, provenance kinds, counts, versions, identifiers — each describes the shape of a change without being the personal data, and each is reconstructible from the live record, so none of them acquires a life the record does not have.

The new test asserts both halves **together**. A test that only checks the value is absent passes against a handler that records no detail at all — which is precisely the state being fixed, and precisely how a regression would look.

## 2. `correlation/analyze` conforms, by answering better

`handle_correlation_analyze` serialised `vta_persona::correlation::Finding`, which carried `sharedWithProfileCount`. The published response schema for `persona/correlation/analyze/1.0` types `findings.items` with `additionalProperties: false` and defines no such member. It defines `sharedWith` — an array of `{profileId?, contextId?, personaDid?, disclosedTo?}`.

So every response carrying a non-empty findings array was non-conformant, and had been since the slice landed. It went unnoticed for a reason worth recording: the only test of the task analysed a pool holding one attribute, which produces no findings, and an empty array conforms to anything. The response-conformance layer at the dispatch spine gates correctly; it had simply never been shown a populated response.

### Which side moved, and why

The implementation, not the spec. `PersonaStore::correlation_count` already carries the reasoning in its own doc comment:

> A count, not identifiers. Returning identifiers on a write would disclose the holder's other compositions to whatever tool made it; the analyze task is holder-authorized and is where identifiers belong.

Identifiers in `analyze` are the design's own intent. The count was therefore both the non-conformant answer *and* the weaker one. Deleting `sharedWith` from the spec would have made the response validate and made the system worse: a holder told "this value links your personas" and handed the number 3 has no way to find those three places short of reading every profile they own. The spec repo is untouched.

### What populates it

Everything needed was already in `vta-persona`:

- `indexed_ids(blind)` — the other attributes holding this exact value.
- `referring_profiles(attribute_id)` — the compositions carrying them, from the `pxr:` reverse index.
- **`bindings_to_anywhere(profile_id)`** — new. `personas_bound_to_anywhere` already scans `pb:` globally but discards the storage key, so it loses the context id; a persona DID with no context beside it is not something a holder can act on. The new sibling keeps it, parsing `pb:{context_id}:{persona_did}` with `split_once(':')` — a persona DID has colons of its own, so a naive `split(':')` with a fixed index returns `"did"` as the context id, which is not obviously wrong when read and completely wrong when acted on. The persona DID itself comes from the deserialised record, not from the remainder, so nothing is reassembled.

A profile carrying the value but bound nowhere yields `{profileId}` alone — still worth naming, since it is one `binding/set` away from a disclosure, but there is no context or persona, and those members are **absent, not null**.

`disclosedTo` is populated as well, from a single pass over the disclosure log indexed on `(contextId, personaDid, claimType)`. One scan per analysis, not one per finding: a whole-pool analysis walks every attribute, and the per-finding shape would re-scan every disclosure record in every context to answer a question about one claim type. It is omitted for a **candidate** — a value the holder is considering but has not written. The disclosures reachable from the shared value belong to the *other* attributes already holding it and are reported under their own findings; attributing them to the candidate would tell the holder their unwritten value had already been presented somewhere, which is false. Omitted means absent, never an empty array standing in for "unknown".

Both published caps are enforced in the store (`sharedWith` 128, `disclosedTo` 64) rather than left to the response layer, because overflowing a cap drops the whole finding at validation — and the finding that overflows is the one about the value that has spread furthest.

### Two smaller conformance points that came with it

- The **count is preserved in the `why` prose**, including on the credential-backed branch, which did not previously state it. `sharedWith` is keyed on profiles and bindings, so two attributes behind one profile collapse to one entry there; the count and the list answer different questions and neither substitutes for the other.
- **`severity` no longer emits `"none"`**, which the schema's `{low, high}` enum rejects — a second, independent way this response failed validation, reachable for a credential-backed attribute presented at the `Derived` or `Predicate` rung. The mapping is not a workaround: `severity()` answers whether *one disclosure* links, and `none` is correct there for an unlinkable proof. A finding asks something wider, and is only emitted when the value is reused — so the weakest true thing a finding can say is `low`, never nothing at all.

## Breaking change

`vta_persona::correlation::Finding` replaces `shared_with_profile_count: usize` with `shared_with: Vec<SharedWith>`, hence the `!` on the second commit. `vta-persona` is unpublished and the only consumer is `vta-service`, which is updated here. The semver report going red on this is the report working; release-plz owns the bump.

## Verified

- `cargo fmt --all` clean.
- `cargo clippy -p vta-persona -p vta-service --all-targets` — no warnings, no errors.
- `cargo test -p vta-persona` — **64 passed, 0 failed**.
- `cargo test -p vta-service --test persona_trust_task` — **17 passed, 0 failed** (15 before, 2 new).
- `cargo test -p vta-service --lib` — **1034 passed, 0 failed, 1 ignored**, including `trust_tasks::audit_coverage::every_consequential_task_records_an_audit_entry` and the conformance census.

No test that was passing before this branch fails on it.
