### PR TITLE
feat(acl): grant authority over the holder's own identity without granting every context

### DIFF
--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1138,6 +1138,10 @@ async fn main() {
                     label: admin_label,
                     expires_at,
                     expires_duration: admin_expires.clone(),
+                    // A community admin is not the holder of the agent's own
+                    // identity; `pnm contexts create --admin-holder` is where
+                    // that grant is made, deliberately.
+                    holder: false,
                 };
                 contexts::cmd_context_create(&client, &id, &name, description, parent, admin).await
             }

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -1725,6 +1725,20 @@ pub(crate) enum ContextCommands {
         /// entry is permanent. Requires `--admin-did`.
         #[arg(long, requires = "admin_did")]
         admin_expires: Option<String>,
+        /// Also grant the admin DID authority over the **holder's own
+        /// identity** — the attribute pool, the profiles built over it, and the
+        /// disclosure history — by adding the `persona-holder` capability.
+        ///
+        /// That identity sits above every trust context, so a context-scoped
+        /// admin cannot reach it. Without this flag a client provisioned here
+        /// can administer its own context and nothing of the holder's; with it,
+        /// it can manage the holder's identity **without** gaining any authority
+        /// over other contexts. Grant it to a client that is the holder's own —
+        /// OpenVTC, a personal agent — and not to an integration.
+        ///
+        /// Super-admin only, like every grant of holder authority.
+        #[arg(long, requires = "admin_did")]
+        admin_holder: bool,
     },
     /// Update an existing context
     Update {
@@ -1957,6 +1971,11 @@ pub(crate) enum AclCommands {
         /// the window a grant-then-narrow pair leaves open. Every name must be
         /// one the role already carries; one that is not is refused. Omit for
         /// everything the role implies.
+        ///
+        /// `persona-holder` is the exception: no role carries it, so it is a
+        /// *grant* rather than a narrowing — it adds authority over the holder's
+        /// own identity without removing anything the role has, and only an
+        /// unscoped holder credential may confer it.
         #[arg(long, value_delimiter = ',')]
         capabilities: Option<Vec<String>>,
     },
@@ -2041,6 +2060,12 @@ pub(crate) enum AclCommands {
         /// It can only narrow: every name must be one the entry's role already
         /// carries, and one that is not is refused rather than dropped. Omit to
         /// leave the narrowing unchanged.
+        ///
+        /// `persona-holder` is the exception — a *grant*, not a narrowing. No
+        /// role carries it, it adds authority over the holder's own identity
+        /// without removing anything the role has, and only an unscoped holder
+        /// credential may confer it. Naming it alone therefore leaves the rest
+        /// of the entry's authority intact rather than narrowing it to nothing.
         #[arg(long, value_delimiter = ',', conflicts_with = "capabilities_all")]
         capabilities: Option<Vec<String>>,
         /// Remove the narrowing — the entry holds everything its role implies.

--- a/pnm-cli/src/commands/contexts.rs
+++ b/pnm-cli/src/commands/contexts.rs
@@ -21,7 +21,13 @@ pub(crate) async fn run(
             admin_did,
             admin_label,
             admin_expires,
-        } => match resolve_admin_acl_options(admin_did, admin_label, admin_expires.as_deref()) {
+            admin_holder,
+        } => match resolve_admin_acl_options(
+            admin_did,
+            admin_label,
+            admin_expires.as_deref(),
+            admin_holder,
+        ) {
             Ok(admin) => {
                 contexts::cmd_context_create(client, &id, &name, description, parent, admin).await
             }
@@ -151,6 +157,7 @@ fn resolve_admin_acl_options(
     admin_did: Option<String>,
     admin_label: Option<String>,
     admin_expires: Option<&str>,
+    admin_holder: bool,
 ) -> Result<contexts::AdminAclOptions, Box<dyn std::error::Error>> {
     let expires_at = match admin_expires {
         Some(s) => Some(
@@ -164,5 +171,6 @@ fn resolve_admin_acl_options(
         label: admin_label,
         expires_at,
         expires_duration: admin_expires.map(str::to_string),
+        holder: admin_holder,
     })
 }

--- a/vta-cli-common/src/commands/contexts.rs
+++ b/vta-cli-common/src/commands/contexts.rs
@@ -230,6 +230,15 @@ pub struct AdminAclOptions {
     /// resolved `expires_at` so conflict hints can re-emit the operator's
     /// original duration verbatim instead of a drift-skewed seconds value.
     pub expires_duration: Option<String>,
+    /// Also grant the `persona-holder` capability — authority over the holder's
+    /// own identity, which sits above every trust context.
+    ///
+    /// Kept separate from the context grant beside it because they are
+    /// different powers, and the whole point of the capability is that one does
+    /// not imply the other: this entry administers exactly one context, and
+    /// with this flag it also manages the identity of the person who owns the
+    /// agent. Super-admin only, refused server-side otherwise.
+    pub holder: bool,
 }
 
 impl AdminAclOptions {
@@ -321,6 +330,12 @@ pub async fn cmd_context_create(
         if let Some(expires_at) = admin.expires_at {
             acl_req = acl_req.expires_at(expires_at);
         }
+        if admin.holder {
+            // Additive: it does not narrow what the admin role carries, so the
+            // entry keeps everything an admin of this context has and gains
+            // the holder-scoped persona tasks on top.
+            acl_req = acl_req.capabilities(vec!["persona-holder".to_string()]);
+        }
         let acl = client.create_acl(acl_req).await?;
 
         println!();
@@ -330,6 +345,9 @@ pub async fn cmd_context_create(
         println!("  Contexts:   {}", acl.allowed_contexts.join(", "));
         if let Some(ref label) = acl.label {
             println!("  Label:      {label}");
+        }
+        if admin.holder {
+            println!("  Identity:   holder (persona-holder capability granted)");
         }
         match acl.expires_at {
             Some(secs) => {

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -14,7 +14,8 @@ use crate::acl::{
     AclEntry, ApproveScope, Capability, ContextDirection, Role, acl_entry_matches_context,
     capabilities_beyond_role, delete_acl_entry, get_acl_entry, is_acl_entry_auditable,
     is_acl_entry_visible, list_acl_entries, store_acl_entry, update_acl_entry_versioned,
-    validate_acl_modification, validate_approve_scope_grant, validate_role_assignment,
+    validate_acl_modification, validate_additive_capability_grant, validate_approve_scope_grant,
+    validate_role_assignment,
 };
 use crate::auth::AuthClaims;
 use crate::auth::session::now_epoch;
@@ -375,6 +376,9 @@ pub async fn create_acl(
              narrow what its role allows, never widen it"
         )));
     }
+    // Additive capabilities pass the check above by construction — no role
+    // carries them — so their gate is a privilege check on the granter.
+    validate_additive_capability_grant(auth, &capabilities)?;
     // Granting approve-authority is its own privilege check: `all` is
     // super-admin-only, a scoped grant requires the caller to hold each context.
     validate_approve_scope_grant(auth, &approve_scope)?;
@@ -556,6 +560,9 @@ async fn update_acl(
                 entry.role
             )));
         }
+        // Same gate as the create path, and needed independently: an update is
+        // the other way an entry could acquire holder authority.
+        validate_additive_capability_grant(auth, &capabilities)?;
         entry.capabilities = capabilities;
     }
     if let Some(approver) = params.step_up_approver {
@@ -2277,6 +2284,120 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)), "got {err:?}");
+    }
+
+    // ── Additive capability grants ──────────────────────────────────
+
+    /// The escalation the granter check exists to stop, in one command.
+    ///
+    /// A context-scoped admin may create ACL entries within their context. If
+    /// naming `persona-holder` were merely a capability like the rest, they
+    /// could mint an entry — for a DID they control, or their own — that reads
+    /// the holder's entire cross-context identity. `capabilities_beyond_role`
+    /// cannot catch it: additive capabilities are excluded there by
+    /// construction, because no role carries them.
+    #[tokio::test]
+    async fn a_scoped_admin_cannot_grant_holder_authority() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-work"]).await;
+
+        let err = create_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &ctx_admin("did:key:zScoped", &["ctx-work"]),
+            CreateAclParams {
+                did: "did:key:zPuppet".into(),
+                role: Role::Admin,
+                allowed_contexts: vec!["ctx-work".into()],
+                capabilities: vec![Capability::PersonaHolder],
+                ..Default::default()
+            },
+            "test",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "a scoped admin must not confer holder authority, got {err:?}"
+        );
+    }
+
+    /// And the grant an unscoped holder makes goes through, additively: the
+    /// entry keeps every capability its role carries and gains this one.
+    #[tokio::test]
+    async fn a_super_admin_grants_holder_authority_without_narrowing() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-work"]).await;
+
+        create_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &super_admin("did:key:zSuper"),
+            CreateAclParams {
+                did: "did:key:zClient".into(),
+                role: Role::Admin,
+                allowed_contexts: vec!["ctx-work".into()],
+                capabilities: vec![Capability::PersonaHolder],
+                ..Default::default()
+            },
+            "test",
+        )
+        .await
+        .unwrap();
+
+        let stored = get_acl_entry(&acl_ks, "did:key:zClient")
+            .await
+            .unwrap()
+            .expect("entry stored");
+        assert!(entry_has_capability(&stored, Capability::PersonaHolder));
+        assert!(
+            entry_has_capability(&stored, Capability::VaultRead),
+            "an additive grant must not narrow the role it rides on"
+        );
+        assert_eq!(
+            stored.allowed_contexts,
+            vec!["ctx-work".to_string()],
+            "and it must not widen the entry's context scope either"
+        );
+    }
+
+    /// The same gate on the other path an entry could acquire it through.
+    #[tokio::test]
+    async fn a_scoped_admin_cannot_grant_holder_authority_by_update() {
+        let (_store, acl_ks, audit, contexts_ks, _dir) = fresh_store().await;
+        seed_contexts(&contexts_ks, &["ctx-work"]).await;
+        seed_target(&acl_ks, "did:key:zPuppet", &["ctx-work"]).await;
+
+        let err = update_acl(
+            &acl_ks,
+            &audit,
+            &contexts_ks,
+            &ctx_admin("did:key:zScoped", &["ctx-work"]),
+            "did:key:zPuppet",
+            UpdateAclParams {
+                capabilities: Some(vec![Capability::PersonaHolder]),
+                allowed_keys: None,
+                role: None,
+                label: None,
+                allowed_contexts: None,
+                step_up_approver: None,
+                step_up_require: None,
+                approve_scope: None,
+                expires_at: None,
+                reason: None,
+            },
+            "test",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "the update path is the other way in, got {err:?}"
+        );
     }
 
     /// Existing contexts in the contexts keyspace are accepted.

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -150,23 +150,92 @@ pub fn reach_of(uri: &str) -> Option<Reach> {
     REACH.iter().find(|(u, _)| *u == uri).map(|(_, r)| *r)
 }
 
