### PR TITLE
docs(rooms): write down the anchoring decision that was blocking in conversation

### DIFF
--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -87,7 +87,7 @@ knowing which half you are standing on saves an afternoon.
 | **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
 | **Governance (`rooms.rego`)** | **On a VTC.** A community decides who may create a room on it, in Rego, with the shipped default hosting `open`/`attributed` for its own members. A standalone `room-host` has no policy engine — T1's governance is its owner (§8.4) |
 | **Read mirrors** (T3) | **Not implemented.** One write-primary, and everyone reads from it |
-| **Witnessed renewal anchoring** | **Not implemented.** §9 of the design note makes this the owner's job, not the host's; nothing does it yet |
+| **Witnessed renewal anchoring** | **Blocked on a decision**, not on effort: §9 says a renewal anchors the epoch authenticator and version watermark in the room's witnessed log, but not *where in the log entry*. See [`epoch anchoring`](../05-design-notes/data-rooms-epoch-anchoring.md) |
 
 ---
 

--- a/docs/05-design-notes/data-rooms-epoch-anchoring.md
+++ b/docs/05-design-notes/data-rooms-epoch-anchoring.md
@@ -1,0 +1,210 @@
+# Anchoring a room's renewals in its witnessed log
+
+Status: **open question, not a plan.** One decision has to be made before any of
+this can be built, and it is written down here because it was blocking in a
+conversation rather than in the repository.
+
+[`data-rooms.md`](data-rooms.md) §9 says a renewal writes the room's current
+**MLS epoch authenticator** and **version watermark** to the room's witnessed
+`did:webvh` log. It does not say *where in the log entry they go*, and there is
+no obvious slot. That is the question.
+
+---
+
+## 1. Why it matters — three attacks that die together
+
+§9 is precise about what the anchor buys, and it is not integrity of the
+records (they are signed and location-bound already). It is three claims a host
+can otherwise make that nobody can contradict:
+
+| Attack | What the anchor gives a member |
+|---|---|
+| A host says a live room lapsed, and reclaims it | The witnessed renewal exists; the host's claim is refutable |
+| A host-as-Delivery-Service **forks the group**, showing different commit sequences to different members | Members compare their own epoch authenticator against the anchored one — a fork shows up as a mismatch |
+| A **mirror** serves a fresh member a rolled-back room | Any client has a witnessed version floor and can tell it is being served an old room |
+
+The middle one is the reason this is not optional decoration. MLS's own threat
+model names DS-driven forking as the deployment risk, and the design's answer is
+"anchor the epoch authenticator somewhere the DS does not control". Without the
+anchor, the fork defence in §5.2 is a promise the code cannot keep.
+
+**None of it works unless the anchor is witnessed**, which is the constraint
+that narrows the options below: witnesses co-sign a *log entry*, so an anchor
+that does not ride one is a value the host could equally have made up.
+
+---
+
+## 2. What a log entry actually offers
+
+`didwebvh-rs` 0.6 (`LogEntry1_0`) is:
+
+```rust
+pub struct LogEntry1_0 {
+    pub version_id: String,                       // integer-prevhash
+    pub version_time: DateTime<FixedOffset>,
+    pub parameters: Parameters1_0,                // closed struct
+    pub state: Value,                             // the DID document
+    pub proof: Vec<DataIntegrityProof>,
+}
+```
+
+Which rules out most of the design space immediately:
+
+- **`parameters` is closed.** `Parameters1_0` is a spec-defined struct
+  (`updateKeys`, `nextKeyHashes`, witness config, …) with no extension member.
+  Putting the anchor here means a didwebvh **specification** change, upstream,
+  before a line of it can be written.
+- **`versionId` / `versionTime` are computed.** Neither carries payload.
+- **`proof` is the witnesses' signature over the rest.** It secures the anchor;
+  it cannot be the anchor.
+- **`state` is a free `serde_json::Value`** — the DID document. It is the only
+  slot in the entry that will carry an ecosystem-defined value today, and
+  anything in it is covered by the proof, and therefore witnessed.
+
+So the answer is "somewhere in `state`", and the real question is **what shape**.
+
+---
+
+## 3. Three shapes, and what each costs
+
+### 3a. A typed service entry (recommended)
+
+```jsonc
+"service": [
+  { "id": "did:webvh:…#tsp", "type": "TSPTransport", "serviceEndpoint": "…" },
+  {
+    "id": "did:webvh:…#epoch-anchor",
+    "type": "RoomEpochAnchor",
+    "serviceEndpoint": {
+      "epoch": 7,
+      "epochAuthenticator": "z6Mk…",   // multibase, from RoomGroup::epoch_authenticator()
+      "versionWatermark": 412
+    }
+  }
+]
+```
+
+**For.** It is the workspace's existing extension point — every transport a VTA
+advertises is a service entry matched on `type` (`TSPTransport`,
+`DIDCommMessaging`, `VTARest`, `WebVHHosting`), and this reads as one more of
+those. It is DID-Core-legal, so no resolver drops it. A member checking the
+anchor *resolves the room DID*, which they already know how to do, rather than
+fetching a log and parsing entries. And the design's own service-ordering rule
+(`sort_services_canonical`) already has a place to put it.
+
+**Against.** A `serviceEndpoint` holding structured data rather than an endpoint
+is a mild abuse of the member's name — though DID Core permits a map, and the
+`#tsp` entry already carries a DID rather than a URL.
+
+### 3b. A top-level extension property on the document
+
+```jsonc
+{ "id": "did:webvh:…", "verificationMethod": [...],
+  "https://openvtc.org/vocab#roomEpochAnchor": { "epoch": 7, … } }
+```
+
+**For.** Honest about not being a service. Fully JSON-LD-legal with a term
+definition in the OpenVTC context, which the workspace already publishes.
+
+**Against.** Unknown top-level properties are the members most likely to be
+dropped by an intermediary or normalised away, and a reader has to know the
+vocabulary URI. Nothing else in this workspace does it.
+
+### 3c. Do not put it in the document at all — take it upstream
+
+Ask the didwebvh working group for a general-purpose `annotations` (or similar)
+member on the log entry, and anchor there.
+
+**For.** The cleanest home: the anchor is metadata *about the entry*, not about
+the DID subject, and it does not deform the document.
+
+**Against.** It blocks on a specification change to a spec the workspace does not
+own, and §9's defences stay unbuilt in the meantime. Reasonable as a *later*
+migration once there is operational experience — and the shape in 3a is what
+that experience would be based on.
+
+---
+
+## 4. The cost nobody has stated: the anchor is public
+
+Worth surfacing before anyone chooses, because it is not in §9 and it cuts
+against the tiers.
+
+A room's DID document is **public and resolvable by anyone**. An anchor in it
+publishes, to the whole world:
+
+- **that the room is being renewed, and how often.** A high-assurance room
+  anchoring per commit publishes its commit rate — which is its membership-change
+  rate.
+- **its version watermark**, which is a monotonic count of writes. Two
+  resolutions a week apart give an observer the room's write volume.
+
+The design already accepts that a room's *existence* and its *owner* are public
+(invariant I1 — the owner is always known). Cadence and volume are new, and they
+are exactly the shape of metadata the `private` tier exists to withhold from the
+**host**. It would be odd to deny it to the host and publish it to everyone.
+
+Three ways out, and the choice belongs with whoever owns the tier semantics:
+
+1. **Accept it.** State plainly that anchoring publishes cadence, and let a room
+   that cares anchor rarely (the anchoring cadence is already a room parameter
+   in §9).
+2. **Anchor a hash, not the values.** Publish `H(epochAuthenticator ‖ watermark ‖
+   salt)` and let a member who knows the values verify the commitment. Kills the
+   volume leak; keeps the cadence leak, which is inherent to writing an entry at
+   all.
+3. **Anchor only on `open`/`attributed`.** Simple, and wrong in the direction
+   that matters: `private` is the tier with the most to fear from a forking host,
+   so withholding its fork defence to protect its metadata trades a security
+   property for a privacy one.
+
+**Recommendation: 2, with the salt held by the room.** It costs one hash, keeps
+the fork and rollback defences intact for every tier, and reduces the public
+signal to "this room renewed at these times" — which a witnessed log leaks
+anyway by having entries.
+
+---
+
+## 5. What else has to be decided at the same time
+
+- **Who publishes the entry.** The room's DID controller is the owner, so the
+  update is an ordinary `did:webvh` update from the owner's VTA. That is
+  mechanism, not question — but it means a room whose DID is host-controlled
+  (§7.1's first row) cannot anchor honestly, since the party being checked
+  would be writing the check. Worth stating as a constraint on that
+  configuration rather than discovering it later.
+- **What a client does with a mismatch.** An anchored authenticator that does
+  not match the member's own is evidence of a fork, and evidence is not an
+  action. Refuse to read? Warn? Both, depending on tier? §9 does not say, and a
+  detection nobody acts on is a log line.
+- **Cadence as a room parameter.** §9 says a high-assurance room anchors per
+  commit. `rooms/create/0.1` has no member for it — the same gap the hosting
+  axes hit in the creation-policy work — so either it is a client-side setting
+  the host never sees, or it needs an upstream schema change.
+
+---
+
+## 6. What this unblocks
+
+With the shape settled, the work is bounded and sits entirely on the owner's
+side:
+
+1. `RoomGroup::epoch_authenticator()` already returns the value (implemented).
+2. On `rooms/epoch/mint`, the owner's client builds the anchor and publishes a
+   webvh update through their VTA.
+3. A member verifying resolves the room DID, reads the anchor, and compares.
+
+None of it needs a host change, which is consistent with §9: the host's
+contribution to lifecycle is *never deciding*, and the anchor is what makes that
+checkable rather than trusted.
+
+---
+
+## 7. Lineage
+
+Written 2026-09-07, after the operator guide
+([`../02-vta/data-rooms.md`](../02-vta/data-rooms.md)) had to describe witnessed
+anchoring as "not implemented" without being able to say what implementing it
+would mean. The two sibling gaps the guide names — read mirrors, and the
+`private` tier's ZK profile — are tracked there; this one is separated out
+because it is blocked on a decision rather than on effort.

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -678,6 +678,14 @@ version floor). What survives is a host that deletes anyway — I2's
 irreducible row — now as **provable misbehaviour** rather than a deniable
 shrug.
 
