### PR TITLE
feat(rooms): a member's CLI surface, driven through the oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10365,6 +10365,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "vta-sdk",
+ "vtc-client",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]

--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -198,8 +198,11 @@
         <tr><td class="hd">Succession — nomination, transfer, claim</td>
             <td>Work, including the property that renewing defeats a pending claim</td></tr>
         <tr><td class="hd">A CLI</td>
-            <td><span class="no">None.</span> No <code>pnm rooms …</code>; drive it from
-            <code>vtc-client</code> or by posting signed Trust Task documents</td></tr>
+            <td><span class="yes">The member's half.</span>
+            <code>pnm rooms {create,list,get,put,curate,renew}</code>, driven through the oracle
+            so the CLI never holds a room credential or a group key. Issuing a room's
+            credentials is the owner's job and needs the room's own signing key — not there
+            yet</td></tr>
         <tr><td class="hd">Credential issuance</td>
             <td><span class="no">Library only.</span> Nothing serves “issue this member a VMC and a
             VAC” — the owner mints them with <code>dtg-credentials</code> and delivers them out of band</td></tr>

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -83,7 +83,7 @@ knowing which half you are standing on saves an afternoon.
 | VTA custody: `rooms/keys/{key-package,welcome,commit,open}` | **Work.** A member's VTA holds the group and opens records for their agents |
 | The presentation oracle: `rooms/keys/present` | **Works.** Attenuates the member's own VAC for an agent |
 | Succession: nomination, transfer, claim | **Work**, including the "renewing defeats a pending claim" property |
-| **A CLI** | **None.** No `pnm rooms …`. Rooms are driven from `vtc-client` (Rust) or by posting signed Trust Task documents |
+| **A CLI** | **`pnm rooms {create,list,get,put,curate,renew}`** — the member's surface, driven through the oracle so the CLI holds no room credentials and no group key. The **owner's** surface (issuing VIC/VMC/VAC) is not there: it needs the room's own signing key |
 | **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
 | **Governance (`rooms.rego`)** | **On a VTC.** A community decides who may create a room on it, in Rego, with the shipped default hosting `open`/`attributed` for its own members. A standalone `room-host` has no policy engine — T1's governance is its owner (§8.4) |
 | **Read mirrors** (T3) | **Not implemented.** One write-primary, and everyone reads from it |
@@ -518,6 +518,34 @@ sign as themselves: put it behind a proxy you control.
 ---
 
 ## 9. Use the room
+
+### From the CLI
+
+```bash
+# Every command needs both parties: your VTA (for the presentation) and the
+# room's host (which stores the bytes). --host-did binds the presentation to
+# that host; omit it and anyone who observes it can replay it for four hours.
+pnm rooms list  --room <room-did> --host https://rooms.example.org --host-did <host-did>
+pnm rooms get   decision/pricing-2026 --room <room-did> --host https://rooms.example.org
+pnm rooms put   decision/pricing-2026 "Agreed not to reprice." --room <room-did> \
+                --host https://rooms.example.org --title "Pricing holds" --expected-version 0
+pnm rooms curate decision/pricing-2026 --status deprecated --room <room-did> --host …
+pnm rooms renew 3 --room <room-did> --host …          # mint the next epoch (needs `admin`)
+```
+
+The CLI **never holds a room credential or a group key**. Each command asks your
+VTA to mint a presentation for exactly the action it performs (`read`, `write`,
+`curate`, `admin`), sends that to the host, and — on a sealed record — hands the
+ciphertext back to the VTA to open. A member who holds less than the action
+needs is refused by their own VTA rather than by the host, which is the earlier
+and clearer of the two.
+
+Two things it deliberately cannot do. **Write to a sealed room**: sealing needs
+the room's group key, which lives in the VTA, and no task seals on a caller's
+behalf. **Issue credentials**: minting a VIC, VMC or VAC needs the *room's*
+signing key, which is the owner's — a different party with different custody.
+
+### From Rust
 
 All record verbs carry a presentation and no token. `RoomSession` holds the
 credentials — build one per room per identity; a member's and their agent's are

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -304,6 +304,155 @@ pub(crate) enum Commands {
         #[command(subcommand)]
         command: MemoryCommands,
     },