+/// Whether this caller has been granted holder authority by name.
+///
+/// Read from the ACL entry per call rather than from the access token, and the
+/// direction matters: a *grant* carried in a JWT outlives its revocation for the
+/// life of the token, so revoking holder authority would leave a window in which
+/// the pool is still readable. (The capability *narrowing* gate reads per call
+/// for the mirror-image reason — see `helpers::require_capability`.)
+///
+/// A store error is not a grant. It is logged with the real reason and answered
+/// as "no", because the alternative — treating an unreadable ACL as permission —
+/// turns a database blip into a boundary crossing.
+async fn holder_capability_granted(state: &AppState, claims: &AuthClaims) -> bool {
+    match vti_common::acl::get_acl_entry(&state.acl_ks, &claims.did).await {
+        Ok(Some(entry)) => vti_common::acl::entry_has_capability(
+            &entry,
+            vti_common::acl::Capability::PersonaHolder,
+        ),
+        // No entry, no grant. Unlike the narrowing gate, there is no role to
+        // fall back to: no role derives this capability.
+        Ok(None) => false,
+        Err(e) => {
+            tracing::error!(
+                error = %e, did = %claims.did,
+                "could not read the ACL entry for a persona holder check; refusing"
+            );
+            false
+        }
+    }
+}
+
 /// Gate a persona task on the reach its URI declares.
 ///
