### PR TITLE
refactor(pnm): persona commands read in the words a person uses

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -214,13 +214,14 @@ pub(crate) enum Commands {
         command: CredVaultCommands,
     },
 
-    /// The holder's own identity — the attributes they hold about themselves,
-    /// the profiles that project over them, which persona a context sees, and
-    /// what other people have disclosed.
+    /// Your own identity — the facts you hold about yourself, the faces that
+    /// show a set of them together, which face each persona wears where, and
+    /// what other people have told you.
     ///
-    /// The pool and profiles sit ABOVE every trust context and need
-    /// unrestricted authority; bindings, contacts and disclosure are
-    /// context-scoped and take `--context`.
+    /// Your facts and your faces sit ABOVE every trust context. Reaching them
+    /// needs an agent credential with no context restriction, or one granted
+    /// `persona-holder`. Wearing, contacts and what leaves are context-scoped
+    /// and take `--context`.
     Persona {
         #[command(subcommand)]
         command: PersonaCommands,
@@ -3107,49 +3108,53 @@ pub(crate) enum ProofRungOpt {
 /// `pnm persona …` — the holder's own identity.
 #[derive(Subcommand)]
 pub(crate) enum PersonaCommands {
-    /// The attribute pool: the facts the holder holds about themselves.
-    /// Holder-scoped — needs unrestricted authority, not a context admin.
+    /// Your facts — what you hold about yourself, each held once.
+    ///
+    /// Sits above every context, so it needs an agent credential with no
+    /// context restriction, or one granted `persona-holder`. A context admin
+    /// holding neither is refused.
     Attribute {
         #[command(subcommand)]
         command: PersonaAttributeCommands,
     },
-    /// Profiles: named projections over the pool. Holder-scoped.
+    /// Faces — the sets of facts you show together. Same authority as your
+    /// facts: above every context.
     Profile {
         #[command(subcommand)]
         command: PersonaProfileCommands,
     },
-    /// Bindings: which profile a persona DID presents in a given context.
+    /// Wearing — which face a persona wears in a given context.
     Binding {
         #[command(subcommand)]
         command: PersonaBindingCommands,
     },
-    /// Contacts: what other people have disclosed to the holder.
+    /// Contacts — what other people have told you about themselves.
     Contact {
         #[command(subcommand)]
         command: PersonaContactCommands,
     },
-    /// Disclosure: preview what would be revealed, then present it.
+    /// What leaves — see it before it goes, then let it go.
     Disclosure {
         #[command(subcommand)]
         command: PersonaDisclosureCommands,
     },
-    /// Profiles and bindings that live INSIDE one context, built only from
-    /// inline values — they cannot reference the holder's pool.
+    /// Faces and wearing that live INSIDE one context, built only from values
+    /// typed there — they cannot reach your facts.
     Local {
         #[command(subcommand)]
         command: PersonaLocalCommands,
     },
-    /// Report how linkable a value, attribute or profile would make the
-    /// holder. Reads the pool; writes nothing. Holder-scoped.
+    /// Report how linkable a value, a fact or a face would make you — "same
+    /// person to anyone who sees both". Reads only; writes nothing.
     ///
-    /// Note the inversion: a credential presented WHOLE correlates more than a
-    /// self-asserted value, because the issuer's signature is identical at
-    /// every verifier — while a derived proof correlates less.
+    /// Note the inversion: a credential shown WHOLE links you more than a value
+    /// you simply said, because the issuer's signature is identical everywhere
+    /// it goes — while a derived proof links you less.
     Correlate {
-        /// Analyse one stored attribute.
+        /// Analyse one fact you hold.
         #[arg(long = "attribute-id")]
         attribute_id: Option<String>,
-        /// Analyse an entire profile.
+        /// Analyse a whole face.
         #[arg(long = "profile-id")]
         profile_id: Option<String>,
         /// Analyse a value that is NOT stored — "what would happen if I gave
@@ -3158,8 +3163,8 @@ pub(crate) enum PersonaCommands {
         candidate_file: Option<String>,
     },
     /// List the output formats this VTA can produce, and what each DISCARDS.
-    /// Worth running before a preview: a renderer that drops provenance turns
-    /// "my employer attested this" into an unattributed value.
+    /// Worth running before a preview: one that drops where a fact came from
+    /// turns "my employer attested this" into something you merely said.
     ///
     /// Open to any authenticated caller — it names nothing about you, and a
     /// context-scoped operator about to request a disclosure needs it.

--- a/vta-cli-common/src/commands/persona.rs
+++ b/vta-cli-common/src/commands/persona.rs
@@ -1,4 +1,19 @@
-//! `persona …` operator commands — the holder's own identity.
+//! `persona …` operator commands — a person's own identity.
+//!
+//! # Two vocabularies, and which one goes where
+//!
+//! Commands and flags keep the spec's words, because that is what they address:
+//! `persona profile put --profile-id` names `persona/profile/put/1.0`, and a
+//! command that did not would be a second name for a task, drifting from the
+//! URI it sends and from every script already written against it.
+//!
+//! What an operator *reads* uses the words a person would
+//! (`design-docs/persona-vocabulary.md`): an attribute is a **fact**, a profile
+//! is a **face** — the set of facts you show together — and a persona **wears**
+//! a face in a context. So `persona profile list` prints `Faces:` above JSON
+//! whose members are `profileId`. That pairing is deliberate: it is where an
+//! operator learns the mapping, once, in the one place both halves are on
+//! screen together.
 //!
 //! Thin wrappers over the `VtaClient::persona_*` methods, with one exception
 //! worth knowing about before reading further: [`cmd_disclosure_preview`]
@@ -67,7 +82,7 @@ pub async fn cmd_attribute_put(
             expected_version,
         )
         .await?;
-    print_result("Attribute:", &result)
+    print_result("Fact:", &result)
 }
 
 /// `persona attribute list` — enumerate the pool.
@@ -93,9 +108,9 @@ pub async fn cmd_attribute_list(
         )
         .await?;
     if !is_json_output() && !include_values {
-        println!("{DIM}Metadata only — add --values to include the values themselves.{RESET}");
+        println!("{DIM}Names only — add --values to include the values themselves.{RESET}");
     }
-    print_result("Attributes:", &result)
+    print_result("Your facts:", &result)
 }
 
 /// `persona attribute delete` — remove one attribute.
@@ -109,7 +124,10 @@ pub async fn cmd_attribute_delete(
         .persona_attribute_delete(&attribute_id, cascade, expected_version)
         .await?;
     if !is_json_output() && cascade {
-        println!("{DIM}Cascaded: profile entries referencing {attribute_id} were removed.{RESET}");
+        println!(
+            "{DIM}Cascaded: {attribute_id} was taken off every face that showed it. Nothing \
+             already shared is affected — that has left.{RESET}"
+        );
     }
     print_result("Result:", &result)
 }
@@ -136,7 +154,7 @@ pub async fn cmd_profile_put(
             expected_version,
         )
         .await?;
-    print_result("Profile:", &result)
+    print_result("Face:", &result)
 }
 
 /// `persona profile get` — read one profile.
@@ -144,10 +162,11 @@ pub async fn cmd_profile_get(client: &VtaClient, profile_id: String, resolve: bo
     let result = client.persona_profile_get(&profile_id, resolve).await?;
     if !is_json_output() && !resolve {
         println!(
-            "{DIM}Showing how the profile is built — add --resolve to see what it would present.{RESET}"
+            "{DIM}Showing how the face is built — add --resolve to see the facts it would \
+             show.{RESET}"
         );
     }
-    print_result("Profile:", &result)
+    print_result("Face:", &result)
 }
 
 /// `persona profile list` — enumerate profiles.
@@ -159,7 +178,7 @@ pub async fn cmd_profile_list(
     let result = client
         .persona_profile_list(limit, cursor.as_deref())
         .await?;
-    print_result("Profiles:", &result)
+    print_result("Faces:", &result)
 }
 
 /// `persona profile delete` — remove a profile.
@@ -174,7 +193,8 @@ pub async fn cmd_profile_delete(
         .await?;
     if !is_json_output() && unbind {
         println!(
-            "{YELLOW}Unbound: every persona presenting under {profile_id} now presents nothing until rebound.{RESET}"
+            "{YELLOW}Taken off: every persona wearing {profile_id} now shows nothing until \
+             it wears another. Nothing already shared is affected — that has left.{RESET}"
         );
     }
     print_result("Result:", &result)
@@ -205,13 +225,12 @@ pub async fn cmd_binding_set(
         .await?;
     if !is_json_output() {
         if clearing {
-            println!(
-                "{DIM}Binding cleared — {persona_did} now presents nothing in {context_id}.{RESET}"
-            );
+            println!("{DIM}Taken off — {persona_did} now shows nothing in {context_id}.{RESET}");
         } else {
             println!(
-                "{DIM}A copy of the profile's values was written into {context_id}. Editing the \
-                 pool refreshes it; nothing inside the context can read back the other way.{RESET}"
+                "{DIM}A context only ever gets a copy: the face's values were written into \
+                 {context_id}. Editing a fact refreshes it; copies go down, and nothing reads \
+                 up.{RESET}"
             );
         }
     }
@@ -380,7 +399,7 @@ fn render_preview(result: &Value, context_id: &str, verifier_did: &str, purpose:
     };
 
     println!();
-    println!("{BOLD}Disclosure preview{RESET} — nothing has been sent.");
+    println!("{BOLD}Before anything leaves{RESET} — nothing has been sent.");
     println!();
     println!("  {DIM}To{RESET}         {verifier_did}");
     println!("  {DIM}Context{RESET}    {context_id}");
@@ -420,7 +439,7 @@ fn render_preview(result: &Value, context_id: &str, verifier_did: &str, purpose:
         };
         let reason = c.get("reason").and_then(Value::as_str).unwrap_or("");
         println!(
-            "  {DIM}Linkable{RESET}   {colour}{}{RESET} {reason}",
+            "  {DIM}Linked{RESET}     {colour}{}{RESET} {reason}",
             severity.to_uppercase()
         );
     }
@@ -433,7 +452,7 @@ fn render_preview(result: &Value, context_id: &str, verifier_did: &str, purpose:
 
     println!();
     if claims.is_empty() {
-        println!("  {DIM}No claims would be disclosed.{RESET}");
+        println!("  {DIM}No facts would leave.{RESET}");
     }
     for claim in claims {
         let ty = claim.get("type").and_then(Value::as_str).unwrap_or("?");
@@ -533,7 +552,7 @@ pub async fn cmd_disclosure_present(
              (`keys derive-and-sign-document`) before sending it to a verifier.{RESET}"
         );
     }
-    print_result("Disclosure:", &result)
+    print_result("What left:", &result)
 }
 
 /// `persona disclosure history` — what was disclosed, to whom, when.
@@ -556,7 +575,7 @@ pub async fn cmd_disclosure_history(
             cursor.as_deref(),
         )
         .await?;
-    print_result("Disclosures:", &result)
+    print_result("What has left:", &result)
 }
 
 // ---------------------------------------------------------------------------
@@ -573,7 +592,7 @@ pub async fn cmd_correlate(
     let result = client
         .persona_correlation_analyze(attribute_id.as_deref(), profile_id.as_deref(), candidate)
         .await?;
-    print_result("Correlation:", &result)
+    print_result("Links:", &result)
 }
 
 /// `persona renderers` — the output formats, and what each one discards.


### PR DESCRIPTION
Part of a sweep bringing the persona vocabulary into sync across VTI, the
browser plugin and OpenVTC. `design-docs/persona-vocabulary.md` names
`pnm persona …` as known drift "until next touched" — this touches it.

## Where I drew the line, and why

**Commands and flags keep the spec's words.** `persona profile put
--profile-id` names `persona/profile/put/1.0`. A command that did not would be a
second name for a task, drifting from the URI it sends and from every script
already written against it.

**What an operator reads uses the person's words.** attribute → *fact*,
profile → *face*, binding → *wearing*.

So `persona profile list` prints `Faces:` above JSON whose members are
`profileId`. That pairing is deliberate rather than an oversight: it is the one
place both halves are on screen together, and therefore where an operator learns
the mapping. The module header records the reasoning so the next person doesn't
"fix" it back.

If you'd rather draw that line elsewhere — labels matching the command instead —
say so; it's a one-line change per label and I'd rather agree the rule than
argue it per string.

## What changed

- printed labels: `Attributes:` → `Your facts:`, `Profile:` → `Face:`,
  `Disclosures:` → `What has left:`, `Correlation:` → `Links:`
- the hints beside them, including the two destructive paths, which now carry
  the table's sentence: *"Nothing already shared is affected — that has left."*
- the disclosure preview's prose — the most-read screen here: *"Before anything
  leaves — nothing has been sent."*, `Linkable` → `Linked`
- `--help` for every persona subcommand
- the reused phrases the table asks for verbatim: *"a context only ever gets a
  copy"*, *"same person to anyone who sees both"*

## One thing that was simply wrong

The top-level help said the holder-scoped tasks need *unrestricted* authority.
That stopped being the only way when `persona-holder` landed (#1286) — it now
names both.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new clients/timeouts (R1.2) — text only, no call sites changed
- [x] No lock held across a network await (R1.3)
- [x] No local state before its remote effect (R2.1)
- [x] Retries bounded (R1.4) — none added
- [x] Loops survive transient errors (R1.5) — n/a
- [x] Acks after durable handoff (R1.6) — n/a
- [x] Wire types (R3.*) — unchanged; command and flag names deliberately kept
- [x] Config absence = most restrictive (R5.*) — unchanged
- [x] Logs/status claim only what was verified (R6.*) — the preview's
      "nothing has been sent" and the unbind warning keep their exact meaning
- [x] "Process dies on the next line" (R2.1) — n/a
- [x] Deviations — none
```

`cargo test -p vta-cli-common -p pnm-cli` green; clippy `-D warnings` clean.