### PR TITLE
feat(provision): let a caller ask for an unrestricted admin, and say what it got

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "url",
  "uuid",
 ]
@@ -492,7 +492,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "url",
  "uuid",
 ]
@@ -617,7 +617,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "uuid",
 ]
 
@@ -8117,7 +8117,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9737,7 +9737,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "uuid",
 ]
 
@@ -9753,7 +9753,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "uuid",
 ]
 
@@ -9772,7 +9772,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "uuid",
 ]
 
@@ -9790,7 +9790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
 ]
 
 [[package]]
@@ -9810,9 +9810,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd898a53522fee7ff4e1a55d4746e32f4ed9f831a4678fb508e17e174cf97005"
+checksum = "65edfb23d5f3b740fd77297d62cd69eaaaa8811282a9823977c6bae26301f6fe"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10568,7 +10568,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "uniffi",
  "vta-sdk",
 ]
@@ -10586,7 +10586,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10665,7 +10665,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "url",
  "utoipa",
  "uuid",
@@ -10750,7 +10750,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "url",
  "urlencoding",
  "utoipa",
@@ -10919,7 +10919,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10991,7 +10991,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -11049,7 +11049,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -11105,7 +11105,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.2",
+ "trust-tasks-rs 0.18.3",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,14 @@ aws-lc-rs = "1.16"
 # `schema_index::schema_for` would answer `None` for every URI, `validate_payload`
 # would stop validating with one `debug!` line to say so, and `spec_policy_for`
 # would stop enforcing SPEC §7.2 the same way. Both fail *open*.
