### PR TITLE
fix(vtc): regenerate the API document #1282 changed

### DIFF
--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -7347,7 +7347,7 @@
       },
       "PolicyPurpose": {
         "type": "string",
-        "description": "What a policy decides. The keyspace `active_policies:<purpose>`\nhas at most one row per variant; the active pointer is a\nper-purpose singleton.\n\nWire shape is `camelCase` ASCII (`join`, `removal`,\n`crossCommunityRoles`) — operators wire purposes into REST\npayloads + the policies CLI verbs.\n\nPer spec §7.1, the workspace ships nine purposes. They split\ninto three groups:\n- **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],\n  [`Self::Personhood`].\n- **Discoverability**: [`Self::Registry`], [`Self::Directory`].\n- **Authorization**: [`Self::RoleDefinitions`],\n  [`Self::CrossCommunityRoles`],\n  [`Self::CrossCommunityRelationships`], [`Self::Relationships`].",
+        "description": "What a policy decides. The keyspace `active_policies:<purpose>`\nhas at most one row per variant; the active pointer is a\nper-purpose singleton.\n\nWire shape is `camelCase` ASCII (`join`, `removal`,\n`crossCommunityRoles`) — operators wire purposes into REST\npayloads + the policies CLI verbs.\n\nPer spec §7.1, the workspace ships ten purposes. They split\ninto four groups:\n- **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],\n  [`Self::Personhood`].\n- **Discoverability**: [`Self::Registry`], [`Self::Directory`].\n- **Authorization**: [`Self::RoleDefinitions`],\n  [`Self::CrossCommunityRoles`],\n  [`Self::CrossCommunityRelationships`], [`Self::Relationships`].\n- **Hosting**: [`Self::Rooms`].",
         "enum": [
           "join",
           "removal",
@@ -7358,7 +7358,8 @@
           "crossCommunityRoles",
           "crossCommunityRelationships",
           "relationships",
-          "roleChange"
+          "roleChange",
+          "rooms"
         ]
       },
       "PolicyStatusFilter": {

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -3615,17 +3615,18 @@ export interface components {
          *     `crossCommunityRoles`) — operators wire purposes into REST
          *     payloads + the policies CLI verbs.
          *
-         *     Per spec §7.1, the workspace ships nine purposes. They split
-         *     into three groups:
+         *     Per spec §7.1, the workspace ships ten purposes. They split
+         *     into four groups:
          *     - **Membership lifecycle**: [`Self::Join`], [`Self::Removal`],
          *       [`Self::Personhood`].
          *     - **Discoverability**: [`Self::Registry`], [`Self::Directory`].
          *     - **Authorization**: [`Self::RoleDefinitions`],
          *       [`Self::CrossCommunityRoles`],
          *       [`Self::CrossCommunityRelationships`], [`Self::Relationships`].
+         *     - **Hosting**: [`Self::Rooms`].
          * @enum {string}
          */
-        PolicyPurpose: "join" | "removal" | "personhood" | "registry" | "directory" | "roleDefinitions" | "crossCommunityRoles" | "crossCommunityRelationships" | "relationships" | "roleChange";
+        PolicyPurpose: "join" | "removal" | "personhood" | "registry" | "directory" | "roleDefinitions" | "crossCommunityRoles" | "crossCommunityRelationships" | "relationships" | "roleChange" | "rooms";
         /** @enum {string} */
         PolicyStatusFilter: "active" | "archived";
         /**


### PR DESCRIPTION
`main` has been failing `Test (VTC)` since #1282: `PolicyPurpose` gained a `rooms` variant there and the checked-in `admin-ui/openapi.json` was not regenerated with it. **#1285 inherited that red rather than causing it** — its own suites are green.

My oversight in #1282, and the guard is doing exactly its job. `openapi.json` generates `admin-ui/src/lib/wire.ts`, so a stale document types the console against an API the daemon no longer has — and nothing else would say so, because the generated types typecheck against themselves either way. That is the gap #1188 added these gates to close.

Both regenerated and both committed, per the guard's own instructions:

```bash
UPDATE_OPENAPI=1 cargo test -p vtc-service --test openapi_snapshot
cd vtc-service/admin-ui && npm run wire:generate
```

The diff is exactly the new variant plus its doc comment, in both files. `package-lock.json` is untouched.

### Why it got past me locally

Adding a variant to a type carrying `#[derive(utoipa::ToSchema)]` is an API-document change, and `cargo test -p vtc-service` does not surface it when the **lib** target fails first — which it does locally under `VTC_SKIP_ADMIN_UI_BUILD=1`, since that leaves the embedded admin-UI dir empty and four `admin_ui::tests` fail. The run stops before reaching the integration targets, and `openapi_snapshot` is one of those.

So the local signal that would have caught this is `cargo test -p vtc-service --test openapi_snapshot` specifically, or `--no-fail-fast` with the output read past the first failure. Worth knowing for the next enum variant.

Merging this unblocks #1285, which needs no change of its own.
