### PR TITLE
fix(deps): align jsonschema with what regorus 0.12 requires

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10966,7 +10966,7 @@ dependencies = [
  "hmac 0.13.0",
  "http-body-util",
  "include_dir",
- "jsonschema 0.47.0",
+ "jsonschema 0.49.9",
  "jsonwebtoken 11.0.0",
  "keyring-core",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ futures-util = "0.3"
 dtg-credentials = "0.6"
 
 # JSON Schema validation (issue-time credentialSchema checks)
-jsonschema = "0.47"
+jsonschema = "0.49"
 
 # Async runtime
 tokio = { version = "1", features = [


### PR DESCRIPTION
**`main` is currently red.** `cargo check --workspace --locked` fails on the tip, and with it every Docker image build and every PR whose merge commit inherits the state. This is two lines.

## What happened

Two dependabot PRs were individually fine and mutually incompatible:

- **#1297** pinned the workspace to `jsonschema = "0.47"`.
- **#1295** bumped regorus to 0.12 — which requires `jsonschema ^0.49.9`.

#1295 was based on a main that predated #1297, so its lock regeneration wrote `jsonschema 0.49.9` while `Cargo.toml` kept saying `"0.47"`. The result is a requirement that **no version in the lock satisfies**, which is exactly what `--locked` exists to catch:

```
error: cannot update the lock file /build/Cargo.lock because --locked was passed to prevent this
```

Neither PR was wrong. They were incompatible, and merged in an order that hid it until the next `--locked` build ran.

## The fix

Align the direct pin forward to the version regorus already pulls in, so one jsonschema serves both:

```diff
-jsonschema = "0.47"
+jsonschema = "0.49"
```

plus the single lock entry that follows (`vtc-service` moves from `jsonschema 0.47.0` to `jsonschema 0.49.9`, which was already in the lock for regorus).

The alternative was reverting regorus to 0.11, which undoes a merged PR. Aligning forward is the smaller move, and `vtc-service` — the only consumer of the direct dependency — compiles and passes against 0.49 unchanged.

## Verification

- `cargo check --workspace --all-features` — clean
- `cargo check --workspace --locked` — **satisfied**, which is the thing that was broken
- `cargo test -p vtc-service --all-features` — green

## What this unblocks

| PR | Was failing | After this |
|---|---|---|
| #1294 (ulid 3.0) | Docker ×2 | needs only its own `Ulid::new` → `Ulid::generate` rename, already pushed |
| #1296 (getrandom 0.4.3) | MSRV, Docker ×2 | **no code change needed** — the "MSRV" failure was this `--locked` error, not a rustc-version problem (getrandom 0.4.3 declares `rust-version = "1.85"`, well under our 1.95). `@dependabot rebase` will clear it |

Both were fine at their branch head and failed only at the merge commit — confirmed by fetching `refs/pull/N/merge` and reproducing locally.

## Worth a follow-up

Nothing in CI checks that a *merged* result stays lock-consistent — each PR was green on its own head. A `cargo check --locked` on the merge commit, or requiring dependabot PRs to be up to date with main before merge, would have caught this at the point of merge rather than three PRs later.