### PR TITLE
feat(auth): whoami reports the capabilities it enforces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "uuid",
 ]
@@ -492,7 +492,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "uuid",
 ]
@@ -617,7 +617,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -3255,7 +3255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.5",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8077,7 +8077,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -8433,7 +8433,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -9710,7 +9710,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -9726,7 +9726,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -9745,7 +9745,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -9763,7 +9763,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
 ]
 
 [[package]]
@@ -9783,9 +9783,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f1699542e5e64000ea7bc4b3b375b44f8babb985160991951af9f0d88dc7ba"
+checksum = "dd898a53522fee7ff4e1a55d4746e32f4ed9f831a4678fb508e17e174cf97005"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10482,7 +10482,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uniffi",
  "vta-sdk",
 ]
@@ -10500,7 +10500,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10579,7 +10579,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "utoipa",
  "uuid",
@@ -10664,7 +10664,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "urlencoding",
  "utoipa",
@@ -10833,7 +10833,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10905,7 +10905,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10963,7 +10963,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -11019,7 +11019,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "vti-common",
 ]
 

--- a/vta-service/src/trust_tasks/auth.rs
+++ b/vta-service/src/trust_tasks/auth.rs
@@ -11,7 +11,7 @@ use serde_json::{Value, json};
 use trust_tasks_rs::{RejectReason, TrustTask};
 use vta_sdk::protocols::auth::{RevokeSessionRequest, RevokeSessionResponse, epoch_to_rfc3339};
 
-use crate::acl::{Role, check_acl_full};
+use crate::acl::{Role, check_acl_entry, effective_capabilities};
 use crate::audit::audit;
 use crate::auth::AuthClaims;
 use crate::auth::session::{SessionState, delete_session, get_session, list_sessions, now_epoch};
@@ -220,13 +220,18 @@ pub(super) async fn handle_whoami(
         }
     };
 