+
+    /// Act in a data room — a shared space governed by credentials the room
+    /// itself issued, not by this VTA's ACL.
+    ///
+    /// Every command talks to two services and never confuses them: your VTA
+    /// mints a presentation (and opens sealed records), and the room's **host**
+    /// stores the bytes. The credentials and the group key stay in the VTA;
+    /// this CLI never holds either.
+    ///
+    /// Needs the `roomPresent` capability, and `roomOpen` to read a sealed
+    /// room. Issuing a room's credentials is the *owner's* job and is not here:
+    /// it needs the room's own signing key.
+    #[command(name = "rooms")]
+    Rooms {
+        #[command(subcommand)]
+        command: RoomCommands,
+    },
+}
+
+/// Member-side room verbs. Each mints its own presentation for exactly the
+/// action it performs — `read` for list/get, `write` for put, `curate` for
+/// curate, `admin` for renew — so a member who holds less is refused by their
+/// own VTA rather than by the host.
+#[derive(Subcommand)]
+pub(crate) enum RoomCommands {
+    /// List the room's records. Metadata only — never bodies.
+    List {
+        /// The room's DID.
+        #[arg(long = "room")]
+        room_id: String,
+        /// Base URL of the host storing the room.
+        #[arg(long)]
+        host: String,
+        /// The host's DID. Omit and the minted presentation is not bound to a
+        /// host — usable by anyone who observes it until it expires.
+        #[arg(long)]
+        host_did: Option<String>,
+        /// Only records whose key starts with this.
+        #[arg(long)]
+        prefix: Option<String>,
+        /// Only records at or after this version — the incremental-sync
+        /// watermark.
+        #[arg(long)]
+        since_version: Option<u64>,
+        /// Show at most this many.
+        #[arg(long)]
+        limit: Option<usize>,
+    },
+
+    /// Read one record, decrypting through your VTA when it is sealed.
+    Get {
+        /// Record key.
+        key: String,
+        #[arg(long = "room")]
+        room_id: String,
+        #[arg(long)]
+        host: String,
+        #[arg(long)]
+        host_did: Option<String>,
+    },
+
+    /// Write a record. `open` rooms only — sealing needs the room's group key,
+    /// which lives in your VTA and has no task that seals for a caller.
+    Put {
+        /// Record key. On a sealed tier keys must be opaque; on `open` they may
+        /// be descriptive.
+        key: String,
+        /// The record body (markdown — written for a human, recalled by an
+        /// agent).
+        body: String,
+        #[arg(long = "room")]
+        room_id: String,
+        #[arg(long)]
+        host: String,
+        #[arg(long)]
+        host_did: Option<String>,
+        /// One-line title.
+        #[arg(long)]
+        title: Option<String>,
+        /// Precondition: `0` means create-only, `n` requires the stored record
+        /// to be at version `n`. A mismatch reports the version you lost to.
+        #[arg(long)]
+        expected_version: Option<u64>,
+    },
+
+    /// Change a record's standing. Needs `curate`, which `write` does not imply.
+    Curate {
+        /// Record key.
+        key: String,
+        #[arg(long = "room")]
+        room_id: String,
+        #[arg(long)]
+        host: String,
+        #[arg(long)]
+        host_did: Option<String>,
+        /// New status: `active`, `deprecated` or `retracted`. `retracted` is a
+        /// tombstone — the body goes, the key and version stay.
+        #[arg(long)]
+        status: Option<String>,
+        /// Pin the record.
+        #[arg(long, conflicts_with = "unpin")]
+        pin: bool,
+        /// Unpin it.
+        #[arg(long)]
+        unpin: bool,
+        /// Why, for the room's trail. Member-authored free text.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Renew the room by minting its next epoch. Needs `admin`.
+    ///
+    /// This is what keeps a room live, and it is the whole defence against a
+    /// hostile succession claim: an owner who renews is safe without thinking
+    /// about it.
+    Renew {
+        /// The epoch to mint — your group's epoch plus one.
+        epoch: u32,
+        #[arg(long = "room")]
+        room_id: String,
+        #[arg(long)]
+        host: String,
+        #[arg(long)]
+        host_did: Option<String>,
+        /// Why, recorded with the renewal.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Register a room with a host.
+    ///
+    /// The only verb needing no presentation — the room has issued nothing yet,
+    /// so the host checks this request's own proof instead. Sign it as the
+    /// owner it names, which this does.
+    Create {
+        /// The room's DID, which you minted before this call.
+        #[arg(long = "room")]
+        room_id: String,
+        #[arg(long)]
+        host: String,
+        #[arg(long)]
+        host_did: Option<String>,
+        /// `open`, `attributed` or `private`. Fixed for the life of the room.
+        #[arg(long, default_value = "open")]
+        visibility: String,
+        /// How long the host holds the room after it lapses. Default 90 days.
+        #[arg(long)]
+        retention_days: Option<u32>,
+    },
 }
 
 /// CRUD over the agent's memory. `plant` creates/updates, `recall` reads,

--- a/pnm-cli/src/commands/mod.rs
+++ b/pnm-cli/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod keys;
 pub(crate) mod memory;
 pub(crate) mod persona;
 pub(crate) mod policy;
+pub(crate) mod rooms;
 pub(crate) mod services;
 pub(crate) mod setup;
 pub(crate) mod vault;

--- a/pnm-cli/src/commands/rooms.rs
+++ b/pnm-cli/src/commands/rooms.rs
@@ -1,0 +1,173 @@
+//! `pnm rooms …` dispatch — thin shim over the shared room commands.
+//!
+//! The implementations live in `vta_cli_common::commands::rooms`; this maps the
+//! parsed subcommand onto them and supplies the one thing the shared layer
+//! cannot obtain for itself: the operator's own signing identity.
+//!
+//! # Why the signer comes from the stored session
+//!
+//! A room request is signed by the party the presentation was minted **for**,
+//! and the VTA mints for the DID the client authenticated as. `VtaClient` does
+//! not expose its signing key — correctly; it is held in the session store —
+//! so the identity is read from the same place authentication reads it. Taking
+//! it from anywhere else would produce a presentation bound to one DID and a
+//! signature by another, which the host refuses and which reads as a
+//! credential problem rather than a wiring one.
+
+use vta_cli_common::commands::rooms::{self, RoomSigner, RoomTarget};
+use vta_sdk::client::VtaClient;
+
+use crate::cli::RoomCommands;
+
+/// The operator's DID and key, from the session this CLI authenticates with.
+fn signer(keyring_key: &str) -> Result<vta_sdk::session::SessionInfo, Box<dyn std::error::Error>> {
+    crate::auth::loaded_session(keyring_key).ok_or_else(|| -> Box<dyn std::error::Error> {
+        "not authenticated — run `pnm auth login` first. A room request is signed by the \
+         DID your VTA minted the presentation for, so this needs your session."
+            .into()
+    })
+}
+
+pub(crate) async fn run(
+    client: &VtaClient,
+    keyring_key: &str,
+    command: RoomCommands,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let session = signer(keyring_key)?;
+    let signer = RoomSigner {
+        did: &session.client_did,
+        key_multibase: &session.private_key_multibase,
+    };
+
+    match command {
+        RoomCommands::List {
+            room_id,
+            host,
+            host_did,
+            prefix,
+            since_version,
+            limit,
+        } => {
+            rooms::cmd_rooms_list(
+                client,
+                RoomTarget {
+                    host_url: &host,
+                    host_did: host_did.as_deref(),
+                    room_id: &room_id,
+                },
+                signer,
+                prefix.as_deref(),
+                since_version,
+                limit,
+            )
+            .await
+        }
+        RoomCommands::Get {
+            key,
+            room_id,
+            host,
+            host_did,
+        } => {
+            rooms::cmd_rooms_get(
+                client,
+                RoomTarget {
+                    host_url: &host,
+                    host_did: host_did.as_deref(),
+                    room_id: &room_id,
+                },
+                signer,
+                &key,
+            )
+            .await
+        }
+        RoomCommands::Put {
+            key,
+            body,
+            room_id,
+            host,
+            host_did,
+            title,
+            expected_version,
+        } => {
+            rooms::cmd_rooms_put(
+                client,
+                RoomTarget {
+                    host_url: &host,
+                    host_did: host_did.as_deref(),
+                    room_id: &room_id,
+                },
+                signer,
+                &key,
+                title,
+                body,
+                expected_version,
+            )
+            .await
+        }
+        RoomCommands::Curate {
+            key,
+            room_id,
+            host,
+            host_did,
+            status,
+            pin,
+            unpin,
+            reason,
+        } => {
+            let pinned = rooms::pinned_from_flags(pin, unpin);
+            rooms::cmd_rooms_curate(
+                client,
+                RoomTarget {
+                    host_url: &host,
+                    host_did: host_did.as_deref(),
+                    room_id: &room_id,
+                },
+                signer,
+                &key,
+                status,
+                pinned,
+                reason,
+            )
+            .await
+        }
+        RoomCommands::Renew {
+            epoch,
+            room_id,
+            host,
+            host_did,
+            reason,
+        } => {
+            rooms::cmd_rooms_renew(
+                client,
+                RoomTarget {
+                    host_url: &host,
+                    host_did: host_did.as_deref(),
+                    room_id: &room_id,
+                },
+                signer,
+                epoch,
+                reason,
+            )
+            .await
+        }
+        RoomCommands::Create {
+            room_id,
+            host,
+            host_did,
+            visibility,
+            retention_days,
+        } => {
+            rooms::cmd_rooms_create(
+                RoomTarget {
+                    host_url: &host,
+                    host_did: host_did.as_deref(),
+                    room_id: &room_id,
+                },
+                signer,
+                &visibility,
+                retention_days,
+            )
+            .await
+        }
+    }
+}

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -303,6 +303,7 @@ async fn main() {
         Commands::Backup { command } => commands::backup::run(&client, command).await,
         Commands::Keys { command } => commands::keys::run(&client, command).await,
         Commands::Memory { command } => commands::memory::run(&client, command).await,
+        Commands::Rooms { command } => commands::rooms::run(&client, &keyring_key, command).await,
     };
 
     client.shutdown().await;

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -25,6 +25,12 @@ vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
 ] }
 # Owner-only file-permission helper (`secure_file`), shared workspace-wide.
 vti-common = { path = "../vti-common", version = "0.17" }