-/// `Holder` requires **unscoped holder** — `Admin` with unrestricted scope.
-/// A context-scoped admin is refused, which is the whole point.
-pub fn authorize(claims: &AuthClaims, uri: &str, context_id: Option<&str>) -> Result<(), AppError> {
+/// `Holder` is satisfied two ways, and only two: an **unscoped holder
+/// credential** (`Admin` with unrestricted scope), or an entry granted
+/// [`Capability::PersonaHolder`](vti_common::acl::Capability::PersonaHolder) by
+/// name. A context-scoped admin holding neither is refused, which is the whole
+/// point.
+///
+/// The capability exists because the first form was, until now, the *only*
+/// form: managing your own identity from a client meant giving that client
+/// authority over every context on the agent. It grants the pool without
+/// granting that.
+///
+/// The ACL read happens only where it can change the answer — a `Holder` task,
+/// for a caller who is not already unscoped — so the context-scoped tasks and
+/// the super-admin path cost exactly what they did.
+pub async fn authorize(
+    state: &AppState,
+    claims: &AuthClaims,
+    uri: &str,
+    context_id: Option<&str>,
+) -> Result<(), AppError> {
+    let granted = matches!(reach_of(uri), Some(Reach::Holder))
+        && !claims.is_super_admin()
+        && holder_capability_granted(state, claims).await;
+    decide(claims, uri, context_id, granted)
+}
+
+/// The decision itself, given whether the caller holds the capability.
+///
+/// Split from [`authorize`] so the whole matrix — every URI against every role
+/// and scope — is testable without standing up a store. The reach table is the
+/// thing most likely to be got wrong, and a test that needs an `AppState` to
+/// ask about it is a test nobody extends when they add a task.
+fn decide(
+    claims: &AuthClaims,
+    uri: &str,
+    context_id: Option<&str>,
+    holder_granted: bool,
+) -> Result<(), AppError> {
     match reach_of(uri) {
         None => Err(AppError::Forbidden(format!(
             "unknown persona task {uri}: refusing rather than defaulting a reach"
         ))),
-        Some(Reach::Holder) => claims.require_super_admin().map_err(|_| {
-            AppError::Forbidden(
+        Some(Reach::Holder) => {
+            if claims.is_super_admin() || holder_granted {
+                return Ok(());
+            }
+            Err(AppError::Forbidden(
                 "this task reads or writes the holder's attribute pool, which sits above every \
-                 trust context. It requires an unscoped holder credential; an administrator \
-                 scoped to a context is refused here exactly as an application would be."
+                 trust context. It requires an unscoped holder credential, or an ACL entry \
+                 granted the `persona-holder` capability; an administrator scoped to a context \
+                 and holding neither is refused here exactly as an application would be."
                     .into(),
-            )
-        }),
+            ))
+        }
         Some(Reach::Context) => match context_id {
             Some(ctx) => claims.require_context(ctx),
             None => Err(AppError::Validation(
@@ -358,7 +427,7 @@ pub(super) async fn handle_attribute_put(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_ATTRIBUTE_PUT_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_ATTRIBUTE_PUT_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -463,7 +532,7 @@ pub(super) async fn handle_attribute_list(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -490,7 +559,7 @@ pub(super) async fn handle_attribute_delete(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_ATTRIBUTE_DELETE_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_ATTRIBUTE_DELETE_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -543,7 +612,7 @@ pub(super) async fn handle_profile_put(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_PUT_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_PROFILE_PUT_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -624,7 +693,7 @@ pub(super) async fn handle_profile_get(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_GET_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_PROFILE_GET_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -695,7 +764,7 @@ pub(super) async fn handle_profile_list(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_LIST_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_PROFILE_LIST_1_0, None).await {
         return reject(&doc, e);
     }
     // No resolve option, deliberately: resolving every profile at once would
@@ -717,7 +786,7 @@ pub(super) async fn handle_profile_delete(
         Ok(r) => r,
         Err(resp) => return resp,
     };
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_PROFILE_DELETE_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_PROFILE_DELETE_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -792,7 +861,7 @@ pub(super) async fn handle_binding_set(
     // Holder-only, and the critical gate: an application able to call this
     // could bind any profile to a persona it controls and read the result back
     // through a disclosure it requests of itself.
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_BINDING_SET_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_BINDING_SET_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -867,7 +936,7 @@ pub(super) async fn handle_binding_get(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_BINDING_GET_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_BINDING_GET_1_0, Some(&ctx)).await {
         return reject(&doc, e);
     }
 
@@ -917,7 +986,7 @@ pub(super) async fn handle_binding_list(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_BINDING_LIST_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_BINDING_LIST_1_0, Some(&ctx)).await {
         return reject(&doc, e);
     }
 
@@ -953,7 +1022,7 @@ pub(super) async fn handle_contact_put(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_PUT_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_CONTACT_PUT_1_0, Some(&ctx)).await {
         return reject(&doc, e);
     }
 
@@ -1017,7 +1086,7 @@ pub(super) async fn handle_contact_get(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_GET_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_CONTACT_GET_1_0, Some(&ctx)).await {
         return reject(&doc, e);
     }
     let id = req.contact_id.to_string();
@@ -1093,7 +1162,7 @@ pub(super) async fn handle_contact_list(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_LIST_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_CONTACT_LIST_1_0, Some(&ctx)).await {
         return reject(&doc, e);
     }
 
@@ -1135,7 +1204,14 @@ pub(super) async fn handle_contact_delete(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CONTACT_DELETE_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_CONTACT_DELETE_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
     let id = req.contact_id.to_string();
@@ -1180,7 +1256,7 @@ pub(super) async fn handle_disclosure_history(
     };
     // Holder-only: omitting contextId queries across every context, which only
     // the holder may do and is the reason this sits above the boundary.
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_DISCLOSURE_HISTORY_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_DISCLOSURE_HISTORY_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -1226,7 +1302,14 @@ pub(super) async fn handle_correlation_analyze(
     // Holder-only: the response is the linkage map between the holder's own
     // identities — the artifact the family exists to keep from being assembled
     // by anyone else.
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_CORRELATION_ANALYZE_1_0, None) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_CORRELATION_ANALYZE_1_0,
+        None,
+    )
+    .await
+    {
         return reject(&doc, e);
     }
 
@@ -1253,7 +1336,7 @@ pub(super) async fn handle_renderers_list(
     // Unused: this task describes the agent's declared capabilities, which are
     // a compile-time constant, not stored state. Taking the parameter anyway
     // keeps every handler one shape for the dispatch table.
-    _state: &AppState,
+    state: &AppState,
     auth: &AuthClaims,
     doc: TrustTask<Value>,
 ) -> TrustTaskOutcome {
@@ -1271,7 +1354,7 @@ pub(super) async fn handle_renderers_list(
     // request, so it attributed nothing; and reading the caller's own list
     // inverted the gate — an `Admin` with an unrestricted (empty) list is the
     // most privileged caller there is, and was the only one refused.
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_RENDERERS_LIST_1_0, None) {
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_RENDERERS_LIST_1_0, None).await {
         return reject(&doc, e);
     }
 
@@ -1308,7 +1391,14 @@ pub(super) async fn handle_local_profile_put(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
 
@@ -1449,7 +1539,14 @@ pub(super) async fn handle_local_profile_get(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_PROFILE_GET_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_LOCAL_PROFILE_GET_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
     let id = req.profile_id.to_string();
@@ -1501,7 +1598,14 @@ pub(super) async fn handle_local_profile_list(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_LOCAL_PROFILE_LIST_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
     let profiles = match store(state).list_local_profiles(&ctx).await {
@@ -1540,10 +1644,13 @@ pub(super) async fn handle_local_profile_delete(
     };
     let ctx = req.context_id.to_string();
     if let Err(e) = authorize(
+        state,
         auth,
         uris::TASK_PERSONA_LOCAL_PROFILE_DELETE_1_0,
         Some(&ctx),
-    ) {
+    )
+    .await
+    {
         return reject(&doc, e);
     }
     let id = req.profile_id.to_string();
@@ -1610,7 +1717,14 @@ pub(super) async fn handle_local_binding_set(
     let ctx = req.context_id.to_string();
     // Safely context-callable — unlike binding/set — because both objects it
     // names live below the boundary.
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_LOCAL_BINDING_SET_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
 
@@ -1672,7 +1786,14 @@ pub(super) async fn handle_disclosure_preview(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_DISCLOSURE_PREVIEW_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
 
@@ -1731,7 +1852,14 @@ pub(super) async fn handle_disclosure_present(
         Err(resp) => return resp,
     };
     let ctx = req.context_id.to_string();
-    if let Err(e) = authorize(auth, uris::TASK_PERSONA_DISCLOSURE_PRESENT_1_0, Some(&ctx)) {
+    if let Err(e) = authorize(
+        state,
+        auth,
+        uris::TASK_PERSONA_DISCLOSURE_PRESENT_1_0,
+        Some(&ctx),
+    )
+    .await
+    {
         return reject(&doc, e);
     }
 
@@ -1843,7 +1971,7 @@ mod tests {
             if *reach != Reach::Holder {
                 continue;
             }
-            let err = authorize(&scoped_admin, uri, Some("ctx-work")).unwrap_err();
+            let err = decide(&scoped_admin, uri, Some("ctx-work"), false).unwrap_err();
             assert!(
                 matches!(err, AppError::Forbidden(_)),
                 "{uri} admitted an admin scoped to one context — an admin in ctx-work must be \
@@ -1857,13 +1985,73 @@ mod tests {
         let holder = claims(Role::Admin, &[]);
         for (uri, reach) in REACH {
             if *reach == Reach::Holder {
-                authorize(&holder, uri, None).unwrap_or_else(|e| {
+                decide(&holder, uri, None, false).unwrap_or_else(|e| {
                     panic!("{uri} refused an unscoped holder: {e:?}");
                 });
             }
         }
     }
 
+    /// The capability's whole reason to exist: a context-scoped admin reaches
+    /// the pool **only** where holder authority was granted by name.
+    ///
+    /// Before it there was one way in — an admin with unrestricted scope — so
+    /// managing your own identity from a client meant handing that client every
+    /// context on the agent.
+    #[test]
+    fn a_granted_scoped_admin_reaches_the_pool() {
+        let scoped_admin = claims(Role::Admin, &["ctx-work"]);
+        for (uri, reach) in REACH {
+            if *reach != Reach::Holder {
+                continue;
+            }
+            assert!(
+                decide(&scoped_admin, uri, Some("ctx-work"), false).is_err(),
+                "{uri} admitted a scoped admin who was granted nothing"
+            );
+            decide(&scoped_admin, uri, Some("ctx-work"), true)
+                .unwrap_or_else(|e| panic!("{uri} refused a granted holder: {e:?}"));
+        }
+    }
+
+    /// The grant is not a role promotion. It opens the holder-scoped tasks and
+    /// changes nothing else — a reader granted it is still a reader everywhere
+    /// a role is what decides.
+    #[test]
+    fn the_grant_does_not_widen_a_context_task() {
+        let app = claims(Role::Application, &["ctx-a"]);
+        assert!(
+            decide(
+                &app,
+                uris::TASK_PERSONA_BINDING_GET_1_0,
+                Some("ctx-b"),
+                true
+            )
+            .is_err(),
+            "holder authority must not carry a caller into a context it has no claim to"
+        );
+    }
+
+    /// An unknown task is refused whatever the caller holds. A grant is not a
+    /// reason to guess at a reach.
+    #[test]
+    fn a_granted_holder_is_still_refused_an_unclassified_task() {
+        let holder = claims(Role::Admin, &["ctx-work"]);
+        // Built rather than written: the produced-URI census sweeps this file's
+        // source text, and a literal that looks like a spec URI is reported as
+        // a task shipped without a schema. The neighbouring unknown-task test
+        // does the same.
+        let unknown = format!("https://trusttasks.org/spec/persona/{}/9.9", "not-a-task");
+        assert!(decide(&holder, &unknown, None, true).is_err());
+    }
+
+    /// No role reaches the pool by being itself — not even one whose empty
+    /// context list looks like an unrestricted admin's.
+    ///
+    /// "Refused" here means *ungranted*. Holder authority is granted by name
+    /// and is deliberately not tied to a role: a personal agent running as
+    /// `application` can be given it, by a super admin, on purpose. What this
+    /// pins is that none of them arrive holding it.
     #[test]
     fn every_non_admin_role_is_refused_the_pool() {
         // An empty context list means *unrestricted* for Admin and *nothing at
@@ -1877,7 +2065,7 @@ mod tests {
         ] {
             let label = format!("{role:?}");
             let c = claims(role, &[]);
-            let err = authorize(&c, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None).unwrap_err();
+            let err = decide(&c, uris::TASK_PERSONA_ATTRIBUTE_LIST_1_0, None, false).unwrap_err();
             assert!(
                 matches!(err, AppError::Forbidden(_)),
                 "{label} reached the pool"
@@ -1888,9 +2076,21 @@ mod tests {
     #[test]
     fn a_context_task_is_confined_to_its_own_context() {
         let app = claims(Role::Application, &["ctx-a"]);
-        authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-a")).expect("own context");
+        decide(
+            &app,
+            uris::TASK_PERSONA_BINDING_GET_1_0,
+            Some("ctx-a"),
+            false,
+        )
+        .expect("own context");
         assert!(
-            authorize(&app, uris::TASK_PERSONA_BINDING_GET_1_0, Some("ctx-b")).is_err(),
+            decide(
+                &app,
+                uris::TASK_PERSONA_BINDING_GET_1_0,
+                Some("ctx-b"),
+                false
+            )
+            .is_err(),
             "a caller scoped to ctx-a must not learn about ctx-b"
         );
     }
@@ -1905,7 +2105,7 @@ mod tests {
         // takes the `format!` shape the census already documents as "not a URI
         // that goes on a wire", rather than being allowlisted as produced.
         let unknown = format!("https://trusttasks.org/spec/persona/{}/9.9", "made-up");
-        let err = authorize(&app, &unknown, Some("ctx")).unwrap_err();
+        let err = decide(&app, &unknown, Some("ctx"), false).unwrap_err();
         assert!(matches!(err, AppError::Forbidden(_)));
     }
 

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -187,6 +187,45 @@ pub enum Capability {
     /// powers. An agent that indexes a room — walking the listing and building
     /// a searchable view — should not thereby be able to read it.
     RoomOpen,
+    /// Acting for the **holder** over their own identity: the ten holder-scoped
+    /// `persona/*` tasks — the attribute pool, the profiles built over it,
+    /// correlation analysis, and cross-context disclosure history.
+    ///
+    /// # The one capability no role implies
+    ///
+    /// Every other member of this enum is a subset of what some role already
+    /// carries, and an entry's list can only narrow that. This one is additive
+    /// (see [`ADDITIVE_CAPABILITIES`]): no role derives it, so it is held only
+    /// where an operator granted it by name.
+    ///
+    /// It has to work that way, because what it gates is not *within* what a
+    /// role allows. The pool sits above every trust context, and until now the
+    /// only credential that could reach it was an admin with unrestricted scope
+    /// — which is to say, to manage your own identity from a client you had to
+    /// give that client authority over every context on the agent. Deriving it
+    /// from [`Role::Admin`] instead would have handed the pool to every
+    /// context-scoped administrator that already exists, silently, on upgrade:
+    /// the exact boundary breach the persona gate was written to prevent.
+    ///
+    /// Granting it is super-admin-only — see `validate_persona_holder_grant` on
+    /// the ACL create/update paths. An administrator scoped to one context
+    /// cannot mint holder authority, for themselves or for anyone else.
+    PersonaHolder,
+}
+
+/// Capabilities that no role derives, and that an entry therefore holds only
+/// where one was granted by name.
+///
+/// Deliberately tiny and deliberately a `const`: every member is an exception to
+/// "a role is an upper bound on its entries", so each has to be argued for
+/// individually and be visible in one place to a reviewer asking what can exceed
+/// a role.
+pub const ADDITIVE_CAPABILITIES: &[Capability] = &[Capability::PersonaHolder];
+
+/// Whether `cap` is granted on its own rather than derived from a role.
+#[must_use]
+pub fn is_additive(cap: Capability) -> bool {
+    ADDITIVE_CAPABILITIES.contains(&cap)
 }
 
 /// Returns true if `role` is granted `cap` by the default capability mapping.
@@ -198,13 +237,14 @@ pub fn role_has_capability(role: &Role, cap: Capability) -> bool {
     derived_capabilities_for_role(role).contains(&cap)
 }
 
-/// What an entry may actually do: its own set, bounded by its role's.
+/// What an entry may actually do: its own set, bounded by its role's, plus any
+/// additive capability granted to it by name.
 ///
-/// **An explicit set only ever narrows.** Empty means "whatever the role
-/// implies" — the shape every entry written before this had — and a non-empty
-/// one is intersected with the role's, never unioned. So `role` stays a true
-/// upper bound: an operator reading `role: reader` knows the entry holds no more
-/// than a reader, whatever else its capability list says, and a capability
+/// **A role-derived capability only ever narrows.** Empty means "whatever the
+/// role implies" — the shape every entry written before this had — and a
+/// non-empty one is intersected with the role's, never unioned. So `role` stays
+/// a true upper bound *for everything a role carries*: an operator reading
+/// `role: reader` knows the entry holds no more than a reader, and a capability
 /// removed from a role's derived set is removed from every entry at once rather
 /// than surviving in the rows that happened to name it.
 ///
@@ -213,15 +253,42 @@ pub fn role_has_capability(role: &Role, cap: Capability) -> bool {
 /// else") at the price of making the role no longer describe the entry, which is
 /// the property the ACL's own display, audit trail and role-assignment checks
 /// all lean on.
+///
+/// # The additive members, and why they do not break that
+///
+/// [`ADDITIVE_CAPABILITIES`] are held only where they were granted by name, and
+/// **no role derives any of them**. So they cannot be narrowed into existence,
+/// and no upgrade can quietly confer one on an entry that never named it: an
+/// entry with an empty list still resolves to exactly its role's set, which is
+/// what every row written before this field existed means.
+///
+/// The narrowing is computed from the **non-additive** members alone. Without
+/// that, granting an entry holder authority and nothing else — a list of one
+/// additive name — would intersect its role's set with a list containing none
+/// of them and silently strip every capability it had. A grant that removes
+/// unrelated authority is not a grant anybody asked for.
 pub fn effective_capabilities(role: &Role, explicit: &[Capability]) -> Vec<Capability> {
     let derived = derived_capabilities_for_role(role);
-    if explicit.is_empty() {
-        return derived;
-    }
-    derived
-        .into_iter()
-        .filter(|c| explicit.contains(c))
-        .collect()
+
+    // Only the role-derived names narrow. An empty narrowing keeps the whole
+    // role, exactly as before.
+    let narrowing: Vec<Capability> = explicit
+        .iter()
+        .copied()
+        .filter(|c| !is_additive(*c))
+        .collect();
+    let mut effective: Vec<Capability> = if narrowing.is_empty() {
+        derived
+    } else {
+        derived
+            .into_iter()
+            .filter(|c| narrowing.contains(c))
+            .collect()
+    };
+
+    // Then the additive grants, which no role could have contributed.
+    effective.extend(explicit.iter().copied().filter(|c| is_additive(*c)));
+    effective
 }
 
 /// Whether `entry` may exercise `cap`, honouring both its role and its own
@@ -230,17 +297,24 @@ pub fn entry_has_capability(entry: &AclEntry, cap: Capability) -> bool {
     effective_capabilities(&entry.role, &entry.capabilities).contains(&cap)
 }
 
-/// Capabilities named in `requested` that `role` does not carry.
+/// Capabilities named in `requested` that `role` does not carry **and** that no
+/// role could carry on its own behalf.
 ///
 /// A grant path calls this to refuse loudly rather than silently dropping what
 /// it cannot honour. Silently intersecting at write time would store a set the
 /// operator did not ask for and report success; the operator would then read the
 /// entry back and find a capability they granted simply absent.
+///
+/// [`ADDITIVE_CAPABILITIES`] are excluded: they are *never* in a role's derived
+/// set, so measuring them against one would refuse every grant of them. What
+/// stands in for the role check there is a privilege check on the granter —
+/// `validate_persona_holder_grant` — because the question for an additive
+/// capability is not "does this role carry it" but "may this caller confer it".
 pub fn capabilities_beyond_role(role: &Role, requested: &[Capability]) -> Vec<Capability> {
     let derived = derived_capabilities_for_role(role);
     requested
         .iter()
-        .filter(|c| !derived.contains(c))
+        .filter(|c| !is_additive(**c) && !derived.contains(c))
         .copied()
         .collect()
 }
@@ -488,6 +562,38 @@ pub fn key_scope_for(allowed_keys: Option<&BTreeSet<String>>) -> KeyScope {
 /// cross-context authorizer, so only a super-admin may confer it; a scoped
 /// `Contexts` grant requires the caller to administer every listed context.
 /// `None` is always allowed.
+/// Refuse an attempt to confer an additive capability by a caller who may not.
+///
+/// [`Capability::PersonaHolder`] is super-admin-only to grant, and that check is
+/// the whole of what stands between the boundary and a context-scoped
+/// administrator. Without it the escalation is one command long: an admin of one
+/// context creates an ACL entry — for a DID they control, or for their own —
+/// naming `persona-holder`, and reads the holder's entire cross-context identity
+/// through a credential that was never supposed to reach above its context.
+///
+/// [`capabilities_beyond_role`] cannot catch this. Additive capabilities are
+/// excluded there by construction, because no role carries them; the question
+/// for one is not "does this role have it" but "may this caller confer it", and
+/// this is where that is answered.
+pub fn validate_additive_capability_grant(
+    caller: &AuthClaims,
+    requested: &[Capability],
+) -> Result<(), AppError> {
+    let additive: Vec<Capability> = requested
+        .iter()
+        .copied()
+        .filter(|c| is_additive(*c))
+        .collect();
+    if additive.is_empty() || caller.is_super_admin() {
+        return Ok(());
+    }
+    Err(AppError::Forbidden(format!(
+        "only an unscoped holder credential can grant {additive:?}: it confers authority over \
+         the holder's own identity, which sits above every trust context, and an administrator \
+         scoped to one context cannot confer what it does not itself hold"
+    )))
+}
+
 pub fn validate_approve_scope_grant(
     caller: &AuthClaims,
     scope: &ApproveScope,
@@ -1465,6 +1571,100 @@ mod tests {
         assert!(
             !entry_has_capability(&entry, Capability::MemoryWrite),
             "narrowed, what the entry did not name is gone even though the role has it"
+        );
+    }
+
+    // ── Additive capabilities ───────────────────────────────────────
+
+    /// The invariant that keeps additive capabilities from being an upgrade
+    /// hazard: **no role derives one**.
+    ///
+    /// If one ever appeared in a role's set, every existing entry with that
+    /// role and an empty capability list would gain it silently — for
+    /// `PersonaHolder`, that is every context-scoped administrator on the agent
+    /// waking up with access to the holder's attribute pool.
+    #[test]
+    fn no_role_derives_an_additive_capability() {
+        for role in [
+            Role::Admin,
+            Role::Initiator,
+            Role::Application,
+            Role::Reader,
+        ] {
+            for cap in ADDITIVE_CAPABILITIES {
+                assert!(
+                    !derived_capabilities_for_role(&role).contains(cap),
+                    "{role:?} must not derive {cap:?} — see ADDITIVE_CAPABILITIES"
+                );
+            }
+        }
+    }
+
+    /// An entry that names nothing still holds exactly its role, additive
+    /// capabilities included-by-nobody. The pre-existing rows keep meaning what
+    /// they meant.
+    #[test]
+    fn an_un_narrowed_entry_gains_no_additive_capability() {
+        let held = effective_capabilities(&Role::Admin, &[]);
+        assert!(!held.contains(&Capability::PersonaHolder));
+    }
+
+    /// Granted by name, it is held — even though the role does not carry it.
+    /// This is the whole point: holder authority is not a subset of what an
+    /// administrator of a context may do.
+    #[test]
+    fn an_additive_capability_is_held_where_it_was_granted() {
+        let held = effective_capabilities(&Role::Admin, &[Capability::PersonaHolder]);
+        assert!(held.contains(&Capability::PersonaHolder));
+    }
+
+    /// Granting *only* an additive capability must not strip the role.
+    ///
+    /// The trap this closes: the narrowing is an intersection, so a list of one
+    /// additive name — which no role contains — would intersect the role's set
+    /// down to nothing. An operator granting an agent holder authority would
+    /// have silently revoked its vault access in the same command.
+    #[test]
+    fn granting_only_an_additive_capability_narrows_nothing() {
+        let held = effective_capabilities(&Role::Admin, &[Capability::PersonaHolder]);
+        for derived in derived_capabilities_for_role(&Role::Admin) {
+            assert!(
+                held.contains(&derived),
+                "{derived:?} was stripped by a grant that named only an additive capability"
+            );
+        }
+    }
+
+    /// The two kinds compose: role-derived names still narrow, and the additive
+    /// one rides alongside whatever survived.
+    #[test]
+    fn an_additive_grant_and_a_narrowing_compose() {
+        let held = effective_capabilities(
+            &Role::Admin,
+            &[Capability::VaultRead, Capability::PersonaHolder],
+        );
+        assert!(held.contains(&Capability::VaultRead));
+        assert!(held.contains(&Capability::PersonaHolder));
+        assert!(
+            !held.contains(&Capability::Sign),
+            "the narrowing still applies to what the role carries: {held:?}"
+        );
+    }
+
+    /// The grant path must not refuse an additive capability for not being in
+    /// the role — it never will be. What guards it instead is a privilege check
+    /// on the *granter*, on the ACL create/update paths.
+    #[test]
+    fn an_additive_capability_is_not_beyond_the_role() {
+        assert!(
+            capabilities_beyond_role(&Role::Admin, &[Capability::PersonaHolder]).is_empty(),
+            "measuring an additive capability against a role would refuse every grant of it"
+        );
+        // And it stays refused where it should be: a name no role carries and
+        // that is not additive is still beyond.
+        assert_eq!(
+            capabilities_beyond_role(&Role::Reader, &[Capability::Sign]),
+            vec![Capability::Sign]
         );
     }
 


### PR DESCRIPTION
## The sentence this removes

> To manage your own identity from a client, you must give that client authority
> over every context on the agent.

The ten holder-scoped `persona/*` tasks — the attribute pool, the profiles over
it, correlation, cross-context disclosure history — were reachable only by an
`Admin` with unrestricted scope. Correct as a boundary; wrong as an
authorization model.

**OpenVTC is the case that found it.** Its setup provisions a context-scoped
admin (`contexts create --admin-did` → `allowed_contexts: ["openvtc"]`), so the
identity pane shipped in openvtc#277 has its Attributes, Profiles and
Disclosures tabs refused on every install — by a gate it cannot satisfy without
becoming a super admin. Bindings (context-scoped) work today; nothing above them
does.

## `Capability::PersonaHolder` — the first additive capability

No role derives it. An entry holds it only where it was granted by name.

Every other member of `Capability` is a subset of what some role carries, and
`effective_capabilities` intersects, never unions — a property the ACL's display,
audit trail and role checks all lean on. Holder authority cannot be expressed
that way, because it is not *within* what a context-scoped admin may do. The two
alternatives were:

- derive it from `Admin` — which hands the pool to **every context-scoped
  administrator that already exists**, silently, on upgrade. That is the exact
  breach the persona gate was written to prevent; or
- let it stand outside a role, which is what this does.

`ADDITIVE_CAPABILITIES` is a `const` list so each future exception has to be
argued for in one place a reviewer can find.

### Two consequences worth reviewing closely

- **The narrowing is computed from the non-additive names alone.** Otherwise
  granting an entry holder authority and nothing else — a list of one name no
  role contains — intersects its role's set down to empty. An operator granting
  a capability would have silently revoked the entry's vault access in the same
  command. Pinned by `granting_only_an_additive_capability_narrows_nothing`.
- **`capabilities_beyond_role` cannot gate it**, because no role carries it, so
  the gate is a privilege check on the *granter*:
  `validate_additive_capability_grant` refuses anyone who is not an unscoped
  holder, on **both** create and update. Without it the escalation is one command
  long — an admin of one context grants a DID it controls `persona-holder`, and
  reads the holder's entire cross-context identity. Pinned by
  `a_scoped_admin_cannot_grant_holder_authority{,_by_update}`.

## At the gate

`persona::authorize` satisfies `Reach::Holder` two ways and only two: an unscoped
holder credential, or an entry granted the capability.

- The ACL read happens **only where it can change the answer** — a holder task,
  for a caller not already unscoped — so context tasks and the super-admin path
  cost what they did.
- The decision is split into a pure `decide(claims, uri, ctx, holder_granted)`,
  so the reach matrix stays testable without standing up a store. The reach table
  is the thing most likely to be got wrong, and a test needing an `AppState` is a
  test nobody extends when they add a task.
- The grant is read **per call, not from the token**: a grant in a JWT outlives
  its revocation for that token's life. (The narrowing gate reads per call for the
  mirror-image reason.) A store error is answered "no" and logged — an unreadable
  ACL must not become permission.

## Granting it

```
pnm contexts create --id openvtc --admin-did <did> --admin-holder   # a client that is the holder's own
pnm acl update --did <did> --capabilities persona-holder            # an existing entry
```

Being additive, naming it alone *adds* authority rather than narrowing the entry
to nothing — the CLI help for both flags now says so, since "every name must be
one the role already carries" is no longer the whole truth.

## Deliberately not done here

- **No role gate on holding it.** A personal agent running as `application` can
  be given holder authority, by a super admin, on purpose — that is the Cierge
  shape. What is gated is who may *confer* it.
- **No `Role::Holder`.** A new role means auditing every `match claims.role` in
  the workspace for a concept that is orthogonal to role, not a point on it.

## Follow-up

openvtc's setup flow needs to emit `--admin-holder` in the `pnm` command it shows
the operator, and its pane should name the grant when it meets the refusal.
That's a separate PR in that repo.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new(); no new outbound clients (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1)
- [x] Every retry bounded + backed off (R1.4) — no retries added
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes after durable handoff (R1.6) — n/a
- [x] New/changed wire types (R3.*) — `Capability` gains a kebab-case variant;
      the enum is already #[non_exhaustive], so downstream matches are unaffected
- [x] Config absence = most restrictive (R5.*) — no entry ⇒ no grant; store
      error ⇒ refuse; no role derives the capability
- [x] Logs/status claim only what was verified (R6.*) — the refusal now names
      both ways to satisfy the gate
- [x] "Process dies on the next line" answered (R2.1) — grant is one ACL write,
      already atomic
- [x] Deviations flagged — the "capabilities only narrow" invariant is now
      "role-derived capabilities only narrow"; stated at effective_capabilities,
      bounded by a const list, and pinned by no_role_derives_an_additive_capability
```

`cargo test -p vta-service --lib` 1040 pass, `-p vti-common` 419 pass, clippy
`--workspace --all-targets` clean.
