### PR TITLE
feat(rooms)!: read mirrors — a host that serves a copy and writes nothing

### DIFF
--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -209,9 +209,15 @@
             <span class="mono">attributed</span> for its own members and refuses
             <span class="mono">private</span> until an operator enables it. A standalone room host
             has no policy engine — T1's governance is its owner</td></tr>
-        <tr><td class="hd">Read mirrors, witnessed renewal anchoring</td>
-            <td><span class="no">Not implemented.</span> One write-primary; anchoring is the owner's
-            job and nothing does it yet</td></tr>
+        <tr><td class="hd">Read mirrors</td>
+            <td><span class="yes">Built.</span> <code>room-host --mirror-config</code> serves a
+            read-only copy fed by <span class="mono">sinceVersion</span> pulls and refuses every
+            write, naming the primary. A mirror pulls <em>as a member</em>, on a room-issued
+            <span class="mono">read</span> chain</td></tr>
+        <tr><td class="hd">Witnessed renewal anchoring</td>
+            <td><span class="no">Blocked on a decision</span> — §9 says a renewal anchors the epoch
+            authenticator and version watermark in the room's witnessed log, but not <em>where in
+            the log entry</em></td></tr>
       </tbody>
     </table>
   </div>

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -86,7 +86,7 @@ knowing which half you are standing on saves an afternoon.
 | **A CLI** | **None.** No `pnm rooms …`. Rooms are driven from `vtc-client` (Rust) or by posting signed Trust Task documents |
 | **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
 | **Governance (`rooms.rego`)** | **On a VTC.** A community decides who may create a room on it, in Rego, with the shipped default hosting `open`/`attributed` for its own members. A standalone `room-host` has no policy engine — T1's governance is its owner (§8.4) |
-| **Read mirrors** (T3) | **Not implemented.** One write-primary, and everyone reads from it |
+| **Read mirrors** (T3) | **`room-host --mirror-config`** — a host serves a read-only copy fed by `sinceVersion` pulls and refuses every write, naming the primary. A mirror pulls **as a member**, presenting a room-issued `read` chain |
 | **Witnessed renewal anchoring** | **Blocked on a decision**, not on effort: §9 says a renewal anchors the epoch authenticator and version watermark in the room's witnessed log, but not *where in the log entry*. See [`epoch anchoring`](../05-design-notes/data-rooms-epoch-anchoring.md) |
 
 ---
@@ -485,11 +485,44 @@ room whose members come from three communities needs no bridging and no special
 configuration. Register the room on whichever host is the home, and every
 member's VTA presents to that one.
 
-What is *not* built is the optional half: **read mirrors** — other hosts holding
-ciphertext copies fed by `sinceVersion` pulls. Until they exist, T3 means one
-write-primary that everyone also reads from. Multi-primary replication is a
-non-goal, not a gap: replicated multi-writer room state needs state-resolution
-machinery whose failure modes took Matrix years to shake out.
+**Read mirrors** are the optional half, and they exist. Another `room-host` can
+hold a read-only copy of a room primaried elsewhere:
+
+```jsonc
+// mirrors.json — hardened to owner-only on load, because it holds a key
+{ "rooms": [{
+    "roomId": "did:webvh:room.example",
+    "primaryUrl": "https://primary.example.org",
+    "primaryDid": "did:web:primary.example.org",
+    "membership": "<the VMC the room issued this mirror>",
+    "authority": ["<a chain conferring read>"],
+    "signerDid": "did:key:zMirror",
+    "signerKeyMultibase": "z…"
+}] }
+```
+
+```bash
+room-host --mirror-config mirrors.json --mirror-interval-secs 300
+```
+
+**A mirror pulls as a member.** It presents a room-issued chain conferring
+`read`, exactly as any other reader does — there is no mirror-shaped exemption
+at the primary and no new verb, so the room admits a mirror the way it admits a
+person and can stop admitting it the same way. Two consequences, neither hidden:
+on `attributed`/`private` the mirror only ever holds ciphertext, so mirroring
+gives its operator nothing the primary's operator lacks; on `open` it reads
+cleartext, because everything on that tier is cleartext to whoever holds it.
+
+What a mirror **cannot** do is tamper — records are signed and AEAD-bound to
+`roomId | key | version | epoch`, so an altered or renumbered copy does not
+verify and does not open. Its only failure modes are **stale** and **silent**,
+and both are visible to a client watching the version watermark. Writes are
+refused naming the primary; even `admin` is refused, because a mirror that
+accepted an epoch mint would fork the lifecycle clock its primary owns.
+
+Multi-primary replication remains a non-goal, not a gap: replicated
+multi-writer room state needs state-resolution machinery whose failure modes
+took Matrix years to shake out.
 
 ### 8.4 T4 — peers, and what still governs creation
 

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -19,6 +19,10 @@ vti-rooms = { path = "../vti-rooms", version = "0.1" }
 # The store and AppError. Nothing else internal.
 vti-common = { path = "../vti-common", version = "0.17" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }
+# The room client, for pulling from a write-primary. Host-neutral despite the
+# name: a mirror reads its primary exactly as any member would, because that is
+# the only way to read a room.
+vtc-client = { path = "../vtc-client", version = "0.5" }
 
 axum = { workspace = true }
 tokio = { workspace = true }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -43,6 +43,8 @@
 //! profile — the refusal comes from `vti-rooms-dtg`, which is also what a VTC uses, so the
 //! two cannot disagree about what is safe to serve.
 