+# The room client. Named for the VTC, but host-neutral by construction: a room's
+# protocol is the same whether a community or a standalone `room-host` serves it,
+# and `room-host`'s own example drives itself with this crate. Taking a second
+# copy of the `rooms/*` wire types into this crate is what the type duplication
+# in `vtc-client` was deleted to avoid.
+vtc-client = { path = "../vtc-client", version = "0.5" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-cli-common/src/commands/mod.rs
+++ b/vta-cli-common/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod memory;
 /// Raw Rego policy management over the canonical `policy/*` family.
 pub mod persona;
 pub mod policy;
+pub mod rooms;
 pub mod services;
 pub mod vault;
 pub mod webvh;

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -1,0 +1,497 @@
+//! `pnm rooms …` — a member's surface on a data room.
+//!
+//! # Two parties, two transports, and why that is the whole design
+//!
+//! Every command here talks to **two** services, and never confuses them:
+//!
+//! - the operator's **VTA**, over the client's existing session, to mint a
+//!   presentation ([`VtaClient::room_present`]) and to open a sealed record
+//!   ([`VtaClient::room_open`]);
+//! - the room's **host**, unauthenticated, carrying that presentation.
+//!
+//! The credentials the presentation is derived from, and the group key that
+//! opens a record, stay inside the VTA. This CLI holds neither at any point,
+//! which is what makes losing the laptop a smaller event than losing the agent.
+//!
+//! # Why a fresh presentation per call
+//!
+//! A presentation names *what may be done*, not who is doing it, and is bound
+//! to the party that signed the request it rides. Caching one across commands
+//! would mean either re-binding it (impossible without the VTA) or sending it
+//! unbound (a bearer token). It is one extra local round-trip and it removes a
+//! whole class of mistake, so every command mints its own.
+//!
+//! # What this surface deliberately does not do
+//!
+//! **Issue credentials.** Minting a VIC, VMC or VAC needs the *room's* signing
+//! key, which is the owner's, not a member's — a different party with different
+//! custody. It belongs in an owner surface and is deliberately absent here
+//! rather than half-present.
+
+use serde_json::Value;
+use vta_sdk::prelude::*;
+use vtc_client::VtcClient;
+use vtc_client::rooms::{CleartextContent, RoomSession, Visibility};
+
+/// Everything a room command needs to reach both parties.
+///
+/// The host DID is optional because an operator may not know it, and the cost
+/// of not knowing is stated rather than hidden: without it the minted
+/// presentation carries no audience, so it is bearer-shaped against that room
+/// for its four-hour life. With it, a captured presentation is worthless to
+/// anyone else.
+pub struct RoomTarget<'a> {
+    pub host_url: &'a str,
+    pub host_did: Option<&'a str>,
+    pub room_id: &'a str,
+}
+
+impl RoomTarget<'_> {
+    fn client(&self) -> VtcClient {
+        // The room surface carries no token — a room operation is authorized by
+        // the presentation, never by a session with the host — so an anonymous
+        // client is the correct one even when the host is a VTC the operator
+        // also has an account on.
+        VtcClient::anonymous(self.host_url, self.host_did.unwrap_or("did:key:zHost"))
+    }
+}
+
+/// Mint a presentation for one action, and warn when it will be unbound.
+async fn present(
+    client: &VtaClient,
+    target: &RoomTarget<'_>,
+    action: &str,
+) -> Result<RoomSession, Box<dyn std::error::Error>> {
+    if target.host_did.is_none() {
+        eprintln!(
+            "note: no --host-did given, so this presentation is not bound to a host. \
+             Anyone who observes it can use it against this room until it expires."
+        );
+    }
+
+    let minted = client
+        .room_present(target.room_id, action, target.host_did, None)
+        .await?;
+    session_from_minted(target.room_id, &minted)
+}
+
+/// Rebuild the session from what the VTA minted.
+///
+/// The VTA answers with the presentation the host expects, so it is read back
+/// rather than reassembled from parts — a second assembly is a second chance to
+/// get the chain order wrong, and the order is load-bearing (leaf first).
+///
+/// Every missing member is an error rather than a default. A presentation with
+/// no chain is not an empty presentation; it is a reply this client does not
+/// understand, and proceeding would send the host something it will refuse for
+/// reasons that read as a credential problem.
+pub fn session_from_minted(
+    room_id: &str,
+    minted: &Value,
+) -> Result<RoomSession, Box<dyn std::error::Error>> {
+    let presentation = minted
+        .get("presentation")
+        .ok_or_else(|| format!("the VTA's reply carried no presentation: {minted}"))?;
+    let membership = presentation
+        .get("membership")
+        .and_then(Value::as_str)
+        .ok_or("the minted presentation carried no membership credential")?;
+    let authority_values = presentation
+        .get("authority")
+        .and_then(Value::as_array)
+        .ok_or("the minted presentation carried no authority chain")?;
+    let authority: Vec<String> = authority_values
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect();
+    // A chain that lost links to a type mismatch is not a shorter chain — it is
+    // a different grant, and a shorter one always confers less than the VTA
+    // minted. Refuse rather than present it.
+    if authority.len() != authority_values.len() {
+        return Err("the minted authority chain contained a non-string link".into());
+    }
+
+    let mut session = RoomSession::new(room_id, membership, authority)?;
+    if let Some(binding) = presentation.get("subjectBinding").and_then(Value::as_str) {
+        session = session.with_subject_binding(binding);
+    }
+    Ok(session)
+}
+
+/// Resolve `--pin` / `--unpin` into the wire value.
+///
+/// Three states from two flags: pinned, unpinned, and **unchanged**. Absence has
+/// to stay distinguishable from `false`, or a curation meaning to change only
+/// the status would silently unpin the record on its way past.
+pub fn pinned_from_flags(pin: bool, unpin: bool) -> Option<bool> {
+    if pin {
+        Some(true)
+    } else if unpin {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// The signer for the room-host leg: the operator's own DID and key.
+///
+/// A room request is signed by the party the presentation was minted *for*, and
+/// the VTA minted it for the DID the CLI authenticates as. Signing with any
+/// other key produces a presentation bound to somebody else, which the host
+/// refuses — correctly, and confusingly, so the two are taken from one place.
+pub struct RoomSigner<'a> {
+    pub did: &'a str,
+    pub key_multibase: &'a str,
+}
+
+/// `rooms list` — the room's records, metadata only.
+pub async fn cmd_rooms_list(
+    client: &VtaClient,
+    target: RoomTarget<'_>,
+    signer: RoomSigner<'_>,
+    prefix: Option<&str>,
+    since_version: Option<u64>,
+    limit: Option<usize>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let session = present(client, &target, "read").await?;
+    let listing = target
+        .client()
+        .list_records(
+            &session,
+            prefix,
+            since_version,
+            signer.did,
+            signer.key_multibase,
+        )
+        .await?;
+
+    if crate::render::is_json_output() {
+        crate::render::print_json(&listing.records)?;
+        return Ok(());
+    }
+    if listing.records.is_empty() {
+        println!(
+            "No records{}.",
+            prefix.map(|p| format!(" under `{p}`")).unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    println!("{} record(s):", listing.records.len());
+    for r in listing.records.iter().take(limit.unwrap_or(usize::MAX)) {
+        let key = r.get("key").and_then(Value::as_str).unwrap_or("?");
+        let version = r.get("version").and_then(Value::as_u64).unwrap_or(0);
+        let status = r.get("status").and_then(Value::as_str).unwrap_or("active");
+        // On a sealed tier there is no title to show — that is the tier working,
+        // not a gap, so say so rather than printing an empty column.
+        let title = r
+            .get("cleartext")
+            .and_then(|c| c.get("title"))
+            .and_then(Value::as_str)
+            .unwrap_or("(sealed)");
+        println!("  {key}  v{version}  {status:<10} {title}");
+    }
+    Ok(())
+}
+
+/// `rooms get` — one record, opened through the VTA when it is sealed.
+pub async fn cmd_rooms_get(
+    client: &VtaClient,
+    target: RoomTarget<'_>,
+    signer: RoomSigner<'_>,
+    key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let session = present(client, &target, "read").await?;
+    let record = target
+        .client()
+        .get_record(&session, key, signer.did, signer.key_multibase)
+        .await?;
+
+    // An `open`-tier record arrives readable. A sealed one arrives as
+    // ciphertext this process cannot decrypt, and must not try to: the group
+    // key is the VTA's.
+    if let Some(cleartext) = record.get("cleartext") {
+        if crate::render::is_json_output() {
+            crate::render::print_json(cleartext)?;
+        } else {
+            if let Some(title) = cleartext.get("title").and_then(Value::as_str) {
+                println!("{title}\n");
+            }
+            println!(
+                "{}",
+                cleartext.get("body").and_then(Value::as_str).unwrap_or("")
+            );
+        }
+        return Ok(());
+    }
+
+    let sealed = record.get("sealed").and_then(Value::as_str).ok_or(
+        "the record carried neither cleartext nor sealed content — is this a room this \
+         host serves?",
+    )?;
+    let nonce = record
+        .get("nonce")
+        .and_then(Value::as_str)
+        .ok_or("a sealed record with no nonce cannot be opened")?;
+    let epoch = record.get("epoch").and_then(Value::as_u64).unwrap_or(0) as u32;
+    let version = record.get("version").and_then(Value::as_u64).unwrap_or(0);
+
+    let opened = client
+        .room_open(target.room_id, key, version, sealed, nonce, epoch)
+        .await
+        .map_err(|e| {
+            // The failure operators will actually hit, named where they will
+            // read it. A record sealed under a later epoch is a missed commit,
+            // and it reads like corruption if nobody says otherwise.
+            format!(
+                "{e}\n\nIf this mentions an epoch, your VTA has not been given the room's \
+                 latest commit — ask the room's owner to deliver it, then retry."
+            )
+        })?;
+
+    let plaintext = opened
+        .get("plaintext")
+        .and_then(Value::as_str)
+        .ok_or("the VTA opened the record but returned no plaintext")?;
+    let bytes =
+        base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, plaintext)?;
+    println!("{}", String::from_utf8_lossy(&bytes));
+    Ok(())
+}
+
+/// `rooms put` — write a record to an `open` room.
+///
+/// Sealed tiers are refused rather than half-served: sealing needs the room's
+/// MLS group, which lives in the VTA, and there is no task that seals on a
+/// caller's behalf. Writing cleartext into a room whose other records are
+/// encrypted would be worse than refusing.
+pub async fn cmd_rooms_put(
+    client: &VtaClient,
+    target: RoomTarget<'_>,
+    signer: RoomSigner<'_>,
+    key: &str,
+    title: Option<String>,
+    body: String,
+    expected_version: Option<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let session = present(client, &target, "write").await?;
+    let put = target
+        .client()
+        .put_record(
+            &session,
+            key,
+            None,
+            Some(CleartextContent {
+                title,
+                body,
+                ..Default::default()
+            }),
+            expected_version,
+            signer.did,
+            signer.key_multibase,
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "{e}\n\nA sealed room (`attributed` / `private`) refuses cleartext: sealing \
+                 needs the room's group key, which lives in your VTA, and no task seals on a \
+                 caller's behalf yet."
+            )
+        })?;
+    println!("Wrote {} at version {}", put.key, put.version);
+    Ok(())
+}
+
+/// `rooms curate` — change a record's standing.
+pub async fn cmd_rooms_curate(
+    client: &VtaClient,
+    target: RoomTarget<'_>,
+    signer: RoomSigner<'_>,
+    key: &str,
+    status: Option<String>,
+    pinned: Option<bool>,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if status.is_none() && pinned.is_none() {
+        return Err("nothing to change — pass --status and/or --pin/--unpin".into());
+    }
+    // `curate` is its own grant, deliberately not implied by `write`: deciding
+    // what a room's shared knowledge is worth is a different act from adding to
+    // it. So the presentation is minted for `curate`, and a member who only
+    // writes is refused here rather than at the host.
+    let session = present(client, &target, "curate").await?;
+
+    let out = target
+        .client()
+        .curate_record(
+            &session,
+            key,
+            status,
+            pinned,
+            reason,
+            signer.did,
+            signer.key_multibase,
+        )
+        .await?;
+    println!(
+        "{} is now {} at version {}{}",
+        out.key,
+        serde_json::to_value(out.status)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_else(|| "?".into()),
+        out.version,
+        if out.pinned { " (pinned)" } else { "" }
+    );
+    Ok(())
+}
+
+/// `rooms renew` — mint the next epoch, which is what keeps a room live.
+///
+/// Needs `admin`. It is the same act as ordinary use, and it is the whole
+/// defence against a hostile succession claim: an owner who renews is
+/// structurally safe without thinking about it.
+pub async fn cmd_rooms_renew(
+    client: &VtaClient,
+    target: RoomTarget<'_>,
+    signer: RoomSigner<'_>,
+    epoch: u32,
+    reason: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let session = present(client, &target, "admin").await?;
+    let minted = target
+        .client()
+        .mint_epoch(
+            &session,
+            epoch,
+            reason.as_deref(),
+            signer.did,
+            signer.key_multibase,
+        )
+        .await?;
+    println!("Room {} is at epoch {}", minted.room_id, minted.epoch);
+    Ok(())
+}
+
+/// `rooms create` — register a room with a host.
+///
+/// The only command here that needs no presentation: the room has issued
+/// nothing yet, so there is no chain to present. The host checks the request's
+/// own proof instead, which is why this must be signed as the owner it names.
+pub async fn cmd_rooms_create(
+    target: RoomTarget<'_>,
+    signer: RoomSigner<'_>,
+    visibility: &str,
+    retention_days: Option<u32>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let visibility: Visibility = serde_json::from_value(Value::String(visibility.to_string()))
+        .map_err(|_| "visibility must be one of: open, attributed, private")?;
+
+    target
+        .client()
+        .create_room(
+            target.room_id,
+            signer.did,
+            visibility,
+            retention_days,
+            signer.did,
+            signer.key_multibase,
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "{e}\n\nA community host decides whose rooms it stores. If this says \
+                 `not-a-member`, you are not a member there; if it says \
+                 `private-tier-not-enabled`, that community has not turned the tier on."
+            )
+        })?;
+    println!("Registered {} as {}", target.room_id, signer.did);
+    println!(
+        "  Next: the room must issue you a membership and an authority credential before \
+         you can act in it."
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn minted(authority: Value) -> Value {
+        json!({
+            "presentation": {
+                "membership": "vmc-blob",
+                "authority": authority,
+            },
+            "expiresAt": "2026-09-07T16:00:00Z",
+        })
+    }
+
+    #[test]
+    fn a_minted_presentation_becomes_a_session() {
+        let session = session_from_minted("did:webvh:room", &minted(json!(["leaf", "root"])))
+            .expect("a well-formed reply rebuilds");
+        assert_eq!(session.room_id(), "did:webvh:room");
+        assert_eq!(session.chain_depth(), 2, "leaf first, root last");
+    }
+
+    /// A private room's presentation carries the same-subject proof, and losing
+    /// it on the way through would turn a valid call into a refusal the
+    /// operator cannot explain.
+    #[test]
+    fn a_subject_binding_survives_the_rebuild() {
+        let mut m = minted(json!(["leaf"]));
+        m["presentation"]["subjectBinding"] = json!("zk-proof-blob");
+        let session =
+            session_from_minted("did:webvh:room", &m).expect("a private presentation rebuilds");
+        assert_eq!(session.chain_depth(), 1);
+    }
+
+    /// Each missing member is refused rather than defaulted. A reply this
+    /// client does not understand must not become a request the host refuses
+    /// for reasons that read as a credential problem.
+    #[test]
+    fn an_unreadable_reply_is_refused_rather_than_guessed() {
+        assert!(
+            session_from_minted("r", &json!({})).is_err(),
+            "no presentation"
+        );
+        assert!(
+            session_from_minted("r", &json!({ "presentation": { "authority": ["a"] } })).is_err(),
+            "no membership"
+        );
+        assert!(
+            session_from_minted("r", &json!({ "presentation": { "membership": "m" } })).is_err(),
+            "no chain"
+        );
+        assert!(
+            session_from_minted("r", &minted(json!([]))).is_err(),
+            "an empty chain authorizes nothing and must not be sent"
+        );
+    }
+
+    /// A link that is not a string would otherwise be filtered out, silently
+    /// shortening the chain — and a shorter chain confers less than the VTA
+    /// minted, so the call would fail somewhere far from the cause.
+    #[test]
+    fn a_malformed_link_does_not_silently_shorten_the_chain() {
+        let err = session_from_minted("r", &minted(json!(["leaf", 7])))
+            .expect_err("a non-string link is refused");
+        assert!(
+            err.to_string().contains("non-string"),
+            "the error must name the cause: {err}"
+        );
+    }
+
+    #[test]
+    fn pin_flags_keep_unchanged_distinct_from_unpinned() {
+        assert_eq!(pinned_from_flags(true, false), Some(true));
+        assert_eq!(pinned_from_flags(false, true), Some(false));
+        assert_eq!(
+            pinned_from_flags(false, false),
+            None,
+            "neither flag must leave the pin alone, not clear it"
+        );
+    }
+}

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -317,6 +317,7 @@ pub mod loopback;
 mod memory;
 mod persona;
 mod policy;
