### PR TITLE
feat(persona): withhold sensitive values from a listing that did not ask for them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "uuid",
 ]
@@ -492,7 +492,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "uuid",
 ]
@@ -617,7 +617,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -8077,7 +8077,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9710,7 +9710,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -9726,7 +9726,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -9745,7 +9745,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uuid",
 ]
 
@@ -9763,7 +9763,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
 ]
 
 [[package]]
@@ -9783,9 +9783,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f1699542e5e64000ea7bc4b3b375b44f8babb985160991951af9f0d88dc7ba"
+checksum = "dd898a53522fee7ff4e1a55d4746e32f4ed9f831a4678fb508e17e174cf97005"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10482,7 +10482,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "uniffi",
  "vta-sdk",
 ]
@@ -10500,7 +10500,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10579,7 +10579,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "utoipa",
  "uuid",
@@ -10664,7 +10664,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "urlencoding",
  "utoipa",
@@ -10833,7 +10833,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10905,7 +10905,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10963,7 +10963,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -11019,7 +11019,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.0",
+ "trust-tasks-rs 0.18.2",
  "vti-common",
 ]
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -3235,6 +3235,11 @@ pub(crate) enum PersonaAttributeCommands {
         /// the holder's identity, so it is opt-in.
         #[arg(long)]
         values: bool,
+        /// Also show the sensitive ones — cards, passports, phone numbers.
+        /// Widens `--values`; on its own it shows nothing extra, because it
+        /// can never be the flag that puts plaintext on your screen.
+        #[arg(long)]
+        sensitive: bool,
         /// Include attributes whose backing credential can no longer be
         /// re-derived. On by default — a holder deciding what to present needs
         /// to see what went stale, not have it quietly omitted.

--- a/pnm-cli/src/commands/persona.rs
+++ b/pnm-cli/src/commands/persona.rs
@@ -92,10 +92,22 @@ async fn attribute(client: &VtaClient, command: PersonaAttributeCommands) -> Cmd
         PersonaAttributeCommands::List {
             type_prefix,
             values,
+            sensitive,
             include_stale,
             limit,
             cursor,
-        } => p::cmd_attribute_list(client, type_prefix, values, include_stale, limit, cursor).await,
+        } => {
+            p::cmd_attribute_list(
+                client,
+                type_prefix,
+                values,
+                sensitive,
+                include_stale,
+                limit,
+                cursor,
+            )
+            .await
+        }
         PersonaAttributeCommands::Delete {
             attribute_id,
             cascade,

--- a/vta-cli-common/src/commands/persona.rs
+++ b/vta-cli-common/src/commands/persona.rs
@@ -90,10 +90,15 @@ pub async fn cmd_attribute_put(
 /// Metadata-only unless `--values` is given. The default is not timidity: a
 /// listing that returns values is a read of the holder's identity, and the
 /// command that does it should be the one the operator typed on purpose.
+///
+/// `--sensitive` is the second half of that, and only widens the first: a card
+/// number or a passport number stays out of a `--values` listing until it is
+/// asked for by name.
 pub async fn cmd_attribute_list(
     client: &VtaClient,
     type_prefix: Option<String>,
     include_values: bool,
+    include_sensitive: bool,
     include_stale: Option<bool>,
     limit: Option<std::num::NonZeroU64>,
     cursor: Option<String>,
@@ -102,13 +107,25 @@ pub async fn cmd_attribute_list(
         .persona_attribute_list(
             type_prefix.as_deref(),
             include_values,
+            include_sensitive,
             include_stale,
             limit,
             cursor.as_deref(),
         )
         .await?;
-    if !is_json_output() && !include_values {
-        println!("{DIM}Names only — add --values to include the values themselves.{RESET}");
+    if !is_json_output() {
+        // Said only where it is true, and said once. The agent withholds a
+        // sensitive value without saying so in the response — the row comes
+        // back with no `value`, which reads exactly like a fact that never had
+        // one — so the person is told here or not at all.
+        if !include_values {
+            println!("{DIM}Names only — add --values to include the values themselves.{RESET}");
+        } else if !include_sensitive {
+            println!(
+                "{DIM}Sensitive values — cards, passports, phone numbers — are held back. \
+                 Add --sensitive to include them.{RESET}"
+            );
+        }
     }
     print_result("Your facts:", &result)
 }

--- a/vta-persona/src/claim_types.rs
+++ b/vta-persona/src/claim_types.rs
@@ -1,0 +1,735 @@
+//! The claim-type registry, and the per-axis resolution its §4 makes normative.
+//!
+//! The table below is transcribed from
+//! `specs/persona/_shared/0.1/claim-types.json` at **`registryVersion` 0.1**,
+//! and the rules it is read by are `CLAIM-TYPES.md` §4 beside it. Both halves
+//! are quoted rather than paraphrased where a paraphrase could drift.
+//!
+//! # Why the table is embedded
+//!
+//! Because there is nowhere yet to fetch it from. `CLAIM-TYPES.md` §6 leaves
+//! `persona/claim-types/list` as an open question — "worth doing when the first
+//! extension type ships, not before" — so no agent serves the table and no
+//! client can learn one its build predates. Until that task exists, a copy is
+//! the only way to have the table at all, and a copy that names its source and
+//! its `registryVersion` is the only kind that can later be checked against it.
+//!
+//! Three columns of the source are deliberately **not** transcribed —
+//! `valueType`, `minimumSet` and `oidc`. Nothing in this workspace reads them,
+//! and a column carried without a reader is a column that goes stale without
+//! anything failing.
+//!
+//! # Three axes, and they are not the same axis
+//!
+//! [`Sensitivity`] is how carefully a value is shown **to its own holder**.
+//! [`ReleaseRequirement`] is what it takes to let the value **leave**.
+//! [`MaskStyle`] is how it is drawn when it is shown at all — and is
+//! independent of the other two: any style that is not [`MaskStyle::None`] is
+//! masked on screen whatever its sensitivity, which is how `email.work` can be
+//! worth hiding from the person behind you without being worth withholding
+//! from every listing.
+//!
+//! Reading any one as a proxy for another produces a consumer that hides the
+//! wrong things, so they resolve independently even though one lookup answers
+//! all three.
+//!
+//! # What this module decides, and what it does not
+//!
+//! Only [`Sensitivity`] is acted on today, by
+//! [`PersonaStore::list_attributes`](crate::PersonaStore::list_attributes),
+//! which is the read-path control that makes the axis more than cosmetic.
+//! Nothing consults [`ReleaseRequirement`]: `persona/disclosure/present` does
+//! not yet demand a fresh authentication for a `stepUp` attribute, and a holder
+//! **cannot** record a `release` override, precisely so that nothing here can
+//! be mistaken for a gate that exists. `MaskStyle` is a renderer's business and
+//! this crate draws nothing.
+//!
+//! They are resolved anyway because §4 is one rule over one table. The
+//! alternative is a second copy of both, added when the disclosure gate lands,
+//! which is how the two would come to disagree.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::Attribute;
+
+/// How carefully a value is shown to its own holder.
+///
+/// `high` means the value is withheld from a listing that did not explicitly
+/// ask for sensitive values — and, being withheld, masked when a consumer holds
+/// it anyway. The withholding is the half that is not cosmetic: masking a value
+/// already fetched defends a screen, and is no defence against a log, a crash
+/// dump, or the memory of the process holding it.
+///
+/// Variants are declared **most protective first**, and [`Ord`] is derived from
+/// that order, so "the more protective of two" is `min()` rather than a
+/// hand-written table that can disagree with itself. [`crate::ProofRung`] is
+/// ordered for the same reason and reads the same way.
+///
+/// The consequence worth stating, because the comparison looks backwards: for
+/// two sensitivities `a < b` means *a is stricter than b*, not *a is less
+/// sensitive*.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Sensitivity {
+    High,
+    Normal,
+}
+
+/// What it takes to let a value leave.
+///
+/// `stepUp` requires a fresh authentication bound to *that* preview rather than
+/// to the session — without the binding, "each time" degrades into "once per
+/// login", which is the failure the requirement exists to prevent.
+///
+/// Ordered most protective first, like [`Sensitivity`]. **Nothing enforces this
+/// axis yet**; see the module documentation for why it is resolved regardless.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ReleaseRequirement {
+    StepUp,
+    Consent,
+}
+
+/// How a value is drawn when it is shown.
+///
+/// A property of the *type*, because only the type knows which characters are
+/// the recognisable ones: the last four of a card, the domain of an email
+/// address, none of a display name. A mask applies to a rendering and never to
+/// what is stored or sent, so this crate stores it and draws nothing.
+///
+/// Ordered most protective first, like the other two axes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MaskStyle {
+    Full,
+    Last2,
+    Last4,
+    EmailLocal,
+    None,
+}
+
+/// The three axes as they resolve for one claim type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Axes {
+    pub sensitivity: Sensitivity,
+    pub release: ReleaseRequirement,
+    pub mask: MaskStyle,
+}
+
+/// One row of the registry.
+#[derive(Clone, Copy, Debug)]
+struct Entry {
+    token: &'static str,
+    axes: Axes,
+}
+
+/// `defaults.unregistered` — what an axis resolves to when neither an exact
+/// entry nor a registered family supplies it.
+///
+/// Deliberately the conservative answer. A vocabulary this registry has never
+/// seen is exactly the one nobody has reasoned about, and an unknown value
+/// rendered in the clear is a decision nobody made.
+const UNREGISTERED: Axes = Axes {
+    sensitivity: Sensitivity::High,
+    release: ReleaseRequirement::Consent,
+    mask: MaskStyle::Full,
+};
+
+/// The open extension namespace. An `x:` token is unregistered **by
+/// construction**: it borrows neither an entry nor a family, however much of a
+/// registered token it happens to spell.
+const EXTENSION_PREFIX: &str = "x:";
+
+/// The core table, transcribed from `claim-types.json` `registryVersion` 0.1.
+///
+/// `payment` and `gov` are **family** rows: they exist so that
+/// `payment.somethingNew` cannot resolve to the unregistered default, whose
+/// `release` is `consent` — weaker than every registered member of the family
+/// it plainly belongs to. A gated family must not be leavable by inventing a
+/// token.
+///
+/// `name` is both: an exact token — a pool that keeps one undifferentiated name
+/// is using it — and a family prefix, where it can only ever tighten.
+const REGISTRY: &[Entry] = &[
+    Entry {
+        token: "payment",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Full,
+        },
+    },
+    Entry {
+        token: "gov",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Full,
+        },
+    },
+    Entry {
+        token: "name",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "name.legal",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "name.given",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "name.family",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "name.display",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    // A former name is not a lesser name. It is the one a holder most often
+    // keeps in order to answer a question once and never show again.
+    Entry {
+        token: "name.previous",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::Full,
+        },
+    },
+    Entry {
+        token: "person.birthDate",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::Full,
+        },
+    },
+    Entry {
+        token: "person.pronouns",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "person.locale",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "email.personal",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::EmailLocal,
+        },
+    },
+    Entry {
+        token: "email.work",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::EmailLocal,
+        },
+    },
+    // High because a mobile number is both a strong join key and an
+    // authentication factor at a great many services. Its harm is not
+    // embarrassment; it is account takeover.
+    Entry {
+        token: "phone.mobile",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::Last2,
+        },
+    },
+    Entry {
+        token: "phone.landline",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::Last2,
+        },
+    },
+    Entry {
+        token: "address.postal",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::Full,
+        },
+    },
+    // Separate from the full address on purpose: country alone answers most
+    // jurisdiction questions and identifies almost nobody.
+    Entry {
+        token: "address.country",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "gov.id.passport",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "gov.id.driverLicence",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "gov.id.national",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "gov.taxId",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "payment.card",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "payment.cardExpiry",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Full,
+        },
+    },
+    Entry {
+        token: "payment.iban",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "payment.accountNumber",
+        axes: Axes {
+            sensitivity: Sensitivity::High,
+            release: ReleaseRequirement::StepUp,
+            mask: MaskStyle::Last4,
+        },
+    },
+    Entry {
+        token: "account.handle",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "url.homepage",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "org.name",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+    Entry {
+        token: "org.role",
+        axes: Axes {
+            sensitivity: Sensitivity::Normal,
+            release: ReleaseRequirement::Consent,
+            mask: MaskStyle::None,
+        },
+    },
+];
+
+/// The registry's defaults for one claim type — §4 rules 2, 3 and 4, applied
+/// per axis.
+///
+/// Rule 1 — the holder's own decision — is not applied here, because this
+/// function is about the *type* and an override belongs to an attribute. See
+/// [`sensitivity_of`].
+///
+/// The rules, in the order they are tried:
+///
+/// 2. An **exact** entry supplies every axis **as written**, and is never
+///    compared against the floor. This is what lets `name` resolve to `normal`
+///    and `none` even though the unregistered default is stricter on both — a
+///    registry that could not say "this one is ordinary" would mask every legal
+///    name in every pool, which teaches holders to reveal reflexively.
+/// 3. Otherwise the **longest registered family** and the unregistered floor
+///    are compared *per axis*, and the **more protective** of the two wins. Not
+///    "the family wins": a family entry can only ever tighten, so `payment`
+///    lends its `stepUp` to `payment.giftCard`, while `name` lends nothing at
+///    all to `name.somethingNew` — which stays `high`, `full`, invisible until
+///    asked for by name.
+/// 4. Otherwise the floor.
+///
+/// Rule 3 is what makes the hierarchy load-bearing rather than merely
+/// appealing, and it was missing from the first draft of the specification.
+/// Without it `payment.somethingNew` resolved to a `release` of `consent`,
+/// weaker than every registered member of the family it plainly belongs to.
+#[must_use]
+pub fn defaults_for(claim_type: &str) -> Axes {
+    // Rule 4, taken first rather than last: `x:` is unregistered by
+    // construction, so it must borrow neither an entry nor a family. Nothing in
+    // the table starts with `x:` today, so the exact lookup below would miss
+    // anyway — but the *family* lookup would not, and `x:payment.card` reading
+    // as a payment instrument is the specific mistake this closes.
+    if claim_type.starts_with(EXTENSION_PREFIX) {
+        return UNREGISTERED;
+    }
+
+    if let Some(entry) = REGISTRY.iter().find(|e| e.token == claim_type) {
+        return entry.axes;
+    }
+
+    match longest_registered_family(claim_type) {
+        Some(family) => Axes {
+            sensitivity: family.axes.sensitivity.min(UNREGISTERED.sensitivity),
+            release: family.axes.release.min(UNREGISTERED.release),
+            mask: family.axes.mask.min(UNREGISTERED.mask),
+        },
+        None => UNREGISTERED,
+    }
+}
+
+/// The longest registered **proper** prefix of `claim_type`, on segment
+/// boundaries.
+///
+/// Segment boundaries, not bytes. `typePrefix` on `persona/attribute/list` is
+/// explicitly a byte comparison and invites the same reading here, where it
+/// would be wrong in a way that matters: a byte prefix makes `paymentology` a
+/// member of the `payment` family and lends it a gate it never asked for — or,
+/// with the axes the other way round, a permission.
+///
+/// Returns the whole [`Entry`] rather than its [`Axes`] so a test can pin
+/// *which* family was chosen. The shipped table has no two nested families that
+/// disagree on any axis, so "longest" is currently unobservable in the result;
+/// pinning the mechanism is what keeps the rule right for the first table that
+/// can tell them apart.
+fn longest_registered_family(claim_type: &str) -> Option<&'static Entry> {
+    claim_type
+        .match_indices('.')
+        .map(|(i, _)| &claim_type[..i])
+        .filter_map(|prefix| REGISTRY.iter().find(|e| e.token == prefix))
+        // `match_indices` walks left to right, so the last match is the
+        // longest — and taken from the back, the first one found is that match.
+        .next_back()
+}
+
+/// The sensitivity of one attribute — §4 in full, rule 1 included.
+///
+/// **Store the override; derive the default.** Only a holder's deliberate
+/// choice is persisted, and a resolved default is computed at read, so
+/// tightening the registry protects the attributes already in the pool rather
+/// than only future ones — while a holder's own decision never changes under
+/// them.
+///
+/// An override wins in **both** directions. A holder who marks their card
+/// `normal` has decided something about their own pool, and a maintainer that
+/// quietly kept withholding it would be overruling the person the control
+/// exists to serve.
+#[must_use]
+pub fn sensitivity_of(attribute: &Attribute) -> Sensitivity {
+    attribute
+        .sensitivity
+        .unwrap_or_else(|| defaults_for(&attribute.r#type).sensitivity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Provenance, ValueType};
+    use crate::store::new_attribute;
+
+    fn attribute_of(claim_type: &str) -> Attribute {
+        new_attribute(
+            claim_type,
+            ValueType::String,
+            serde_json::json!("v"),
+            Provenance::SelfAsserted,
+        )
+    }
+
+    /// Rule 2. An exact entry is used as written and is never compared against
+    /// the floor — which is the only way the registry can say "this one is
+    /// ordinary" about a type the floor would otherwise hide.
+    #[test]
+    fn an_exact_entry_beats_the_family_and_the_floor() {
+        // `name` is an exact entry AND a family prefix. As an entry it is
+        // permissive on every axis, and rule 2 keeps it that way.
+        assert_eq!(
+            defaults_for("name"),
+            Axes {
+                sensitivity: Sensitivity::Normal,
+                release: ReleaseRequirement::Consent,
+                mask: MaskStyle::None,
+            }
+        );
+
+        // `name.previous` sits under a permissive family and is stricter than
+        // it on two axes. Rule 2 keeps that too: an exact entry tightens as
+        // freely as it loosens.
+        assert_eq!(
+            defaults_for("name.previous"),
+            Axes {
+                sensitivity: Sensitivity::High,
+                release: ReleaseRequirement::Consent,
+                mask: MaskStyle::Full,
+            }
+        );
+
+        // And an exact entry more permissive than its family on one axis:
+        // `payment.card` shows its last four where the `payment` family says
+        // `full`.
+        assert_eq!(defaults_for("payment.card").mask, MaskStyle::Last4);
+    }
+
+    /// Rule 3, the direction it was written for. `payment` lends its `stepUp`
+    /// to a token nobody has registered, so a gated family cannot be made
+    /// leavable by inventing a member.
+    #[test]
+    fn a_family_tightens_an_unregistered_member() {
+        let invented = defaults_for("payment.giftCard");
+        assert_eq!(
+            invented.release,
+            ReleaseRequirement::StepUp,
+            "an unregistered member of a gated family escaped the gate"
+        );
+        assert_eq!(invented.sensitivity, Sensitivity::High);
+        assert_eq!(invented.mask, MaskStyle::Full);
+
+        // The same, one level deeper, where the family is two segments above
+        // the token rather than one.
+        assert_eq!(
+            defaults_for("gov.id.somethingNew").release,
+            ReleaseRequirement::StepUp
+        );
+    }
+
+    /// Rule 3, the direction that is easy to get backwards. A family entry can
+    /// only ever TIGHTEN: `name` does not make an unregistered `name.*`
+    /// visible.
+    #[test]
+    fn a_family_cannot_loosen_an_unregistered_member() {
+        let invented = defaults_for("name.somethingNew");
+        assert_eq!(
+            invented.sensitivity,
+            Sensitivity::High,
+            "an invented token inherited the family's permissiveness — a name \
+             nobody has reasoned about is not thereby ordinary"
+        );
+        assert_eq!(invented.mask, MaskStyle::Full);
+        // The axis both agree on stays where both put it.
+        assert_eq!(invented.release, ReleaseRequirement::Consent);
+    }
+
+    /// Rule 3's tie-break, pinned against the mechanism rather than the result.
+    ///
+    /// The shipped table has no two nested families that disagree on an axis,
+    /// so a shortest-prefix implementation would pass every assertion above.
+    #[test]
+    fn the_longest_registered_family_is_the_one_that_applies() {
+        let chosen = longest_registered_family("name.legal.somethingNew")
+            .expect("`name.legal` is registered and is a proper prefix");
+        assert_eq!(
+            chosen.token, "name.legal",
+            "a shorter registered prefix won over a longer one"
+        );
+
+        // Proper prefixes only. A registered token is never its own family: it
+        // is rule 2's business, and a token that matched itself here would let
+        // rule 3 compare an exact entry against the floor — which is precisely
+        // what rule 2 says must not happen.
+        assert_eq!(
+            longest_registered_family("name.legal").map(|e| e.token),
+            Some("name")
+        );
+        assert!(
+            longest_registered_family("name").is_none(),
+            "a single-segment token has no proper prefix to inherit from"
+        );
+
+        // Segment boundaries, not bytes.
+        assert!(
+            longest_registered_family("paymentology.card").is_none(),
+            "a byte prefix admitted a token that is not in the family"
+        );
+    }
+
+    /// Rule 4. An `x:` token borrows nothing — not an entry, not a family.
+    #[test]
+    fn an_extension_token_borrows_nothing() {
+        for token in ["x:payment", "x:payment.card", "x:name.given", "x:anything"] {
+            assert_eq!(
+                defaults_for(token),
+                UNREGISTERED,
+                "{token} borrowed from the registry; `x:` is unregistered by construction"
+            );
+        }
+
+        // The contrast is the point: strip the `x:` and two of those resolve
+        // somewhere else entirely.
+        assert_eq!(defaults_for("payment.card").mask, MaskStyle::Last4);
+        assert_eq!(defaults_for("name.given").sensitivity, Sensitivity::Normal);
+    }
+
+    /// Rule 4 for an ordinary unknown, which is the common case for an
+    /// extension vocabulary that did not use the `x:` namespace.
+    #[test]
+    fn an_unknown_root_gets_the_floor() {
+        assert_eq!(defaults_for("wibble"), UNREGISTERED);
+        assert_eq!(defaults_for("wibble.wobble"), UNREGISTERED);
+    }
+
+    /// Rule 1, in both directions. The holder's decision is the first thing
+    /// consulted and the last word.
+    #[test]
+    fn a_holder_override_wins_over_the_registry() {
+        // Tightening a type the registry calls ordinary.
+        let mut ordinary = attribute_of("name.given");
+        assert_eq!(sensitivity_of(&ordinary), Sensitivity::Normal);
+        ordinary.sensitivity = Some(Sensitivity::High);
+        assert_eq!(sensitivity_of(&ordinary), Sensitivity::High);
+
+        // And loosening one it calls sensitive. This direction is the one an
+        // implementation is tempted to refuse; refusing it would overrule the
+        // person the control exists to serve.
+        let mut sensitive = attribute_of("payment.card");
+        assert_eq!(sensitivity_of(&sensitive), Sensitivity::High);
+        sensitive.sensitivity = Some(Sensitivity::Normal);
+        assert_eq!(
+            sensitivity_of(&sensitive),
+            Sensitivity::Normal,
+            "the holder's own decision was overruled by the registry"
+        );
+
+        // An unset override is not `normal`: it records that the holder decided
+        // nothing, and an unregistered token then resolves conservatively.
+        assert_eq!(
+            sensitivity_of(&attribute_of("x:whatever")),
+            Sensitivity::High
+        );
+    }
+
+    /// The transcription, checked against the source it names.
+    ///
+    /// Two ways for an embedded copy to be wrong that a reader will not notice:
+    /// a variant spelled differently from the JSON, and a variant declared in
+    /// the wrong place in the strictness order. The second is the dangerous
+    /// one — `min()` is the whole of rule 3, so a misplaced variant silently
+    /// resolves the wrong way round on every unregistered token.
+    #[test]
+    fn each_axis_matches_the_strictness_order_in_claim_types_json() {
+        // Verbatim from the `strictness` block, most protective first.
+        let sensitivity: Vec<String> = [Sensitivity::High, Sensitivity::Normal]
+            .iter()
+            .map(|v| serde_json::to_value(v).unwrap().as_str().unwrap().into())
+            .collect();
+        assert_eq!(sensitivity, ["high", "normal"]);
+
+        let release: Vec<String> = [ReleaseRequirement::StepUp, ReleaseRequirement::Consent]
+            .iter()
+            .map(|v| serde_json::to_value(v).unwrap().as_str().unwrap().into())
+            .collect();
+        assert_eq!(release, ["stepUp", "consent"]);
+
+        let mask: Vec<String> = [
+            MaskStyle::Full,
+            MaskStyle::Last2,
+            MaskStyle::Last4,
+            MaskStyle::EmailLocal,
+            MaskStyle::None,
+        ]
+        .iter()
+        .map(|v| serde_json::to_value(v).unwrap().as_str().unwrap().into())
+        .collect();
+        assert_eq!(mask, ["full", "last2", "last4", "emailLocal", "none"]);
+
+        // The arrays above are the declaration order only if `min()` agrees
+        // with them, which is the property rule 3 actually uses.
+        assert_eq!(
+            Sensitivity::High.min(Sensitivity::Normal),
+            Sensitivity::High
+        );
+        assert_eq!(
+            ReleaseRequirement::StepUp.min(ReleaseRequirement::Consent),
+            ReleaseRequirement::StepUp
+        );
+        assert_eq!(MaskStyle::Full.min(MaskStyle::None), MaskStyle::Full);
+    }
+
+    /// The table's own invariants. A duplicate token makes the exact lookup
+    /// depend on declaration order, and an `x:` row is unreachable by
+    /// construction — both are transcription mistakes with no symptom.
+    #[test]
+    fn the_embedded_table_is_well_formed() {
+        let mut seen = std::collections::HashSet::new();
+        for entry in REGISTRY {
+            assert!(
+                seen.insert(entry.token),
+                "duplicate registry token {}",
+                entry.token
+            );
+            assert!(
+                !entry.token.starts_with(EXTENSION_PREFIX),
+                "{} is in the `x:` namespace and can never be looked up",
+                entry.token
+            );
+        }
+        // The two rows rule 3 exists for. Losing either is how an invented
+        // member of a gated family becomes leavable.
+        assert!(seen.contains("payment"));
+        assert!(seen.contains("gov"));
+    }
+}

--- a/vta-persona/src/correlation.rs
+++ b/vta-persona/src/correlation.rs
@@ -431,7 +431,16 @@ impl crate::PersonaStore {
 
         let subjects: Vec<crate::Attribute> = match attribute_id {
             Some(id) => self.get(id).await?.into_iter().collect(),
-            None => self.list_attributes(None, true).await?,
+            // Every value, sensitive ones included. The sensitivity control is
+            // about what a listing *carries out*; here the values are hashed
+            // against the correlation index and never leave — a `payment.card`
+            // skipped for sensitivity would be a card whose reuse the holder is
+            // never warned about.
+            None => {
+                self.list_attributes(None, crate::ValueVisibility::All)
+                    .await?
+                    .attributes
+            }
         };
 
         for a in subjects {

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -38,6 +38,7 @@
 //! so there is one BBS implementation in the workspace rather than two.
 
 pub mod binding;
+pub mod claim_types;
 pub mod contact;
 pub mod correlation;
 pub mod disclosure;
@@ -48,6 +49,10 @@ pub mod storage;
 pub mod store;
 
 pub use binding::{BindingSummary, Bound, MaterialisedClaim};
+// Types only. `defaults_for` and `sensitivity_of` keep their module in the
+// path: at the crate root their names say nothing about which registry, and
+// there will be more than one thing with defaults.
+pub use claim_types::{Axes, MaskStyle, ReleaseRequirement, Sensitivity};
 pub use contact::{Contact, ContactClaim, ContactDocument, ContactRevision, ContactSummary, Filed};
 pub use disclosure::{DisclosedClaim, DisclosureRecord, HistoryQuery, new_disclosure};
 pub use model::{
@@ -56,7 +61,7 @@ pub use model::{
 };
 pub use present::{PREVIEW_TTL_SECONDS, Preview, PreviewClaim, Renderer, renderer};
 pub use profile::{ResolvedClaim, is_pool_free, new_profile};
-pub use store::{Deleted, PersonaStore, Written, new_attribute};
+pub use store::{Deleted, Listing, PersonaStore, ValueVisibility, Written, new_attribute};
 
 #[cfg(test)]
 mod published_types {
@@ -83,6 +88,25 @@ mod published_types {
             <put::Payload as trust_tasks_rs::Payload>::TYPE_URI,
             "https://trusttasks.org/spec/persona/attribute/put/1.0"
         );
+    }
+
+    /// The axis the read path acts on, so a variant renamed upstream cannot
+    /// reach the wire spelled one way here and another there. `high` is the
+    /// value that withholds a plaintext; a spelling drift would silently stop
+    /// withholding it.
+    #[test]
+    fn our_sensitivity_matches_the_published_enum() {
+        use trust_tasks_rs::specs::persona::attribute::list::v1_0 as list;
+        for (ours, theirs) in [
+            (crate::Sensitivity::Normal, list::Sensitivity::Normal),
+            (crate::Sensitivity::High, list::Sensitivity::High),
+        ] {
+            assert_eq!(
+                serde_json::to_value(ours).unwrap(),
+                serde_json::to_value(theirs).unwrap(),
+                "our Sensitivity and the published one disagree on the wire"
+            );
+        }
     }
 
     #[test]

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -16,6 +16,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::claim_types::Sensitivity;
+
 /// A ULID in Crockford base32. Record identity for attributes and profiles.
 ///
 /// Chosen over a UUID because the leading 48 bits are a timestamp, so a
@@ -185,6 +187,20 @@ pub struct Attribute {
     pub stale: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stale_reason: Option<StaleReason>,
+    /// Set **only** where the holder decided it explicitly.
+    ///
+    /// Absent is not `normal`: it records that no decision was made, and the
+    /// default is derived from the claim-type registry at read
+    /// ([`crate::claim_types::sensitivity_of`]). Storing the resolved value
+    /// instead would freeze it — a later tightening of the registry would then
+    /// protect new attributes and leave this one exposed.
+    ///
+    /// There is deliberately no `release` counterpart. The published schema
+    /// defines one, and nothing in this workspace enforces a `stepUp` at
+    /// disclosure yet; a stored override for a gate that does not exist is a
+    /// promise the holder would be entitled to rely on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sensitivity: Option<Sensitivity>,
     pub version: Version,
     pub created_at: String,
     pub updated_at: String,

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -32,6 +32,7 @@ use tokio::sync::Mutex;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
+use crate::claim_types::{self, Sensitivity};
 use crate::correlation;
 use crate::model::{Attribute, Provenance, Ulid, ValueType, Version};
 use crate::storage;
@@ -61,6 +62,55 @@ pub(crate) enum Slot {
 pub struct Written {
     pub version: Version,
     pub created: bool,
+}
+
+/// How much of a listing's plaintext the caller asked for.
+///
+/// Three states rather than two booleans, because the fourth combination —
+/// sensitive values without values — is not a request. `persona/attribute/list`
+/// says `includeSensitive` "widens `includeValues`, and can never be the
+/// thing that introduces plaintext on its own"; a pair of booleans lets a call
+/// site express the combination anyway and obliges every reader to remember
+/// that it means nothing. [`ValueVisibility::from_flags`] performs that
+/// collapse once, where the wire members arrive.
+///
+/// Ordered least revealing first, so a variant added in the wrong place reads
+/// wrong rather than merely being wrong.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValueVisibility {
+    /// Metadata only. The default, and what a picker needs.
+    Metadata,
+    /// Values, except those resolving to [`Sensitivity::High`].
+    Ordinary,
+    /// Every value, sensitive ones included.
+    All,
+}
+
+impl ValueVisibility {
+    /// Collapse the two wire members into the three states they can express.
+    #[must_use]
+    pub fn from_flags(include_values: bool, include_sensitive: bool) -> Self {
+        match (include_values, include_sensitive) {
+            (false, _) => Self::Metadata,
+            (true, false) => Self::Ordinary,
+            (true, true) => Self::All,
+        }
+    }
+}
+
+/// The attributes a listing returned, and what it withheld to return them.
+///
+/// The count travels with the rows because the alternative is deriving it at
+/// the call site from an absent `value` — which cannot tell a value withheld
+/// for sensitivity from one that was never asked for or one whose credential
+/// went stale. Three causes, one symptom; only the store knows which applied.
+#[derive(Clone, Debug)]
+pub struct Listing {
+    pub attributes: Vec<Attribute>,
+    /// How many values [`ValueVisibility::Ordinary`] held back. Zero for every
+    /// other visibility, including [`ValueVisibility::Metadata`], which
+    /// withholds everything for a different reason.
+    pub withheld_sensitive: usize,
 }
 
 /// Outcome of a delete. `existed` distinguishes a removal from a no-op.
@@ -302,10 +352,16 @@ impl PersonaStore {
 
     /// Every live attribute, optionally narrowed by vocabulary prefix.
     ///
-    /// `include_values` is opt-in because the common case — rendering a picker
-    /// so a holder can choose what to compose with — needs type and label, not
-    /// plaintext. Making the sensitive path the one a caller has to ask for
-    /// means it is never the one they get by forgetting.
+    /// [`ValueVisibility`] is opt-in because the common case — rendering a
+    /// picker so a holder can choose what to compose with — needs type and
+    /// label, not plaintext. Making the sensitive path the one a caller has to
+    /// ask for means it is never the one they get by forgetting.
+    ///
+    /// A value withheld for sensitivity leaves its **row** in place: type,
+    /// label, provenance, version and staleness all come back. This is
+    /// withholding a value, not hiding a fact — a holder listing their pool
+    /// must still see that the card is there, or the control teaches them their
+    /// own store has lost something.
     ///
     /// Stale credential-backed attributes are returned carrying their reason
     /// rather than omitted: a pool that looks smaller than it is would leave
@@ -313,13 +369,15 @@ impl PersonaStore {
     pub async fn list_attributes(
         &self,
         type_prefix: Option<&str>,
-        include_values: bool,
-    ) -> Result<Vec<Attribute>, AppError> {
+        values: ValueVisibility,
+    ) -> Result<Listing, AppError> {
         let rows = self
             .ks
             .prefix_iter_raw(storage::ATTRIBUTE_PREFIX.as_bytes().to_vec())
             .await?;
-        Ok(rows
+
+        let mut withheld_sensitive = 0usize;
+        let attributes = rows
             .into_iter()
             .filter_map(|(_k, v)| match serde_json::from_slice::<Slot>(&v) {
                 Ok(Slot::Live(a)) => Some(a),
@@ -327,12 +385,29 @@ impl PersonaStore {
             })
             .filter(|a| type_prefix.is_none_or(|p| a.r#type.starts_with(p)))
             .map(|mut a| {
-                if !include_values {
-                    a.value = None;
+                match values {
+                    ValueVisibility::Metadata => a.value = None,
+                    ValueVisibility::Ordinary
+                        if a.value.is_some()
+                            && claim_types::sensitivity_of(&a) == Sensitivity::High =>
+                    {
+                        // Counted only here, so the count means "the
+                        // sensitivity control did this" rather than "no value
+                        // came back". A metadata-only listing withholds every
+                        // value and none of them for this reason.
+                        withheld_sensitive += 1;
+                        a.value = None;
+                    }
+                    ValueVisibility::Ordinary | ValueVisibility::All => {}
                 }
                 a
             })
-            .collect())
+            .collect();
+
+        Ok(Listing {
+            attributes,
+            withheld_sensitive,
+        })
     }
 
     /// Profiles whose entries refer to this attribute, from the reverse index —
@@ -459,6 +534,9 @@ pub fn new_attribute(
         provenance,
         stale: None,
         stale_reason: None,
+        // Unset, not `normal`: a new attribute records no holder decision, so
+        // its sensitivity resolves from the registry every time it is read.
+        sensitivity: None,
         version: 0,
         created_at: now.clone(),
         updated_at: now,
@@ -632,81 +710,262 @@ mod list_tests {
     use vti_common::config::StoreConfig;
     use vti_common::store::Store;
 
-    #[tokio::test]
-    async fn listing_withholds_values_unless_asked() {
+    async fn fresh_store() -> (tempfile::TempDir, PersonaStore) {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(&StoreConfig {
             data_dir: dir.path().to_path_buf(),
         })
         .unwrap();
-        let s = PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [1u8; 32]);
+        let ks = store.keyspace(vta_keyspaces::PERSONA).unwrap();
+        (dir, PersonaStore::new(ks, [1u8; 32]))
+    }
 
-        s.put(
-            new_attribute(
-                "phone.mobile",
-                ValueType::String,
-                serde_json::json!("+61"),
-                Provenance::SelfAsserted,
-            ),
-            None,
-        )
-        .await
-        .unwrap();
+    async fn store_one(s: &PersonaStore, claim_type: &str, value: &str) -> Attribute {
+        let a = new_attribute(
+            claim_type,
+            ValueType::String,
+            serde_json::json!(value),
+            Provenance::SelfAsserted,
+        );
+        s.put(a.clone(), None).await.unwrap();
+        a
+    }
 
-        let quiet = s.list_attributes(None, false).await.unwrap();
-        assert_eq!(quiet.len(), 1);
+    /// Find one attribute in a listing by claim type.
+    fn of_type<'a>(listing: &'a Listing, claim_type: &str) -> &'a Attribute {
+        listing
+            .attributes
+            .iter()
+            .find(|a| a.r#type == claim_type)
+            .unwrap_or_else(|| panic!("{claim_type} is missing from the listing"))
+    }
+
+    #[tokio::test]
+    async fn listing_withholds_values_unless_asked() {
+        let (_d, s) = fresh_store().await;
+        // `account.handle` resolves to `normal`, so this test is about
+        // `includeValues` alone and cannot pass by accident on sensitivity.
+        store_one(&s, "account.handle", "ada").await;
+
+        let quiet = s
+            .list_attributes(None, ValueVisibility::Metadata)
+            .await
+            .unwrap();
+        assert_eq!(quiet.attributes.len(), 1);
         assert!(
-            quiet[0].value.is_none(),
+            quiet.attributes[0].value.is_none(),
             "the default must not move plaintext"
         );
+        assert_eq!(
+            quiet.withheld_sensitive, 0,
+            "a metadata listing withholds everything, but not for sensitivity"
+        );
 
-        let loud = s.list_attributes(None, true).await.unwrap();
-        assert!(loud[0].value.is_some());
+        let loud = s
+            .list_attributes(None, ValueVisibility::Ordinary)
+            .await
+            .unwrap();
+        assert!(loud.attributes[0].value.is_some());
     }
 
     #[tokio::test]
     async fn a_prefix_selects_a_vocabulary_family_and_a_tombstone_is_not_listed() {
-        let dir = tempfile::tempdir().unwrap();
-        let store = Store::open(&StoreConfig {
-            data_dir: dir.path().to_path_buf(),
-        })
-        .unwrap();
-        let s = PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [1u8; 32]);
+        let (_d, s) = fresh_store().await;
 
-        let a = new_attribute(
-            "phone.work",
-            ValueType::String,
-            serde_json::json!("1"),
-            Provenance::SelfAsserted,
-        );
-        s.put(a.clone(), None).await.unwrap();
-        s.put(
-            new_attribute(
-                "name.legal",
-                ValueType::String,
-                serde_json::json!("n"),
-                Provenance::SelfAsserted,
-            ),
-            None,
-        )
-        .await
-        .unwrap();
+        let a = store_one(&s, "phone.work", "1").await;
+        store_one(&s, "name.legal", "n").await;
 
-        assert_eq!(
-            s.list_attributes(Some("phone"), false).await.unwrap().len(),
-            1
-        );
-        assert_eq!(
-            s.list_attributes(Some("name"), false).await.unwrap().len(),
-            1
-        );
-        assert_eq!(s.list_attributes(None, false).await.unwrap().len(), 2);
+        for (prefix, expected) in [(Some("phone"), 1), (Some("name"), 1), (None, 2)] {
+            assert_eq!(
+                s.list_attributes(prefix, ValueVisibility::Metadata)
+                    .await
+                    .unwrap()
+                    .attributes
+                    .len(),
+                expected
+            );
+        }
 
         s.delete(&a.attribute_id, false).await.unwrap();
         assert_eq!(
-            s.list_attributes(Some("phone"), false).await.unwrap().len(),
+            s.list_attributes(Some("phone"), ValueVisibility::Metadata)
+                .await
+                .unwrap()
+                .attributes
+                .len(),
             0,
             "a tombstone is not a live attribute"
         );
+    }
+
+    /// The control this whole path exists for: a listing that asked for values
+    /// still does not carry a sensitive one.
+    ///
+    /// Paired with its success case below, deliberately. A refusal test alone
+    /// passes against an implementation that withholds everything, which is a
+    /// picker that shows the holder nothing.
+    #[tokio::test]
+    async fn a_sensitive_value_is_withheld_from_a_listing_that_asked_only_for_values() {
+        let (_d, s) = fresh_store().await;
+        store_one(&s, "payment.card", "4242424242424242").await;
+        store_one(&s, "name.given", "Ada").await;
+
+        let listing = s
+            .list_attributes(None, ValueVisibility::Ordinary)
+            .await
+            .unwrap();
+
+        assert!(
+            of_type(&listing, "payment.card").value.is_none(),
+            "a card number left the store on a listing that never asked for \
+             sensitive values — masking it afterwards defends a screen and not \
+             a log, a crash dump, or this process's memory"
+        );
+        assert_eq!(
+            of_type(&listing, "name.given").value,
+            Some(serde_json::json!("Ada")),
+            "an ordinary value was withheld too, which is a picker that shows \
+             the holder nothing"
+        );
+        assert_eq!(listing.withheld_sensitive, 1);
+    }
+
+    #[tokio::test]
+    async fn a_sensitive_value_is_returned_when_the_listing_asked_for_sensitive_values() {
+        let (_d, s) = fresh_store().await;
+        store_one(&s, "payment.card", "4242424242424242").await;
+
+        let listing = s.list_attributes(None, ValueVisibility::All).await.unwrap();
+        assert_eq!(
+            of_type(&listing, "payment.card").value,
+            Some(serde_json::json!("4242424242424242")),
+            "the holder could not read their own card back by asking for it"
+        );
+        assert_eq!(
+            listing.withheld_sensitive, 0,
+            "nothing was withheld, so nothing should be counted"
+        );
+    }
+
+    /// Withholding a value is not hiding a fact. The row and everything about
+    /// it still come back, or a holder listing their own pool would conclude
+    /// the store had lost the card.
+    #[tokio::test]
+    async fn a_withheld_attribute_keeps_its_metadata() {
+        let (_d, s) = fresh_store().await;
+        let mut card = new_attribute(
+            "payment.card",
+            ValueType::String,
+            serde_json::json!("4242424242424242"),
+            Provenance::SelfAsserted,
+        );
+        card.label = Some("the blue one".into());
+        s.put(card.clone(), None).await.unwrap();
+
+        let listing = s
+            .list_attributes(None, ValueVisibility::Ordinary)
+            .await
+            .unwrap();
+        let row = of_type(&listing, "payment.card");
+        assert_eq!(row.attribute_id, card.attribute_id);
+        assert_eq!(row.label.as_deref(), Some("the blue one"));
+        assert_eq!(row.value_type, ValueType::String);
+        assert!(row.version > 0);
+        assert!(row.value.is_none());
+    }
+
+    /// `includeSensitive` widens `includeValues`; it is never the member that
+    /// introduces plaintext.
+    #[tokio::test]
+    async fn asking_for_sensitive_values_without_values_asks_for_no_plaintext() {
+        assert_eq!(
+            ValueVisibility::from_flags(false, true),
+            ValueVisibility::Metadata
+        );
+        assert_eq!(
+            ValueVisibility::from_flags(false, false),
+            ValueVisibility::Metadata
+        );
+        assert_eq!(
+            ValueVisibility::from_flags(true, false),
+            ValueVisibility::Ordinary
+        );
+        assert_eq!(
+            ValueVisibility::from_flags(true, true),
+            ValueVisibility::All
+        );
+
+        let (_d, s) = fresh_store().await;
+        store_one(&s, "payment.card", "4242424242424242").await;
+        let listing = s
+            .list_attributes(None, ValueVisibility::from_flags(false, true))
+            .await
+            .unwrap();
+        assert!(
+            listing.attributes[0].value.is_none(),
+            "`includeSensitive` alone introduced plaintext"
+        );
+    }
+
+    /// The registry decides, and the holder overrules it — both directions, on
+    /// the read path rather than only in the classifier's own tests.
+    #[tokio::test]
+    async fn the_holders_own_sensitivity_decides_what_a_listing_carries() {
+        let (_d, s) = fresh_store().await;
+
+        // A type the registry calls ordinary, which the holder does not.
+        let mut handle = new_attribute(
+            "account.handle",
+            ValueType::String,
+            serde_json::json!("ada"),
+            Provenance::SelfAsserted,
+        );
+        handle.sensitivity = Some(Sensitivity::High);
+        s.put(handle, None).await.unwrap();
+
+        // A type the registry calls sensitive, which the holder does not.
+        let mut card = new_attribute(
+            "payment.card",
+            ValueType::String,
+            serde_json::json!("4242424242424242"),
+            Provenance::SelfAsserted,
+        );
+        card.sensitivity = Some(Sensitivity::Normal);
+        s.put(card, None).await.unwrap();
+
+        let listing = s
+            .list_attributes(None, ValueVisibility::Ordinary)
+            .await
+            .unwrap();
+        assert!(
+            of_type(&listing, "account.handle").value.is_none(),
+            "the holder marked this sensitive and the listing carried it anyway"
+        );
+        assert!(
+            of_type(&listing, "payment.card").value.is_some(),
+            "the holder's own decision about their own pool was overruled"
+        );
+        assert_eq!(listing.withheld_sensitive, 1);
+    }
+
+    /// An unregistered token is withheld, and that is the conservative answer
+    /// working rather than a bug. `x:` borrows nothing from the registry.
+    #[tokio::test]
+    async fn an_unregistered_token_is_withheld_by_default() {
+        let (_d, s) = fresh_store().await;
+        store_one(&s, "x:loyaltyNumber", "9911").await;
+        store_one(&s, "name.somethingNew", "Ada").await;
+
+        let listing = s
+            .list_attributes(None, ValueVisibility::Ordinary)
+            .await
+            .unwrap();
+        assert!(of_type(&listing, "x:loyaltyNumber").value.is_none());
+        assert!(
+            of_type(&listing, "name.somethingNew").value.is_none(),
+            "an invented token inherited `name`'s permissiveness — a family \
+             entry can only ever tighten"
+        );
+        assert_eq!(listing.withheld_sensitive, 2);
     }
 }

--- a/vta-sdk/src/client/persona.rs
+++ b/vta-sdk/src/client/persona.rs
@@ -112,10 +112,16 @@ impl VtaClient {
     /// difference between "how many phone numbers do I hold" and a read of the
     /// holder's identity, so it is opt-in rather than something a caller has
     /// to remember to narrow.
+    ///
+    /// `include_sensitive` is the second escalation, and only ever widens the
+    /// first: values resolving to `sensitivity: high` — a card number, a
+    /// passport number, a mobile — are omitted from a listing that asked for
+    /// values but not for these.
     pub async fn persona_attribute_list(
         &self,
         type_prefix: Option<&str>,
         include_values: bool,
+        include_sensitive: bool,
         include_stale: Option<bool>,
         limit: Option<std::num::NonZeroU64>,
         cursor: Option<&str>,
@@ -123,6 +129,7 @@ impl VtaClient {
         let payload = body(PersonaAttributeListBody {
             type_prefix: type_prefix.map(str::to_string),
             include_values: include_values.then_some(true),
+            include_sensitive: include_sensitive.then_some(true),
             include_stale,
             limit,
             cursor: cursor.map(str::to_string),

--- a/vta-sdk/src/protocols/persona.rs
+++ b/vta-sdk/src/protocols/persona.rs
@@ -280,6 +280,16 @@ pub struct PersonaAttributeListBody {
     /// Return values, not just metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub include_values: Option<bool>,
+    /// Also return the values of attributes resolving to `sensitivity: high`.
+    ///
+    /// Widens [`include_values`](Self::include_values) and is never the member
+    /// that introduces plaintext: without it, a listing that asked for values
+    /// still omits the card number and returns the row around it. Separate from
+    /// `include_values` because a picker wants every name and no card, and
+    /// should not have to choose between plaintext for everything and plaintext
+    /// for nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_sensitive: Option<bool>,
     /// Include attributes whose backing credential could no longer be
     /// re-derived. Defaults to true: a holder deciding what to present needs
     /// to see that something went stale, not to have it quietly omitted.

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -260,7 +260,7 @@ fn decide(
 // noticing. The generated types cannot.
 
 use trust_tasks_rs::specs::persona as spec;
-use vta_persona::{PersonaStore, ValueType, new_attribute};
+use vta_persona::{Listing, PersonaStore, Sensitivity, ValueType, ValueVisibility, new_attribute};
 
 /// Open the store for this request.
 ///
@@ -370,11 +370,12 @@ fn provenance_kind(p: &vta_persona::Provenance) -> &'static str {
     }
 }
 
-/// The wire spelling of a value type — `string`, `number`, `date`, …
+/// The wire spelling of a string-valued enum — `string`, `date`, `high`, …
 ///
-/// Via serde rather than a second `match`, so a variant added to `ValueType`
-/// cannot end up spelled one way in a response and another in the audit row.
-fn value_type_name(v: ValueType) -> String {
+/// Via serde rather than a second `match` per enum, so a variant added to
+/// `ValueType` or `Sensitivity` cannot end up spelled one way in a response and
+/// another in the audit row.
+fn wire_name<T: serde::Serialize>(v: T) -> String {
     serde_json::to_value(v)
         .ok()
         .and_then(|j| j.as_str().map(str::to_string))
@@ -454,6 +455,31 @@ pub(super) async fn handle_attribute_put(
     // `CredentialBacked` provenance must not.
     let provenance_kind = provenance_kind(&provenance);
 
+    // The holder's own decision, and only where they made one. Absent is not
+    // `normal`: it records that nothing was decided, so the default resolves
+    // from the claim-type registry at every read and a later tightening of that
+    // registry protects the attributes already in the pool.
+    //
+    // Through the wire spelling rather than a match, for the reason `valueType`
+    // above takes the same route: the generated enum is `#[non_exhaustive]`, so
+    // a match needs a wildcard arm, and a wildcard arm is where a variant added
+    // upstream would land silently.
+    let sensitivity: Option<Sensitivity> = match req.sensitivity.as_ref() {
+        None => None,
+        Some(s) => match serde_json::to_value(s)
+            .ok()
+            .and_then(|v| serde_json::from_value(v).ok())
+        {
+            Some(parsed) => Some(parsed),
+            None => {
+                return reject(
+                    &doc,
+                    AppError::Validation("unrecognised sensitivity".into()),
+                );
+            }
+        },
+    };
+
     let mut attribute = new_attribute(
         req.type_.to_string(),
         value_type,
@@ -464,6 +490,7 @@ pub(super) async fn handle_attribute_put(
         attribute.attribute_id = id.to_string();
     }
     attribute.label = req.label.as_ref().map(|l| (**l).clone());
+    attribute.sensitivity = sensitivity;
 
     let attribute_id = attribute.attribute_id.clone();
     let value = attribute.value.clone();
@@ -482,11 +509,20 @@ pub(super) async fn handle_attribute_put(
         None => 0,
     };
 
+    // A sensitivity override points either way — `normal` on a card is a
+    // holder deciding their own tooling may show it — so the row records the
+    // decision and not merely that a write happened. Without it a holder
+    // reviewing the trail cannot see when the withholding stopped.
+    let sensitivity_note = match sensitivity {
+        Some(s) => format!(", sensitivity {} set by the holder", wire_name(s)),
+        None => String::new(),
+    };
+
     // Type, value TYPE, provenance kind and version — never `value`. See
     // `audit_persona` for why that line is drawn on lifetime rather than on
     // who may read the row.
     let detail = format!(
-        "{} attribute {attribute_id}: claim type {}, valueType {}, provenance {}, now at \
+        "{} attribute {attribute_id}: claim type {}, valueType {}, provenance {}{}, now at \
          version {}",
         if written.created {
             "created"
@@ -494,8 +530,9 @@ pub(super) async fn handle_attribute_put(
             "updated"
         },
         req.type_.as_str(),
-        value_type_name(value_type),
+        wire_name(value_type),
         provenance_kind,
+        sensitivity_note,
         written.version,
     );
     audit_persona(
@@ -537,17 +574,64 @@ pub(super) async fn handle_attribute_list(
     }
 
     // Values are withheld unless asked for: the common case — rendering a
-    // picker — needs type and label, not plaintext.
-    let include_values = req.include_values;
+    // picker — needs type and label, not plaintext. `includeSensitive` widens
+    // that request and can never be the member that introduces plaintext on its
+    // own, so the two collapse into one visibility here rather than travelling
+    // as a pair every reader has to remember the fourth state of.
+    let visibility = ValueVisibility::from_flags(req.include_values, req.include_sensitive);
     let s = store(state);
     let prefix = req.type_prefix.as_ref().map(|p| p.as_str());
-    let attributes = match s.list_attributes(prefix, include_values).await {
-        Ok(a) => a,
+    let listing = match s.list_attributes(prefix, visibility).await {
+        Ok(l) => l,
         Err(e) => return reject(&doc, e),
     };
 
-    audit_persona(state, "persona.attribute.list", auth, None, None, None).await;
-    success_response(&doc, serde_json::json!({ "attributes": attributes }))
+    let detail = list_detail(&listing, visibility, prefix);
+    audit_persona(
+        state,
+        "persona.attribute.list",
+        auth,
+        None,
+        None,
+        Some(&detail),
+    )
+    .await;
+    success_response(
+        &doc,
+        serde_json::json!({ "attributes": listing.attributes }),
+    )
+}
+
+/// What a listing did, for the audit trail.
+///
+/// A read is audited at all because this one enumerates the holder's identity;
+/// what makes the row worth keeping is which of the three listings it was. A
+/// trail in which "showed me the names" and "handed a process every card
+/// number" are the same row cannot answer the question a holder reviewing it
+/// actually has.
+///
+/// Counts, a claim-type prefix and the visibility — never a value. See
+/// [`audit_persona`] for why that line is drawn on lifetime rather than on who
+/// may read the row: `attribute/list` hands the values themselves to exactly
+/// the caller who can read the audit log, so a value here would disclose
+/// nothing new and would outlive the record it came from.
+fn list_detail(listing: &Listing, visibility: ValueVisibility, prefix: Option<&str>) -> String {
+    let scope = match prefix {
+        Some(p) => format!(" under {p}"),
+        None => String::new(),
+    };
+    let plaintext = match visibility {
+        ValueVisibility::Metadata => "metadata only, no values".to_string(),
+        ValueVisibility::Ordinary => format!(
+            "values included, {} sensitive value(s) withheld",
+            listing.withheld_sensitive
+        ),
+        ValueVisibility::All => "values included, sensitive values included".to_string(),
+    };
+    format!(
+        "listed {} attribute(s){scope}: {plaintext}",
+        listing.attributes.len()
+    )
 }
 
 pub(super) async fn handle_attribute_delete(

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -1274,6 +1274,269 @@ async fn a_persona_write_is_audited_with_what_changed_and_not_the_value() {
 }
 
 // ---------------------------------------------------------------------------
+// 5b. A listing withholds sensitive values, and the trail says which listing
+//     it was
+// ---------------------------------------------------------------------------
+
+/// One attribute out of a listing response, by claim type.
+fn listed<'a>(body: &'a Value, claim_type: &str) -> &'a Value {
+    payload_of(body)
+        .get("attributes")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("no attributes array in {body}"))
+        .iter()
+        .find(|a| a.get("type").and_then(Value::as_str) == Some(claim_type))
+        .unwrap_or_else(|| panic!("{claim_type} is missing from the listing: {body}"))
+}
+
+/// Every `detail` the trail holds for `action`.
+///
+/// A set rather than "the most recent one": the storage key is
+/// `log:{timestamp:020}:{uuid}`, so rows written inside the same second are
+/// ordered by a random uuid and "latest" is not a thing a test can ask for.
+/// What the trail has to support is telling one listing from another, and that
+/// is a claim about the whole set.
+async fn details_for(ctx: &TestAppContext, action: &str) -> Vec<String> {
+    audit_rows(ctx)
+        .await
+        .iter()
+        .filter(|r| r.action == action)
+        .map(|r| {
+            r.detail
+                .clone()
+                .unwrap_or_else(|| panic!("a {action} audit row carries no detail: {r:#?}"))
+        })
+        .collect()
+}
+
+/// `includeValues` moves the ordinary facts and leaves the card behind;
+/// `includeSensitive` is what moves the card.
+///
+/// Asserted at the wire, because that is the only place the claim is about the
+/// system. The store's own tests say `list_attributes` withholds; they cannot
+/// say that the handler passes `includeSensitive` through, and a handler that
+/// dropped it would pass every one of them while shipping card numbers to any
+/// caller that asked for values.
+///
+/// The three listings are asserted together and so are their audit rows. A
+/// trail in which "showed me my names" and "handed a process every card
+/// number" are the same row cannot answer the question a holder reviewing it
+/// has, and each half of that pair passes on its own against an implementation
+/// that is wrong in the other direction.
+#[tokio::test]
+async fn a_listing_withholds_sensitive_values_and_says_so_in_the_audit_trail() {
+    let (router, ctx) = build_test_app().await;
+    let holder = authed(&ctx, "sensitive", "admin", &[]).await;
+
+    // Distinctive enough that finding it anywhere in a response or a row is
+    // unambiguous.
+    const CARD: &str = "4242424242424242";
+    const GIVEN: &str = "Ada";
+    put_attribute(&router, &holder, "payment.card", CARD).await;
+    put_attribute(&router, &holder, "name.given", GIVEN).await;
+
+    // 1. Values, but not the sensitive ones. `payment.card` resolves to `high`
+    //    from the registry — no holder set anything here.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_LIST,
+        json!({ "includeValues": true }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/list: {status} {body}");
+    assert!(
+        listed(&body, "payment.card").get("value").is_none(),
+        "a card number left the agent on a listing that asked only for values. \
+         Masking it in the consumer defends a screen and not a log, a crash \
+         dump, or the memory of the process holding it: {body}"
+    );
+    assert_eq!(
+        listed(&body, "name.given")
+            .get("value")
+            .and_then(Value::as_str),
+        Some(GIVEN),
+        "an ordinary value was withheld too, which is a picker that shows the \
+         holder nothing: {body}"
+    );
+    assert!(
+        !serde_json::to_string(&body).unwrap().contains(CARD),
+        "the card number is somewhere else in the response: {body}"
+    );
+    // The row is still there. This is withholding a value, not hiding a fact:
+    // a holder must not conclude their agent has lost the card.
+    assert_eq!(
+        listed(&body, "payment.card")
+            .get("type")
+            .and_then(Value::as_str),
+        Some("payment.card")
+    );
+
+    // 2. And the escalation that moves it. The holder can always read their own
+    //    pool back; what they cannot do is get there by forgetting.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_LIST,
+        json!({ "includeValues": true, "includeSensitive": true }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/list: {status} {body}");
+    assert_eq!(
+        listed(&body, "payment.card")
+            .get("value")
+            .and_then(Value::as_str),
+        Some(CARD),
+        "the holder could not read their own card back by asking for it: {body}"
+    );
+    // 3. `includeSensitive` alone introduces no plaintext. It widens
+    //    `includeValues` and is never a request of its own.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_LIST,
+        json!({ "includeSensitive": true }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/list: {status} {body}");
+    for claim_type in ["payment.card", "name.given"] {
+        assert!(
+            listed(&body, claim_type).get("value").is_none(),
+            "`includeSensitive` without `includeValues` produced plaintext for \
+             {claim_type}: {body}"
+        );
+    }
+
+    // Three listings, three rows, and no two of them alike. The three ways this
+    // task can behave are the three the holder most needs told apart, and the
+    // response carries nothing that would let a reviewer reconstruct which was
+    // which — a withheld value and a fact that never had one look identical on
+    // the wire.
+    let details = details_for(&ctx, "persona.attribute.list").await;
+    assert_eq!(details.len(), 3, "one row per listing: {details:#?}");
+    assert_eq!(
+        details
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        3,
+        "two listings are indistinguishable in the audit trail: {details:#?}"
+    );
+    for expected in [
+        "values included, 1 sensitive value(s) withheld",
+        "values included, sensitive values included",
+        "metadata only",
+    ] {
+        assert!(
+            details.iter().any(|d| d.contains(expected)),
+            "no audit row says `{expected}`: {details:#?}"
+        );
+    }
+}
+
+/// The holder's own decision survives the write and decides the read — in the
+/// direction the registry would not have chosen.
+///
+/// Both directions, because an implementation that honours only the tightening
+/// one is not honouring an override at all: it is applying `max()` to the
+/// holder's opinion and the registry's, which overrules the person the control
+/// exists to serve.
+#[tokio::test]
+async fn a_holders_sensitivity_override_survives_the_write_and_decides_the_read() {
+    let (router, ctx) = build_test_app().await;
+    let holder = authed(&ctx, "sensitivity-override", "admin", &[]).await;
+
+    // `account.handle` is `normal` in the registry; this holder disagrees.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_PUT,
+        json!({
+            "type": "account.handle",
+            "value": "ada",
+            "valueType": "string",
+            "provenance": { "kind": "selfAsserted" },
+            "sensitivity": "high",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/put: {status} {body}");
+
+    // `payment.card` is `high` in the registry; this holder disagrees.
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_PUT,
+        json!({
+            "type": "payment.card",
+            "value": "4111111111111111",
+            "valueType": "string",
+            "provenance": { "kind": "selfAsserted" },
+            "sensitivity": "normal",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/put: {status} {body}");
+
+    let (status, body) = post(
+        &router,
+        &holder,
+        ATTR_LIST,
+        json!({ "includeValues": true }),
+    )
+    .await;
+    assert!(!refused(status, &body), "attribute/list: {status} {body}");
+    assert!(
+        listed(&body, "account.handle").get("value").is_none(),
+        "the holder marked this sensitive and the listing carried it anyway: {body}"
+    );
+    assert_eq!(
+        listed(&body, "payment.card")
+            .get("value")
+            .and_then(Value::as_str),
+        Some("4111111111111111"),
+        "the holder's own decision about their own pool was overruled by the \
+         registry: {body}"
+    );
+
+    // The override is stored, not merely obeyed once — and it comes back on the
+    // wire, which is what a client needs to render the decision the holder
+    // made rather than the default it would otherwise infer.
+    assert_eq!(
+        listed(&body, "account.handle")
+            .get("sensitivity")
+            .and_then(Value::as_str),
+        Some("high")
+    );
+    // An attribute nobody decided anything about carries no member at all.
+    // Absent is not `normal`: it is what lets a later tightening of the
+    // registry protect this attribute too.
+    let handle = put_attribute(&router, &holder, "org.role", "Engineer").await;
+    let (_status, body) = post(
+        &router,
+        &holder,
+        ATTR_LIST,
+        json!({ "typePrefix": "org", "includeValues": true }),
+    )
+    .await;
+    assert!(
+        listed(&body, "org.role").get("sensitivity").is_none(),
+        "an attribute with no holder decision reported one: {body}"
+    );
+    assert!(!handle.is_empty());
+
+    // A write that records the decision leaves a trail that says so.
+    let rows = audit_rows(&ctx).await;
+    assert!(
+        rows.iter().any(|r| r.action == "persona.attribute.put"
+            && r.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("sensitivity normal set by the holder"))),
+        "no audit row records the holder loosening a card: {rows:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // 6. `correlation/analyze` names where a value went
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`persona/attribute/list` now honours `includeSensitive` — the read-path control that makes `sensitivity` more than cosmetic. A listing that asked for values still omits the plaintext of anything resolving to `sensitivity: high` unless `includeSensitive` is also set; `includeSensitive` on its own introduces no plaintext, because it widens `includeValues` and is never a request of its own.

Withholding a value is not hiding a fact. The row comes back with its type, label, provenance, staleness and version — a holder listing their own pool must still see that the card is there.

### The classifier

New `vta-persona/src/claim_types.rs`. The table is **embedded** from `specs/persona/_shared/0.1/claim-types.json` at `registryVersion` 0.1, named as such in the module doc, because `persona/claim-types/list` does not exist yet (CLAIM-TYPES.md §6 leaves it open) and there is nowhere to fetch it from. Three source columns — `valueType`, `minimumSet`, `oidc` — are deliberately not transcribed: nothing reads them, and a column with no reader goes stale silently.

§4 resolves **per axis**, in order:

1. the holder's override on the attribute;
2. an **exact** entry, used as written and never compared against anything;
3. otherwise the **more protective** of the longest registered family and `defaults.unregistered` — so a family can only ever *tighten*;
4. otherwise the floor (`high` / `consent` / `full`).

Consequences pinned by tests: `payment.giftCard` inherits `payment`'s `stepUp`; `name.somethingNew` inherits **none** of `name`'s permissiveness and stays `high`/`full`; `name` itself stays `normal`/`none` because rule 2 does not compare an exact entry against the floor; `x:` borrows neither an entry nor a family.

The three axis enums declare their variants **most protective first** and derive `Ord`, so "more protective" is `min()` rather than a hand-written table — the same choice `ProofRung` already made in this crate.

### Where §4 was ambiguous, and how it was read

- **"Longest registered prefix" — bytes or segments?** §4 does not say, and `typePrefix` on this very task is explicitly a byte comparison, which invites the wrong reading. Resolved as **dot-segment boundaries**: a byte prefix makes `paymentology.card` a member of the `payment` family and lends it a gate it never asked for. Worth stating in the spec.
- **Is a token its own prefix?** Read as **proper prefixes only**. If a token could match itself in rule 3, an exact entry would be compared against the floor, which is exactly what rule 2 forbids.
- **"Longest" is currently unobservable.** No two nested families in the shipped table disagree on any axis, and because the floor is already maximal on `sensitivity` and `mask`, rule 3 can only ever change `release` today. A shortest-prefix implementation would pass every outcome-level test, so `the_longest_registered_family_is_the_one_that_applies` pins the *mechanism* (`name.legal` beats `name`) rather than a result.
- **`x:` with a registered-looking tail.** §4 says "anything under `x:`" and claim-types.json says unregistered by construction; `x:payment.card` therefore borrows nothing. Handled before the exact lookup rather than after, since the *family* lookup would otherwise match.

### Holder override

`Attribute.sensitivity` is a new optional member, and absent is **not** `normal` — it records that the holder decided nothing, so the default is derived at read and a later tightening of the registry protects attributes already in the pool. The override wins in **both** directions: a holder marking their own card `normal` is not overruled.

`attribute/put` now stores it. It previously accepted `sensitivity` (the member is in the published payload schema and the generated type) and silently dropped it, so the override was unreachable.

There is deliberately **no `release` override stored**, and nothing consults the `release` axis. `disclosure/present` does not yet demand a fresh authentication for a `stepUp` attribute; a stored override for a gate that does not exist is a promise the holder would be entitled to rely on. The axis is *resolved* because §4 is one rule over one table and a second copy added later is how the two would drift.

### Audit

**No schema change was needed.** `AuditEnvelope` already carries `detail`, which the console renders in full and which `persona.attribute.list` was passing as `None`. The three listings are now distinguishable:

- `listed 4 attribute(s): metadata only, no values`
- `listed 4 attribute(s) under payment: values included, 1 sensitive value(s) withheld`
- `listed 4 attribute(s): values included, sensitive values included`

Counts, a claim-type prefix, and the visibility — never a value, for the lifetime reason `audit_persona` documents at length. A `put` that records a holder override says so too, because an override points either way and a trail that recorded the write but not the decision cannot show when the withholding stopped.

### Reachability (why this is not VTA-only)

`pnm persona attribute list --values` returned card numbers before this change. Left server-only, the change would remove function from the only client, so `--sensitive` is plumbed through `vta-sdk` → `vta-cli-common` → `pnm`, and the CLI now says out loud that sensitive values were held back — the wire cannot say it, since a withheld value and a fact that never had one look identical.

`--sensitivity` on `pnm persona attribute put` is **not** added: nothing regresses without it, and any conformant producer can already send the member.

### Bindings

`cargo update trust-tasks-rs@0.18.0` → 0.18.2 (adds `includeSensitive` and `Attribute.sensitivity`/`release`). The `0.17.10` copy in the graph is dev-dependency-only via `affinidi-messaging-sdk` and is untouched. Two incidental lockfile edges that `cargo update` rewrote (`syn`, `base64` under unrelated crates) were reverted so the lock diff is only the intended bump; `cargo check --locked` and `scripts/check-lockfile-self-pins.sh` both pass.

**Expect a red `semver-checks`.** `PersonaStore::list_attributes` changed shape, `VtaClient::persona_attribute_list` gained a parameter, and `Attribute` gained a field. No `version =` was touched — release-plz owns those, and the report going red is the report working.

## Tests

- `claim_types`: the §4 matrix — exact-beats-family, family-tightens, family-cannot-loosen, longest-family, `x:`-borrows-nothing, unknown-root-floor, holder-override-both-ways, strictness order vs `claim-types.json`, table well-formedness.
- `store::list_tests`: refusal/success pairs — sensitive withheld vs returned, metadata preserved on a withheld row, `includeSensitive` alone yields no plaintext, holder override decides both ways, unregistered token withheld.
- `vta-service/tests/persona_trust_task.rs`: the same three listings at the wire, their three distinct audit rows, and the override surviving a `put` and deciding a `list`. The response-conformance gate validates each response against the published schema.
- `lib.rs::published_types`: our `Sensitivity` and the published enum agree on the wire.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p vta-persona -p vta-service --lib` (80 + 1040 passed), and `cargo test -p vta-service --test persona_trust_task` (19 passed) are all clean.

## Pre-merge checklist

- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no client code added; the SDK call reuses the existing `PERSONA_TT_TIMEOUT` dispatch.
- [x] No lock held across a network await (R1.3) — `list_attributes` takes no lock at all; the read path is lock-free.
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — the read path writes nothing. The one write touched (`attribute/put`) sets a field on the record before the existing single `insert`; no new ordering.
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — no retries added.
- [x] Accept/poll/listen loops survive transient errors (R1.5) — no loops added.
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a.
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — `sensitivity` is camelCase and `skip_serializing_if`, matching the published `Attribute`; `includeSensitive` comes from the generated payload type; `PersonaAttributeListBody` keeps `deny_unknown_fields`. **No JS consumer exists for the persona family in this repo**; `trust-tasks-ts` already carries the member from the spec release.
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — absence is the whole design here: an absent override resolves from the registry, an unregistered token resolves to the conservative floor, and both wire members default false.
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — the audit detail reports the visibility that was actually applied and a count the store computed, not the flags the caller sent.
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — `attribute/put`'s only mutation sequence is unchanged (index before record, version reserved before use); the new field rides inside the same record write.
- [ ] Deviations from this guide flagged explicitly with rule numbers — none.
