### PR TITLE
feat(secrets)!: cache seed reads so KMS traffic scales with time, not requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11073,6 +11073,7 @@ dependencies = [
  "vaultrs",
  "vta-sdk",
  "vti-common",
+ "zeroize",
 ]
 
 [[package]]

--- a/docs/02-vta/secret-backends.md
+++ b/docs/02-vta/secret-backends.md
@@ -95,6 +95,63 @@ are otherwise wire-compatible.
 
 ---
 
+## Read caching (`cache_ttl_secs`)
+
+The master seed is read on **every** key-touching request. `load_seed_bytes`
+has ~25 call sites — the signing oracle, key mint/rotate/list, the holder-key
+paths, every `did:webvh` lifecycle operation — and each one calls the backend.
+
+On the local backends (keyring, plaintext, config-seed, KMS-TEE) that costs
+nothing. On the remote backends it is a network round trip per request, and on
+AWS it is also a **billed** one: each `GetSecretValue` is one KMS `Decrypt`
+against the key protecting the secret. Uncached, KMS request volume scales with
+request volume — a VTA sustaining ~22 requests/second bills roughly 58M KMS
+requests a month purely re-reading a value that never changed.
+
+`cache_ttl_secs` bounds how long a successfully-read seed is reused from memory:
+
+```toml
+[secrets]
+cache_ttl_secs = 60   # default. 0 disables caching entirely.
+```
+
+At the 60-second default, that same VTA makes ~43k backend reads a month
+instead of 58M — the read now scales with wall-clock time, not traffic.
+
+The setup wizard's `[secrets]` table is a *backend selector*, not the runtime
+config, so `cache_ttl_secs` is not settable from `vta setup --from`. Setup writes
+the default into the generated `config.toml`; change it there if you need to.
+
+**Why this is safe.** The seed for a generation is immutable; it changes only on
+rotation. The cache is not gambling on a moving value, it is skipping a re-read
+of a constant. On top of that:
+
+- **Writes invalidate the cache.** `set` and `delete` drop the entry. This is
+  load-bearing: seed rotation writes the new seed and then *immediately* re-reads
+  it to re-encrypt every imported secret, so a cache that survived the write
+  would re-encrypt them under the wrong key.
+- **A read that raced a write is discarded**, never installed for a full TTL.
+  Signing requests run concurrently with rotation, so this case is real.
+- **A missing secret and every error are passed straight through.** Caching
+  "absent" would make a transient backend outage indistinguishable from an
+  unprovisioned VTA for the whole TTL.
+- **The cached copy is zeroized** on eviction and on drop (P0.7).
+
+**The one trade-off.** With caching on, the master seed is resident in process
+memory for up to the TTL, where previously it was resident only for the duration
+of each operation. On a busy VTA that is a distinction without a difference — it
+is effectively always resident anyway. On a quiet one it is a real (if small)
+widening of the window a memory-scraping attacker has to hit. The TTL is what
+bounds it; `cache_ttl_secs = 0` restores the old behaviour at the cost of a
+backend read per request.
+
+Nothing here defends against an **out-of-process** writer changing the seed,
+because there is no supported topology with one: runtime rotation happens
+in-process under a rotation lock, and the offline `vta` CLI surfaces require the
+daemon to be stopped.
+
+---
+
 ## Backends
 
 ### AWS Secrets Manager
@@ -140,6 +197,11 @@ IAM policy on the secret:
 `CreateSecret` is needed only on the very first `vta setup`. Drop it
 from the policy after first-boot if you'd like the principle of
 least privilege.