+mod rooms;
 mod secrets;
 mod vault;
 mod vta_management;

--- a/vta-sdk/src/client/rooms.rs
+++ b/vta-sdk/src/client/rooms.rs
@@ -1,0 +1,115 @@
+//! Room-oracle Trust Task client methods (`spec/rooms/keys/{present,open}/0.1`).
+//!
+//! The two calls a member's own VTA answers about a data room, and the reason a
+//! client never holds room credentials or room keys:
+//!
+//! - [`VtaClient::room_present`] asks the VTA to mint a **presentation** for one
+//!   operation — attenuated from the member's own authority, one action, bound
+//!   to the caller, four hours. The presentation goes to the room's host; the
+//!   credentials it was derived from never leave the VTA.
+//! - [`VtaClient::room_open`] hands the VTA a sealed record and gets the
+//!   plaintext back. The group key stays inside.
+//!
+//! Both are gated on their own capability (`roomPresent` / `roomOpen`) plus
+//! access to the context holding the principal's key. Neither is `Sign`: an
+//! agent that may ask for a scoped presentation is not thereby an agent that
+//! may sign anything at all with its principal's key.
+//!
+//! # What this module deliberately does not do
+//!
+//! Talk to the room's **host**. These are calls to *your* VTA. Posting the
+//! resulting presentation to whoever stores the room is a different transport
+//! to a different party, and keeping the two apart is what stops a client
+//! quietly sending its principal's credentials somewhere they were not minted
+//! for.
+
+use serde_json::{Value, json};
+
+use super::VtaClient;
+use crate::error::VtaError;
+use crate::trust_tasks;
+
+/// Round-trip timeout (seconds) for the room-oracle tasks.
+///
+/// Both are local work on the VTA — a credential attenuation and a symmetric
+/// decrypt — so they are quick, and a long timeout would only mask a VTA that
+/// has stopped answering.
+const ROOM_TT_TIMEOUT: u64 = 30;
+
+impl VtaClient {
+    /// `rooms/keys/present/0.1` — mint a presentation for **one** operation.
+    ///
+    /// `action` is a single room verb (`read`, `write`, `curate`, `admin`);
+    /// there is no "everything" value, deliberately. `audience`, when given,
+    /// binds the minted leaf to that party so a captured presentation is
+    /// worthless elsewhere — pass the host's DID whenever you know it.
+    ///
+    /// The reply carries `presentation` (send this to the host) and
+    /// `expiresAt`. A request for more than the principal holds fails at the
+    /// VTA, in the credential library, rather than producing a presentation the
+    /// host will later refuse.
+    pub async fn room_present(
+        &self,
+        room_id: &str,
+        action: &str,
+        audience: Option<&str>,
+        nonce: Option<&str>,
+    ) -> Result<Value, VtaError> {
+        let mut payload = json!({
+            "roomId": room_id,
+            "action": action,
+        });
+        // Omitted rather than sent as null: the published payload types the
+        // members as strings, and a `null` would fail schema validation at the
+        // spine — the defect class #919 and #921 both landed in.
+        if let Some(audience) = audience {
+            payload["audience"] = Value::String(audience.to_string());
+        }
+        if let Some(nonce) = nonce {
+            payload["nonce"] = Value::String(nonce.to_string());
+        }
+        self.dispatch_trust_task(
+            trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1,
+            payload,
+            ROOM_TT_TIMEOUT,
+        )
+        .await
+    }
+
+    /// `rooms/keys/open/0.1` — decrypt one sealed record.
+    ///
+    /// `version` and the sealed triple must be exactly what the host returned:
+    /// the record's AEAD is bound to `roomId | key | version | epoch`, so a
+    /// value adjusted in transit does not open. The reply carries `plaintext`
+    /// as base64url.
+    ///
+    /// **A record sealed under a later epoch than this VTA holds means a missed
+    /// commit**, not corruption. The VTA says which epoch it has; deliver the
+    /// commit and retry rather than treating the record as damaged.
+    pub async fn room_open(
+        &self,
+        room_id: &str,
+        key: &str,
+        version: u64,
+        ciphertext: &str,
+        nonce: &str,
+        epoch: u32,
+    ) -> Result<Value, VtaError> {
+        let payload = json!({
+            "roomId": room_id,
+            "key": key,
+            "version": version,
+            "sealed": {
+                "ciphertext": ciphertext,
+                "nonce": nonce,
+                "epoch": epoch,
+            },
+        });
+        self.dispatch_trust_task(
+            trust_tasks::TASK_ROOMS_KEYS_OPEN_0_1,
+            payload,
+            ROOM_TT_TIMEOUT,
+        )
+        .await
+    }
+}