+**Where in the log entry the anchor goes is undecided, and blocks the build.**
+`Parameters1_0` is a closed struct, so the only slot that takes an
+ecosystem-defined value today is the DID document itself — and publishing an
+epoch authenticator there publishes the room's renewal cadence and write volume
+to anyone who resolves it, which is the shape of metadata the tiers exist to
+withhold. The candidates, the cost, and a recommendation are in
+[`data-rooms-epoch-anchoring.md`](data-rooms-epoch-anchoring.md).
+
 Owner absence must not kill a live room: the nominated successor claims
 (§10), or the k-of-n quorum renews. Where the host stores nothing (owner-hosted
 content), lifecycle is wholly the owner's.

--- a/docs/README.md
+++ b/docs/README.md
@@ -204,6 +204,11 @@ are implementer-facing rather than operator-facing.
   **the trust boundary is per operator, not per service**.
   ([v1](05-design-notes/data-rooms-security-review-v1.md) is the dated
   record of the revision-2 review that reshaped the design.)
+- **[Data rooms — epoch anchoring](05-design-notes/data-rooms-epoch-anchoring.md)** —
+  the one open *decision* in the rooms design: §9 says a renewal anchors the MLS
+  epoch authenticator and version watermark in the room's witnessed log, but not
+  where in the log entry they go. Three candidate shapes, the metadata cost of
+  a public anchor, and what settling it unblocks. Open question, not a plan.
 - **[vta-service decomposition](05-design-notes/vta-service-decomposition.md)** —
   how the ~114k-line VTA crate was split into subsystem crates, the
   extraction technique, and the rule for where the program stops.


