### PR TITLE
feat(persona): enforce release: stepUp on disclosure

### DIFF
--- a/vta-persona/src/present.rs
+++ b/vta-persona/src/present.rs
@@ -124,6 +124,20 @@ pub struct Preview {
     pub renderer_drops: Vec<String>,
     pub purpose: Option<String>,
     pub expires_at: String,
+    /// When a step-up approval bound to this preview was recorded, if one was.
+    ///
+    /// **On the preview, not beside it.** An approval authorises one disclosure
+    /// — this one — so it shares the preview's lifetime by living in the same
+    /// record: consumed when the preview is consumed, expired when it expires,
+    /// and incapable of outliving the decision it belongs to. A separate
+    /// approval record would need its own expiry, its own cleanup, and a reason
+    /// why the two could not disagree.
+    ///
+    /// It also means freshness needs no separate rule. "Each time" is bounded
+    /// by the preview's own TTL, because an approval cannot be older than the
+    /// preview it is written on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<u64>,
 }
 
 impl PersonaStore {
@@ -199,6 +213,7 @@ impl PersonaStore {
             purpose: purpose.map(str::to_string),
             expires_at: (chrono::Utc::now() + chrono::Duration::seconds(PREVIEW_TTL_SECONDS))
                 .to_rfc3339(),
+            approved_at: None,
         };
 
         let _guard = self.write_lock.lock().await;
@@ -206,6 +221,58 @@ impl PersonaStore {
             .insert(preview_key(&preview.preview_id), &preview)
             .await?;
         Ok(preview)
+    }
+
+    /// Read a preview without consuming it.
+    ///
+    /// The gate that refuses a disclosure for want of a step-up approval has to
+    /// run *before* the preview is taken: refusing for want of an approval must
+    /// not cost the holder the decision they already made, and
+    /// [`consume_preview`](Self::consume_preview) removes the record before it
+    /// validates anything.
+    ///
+    /// Deliberately does not check expiry. A caller reading a preview to decide
+    /// whether to ask for an approval wants to know what is there; the expiry
+    /// refusal belongs to the consume, which is the operation that would
+    /// otherwise act on it.
+    pub async fn peek_preview(&self, preview_id: &str) -> Result<Option<Preview>, AppError> {
+        self.ks.get::<Preview>(preview_key(preview_id)).await
+    }
+
+    /// Record that a step-up approval bound to this preview was obtained.
+    ///
+    /// Returns whether a preview was there to mark. `false` is not an error:
+    /// an approval can arrive after its preview has expired or been consumed,
+    /// and the honest response is to have changed nothing. The disclosure it
+    /// would have authorised is gone, and the holder previews again.
+    pub async fn approve_preview(&self, preview_id: &str) -> Result<bool, AppError> {
+        let _guard = self.write_lock.lock().await;
+        let key = preview_key(preview_id);
+        let Some(mut preview) = self.ks.get::<Preview>(key.clone()).await? else {
+            return Ok(false);
+        };
+        preview.approved_at = Some(vti_common::auth::session::now_epoch());
+        self.ks.insert(key, &preview).await?;
+        Ok(true)
+    }
+
+    /// Whether this preview would disclose anything the holder has to approve
+    /// afresh — any claim whose type resolves to [`ReleaseRequirement::StepUp`].
+    ///
+    /// Resolved from the claim **type**, which is all this side of the boundary
+    /// has. A preview is built from the *materialised* copy in the context, and
+    /// a materialised claim deliberately carries no pool identifier — so a
+    /// holder's per-attribute `release` override cannot be read from here. It
+    /// would have to be carried down with the value when the binding is
+    /// written, which is the same direction everything else travels: copies go
+    /// down, nothing reads up. Until it is, no override is stored, so the
+    /// registry default is the whole answer rather than most of it.
+    #[must_use]
+    pub fn requires_step_up(preview: &Preview) -> bool {
+        preview.claims.iter().any(|c| {
+            crate::claim_types::defaults_for(&c.r#type).release
+                == crate::claim_types::ReleaseRequirement::StepUp
+        })
     }
 
     /// Take a preview, destroying it.
@@ -419,6 +486,139 @@ mod tests {
             dir,
             PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [31u8; 32]),
         )
+    }
+
+    /// A persona bound to a profile carrying one claim of the given type — used
+    /// to put a `release: stepUp` type in front of the gate.
+    async fn bound_with_type(s: &PersonaStore, claim_type: &str) -> String {
+        let a = new_attribute(
+            claim_type,
+            ValueType::String,
+            serde_json::json!("4111111111111111"),
+            Provenance::SelfAsserted,
+        );
+        s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+        s.set_binding("ctx", "did:persona:a", Some(&p.profile_id), vec![], None)
+            .await
+            .unwrap();
+        p.profile_id
+    }
+
+    /// A card number needs a fresh approval; a display name does not. The pair
+    /// is the point — a gate that answered "yes" to everything would pass the
+    /// first assertion alone.
+    #[tokio::test]
+    async fn only_a_step_up_type_requires_an_approval() {
+        let (_d, s) = fresh().await;
+        bound_with_type(&s, "payment.card").await;
+        let gated = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(PersonaStore::requires_step_up(&gated));
+
+        let (_d2, s2) = fresh().await;
+        bound_with_type(&s2, "name.display").await;
+        let ungated = s2
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(!PersonaStore::requires_step_up(&ungated));
+    }
+
+    /// A token invented under a gated family is gated too — the registry's
+    /// prefix rule reaching the disclosure path, not just the listing one.
+    #[tokio::test]
+    async fn an_unregistered_member_of_a_gated_family_still_requires_approval() {
+        let (_d, s) = fresh().await;
+        bound_with_type(&s, "payment.giftCard").await;
+        let preview = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            PersonaStore::requires_step_up(&preview),
+            "a gated family must not be leavable by inventing a token"
+        );
+    }
+
+    /// A preview is minted unapproved, and an approval is recorded on it.
+    #[tokio::test]
+    async fn an_approval_is_recorded_on_the_preview_it_authorises() {
+        let (_d, s) = fresh().await;
+        bound_with_type(&s, "payment.card").await;
+        let preview = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(preview.approved_at.is_none(), "minted unapproved");
+
+        assert!(s.approve_preview(&preview.preview_id).await.unwrap());
+        let seen = s
+            .peek_preview(&preview.preview_id)
+            .await
+            .unwrap()
+            .expect("still there");
+        assert!(seen.approved_at.is_some());
+    }
+
+    /// Peeking must not consume. The gate reads the preview before deciding
+    /// whether to refuse, and a refusal that ate the preview would cost the
+    /// holder the decision they already made — which is the whole reason
+    /// `stepUpRequired` is retryable.
+    #[tokio::test]
+    async fn peeking_leaves_the_preview_for_the_retry() {
+        let (_d, s) = fresh().await;
+        bound_with_type(&s, "payment.card").await;
+        let preview = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+
+        assert!(s.peek_preview(&preview.preview_id).await.unwrap().is_some());
+        assert!(
+            s.peek_preview(&preview.preview_id).await.unwrap().is_some(),
+            "a peek is not a consume, however many times it is done"
+        );
+        // And the consume still works afterwards, once.
+        s.consume_preview(&preview.preview_id).await.unwrap();
+        assert!(s.consume_preview(&preview.preview_id).await.is_err());
+    }
+
+    /// An approval arriving for a preview that is gone changes nothing and is
+    /// not an error. The disclosure it would have authorised no longer exists;
+    /// the holder previews again.
+    #[tokio::test]
+    async fn approving_a_vanished_preview_is_not_an_error() {
+        let (_d, s) = fresh().await;
+        assert!(!s.approve_preview("01JUNKUNKNOWN").await.unwrap());
+    }
+
+    /// An approval cannot outlive the disclosure it authorised: consuming the
+    /// preview takes the approval with it, so a second disclosure needs a
+    /// second approval. This is what "each time" means.
+    #[tokio::test]
+    async fn an_approval_does_not_survive_the_disclosure_it_authorised() {
+        let (_d, s) = fresh().await;
+        bound_with_type(&s, "payment.card").await;
+        let preview = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        s.approve_preview(&preview.preview_id).await.unwrap();
+        s.consume_preview(&preview.preview_id).await.unwrap();
+
+        assert!(
+            s.peek_preview(&preview.preview_id).await.unwrap().is_none(),
+            "the approval goes with the preview it was written on"
+        );
     }
 
     /// A persona bound to a profile with one self-asserted claim.

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -266,7 +266,7 @@ use vta_persona::{Listing, PersonaStore, Sensitivity, ValueType, ValueVisibility
 ///
 /// The correlation key is derived per agent and lives beside the at-rest key;
 /// it never leaves the agent, which is what makes the blinded index blinded.
-fn store(state: &AppState) -> PersonaStore {
+pub(super) fn store(state: &AppState) -> PersonaStore {
     PersonaStore::new(state.persona_ks.clone(), state.persona_correlation_key)
 }
 
@@ -416,6 +416,25 @@ fn reject(doc: &TrustTask<Value>, e: AppError) -> TrustTaskOutcome {
     if let Some(d) = details {
         payload = payload.with_details(d);
     }
+    error_response(doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload))
+}
+
+/// Refuse a disclosure for want of a fresh approval, with the code
+/// `persona/disclosure/present/1.0` rule 6 declares.
+///
+/// A **specification-extended** code rather than `taskFailed`, because the two
+/// say different things to a client. `taskFailed` means "attempted and could
+/// not complete", and the whole point of this refusal is that nothing was
+/// attempted: the preview is intact and the same request succeeds once the
+/// holder approves. A client that cannot tell those apart cannot offer the
+/// retry, which is the only useful thing it can do here.
+///
+/// The slug comes from the document, like every other extended code in this
+/// slice, so the code and the task it refuses cannot drift into two spellings.
+fn step_up_required(doc: &TrustTask<Value>, details: Value) -> TrustTaskOutcome {
+    let payload = ErrorPayload::new(ext(&slug_from_doc(doc), "stepUpRequired"))
+        .with_message("a claim in this preview requires a fresh approval")
+        .with_details(details);
     error_response(doc.reject_with(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload))
 }
 
@@ -1948,6 +1967,44 @@ pub(super) async fn handle_disclosure_present(
     }
 
     let durable = req.mint.as_ref().is_some_and(|m| m.durable);
+    let preview_id = req.preview_id.to_string();
+
+    // The step-up gate runs BEFORE the preview is taken.
+    //
+    // `present` consumes the preview as its first act, so a refusal after that
+    // point would cost the holder the decision they already made — and the one
+    // refusal that is *retryable* is this one. It is retryable precisely
+    // because the preview survives it: the holder obtains an approval and
+    // presents the same preview again.
+    //
+    // A peek rather than a read-modify-write: nothing here mutates, and the
+    // consume below re-reads under the store's own lock.
+    match store(state).peek_preview(&preview_id).await {
+        Ok(Some(preview)) => {
+            if PersonaStore::requires_step_up(&preview) && preview.approved_at.is_none() {
+                let claim_types: Vec<String> =
+                    preview.claims.iter().map(|c| c.r#type.clone()).collect();
+                return match super::step_up::initiate_disclosure_step_up(
+                    state,
+                    auth,
+                    &preview_id,
+                    &preview.verifier_did,
+                    preview.purpose.as_deref(),
+                    &claim_types,
+                )
+                .await
+                {
+                    Ok(details) => step_up_required(&doc, details),
+                    Err(reason) => super::helpers::reject_with(&doc, reason),
+                };
+            }
+        }
+        // Absent is not this gate's business. The consume below distinguishes
+        // unknown from consumed from expired and has the error vocabulary for
+        // it; guessing here would give two paths for one answer.
+        Ok(None) => {}
+        Err(e) => return reject(&doc, e),
+    }
 
     // The store consumes the preview, refuses an expired one, refuses whole on
     // a stale claim, and writes the disclosure record BEFORE returning the
@@ -1955,7 +2012,7 @@ pub(super) async fn handle_disclosure_present(
     // holder could never afterwards discover they had released.
     let (artifact, record) = match store(state)
         .present(
-            &req.preview_id.to_string(),
+            &preview_id,
             req.challenge.as_ref().map(|c| c.to_string()).as_deref(),
             durable,
         )

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -430,6 +430,55 @@ pub(super) async fn handle_approve_response(
         );
     }
 
+    // 7a. A *bound* approval marks the operation it was taken for.
+    //
+    // This is what authorises the disclosure — not the elevation below. The
+    // gate in `persona::handle_disclosure_present` reads the preview's own
+    // `approved_at` and never the session's `acr`, so the next `release:
+    // stepUp` disclosure is refused however freshly the session authenticated:
+    // its preview carries no approval. That is the whole of what "each time"
+    // asks for, and it is why the binding is to the `previewId`.
+    //
+    // The session is then elevated as it always is, because that is what this
+    // ceremony *is*: the subject proved, freshly, that they are still
+    // themselves, and `aal2` is the name for having done so. Recording that
+    // fact and refusing to record it are not made different by which operation
+    // prompted it — every other `initiate_self_step_up` caller shows its own
+    // authorization context and yields the same session-wide `aal2`.
+    //
+    // What that costs, stated plainly: an approval taken to disclose a card
+    // number leaves a session that satisfies an unrelated `requireStepUp` rule
+    // for the elevation window. The narrower answer — record the approval and
+    // elevate nothing — needs a third `status` on the ack, and the ack's
+    // version is the one the approver's request named, so a maintainer cannot
+    // reach for a newer minor on its own. See the PR for the follow-up.
+    //
+    // Marking a preview that is no longer there is not an error. An approval
+    // can arrive after its preview expired or was consumed; the disclosure it
+    // would have authorised is gone, the holder previews again, and the honest
+    // response is to have changed nothing.
+    if let Some(preview_id) = pending.bound_to.as_deref() {
+        let store = super::persona::store(state);
+        match store.approve_preview(preview_id).await {
+            Ok(marked) => {
+                audit!(
+                    "persona.disclosure.step_up_approved",
+                    actor = &pending.subject,
+                    resource = preview_id,
+                    outcome = if marked { "success" } else { "expired" }
+                );
+            }
+            Err(e) => {
+                return reject_with(
+                    &doc,
+                    RejectReason::InternalError {
+                        reason: format!("record disclosure approval: {e}"),
+                    },
+                );
+            }
+        }
+    }
+
     // 7. Load + elevate the session.
     let mut session = match get_session(&state.sessions_ks, &session_id).await {
         Ok(Some(s)) => s,
@@ -587,6 +636,10 @@ async fn mint_pending_step_up(
     // break every typed consumer). `None` leaves the payload byte-identical to
     // the reason-only form.
     authorization_context: Option<&Value>,
+    // The single operation this approval authorises, when it authorises one
+    // rather than elevating the session. `None` is the ordinary session
+    // step-up. See `PendingStepUp::bound_to`.
+    bound_to: Option<&str>,
 ) -> Result<Value, ()> {
     // The *stored* pending record keeps the kebab canonical form
     // (`did-signed`) that `vti_common::auth::step_up` documents — it's internal
@@ -601,7 +654,7 @@ async fn mint_pending_step_up(
     raw.extend_from_slice(Uuid::new_v4().as_bytes());
     let challenge = general_purpose::URL_SAFE_NO_PAD.encode(&raw);
 
-    let pending = new_pending_step_up(
+    let mut pending = new_pending_step_up(
         challenge.clone(),
         session_id,
         subject,
@@ -615,6 +668,7 @@ async fn mint_pending_step_up(
         acceptable.clone(),
         STEP_UP_TTL_SECS,
     );
+    pending.bound_to = bound_to.map(str::to_string);
     if let Err(e) = store_pending_step_up(sessions_ks, &pending).await {
         tracing::error!(error = %e, "failed to persist pending step-up");
         return Err(());
@@ -988,6 +1042,91 @@ fn wake_reply_status(envelope_body: &Value) -> Option<push_wake::ResponseStatus>
 /// threshold, re-checks at consume time that the approvers are still
 /// authorized, and shows the human a signed statement of the effects —
 /// none of which a delegated step-up floor ever did.
+/// Ask the holder to approve **one disclosure**, and return the refusal that
+/// says so.
+///
+/// Distinct from [`initiate_self_step_up`] in the one way that matters: the
+/// pending record is bound to the `previewId`, so the approval it yields marks
+/// that preview. The gate reads the mark, never the session's `acr` — which is
+/// what keeps "each time" from meaning "once per login". See
+/// `PendingStepUp::bound_to`.
+///
+/// The approver's device is shown *what would leave* — the verifier, the claim
+/// types, the purpose the verifier gave — because an approval prompt that says
+/// only "approve a disclosure?" is one a person learns to answer yes to. Values
+/// are deliberately absent: this document travels to a second device, and the
+/// approver is being asked to authorise a release, not shown its contents.
+pub(super) async fn initiate_disclosure_step_up(
+    state: &AppState,
+    auth: &AuthClaims,
+    preview_id: &str,
+    verifier_did: &str,
+    purpose: Option<&str>,
+    claim_types: &[String],
+) -> Result<Value, RejectReason> {
+    let vta_did = state
+        .config
+        .read()
+        .await
+        .vta_did
+        .clone()
+        .unwrap_or_default();
+    let secret = match load_step_up_signing_secret(state, &vta_did).await {
+        Ok(s) => s,
+        Err(()) => {
+            return Err(RejectReason::InternalError {
+                reason: "failed to initiate step-up".to_string(),
+            });
+        }
+    };
+
+    let reason = format!(
+        "Approve disclosing {} to {verifier_did}",
+        match claim_types.len() {
+            1 => "1 fact".to_string(),
+            n => format!("{n} facts"),
+        }
+    );
+    let mut context = json!({
+        "operation": "persona/disclosure/present",
+        "previewId": preview_id,
+        "verifierDid": verifier_did,
+        "claimTypes": claim_types,
+    });
+    if let Some(p) = purpose {
+        context["purpose"] = json!(p);
+    }
+
+    match mint_pending_step_up(
+        &state.sessions_ks,
+        &vta_did,
+        &secret,
+        &auth.did,
+        &auth.did, // the holder approves their own disclosure
+        false,
+        &auth.session_id,
+        &reason,
+        Some(&context),
+        Some(preview_id),
+    )
+    .await
+    {
+        Ok(approve_request) => {
+            maybe_push_step_up(state, &auth.did, &auth.did, &approve_request).await;
+            Ok(json!({
+                "previewId": preview_id,
+                // The preview is still there. This refusal is retryable in the
+                // strong sense: the same preview, once approved.
+                "previewRetained": true,
+                "approveRequest": approve_request,
+            }))
+        }
+        Err(()) => Err(RejectReason::InternalError {
+            reason: "failed to initiate step-up for disclosure".to_string(),
+        }),
+    }
+}
+
 pub(super) async fn initiate_self_step_up(
     state: &AppState,
     auth: &AuthClaims,
@@ -1019,6 +1158,7 @@ pub(super) async fn initiate_self_step_up(
         &auth.session_id,
         reason,
         authorization_context,
+        None,
     )
     .await
     {
@@ -1143,6 +1283,7 @@ mod tests {
                 "sess-9",
                 "rotate keys",
                 None,
+                None,
             )
             .await
             .expect("mint succeeds"),
@@ -1261,6 +1402,7 @@ mod tests {
                 "sess-ctx",
                 "finance wants to share salaryBand with travel",
                 Some(&ctx),
+                None,
             )
             .await
             .expect("mint succeeds"),

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -27,7 +27,7 @@ use multibase::Base;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
-use vta_service::test_support::{TestAppContext, build_test_app};
+use vta_service::test_support::{TestAppContext, build_provisionable_test_app, build_test_app};
 use vti_common::auth::session::{Session, SessionState, now_epoch, store_session};
 
 // URIs as literals, so a constant rename in the SDK surfaces here too.
@@ -102,10 +102,27 @@ async fn authed(ctx: &TestAppContext, tag: &str, role: &str, allowed_contexts: &
     ctx.jwt_keys.encode(&claims).unwrap()
 }
 
-/// POST a persona Trust Task and return `(status, parsed body)`.
+/// POST a persona Trust Task to the cheap sentinel-DID app and return
+/// `(status, parsed body)`.
 async fn post(
     router: &axum::Router,
     token: &str,
+    uri: &str,
+    payload: Value,
+) -> (StatusCode, Value) {
+    post_to(router, token, "did:key:z6MkTestVTA", uri, payload).await
+}
+
+/// As [`post`], addressed to `recipient`.
+///
+/// SPEC §7.2 item 5 enforces the recipient in band, so a test running against
+/// [`build_provisionable_test_app`] — whose VTA has a real, self-resolving
+/// signing identity rather than the sentinel DID — has to say so, or every
+/// request is refused for the wrong reason.
+async fn post_to(
+    router: &axum::Router,
+    token: &str,
+    recipient: &str,
     uri: &str,
     payload: Value,
 ) -> (StatusCode, Value) {
@@ -114,7 +131,7 @@ async fn post(
         "type": uri,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": holder_did(),
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": recipient,
         "payload": payload,
     }))
     .expect("envelope deserialises");
@@ -160,9 +177,21 @@ async fn put_attribute(
     claim_type: &str,
     value: &str,
 ) -> String {
-    let (status, body) = post(
+    put_attribute_at(router, token, "did:key:z6MkTestVTA", claim_type, value).await
+}
+
+/// As [`put_attribute`], against the VTA named by `recipient`.
+async fn put_attribute_at(
+    router: &axum::Router,
+    token: &str,
+    recipient: &str,
+    claim_type: &str,
+    value: &str,
+) -> String {
+    let (status, body) = post_to(
         router,
         token,
+        recipient,
         ATTR_PUT,
         json!({
             "type": claim_type,
@@ -1660,5 +1689,341 @@ async fn a_correlation_finding_names_where_the_shared_value_went() {
         reached.persona_did.as_deref(),
         Some(persona),
         "the binding is named without the persona presenting it: {payload:#}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. `release: stepUp` — a fresh approval per disclosure
+// ---------------------------------------------------------------------------
+
+const APPROVE_RESPONSE: &str = "https://trusttasks.org/spec/auth/step-up/approve-response/0.2";
+
+/// Build the face, bind it, preview it, and return `(scoped token, previewId)`.
+///
+/// Parameterised on the claim type because the whole subject here is that one
+/// type is gated and another is not, over the same path. A helper that only
+/// ever built the gated case would let a gate that refuses *everything* pass.
+async fn preview_a_face_holding(
+    router: &axum::Router,
+    ctx: &TestAppContext,
+    tag: &str,
+    claim_type: &str,
+    value: &str,
+) -> (String, String) {
+    let holder = authed(ctx, &format!("{tag}-holder"), "admin", &[]).await;
+    let scoped = authed(ctx, &format!("{tag}-scoped"), "admin", &[CTX]).await;
+
+    let vta = &ctx.vta_did;
+    let attr = put_attribute_at(router, &holder, vta, claim_type, value).await;
+    let (status, body) = post_to(
+        router,
+        &holder,
+        vta,
+        PROFILE_PUT,
+        json!({ "name": tag, "entries": [{ "ref": attr }] }),
+    )
+    .await;
+    assert!(!refused(status, &body), "profile/put: {status} {body}");
+    let profile = payload_of(&body)
+        .get("profileId")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("no profileId in {body}"))
+        .to_string();
+
+    let persona = format!("did:key:z6MkPersona{tag}");
+    let (status, body) = post_to(
+        router,
+        &holder,
+        vta,
+        BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona, "profileId": profile }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/set: {status} {body}");
+
+    let (status, body) = post_to(
+        router,
+        &scoped,
+        vta,
+        PREVIEW,
+        json!({
+            "contextId": CTX,
+            "personaDid": persona,
+            "verifierDid": "did:key:z6MkVerifier",
+            "purpose": "checkout",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "preview: {status} {body}");
+    let preview_id = payload_of(&body)
+        .get("previewId")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("no previewId in {body}"))
+        .to_string();
+
+    (scoped, preview_id)
+}
+
+/// A `release: stepUp` claim is refused without an approval, approved once, and
+/// disclosed — and the refusal costs the holder nothing.
+///
+/// Four properties, and each of them is a way this could be built wrong:
+///
+/// 1. **It refuses.** `payment.card` resolves to `release: stepUp` through the
+///    registry, and the gate reads the resolution rather than a list of types
+///    it happens to know.
+/// 2. **It refuses with the code the specification declares**, not
+///    `taskFailed`. A client can only offer the retry if it can recognise the
+///    refusal, and `taskFailed` means "attempted and could not complete" —
+///    which is the opposite of what happened.
+/// 3. **The preview survives.** A refusal that consumed it would make the
+///    holder preview again to obtain an approval for a preview that no longer
+///    exists, and the retry the code promises would be unreachable. Asserted
+///    by refusing *twice* on the same id: the second refusal must still be
+///    `stepUpRequired`, not "unknown preview".
+/// 4. **The approval authorises that disclosure**, and it is the mark on the
+///    preview that does so — not the session elevation the ceremony also
+///    performs. `an_approval_does_not_carry_to_the_next_disclosure` is the
+///    other side of the same claim.
+#[tokio::test]
+async fn a_step_up_claim_needs_an_approval_bound_to_that_preview() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let (scoped, preview_id) =
+        preview_a_face_holding(&router, &ctx, "gated", "payment.card", "4242424242424242").await;
+
+    // 1 + 2. Refused, with the declared code.
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(
+        refused(status, &body),
+        "a payment.card disclosure was released with no approval: {status} {body}"
+    );
+    let payload = payload_of(&body);
+    assert_eq!(
+        payload["code"], "persona/disclosure/present:stepUpRequired",
+        "the refusal does not carry the code the specification declares, so a client \
+         cannot tell it apart from a failure and cannot offer the retry: {body}"
+    );
+    assert_eq!(
+        payload["details"]["previewRetained"], true,
+        "the refusal does not say the preview survived it: {body}"
+    );
+    let approve_request = payload["details"]["approveRequest"].clone();
+    let challenge = approve_request["payload"]["challenge"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no challenge in the approve request: {body}"))
+        .to_string();
+    let session_id = approve_request["payload"]["sessionId"]
+        .as_str()
+        .expect("the approve request names the session")
+        .to_string();
+
+    // The approver is shown what would leave — the verifier, the types and the
+    // purpose — because "approve a disclosure?" is a prompt people learn to
+    // answer yes to. Values are deliberately absent: this document travels to a
+    // second device, and the approver authorises a release rather than reading
+    // one.
+    let context = &approve_request["payload"]["ext"]["org.openvtc.authorization-context"];
+    assert_eq!(context["operation"], "persona/disclosure/present", "{body}");
+    assert_eq!(context["previewId"], preview_id, "{body}");
+    assert_eq!(context["verifierDid"], "did:key:z6MkVerifier", "{body}");
+    assert_eq!(context["claimTypes"][0], "payment.card", "{body}");
+    assert_eq!(context["purpose"], "checkout", "{body}");
+    assert!(
+        !serde_json::to_string(&approve_request)
+            .unwrap()
+            .contains("4242424242424242"),
+        "the approve request carries the card number to a second device: {approve_request:#}"
+    );
+
+    // 3. The same preview, refused again the same way — it was not consumed.
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(refused(status, &body), "{status} {body}");
+    assert_eq!(
+        payload_of(&body)["code"],
+        "persona/disclosure/present:stepUpRequired",
+        "the refusal consumed the preview, so the retry it promises is unreachable: {body}"
+    );
+
+    // 4. Approve it, over the wire.
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        APPROVE_RESPONSE,
+        json!({
+            "subject": holder_did(),
+            "sessionId": session_id,
+            "challenge": challenge,
+            "decision": "approved",
+            "grantedAcr": "aal2",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "approve-response: {status} {body}");
+
+    // And now the disclosure goes through.
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "the approval did not authorise the disclosure it was taken for: {status} {body}"
+    );
+}
+
+/// An approval authorises **one** disclosure, not the next one.
+///
+/// The preview is single-use, so the approval recorded on it dies with it. That
+/// is the mechanism; this asserts the property it exists for — a second
+/// preview of the same face is gated exactly as the first was, with no memory
+/// of the approval the holder just gave.
+///
+/// And it asserts it **against an elevated session**, which is the sharp part.
+/// The step-up ceremony raises the session to `aal2` as it does for every
+/// other caller, so a gate that read `acr` — the obvious way to write one, and
+/// the way every other step-up-gated operation in this service works — would
+/// wave this second disclosure straight through. "Each time" survives only
+/// because the gate reads the preview.
+#[tokio::test]
+async fn an_approval_does_not_carry_to_the_next_disclosure() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let (scoped, first) =
+        preview_a_face_holding(&router, &ctx, "again", "payment.card", "4242424242424242").await;
+
+    let (_, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": first }),
+    )
+    .await;
+    let ar = payload_of(&body)["details"]["approveRequest"].clone();
+    let session_id = ar["payload"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("the approve request names the session: {body}"))
+        .to_string();
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        APPROVE_RESPONSE,
+        json!({
+            "subject": holder_did(),
+            "sessionId": session_id,
+            "challenge": ar["payload"]["challenge"],
+            "decision": "approved",
+            "grantedAcr": "aal2",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "approve-response: {status} {body}");
+    assert_eq!(
+        payload_of(&body)["status"],
+        "elevated",
+        "the ceremony did not complete, so nothing below tests what it means to: {body}"
+    );
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": first }),
+    )
+    .await;
+    assert!(!refused(status, &body), "present: {status} {body}");
+
+    // A second preview of the same face, from the same session, moments later.
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PREVIEW,
+        json!({
+            "contextId": CTX,
+            "personaDid": "did:key:z6MkPersonaagain",
+            "verifierDid": "did:key:z6MkVerifier",
+            "purpose": "checkout",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "second preview: {status} {body}");
+    let second = payload_of(&body)["previewId"]
+        .as_str()
+        .expect("previewId")
+        .to_string();
+
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .expect("the session is still there");
+    assert_eq!(
+        stored.acr, "aal2",
+        "the session is not elevated, so the refusal below would prove nothing: {stored:?}"
+    );
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": second }),
+    )
+    .await;
+    assert!(
+        refused(status, &body),
+        "the second disclosure rode the first one's approval — 'each time' means each \
+         time: {status} {body}"
+    );
+    assert_eq!(
+        payload_of(&body)["code"],
+        "persona/disclosure/present:stepUpRequired",
+        "{body}"
+    );
+}
+
+/// An ungated claim reaches `present` with no approval at all.
+///
+/// The other half of the gate, and the half that is easy to lose: a gate that
+/// refuses everything satisfies every test above. `name.display` resolves to
+/// `release: consent`, which the two-call preview already is, and adding a
+/// second human decision to every disclosure is how a step-up becomes noise.
+#[tokio::test]
+async fn an_ungated_claim_is_not_gated() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let (scoped, preview_id) =
+        preview_a_face_holding(&router, &ctx, "plain", "name.display", "Ada").await;
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "a name.display disclosure was gated behind a step-up: {status} {body}"
     );
 }

--- a/vti-common/src/auth/step_up.rs
+++ b/vti-common/src/auth/step_up.rs
@@ -60,6 +60,25 @@ pub struct PendingStepUp {
     pub created_at: u64,
     /// Unix seconds after which the step-up is no longer valid.
     pub expires_at: u64,
+    /// The single operation this approval authorises, **in addition to**
+    /// completing the ceremony.
+    ///
+    /// A `persona/disclosure/present` gated by `release: stepUp` needs an
+    /// approval it cannot get from an already-elevated session: reading `acr`
+    /// makes "each time" mean "once per login", which is the failure the
+    /// requirement exists to prevent. So the request that gates a disclosure
+    /// carries the `previewId` here, the relying party marks *that* preview
+    /// approved, and the gate reads the mark rather than the session.
+    ///
+    /// The session is still elevated — the subject did authenticate freshly,
+    /// and that is what the ceremony records. Recording it is not what
+    /// authorises the disclosure.
+    ///
+    /// `None` is the ordinary step-up with nothing bound to it.
+    /// `#[serde(default)]` so a record written before this field existed
+    /// deserialises as one, which is what it was.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bound_to: Option<String>,
 }
 
 // The `op_class` module lived here: eleven slugs (`acl/grant`,
@@ -190,6 +209,7 @@ pub fn new_pending_step_up(
         acceptable_evidence,
         created_at,
         expires_at: created_at.saturating_add(ttl_secs),
+        bound_to: None,
     }
 }
 
@@ -221,6 +241,7 @@ mod tests {
             acceptable_evidence: vec!["did-signed".into(), "webauthn".into()],
             created_at: 1000,
             expires_at,
+            bound_to: None,
         }
     }
 


### PR DESCRIPTION
Implements `persona/disclosure/present/1.0` rule 6: a claim whose type resolves
to `release: stepUp` cannot leave without a **fresh approval bound to that
`previewId`**. The rule was specified in trust-tasks #380 and unimplemented —
`payment.*` and `gov.*` disclosed on the ordinary two-call consent gate like
anything else.

## The binding is to the preview, and that is the whole design

`CLAIM-TYPES.md` §3.2: *"`stepUp` requires a fresh authentication bound to
**that** preview — not to the session. Without the binding 'each time'
degrades into 'once per login', which is the failure this exists to prevent."*

So the approval lives on the `Preview` record (`approved_at`), which is the
only place with the right lifetime: single-use, TTL-bounded, and destroyed by
the disclosure it authorised. Consumed with it, expired with it, and incapable
of outliving the decision it belongs to — no second record, no second expiry,
no way for the two to disagree. It also means freshness needs no rule of its
own: an approval cannot be older than the preview it is written on.

**The approval is the maintainer's state, never a member of the request**
(`CONVENTIONS.md` §5). A producer carrying its own approval would be carrying a
bearer token, and a bearer token authorising a disclosure is replayable by
whoever holds it.

## The gate runs before the preview is taken

`present` consumes the preview as its first act. A refusal after that point
would cost the holder the decision they already made — and this refusal is the
one that is *retryable*, precisely because the preview survives it. So the gate
`peek_preview`s (no expiry check, no consume), and the refusal says
`previewRetained: true`.

Refused with the code the specification declares —
`persona/disclosure/present:stepUpRequired`, via `reject_with_code` — rather
than `taskFailed`. `taskFailed` means "attempted and could not complete", which
is the opposite of what happened, and a client that cannot recognise the
refusal cannot offer the retry, which is the only useful thing it can do here.

## The approver is shown what would leave

The `approveRequest`'s `authorizationContext` names the operation, the
`previewId`, the verifier, the claim types and the verifier's stated purpose —
because "approve a disclosure?" is a prompt people learn to answer yes to.
**Values are deliberately absent**: the document travels to a second device, and
the approver is authorising a release rather than reading one. Pinned by a test
that greps the whole request for the card number.

## What I changed my mind about mid-implementation, and why it matters

I first had a bound approval mark the preview and **not** elevate the session,
on the reasoning that an approval taken to disclose a card number should not be
spendable on an ACL mutation. The response-conformance layer refused it:
`auth/step-up/approve-response`'s ack has exactly two statuses, `elevated` and
`rejected`, and neither is "recorded, nothing elevated". A response's version is
the one the *approver's request* named, so a maintainer cannot reach for a newer
minor on its own — the spec cannot be fixed from this side.

The bound approval therefore does both: it marks the preview **and** completes
the ceremony as every other step-up does. The subject authenticated freshly and
`aal2` is the name for having done so; recording that fact is not made wrong by
which operation prompted it.

**What that costs, stated plainly:** an approval taken to disclose a card number
leaves a session that satisfies an unrelated `requireStepUp` rule for the
elevation window. This is a pre-existing property of this VTA's step-up rather
than something introduced here — every `initiate_self_step_up` caller shows its
own authorization context and yields the same session-wide `aal2`.

**What it does not cost is the property the spec asks for.** "Each time"
survives because the gate reads `preview.approved_at` and *never* the session's
`acr`. `an_approval_does_not_carry_to_the_next_disclosure` asserts exactly that,
and asserts it against a session it first proves is at `aal2` — so a gate
written the obvious way, the way every other step-up-gated operation in this
service works, fails it.

Follow-up worth doing separately: an `auth/step-up/approve-response` minor with
a third status, and both approver stacks taught to send it.

## Tests

`vta-persona` (6, unit): a gated type requires an approval and an ungated one
does not (the pair — a gate answering "yes" to everything passes the first
alone); an unregistered member of a gated family is still gated (the registry's
prefix rule reaching the disclosure path); a preview is minted unapproved;
peeking never consumes; approving a vanished preview is not an error; an
approval does not survive the disclosure it authorised.

`vta-service` (3, end-to-end through the real dispatch spine): the refusal
carries the declared code and the retained-preview flag and the approver's
context but not the value; the same preview refuses twice the same way (so the
retry it promises is reachable); the approval, taken over the wire, lets the
disclosure through; a second preview is gated again *while the session is
`aal2`*; an ungated claim is not gated at all.

## Known limitation

A holder's per-attribute `release` **override** is not honoured — only the
registry default is. A preview is built from the materialised copy in the
context, which deliberately carries no pool identifier, so the override cannot
be read from that side of the boundary. It has to be carried *down* with the
value at bind time, which is the direction everything else travels. Complete as
of today, since nothing stores an override yet.

## Guide checklist (§9)

- [x] No new `reqwest::Client::new()` / bare `fetch()`; all clients have finite timeouts (R1.2) — no new clients
- [x] No lock held across a network await (R1.3) — `approve_preview` takes the store's write lock across two keyspace ops and no network
- [x] No local state committed before its remote effect (R2.1) — the approval is marked before the ack is returned; a death after the mark leaves a preview the holder can present, which is the same state a successful ack produces
- [x] Every retry is bounded + backed off (R1.4) — no retries added
- [x] Accept/poll/listen loops survive transient errors (R1.5) — none touched
- [x] Acks/deletes happen only after durable handoff (R1.6) — `approve_preview` writes before `handle_approve_response` returns
- [x] New/changed wire types: camelCase, schema registered, all consumers updated (R3.*) — `previewRetained`/`approveRequest` ride in the declared error code's `details`; `PendingStepUp.bound_to` is internal state, `#[serde(default)]`, never on the wire
- [x] Config absence = most restrictive; fail-closed (R5.*) — a store error in the gate rejects; an unregistered or `x:` claim type resolves to the conservative floor, and `release: consent` there is the registry's own decision (`CLAIM-TYPES.md` §4)
- [x] Logs/status claim only what was verified (R6.*) — the audit row records `expired` when there was no preview to mark, not `success`
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
- [x] Deviations flagged — the session-elevation trade-off above

Expect the semver report to be red: `PendingStepUp` gains a field and
`vta-persona` gains public methods. That is the report working; release-plz
assigns the bump.

`Cargo.lock` is untouched — this change adds no dependency. (The first push
carried incidental lock churn; it was noise from an older main, and #1302 had
already fixed the real thing on main.)