--- a/vtc-client/src/rooms/mod.rs
+++ b/vtc-client/src/rooms/mod.rs
@@ -45,10 +45,10 @@ use crate::{VtcClient, VtcError};
 pub use vti_rooms::Visibility;
 pub use vti_rooms::authz::MAX_CHAIN_DEPTH;
 pub use vti_rooms::wire::{
-    AuthorityPresentation, CleartextContent, ListRecordsResponse, MintEpochResponse, OwnerResponse,
-    PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_OWNER_CLAIM_TYPE,
-    ROOMS_OWNER_TRANSFER_TYPE, ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE,
-    ROOMS_RECORDS_PUT_TYPE, SealedContent,
+    AuthorityPresentation, CleartextContent, CurateRecordResponse, ListRecordsResponse,
+    MintEpochResponse, OwnerResponse, PutRecordResponse, ROOMS_CREATE_TYPE, ROOMS_EPOCH_MINT_TYPE,
+    ROOMS_OWNER_CLAIM_TYPE, ROOMS_OWNER_TRANSFER_TYPE, ROOMS_RECORDS_CURATE_TYPE,
+    ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE, SealedContent,
 };
 
 /// A caller's standing in one room.
@@ -293,6 +293,62 @@ impl VtcClient {
         serde_json::from_value(value).map_err(|e| VtcError::Http {
             status: 200,
             body: format!("mint response is not a MintEpochResponse: {e}"),
+        })
+    }
+
+    /// Change a record's **standing** — its status, whether it is pinned, or both.
+    ///
+    /// Needs a chain conferring `curate`, which is deliberately *not* implied by `write`:
+    /// deciding what a room's shared knowledge is worth is a different grant from being
+    /// able to add to it.
+    ///
+    /// Separate from [`Self::put_record`] because standing is not content. On a sealed tier
+    /// a host cannot read what it stores, so "same body, now deprecated" through `put` would
+    /// make a member re-seal and re-upload bytes the host already holds, to say something
+    /// that is not about the bytes.
+    ///
+    /// `status` and `pinned` are independent: omit either to leave it unchanged, and passing
+    /// neither changes nothing. The curation assigns a **new version**, because a change
+    /// others must converge on is a change like any other — one that left the version alone
+    /// would be invisible to every `sinceVersion` watermark in the room.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn curate_record(
+        &self,
+        session: &RoomSession,
+        key: &str,
+        status: Option<String>,
+        pinned: Option<bool>,
+        reason: Option<String>,
+        signer_did: &str,
+        private_key_multibase: &str,
+    ) -> Result<CurateRecordResponse, VtcError> {
+        let mut payload = serde_json::json!({
+            "roomId": session.room_id,
+            "key": key,
+            "presentation": session.presentation,
+        });
+        // Each member is omitted when absent rather than sent as null: the
+        // published schema types them, and "leave unchanged" is absence.
+        if let Some(s) = status {
+            payload["status"] = serde_json::json!(s);
+        }
+        if let Some(p) = pinned {
+            payload["pinned"] = serde_json::json!(p);
+        }
+        if let Some(r) = reason {
+            payload["reason"] = serde_json::json!(r);
+        }
+        let value = self
+            .room_task(
+                ROOMS_RECORDS_CURATE_TYPE,
+                payload,
+                signer_did,
+                private_key_multibase,
+            )
+            .await?;
+        serde_json::from_value(value).map_err(|e| VtcError::Http {
+            status: 200,
+            body: format!("curate response is not a CurateRecordResponse: {e}"),
         })
     }
 