-trust-tasks-rs = { version = "0.18", default-features = false, features = [
+# 0.18.3 is a FLOOR, not a preference: it is the first release whose
+# `provision/integration/0.3` schema carries `adminScope` and the `context` /
+# `adminScope` summary members. The dispatch spine validates outgoing responses
+# against this crate's embedded schema, so against 0.18.2 a provisioning that
+# fully succeeded comes back as a 500 `responseSchemaViolation` — the members
+# are emitted and the schema rejects them. A caret on "0.18" would let a
+# resolver pick 0.18.2 and reintroduce exactly that.
+trust-tasks-rs = { version = "0.18.3", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -511,9 +511,10 @@ pub async fn run_provision_integration(
     vc_validity_seconds: Option<i64>,
     out: PathBuf,
     create_context: bool,
+    admin_scope: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use vta_sdk::provision_integration::http::{
-        AssertionMode as WireAssertionMode, ProvisionIntegrationRequest,
+        AdminScope, AssertionMode as WireAssertionMode, ProvisionIntegrationRequest,
     };
 
     // 1. Parse the integration's VP (but don't verify locally — the
@@ -549,6 +550,21 @@ pub async fn run_provision_integration(
         }
     };
 
+    // 3b. Map the admin-scope flag. Clap's `value_parser` already rejects
+    //     anything outside the pair, so the fallthrough is a wiring bug rather
+    //     than operator input — say so instead of inventing a default, which
+    //     would silently narrow a grant someone asked to widen.
+    let admin_scope = match admin_scope.as_str() {
+        "context" => AdminScope::Context,
+        "unrestricted" => AdminScope::Unrestricted,
+        other => {
+            return Err(format!(
+                "invalid --admin-scope value '{other}' — use 'context' or 'unrestricted'"
+            )
+            .into());
+        }
+    };
+
     // 4. Submit.
     let resp = client
         .provision_integration(ProvisionIntegrationRequest {
@@ -561,6 +577,7 @@ pub async fn run_provision_integration(
             assertion: Some(assertion_mode),
             vc_validity_seconds,
             create_context,
+            admin_scope,
         })
         .await?;
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -711,6 +711,23 @@ pub(crate) enum BootstrapCommands {
         /// --create-context`.
         #[arg(long)]
         create_context: bool,
+        /// How wide the minted admin's ACL entry should be: `context`
+        /// (default) binds it to `--context` alone; `unrestricted` binds it
+        /// to no context at all, which is what an ACL reads as a super-admin
+        /// — authority over every context this VTA holds now and every one
+        /// created later.
+        ///
+        /// This does not replace `--context`, which is still required and
+        /// still says where the admin DID is minted and where its owner keeps
+        /// its own configuration. The two are different questions: an
+        /// operator console needs authority everywhere *and* one ordinary
+        /// context to store its state in.
+        ///
+        /// `unrestricted` requires the calling DID to be a super-admin
+        /// itself; a context-scoped admin gets `Forbidden` rather than a
+        /// quietly narrowed entry.
+        #[arg(long, default_value = "context", value_parser = ["context", "unrestricted"])]
+        admin_scope: String,
     },
 }
 

--- a/pnm-cli/src/commands/bootstrap.rs
+++ b/pnm-cli/src/commands/bootstrap.rs
@@ -96,6 +96,7 @@ pub(crate) async fn run_authed(
             vc_validity_seconds,
             out,
             create_context,
+            admin_scope,
         } => {
             bootstrap::run_provision_integration(
                 client,
@@ -105,6 +106,7 @@ pub(crate) async fn run_authed(
                 vc_validity_seconds,
                 out,
                 create_context,
+                admin_scope,
             )
             .await
         }

--- a/vta-sdk/src/protocols/provision_integration_management.rs
+++ b/vta-sdk/src/protocols/provision_integration_management.rs
@@ -107,7 +107,9 @@ pub mod request {
     //!
     //! Equivalent to [`crate::provision_integration::http::ProvisionIntegrationRequest`]
     //! — same field semantics, same JSON layout.
-    pub use crate::provision_integration::http::{AssertionMode, ProvisionIntegrationRequest};
+    pub use crate::provision_integration::http::{
+        AdminScope, AssertionMode, ProvisionIntegrationRequest,
+    };
 }
 
 pub mod result {
@@ -293,6 +295,7 @@ pub fn response_body_for_version(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provision_integration::http::AdminScope;
 
     #[test]
     fn result_uri_for_v0_1_request_emits_v0_1_response() {
@@ -443,6 +446,7 @@ mod tests {
             assertion,
             vc_validity_seconds,
             create_context,
+            admin_scope: AdminScope::default(),
         };
         (req, vp_value)
     }
@@ -564,6 +568,7 @@ mod tests {
                 assertion: None,
                 vc_validity_seconds: None,
                 create_context: false,
+                admin_scope: AdminScope::default(),
             };
             let body = request_body_for_version(&req, uri).expect("build body");
             assert_eq!(
@@ -595,6 +600,8 @@ mod tests {
                 output_count: 1,
                 webvh_server_id: None,
                 context_created: true,
+                context: Some("ctx".into()),
+                admin_scope: Some(AdminScope::Unrestricted),
             },
         };
         // 0.1 — snake_case preserved.
@@ -609,6 +616,13 @@ mod tests {
         assert_eq!(v02["summary"]["secretCount"], 2);
         assert_eq!(v02["summary"]["adminRolledOver"], true);
         assert_eq!(v02["summary"]["contextCreated"], true);
+        assert_eq!(v02["summary"]["context"], "ctx");
+        assert_eq!(
+            v02["summary"]["adminScope"], "unrestricted",
+            "adminScope is what the caller reads to learn whether the ask was honoured; \
+             a snake_case or absent member reads as `context` and silently understates \
+             the authority that was granted"
+        );
         assert!(v02["summary"].get("client_did").is_none());
         assert_eq!(v02["bundle"], "armored");
         assert_eq!(

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::client::VtaClient;
 use crate::did_key::decode_private_key_multibase;
-use crate::provision_integration::http::ProvisionIntegrationRequest;
+use crate::provision_integration::http::{AdminScope, ProvisionIntegrationRequest};
 
 use super::ask::ProvisionAsk;
 use super::diagnostics::{DiagCheck, DiagStatus};
@@ -267,6 +267,7 @@ pub(crate) async fn run_rest_attempt_full_setup(
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,
+        admin_scope: AdminScope::default(),
     };
     let response = match client.provision_integration(req).await {
         Ok(r) => r,
@@ -476,6 +477,7 @@ pub(crate) async fn run_rest_attempt_admin_rotated(
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,
+        admin_scope: AdminScope::default(),
     };
     let response = match client.provision_integration(req).await {
         Ok(r) => r,

--- a/vta-sdk/src/provision_client/runner_tsp.rs
+++ b/vta-sdk/src/provision_client/runner_tsp.rs
@@ -513,6 +513,7 @@ async fn dispatch_provision_integration(
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,
+        admin_scope: crate::provision_integration::http::AdminScope::default(),
     };
     let request_uri = ProvisionSpecVersion::CURRENT.request_uri();
     let payload = request_body_for_version(&body_struct, request_uri)

--- a/vta-sdk/src/provision_client/test_helpers.rs
+++ b/vta-sdk/src/provision_client/test_helpers.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 
 use serde_json::json;
 
-use crate::provision_integration::http::ProvisionSummary;
+use crate::provision_integration::http::{AdminScope, ProvisionSummary};
 use crate::provision_integration::payload::{
     DidKeyMaterial, KeyPair, TemplateBootstrapConfig, TemplateBootstrapPayload, TemplateOutput,
     VtaTrustBundle,
@@ -103,6 +103,8 @@ pub fn sample_provision_result(rolled_over: bool) -> ProvisionResult {
             output_count: 1,
             webvh_server_id: None,
             context_created: false,
+            context: Some("ctx-1".into()),
+            admin_scope: Some(AdminScope::Context),
         },
         payload,
     }

--- a/vta-sdk/src/provision_integration/didcomm.rs
+++ b/vta-sdk/src/provision_integration/didcomm.rs
@@ -35,7 +35,9 @@ use crate::protocols::provision_integration_management::{
 
 use serde_json::Value;
 
-use super::http::{AssertionMode, ProvisionIntegrationRequest, ProvisionIntegrationResponse};
+use super::http::{
+    AdminScope, AssertionMode, ProvisionIntegrationRequest, ProvisionIntegrationResponse,
+};
 
 /// Default DIDComm round-trip timeout (seconds). Generous so the VTA
 /// has time to mint keys, render templates, build the webvh log, and
@@ -106,6 +108,14 @@ pub async fn provision_integration_didcomm(
         assertion,
         vc_validity_seconds,
         create_context,
+        // Always the default. This helper drives *integration-class*
+        // provisioning — a mediator, a DID-hosting control plane — which acts
+        // in the context it was provisioned into and nowhere else. The
+        // unrestricted scope exists for an operator console, which reaches
+        // this task over the Trust-Task spine rather than through this
+        // client; if that ever changes, this becomes a parameter, not a
+        // default someone flipped.
+        admin_scope: AdminScope::default(),
     };
     let request_uri = spec_version.request_uri();
     let body = request_body_for_version(&body_struct, request_uri).map_err(VtaError::from)?;

--- a/vta-sdk/src/provision_integration/http.rs
+++ b/vta-sdk/src/provision_integration/http.rs
@@ -81,10 +81,63 @@ pub struct ProvisionIntegrationRequest {
         alias = "create_context"
     )]
     pub create_context: bool,
+    /// How wide the ACL entry written for the minted admin should be.
+    ///
+    /// [`AdminScope::Context`] (the default) binds the admin to `context`
+    /// alone — right for every integration-class consumer, which acts where
+    /// it was provisioned and nowhere else. [`AdminScope::Unrestricted`]
+    /// binds it to no context at all, the shape [`vti_common::acl`] reads as
+    /// a **super-admin**.
+    ///
+    /// This does **not** make `context` optional, and that is the point of
+    /// having two fields rather than one. `context` is where the admin DID is
+    /// minted and where its owner keeps its own configuration; an operator
+    /// console needs authority over every context *and* one ordinary context
+    /// to store its state in. Collapsing the two would leave it nowhere to
+    /// put it.
+    ///
+    /// Requires the relayer to be a super-admin: an admin may not confer
+    /// authority it does not itself hold, and routing the grant through a
+    /// provisioning maintainer does not launder it. Non-super-admin callers
+    /// get `Forbidden`, never a quiet narrowing — a caller that asked for
+    /// authority and received a success has no other way to learn it did not
+    /// get it.
+    #[serde(
+        default,
+        skip_serializing_if = "AdminScope::is_default",
+        rename = "adminScope"
+    )]
+    pub admin_scope: AdminScope,
 }
 
 fn is_false(b: &bool) -> bool {
     !b
+}
+
+/// Scope of the ACL entry `provision/integration` writes for the minted
+/// admin — the wire enum of `payload.adminScope`.
+///
+/// The vocabulary is the *shape of the entry*, not the informal name of the
+/// role it produces: `unrestricted` says "no context list", which is what an
+/// ACL evaluates. "super-admin" is what an operator calls the result.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum AdminScope {
+    /// Bind the admin to the resolved target context.
+    #[default]
+    Context,
+    /// Bind the admin to no context — authority over every context the VTA
+    /// holds now and every one created later.
+    Unrestricted,
+}
+
+impl AdminScope {
+    /// Whether this is the default, so the common request stays the minimal
+    /// document rather than carrying a member that says nothing.
+    fn is_default(&self) -> bool {
+        matches!(self, AdminScope::Context)
+    }
 }
 
 /// Producer assertion mode on the returned sealed bundle. Mirrors the
@@ -223,6 +276,31 @@ pub struct ProvisionSummary {
     /// Defaults to `false` on the wire for backward compatibility.
     #[serde(default, alias = "context_created")]
     pub context_created: bool,
+    /// The context the integration was provisioned into — the request's
+    /// `context` verbatim when it carried one, otherwise whatever the
+    /// inference rules resolved.
+    ///
+    /// Echoed because a caller that omitted `context` otherwise has no way to
+    /// learn where it landed except by re-deriving it from its own view of
+    /// this VTA's layout — which is exactly what the inference rules exist
+    /// because it cannot do. `None` from VTAs that pre-date the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+    /// The scope of the ACL entry actually written for `admin_did`.
+    ///
+    /// Echoed rather than assumed from the ask: a maintainer that does not
+    /// implement `admin_scope` ignores an `Unrestricted` request and writes a
+    /// context-scoped entry, and its success response is otherwise
+    /// indistinguishable from one that honoured it. `None` from VTAs that
+    /// pre-date the field, which a caller MUST read as
+    /// [`AdminScope::Context`].
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "adminScope",
+        alias = "admin_scope"
+    )]
+    pub admin_scope: Option<AdminScope>,
 }
 
 #[cfg(test)]

--- a/vta-sdk/tests/provision_client_e2e.rs
+++ b/vta-sdk/tests/provision_client_e2e.rs
@@ -28,7 +28,7 @@ use vta_sdk::provision_client::provision_via_rest;
 use vta_sdk::provision_client::result::ProvisionResult;
 use vta_sdk::provision_client::setup_key::EphemeralSetupKey;
 use vta_sdk::provision_integration::http::{
-    ProvisionIntegrationRequest, ProvisionIntegrationResponse, ProvisionSummary,
+    AdminScope, ProvisionIntegrationRequest, ProvisionIntegrationResponse, ProvisionSummary,
 };
 use vta_sdk::provision_integration::payload::{
     DidKeyMaterial, KeyPair, TemplateBootstrapConfig, TemplateBootstrapPayload, TemplateOutput,
@@ -195,6 +195,11 @@ impl Respond for SealResponder {
                 output_count: 1,
                 webvh_server_id: None,
                 context_created: false,
+                // Echoed the way a real VTA echoes them, so the success path
+                // these mocks cover exercises the response shape that is
+                // actually sent rather than an older one.
+                context: Some("ctx-1".into()),
+                admin_scope: Some(AdminScope::Context),
             },
         };
 
@@ -471,6 +476,11 @@ impl Respond for AdminRotationResponder {
                 output_count: 0,
                 webvh_server_id: None,
                 context_created: false,
+                // Echoed the way a real VTA echoes them, so the success path
+                // these mocks cover exercises the response shape that is
+                // actually sent rather than an older one.
+                context: Some("ctx-1".into()),
+                admin_scope: Some(AdminScope::Context),
             },
         };
 
@@ -554,6 +564,7 @@ async fn admin_rotated_via_rest_round_trip() {
         assertion: None,
         vc_validity_seconds: None,
         create_context: false,
+        admin_scope: AdminScope::default(),
     };
     let response = client
         .provision_integration(req)
@@ -710,6 +721,8 @@ async fn admin_rotated_didcomm_response_decoder_extracts_rotated_credentials() {
             output_count: 0,
             webvh_server_id: None,
             context_created: false,
+            context: Some("ctx-1".into()),
+            admin_scope: Some(AdminScope::Context),
         },
     };
 

--- a/vta-service/src/bootstrap_cli.rs
+++ b/vta-service/src/bootstrap_cli.rs
@@ -12,6 +12,7 @@
 
 use std::path::PathBuf;
 
+use vta_sdk::provision_integration::http::AdminScope;
 use vta_sdk::sealed_transfer::{
     AssertionProof, BootstrapRequest, ProducerAssertion, SealedPayloadV1, armor, bundle_digest,
     generate_ed25519_keypair, seal_payload,
@@ -580,6 +581,12 @@ pub async fn run_provision_integration(
         ProvisionIntegrationParams {
             request: verified,
             context: target_context,
+            // The offline path provisions an integration into a context the
+            // operator named on the command line, which is the context-scoped
+            // shape. An unrestricted admin is an online ask — it has to be
+            // conferred by a super-admin, and this path runs with the
+            // synthesized local authority instead of one.
+            admin_scope: AdminScope::Context,
             assertion_mode,
             vc_validity,
         },

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -1504,6 +1504,7 @@ pub async fn handle_provision_integration(
             operations::provision_integration::ProvisionIntegrationParams {
                 request: verified,
                 context,
+                admin_scope: body.admin_scope,
                 assertion_mode,
                 vc_validity,
             },
@@ -1527,6 +1528,8 @@ pub async fn handle_provision_integration(
             output_count: output.summary.output_count,
             webvh_server_id: output.summary.webvh_server_id,
             context_created,
+            context: Some(output.summary.context),
+            admin_scope: Some(output.summary.admin_scope),
         },
     };
 

--- a/vta-service/src/operations/provision_integration/mod.rs
+++ b/vta-service/src/operations/provision_integration/mod.rs
@@ -75,6 +75,7 @@ use crate::store::KeyspaceHandle;
 use vta_sdk::provision_integration::{
     AdminOfClaim, OperatorOfClaim, VerifiedBootstrapRequest, VtaAuthorizationClaim,
     credential::{VtaAuthorizationParams, issue_vta_authorization_credential},
+    http::AdminScope,
 };
 use vta_sdk::sealed_transfer::{
     SealedPayloadV1,
@@ -160,6 +161,14 @@ pub struct ProvisionIntegrationParams {
     /// request. If both are present and disagree, the caller should
     /// reject before calling us — we don't silently normalize.
     pub context: String,
+    /// How wide the ACL entry written for the minted admin should be.
+    ///
+    /// Orthogonal to `context`, not an alternative spelling of it: `context`
+    /// is where the admin DID is minted and where its owner keeps its own
+    /// configuration, this is whether the resulting ACL entry names that
+    /// context or nothing at all. An operator console needs both — authority
+    /// everywhere, and one ordinary context to store its state in.
+    pub admin_scope: AdminScope,
     /// See [`AssertionMode`].
     pub assertion_mode: AssertionMode,
     /// Override for the VC's `validUntil` window. Defaults to 1 hour
@@ -220,6 +229,26 @@ pub struct ProvisionSummary {
     /// it was explicitly null), or when the request was
     /// `AdminRotation` (no integration mint at all).
     pub webvh_server_id: Option<String>,
+    /// The context the integration was provisioned into. Echoed so a caller
+    /// that omitted `context` and let inference run learns where it landed
+    /// rather than re-deriving it from its own view of this VTA's layout.
+    pub context: String,
+    /// The scope of the ACL entry actually written for `admin_did` — what was
+    /// done, not what was asked for.
+    pub admin_scope: AdminScope,
+}
+
+/// The `allowed_contexts` an [`AdminScope`] means, as an ACL entry reads it.
+///
+/// An empty list is not "no contexts" for an admin — [`vti_common::acl`]'s
+/// `act_scope` reads it as `ActScope::All`, which is the whole mechanism
+/// behind a super-admin and the reason the empty case has to be written
+/// deliberately rather than reached by a `context` that happened to be blank.
+fn allowed_contexts_for(scope: AdminScope, context: &str) -> Vec<String> {
+    match scope {
+        AdminScope::Context => vec![context.to_string()],
+        AdminScope::Unrestricted => Vec::new(),
+    }
 }
 
 /// Main entry point. See module docs for the flow.
@@ -231,6 +260,7 @@ pub async fn provision_integration(
     let ProvisionIntegrationParams {
         request,
         context,
+        admin_scope,
         assertion_mode,
         vc_validity,
     } = params;
@@ -244,7 +274,7 @@ pub async fn provision_integration(
         .map_err(|e| AppError::Validation(format!("bootstrap request X25519 derivation: {e}")))?;
 
     // ── 1. Preconditions ────────────────────────────────────────────
-    preconditions::preconditions(state, auth, &context, &request).await?;
+    preconditions::preconditions(state, auth, &context, admin_scope, &request).await?;
 
     // ── 2. Dispatch on the bootstrap intent ─────────────────────────
     //
@@ -264,6 +294,7 @@ pub async fn provision_integration(
             auth,
             &request,
             &context,
+            admin_scope,
             assertion_mode,
             vc_validity,
             bundle_id,
@@ -638,7 +669,7 @@ pub async fn provision_integration(
             did: admin_did.clone(),
             role: Role::Admin,
             label: request.label().map(str::to_string),
-            allowed_contexts: vec![context.clone()],
+            allowed_contexts: allowed_contexts_for(admin_scope, &context),
             ..Default::default()
         },
         "provision-integration",
@@ -802,6 +833,8 @@ pub async fn provision_integration(
             secret_count,
             output_count,
             webvh_server_id,
+            context,
+            admin_scope,
         },
     })
 }
@@ -879,6 +912,7 @@ async fn provision_admin_rotation(
     auth: &AuthClaims,
     request: &VerifiedBootstrapRequest,
     context: &str,
+    admin_scope: AdminScope,
     assertion_mode: AssertionMode,
     vc_validity: Option<Duration>,
     bundle_id: [u8; 16],
@@ -913,7 +947,7 @@ async fn provision_admin_rotation(
             did: admin_did.clone(),
             role: Role::Admin,
             label: request.label().map(str::to_string),
-            allowed_contexts: vec![context.to_string()],
+            allowed_contexts: allowed_contexts_for(admin_scope, context),
             ..Default::default()
         },
         "provision-integration",
@@ -1024,6 +1058,8 @@ async fn provision_admin_rotation(
             secret_count: 1,
             output_count: 0,
             webvh_server_id: None,
+            context: context.to_string(),
+            admin_scope,
         },
     })
 }
@@ -1467,6 +1503,22 @@ mod tests {
         vars
     }
 
+    /// The empty list is not "no contexts" — `act_scope` reads it as
+    /// `ActScope::All`. Pinned because the difference between the two arms is
+    /// the entire feature, and both are one `vec![]` away from each other.
+    #[test]
+    fn allowed_contexts_follows_the_scope() {
+        assert_eq!(
+            allowed_contexts_for(AdminScope::Context, "ctx-a"),
+            vec!["ctx-a".to_string()]
+        );
+        assert!(
+            allowed_contexts_for(AdminScope::Unrestricted, "ctx-a").is_empty(),
+            "an unrestricted admin names no context — including not the one it was \
+             provisioned into, which would silently scope it"
+        );
+    }
+
     #[tokio::test]
     async fn preconditions_accepts_builtin_integration_template() {
         let ts = open_test_store().await;
@@ -1478,7 +1530,7 @@ mod tests {
         let auth = super_admin_claims();
         let request = signed_request("didcomm-mediator", "prod-mediator").await;
 
-        preconditions(&deps, &auth, "prod-mediator", &request)
+        preconditions(&deps, &auth, "prod-mediator", AdminScope::Context, &request)
             .await
             .expect("built-in didcomm-mediator should satisfy preconditions");
     }
@@ -1494,7 +1546,7 @@ mod tests {
         let auth = super_admin_claims();
         let request = signed_request("never-registered", "prod-mediator").await;
 
-        let err = preconditions(&deps, &auth, "prod-mediator", &request)
+        let err = preconditions(&deps, &auth, "prod-mediator", AdminScope::Context, &request)
             .await
             .expect_err("unknown template must be rejected");
         assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
@@ -1590,6 +1642,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "prod-mediator".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -1643,6 +1696,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "prod-mediator".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -1687,6 +1741,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "prod-mediator".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -1785,6 +1840,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "signer-ctx".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -1857,6 +1913,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "agents".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -1975,6 +2032,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "agents".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -2028,6 +2086,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "prod-mediator".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -2118,6 +2177,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "ctx-1".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -2225,6 +2285,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "ctx-swap".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -2307,6 +2368,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "ctx-relayer".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },
@@ -2362,6 +2424,7 @@ mod tests {
             ProvisionIntegrationParams {
                 request,
                 context: "ctx-2".into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: AssertionMode::PinnedOnly,
                 vc_validity: None,
             },

--- a/vta-service/src/operations/provision_integration/preconditions.rs
+++ b/vta-service/src/operations/provision_integration/preconditions.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use crate::auth::AuthClaims;
 use crate::error::AppError;
 use crate::store::KeyspaceHandle;
+use vta_sdk::provision_integration::http::AdminScope;
 use vta_sdk::provision_integration::{BootstrapAsk, DidTemplateRef, VerifiedBootstrapRequest};
 
 use super::ProvisionIntegrationDeps;
@@ -216,14 +217,51 @@ pub async fn resolve_target_context(
     Ok((context, created))
 }
 
+/// Whether this caller may confer the requested [`AdminScope`].
+///
+/// An unrestricted admin may only be conferred by a super-admin — no admin
+/// hands out authority it does not itself hold, and routing the grant through
+/// a provisioning maintainer does not launder it.
+///
+/// `create_acl` enforces exactly this rule (`validate_acl_modification`
+/// refuses `ActScope::All` from a scoped caller) and remains *the*
+/// enforcement. This is the same rule read before any state changes: without
+/// it the refusal lands after the admin DID has been minted, published and
+/// issued a credential, leaving debris behind a request that was never going
+/// to be allowed — which is the whole reason this module runs first.
+///
+/// Its own function so it can be tested without standing up a store, a
+/// template registry and a signed VP, which is what reaching it through
+/// [`preconditions`] costs.
+pub(super) fn require_scope_authority(
+    auth: &AuthClaims,
+    admin_scope: AdminScope,
+) -> Result<(), AppError> {
+    if admin_scope == AdminScope::Context {
+        return Ok(());
+    }
+    auth.require_super_admin().map_err(|_| {
+        AppError::Forbidden(
+            "adminScope 'unrestricted' provisions an admin with authority over every \
+             context, which only a super-admin may confer. Re-run the grant for the \
+             relaying DID without '--contexts' and retry, or provision with the default \
+             context scope."
+                .into(),
+        )
+    })
+}
+
 pub(super) async fn preconditions(
     state: &ProvisionIntegrationDeps,
     auth: &AuthClaims,
     context: &str,
+    admin_scope: AdminScope,
     request: &VerifiedBootstrapRequest,
 ) -> Result<(), AppError> {
     auth.require_admin()?;
     auth.require_context(context)?;
+
+    require_scope_authority(auth, admin_scope)?;
 
     // Context must exist.
     if crate::contexts::get_context(&state.contexts_ks, context)
@@ -343,6 +381,65 @@ pub(super) fn extract_admin_template(ask: &BootstrapAsk) -> Option<DidTemplateRe
 }
 
 #[cfg(test)]
+mod scope_tests {
+    use super::*;
+    use crate::acl::Role;
+
+    fn claims(role: Role, allowed_contexts: &[&str]) -> AuthClaims {
+        super::tests::auth(role, allowed_contexts.to_vec())
+    }
+
+    /// The default scope asks for nothing beyond what provisioning already
+    /// requires, so a context admin provisioning into its own context is
+    /// untouched by this gate.
+    #[test]
+    fn context_scope_needs_no_extra_authority() {
+        assert!(
+            require_scope_authority(&claims(Role::Admin, &["ctx-a"]), AdminScope::Context).is_ok()
+        );
+    }
+
+    /// The rule this whole member exists to keep: a context-scoped admin
+    /// cannot mint an admin wider than itself. Refused *here*, before any
+    /// minting — `create_acl` would refuse too, but only after a DID has been
+    /// published and a credential issued.
+    #[test]
+    fn scoped_admin_may_not_confer_unrestricted() {
+        let err =
+            require_scope_authority(&claims(Role::Admin, &["ctx-a"]), AdminScope::Unrestricted)
+                .expect_err("a context admin must not be able to mint a super-admin");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "must be Forbidden, not a validation error: the request is well-formed and the \
+             caller simply lacks the authority — got {err:?}"
+        );
+    }
+
+    /// An empty context list is *unrestricted* for an admin and *nothing at
+    /// all* for every other role, so the role test is not redundant with the
+    /// scope test. Without it a scope-less monitor would read as the most
+    /// privileged caller there is.
+    #[test]
+    fn scopeless_non_admin_may_not_confer_unrestricted() {
+        for role in [Role::Reader, Role::Initiator, Role::Application] {
+            let label = format!("{role:?}");
+            assert!(
+                require_scope_authority(&claims(role, &[]), AdminScope::Unrestricted).is_err(),
+                "{label} with no contexts is not a super-admin"
+            );
+        }
+    }
+
+    #[test]
+    fn super_admin_may_confer_unrestricted() {
+        assert!(
+            require_scope_authority(&claims(Role::Admin, &[]), AdminScope::Unrestricted).is_ok(),
+            "admin with an empty context list is the super-admin shape"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::acl::Role;
@@ -361,7 +458,7 @@ mod tests {
         (dir, store, ks)
     }
 
-    fn auth(role: Role, allowed_contexts: Vec<&str>) -> AuthClaims {
+    pub(super) fn auth(role: Role, allowed_contexts: Vec<&str>) -> AuthClaims {
         AuthClaims {
             did: "did:key:zTestCaller".into(),
             role,

--- a/vta-service/src/routes/bootstrap.rs
+++ b/vta-service/src/routes/bootstrap.rs
@@ -631,6 +631,7 @@ mod provision {
     };
     use crate::server::AppState;
     use vta_sdk::provision_integration::BootstrapRequest;
+    use vta_sdk::provision_integration::http::AdminScope as SdkAdminScope;
 
     /// Request body for `POST /bootstrap/provision-integration`.
     #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -669,8 +670,45 @@ mod provision {
         /// doesn't already exist. **Requires super-admin** — the
         /// op-layer `create_context` enforces this. Idempotent when
         /// the context already exists. Defaults to `false`.
-        #[serde(default)]
+        ///
+        /// The `createContext` alias is what the SDK's request struct
+        /// actually emits (`rename = "createContext"`, canonical 0.2+ casing).
+        /// Without it this route read only the snake_case spelling and
+        /// nothing sends that, so `#[serde(default)]` quietly answered
+        /// `false` and `pnm bootstrap provision-integration --create-context`
+        /// failed with "context is not registered" against the very context
+        /// it had asked to create.
+        #[serde(default, alias = "createContext")]
         pub create_context: bool,
+        /// How wide the ACL entry for the minted admin should be.
+        ///
+        /// `Context` (the default) binds it to the resolved target context.
+        /// `Unrestricted` binds it to no context — a super-admin — and
+        /// requires the caller to be a super-admin itself; the op layer's
+        /// preconditions refuse otherwise, before anything is minted.
+        ///
+        /// This does not make `context` optional. `context` is where the
+        /// admin DID is minted and where its owner keeps its configuration;
+        /// this is only how far the resulting entry reaches.
+        #[serde(default, alias = "adminScope")]
+        pub admin_scope: AdminScopeWire,
+    }
+
+    /// Wire-form enum for `adminScope`.
+    ///
+    /// Local to this route for the same reason `AssertionModeWire` is: the
+    /// HTTP surface owns its own wire vocabulary, and the op layer's enum is
+    /// free to move without changing what this endpoint accepts.
+    #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[derive(utoipa::ToSchema)]
+    pub enum AdminScopeWire {
+        /// Bind the admin to the resolved target context.
+        #[default]
+        Context,
+        /// Bind the admin to no context at all — authority over every context
+        /// this VTA holds now and every one created later.
+        Unrestricted,
     }
 
     /// Wire-form enum for `assertion` (camelCase-serialised via
@@ -740,6 +778,15 @@ mod provision {
         /// `--create-context` actually did something.
         #[serde(default)]
         pub context_created: bool,
+        /// The context the integration was provisioned into — sent or
+        /// inferred. Echoed so a caller that omitted `context` learns where
+        /// it landed instead of guessing at this VTA's layout.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub context: Option<String>,
+        /// The scope of the ACL entry actually written — what was done, not
+        /// what was asked for.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub admin_scope: Option<AdminScopeWire>,
     }
 
     /// Handler. Gated by `AdminAuth` — the caller must have admin role
@@ -807,6 +854,10 @@ mod provision {
             ProvisionIntegrationParams {
                 request: verified,
                 context,
+                admin_scope: match req.admin_scope {
+                    AdminScopeWire::Context => SdkAdminScope::Context,
+                    AdminScopeWire::Unrestricted => SdkAdminScope::Unrestricted,
+                },
                 assertion_mode,
                 vc_validity,
             },
@@ -828,6 +879,11 @@ mod provision {
                 secret_count: output.summary.secret_count,
                 output_count: output.summary.output_count,
                 webvh_server_id: output.summary.webvh_server_id,
+                context: Some(output.summary.context),
+                admin_scope: Some(match output.summary.admin_scope {
+                    SdkAdminScope::Context => AdminScopeWire::Context,
+                    SdkAdminScope::Unrestricted => AdminScopeWire::Unrestricted,
+                }),
                 context_created,
             },
         }))

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2432,6 +2432,17 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 output_count: 1,
                 webvh_server_id: Some("srv-1".into()),
                 context_created: true,
+                // Both carried, and `Unrestricted` on purpose. The emitting
+                // code always sets these, so a witness that left them absent
+                // would exercise a response this VTA never sends — and the
+                // response-conformance guard is the check that actually
+                // caught them missing from the 0.18.2 schema, turning a
+                // successful provisioning into a 500. Present here, they keep
+                // the floor in `Cargo.toml` honest: drop back to a
+                // `trust-tasks-rs` without them and this witness fails rather
+                // than the failure waiting for live traffic.
+                context: Some("ctx-1".into()),
+                admin_scope: Some(prov::AdminScope::Unrestricted),
             },
         });
         // Prove the canonical request also parses into our consumer type —

--- a/vta-service/src/trust_tasks/provision_integration.rs
+++ b/vta-service/src/trust_tasks/provision_integration.rs
@@ -39,7 +39,9 @@ use super::helpers::{
 
 /// Handler for canonical `provision/integration/0.2`. Admin
 /// role on the target context required; super-admin required if the
-/// request asks to create the context inline.
+/// request asks to create the context inline, or if it asks for an
+/// `unrestricted` admin scope — an admin may not confer authority it does
+/// not itself hold.
 pub(super) async fn handle_request(
     state: &AppState,
     auth: &AuthClaims,
@@ -142,6 +144,7 @@ pub(super) async fn handle_request(
         ProvisionIntegrationParams {
             request: verified,
             context,
+            admin_scope: req.admin_scope,
             assertion_mode: AssertionModeOpAdapter(assertion_mode).into(),
             vc_validity,
         },
@@ -168,6 +171,13 @@ pub(super) async fn handle_request(
             output_count: output.summary.output_count,
             webvh_server_id: output.summary.webvh_server_id,
             context_created,
+            // From the op's own record of what it did, not from the request.
+            // A caller that omitted `context` learns where it landed, and one
+            // that asked for `unrestricted` learns whether it got it — which
+            // is the only way to tell an honoured ask from a maintainer that
+            // ignored an unknown member.
+            context: Some(output.summary.context),
+            admin_scope: Some(output.summary.admin_scope),
         },
     };
     success_response(&doc, body)

--- a/vta-service/tests/provision_integration_provisionable.rs
+++ b/vta-service/tests/provision_integration_provisionable.rs
@@ -11,6 +11,7 @@
 //! arbitrary template variables (mutating [`provisionable_mediator_vars`])
 //! through the real renderer/sealer/issuer.
 
+use vta_sdk::provision_integration::http::AdminScope;
 use vta_service::operations::provision_integration::{
     AssertionMode, ProvisionIntegrationParams, provision_integration,
 };
@@ -41,6 +42,7 @@ async fn provisionable_vta_reaches_render_seal_issue_for_both_assertion_modes() 
             ProvisionIntegrationParams {
                 request,
                 context: PROVISIONABLE_CONTEXT.into(),
+                admin_scope: AdminScope::Context,
                 assertion_mode: mode,
                 vc_validity: None,
             },
@@ -79,6 +81,7 @@ async fn plain_bootstrap_test_vta_errors_before_render_without_a_context() {
         ProvisionIntegrationParams {
             request,
             context: PROVISIONABLE_CONTEXT.into(),
+            admin_scope: AdminScope::Context,
             assertion_mode: AssertionMode::PinnedOnly,
             vc_validity: None,
         },


### PR DESCRIPTION
`provision/integration` wrote the minted admin's ACL entry with `allowed_contexts: vec![context]` unconditionally (`operations/provision_integration/mod.rs:641` and `:916`), so a wallet or integration could only ever come out of provisioning scoped to one context.

That is right for a mediator, and it made one consumer unrepresentable: an operator console, whose whole job is administering this VTA. The browser plugin's management console had no way to be granted what it needs, and the ephemeral relayer's own super-admin-ness was never inherited — it only ever affected context inference and inline context creation.

## `adminScope` is a second axis, not a replacement for `context`

`context` is where the admin DID is minted and where its owner keeps its own configuration. `adminScope` is whether the resulting entry names that context or nothing at all. A console needs both — authority everywhere, and one ordinary context to store its state in — which is why making `context` optional would have been the wrong spelling.

## The gate, and why it is read twice

`Unrestricted` is refused unless the relayer is itself a super-admin. `create_acl` already enforces exactly that (`validate_acl_modification` refuses `ActScope::All` from a scoped caller) and **remains the enforcement**; `require_scope_authority` reads the same rule in preconditions, before anything is minted, so the refusal does not land after a DID has been published and a credential issued. Its own function so it can be tested without standing up a store, a template registry and a signed VP.

## The outcome is echoed

`summary.context` and `summary.adminScope` are the VTA's account of what it did. A caller that omitted `context` and let inference run had no way to learn where it landed except by guessing at this VTA's layout — the thing the inference rules exist because it cannot do. And a maintainer that does not implement `adminScope` ignores it and writes a context-scoped entry, whose success response is otherwise indistinguishable from one that honoured the ask.

## Also fixes an adjacent live bug

Found while adding the sibling field: the REST route read `create_context` only in snake_case while the SDK request struct emits `createContext`, so `#[serde(default)]` quietly answered `false` and `pnm bootstrap provision-integration --create-context` failed with *"context is not registered"* against the very context it had asked to create. Aliased, as the new member is.

## Surface

* `vta-sdk`: `AdminScope` enum, `ProvisionIntegrationRequest::admin_scope`, `ProvisionSummary::{context, admin_scope}`.
* `vta-service`: threaded through the Trust-Task spine, the legacy DIDComm handler and the REST route; `allowed_contexts_for` is the one place the two shapes are distinguished.
* `pnm-cli`: `pnm bootstrap provision-integration --admin-scope context|unrestricted`, so the feature is operable and testable without a browser.
* Client helpers that drive integration-class provisioning pass the default explicitly rather than inheriting it, with the reasoning inline.

Tests: 1351 pass across `vta-sdk` and `vta-service`; `cargo clippy --workspace --all-targets` clean. New unit coverage for the scope gate (including a scope-less non-admin, since an empty context list means opposite things by role) and for `allowed_contexts_for`.

## Ordering — resolved

Depends on trustoverip/dtgwg-trust-tasks-tf#385, released as `trust-tasks-rs` **0.18.3** (#386). The dependency is bumped here and pinned to that as a **floor**, not left on the caret `"0.18"`.

The reason is sharper than "an older schema would ignore the new member". The dispatch spine validates **outgoing** responses against the schema this crate embeds, so against 0.18.2 the two new summary members are emitted and then rejected by our own guard — a provisioning that fully succeeded comes back `500 responseSchemaViolation`. `delegated_consent_e2e::a_reprovision_is_refused_pending_consent_and_executes_once_approved` caught precisely that on the first CI run. A caret would let a resolver pick 0.18.2 and reintroduce it.

The conformance witness now carries `context` and `adminScope` for the same reason: left absent it would exercise a response this VTA never sends, and lowering the floor again would fail nothing. Carrying them, the guard fails in CI rather than waiting for live traffic.

Rebased onto `main` past #1301 (`fix(deps): align jsonschema with what regorus 0.12 requires`). The first push carried a hand-rolled `Cargo.lock` update, which was a workaround for that same staleness — this branch was cut from #1295, where `--locked` did not resolve. #1301 fixes it properly, so the workaround is gone; the only lockfile change here is the `trust-tasks-rs` bump.