-    // Re-resolve roles/scopes so a policy/ACL change since the token was minted
-    // is reflected. A caller deauthorised mid-token surfaces here as the ACL
-    // error (their authority really is gone).
-    let (role, contexts) = match check_acl_full(&state.acl_ks, &auth.did).await {
-        Ok(rc) => rc,
+    // Re-resolve roles/scopes/capabilities so a policy/ACL change since the token
+    // was minted is reflected. A caller deauthorised mid-token surfaces here as
+    // the ACL error (their authority really is gone).
+    //
+    // One read of the whole entry rather than two of its members: a second read
+    // could straddle a concurrent ACL edit and answer with a role from before it
+    // and a capability set from after.
+    let entry = match check_acl_entry(&state.acl_ks, &auth.did).await {
+        Ok(entry) => entry,
         Err(e) => return app_error_to_reject(&doc, e),
     };
+    let (role, contexts) = (entry.role.clone(), entry.allowed_contexts.clone());
 
     let mut session_info = json!({
         "id": auth.session_id,
@@ -243,10 +248,30 @@ pub(super) async fn handle_whoami(
     // Mirror the access token's scope representation (`ctx:<id>`), built by the
     // canonical authenticate handler.
     let scopes: Vec<String> = contexts.iter().map(|c| format!("ctx:{c}")).collect();
+    // Effective, not stored. The question a caller is asking is "what may I do",
+    // and an entry that narrows nothing means everything its role implies —
+    // returning the stored list would answer a different question and read as
+    // empty for the commonest entry there is. It is also the only way the
+    // additive capabilities are visible at all: no role derives `persona-holder`,
+    // so a consumer computing the role's own set would never see it.
+    let capabilities: Vec<String> = effective_capabilities(&entry.role, &entry.capabilities)
+        .into_iter()
+        .map(|c| {
+            serde_json::to_value(c)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                // Serialization of a fieldless enum cannot fail; the fallback
+                // exists so an unreachable branch cannot drop a capability
+                // silently from an authorization answer.
+                .unwrap_or_else(|| format!("{c:?}"))
+        })
+        .collect();
+
     let body = json!({
         "session": session_info,
         "roles": [role.to_string()],
         "scopes": scopes,
+        "capabilities": capabilities,
     });
 
     audit!(

--- a/vta-service/tests/whoami_trust_task.rs
+++ b/vta-service/tests/whoami_trust_task.rs
@@ -5,7 +5,8 @@
 //! token minted at AAL1 keeps saying `acr=aal1` until it's refreshed, but if
 //! the session was stepped up to AAL2 in the meantime, whoami reports the
 //! current `acr` (read from the session, not the stale token) plus
-//! freshly-resolved roles/scopes — without re-issuing any token.
+//! freshly-resolved roles, scopes and capabilities — without re-issuing any
+//! token.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -123,6 +124,187 @@ async fn whoami_reports_live_session_acr_not_stale_token() {
     // issuedAt / expiresAt are present timestamps.
     assert!(s["issuedAt"].as_str().is_some(), "{v}");
     assert!(s["expiresAt"].as_str().is_some(), "{v}");
+}
+
+/// The capability set whoami reports is the **effective** one, and the
+/// difference is the whole reason the member exists.
+///
+/// An entry that narrows nothing is the commonest entry there is, and its
+/// stored list is empty. Reporting the stored list would answer "what has this
+/// entry been narrowed to" — a question almost nobody is asking — and read as
+/// "you may do nothing" for a full administrator.
+///
+/// The additive capabilities make it sharper still: no role derives
+/// `persona-holder`, so a consumer computing a role's own set would never see a
+/// grant of it, which is exactly the case the console could not previously tell
+/// apart from an absence of authority.
+#[tokio::test]
+async fn whoami_reports_effective_capabilities_including_an_additive_grant() {
+    let (router, ctx) = build_test_app().await;
+    const SUBJECT_SEED: u8 = 0xB3;
+    let did = vta_service::test_support::did_for_seed(SUBJECT_SEED).0;
+    let did = did.as_str();
+    let session_id = "sess-whoami-caps";
+
+    // A context-SCOPED admin, granted holder authority by name. Before
+    // `persona-holder` existed this shape could not be expressed at all: the
+    // pool was reachable only by an admin with no context restriction.
+    let entry = vti_common::acl::AclEntry::new(did, vti_common::acl::Role::Admin, "test")
+        .with_contexts(vec!["ctx1".to_string()])
+        .with_capabilities(vec![vti_common::acl::Capability::PersonaHolder])
+        .with_created_at(1);
+    vti_common::acl::store_acl_entry(&ctx.acl_ks, &entry)
+        .await
+        .expect("seed scoped admin with a holder grant");
+
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        last_seen: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into()],
+        acr: "aal1".into(),
+        acr_expires_at: None,
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+
+    let claims = ctx.jwt_keys.new_claims(
+        did.into(),
+        session_id.into(),
+        "admin".into(),
+        vec!["ctx1".to_string()],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
+        "id": "urn:uuid:whoami-caps-1",
+        "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(SUBJECT_SEED, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    assert_eq!(status, StatusCode::OK, "whoami must succeed: {v}");
+    let caps = v["payload"]["capabilities"]
+        .as_array()
+        .unwrap_or_else(|| panic!("capabilities must be reported: {v}"));
+
+    // The grant, in the kebab-case the wire uses.
+    assert!(
+        caps.iter().any(|c| c == "persona-holder"),
+        "a capability granted by name must be visible, or a client cannot tell \
+         it apart from an absence of authority: {v}"
+    );
+    // And the role's own set rides alongside it — an additive grant narrows
+    // nothing, and a client reading this to decide what to offer needs both.
+    assert!(
+        caps.iter().any(|c| c == "vault-read"),
+        "the role's derived capabilities must still be reported: {v}"
+    );
+    // The grant is not a promotion: the entry is still scoped to one context.
+    assert!(
+        v["payload"]["scopes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c == "ctx:ctx1"),
+        "holder authority must not widen the entry's context scope: {v}"
+    );
+}
+
+/// An ungranted entry reports its role's set and nothing more — the other half
+/// of the pair, without which the test above would pass against a handler that
+/// reported every capability that exists.
+#[tokio::test]
+async fn whoami_does_not_invent_a_capability_nobody_granted() {
+    let (router, ctx) = build_test_app().await;
+    const SUBJECT_SEED: u8 = 0xB4;
+    let did = vta_service::test_support::did_for_seed(SUBJECT_SEED).0;
+    let did = did.as_str();
+    let session_id = "sess-whoami-nocaps";
+    seed_admin_acl(&ctx, did, vec!["ctx1".into()]).await;
+
+    let session = Session {
+        session_id: session_id.into(),
+        did: did.into(),
+        challenge: String::new(),
+        state: SessionState::Authenticated,
+        created_at: now_epoch(),
+        last_seen: now_epoch(),
+        refresh_token: None,
+        refresh_expires_at: Some(now_epoch() + 86_400),
+        tee_attested: false,
+        amr: vec!["did".into()],
+        acr: "aal1".into(),
+        acr_expires_at: None,
+        token_id: None,
+        session_pubkey_b58btc: None,
+    };
+    store_session(&ctx.sessions_ks, &session).await.unwrap();
+
+    let claims = ctx.jwt_keys.new_claims(
+        did.into(),
+        session_id.into(),
+        "admin".into(),
+        vec!["ctx1".to_string()],
+        900,
+        false,
+    );
+    let token = ctx.jwt_keys.encode(&claims).unwrap();
+
+    let mut typed: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
+        "id": "urn:uuid:whoami-caps-2",
+        "type": "https://trusttasks.org/spec/auth/whoami/0.1",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "issuer": did,
+        "recipient": "did:key:z6MkTestVTA",
+        "payload": {},
+    }))
+    .expect("envelope deserialises");
+    vta_service::test_support::sign_as(SUBJECT_SEED, &mut typed);
+    let doc = serde_json::to_value(&typed).expect("envelope serialises");
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/trust-tasks")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&doc).unwrap()))
+        .unwrap();
+    let resp = router.clone().oneshot(req).await.unwrap();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+    let caps = v["payload"]["capabilities"].as_array().expect("reported");
+    assert!(
+        !caps.iter().any(|c| c == "persona-holder"),
+        "no role derives holder authority, so an ungranted entry must not report \
+         it — this is the assertion that makes the granted case mean something: {v}"
+    );
+    assert!(caps.iter().any(|c| c == "vault-read"), "{v}");
 }
 
 #[tokio::test]

--- a/vti-common/src/acl/mod.rs
+++ b/vti-common/src/acl/mod.rs
@@ -1010,11 +1010,24 @@ pub async fn check_acl_full(
     acl: &KeyspaceHandle,
     did: &str,
 ) -> Result<(Role, Vec<String>), AppError> {
+    let entry = check_acl_entry(acl, did).await?;
+    Ok((entry.role, entry.allowed_contexts))
+}
+
+/// The whole live entry, under the same expiry and membership rules as
+/// [`check_acl_full`].
+///
+/// [`check_acl_full`] reads the entry and returns two of its members. A caller
+/// wanting a third — `whoami` wants the capabilities, to answer "what may I do"
+/// — would otherwise read the same row a second time, and the two reads could
+/// disagree across a concurrent ACL edit: a caller could be told a role from
+/// before an update and a capability set from after it. One read, one answer.
+pub async fn check_acl_entry(acl: &KeyspaceHandle, did: &str) -> Result<AclEntry, AppError> {
     match get_acl_entry(acl, did).await? {
         Some(entry) if entry.is_expired(now_epoch()) => {
             Err(AppError::Forbidden(format!("ACL entry expired: {did}")))
         }
-        Some(entry) => Ok((entry.role, entry.allowed_contexts)),
+        Some(entry) => Ok(entry),
         None => Err(AppError::Forbidden(format!("DID not in ACL: {did}"))),
     }
 }


### PR DESCRIPTION
First of the VTA-side work now that `trust-tasks-rs 0.18.2` is released.

## The gap

A client could see roles and scopes, and not whether a caller held a capability
its role does not imply. Since `Capability::PersonaHolder` (#1286) that is
concrete: the capability is **additive** — no role derives it — so a client
computing a role's own set can never see a grant of one.

The console hit this the same day. Unable to tell a granted entry from an
unauthorised one, it disabled the persona pane for every caller that was not an
unscoped admin — which, once OpenVTC's setup began asking for exactly the
scoped-plus-granted shape, meant **disabling itself for the configuration the
stack recommends**. vta-browser-plugin#183 made it explain and stand aside,
which was the best answer available to a client that cannot see the answer.
This is the answer.

## Effective, not stored

An entry that narrows nothing is the commonest entry there is, and its stored
list is empty. Reporting the stored list would answer "what has this entry been
narrowed to" — a question almost nobody asks — and read as "you may do nothing"
for a full administrator.

`effective_capabilities` is the same function the enforcement path calls, so the
report cannot drift from the decision it describes.

## One read, not two

`check_acl_full` read the whole entry and returned two of its members. Adding a
second read for the third would open a window across a concurrent ACL edit: a
caller told a role from before the edit and a capability set from after it.
`check_acl_entry` now returns the entry; `check_acl_full` is a thin wrapper over
it, so every existing caller is unchanged.

## Tests

Two, and the second is what makes the first mean anything — an **ungranted**
entry must not report `persona-holder`, or a handler that returned every
capability in the enum would pass the granted case. The granted test also pins
that the grant is not a promotion: the entry stays scoped to its one context.

## Note on where this was built

`verifiable-trust-infrastructure` had uncommitted `vti-rooms` work in the
checkout when I started — another session's. I moved to a separate git worktree
rather than continue in a tree I was sharing; nothing in `vti-rooms` is touched
here, and an earlier `git stash` of mine that had swept those files up has been
reverted.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new(); no new outbound clients (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1) — read-only task
- [x] Retries bounded (R1.4) — none added
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes after durable handoff (R1.6) — n/a
- [x] Wire types (R3.*) — `capabilities` is an optional member of the published
      `auth/whoami/0.1` response (trust-tasks#377, released 0.18.2); the
      response-conformance gate covers it
- [x] Config absence = most restrictive (R5.*) — an entry with no grant reports
      only its role's set; expiry and membership rules are unchanged
- [x] Logs/status claim only what was verified (R6.*) — the report is computed
      by the enforcement path's own function
- [x] "Process dies on the next line" (R2.1) — n/a, no mutation
- [x] Deviations flagged — none
```

`cargo clippy -p vta-service -p vti-common --all-targets -- -D warnings` clean;
`whoami_trust_task` 4 passing, `vti-common` acl suite 81 passing.