+pub mod mirror;
+
 use std::sync::Arc;
 
 use axum::body::Bytes;
@@ -110,6 +112,18 @@ impl HostState {
     /// write records around every authorization check in this file.
     pub fn rooms(&self) -> &KeyspaceHandle {
         &self.rooms
+    }
+
+    /// The record keyspace, for the mirror puller.
+    ///
+    /// Deliberately *not* the general-purpose escape hatch `rooms()` is careful
+    /// not to be: a mirror writes records this host did not authorize, which is
+    /// exactly what a copy is, and `storage::store_mirrored_record` refuses to
+    /// do it on a room this host primaries. An embedder reaching for this to
+    /// write records around the authorization checks would be writing them into
+    /// a room whose version counter disagrees.
+    pub fn records(&self) -> &KeyspaceHandle {
+        &self.records
     }
 
     /// The presenter — proven by the document's own proof, never claimed in its payload.
@@ -310,6 +324,7 @@ async fn create(
         epoch_expires_at: Some(now() + EPOCH_LIFETIME_DAYS_SECS),
         created_at: now(),
         updated_at: now(),
+        mirror_of: None,
     };
     match storage::create_room(&state.rooms, &room).await {
         Ok(()) => respond(
@@ -904,6 +919,170 @@ mod tests {
             "every reply must be a Trust Task document: {doc}"
         );
         (status, doc.get("payload").cloned().unwrap_or(Value::Null))
+    }
+
+    // ── read mirrors, end to end (§7.3) ─────────────────────────────────────
+
+    /// Serve `app` on an ephemeral port and hand back its base URL.
+    ///
+    /// A mirror reaches its primary over HTTP like any other client, so the
+    /// primary in these tests is a real socket rather than a direct call: a
+    /// mirror that only worked in-process would prove nothing about the pull.
+    async fn serve(app: Router) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
+    /// The whole point of a mirror: records written at the primary become
+    /// readable at the copy, under the primary's own version numbers.
+    #[tokio::test]
+    async fn a_mirror_serves_what_its_primary_wrote() {
+        let (_pd, primary_state) = state();
+        let (_md, mirror_state) = state();
+        let f = RoomFixture::new(Visibility::Open).await;
+
+        // The primary: an ordinary room with two records in it.
+        let primary_app = router(primary_state.clone());
+        register(&primary_app, &f).await;
+        for (key, body) in [("decision/one", "first"), ("decision/two", "second")] {
+            let (status, out) = call(
+                &primary_app,
+                ROOMS_RECORDS_PUT_TYPE,
+                serde_json::json!({
+                    "roomId": f.room.room_id,
+                    "key": key,
+                    "presentation": f.as_owner(),
+                    "cleartext": { "body": body },
+                }),
+                &f.owner,
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{out}");
+        }
+        let primary_url = serve(primary_app).await;
+
+        // The mirror: the same room id, registered as a copy of that primary.
+        vti_rooms::storage::create_room(
+            mirror_state.rooms(),
+            &vti_rooms::Room {
+                mirror_of: Some(primary_url.clone()),
+                next_version: 1,
+                ..f.room.clone()
+            },
+        )
+        .await
+        .unwrap();
+
+        let outcome = crate::mirror::pull_once(
+            &mirror_state,
+            &crate::mirror::MirroredRoom {
+                room_id: f.room.room_id.clone(),
+                primary_url,
+                primary_did: Some("did:key:zHost".into()),
+                membership: f.membership.clone(),
+                authority: f.owner_chain.clone(),
+                signer_did: f.owner.did.clone(),
+                signer_key_multibase: f.owner.secret_multibase.clone(),
+            },
+        )
+        .await
+        .expect("the mirror pulls from its primary");
+        assert_eq!(outcome.copied, 2, "both records copied");
+
+        // Readable from the copy, with the primary's numbering intact — which is
+        // what makes a sealed record openable and a watermark comparable.
+        let mirror_app = router(mirror_state.clone());
+        let (status, body) = call(
+            &mirror_app,
+            ROOMS_RECORDS_GET_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "key": "decision/one",
+                "presentation": f.as_owner(),
+            }),
+            &f.owner,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["cleartext"]["body"], "first");
+        assert_eq!(
+            body["version"], 1,
+            "the primary's version, not the mirror's"
+        );
+
+        // A second pull is a no-op: the watermark resumed where the first left off.
+        let again = crate::mirror::pull_once(
+            &mirror_state,
+            &crate::mirror::MirroredRoom {
+                room_id: f.room.room_id.clone(),
+                // Deliberately unreachable: an unreachable primary must leave
+                // the mirror serving what it has rather than losing it.
+                primary_url: "http://127.0.0.1:1".to_string(),
+                primary_did: None,
+                membership: f.membership.clone(),
+                authority: f.owner_chain.clone(),
+                signer_did: f.owner.did.clone(),
+                signer_key_multibase: f.owner.secret_multibase.clone(),
+            },
+        )
+        .await;
+        assert!(again.is_err(), "an unreachable primary is an error");
+        let (status, body) = call(
+            &mirror_app,
+            ROOMS_RECORDS_GET_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "key": "decision/one",
+                "presentation": f.as_owner(),
+            }),
+            &f.owner,
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "still serving the copy it has: {body}"
+        );
+    }
+
+    /// The refusal that makes a mirror a mirror, over the wire — and it names
+    /// the primary, so an operator knows where the write belongs.
+    #[tokio::test]
+    async fn a_mirror_refuses_a_write_and_says_where_it_goes() {
+        let (_d, st) = state();
+        let f = RoomFixture::new(Visibility::Open).await;
+        vti_rooms::storage::create_room(
+            st.rooms(),
+            &vti_rooms::Room {
+                mirror_of: Some("https://primary.example.org".into()),
+                ..f.room.clone()
+            },
+        )
+        .await
+        .unwrap();
+
+        let app = router(st);
+        let (status, body) = call(
+            &app,
+            ROOMS_RECORDS_PUT_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "key": "decision/three",
+                "presentation": f.as_owner(),
+                "cleartext": { "body": "not here" },
+            }),
+            &f.owner,
+        )
+        .await;
+        assert_ne!(status, StatusCode::OK, "a mirror performs no writes");
+        assert!(
+            body.to_string().contains("primary.example.org"),
+            "the refusal must name the primary: {body}"
+        );
     }
 
     /// Register `f`'s room with the host.

