### PR TITLE
fix(admin-ui): regenerate the API document that #1282 moved

### DIFF
--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -7347,7 +7347,7 @@
       },
       "PolicyPurpose": {
         "type": "string",
-        "description": "What a policy decides. The keyspace `active_policies:<purpose>`\nhas at most one row per variant; the active pointer is a\nper-purpose singleton.\n\nWire shape is `camelCase` ASCII (`join`, `removal`,\n`crossCommunityRoles`) — operators wire purposes into REST\npayloads + the policies CLI verbs.\n\nPer spec §7.1, the workspace ships nine purposes. They split\ninto three groups:\n- **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],\n  [`Self::Personhood`].\n- **Discoverability**: [`Self::Registry`], [`Self::Directory`].\n- **Authorization**: [`Self::RoleDefinitions`],\n  [`Self::CrossCommunityRoles`],\n  [`Self::CrossCommunityRelationships`], [`Self::Relationships`].",
+        "description": "What a policy decides. The keyspace `active_policies:<purpose>`\nhas at most one row per variant; the active pointer is a\nper-purpose singleton.\n\nWire shape is `camelCase` ASCII (`join`, `removal`,\n`crossCommunityRoles`) — operators wire purposes into REST\npayloads + the policies CLI verbs.\n\nPer spec §7.1, the workspace ships ten purposes. They split\ninto four groups:\n- **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],\n  [`Self::Personhood`].\n- **Discoverability**: [`Self::Registry`], [`Self::Directory`].\n- **Authorization**: [`Self::RoleDefinitions`],\n  [`Self::CrossCommunityRoles`],\n  [`Self::CrossCommunityRelationships`], [`Self::Relationships`].\n- **Hosting**: [`Self::Rooms`].",
         "enum": [
           "join",
           "removal",
@@ -7358,7 +7358,8 @@
           "crossCommunityRoles",
           "crossCommunityRelationships",
           "relationships",
-          "roleChange"
+          "roleChange",
+          "rooms"
         ]
       },
       "PolicyStatusFilter": {

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -3615,17 +3615,18 @@ export interface components {
          *     `crossCommunityRoles`) — operators wire purposes into REST
          *     payloads + the policies CLI verbs.
          *
-         *     Per spec §7.1, the workspace ships nine purposes. They split
-         *     into three groups:
+         *     Per spec §7.1, the workspace ships ten purposes. They split
+         *     into four groups:
          *     - **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],
          *       [`Self::Personhood`].
          *     - **Discoverability**: [`Self::Registry`], [`Self::Directory`].
          *     - **Authorization**: [`Self::RoleDefinitions`],
          *       [`Self::CrossCommunityRoles`],
          *       [`Self::CrossCommunityRelationships`], [`Self::Relationships`].
+         *     - **Hosting**: [`Self::Rooms`].
          * @enum {string}
          */
-        PolicyPurpose: "join" | "removal" | "personhood" | "registry" | "directory" | "roleDefinitions" | "crossCommunityRoles" | "crossCommunityRelationships" | "relationships" | "roleChange";
+        PolicyPurpose: "join" | "removal" | "personhood" | "registry" | "directory" | "roleDefinitions" | "crossCommunityRoles" | "crossCommunityRelationships" | "relationships" | "roleChange" | "rooms";
         /** @enum {string} */
         PolicyStatusFilter: "active" | "archived";
         /**


### PR DESCRIPTION
`main` is red, and every PR against it inherits the failure.

#1282 added `PolicyPurpose::Rooms` without regenerating
`vtc-service/admin-ui/openapi.json` or the `wire.ts` generated from it, so
`the_checked_in_openapi_document_matches_this_build` fails on `main` itself
(confirmed by checking out `origin/main` clean and running it).

This is the regeneration and nothing else:

```
UPDATE_OPENAPI=1 cargo test -p vtc-service --test openapi_snapshot
cd vtc-service/admin-ui && npm run wire:generate
```

Both generated files are committed, as the test's own message asks. The console
was typed against an API the daemon no longer serves — the condition this test
exists to catch, and one that stays silent otherwise, since the generated types
typecheck against themselves either way.

Found while getting #1286 green.