### PR DESCRIPTION
Of the data-room gaps the guide names, witnessed renewal anchoring is the only one blocked on a **decision** rather than on effort — and that decision was living in a conversation instead of the repository. This writes it down.

§9 says a renewal anchors the MLS epoch authenticator and the room's version watermark in its witnessed `did:webvh` log. It does not say *where in the log entry*, and there is no obvious slot.

### What the log entry actually offers

`didwebvh-rs` 0.6 settles most of the design space by itself:

| Slot | |
|---|---|
| `parameters` | Closed struct (`Parameters1_0`) — anchoring here needs a **didwebvh specification change**, upstream |
| `versionId` / `versionTime` | Computed; carry no payload |
| `proof` | What *secures* the anchor, not what carries it |
| `state` | The DID document — a free `Value`, covered by the proof, and therefore witnessed |

So the answer is "somewhere in `state`", and the question is what shape. The note compares a typed service entry (`RoomEpochAnchor`, matching the workspace's existing `type`-matched service convention), a JSON-LD extension property, and taking it upstream — and recommends the first, with the third as a later migration once there is operational experience to base it on.

### The cost §9 does not mention

A room's DID document is **public and resolvable by anyone**. An anchor in it publishes the room's renewal cadence — a high-assurance room anchoring per commit publishes its membership-change rate — and its version watermark, which two resolutions a week apart turn into a write-volume estimate.

That is the shape of metadata the tiers exist to withhold from the *host*, and it would be odd to deny it to the host and publish it to the world. Of the three ways out, the note recommends anchoring a **salted commitment** rather than the values: it keeps the fork and rollback defences intact for every tier and reduces the public signal to "this room renewed at these times", which a witnessed log leaks by having entries at all. Notably it argues *against* the tempting option — anchoring only on `open`/`attributed` — since `private` is the tier with the most to fear from a forking host.

### Three things that have to be decided alongside it

Listed rather than assumed: a **host-controlled room DID cannot anchor honestly** (the party being checked would be writing the check, which is a real constraint on §7.1's first hosting row); what a client **does with a mismatch**, since evidence is not an action and a detection nobody acts on is a log line; and whether the **anchoring cadence** needs an upstream schema member, given `rooms/create/0.1` has none — the same gap the hosting axes hit in #1282.

### Not a plan

No code, no commitment to a shape. The guide's status table and the design note's §9 both point here, so the blocker is now reviewable. If the recommendation survives review, §6 sketches the bounded work it unblocks — all of it on the owner's side, none of it needing a host change, which is consistent with §9's rule that the host's contribution to lifecycle is never deciding.