--- a/room-host/src/main.rs
+++ b/room-host/src/main.rs
@@ -23,6 +23,21 @@ struct Args {
     /// makes rather than a default they inherit.
     #[arg(long)]
     resolve_dids: bool,
+    /// Rooms this host **mirrors**: a JSON file naming each room's write-primary
+    /// and the read credentials this mirror presents to it.
+    ///
+    /// A mirrored room serves reads from the copy and refuses every write,
+    /// naming its primary. The file holds a private key, so it is hardened to
+    /// owner-only on load.
+    #[arg(long)]
+    mirror_config: Option<std::path::PathBuf>,
+    /// Seconds between mirror pulls.
+    ///
+    /// A mirror is not latency-critical — it serves a copy, and a client that
+    /// needs the newest record reads the primary — so the default is unhurried.
+    /// Shorter intervals cost the primary a listing per room per pass.
+    #[arg(long, default_value_t = 300)]
+    mirror_interval_secs: u64,
 }
 
 #[tokio::main]
@@ -43,6 +58,24 @@ async fn main() -> anyhow::Result<()> {
         vti_common::auth::TrustTaskVmResolver::did_key_only()
     };
     let state = open_state_with_resolver(&args.data_dir, resolver)?;
+
+    // Mirrors start before the listener: a host that is going to serve a copy
+    // should begin catching up before it starts answering reads from it, and a
+    // config that does not parse is a startup failure rather than a warning
+    // discovered later.
+    if let Some(path) = &args.mirror_config {
+        let config = room_host::mirror::MirrorConfig::load(path)?;
+        tracing::info!(
+            rooms = config.rooms.len(),
+            interval_secs = args.mirror_interval_secs,
+            "mirroring rooms from their write-primaries"
+        );
+        tokio::spawn(room_host::mirror::run(
+            state.clone(),
+            config,
+            args.mirror_interval_secs,
+        ));
+    }
 
     let listener = tokio::net::TcpListener::bind(&args.listen).await?;
     tracing::info!(

--- a/room-host/src/mirror.rs
+++ b/room-host/src/mirror.rs
@@ -1,0 +1,317 @@
+//! Pulling a room from its write-primary — §7.3's read mirrors.
+//!
+//! # What a mirror is, and what it is not
+//!
+//! A mirror holds a **read-only copy** of a room primaried somewhere else. It
+//! serves reads from that copy and refuses every write, naming the primary
+//! (`vti_rooms::authz`). It is not a replica in the multi-writer sense: a room
+//! has exactly one write-primary, MLS needs a single sequencer anyway, and
+//! multi-primary replication is a stated non-goal.
+//!
+//! What a mirror **cannot** do is tamper. Records are signed and their AEAD
+//! binds `roomId | key | version | epoch`, so a mirror that altered or
+//! relocated one produces something that does not verify and does not open. The
+//! only failures available to it are being **stale** or being **silent**, and
+//! both are visible to a client watching the version watermark.
+//!
+//! # A mirror pulls as a member, because there is no other way to read
+//!
+//! This is the design decision the note left implicit, and it is worth stating
+//! plainly: **a mirror presents a room-issued chain conferring `read`**, exactly
+//! as any other reader does. There is no mirror-shaped exemption at the primary
+//! and no new verb — the room admits the mirror the same way it admits a person,
+//! and can stop admitting it the same way.
+//!
+//! Two consequences follow, and neither is hidden:
+//!
+//! - On `attributed` / `private` the mirror reads **ciphertext**, which is all
+//!   it needs to store and all it can ever have. Mirroring one of those rooms
+//!   gives the mirror operator nothing the primary's operator does not already
+//!   have.
+//! - On `open` the mirror reads cleartext, because everything on that tier is
+//!   cleartext to whoever holds it. Mirroring an `open` room to a host you would
+//!   not let read it is not a thing this can do, and pretending otherwise would
+//!   be the dishonest option.
+//!
+//! # Credentials come from a file, deliberately
+//!
+//! A mirror is a service, not an agent: nothing mints presentations for it, so
+//! it holds its own room credentials. They are read from an operator-supplied
+//! file rather than a flag, because a credential on a command line is a
+//! credential in the process table and in the shell history.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use vtc_client::VtcClient;
+use vtc_client::rooms::RoomSession;
+use vti_rooms::{Record, storage};
+
+use crate::HostState;
+
+/// One room this host mirrors, and everything needed to keep it current.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MirroredRoom {
+    /// The room's DID — the same identifier the primary knows it by. A mirror
+    /// that renamed what it copied would be a different room.
+    pub room_id: String,
+    /// Base URL of the write-primary.
+    pub primary_url: String,
+    /// The primary's DID, when known. Used to bind this mirror's presentation
+    /// to it, so a captured one is worthless elsewhere.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_did: Option<String>,
+    /// The membership credential the room issued this mirror.
+    pub membership: String,
+    /// Its authority chain, leaf first, conferring `read`.
+    pub authority: Vec<String>,
+    /// The DID this mirror signs its requests as — the party the chain's leaf
+    /// grants to. A mismatch is refused at the primary, correctly and
+    /// confusingly, so the two travel together.
+    pub signer_did: String,
+    /// That DID's private key, multibase.
+    pub signer_key_multibase: String,
+}
+
+/// The file an operator points `--mirror-config` at.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MirrorConfig {
+    #[serde(default)]
+    pub rooms: Vec<MirroredRoom>,
+}
+
+impl MirrorConfig {
+    /// Read the config, hardening it to owner-only first.
+    ///
+    /// It holds a private key and a room's credentials, so it gets the same
+    /// treatment as every other secret this workspace writes to disk. The
+    /// hardening is applied rather than merely asserted: a config an operator
+    /// created with a permissive umask is the common case, and refusing to
+    /// start over it would teach them to `chmod` and move on rather than fixing
+    /// anything. A failure to tighten is *not* fatal — it is logged, because a
+    /// filesystem that cannot express the mode (a mounted volume, a container
+    /// overlay) is not a reason to refuse to mirror.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        if let Err(e) = vti_common::secure_file::restrict_file_to_owner(path) {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "could not restrict the mirror config to its owner; it holds a private key"
+            );
+        }
+        let raw = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&raw)?)
+    }
+}
+
+/// What one pull did, for the log and for the tests.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PullOutcome {
+    /// Records copied.
+    pub copied: usize,
+    /// The watermark this mirror now holds.
+    pub watermark: u64,
+}
+
+/// Pull everything the primary has that this mirror does not.
+///
+/// Resumes from the mirror's own watermark, so a pull is incremental and
+/// interrupting one costs at most the records it had not yet stored. Tombstones
+/// come through like any other record — that is why they exist, and a mirror
+/// that skipped them would resurrect deletions on its next full rebuild.
+///
+/// # Failure is stale, never wrong
+///
+/// Any error leaves the mirror exactly as current as it was: each record is
+/// stored as it arrives, and the watermark only advances past a record already
+/// written. A mirror that cannot reach its primary keeps serving what it has,
+/// which is the failure mode the design allows it — silent or stale, never
+/// forged.
+pub async fn pull_once(state: &HostState, mirror: &MirroredRoom) -> anyhow::Result<PullOutcome> {
+    let room = storage::get_room(state.rooms(), &mirror.room_id).await?;
+    if !room.is_mirror() {
+        anyhow::bail!(
+            "room `{}` is not registered here as a mirror; refusing to pull into a primary",
+            mirror.room_id
+        );
+    }
+
+    let client = VtcClient::anonymous(
+        &mirror.primary_url,
+        mirror.primary_did.as_deref().unwrap_or("did:key:zPrimary"),
+    );
+    let session = RoomSession::new(
+        &mirror.room_id,
+        mirror.membership.clone(),
+        mirror.authority.clone(),
+    )?;
+
+    let since = room.watermark();
+    let listing = client
+        .list_records(
+            &session,
+            None,
+            Some(since),
+            &mirror.signer_did,
+            &mirror.signer_key_multibase,
+        )
+        .await?;
+
+    let mut outcome = PullOutcome {
+        copied: 0,
+        watermark: since,
+    };
+
+    // Ordered by version so an interrupted pull leaves a prefix rather than a
+    // hole: the watermark then resumes from the last record actually stored,
+    // and nothing between it and the primary's head is silently skipped.
+    let mut pending: Vec<serde_json::Value> = listing.records;
+    pending.sort_by_key(|r| {
+        r.get("version")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0)
+    });
+
+    for meta in pending {
+        let Some(key) = meta.get("key").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        // The listing carries metadata only, so the body is a second call. That
+        // is the same shape a member's read takes, and it is why a mirror needs
+        // `read` rather than some listing-only grant.
+        let full = client
+            .get_record(
+                &session,
+                key,
+                &mirror.signer_did,
+                &mirror.signer_key_multibase,
+            )
+            .await?;
+        let record: Record = serde_json::from_value(full)?;
+        let version = record.version;
+
+        match storage::store_mirrored_record(
+            state.rooms(),
+            state.records(),
+            &mirror.room_id,
+            record,
+            now(),
+        )
+        .await
+        {
+            Ok(_) => {
+                outcome.copied += 1;
+                outcome.watermark = version;
+            }
+            // A record the mirror already has is not an error: two pulls can
+            // overlap, and refusing to go backwards is the storage layer doing
+            // its job rather than a fault to abort on.
+            Err(vti_common::error::AppError::Conflict(_)) => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Ok(outcome)
+}
+
+fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Keep every configured mirror current, forever.
+///
+/// One sequential pass per interval rather than a task per room: a mirror is
+/// not latency-critical (it serves a copy, and a client that needs the newest
+/// record reads the primary), and a task per room turns one unreachable primary
+/// into unbounded concurrent retries.
+pub async fn run(state: std::sync::Arc<HostState>, config: MirrorConfig, interval_secs: u64) {
+    let interval = std::time::Duration::from_secs(interval_secs.max(1));
+    loop {
+        for mirror in &config.rooms {
+            match pull_once(&state, mirror).await {
+                Ok(outcome) if outcome.copied > 0 => tracing::info!(
+                    room = %mirror.room_id,
+                    copied = outcome.copied,
+                    watermark = outcome.watermark,
+                    "mirror pulled from primary"
+                ),
+                Ok(_) => tracing::debug!(room = %mirror.room_id, "mirror already current"),
+                // Logged and carried on: an unreachable primary makes this
+                // mirror stale, which is a state the design allows it to be and
+                // a client can detect. Stopping the loop would make every other
+                // mirror stale too.
+                Err(e) => tracing::warn!(
+                    room = %mirror.room_id,
+                    primary = %mirror.primary_url,
+                    error = %e,
+                    "mirror pull failed; serving what we have"
+                ),
+            }
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> MirroredRoom {
+        MirroredRoom {
+            room_id: "did:webvh:room.example".into(),
+            primary_url: "https://primary.example.org".into(),
+            primary_did: Some("did:web:primary.example.org".into()),
+            membership: "vmc".into(),
+            authority: vec!["vac-read".into()],
+            signer_did: "did:key:zMirror".into(),
+            signer_key_multibase: "z6Mk…".into(),
+        }
+    }
+
+    /// The config is operator-authored JSON, so its member names are a contract.
+    #[test]
+    fn the_config_round_trips_under_its_wire_names() {
+        let config = MirrorConfig {
+            rooms: vec![sample()],
+        };
+        let v = serde_json::to_value(&config).unwrap();
+        let room = &v["rooms"][0];
+        assert!(room.get("roomId").is_some(), "{v}");
+        assert!(room.get("primaryUrl").is_some(), "{v}");
+        assert!(room.get("signerKeyMultibase").is_some(), "{v}");
+
+        let back: MirrorConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(back.rooms[0].room_id, sample().room_id);
+    }
+
+    /// A primary's DID is optional, and its absence must not read as an empty
+    /// string — that would bind the presentation to a party named "".
+    #[test]
+    fn an_absent_primary_did_stays_absent() {
+        let json = serde_json::json!({
+            "rooms": [{
+                "roomId": "did:webvh:room.example",
+                "primaryUrl": "https://primary.example.org",
+                "membership": "vmc",
+                "authority": ["vac"],
+                "signerDid": "did:key:zMirror",
+                "signerKeyMultibase": "z6Mk",
+            }]
+        });
+        let config: MirrorConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.rooms[0].primary_did, None);
+    }
+
+    /// An empty config is a valid one: a host with no mirrors is the ordinary
+    /// case, and it must not need the member spelled out.
+    #[test]
+    fn an_empty_config_is_valid() {
+        let config: MirrorConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.rooms.is_empty());
+    }
+}

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -239,6 +239,7 @@ pub(crate) async fn handle_create(state: &AppState, doc: TrustTask<Value>) -> Tr
         epoch_expires_at: Some(now() + EPOCH_LIFETIME_DAYS_SECS),
         created_at: now(),
         updated_at: now(),
+        mirror_of: None,
     };
 
     if let Err(e) = storage::create_room(&state.rooms_ks, &room).await {

--- a/vti-rooms-dtg/src/lib.rs
+++ b/vti-rooms-dtg/src/lib.rs
@@ -396,6 +396,7 @@ mod tests {
             epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
+            mirror_of: None,
         }
     }
 