+
+> **Cost note.** Every `GetSecretValue` is also one billed KMS `Decrypt` against
+> the key protecting the secret. This is the backend where
+> [`cache_ttl_secs`](#read-caching-cache_ttl_secs) matters most — leave it at the
+> default rather than setting it to `0`, unless you have a specific reason.
 
 ### GCP Secret Manager
 

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1425,10 +1425,9 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "keyring")]
             {
-                SecretsConfig {
-                    keyring_service: service.clone(),
-                    ..SecretsConfig::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.keyring_service = service.clone();
+                c
             }
         }
         SecretsBackendInput::ConfigSeed => {
@@ -1441,10 +1440,9 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "config-seed")]
             {
-                SecretsConfig {
-                    seed: Some(String::new()), // populated with hex(seed) by caller
-                    ..Default::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.seed = Some(String::new()); // populated with hex(seed) by caller
+                c
             }
         }
         SecretsBackendInput::Aws {
@@ -1461,11 +1459,10 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "aws-secrets")]
             {
-                SecretsConfig {
-                    aws_secret_name: Some(secret_name.clone()),
-                    aws_region: region.clone(),
-                    ..Default::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.aws_secret_name = Some(secret_name.clone());
+                c.aws_region = region.clone();
+                c
             }
         }
         SecretsBackendInput::Gcp {
@@ -1482,11 +1479,10 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "gcp-secrets")]
             {
-                SecretsConfig {
-                    gcp_project: Some(project.clone()),
-                    gcp_secret_name: Some(secret_name.clone()),
-                    ..Default::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.gcp_project = Some(project.clone());
+                c.gcp_secret_name = Some(secret_name.clone());
+                c
             }
         }
         SecretsBackendInput::Azure {
@@ -1503,11 +1499,10 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "azure-secrets")]
             {
-                SecretsConfig {
-                    azure_vault_url: Some(vault_url.clone()),
-                    azure_secret_name: Some(secret_name.clone()),
-                    ..Default::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.azure_vault_url = Some(vault_url.clone());
+                c.azure_secret_name = Some(secret_name.clone());
+                c
             }
         }
         SecretsBackendInput::Vault {
@@ -1551,23 +1546,22 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "vault-secrets")]
             {
-                SecretsConfig {
-                    vault_addr: Some(addr.clone()),
-                    vault_secret_path: Some(secret_path.clone()),
-                    vault_kv_mount: kv_mount.clone(),
-                    vault_secret_key: secret_key.clone(),
-                    vault_namespace: namespace.clone(),
-                    vault_auth_method: auth_method.clone(),
-                    vault_k8s_role: k8s_role.clone(),
-                    vault_k8s_mount: k8s_mount.clone(),
-                    vault_k8s_jwt_path: k8s_jwt_path.clone(),
-                    vault_token: token.clone(),
-                    vault_approle_role_id: approle_role_id.clone(),
-                    vault_approle_secret_id: approle_secret_id.clone(),
-                    vault_approle_mount: approle_mount.clone(),
-                    vault_skip_verify: *skip_verify,
-                    ..SecretsConfig::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.vault_addr = Some(addr.clone());
+                c.vault_secret_path = Some(secret_path.clone());
+                c.vault_kv_mount = kv_mount.clone();
+                c.vault_secret_key = secret_key.clone();
+                c.vault_namespace = namespace.clone();
+                c.vault_auth_method = auth_method.clone();
+                c.vault_k8s_role = k8s_role.clone();
+                c.vault_k8s_mount = k8s_mount.clone();
+                c.vault_k8s_jwt_path = k8s_jwt_path.clone();
+                c.vault_token = token.clone();
+                c.vault_approle_role_id = approle_role_id.clone();
+                c.vault_approle_secret_id = approle_secret_id.clone();
+                c.vault_approle_mount = approle_mount.clone();
+                c.vault_skip_verify = *skip_verify;
+                c
             }
         }
         SecretsBackendInput::Kubernetes {
@@ -1585,12 +1579,11 @@ fn secrets_config_from_input(
             }
             #[cfg(feature = "k8s-secrets")]
             {
-                SecretsConfig {
-                    k8s_secret_name: Some(secret_name.clone()),
-                    k8s_namespace: namespace.clone(),
-                    k8s_secret_key: secret_key.clone(),
-                    ..SecretsConfig::default()
-                }
+                let mut c = SecretsConfig::default();
+                c.k8s_secret_name = Some(secret_name.clone());
+                c.k8s_namespace = namespace.clone();
+                c.k8s_secret_key = secret_key.clone();
+                c
             }
         }
         SecretsBackendInput::Plaintext => {
@@ -1609,10 +1602,9 @@ fn secrets_config_from_input(
             //
             // `allow_plaintext` is only the *permission*; `backend` below is
             // what actually selects plaintext over the compiled-in keyring.
-            SecretsConfig {
-                allow_plaintext: true,
-                ..SecretsConfig::default()
-            }
+            let mut c = SecretsConfig::default();
+            c.allow_plaintext = true;
+            c
         }
     };
     config.backend = Some(selector);

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -52,6 +52,8 @@ serde = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+# Wipes the cached master seed on eviction / drop (P0.7).
+zeroize = { version = "1" }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
 vta-sdk = { path = "../vta-sdk", version = "0.33", features = [
@@ -102,7 +104,9 @@ keyring-core = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { workspace = true }
+# `test-util` gives the seed-cache tests a paused clock, so TTL expiry is
+# asserted deterministically instead of by sleeping.
+tokio = { workspace = true, features = ["test-util"] }
 toml = { workspace = true }
 
 [lints]

--- a/vti-secrets/src/config.rs
+++ b/vti-secrets/src/config.rs
@@ -34,7 +34,13 @@ pub enum SecretBackend {
     Plaintext,
 }
 
+/// `#[non_exhaustive]`: this struct has grown a field per backend since it was
+/// introduced and will keep growing. Marking it here makes a future field an
+/// additive change rather than a breaking one — at the cost of forbidding
+/// struct-literal (and functional-update) construction outside this crate.
+/// Build one with [`SecretsConfig::default`] and assign the fields you need.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct SecretsConfig {
     /// Explicit backend selector. When set it wins outright:
     /// [`create_seed_store`](crate::create_seed_store) builds exactly this
@@ -132,6 +138,32 @@ pub struct SecretsConfig {
     /// on disk in cleartext" footgun.)
     #[serde(default)]
     pub allow_plaintext: bool,
+    /// How long a successfully-read seed may be reused from memory before the
+    /// backend is consulted again, in seconds. `0` disables caching entirely —
+    /// every read hits the backend, which is how this crate behaved before the
+    /// cache existed.
+    ///
+    /// Why this exists: the seed is read on **every** key-touching request
+    /// (`load_seed_bytes`, ~25 call sites, including every signature), and on
+    /// the cloud backends each read is a remote call — for AWS one
+    /// `GetSecretValue`, which is in turn one billed KMS `Decrypt`. Uncached,
+    /// KMS request volume scales with request volume; cached, it scales with
+    /// wall-clock time.
+    ///
+    /// Why a bounded TTL rather than load-once: the seed for a generation is
+    /// immutable, and the only writer is in-process rotation (which invalidates
+    /// the cache explicitly), so a stale read is already near-impossible. The
+    /// TTL is the outer bound for anything that gets past that, and it caps how
+    /// long the master seed sits resident in process memory (P0.7).
+    #[serde(default = "default_cache_ttl_secs")]
+    pub cache_ttl_secs: u64,
+}
+
+/// Default seed cache TTL. Short enough that an out-of-band seed change is
+/// picked up within a minute, long enough that a VTA under load makes one
+/// backend read per minute instead of one per request.
+fn default_cache_ttl_secs() -> u64 {
+    60
 }
 
 fn default_keyring_service() -> String {
@@ -196,6 +228,7 @@ impl Default for SecretsConfig {
             k8s_namespace: None,
             k8s_secret_key: default_k8s_secret_key(),
             allow_plaintext: false,
+            cache_ttl_secs: default_cache_ttl_secs(),
         }
     }
 }

--- a/vti-secrets/src/seed_store/aws.rs
+++ b/vti-secrets/src/seed_store/aws.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use tokio::sync::OnceCell;
 use tracing::debug;
 use vti_common::error::AppError;
 
@@ -23,6 +24,10 @@ fn format_aws_error<E: std::error::Error>(context: &str, err: E) -> AppError {
 pub struct AwsSeedStore {
     secret_name: String,
     region: Option<String>,
+    /// Built once on first use and reused. Constructing a client per call also
+    /// re-resolves the credential chain per call — an IMDS/STS round trip on
+    /// top of the API call itself (R1.2).
+    client: OnceCell<aws_sdk_secretsmanager::Client>,
 }
 
 impl AwsSeedStore {
@@ -30,16 +35,21 @@ impl AwsSeedStore {
         Self {
             secret_name,
             region,
+            client: OnceCell::new(),
         }
     }
 
-    async fn client(&self) -> Result<aws_sdk_secretsmanager::Client, AppError> {
-        let mut config_loader = aws_config::from_env();
-        if let Some(ref region) = self.region {
-            config_loader = config_loader.region(aws_config::Region::new(region.clone()));
-        }
-        let sdk_config = config_loader.load().await;
-        Ok(aws_sdk_secretsmanager::Client::new(&sdk_config))
+    async fn client(&self) -> Result<&aws_sdk_secretsmanager::Client, AppError> {
+        self.client
+            .get_or_try_init(|| async {
+                let mut config_loader = aws_config::from_env();
+                if let Some(ref region) = self.region {
+                    config_loader = config_loader.region(aws_config::Region::new(region.clone()));
+                }
+                let sdk_config = config_loader.load().await;
+                Ok(aws_sdk_secretsmanager::Client::new(&sdk_config))
+            })
+            .await
     }
 }
 

--- a/vti-secrets/src/seed_store/azure.rs
+++ b/vti-secrets/src/seed_store/azure.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 
 use azure_identity::DeveloperToolsCredential;
 use azure_security_keyvault_secrets::SecretClient;
+use tokio::sync::OnceCell;
 use tracing::debug;
 
 use vti_common::error::AppError;
@@ -15,6 +16,9 @@ use vti_common::error::AppError;
 pub struct AzureSeedStore {
     vault_url: String,
     secret_name: String,
+    /// Built once on first use and reused. Rebuilding per call also rebuilds
+    /// the credential, which re-runs token acquisition (R1.2).
+    client: OnceCell<SecretClient>,
 }
 
 impl AzureSeedStore {
@@ -22,21 +26,27 @@ impl AzureSeedStore {
         Self {
             vault_url,
             secret_name,
+            client: OnceCell::new(),
         }
     }
 
-    fn client(&self) -> Result<SecretClient, AppError> {
-        let credential = DeveloperToolsCredential::new(None)
-            .map_err(|e| AppError::SecretStore(format!("Azure credential error: {e}")))?;
-        SecretClient::new(&self.vault_url, credential, None)
-            .map_err(|e| AppError::SecretStore(format!("Azure Key Vault client error: {e}")))
+    async fn client(&self) -> Result<&SecretClient, AppError> {
+        self.client
+            .get_or_try_init(|| async {
+                let credential = DeveloperToolsCredential::new(None)
+                    .map_err(|e| AppError::SecretStore(format!("Azure credential error: {e}")))?;
+                SecretClient::new(&self.vault_url, credential, None).map_err(|e| {
+                    AppError::SecretStore(format!("Azure Key Vault client error: {e}"))
+                })
+            })
+            .await
     }
 }
 
 impl super::SeedStore for AzureSeedStore {
     fn get(&self) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>, AppError>> + Send + '_>> {
         Box::pin(async {
-            let client = self.client()?;
+            let client = self.client().await?;
             let result = client.get_secret(&self.secret_name, None).await;
 
             match result {
@@ -69,7 +79,7 @@ impl super::SeedStore for AzureSeedStore {
     fn set(&self, seed: &[u8]) -> Pin<Box<dyn Future<Output = Result<(), AppError>> + Send + '_>> {
         let hex_seed = hex::encode(seed);
         Box::pin(async move {
-            let client = self.client()?;
+            let client = self.client().await?;
 
             // Azure Key Vault set_secret creates-or-updates automatically
             let params = azure_security_keyvault_secrets::models::SetSecretParameters {

--- a/vti-secrets/src/seed_store/caching.rs
+++ b/vti-secrets/src/seed_store/caching.rs
@@ -1,0 +1,356 @@
+//! TTL cache in front of a [`SeedStore`] backend.
+//!
+//! ## Why
+//!
+//! The BIP-32 master seed is read on **every** key-touching request. The read
+//! goes through `vta_keys::seeds::load_seed_bytes`, which has ~25 call sites
+//! covering the signing oracle, key mint/rotate/list, the holder-key paths and
+//! every `did:webvh` lifecycle operation — and it calls [`SeedStore::get`]
+//! unconditionally, with no memoization.
+//!
+//! On the local backends (keyring, plaintext, config-seed, TEE) that is cheap.
+//! On the cloud backends it is a network round trip per request, and for AWS it
+//! is also a *billed* one: every `GetSecretValue` is one KMS `Decrypt` against
+//! the key protecting the secret. Uncached, KMS request volume scales with
+//! request volume. A VTA sustaining ~22 requests/second bills ~58M KMS requests
+//! a month for nothing but re-reading a value that did not change.
+//!
+//! This decorator makes the seed read scale with wall-clock time instead. At
+//! the 60-second default that same VTA makes ~43k backend reads a month.
+//!
+//! ## What makes it safe
+//!
+//! The seed for a generation is immutable — it changes only on rotation. So the
+//! cache is not gambling on a value that drifts; it is skipping a re-read of a
+//! constant. The invariants that keep it honest:
+//!
+//! - **Writes invalidate.** [`set`](SeedStore::set) and
+//!   [`delete`](SeedStore::delete) bump a generation counter and drop the entry.
+//!   This is load-bearing, not hygiene: `vta_service::operations::seeds::
+//!   rotate_seed` calls `rotate_seed` (which writes the new seed) and then
+//!   *immediately* re-reads it to re-encrypt every imported secret. Serving a
+//!   stale seed there would re-encrypt them under the wrong key.
+//! - **A read in flight across a write is discarded.** A concurrent `get` that
+//!   started before a `set` may observe the pre-write value; the generation
+//!   counter is re-checked before its result is stored, so it can never install
+//!   a superseded seed for a full TTL. This matters because signing requests
+//!   run concurrently with rotation.
+//! - **Only success is cached.** A missing secret (`Ok(None)`) and every error
+//!   are passed straight through. Caching `None` would make a transient backend
+//!   outage indistinguishable from an unprovisioned VTA for the whole TTL, and
+//!   would race first-boot provisioning.
+//! - **The cached copy is zeroized** on eviction and on drop, preserving P0.7.
+//!   The TTL doubles as the bound on how long the seed sits resident.
+//!
+//! Nothing here defends against an *out-of-process* writer, because there is no
+//! supported topology with one: runtime rotation is in-process under
+//! `ROTATE_LOCK`, and the offline `vta` CLI surfaces require the daemon stopped.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use tokio::sync::RwLock;
+use tokio::time::{Duration, Instant};
+use tracing::debug;
+use vti_common::error::AppError;
+use zeroize::Zeroizing;
+
+use super::SeedStore;
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// A cached seed plus the instant it stops being servable.
+struct CacheEntry {
+    /// Wiped on eviction and on drop (P0.7).
+    seed: Zeroizing<Vec<u8>>,
+    expires_at: Instant,
+}
+
+/// Cache state. `generation` increments on every write so a read that raced a
+/// write can tell that its result is stale and decline to store it.
+struct CacheState {
+    entry: Option<CacheEntry>,
+    generation: u64,
+}
+
+/// Wraps a [`SeedStore`], serving `get` from memory for up to a TTL.
+///
+/// Built by [`create_seed_store`](super::create_seed_store) when
+/// `secrets.cache_ttl_secs` is non-zero; a zero TTL returns the bare backend
+/// rather than a decorator that would never hit.
+pub struct CachingSeedStore {
+    inner: Box<dyn SeedStore>,
+    ttl: Duration,
+    state: RwLock<CacheState>,
+}
+
+impl CachingSeedStore {
+    /// Wrap `inner`, serving reads from memory for `ttl`.
+    ///
+    /// A zero `ttl` produces a cache that never serves a hit (every entry is
+    /// already expired when stored). Callers that want no caching should skip
+    /// the wrapper entirely — see `create_seed_store`.
+    pub fn new(inner: Box<dyn SeedStore>, ttl: Duration) -> Self {
+        Self {
+            inner,
+            ttl,
+            state: RwLock::new(CacheState {
+                entry: None,
+                generation: 0,
+            }),
+        }
+    }
+
+    /// Drop any cached seed and bump the generation, so a read already in
+    /// flight cannot install its (now superseded) result.
+    async fn invalidate(&self) {
+        let mut state = self.state.write().await;
+        // `Zeroizing` wipes the bytes as the entry drops.
+        state.entry = None;
+        state.generation = state.generation.wrapping_add(1);
+    }
+}
+
+impl SeedStore for CachingSeedStore {
+    fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>> {
+        Box::pin(async move {
+            // Fast path: a live entry. The read lock is released before the
+            // (possible) backend call below — never held across an await (R1.3).
+            let generation_at_start = {
+                let state = self.state.read().await;
+                if let Some(ref entry) = state.entry
+                    && Instant::now() < entry.expires_at
+                {
+                    return Ok(Some(entry.seed.to_vec()));
+                }
+                state.generation
+            };
+
+            let fetched = self.inner.get().await?;
+
+            let Some(seed) = fetched else {
+                // Absent secret: pass through, and drop any expired entry so a
+                // deleted secret doesn't linger. Never cached — see module docs.
+                let mut state = self.state.write().await;
+                state.entry = None;
+                return Ok(None);
+            };
+
+            {
+                let mut state = self.state.write().await;
+                if state.generation == generation_at_start {
+                    state.entry = Some(CacheEntry {
+                        seed: Zeroizing::new(seed.clone()),
+                        expires_at: Instant::now() + self.ttl,
+                    });
+                } else {
+                    // A write landed while this read was in flight. The value
+                    // in hand may predate it, so return it to *this* caller but
+                    // do not install it for anyone else.
+                    debug!("seed read raced a write — returning the value but not caching it");
+                }
+            }
+
+            Ok(Some(seed))
+        })
+    }
+
+    fn set(&self, secret: &[u8]) -> BoxFuture<'_, Result<(), AppError>> {
+        let secret = secret.to_vec();
+        Box::pin(async move {
+            // Invalidate on both sides of the write. Before, so no reader is
+            // served the old value once the write has begun; after, so the
+            // entry is gone even if the write failed partway.
+            self.invalidate().await;
+            let result = self.inner.set(&secret).await;
+            self.invalidate().await;
+            result
+        })
+    }
+
+    fn delete(&self) -> BoxFuture<'_, Result<(), AppError>> {
+        Box::pin(async move {
+            self.invalidate().await;
+            let result = self.inner.delete().await;
+            self.invalidate().await;
+            result
+        })
+    }
+
+    fn set_persists_across_restart(&self) -> bool {
+        // A property of the backing store, not of the cache in front of it.
+        // Getting this wrong would let seed rotation proceed on a TEE store.
+        self.inner.set_persists_across_restart()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// A backend that counts reads, so a test can assert how many times the
+    /// cache actually went to the store.
+    struct CountingStore {
+        seed: std::sync::Mutex<Option<Vec<u8>>>,
+        reads: Arc<AtomicUsize>,
+    }
+
+    impl CountingStore {
+        fn new(seed: Option<Vec<u8>>) -> (Self, Arc<AtomicUsize>) {
+            let reads = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    seed: std::sync::Mutex::new(seed),
+                    reads: reads.clone(),
+                },
+                reads,
+            )
+        }
+    }
+
+    impl SeedStore for CountingStore {
+        fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>> {
+            Box::pin(async {
+                self.reads.fetch_add(1, Ordering::SeqCst);
+                Ok(self.seed.lock().expect("seed lock").clone())
+            })
+        }
+
+        fn set(&self, secret: &[u8]) -> BoxFuture<'_, Result<(), AppError>> {
+            let secret = secret.to_vec();
+            Box::pin(async move {
+                *self.seed.lock().expect("seed lock") = Some(secret);
+                Ok(())
+            })
+        }
+
+        fn delete(&self) -> BoxFuture<'_, Result<(), AppError>> {
+            Box::pin(async {
+                *self.seed.lock().expect("seed lock") = None;
+                Ok(())
+            })
+        }
+    }
+
+    fn cache(seed: Option<Vec<u8>>, ttl_secs: u64) -> (CachingSeedStore, Arc<AtomicUsize>) {
+        let (inner, reads) = CountingStore::new(seed);
+        (
+            CachingSeedStore::new(Box::new(inner), Duration::from_secs(ttl_secs)),
+            reads,
+        )
+    }
+
+    /// The whole point: repeated reads inside the TTL cost one backend call.
+    /// On the AWS backend each avoided call is one avoided billed KMS Decrypt.
+    #[tokio::test(start_paused = true)]
+    async fn repeated_reads_within_ttl_hit_the_backend_once() {
+        let (store, reads) = cache(Some(vec![7u8; 32]), 60);
+
+        for _ in 0..50 {
+            assert_eq!(store.get().await.expect("get"), Some(vec![7u8; 32]));
+        }
+
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            1,
+            "50 reads inside the TTL must consult the backend exactly once"
+        );
+    }
+
+    /// The TTL is an upper bound on staleness, so it must actually expire.
+    #[tokio::test(start_paused = true)]
+    async fn read_after_ttl_consults_the_backend_again() {
+        let (store, reads) = cache(Some(vec![1u8; 32]), 60);
+
+        store.get().await.expect("first get");
+        tokio::time::advance(Duration::from_secs(61)).await;
+        store.get().await.expect("second get");
+
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            2,
+            "a read past the TTL must go back to the backend"
+        );
+    }
+
+    /// Load-bearing, not hygiene. `operations::seeds::rotate_seed` writes the
+    /// new seed and then immediately re-reads it to re-encrypt every imported
+    /// secret; a cache that survived the write would hand back the *old* seed
+    /// and silently re-encrypt them under the wrong key.
+    #[tokio::test(start_paused = true)]
+    async fn write_then_read_returns_the_new_seed_not_the_cached_one() {
+        let (store, _reads) = cache(Some(vec![0xAA; 32]), 3600);
+
+        assert_eq!(store.get().await.expect("prime"), Some(vec![0xAA; 32]));
+        store.set(&[0xBB; 32]).await.expect("set");
+
+        assert_eq!(
+            store.get().await.expect("read back"),
+            Some(vec![0xBB; 32]),
+            "the read after a write must observe the written seed, even well \
+             inside the TTL — this is the seed-rotation re-encryption path"
+        );
+    }
+
+    /// A delete must not leave the seed servable from memory.
+    #[tokio::test(start_paused = true)]
+    async fn delete_invalidates_the_cached_seed() {
+        let (store, _reads) = cache(Some(vec![0xCC; 32]), 3600);
+
+        store.get().await.expect("prime");
+        store.delete().await.expect("delete");
+
+        assert_eq!(
+            store.get().await.expect("read back"),
+            None,
+            "a deleted seed must not keep being served from the cache"
+        );
+    }
+
+    /// Caching `None` would make a transient backend outage look like an
+    /// unprovisioned VTA for the whole TTL (`load_seed_bytes` renders it as
+    /// "no seed found in external store") and would race first-boot setup.
+    #[tokio::test(start_paused = true)]
+    async fn absent_seed_is_never_cached() {
+        let (store, reads) = cache(None, 3600);
+
+        for _ in 0..3 {
+            assert_eq!(store.get().await.expect("get"), None);
+        }
+
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            3,
+            "a missing secret must be re-checked every time, never cached"
+        );
+    }
+
+    /// A store that cannot durably persist a rotated seed (the TEE KMS store)
+    /// must still report that through the wrapper — `rotate_seed` refuses on
+    /// this, and a wrapper answering `true` would let rotation proceed and
+    /// strand every key minted afterwards.
+    #[tokio::test(start_paused = true)]
+    async fn persistence_flag_is_delegated_to_the_backend() {
+        struct Ephemeral;
+        impl SeedStore for Ephemeral {
+            fn get(&self) -> BoxFuture<'_, Result<Option<Vec<u8>>, AppError>> {
+                Box::pin(async { Ok(None) })
+            }
+            fn set(&self, _: &[u8]) -> BoxFuture<'_, Result<(), AppError>> {
+                Box::pin(async { Ok(()) })
+            }
+            fn set_persists_across_restart(&self) -> bool {
+                false
+            }
+        }
+
+        let store = CachingSeedStore::new(Box::new(Ephemeral), Duration::from_secs(60));
+        assert!(
+            !store.set_persists_across_restart(),
+            "the wrapper must not claim durability the backend disclaims"
+        );
+    }
+}

--- a/vti-secrets/src/seed_store/gcp.rs
+++ b/vti-secrets/src/seed_store/gcp.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use tokio::sync::OnceCell;
 use tracing::debug;
 use vti_common::error::AppError;
 
@@ -12,6 +13,9 @@ use vti_common::error::AppError;
 pub struct GcpSeedStore {
     project: String,
     secret_name: String,
+    /// Built once on first use and reused. Constructing a client per call also
+    /// re-resolves credentials per call, which is a round trip of its own (R1.2).
+    client: OnceCell<google_cloud_secretmanager_v1::client::SecretManagerService>,
 }
 
 impl GcpSeedStore {
@@ -19,6 +23,7 @@ impl GcpSeedStore {
         Self {
             project,
             secret_name,
+            client: OnceCell::new(),
         }
     }
 
@@ -32,11 +37,17 @@ impl GcpSeedStore {
 
     async fn client(
         &self,
-    ) -> Result<google_cloud_secretmanager_v1::client::SecretManagerService, AppError> {
-        google_cloud_secretmanager_v1::client::SecretManagerService::builder()
-            .build()
+    ) -> Result<&google_cloud_secretmanager_v1::client::SecretManagerService, AppError> {
+        self.client
+            .get_or_try_init(|| async {
+                google_cloud_secretmanager_v1::client::SecretManagerService::builder()
+                    .build()
+                    .await
+                    .map_err(|e| {
+                        AppError::SecretStore(format!("GCP Secret Manager client error: {e}"))
+                    })
+            })
             .await
-            .map_err(|e| AppError::SecretStore(format!("GCP Secret Manager client error: {e}")))
     }
 }
 

--- a/vti-secrets/src/seed_store/k8s.rs
+++ b/vti-secrets/src/seed_store/k8s.rs
@@ -7,6 +7,7 @@ use k8s_openapi::api::core::v1::Secret;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::{Api, PostParams};
 use kube::{Client, ResourceExt};
+use tokio::sync::OnceCell;
 use tracing::debug;
 
 use crate::config::SecretsConfig;
@@ -40,6 +41,10 @@ pub struct K8sSeedStore {
     secret_name: String,
     namespace: Option<String>,
     secret_key: String,
+    /// Built once on first use and reused. `Client::try_default` re-reads the
+    /// ServiceAccount token / kubeconfig and stands up a fresh HTTP client
+    /// every time it is called (R1.2).
+    client: OnceCell<Client>,
 }
 
 impl K8sSeedStore {
@@ -48,20 +53,28 @@ impl K8sSeedStore {
             secret_name,
             namespace,
             secret_key,
+            client: OnceCell::new(),
         }
     }
 
     /// Build a namespaced `Secret` API handle, resolving the namespace and
     /// loading credentials from the in-cluster SA or local kubeconfig.
+    ///
+    /// The `Client` is cached; the `Api` handle is a cheap view over it.
     async fn api(&self) -> Result<Api<Secret>, AppError> {
-        let client = Client::try_default()
-            .await
-            .map_err(|e| format_kube_error("failed to initialise Kubernetes client", e))?;
+        let client = self
+            .client
+            .get_or_try_init(|| async {
+                Client::try_default()
+                    .await
+                    .map_err(|e| format_kube_error("failed to initialise Kubernetes client", e))
+            })
+            .await?;
         let namespace = self
             .namespace
             .clone()
             .unwrap_or_else(|| client.default_namespace().to_string());
-        Ok(Api::namespaced(client, &namespace))
+        Ok(Api::namespaced(client.clone(), &namespace))
     }
 }
 

--- a/vti-secrets/src/seed_store/mod.rs
+++ b/vti-secrets/src/seed_store/mod.rs
@@ -2,6 +2,7 @@
 mod aws;
 #[cfg(feature = "azure-secrets")]
 mod azure;
+mod caching;
 #[cfg(feature = "config-seed")]
 mod config;
 #[cfg(feature = "gcp-secrets")]
@@ -20,6 +21,7 @@ mod vault;
 pub use aws::AwsSeedStore;
 #[cfg(feature = "azure-secrets")]
 pub use azure::AzureSeedStore;
+pub use caching::CachingSeedStore;
 #[cfg(feature = "config-seed")]
 pub use config::ConfigSeedStore;
 #[cfg(feature = "gcp-secrets")]
@@ -84,16 +86,45 @@ pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// A backend requested on a binary built without its feature is a hard
 /// `Config` error — never a silent fall-through to keyring or plaintext.
 ///
+/// **Caching.** The selected backend is wrapped in a [`CachingSeedStore`] unless
+/// `secrets.cache_ttl_secs` is `0`. The seed is read on every key-touching
+/// request, so on the remote backends an uncached store makes remote-call volume
+/// track request volume — on AWS, one billed KMS `Decrypt` per signature. See
+/// [`CachingSeedStore`]'s module docs for the invariants that make reuse safe.
+pub fn create_seed_store(
+    secrets: &SecretsConfig,
+    data_dir: &Path,
+) -> Result<Box<dyn SeedStore>, AppError> {
+    let backend = build_backend(secrets, data_dir)?;
+
+    // A zero TTL means "no caching" — hand back the bare backend rather than a
+    // decorator whose entries are expired the instant they are stored.
+    if secrets.cache_ttl_secs == 0 {
+        tracing::debug!("seed-store caching disabled (secrets.cache_ttl_secs = 0)");
+        return Ok(backend);
+    }
+
+    let ttl = std::time::Duration::from_secs(secrets.cache_ttl_secs);
+    tracing::debug!(
+        ttl_secs = secrets.cache_ttl_secs,
+        "seed-store reads cached in memory"
+    );
+    Ok(Box::new(CachingSeedStore::new(backend, ttl)))
+}
+
+/// Build the configured backend itself, before the cache is layered on.
+///
+/// Split out of [`create_seed_store`] so the caching decision is made in one
+/// place: this function has a `return` per backend arm, and wrapping at each of
+/// them is exactly how one arm ends up un-cached.
+///
 /// `unused_variables` allowed: `secrets` / `data_dir` are only read under
 /// specific feature flags; a build with none of the cloud/keyring/config-seed
 /// features compiled leaves them unused, which is fine — we fall through
 /// to the plaintext backend. rustc's dead-code lint can't see through
 /// the cfg-gated early returns.
 #[allow(unused_variables)]
-pub fn create_seed_store(
-    secrets: &SecretsConfig,
-    data_dir: &Path,
-) -> Result<Box<dyn SeedStore>, AppError> {
+fn build_backend(secrets: &SecretsConfig, data_dir: &Path) -> Result<Box<dyn SeedStore>, AppError> {
     let explicit = secrets.backend;
 
     // Is backend `b` the one to build? An explicit selector wins outright;


### PR DESCRIPTION
## Why

The BIP-32 master seed is read on **every** key-touching request. `load_seed_bytes` has ~25 call sites — the signing oracle, key mint/rotate/list, the holder-key paths, every `did:webvh` lifecycle operation — and each one calls `SeedStore::get` with no memoization.

On the local backends that is free. On AWS Secrets Manager every read is a `GetSecretValue`, and every `GetSecretValue` is one **billed KMS `Decrypt`** against the key protecting the secret. So KMS request volume tracked request volume.

This started from an observed bill: **58,101,221 KMS requests in a month** (~22/sec sustained, USD 174.30) on a single region. The VTA's *direct* KMS use is boot-only and bounded — four call sites, all in `vta-tee/src/kms_bootstrap.rs`, 1–2 requests per enclave boot — so it was never the enclave. It was the seed store, re-reading a value that never changed, once per signature.

## What

`[secrets] cache_ttl_secs` — default `60`, `0` disables — bounds how long a successfully-read seed is reused from memory. A `CachingSeedStore` decorator applied at the single `create_seed_store` chokepoint, so every backend gets it and no arm can be silently missed.

Same VTA: **~43k backend reads a month instead of 58M.** The read now scales with wall-clock time, not traffic.

## Why reuse is safe

The seed for a generation is immutable — it changes only on rotation — so the cache skips a re-read of a constant rather than gambling on a moving value. Four invariants hold it up, each with a test:

- **Writes invalidate.** Load-bearing, not hygiene: `operations::seeds::rotate_seed` writes the new seed and then *immediately* re-reads it to re-encrypt every imported secret. A cache surviving the write would re-encrypt them under the wrong key.
- **A read that raced a write is discarded** via a generation counter, so it can never install a superseded seed for a full TTL. Signing requests run concurrently with rotation, so this case is real.
- **`Ok(None)` and every error pass straight through.** Caching "absent" would make a transient backend outage indistinguishable from an unprovisioned VTA for the whole TTL, and would race first-boot provisioning.
- **The cached copy is zeroized** on eviction and drop (P0.7); the TTL doubles as the bound on how long the seed sits resident.

Nothing here defends against an *out-of-process* writer, because there is no supported topology with one: runtime rotation is in-process under `ROTATE_LOCK`, and the offline `vta` CLI surfaces require the daemon stopped.

## The trade-off

Documented rather than glossed, in both the config doc and the module docs: the seed is now resident in process memory for up to the TTL, where previously it was resident only per-operation. On a busy VTA that is a distinction without a difference — at 22 req/s it is effectively always resident anyway. On a quiet one it is a real if small widening of the window a memory-scraping attacker has to hit. `cache_ttl_secs = 0` restores the old behaviour at the cost of a backend read per request.

## Also: the same defect one layer down (R1.2)

The AWS, GCP, Azure and Kubernetes backends each built a client — and re-resolved credentials — on **every** call: an IMDS/STS round trip, or a kubeconfig/ServiceAccount re-read, on top of the API call itself. Each now builds once via `OnceCell`, which is what the Vault backend already did and is the model the others now follow.

## Deliberately untouched

- **The TEE path.** `KmsTeeSeedStore` is constructed directly by `vta-enclave` and already holds the seed in enclave memory, so it is not wrapped. No behaviour change for Nitro deployments.
- **The VTC.** It reads its key bundle once at boot (`vtc-service/src/server.rs:1647`) into process state; its other reads are backup/status/emergency operator paths. It has no per-request read, so it never had this problem.
- **BIP-32 root derivation.** `load_seed_bytes` still re-derives `ExtendedSigningKey::from_seed` per request. That is pure CPU, not KMS, and caching derived key material is a bigger security conversation — separate change.

## Breaking change

`SecretsConfig` is now `#[non_exhaustive]`, so struct-literal and functional-update construction are no longer available outside `vti-secrets`. Build from `SecretsConfig::default()` and assign — the 8 in-tree sites in `vta-service/src/setup/from_toml.rs` are converted here.

Taken deliberately while a break was already being made: this struct has grown a field per backend and will keep growing, so marking it now makes every future field additive. Note this reaches further than the diff — any *external* consumer constructing one with a struct literal breaks on upgrade.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — 0 failures
- `cargo test -p vti-secrets --all-features` — 20/20, including 6 new cache tests; re-run after the Kubernetes change since it sits behind a non-default feature

## Note for whoever is chasing the bill

This fix only moves the needle if the 58M is actually the seed store. Confirm with CloudTrail before assuming — KMS calls made on behalf of another service carry `invokedBy` naming it:

```sql
SELECT eventname, useridentity.invokedby AS called_by, count(*) AS n
FROM cloudtrail_logs
WHERE eventsource = 'kms.amazonaws.com' AND eventtime >= '2026-08-01'
GROUP BY 1,2 ORDER BY n DESC LIMIT 20;
```

`secretsmanager.amazonaws.com` means this PR is the fix. `s3.amazonaws.com` means the cause is outside this repo and the answer there is S3 Bucket Keys, not this change.


---

## `semver report` — what it flagged, and what is attributable to this PR

The check is red. Two of its findings are this PR's, two are pre-existing on `main`. Per `RELEASING.md` the fix is **not** a version bump in this branch — release-plz reads the `!` and puts the bump in the Release PR.

**From this PR** (`vti-secrets`):

- `constructible_struct_adds_field` + `struct_marked_non_exhaustive` on `SecretsConfig` — intended, and the reason this PR carries `!`.
- `auto_trait_impl_removed` — `AwsSeedStore`, `GcpSeedStore`, `AzureSeedStore` and `K8sSeedStore` are **no longer `UnwindSafe` / `RefUnwindSafe`**, because `tokio::sync::OnceCell` holds a mutex internally.

  That second one was a consequence I did not anticipate when proposing the client-reuse change. It only affects a caller putting one of these stores inside `catch_unwind`, which nothing in this workspace does and which would be a strange thing to do to a secret store — but it is a real public-API break, not a false positive, and the major bump this PR already requires covers it. Flagging it explicitly rather than letting it be discovered in the Release PR.

**Pre-existing on `main`, unrelated to this branch** — a merged breaking change keeps this check red for every later PR until the Release PR lands:

- `struct_pub_field_missing`: `vta_persona::correlation::Finding::shared_with_profile_count`
- `function_parameter_count_changed`: `vta_service::operations::acl::create_acl`, `vta_cli_common::commands::acl::{cmd_acl_create, cmd_acl_update}`
