### PR TITLE
feat: pnm clients self-provision their own mediator ACL (health + key rotation)

### DIFF
--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -208,6 +208,22 @@ pub(crate) async fn run(
         println!("  {DIM}No transport advertised{RESET}");
     }
 
+    // Re-read the session before anything below uses its key material.
+    //
+    // The `session` above is a snapshot taken at the top of `run`, but the
+    // Authentication section just called `ensure_authenticated`, which rotates a
+    // `needs_rotation` temp did:key: it mints a fresh DID, moves the ACL entry
+    // onto it and *deletes the temp entry at the VTA*. The snapshot's
+    // `client_did` / `private_key_multibase` are the dead temp identity from
+    // that point on.
+    //
+    // Reading a stale identity used to cost only a failing ping. It now costs a
+    // write: the DIDComm probe below provisions an allow-all mediator account
+    // keyed on `sha256(client_did)`, so a stale DID here leaves a permanently
+    // open account for a throwaway credential — exactly the litter
+    // `vta_sdk::acl_setup`'s module docs say the SDK avoids.
+    let session = auth::loaded_session(keyring_key).or(session);
+
     // ── Mediator + DIDComm pings ──────────────────────────────────
     print_section("Mediator");
 

--- a/pnm-cli/src/commands/health.rs
+++ b/pnm-cli/src/commands/health.rs
@@ -294,6 +294,13 @@ pub(crate) async fn run(
                 .await
                 {
                     Ok(Ok(session)) => {
+                        // Open this client's own mediator account (allow-all)
+                        // over the session's live socket before the forwarded
+                        // VTA trust-ping. A freshly bootstrapped or rotated
+                        // client is closed for forwarded delivery, so the VTA's
+                        // pong would otherwise be dropped by the mediator.
+                        session.provision_client_acl("pnm").await;
+
                         // Ping mediator (steady-state: warm-up + measured)
                         match tokio::time::timeout(
                             std::time::Duration::from_secs(20),

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -110,16 +110,8 @@ async fn set_client_acl_internal(
     .await
     .map_err(|e| format!("failed to create ATM profile: {e}"))?;
 
-    // Hash the client's DID for the mediator's ACL record (self-reference).
-    // SHA-256 hex to match the mediator's account-key convention
-    // (`sha256::digest(did)` in affinidi-messaging-sdk).
-    let mut hasher = Sha256::new();
-    hasher.update(client_did);
-    let hash_bytes = hasher.finalize();
-    let client_did_hash = hash_bytes
-        .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<String>();
+    // SHA-256 hex of the DID — the mediator's account-key convention.
+    let client_did_hash = client_acl_hash(client_did);
 
     // Build an "allow all" ACL that accepts every message type. Fields left
     // `None` (e.g. the self-manage flags) keep the mediator's existing value.
@@ -171,6 +163,78 @@ async fn set_client_acl_internal(
     Ok(())
 }
 
+/// Provision a client's own allow-all mediator ACL over an **already
+/// connected** profile, awaiting the result.
+///
+/// Unlike [`set_client_acl_on_connection`] (fire-and-forget, which builds its
+/// own second `ATMProfile` for the DID), this reuses the caller's live
+/// profile/socket — so no second websocket contends for the DID's
+/// one-socket-per-DID slot — and *awaits* the mediator round-trip under a
+/// timeout. A caller can therefore rely on the account being open before its
+/// next forwarded-message operation, e.g. a health trust-ping whose reply the
+/// mediator must forward back to this client (which a closed account rejects
+/// with `receive_forwarded`).
+///
+/// The `account_update` reply rides the same live socket (direct delivery, not
+/// forwarded), so it returns even while the account is still closed. Errors and
+/// timeouts are logged, not propagated: the mediator applies the ACL before
+/// responding, so a lost/late reply does not mean the update failed.
+pub async fn set_client_acl_with_profile(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    client_did: &str,
+    channel: &str,
+    client_name: &str,
+) {
+    // SHA-256 hex of the DID — the mediator's account-key convention.
+    let client_did_hash = client_acl_hash(client_did);
+
+    let acl = build_allow_all_acl();
+
+    // Bound the round-trip so a stuck mediator can't hang the caller.
+    const ACL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+    match tokio::time::timeout(
+        ACL_TIMEOUT,
+        atm.trust_tasks()
+            .account_update(profile, Some(client_did_hash), None, Some(acl), None),
+    )
+    .await
+    {
+        Ok(Ok(_)) => info!(
+            channel,
+            client_did = %client_did,
+            client = client_name,
+            "client ACL configured on mediator"
+        ),
+        Ok(Err(e)) => debug!(
+            channel,
+            client_did = %client_did,
+            error = %e,
+            client = client_name,
+            "client ACL request error (mediator may still process asynchronously)"
+        ),
+        Err(_) => debug!(
+            channel,
+            client_did = %client_did,
+            client = client_name,
+            "client ACL request timed out (mediator may still process asynchronously)"
+        ),
+    }
+}
+
+/// SHA-256 hex of a DID — the mediator's per-account ACL key
+/// (`sha256::digest(did)` in affinidi-messaging-sdk). Self-referential: a
+/// client always provisions the account keyed by the hash of its own DID.
+fn client_acl_hash(did: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(did);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect()
+}
+
 /// Build a wire-format ACL that allows all message types.
 ///
 /// This creates a `MediatorAcl` wire format (the `acl` member of the trust-tasks
@@ -196,4 +260,55 @@ fn build_allow_all_acl() -> account::update::v0_1::MediatorAcl {
         ))
         .try_into()
         .expect("MediatorAcl has no required member")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_acl_hash_matches_mediator_account_key_convention() {
+        // Vector = sha256(did) hex, taken from a real mediator ACL entry — this
+        // is exactly the account key the mediator derives, so a mismatch means
+        // we would provision the wrong account.
+        assert_eq!(
+            client_acl_hash("did:key:z6MkovnNkdRq64BNcpZqpCnQGDhPe3g2cHeB35A5e7k4sNkS"),
+            "30a923cb69a99f8247469b72ea5b45b534e9f52a09200f92ce72f44e16714136"
+        );
+    }
+
+    #[test]
+    fn client_acl_hash_is_64_char_lowercase_hex() {
+        let h = client_acl_hash("did:webvh:QmExample:vta.example.com");
+        assert_eq!(h.len(), 64);
+        assert!(
+            h.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+    }
+
+    #[test]
+    fn allow_all_acl_opens_everything_but_blocked() {
+        // Serialize so the assertion is agnostic to the wire type's field-name
+        // casing: every boolean must be `true` except the `blocked` flag, and
+        // the forwarded-delivery flags (the whole point) must be present.
+        let v = serde_json::to_value(build_allow_all_acl()).expect("MediatorAcl serializes");
+        let obj = v.as_object().expect("acl serializes to a JSON object");
+        let mut saw_forwarded = false;
+        for (field, value) in obj {
+            let Some(b) = value.as_bool() else { continue };
+            if field.to_ascii_lowercase().contains("block") {
+                assert!(!b, "`{field}` must be false in an allow-all ACL");
+            } else {
+                assert!(b, "`{field}` must be true in an allow-all ACL");
+            }
+            if field.to_ascii_lowercase().contains("forwarded") {
+                saw_forwarded = true;
+            }
+        }
+        assert!(
+            saw_forwarded,
+            "allow-all ACL must set the forwarded-delivery flags"
+        );
+    }
 }

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -126,10 +126,15 @@ async fn set_client_acl_internal(
     // `queueLimits` — passing `None` for those two leaves them untouched, so this
     // is an ACL-only partial update exactly as `acl_set` was.
     //
-    // `account_update` waits for a response, which on an `ExplicitAllow` mediator
-    // cannot arrive until this very ACL grants `receive_forwarded` — so an `Err`
-    // here (typically a timeout) does NOT mean the request was dropped; the
-    // mediator still applies it. Hence debug, not warn, on error.
+    // `account_update` waits for a response, but that response is *direct*
+    // delivery on the socket this request arrived on — the mediator answering
+    // its own client — not a forward. `receive_forwarded` gates only the
+    // routing path (`Capability::ReceiveForwarded` is checked against the *next
+    // hop's* ACL in the mediator's `routing.rs`), so a still-closed account does
+    // not withhold this reply. An `Err` here is therefore a genuine transport
+    // failure or a slow mediator; it is logged at debug rather than propagated
+    // because the mediator applies the ACL before responding, so a lost or late
+    // reply still leaves the update applied.
     match atm
         .trust_tasks()
         .account_update(

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -1176,6 +1176,20 @@ impl VtaClient {
         }
     }
 
+    /// Provision this client's own allow-all mediator ACL over its live DIDComm
+    /// socket, awaiting the result. No-op on a REST or TSP-only client.
+    ///
+    /// Call before an operation whose reply the mediator must *forward* back to
+    /// this DID — a freshly bootstrapped or rotated client is otherwise closed
+    /// for forwarded delivery and the reply is dropped. Reuses the connection
+    /// already open here rather than building a second one for the same DID.
+    #[cfg(feature = "session")]
+    pub async fn provision_client_acl(&self, client_name: &str) {
+        if let Transport::DIDComm { session, .. } = &self.transport {
+            session.provision_client_acl(client_name).await;
+        }
+    }
+
     /// Gracefully shut down the client.
     ///
     /// **Required for every DIDComm client** (no-op for REST). A DIDComm

--- a/vta-sdk/src/didcomm_session.rs
+++ b/vta-sdk/src/didcomm_session.rs
@@ -849,6 +849,28 @@ impl DIDCommSession {
     /// session in this SDK registered one, so `shutdown()` stopped the deletion
     /// handler and left a reconnecting socket behind for the life of the
     /// process.
+    /// Provision this session's own allow-all mediator ACL over its **live**
+    /// socket, awaiting the result.
+    ///
+    /// The connect-time hook ([`crate::acl_setup::set_client_acl_on_connection`])
+    /// is fire-and-forget and builds a second profile for the same DID; this
+    /// reuses the profile already attached here, so nothing contends for the
+    /// DID's one-socket-per-DID slot at the mediator. Best-effort: errors are
+    /// logged inside, not returned. No-op unless `acl-setup` is enabled.
+    pub async fn provision_client_acl(&self, client_name: &str) {
+        #[cfg(feature = "acl-setup")]
+        crate::acl_setup::set_client_acl_with_profile(
+            &self.atm,
+            &self.identity.profile,
+            &self.identity.did,
+            "didcomm-session",
+            client_name,
+        )
+        .await;
+        #[cfg(not(feature = "acl-setup"))]
+        let _ = client_name;
+    }
+
     ///
     /// On a shared hub the detach is the whole teardown: siblings keep running.
     /// On a hub this session built for itself, the hub is torn down too.

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -500,6 +500,17 @@ impl SessionStore {
             session.access_token = Some(new_token_result.access_token.clone());
             session.access_expires_at = Some(new_token_result.access_expires_at);
             self.save_session(key, &session)?;
+
+            // Only now — with the rotated key on disk — is it safe to touch the
+            // network again. If the VTA advertises a mediator, open the rotated
+            // DID's account so DIDComm (e.g. `pnm health`) works immediately;
+            // pure-REST VTAs resolve to no mediator and are skipped. Strictly
+            // best-effort and strictly *after* the commit: a failure here only
+            // means the account opens lazily on the next connect, whereas the
+            // same call before `save_session` could hang past a Ctrl-C and leave
+            // the operator locked out (the temp DID is already deleted by then).
+            open_rotated_mediator_account(&session_vta_did, &session).await;
+
             return Ok(new_token_result.access_token);
         }
 
@@ -581,7 +592,13 @@ impl SessionStore {
         };
 
         // Open the DIDComm session as the (possibly temp) DID.
-        let client = crate::client::VtaClient::connect_didcomm(
+        //
+        // Bounded, like every other DIDComm connect in this file: this path is
+        // reached from `connect_with_transport` whenever a session is pending
+        // rotation, so an unbounded connect here would turn an unreachable
+        // mediator from "errors in 30s naming `--transport rest`" back into an
+        // indefinite hang for exactly the operators least able to diagnose it.
+        let client = connect_didcomm_bounded(
             &session.client_did,
             &session.private_key,
             &vta_did,
@@ -603,7 +620,7 @@ impl SessionStore {
         client.shutdown().await;
         self.save_session(key, &rotated)?;
 
-        let new_client = crate::client::VtaClient::connect_didcomm(
+        let new_client = connect_didcomm_bounded(
             &rotated.client_did,
             &rotated.private_key,
             &vta_did,
@@ -740,6 +757,31 @@ impl SessionStore {
             debug!(url = %url, "connecting via REST (forced --transport rest)");
             let client = self.rest_client(&url, key).await?;
             return Ok(client);
+        }
+
+        // A pending-rotation session must swap its temp did:key before *any*
+        // mediator connect below, not just the one arm that used to check.
+        //
+        // Only the REST path (`rest_client` → `ensure_authenticated`) rotates on
+        // its own, so every other priority here would otherwise connect with the
+        // temp key and return, leaving the session flagged `needs_rotation`
+        // forever. That is three paths, not one: the explicit `mediator_did`
+        // config hint (priority 1), the `DIDComm` arm, and the `Tsp` arm — and a
+        // VTA advertising both TSP and DIDComm never reaches the `DIDComm` arm
+        // at all, so checking there alone left dual-transport deployments, the
+        // direction the workspace is moving, permanently unrotated.
+        //
+        // Gated on a DIDComm mediator actually being advertised: rotation runs
+        // over DIDComm, so a REST-only or TSP-only VTA must fall through to the
+        // paths below rather than fail here. Resolution is only performed while
+        // a rotation is pending — once per session lifetime — so the hint's
+        // resolution-free fast path is unaffected in steady state.
+        if session.needs_rotation
+            && transport != TransportChoice::Rest
+            && didcomm_mediator_advertised(&session_vta_did).await
+        {
+            debug!("session is pending rotation, delegating to the DIDComm rotation path");
+            return self.ensure_authenticated_didcomm(key).await;
         }
 
         // Priority 1: Explicit mediator DID from config → DIDComm directly.
@@ -919,16 +961,6 @@ impl SessionStore {
                 if transport == TransportChoice::Tsp {
                     return Err(no_tsp_endpoint_error(&vta_did, true, rest_url.is_some()));
                 }
-                // A pending-rotation session must swap its temp did:key here.
-                // This DIDComm connect path (unlike the REST one via
-                // `rest_client` → `ensure_authenticated`) previously ignored
-                // `needs_rotation`, so a DIDComm-only VTA never rotated. Delegate
-                // to the rotation-aware DIDComm path: it mints the fresh key,
-                // moves the ACL entry, opens the new DID's mediator account, and
-                // returns a client connected as the rotated DID.
-                if session.needs_rotation {
-                    return self.ensure_authenticated_didcomm(key).await;
-                }
                 debug!("connecting via DIDComm");
                 let client = connect_didcomm_bounded(
                     &session.client_did,
@@ -1077,7 +1109,23 @@ async fn rotate_key_didcomm(
         )
     })?;
 
-    // 5. Drop the temp DID from the ACL using the new DID's session.
+    // 5. Open the new DID's own mediator account over the probe's **live**
+    //    socket, while the temp DID is still authoritative.
+    //
+    //    Deliberately before step 6, and deliberately on this connection:
+    //    - Before, because everything after the temp DID is deleted runs in a
+    //      window where the caller has not yet persisted `new_private_key`.
+    //      Optional work must not sit there — a hang past a Ctrl-C would leave
+    //      the operator with neither DID usable. Here, a failure is free: the
+    //      temp entry still exists, so the caller can simply retry.
+    //    - On this connection, because the mediator permits one socket per DID.
+    //      Opening a second session for `new_did` would make three open/close
+    //      cycles on that one slot in quick succession, and a slow teardown
+    //      surfaces as a `duplicate-channel` eviction of the authoritative
+    //      client the caller is about to build.
+    probe.provision_client_acl("pnm-rotate").await;
+
+    // 6. Drop the temp DID from the ACL using the new DID's session.
     //    Best-effort — if it fails, the new DID is already live, so
     //    we log and continue rather than leave the caller unauthenticated.
     match probe.delete_acl(&session.client_did).await {
@@ -1094,11 +1142,6 @@ async fn rotate_key_didcomm(
         }
     }
     probe.shutdown().await;
-
-    // Open the rotated DID's own mediator account now, over its live socket —
-    // the probe's connect-time self-provision is fire-and-forget and races the
-    // teardown above, so do it explicitly and awaited here.
-    provision_rotated_client_acl(&new_did, &new_private_key, mediator_did).await;
 
     let Session { vta_did, .. } = session.clone();
     Ok(Session {
@@ -1134,24 +1177,73 @@ fn generate_did_key()
     Ok((did, private_key_multibase, signing))
 }
 
+/// Whether `vta_did`'s DID document advertises a DIDComm mediator.
+///
+/// Used only to decide whether a pending rotation can be served over DIDComm.
+/// A resolution failure answers `false` — the caller then falls through to the
+/// transport priorities, which report their own (better-targeted) errors rather
+/// than turning an unresolvable DID into a rotation failure.
+async fn didcomm_mediator_advertised(vta_did: &str) -> bool {
+    matches!(
+        resolve_vta_endpoint(vta_did).await,
+        Ok(VtaEndpoint::DIDComm { .. })
+            | Ok(VtaEndpoint::Tsp {
+                didcomm_mediator_did: Some(_),
+                ..
+            })
+    )
+}
+
 /// Open a freshly rotated DID's own allow-all mediator account so it is
 /// reachable for forwarded DIDComm immediately after rotation.
 ///
 /// The connect-time self-provision ([`crate::acl_setup::set_client_acl_on_connection`])
-/// is fire-and-forget and races the rotation probe's teardown, so this awaited
-/// pass over a dedicated [`TrustPingSession`] makes reachability deterministic.
-/// Best-effort: a failure only means the account opens lazily on the next
-/// connect, exactly as before this hook existed.
-async fn provision_rotated_client_acl(client_did: &str, private_key: &str, mediator_did: &str) {
-    match TrustPingSession::new(client_did, private_key, mediator_did).await {
-        Ok(session) => {
-            session.provision_client_acl("pnm-rotate").await;
-            session.shutdown().await;
+/// is fire-and-forget and races a rotation teardown, so this awaited pass makes
+/// reachability deterministic.
+///
+/// **Call only after the rotated session has been persisted.** Everything here
+/// is optional — a failure means the account opens lazily on the next connect,
+/// exactly as before this hook existed — but between `acl/swap` and
+/// `save_session` the temp DID is already gone from the VTA's ACL while the new
+/// private key exists only in memory. Optional work that can block in that
+/// window can strand an operator with no usable credential, so the whole thing
+/// (DID resolution *and* the mediator round-trip) is bounded and never
+/// propagates an error.
+///
+/// Pure-REST VTAs resolve to no mediator and are skipped.
+async fn open_rotated_mediator_account(session_vta_did: &str, session: &Session) {
+    /// Covers `resolve_mediator_did` plus the socket and its round-trip. Well
+    /// clear of the 10s `set_client_acl_with_profile` uses internally, so a slow
+    /// mediator still reports through that path rather than being cut off here.
+    const ROTATED_ACL_TIMEOUT: Duration = Duration::from_secs(25);
+
+    let provision = async {
+        let Ok(Some(mediator_did)) = resolve_mediator_did(session_vta_did).await else {
+            return;
+        };
+        match TrustPingSession::new(&session.client_did, &session.private_key, &mediator_did).await
+        {
+            Ok(probe) => {
+                probe.provision_client_acl("pnm-rotate").await;
+                probe.shutdown().await;
+            }
+            Err(e) => debug!(
+                error = %e,
+                "rotate: could not open session to provision rotated DID's mediator ACL \
+                 (non-fatal)"
+            ),
         }
-        Err(e) => debug!(
-            error = %e,
-            "rotate: could not open session to provision rotated DID's mediator ACL (non-fatal)"
-        ),
+    };
+
+    if tokio::time::timeout(ROTATED_ACL_TIMEOUT, provision)
+        .await
+        .is_err()
+    {
+        debug!(
+            client_did = %session.client_did,
+            "rotate: opening the rotated DID's mediator account timed out (non-fatal — \
+             the account opens on the next connect)"
+        );
     }
 }
 
@@ -1228,13 +1320,12 @@ async fn rotate_key(
             .await
             .map_err(|e| format!("rotate: new DID failed challenge-response after swap: {e}"))?;
 
-    // If the VTA advertises a mediator, open the rotated DID's mediator account
-    // so DIDComm (e.g. `pnm health`) works immediately. Pure-REST VTAs resolve
-    // to no mediator and are skipped.
-    if let Ok(Some(mediator_did)) = resolve_mediator_did(&session_vta_did).await {
-        provision_rotated_client_acl(&new_did, &new_private_key, &mediator_did).await;
-    }
-
+    // NOTE: opening the rotated DID's mediator account deliberately does *not*
+    // happen here. Between the `acl/swap` above and the caller's `save_session`,
+    // `new_private_key` exists only in memory while the temp DID is already gone
+    // from the VTA's ACL — so anything that can block in this window can strand
+    // an operator with no usable credential. The caller runs it after the
+    // session is durable; see `SessionStore::ensure_authenticated`.
     let Session { vta_did, .. } = session;
     let rotated = Session {
         client_did: new_did,
@@ -2104,7 +2195,6 @@ pub struct TrustPingSession {
     identity: crate::session_hub::AttachedIdentity,
     ownership: crate::session_hub::HubOwnership,
     mediator_did: String,
-    client_did: String,
 }
 
 impl TrustPingSession {
@@ -2195,7 +2285,6 @@ impl TrustPingSession {
             identity,
             ownership,
             mediator_did: mediator_did.to_string(),
-            client_did: client_did.to_string(),
         })
     }
 
@@ -2230,7 +2319,7 @@ impl TrustPingSession {
         crate::acl_setup::set_client_acl_with_profile(
             self.identity.hub.atm(),
             &self.identity.profile,
-            &self.client_did,
+            &self.identity.did,
             "trust-ping-session",
             client_name,
         )
@@ -3476,6 +3565,135 @@ mod tests {
         let msg = no_rest_endpoint_error("did:webvh:scid:host.example.com").to_string();
         assert!(msg.contains("--url"));
         assert!(msg.contains("did:webvh:scid:host.example.com"));
+    }
+
+    // ── Rotation ordering guards ───────────────────────────────────
+    //
+    // Key rotation deletes the temp DID's ACL entry *at the VTA* before the
+    // caller persists the new private key. Anything that can block in that
+    // window — a DID resolution, a mediator socket — can be killed by a Ctrl-C
+    // or a CI timeout and leave the operator with the temp DID gone and the new
+    // key never written: locked out, with nothing to recover from.
+    //
+    // The ordering is what makes that safe, and it lives across three functions,
+    // so nothing type-level enforces it. These read this file's own source and
+    // fail if the calls move back into the window. Source-level because the
+    // alternative is a live mediator: the bug is *where* an await sits, which no
+    // unit-testable return value observes.
+
+    /// This file's own source, for the ordering guards below.
+    const SRC: &str = include_str!("session.rs");
+
+    /// Body of the item starting at `signature`, up to `terminator`
+    /// (`"\n}\n"` for a free function, `"\n    }\n"` for a method).
+    fn body_of(signature: &str, terminator: &str) -> &'static str {
+        let start = SRC
+            .find(signature)
+            .unwrap_or_else(|| panic!("`{signature}` not found — did it get renamed?"));
+        let rest = &SRC[start..];
+        let end = rest
+            .find(terminator)
+            .unwrap_or_else(|| panic!("could not find the end of `{signature}`"));
+        &rest[..end]
+    }
+
+    #[test]
+    fn rest_rotation_opens_the_mediator_account_only_after_the_key_is_saved() {
+        let rotate = body_of("async fn rotate_key(", "\n}\n");
+        assert!(
+            !rotate.contains("open_rotated_mediator_account"),
+            "`rotate_key` must not open the rotated DID's mediator account: it returns \
+             between `acl/swap` (which deletes the temp entry at the VTA) and the \
+             caller's `save_session`, so anything that blocks there can strand the \
+             operator with no usable credential. `ensure_authenticated` calls it after \
+             the session is durable."
+        );
+
+        let ensure = body_of("pub async fn ensure_authenticated(", "\n    }\n");
+        let saved = ensure
+            .find("self.save_session(key, &session)?;")
+            .expect("`ensure_authenticated` must persist the rotated session");
+        let opened = ensure.find("open_rotated_mediator_account").expect(
+            "`ensure_authenticated` must open the rotated DID's mediator account so \
+             DIDComm works immediately after rotation",
+        );
+        assert!(
+            saved < opened,
+            "`open_rotated_mediator_account` must run *after* `save_session` — before it, \
+             the rotated key exists only in memory while the temp DID is already gone."
+        );
+    }
+
+    #[test]
+    fn didcomm_rotation_opens_the_mediator_account_before_deleting_the_temp_entry() {
+        let rotate = body_of("async fn rotate_key_didcomm(", "\n}\n");
+
+        let provisioned = rotate.find("provision_client_acl").expect(
+            "`rotate_key_didcomm` must open the rotated DID's mediator account so its \
+             forwarded replies are not dropped",
+        );
+        let deleted = rotate
+            .find("delete_acl")
+            .expect("`rotate_key_didcomm` must delete the temp DID's ACL entry");
+        assert!(
+            provisioned < deleted,
+            "the mediator account must be opened *before* `delete_acl`: once the temp \
+             entry is gone the caller has not yet persisted the rotated key, so optional \
+             work in that window can lock the operator out. Before it, a failure is free \
+             — the temp DID is still authoritative and the caller can retry."
+        );
+
+        assert!(
+            !rotate.contains("TrustPingSession::new"),
+            "`rotate_key_didcomm` must provision over the probe's live socket, not a \
+             second session: the mediator permits one socket per DID, and a slow teardown \
+             of an extra one evicts the authoritative client as `duplicate-channel`."
+        );
+    }
+
+    #[test]
+    fn didcomm_rotation_path_bounds_its_connects() {
+        let ensure = body_of("pub async fn ensure_authenticated_didcomm(", "\n    }\n");
+        assert!(
+            !ensure.contains("VtaClient::connect_didcomm("),
+            "`ensure_authenticated_didcomm` must connect via `connect_didcomm_bounded`. \
+             `connect_with_transport` delegates here for every pending-rotation session, \
+             so an unbounded connect turns an unreachable mediator back into an \
+             indefinite hang instead of an error naming `--transport rest`."
+        );
+        assert!(
+            ensure.matches("connect_didcomm_bounded(").count() >= 2,
+            "both the pre-rotation and post-rotation connects must be bounded"
+        );
+    }
+
+    #[test]
+    fn every_didcomm_capable_transport_path_rotates() {
+        let connect = body_of("pub async fn connect_with_transport(", "\n    }\n");
+        let rotation_gate = connect
+            .find("session.needs_rotation")
+            .expect("`connect_with_transport` must handle a pending rotation");
+
+        // The check has to precede *every* mediator connect, not just one arm.
+        // It used to sit in the `DIDComm` arm alone, which a VTA advertising
+        // both TSP and DIDComm never reaches — so dual-transport deployments
+        // stayed flagged `needs_rotation` forever and never retired their temp
+        // did:key. Same for an explicit `mediator_did` config hint, which
+        // short-circuits earlier still.
+        let first_connect = connect
+            .find("connect_didcomm_bounded(")
+            .expect("`connect_with_transport` must connect over DIDComm somewhere");
+        assert!(
+            rotation_gate < first_connect,
+            "the `needs_rotation` check must come before the first mediator connect, so \
+             the config-hint, `DIDComm` and `Tsp` paths are all covered by one gate"
+        );
+        assert_eq!(
+            connect.matches("session.needs_rotation").count(),
+            1,
+            "one gate, not one per arm — a per-arm check is how the `Tsp` and \
+             config-hint paths were missed"
+        );
     }
 }
 

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -919,6 +919,16 @@ impl SessionStore {
                 if transport == TransportChoice::Tsp {
                     return Err(no_tsp_endpoint_error(&vta_did, true, rest_url.is_some()));
                 }
+                // A pending-rotation session must swap its temp did:key here.
+                // This DIDComm connect path (unlike the REST one via
+                // `rest_client` → `ensure_authenticated`) previously ignored
+                // `needs_rotation`, so a DIDComm-only VTA never rotated. Delegate
+                // to the rotation-aware DIDComm path: it mints the fresh key,
+                // moves the ACL entry, opens the new DID's mediator account, and
+                // returns a client connected as the rotated DID.
+                if session.needs_rotation {
+                    return self.ensure_authenticated_didcomm(key).await;
+                }
                 debug!("connecting via DIDComm");
                 let client = connect_didcomm_bounded(
                     &session.client_did,
@@ -1085,6 +1095,11 @@ async fn rotate_key_didcomm(
     }
     probe.shutdown().await;
 
+    // Open the rotated DID's own mediator account now, over its live socket —
+    // the probe's connect-time self-provision is fire-and-forget and races the
+    // teardown above, so do it explicitly and awaited here.
+    provision_rotated_client_acl(&new_did, &new_private_key, mediator_did).await;
+
     let Session { vta_did, .. } = session.clone();
     Ok(Session {
         client_did: new_did,
@@ -1117,6 +1132,27 @@ fn generate_did_key()
     );
     let private_key_multibase = multibase::encode(multibase::Base::Base58Btc, seed);
     Ok((did, private_key_multibase, signing))
+}
+
+/// Open a freshly rotated DID's own allow-all mediator account so it is
+/// reachable for forwarded DIDComm immediately after rotation.
+///
+/// The connect-time self-provision ([`crate::acl_setup::set_client_acl_on_connection`])
+/// is fire-and-forget and races the rotation probe's teardown, so this awaited
+/// pass over a dedicated [`TrustPingSession`] makes reachability deterministic.
+/// Best-effort: a failure only means the account opens lazily on the next
+/// connect, exactly as before this hook existed.
+async fn provision_rotated_client_acl(client_did: &str, private_key: &str, mediator_did: &str) {
+    match TrustPingSession::new(client_did, private_key, mediator_did).await {
+        Ok(session) => {
+            session.provision_client_acl("pnm-rotate").await;
+            session.shutdown().await;
+        }
+        Err(e) => debug!(
+            error = %e,
+            "rotate: could not open session to provision rotated DID's mediator ACL (non-fatal)"
+        ),
+    }
 }
 
 /// Swap a `needs_rotation=true` session's temp did:key for a fresh one via the
@@ -1191,6 +1227,13 @@ async fn rotate_key(
         challenge_response(base_url, &new_did, &new_private_key, &session_vta_did)
             .await
             .map_err(|e| format!("rotate: new DID failed challenge-response after swap: {e}"))?;
+
+    // If the VTA advertises a mediator, open the rotated DID's mediator account
+    // so DIDComm (e.g. `pnm health`) works immediately. Pure-REST VTAs resolve
+    // to no mediator and are skipped.
+    if let Ok(Some(mediator_did)) = resolve_mediator_did(&session_vta_did).await {
+        provision_rotated_client_acl(&new_did, &new_private_key, &mediator_did).await;
+    }
 
     let Session { vta_did, .. } = session;
     let rotated = Session {
@@ -2061,6 +2104,7 @@ pub struct TrustPingSession {
     identity: crate::session_hub::AttachedIdentity,
     ownership: crate::session_hub::HubOwnership,
     mediator_did: String,
+    client_did: String,
 }
 
 impl TrustPingSession {
@@ -2151,6 +2195,7 @@ impl TrustPingSession {
             identity,
             ownership,
             mediator_did: mediator_did.to_string(),
+            client_did: client_did.to_string(),
         })
     }
 
@@ -2173,6 +2218,25 @@ impl TrustPingSession {
             )
             .await?;
         Ok(start.elapsed().as_millis())
+    }
+
+    /// Provision this client's own allow-all mediator ACL over the session's
+    /// live socket, awaiting the result. Call before pinging a VTA whose pong
+    /// the mediator must forward back: a freshly bootstrapped or rotated client
+    /// is otherwise closed for forwarded delivery and the reply is dropped.
+    /// No-op unless the `acl-setup` feature is enabled.
+    pub async fn provision_client_acl(&self, client_name: &str) {
+        #[cfg(feature = "acl-setup")]
+        crate::acl_setup::set_client_acl_with_profile(
+            self.identity.hub.atm(),
+            &self.identity.profile,
+            &self.client_did,
+            "trust-ping-session",
+            client_name,
+        )
+        .await;
+        #[cfg(not(feature = "acl-setup"))]
+        let _ = client_name;
     }
 
     /// Detach this identity — which is what stops its websocket — and, if this


### PR DESCRIPTION
Fresh/rotated pnm clients now open their own mediator account automatically, so
DIDComm reply-bearing calls (e.g. `pnm health` trust-ping) work without a manual
mediator ACL edit.

- Health: provision over the live TrustPingSession socket before the VTA ping.
- Rotation: `connect_with_transport` now honours `needs_rotation` for DIDComm
  (previously dead code — DIDComm-only VTAs never rotated); rotated DID's
  mediator account opened on both rotate paths.

Verified live against a TEE VTA. Unit tests added for the ACL-hash convention
and allow-all ACL shape.
[2-before-fix-no-rotation.log](https://github.com/user-attachments/files/31916893/2-before-fix-no-rotation.log)
[3-after-fix-rotation-evidence.log](https://github.com/user-attachments/files/31916894/3-after-fix-rotation-evidence.log)