### PR DESCRIPTION
Rooms had no CLI. Using one meant writing Rust against `vtc-client` or hand-building signed Trust Task documents — not a surface an operator has. This is the **member's** half: `pnm rooms {create,list,get,put,curate,renew}`.

### Two parties, never confused

Every command talks to both and keeps them apart: the operator's **VTA** mints a presentation (`rooms/keys/present`) and opens sealed records (`rooms/keys/open`), and the room's **host** stores the bytes. The credentials the presentation is derived from, and the group key that opens a record, stay inside the VTA — **this CLI holds neither at any point**.

That makes the CLI the room oracle's first real consumer, and the model holds up: a member who holds less than an action needs is refused *by their own VTA*, before anything reaches the host — the earlier and clearer of the two refusals.

Each command mints its own presentation for exactly the action it performs — `read` for list/get, `write` for put, `curate` for curate, `admin` for renew. Caching one across commands would mean re-binding it (impossible without the VTA) or sending it unbound, which is a bearer token.

```bash
pnm rooms list --room <room-did> --host https://rooms.example.org --host-did <host-did>
pnm rooms get  decision/pricing-2026 --room <room-did> --host …
pnm rooms put  decision/pricing-2026 "Agreed not to reprice." --room <room-did> --host … \
               --title "Pricing holds" --expected-version 0
pnm rooms renew 3 --room <room-did> --host …
```