@@ -648,6 +649,7 @@ mod signed {
                 epoch_expires_at: None,
                 created_at: 0,
                 updated_at: 0,
+                mirror_of: None,
             },
             owner_chain: vec![enc(&owner_vac)],
             owner_did,
@@ -1019,6 +1021,7 @@ pub mod test_support {
                     epoch_expires_at: None,
                     created_at: 0,
                     updated_at: 0,
+                    mirror_of: None,
                 },
                 owner_chain: vec![enc(&owner_vac)],
                 agent_chain: vec![enc(&agent_vac), enc(&owner_vac)],

--- a/vti-rooms-dtg/src/nomination.rs
+++ b/vti-rooms-dtg/src/nomination.rs
@@ -292,6 +292,7 @@ mod tests {
             epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
+            mirror_of: None,
         };
         let verifier = crate::DtgChainVerifier::without_zk(Box::new(DidKeyResolver));
 

--- a/vti-rooms/src/audit.rs
+++ b/vti-rooms/src/audit.rs
@@ -216,6 +216,7 @@ mod tests {
             epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
+            mirror_of: None,
         };
         let presentation = AuthorityPresentation {
             membership: "vmc".into(),

--- a/vti-rooms/src/authz.rs
+++ b/vti-rooms/src/authz.rs
@@ -371,6 +371,27 @@ pub async fn authorize(
     // minting an epoch *is* the renewal, so a gate that refused it would leave a lapsed
     // room lapsed forever. It is checked before verification for the same reason depth is —
     // no point verifying a chain for an operation the room cannot accept.
+    // A **mirror** serves reads and refuses everything else, and says where the
+    // writes go. This is not an authorization decision about the caller — their
+    // chain may confer exactly what they asked for — it is this host declaring
+    // it is not the room's write-primary. Checked before verification for the
+    // same reason as the two above: no point verifying a chain for an operation
+    // this host would not perform however good the chain was.
+    //
+    // `Admin` is *not* exempt here, unlike the lapse gate below. Minting an
+    // epoch is a write to the room's own row, and a mirror that accepted one
+    // would fork the lifecycle clock its primary owns — the room would be live
+    // on the copy and lapsed at home.
+    if let Some(primary) = &room.mirror_of
+        && action != Action::Read
+    {
+        return Err(AppError::Forbidden(format!(
+            "this host holds a read mirror of room `{}`; {} goes to the write-primary at {primary}",
+            room.room_id,
+            action.as_str()
+        )));
+    }
+
     let lifecycle = room.lifecycle(now);
     if !matches!(action, Action::Admin) && !lifecycle.accepts_writes() && action != Action::Read {
         return Err(AppError::Forbidden(format!(
@@ -431,6 +452,7 @@ mod tests {
             epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
+            mirror_of: None,
         }
     }
 
@@ -505,6 +527,75 @@ mod tests {
             )
             .is_err(),
             "a fragment must not make two different DIDs equal"
+        );
+    }
+
+    /// A mirror serves reads and refuses everything else, whatever the chain
+    /// says. This is the host declaring it is not the write-primary, not a
+    /// judgement about the caller — so it holds for a chain conferring the
+    /// action outright.
+    #[tokio::test]
+    async fn a_mirror_serves_reads_and_refuses_every_write() {
+        let mirror = Room {
+            mirror_of: Some("https://primary.example.org".into()),
+            ..room(Visibility::Open)
+        };
+
+        authorize(
+            &mirror,
+            &presentation(1, false),
+            Action::Read,
+            PRESENTER,
+            NOW,
+            &Vouches::for_all(),
+        )
+        .await
+        .expect("a read is what a mirror is for");
+
+        for action in [Action::Write, Action::Curate, Action::Admin] {
+            let err = authorize(
+                &mirror,
+                &presentation(1, false),
+                action,
+                PRESENTER,
+                NOW,
+                &Vouches::for_all(),
+            )
+            .await
+            .expect_err("a mirror performs no writes");
+            // The refusal names where the write goes, per the workspace rule
+            // that an operator error should carry its own fix.
+            assert!(
+                matches!(&err, AppError::Forbidden(m) if m.contains("primary.example.org")),
+                "{action:?}: {err:?}"
+            );
+        }
+    }
+
+    /// `Admin` is exempt from the *lapse* gate — minting an epoch is the
+    /// renewal — but not from the mirror gate. A mirror that accepted an epoch
+    /// mint would fork the lifecycle clock its primary owns: live on the copy,
+    /// lapsed at home.
+    #[tokio::test]
+    async fn a_mirror_refuses_an_epoch_mint_even_though_a_lapsed_primary_would_not() {
+        let lapsed_mirror = Room {
+            mirror_of: Some("https://primary.example.org".into()),
+            epoch_expires_at: Some(NOW - 1),
+            ..room(Visibility::Open)
+        };
+        let err = authorize(
+            &lapsed_mirror,
+            &presentation(1, false),
+            Action::Admin,
+            PRESENTER,
+            NOW,
+            &Vouches::for_all(),
+        )
+        .await
+        .expect_err("renewal happens at the primary");
+        assert!(
+            matches!(&err, AppError::Forbidden(m) if m.contains("read mirror")),
+            "the mirror gate must answer first: {err:?}"
         );
     }
 

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -174,10 +174,45 @@ pub struct Room {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch_expires_at: Option<u64>,
 
+    /// Where this room's write-primary is, when this host holds a **read mirror**
+    /// rather than the room itself.
+    ///
+    /// `None` — the shape every room stored before this field existed
+    /// deserialises to — means this host *is* the primary. `Some(url)` means it
+    /// serves reads from a copy and refuses every write, pointing the caller at
+    /// the primary instead (§7.3).
+    ///
+    /// A room has exactly one write-primary. MLS needs a single sequencer
+    /// anyway, and multi-primary replication is a stated non-goal: replicated
+    /// multi-writer room state needs state-resolution machinery whose failure
+    /// modes took Matrix years to shake out. A mirror cannot tamper — records
+    /// are signed and bound to `roomId | key | version | epoch` — so the only
+    /// things it can be are **stale** or **silent**, and both are detectable by
+    /// a client that watches the version watermark.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mirror_of: Option<String>,
+
     /// Unix-epoch seconds.
     pub created_at: u64,
     /// Unix-epoch seconds; bumped on epoch advance and on record writes.
     pub updated_at: u64,
+}
+
+impl Room {
+    /// Whether this host holds a read mirror of a room primaried elsewhere.
+    pub fn is_mirror(&self) -> bool {
+        self.mirror_of.is_some()
+    }
+
+    /// The highest version this host has, which is the watermark a puller
+    /// resumes from and the floor a client compares against.
+    ///
+    /// `next_version` is the *next* number to assign, so the highest assigned
+    /// is one less — and zero on a room that has never held a record, which is
+    /// why this saturates rather than wrapping.
+    pub fn watermark(&self) -> u64 {
+        self.next_version.saturating_sub(1)
+    }
 }
 
 /// Curation state of a record.

--- a/vti-rooms/src/lifecycle.rs
+++ b/vti-rooms/src/lifecycle.rs
@@ -191,6 +191,7 @@ mod tests {
             epoch_expires_at: expires_at,
             created_at: 0,
             updated_at: 0,
+            mirror_of: None,
         }
     }
 

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -247,6 +247,68 @@ pub async fn put_record(
     Ok(record)
 }
 
+/// Store a record **pulled from a primary**, exactly as the primary assigned it.
+///
+/// The mirror path, and it differs from [`put_record`] in the one way that
+/// matters: the version is the primary's, not this host's. A mirror that
+/// re-numbered what it copied would produce a room whose records disagree with
+/// their own AEAD binding — every sealed record commits to
+/// `roomId | key | version | epoch`, so a renumbered copy does not open — and
+/// whose watermark means something different from the primary's, which is the
+/// number every `sinceVersion` pull and every client's staleness check compares.
+///
+/// # What this deliberately does not check
+///
+/// The visibility/epoch shape checks `put_record` runs are the *primary's* job,
+/// and were run there before the record was ever signed. Re-running them here
+/// would mean a mirror refusing to copy a record its primary accepted — which
+/// is a mirror silently diverging, the one failure mode a copy must not have.
+/// What a mirror can still not do is forge: it holds ciphertext it cannot read
+/// and signatures it cannot produce.
+///
+/// # Refusing to go backwards
+///
+/// A pulled version at or below the mirror's watermark is refused. Records only
+/// ever gain versions, so a lower one means either a replayed pull or a primary
+/// that has rolled back — and quietly accepting it would let a mirror serve a
+/// fresh member an older room than the one it already had (R2‑5).
+pub async fn store_mirrored_record(
+    rooms: &KeyspaceHandle,
+    records: &KeyspaceHandle,
+    room_id: &str,
+    record: Record,
+    now: u64,
+) -> Result<Record, AppError> {
+    let mut room = get_room(rooms, room_id).await?;
+    if !room.is_mirror() {
+        // Writing a "mirrored" record into a room this host is the primary of
+        // would put a version on the row that its own counter did not assign,
+        // and the next local write would then collide with it.
+        return Err(AppError::Validation(format!(
+            "room `{room_id}` is primaried here; a mirrored record has no meaning on a primary"
+        )));
+    }
+    if record.version <= room.watermark() && room.watermark() > 0 {
+        return Err(AppError::Conflict(format!(
+            "record `{}` arrived at version {}, at or below this mirror's watermark {};              a mirror does not go backwards",
+            record.key,
+            record.version,
+            room.watermark()
+        )));
+    }
+
+    // The mirror's watermark tracks the primary's numbering rather than counting
+    // its own writes, so a gap in what it has pulled stays a gap it can see.
+    room.next_version = record.version + 1;
+    room.updated_at = now;
+
+    records
+        .insert(record_key(room_id, &record.key), &record)
+        .await?;
+    rooms.insert(room_key(room_id), &room).await?;
+    Ok(record)
+}
+
 /// Fetch one record.
 pub async fn get_record(
     records: &KeyspaceHandle,
@@ -441,6 +503,7 @@ mod tests {
             epoch_expires_at: None,
             created_at: 0,
             updated_at: 0,
+            mirror_of: None,
         }
     }
 
@@ -917,5 +980,102 @@ mod tests {
             .expect("a real DID");
         assert_eq!(moved.owner_did, "did:key:zBob");
         assert_eq!(moved.updated_at, 99);
+    }
+
+    // ── read mirrors (§7.3) ─────────────────────────────────────────────────
+
+    /// A mirror room, primaried elsewhere.
+    fn mirror(id: &str, visibility: Visibility) -> Room {
+        Room {
+            mirror_of: Some("https://primary.example.org".into()),
+            ..room(id, visibility)
+        }
+    }
+
+    /// The property that makes a copy usable: the primary's numbering survives.
+    /// A mirror that renumbered would break every sealed record's AEAD binding
+    /// and give its watermark a different meaning from the one clients compare.
+    #[tokio::test]
+    async fn a_mirrored_record_keeps_the_primarys_version() {
+        let (_d, rooms, records) = open().await;
+        create_room(&rooms, &mirror("r1", Visibility::Open))
+            .await
+            .unwrap();
+
+        let mut pulled = open_record("k1");
+        pulled.version = 42; // assigned by the primary, not by this host
+        let stored = store_mirrored_record(&rooms, &records, "r1", pulled, 10)
+            .await
+            .expect("a mirror stores what its primary assigned");
+        assert_eq!(stored.version, 42, "the primary's number, verbatim");
+
+        // …and the watermark tracks the primary rather than counting local writes,
+        // so the next pull resumes from the right place.
+        let room = get_room(&rooms, "r1").await.unwrap();
+        assert_eq!(room.watermark(), 42);
+        assert_eq!(room.next_version, 43);
+    }
+
+    /// R2-5: records only gain versions, so a lower one means a replayed pull or
+    /// a rolled-back primary. Accepting it would let the mirror serve a fresh
+    /// member an older room than the one it already had.
+    #[tokio::test]
+    async fn a_mirror_does_not_go_backwards() {
+        let (_d, rooms, records) = open().await;
+        create_room(&rooms, &mirror("r1", Visibility::Open))
+            .await
+            .unwrap();
+
+        let mut first = open_record("k1");
+        first.version = 42;
+        store_mirrored_record(&rooms, &records, "r1", first, 10)
+            .await
+            .unwrap();
+
+        let mut replayed = open_record("k2");
+        replayed.version = 41;
+        let err = store_mirrored_record(&rooms, &records, "r1", replayed, 11)
+            .await
+            .expect_err("a version at or below the watermark is refused");
+        assert!(
+            matches!(err, AppError::Conflict(ref m) if m.contains("backwards")),
+            "got {err:?}"
+        );
+    }
+
+    /// A "mirrored" record on a primary would carry a version its own counter
+    /// never assigned, and the next local write would collide with it.
+    #[tokio::test]
+    async fn a_primary_refuses_a_mirrored_record() {
+        let (_d, rooms, records) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+
+        let mut pulled = open_record("k1");
+        pulled.version = 42;
+        let err = store_mirrored_record(&rooms, &records, "r1", pulled, 10)
+            .await
+            .expect_err("this host is the primary");
+        assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+    }
+
+    /// A mirror copies what its primary accepted, including shapes this host
+    /// would refuse to originate. Re-running the primary's validation here is
+    /// how a copy silently diverges from the room it is copying.
+    #[tokio::test]
+    async fn a_mirror_copies_a_record_sealed_under_another_epoch() {
+        let (_d, rooms, records) = open().await;
+        create_room(&rooms, &mirror("r1", Visibility::Attributed))
+            .await
+            .unwrap();
+
+        // The room row says epoch 1; the record was sealed under 7 at the
+        // primary. `put_record` would refuse this. A mirror must not.
+        let mut pulled = sealed_record("k1", 7);
+        pulled.version = 3;
+        store_mirrored_record(&rooms, &records, "r1", pulled, 10)
+            .await
+            .expect("a mirror stores what the primary sealed");
     }
 }


### PR DESCRIPTION
§7.3's optional half, and the last of the data-room gaps that was buildable. A room has one write-primary; another host can now hold a read-only copy of it, fed by `sinceVersion` pulls, serving reads and refusing every write.

### The decision the design left implicit

It says mirrors are "fed by `sinceVersion` pulls" without saying *by whom* — and reads are authorized. So this makes a call, and states it rather than burying it: **a mirror pulls as a member**, presenting a room-issued chain conferring `read`, exactly as any other reader does. No mirror-shaped exemption at the primary, no new verb. The room admits a mirror the way it admits a person, and can stop admitting it the same way.

Two consequences, both in the module docs and the guide:

- On `attributed` / `private` a mirror only ever holds **ciphertext** — mirroring gives its operator nothing the primary's operator lacks.
- On `open` it reads **cleartext**, because everything on that tier is cleartext to whoever holds it. Mirroring an `open` room to a host you would not let read it is not a thing this can do, and pretending otherwise would be the dishonest option.

Worth a look in review — if a mirror should instead hold something narrower than a member's `read`, that needs a new grant upstream.

### What a mirror cannot do

Tamper. Records are signed and AEAD-bound to `roomId | key | version | epoch`, so an altered or renumbered copy does not verify and does not open. Its only failure modes are **stale** and **silent**, and a client watching the version watermark sees both.

That shapes `store_mirrored_record`:

| | |
|---|---|
| Keeps the **primary's version** verbatim | Renumbering breaks the AEAD binding *and* gives the watermark a different meaning from the one every `sinceVersion` pull compares |
| Refuses a version **at or below** the mirror's watermark | Records only gain versions, so a lower one is a replayed pull or a rolled-back primary; accepting it would serve a fresh member an older room than the copy already had (R2‑5) |
| **Skips** the primary's visibility/epoch validation | Deliberately. Re-running it would mean a mirror refusing to copy a record its primary accepted — a copy silently diverging, the one failure mode a mirror must not have |

### The write refusal covers `admin`

`authz` refuses every non-read action on a mirror and names the primary. `Admin` is **not** exempt here, unlike the lapse gate: a mirror that accepted an epoch mint would fork the lifecycle clock its primary owns — live on the copy, lapsed at home.

### Operating one

```bash
room-host --mirror-config mirrors.json --mirror-interval-secs 300
```

The config holds a private key and the room's credentials, so it is hardened to owner-only on load and read from a file rather than a flag — a credential on a command line is a credential in the process table. One sequential pass per interval rather than a task per room: a mirror is not latency-critical, and a task per room turns one unreachable primary into unbounded concurrent retries. A failed pull is logged and the loop carries on, because stale is a state the design allows a mirror to be, and stopping would make every other mirror stale too.

### Tests

Four on the storage invariants, two on the authorization gate, three on the config shape, and two end to end **against a real socket**: two hosts, records written at the primary, pulled, and served from the copy under the primary's own numbers; an unreachable primary leaving the mirror serving what it has rather than losing it; and the write refusal naming the primary over the wire.

`clippy --all-targets` and `fmt --check` clean across `vti-rooms`, `room-host` and `vtc-service`; the `data_room` example still runs end to end.

### Breaking

`vti_rooms::Room` gains `mirror_of`, so struct literals need the field (every in-tree one is updated). It is `#[serde(default)]`, so every stored room deserialises as a primary — which is what they all are.