`--host-did` binds the presentation to that host; omitting it warns, because an unbound presentation is usable by anyone who observes it for its four-hour life.

### Where the pieces had to live — a cycle forced the shape

`vta-sdk` gains `room_present` / `room_open`, since those are calls to *your own* VTA. It **cannot** gain the room wire types: `vti-common` re-exports `vta_sdk::acl`, so `vta-sdk → vti-rooms → vti-common → vta-sdk` is a dependency cycle.

So `vta-cli-common` takes `vtc-client` — which, despite its name, is the host-neutral room client (`room-host`'s own example drives itself with it). Worth a look in review: the alternative was a second copy of the `rooms/*` wire types in the CLI, which is exactly the duplication that crate deleted when the group-key layer moved out.

`vtc-client` also gains `curate_record` — nothing had implemented it, and it's the shared surface a mirrors PR would build beside.

### What it deliberately cannot do

| | |
|---|---|
| Write to a **sealed** room | Sealing needs the room's group key, which lives in the VTA, and no task seals on a caller's behalf. Refused with that reason rather than writing cleartext into an encrypted room |
| **Issue credentials** | Minting a VIC/VMC/VAC needs the *room's* signing key — the owner's, a different party with different custody. It belongs in an owner surface and is absent rather than half-present |

`get` also translates the epoch-mismatch failure into *"your VTA has not been given the room's latest commit"* — which is what it means, and not what it reads like.

### Tests

Five, on the two pure decisions worth pinning: rebuilding a session from what the VTA minted (every missing member refused rather than defaulted; a private room's subject binding surviving the rebuild; a non-string chain link refused rather than silently shortening the chain, since a shorter chain confers less than was minted); and the pin/unpin tri-state, where absence must stay distinct from `false` or a status-only curation would silently unpin the record.

`clippy --all-targets` and `fmt --check` clean; `vta-sdk`, `vtc-client` and `vta-cli-common` suites green.
