### PR TITLE
fix(rooms)!: bind an epoch link to its room, as rooms/epoch/chain requires

### DIFF
--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -511,8 +511,9 @@ group layer without deciding what the *storage* layer wanted from it is what
 produced a room that erased itself.
 
 **The mechanism.** At each commit the committer seals the outgoing epoch's
-storage key under the incoming one — an `EpochLink`. The links form a chain a
-holder of the current key walks *backwards*:
+storage key under the incoming one — an `EpochLink`, bound by its associated
+data to `roomId` and to its own rung, exactly as a sealed record is. The links
+form a chain a holder of the current key walks *backwards*:
 
 ```
   epoch 4 key ──opens──▶ link(4) ──yields──▶ epoch 3 key
@@ -562,6 +563,12 @@ it needs a spec (§12.2).
   carries the current epoch and nothing below it, so a new member reads the
   room's history only once the links reach them. The crate supports it
   (`SealedRoom::{links, add_links}`) and the wire does not yet — §12.2.
+- *A rung is minted by `SealedRoom`, not by `RoomGroup`.* The binding names the
+  room, and the group deliberately does not know which room it is for — the same
+  separation that put `room_id` on `SealedRoom` for record sealing. The first
+  implementation bound only the epoch pair and rested cross-room safety on two
+  rooms deriving different keys; that holds, but it is an accident rather than a
+  statement, and `rooms/epoch/chain/0.1` requires the statement.
 
 ---
 

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -441,13 +441,18 @@ async fn act_three(client: &VtcClient) -> anyhow::Result<()> {
          where a room erases itself — for everyone, including whoever wrote the record.",
     );
     let (carol_snapshot, carol_package) = IdentitySnapshot::mint("did:key:zCarol")?;
-    let change = alice_room.add_member(&carol_package)?;
+    let (change, link) = alice_room.add_member(&carol_package)?;
     let carol_welcome = change.welcome.clone().expect("an add produces a welcome");
     let commit = change.commit.clone();
+    note(&format!(
+        "the advance produced a rung for epoch {} — bound to this room, so a host cannot \
+         serve it under another",
+        link.as_ref().map(|l| l.epoch).unwrap_or(0)
+    ));
 
     // Bob is an existing member: he applies the commit, and *that* is what carries his
     // chain across the change. A member who skips it loses both directions at once.
-    bob_room.apply_commit(&commit)?;
+    let (_, _) = bob_room.apply_commit(&commit)?;
 
     let minted = client
         .mint_epoch(

--- a/vta-service/src/operations/room_groups.rs
+++ b/vta-service/src/operations/room_groups.rs
@@ -183,9 +183,15 @@ pub async fn apply_commit(
             "this VTA holds no group state for room `{room_id}`"
         ))
     })?;
-    let mut group = RoomGroup::restore(&record.snapshot)
-        .map_err(|e| AppError::Internal(format!("restore the group: {e}")))?;
-    let current = group.epoch();
+    // A `SealedRoom` rather than a bare group: the epoch link this commit produces is bound
+    // to the room, so minting one needs the room's identifier and the group does not carry
+    // it. Restoring through the room type is what makes the link mintable at all.
+    let mut room = SealedRoom::new(
+        room_id,
+        RoomGroup::restore(&record.snapshot)
+            .map_err(|e| AppError::Internal(format!("restore the group: {e}")))?,
+    );
+    let current = room.group().epoch();
 
     if claimed_epoch == current {
         // Already applied. Reporting success with the unchanged epoch is what makes
@@ -203,16 +209,24 @@ pub async fn apply_commit(
     // The link is what keeps everything already in the room readable across this commit.
     // Dropping it here would advance the epoch and silently sever the history — the defect
     // the chain exists to fix, so it is retained in the same write that advances the group.
-    let (_, link) = group
+    let (_, link) = room
         .apply_commit(commit)
         .map_err(|e| AppError::Validation(format!("the commit did not process: {e}")))?;
-    let epoch = group.epoch();
+    let epoch = room.group().epoch();
 
     let mut links = record.links;
     if let Some(link) = link {
         links.push(link);
     }
-    store(groups, room_id, &record.member_did, &group, links, now).await?;
+    store(
+        groups,
+        room_id,
+        &record.member_did,
+        room.group(),
+        links,
+        now,
+    )
+    .await?;
     Ok(epoch)
 }
 

--- a/vti-rooms/src/mls.rs
+++ b/vti-rooms/src/mls.rs
@@ -60,8 +60,6 @@ use openmls_traits::OpenMlsProvider;
 use tls_codec::{Deserialize as _, Serialize as _};
 
 use crate::error::RoomKeyError;
-use crate::retention::{self, StorageKey};
-use crate::wire::EpochLink;
 
 /// The MLS ciphersuite every room uses.
 ///
@@ -153,16 +151,6 @@ pub struct MembershipChange {
     pub welcome: Option<Vec<u8>>,
     /// The epoch the group is in after merging.
     pub epoch: u64,
-    /// The outgoing epoch's storage key, sealed under the incoming one.
-    ///
-    /// **Returned rather than applied**, because the caller is the only party that knows the
-    /// room's [`RetentionPolicy`](crate::RetentionPolicy) and where the link should be
-    /// stored. It is in the return type rather than reachable through a separate call so
-    /// that advancing an epoch and being handed the means to keep the room readable are one
-    /// act: a caller can still drop it, but not without seeing it.
-    ///
-    /// `None` only for a group at epoch 1, which has no predecessor.
-    pub link: Option<EpochLink>,
 }
 
 impl RoomGroup {
@@ -245,8 +233,6 @@ impl RoomGroup {
         &mut self,
         key_package: KeyPackage,
     ) -> Result<MembershipChange, RoomKeyError> {
-        let outgoing = self.storage_key()?;
-
         let (commit, welcome, _) = self
             .group
             .add_members(&self.provider, &self.identity.signer, &[key_package])
@@ -266,7 +252,6 @@ impl RoomGroup {
                     .map_err(|e| RoomKeyError::Group(format!("serialise welcome: {e:?}")))?,
             ),
             epoch: self.group.epoch().as_u64(),
-            link: self.link_from(outgoing)?,
         })
     }
 
@@ -280,8 +265,6 @@ impl RoomGroup {
         &mut self,
         index: LeafNodeIndex,
     ) -> Result<MembershipChange, RoomKeyError> {
-        let outgoing = self.storage_key()?;
-
         let (commit, _, _) = self
             .group
             .remove_members(&self.provider, &self.identity.signer, &[index])
@@ -297,39 +280,15 @@ impl RoomGroup {
                 .map_err(|e| RoomKeyError::Group(format!("serialise commit: {e:?}")))?,
             welcome: None,
             epoch: self.group.epoch().as_u64(),
-            link: self.link_from(outgoing)?,
         })
-    }
-
-    /// Seal the outgoing epoch's storage key under the incoming one.
-    ///
-    /// Called immediately after a merge, while this group is at the new epoch and `outgoing`
-    /// still holds the old key — the only moment either party knows both.
-    fn link_from(&self, outgoing: StorageKey) -> Result<Option<EpochLink>, RoomKeyError> {
-        let room_epoch = self.group.epoch().as_u64() + 1;
-        if room_epoch < 2 {
-            return Ok(None);
-        }
-        let epoch = u32::try_from(room_epoch)
-            .map_err(|_| RoomKeyError::Group(format!("epoch {room_epoch} exceeds u32")))?;
-        Ok(Some(retention::seal_link(
-            epoch,
-            &self.storage_key()?,
-            &outgoing,
-        )?))
     }
 
     /// Apply a commit produced by another member.
     ///
-    /// Returns the new epoch and the link that keeps everything below it readable — see
-    /// [`MembershipChange::link`] for why the link is in the return type rather than behind
-    /// a second call.
-    pub fn apply_commit(
-        &mut self,
-        commit: &[u8],
-    ) -> Result<(u64, Option<EpochLink>), RoomKeyError> {
-        let outgoing = self.storage_key()?;
-
+    /// Returns the new epoch. The epoch **link** that keeps everything below it readable is
+    /// minted by [`crate::sealed::SealedRoom`], not here: a rung is bound to the room, and
+    /// this type deliberately does not know which room it is for.
+    pub fn apply_commit(&mut self, commit: &[u8]) -> Result<u64, RoomKeyError> {
         let msg = MlsMessageIn::tls_deserialize_exact(commit)
             .map_err(|e| RoomKeyError::Group(format!("parse commit: {e:?}")))?;
         let protocol_message: ProtocolMessage = msg
@@ -346,8 +305,7 @@ impl RoomGroup {
                 self.group
                     .merge_staged_commit(&self.provider, *staged)
                     .map_err(|e| RoomKeyError::Group(format!("merge staged commit: {e:?}")))?;
-                let link = self.link_from(outgoing)?;
-                Ok((self.group.epoch().as_u64(), link))
+                Ok(self.group.epoch().as_u64())
             }
             _ => Err(RoomKeyError::Group(
                 "expected a commit, got another message type".into(),

--- a/vti-rooms/src/retention.rs
+++ b/vti-rooms/src/retention.rs
@@ -75,8 +75,8 @@ pub type StorageKey = [u8; STORAGE_KEY_LEN];
 /// on its own. The binding would be belt-and-braces, and the cost is real: it would put a
 /// room identifier into [`crate::mls::RoomGroup`], which deliberately does not know which
 /// room it is for.
-fn link_aad(epoch: u32) -> Vec<u8> {
-    format!("epoch-link|{epoch}|{}", epoch.saturating_sub(1)).into_bytes()
+fn link_aad(room_id: &str, epoch: u32) -> Vec<u8> {
+    format!("{room_id}|epoch-link|{epoch}|{}", epoch.saturating_sub(1)).into_bytes()
 }
 
 /// Seal `predecessor` (epoch `epoch - 1`'s storage key) under `current` (epoch `epoch`'s).
@@ -84,6 +84,7 @@ fn link_aad(epoch: u32) -> Vec<u8> {
 /// Called at the moment of a commit, by the party making it — the only party holding both
 /// keys at once.
 pub fn seal_link(
+    room_id: &str,
     epoch: u32,
     current: &StorageKey,
     predecessor: &StorageKey,
@@ -105,7 +106,7 @@ pub fn seal_link(
             Nonce::from_slice(&nonce_bytes),
             Payload {
                 msg: predecessor.as_slice(),
-                aad: &link_aad(epoch),
+                aad: &link_aad(room_id, epoch),
             },
         )
         .map_err(|e| RoomKeyError::Seal(format!("seal the epoch link: {e}")))?;
@@ -118,7 +119,11 @@ pub fn seal_link(
 }
 
 /// Recover epoch `link.epoch - 1`'s storage key, given epoch `link.epoch`'s.
-pub fn open_link(link: &EpochLink, current: &StorageKey) -> Result<StorageKey, RoomKeyError> {
+pub fn open_link(
+    room_id: &str,
+    link: &EpochLink,
+    current: &StorageKey,
+) -> Result<StorageKey, RoomKeyError> {
     let wrapped = B64
         .decode(&link.wrapped)
         .map_err(|e| RoomKeyError::Seal(format!("decode the epoch link: {e}")))?;
@@ -138,7 +143,7 @@ pub fn open_link(link: &EpochLink, current: &StorageKey) -> Result<StorageKey, R
             Nonce::from_slice(&nonce),
             Payload {
                 msg: &wrapped,
-                aad: &link_aad(link.epoch),
+                aad: &link_aad(room_id, link.epoch),
             },
         )
         .map_err(|_| RoomKeyError::DidNotOpen)?;
@@ -163,17 +168,27 @@ pub fn open_link(link: &EpochLink, current: &StorageKey) -> Result<StorageKey, R
 /// Resolution is memoised, so opening a room's whole history walks each rung once rather
 /// than once per record. Memoised keys survive re-anchoring: epoch 3's key is epoch 3's key
 /// whatever epoch the group has since reached.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct EpochKeyChain {
+    room_id: String,
     anchor_epoch: u32,
     links: BTreeMap<u32, EpochLink>,
     resolved: BTreeMap<u32, StorageKey>,
 }
 
 impl EpochKeyChain {
-    /// An empty chain: no links, no anchor, nothing resolvable until [`Self::reanchor`].
-    pub fn new() -> Self {
-        Self::default()
+    /// An empty chain for one room: no links, no anchor, nothing resolvable until
+    /// [`Self::reanchor`].
+    ///
+    /// The room is held because every rung is bound to it. A chain cannot be handed a rung
+    /// from another room and quietly make use of it.
+    pub fn new(room_id: impl Into<String>) -> Self {
+        Self {
+            room_id: room_id.into(),
+            anchor_epoch: 0,
+            links: BTreeMap::new(),
+            resolved: BTreeMap::new(),
+        }
     }
 
     /// Set the epoch this chain resolves *from*, and the key for it.
@@ -254,7 +269,7 @@ impl EpochKeyChain {
                     sealed: epoch,
                     earliest: cursor,
                 })?;
-            let previous = open_link(link, &key)?;
+            let previous = open_link(&self.room_id, link, &key)?;
             cursor -= 1;
             self.resolved.insert(cursor, previous);
         }
@@ -270,6 +285,8 @@ impl EpochKeyChain {
 mod tests {
     use super::*;
 
+    const ROOM: &str = "did:webvh:zRoom";
+
     fn key(seed: u8) -> StorageKey {
         [seed; STORAGE_KEY_LEN]
     }
@@ -278,8 +295,8 @@ mod tests {
     fn a_link_round_trips() {
         let current = key(2);
         let previous = key(1);
-        let link = seal_link(2, &current, &previous).expect("seal");
-        assert_eq!(open_link(&link, &current).expect("open"), previous);
+        let link = seal_link(ROOM, 2, &current, &previous).expect("seal");
+        assert_eq!(open_link(ROOM, &link, &current).expect("open"), previous);
     }
 
     /// A link is 32 sealed bytes like every other link. Only the binding says which rung it
@@ -287,26 +304,48 @@ mod tests {
     #[test]
     fn a_link_lifted_to_another_rung_does_not_open() {
         let current = key(2);
-        let link = seal_link(2, &current, &key(1)).expect("seal");
+        let link = seal_link(ROOM, 2, &current, &key(1)).expect("seal");
 
         let mut moved = link.clone();
         moved.epoch = 3;
         assert!(
-            open_link(&moved, &current).is_err(),
+            open_link(ROOM, &moved, &current).is_err(),
             "relabelling a link's epoch must fail authentication"
+        );
+    }
+
+    /// The binding this room identifier is in the associated data for.
+    ///
+    /// Two rooms derive different keys, so a rung served under the wrong room would fail to
+    /// open anyway — which is exactly why this test pins the *stated* reason instead. A
+    /// property that holds by accident is one a later refactor is free to remove, and the
+    /// specification (`rooms/epoch/chain/0.1`) requires the binding rather than the accident.
+    #[test]
+    fn a_link_served_under_another_room_does_not_open() {
+        let current = key(2);
+        let link = seal_link(ROOM, 2, &current, &key(1)).expect("seal");
+
+        // Same rung, same key, same everything but the room it is presented as belonging to.
+        assert!(
+            open_link("did:webvh:zOtherRoom", &link, &current).is_err(),
+            "a rung must not open under a room it was not sealed for"
+        );
+        assert_eq!(
+            open_link(ROOM, &link, &current).expect("opens under its own room"),
+            key(1)
         );
     }
 
     #[test]
     fn the_wrong_key_does_not_open_a_link() {
-        let link = seal_link(2, &key(2), &key(1)).expect("seal");
-        assert!(open_link(&link, &key(9)).is_err());
+        let link = seal_link(ROOM, 2, &key(2), &key(1)).expect("seal");
+        assert!(open_link(ROOM, &link, &key(9)).is_err());
     }
 
     #[test]
     fn the_first_epoch_has_no_predecessor() {
-        assert!(seal_link(1, &key(1), &key(0)).is_err());
-        assert!(seal_link(0, &key(1), &key(0)).is_err());
+        assert!(seal_link(ROOM, 1, &key(1), &key(0)).is_err());
+        assert!(seal_link(ROOM, 0, &key(1), &key(0)).is_err());
     }
 
     /// The property the whole module exists for.
@@ -314,10 +353,12 @@ mod tests {
     fn a_chain_walks_back_to_the_first_epoch() {
         let keys: Vec<StorageKey> = (1..=5).map(key).collect();
         let links: Vec<EpochLink> = (2..=5)
-            .map(|e| seal_link(e, &keys[(e - 1) as usize], &keys[(e - 2) as usize]).expect("seal"))
+            .map(|e| {
+                seal_link(ROOM, e, &keys[(e - 1) as usize], &keys[(e - 2) as usize]).expect("seal")
+            })
             .collect();
 
-        let mut chain = EpochKeyChain::new();
+        let mut chain = EpochKeyChain::new(ROOM);
         chain.reanchor(5, keys[4]);
         chain.add_links(links);
 
@@ -337,11 +378,13 @@ mod tests {
         let keys: Vec<StorageKey> = (1..=4).map(key).collect();
         let links: Vec<EpochLink> = [3u32, 4]
             .iter()
-            .map(|&e| seal_link(e, &keys[(e - 1) as usize], &keys[(e - 2) as usize]).expect("seal"))
+            .map(|&e| {
+                seal_link(ROOM, e, &keys[(e - 1) as usize], &keys[(e - 2) as usize]).expect("seal")
+            })
             .collect();
 
         // link(2) is absent: everything below epoch 2 has been cryptographically deleted.
-        let mut chain = EpochKeyChain::new();
+        let mut chain = EpochKeyChain::new(ROOM);
         chain.reanchor(4, keys[3]);
         chain.add_links(links);
 
@@ -356,7 +399,7 @@ mod tests {
     /// Behind is not the same as severed, and the error must not say it is.
     #[test]
     fn an_epoch_ahead_is_reported_as_ahead() {
-        let mut chain = EpochKeyChain::new();
+        let mut chain = EpochKeyChain::new(ROOM);
         chain.reanchor(2, key(2));
         assert!(matches!(
             chain.key_for(5),
@@ -366,10 +409,11 @@ mod tests {
 
     #[test]
     fn re_anchoring_commit_by_commit_keeps_everything_below_reachable() {
-        let mut chain = EpochKeyChain::new();
+        let mut chain = EpochKeyChain::new(ROOM);
         chain.reanchor(1, key(1));
         for epoch in 2..=4u32 {
-            let link = seal_link(epoch, &key(epoch as u8), &key((epoch - 1) as u8)).expect("seal");
+            let link =
+                seal_link(ROOM, epoch, &key(epoch as u8), &key((epoch - 1) as u8)).expect("seal");
             chain.add_links(Some(link));
             chain.reanchor(epoch, key(epoch as u8));
         }
@@ -385,8 +429,8 @@ mod tests {
     /// stays walked out — the anchor is where resolution *starts*, not a rollback point.
     #[test]
     fn re_anchoring_is_idempotent() {
-        let link = seal_link(2, &key(2), &key(1)).expect("seal");
-        let mut chain = EpochKeyChain::new();
+        let link = seal_link(ROOM, 2, &key(2), &key(1)).expect("seal");
+        let mut chain = EpochKeyChain::new(ROOM);
         chain.add_links(Some(link));
 
         chain.reanchor(2, key(2));
@@ -405,7 +449,7 @@ mod tests {
     /// the anchor and no history.
     #[test]
     fn advancing_without_a_link_hands_on_no_history() {
-        let mut chain = EpochKeyChain::new();
+        let mut chain = EpochKeyChain::new(ROOM);
         chain.reanchor(1, key(1));
         chain.reanchor(2, key(2)); // a commit arrived, and carried no link
 
@@ -416,7 +460,7 @@ mod tests {
         );
 
         // The state anyone else — or this member after a restart — actually receives.
-        let mut rebuilt = EpochKeyChain::new();
+        let mut rebuilt = EpochKeyChain::new(ROOM);
         rebuilt.reanchor(2, key(2));
         rebuilt.add_links(chain.links());
         assert!(matches!(

--- a/vti-rooms/src/sealed.rs
+++ b/vti-rooms/src/sealed.rs
@@ -43,7 +43,7 @@ use openmls::prelude::LeafNodeIndex;
 
 use crate::error::RoomKeyError;
 use crate::mls::{MembershipChange, RoomGroup};
-use crate::retention::EpochKeyChain;
+use crate::retention::{self, EpochKeyChain};
 use crate::wire::{EpochLink, SealedContent};
 
 /// A room whose records are sealed, and the group state that seals them.
@@ -69,10 +69,11 @@ impl SealedRoom {
     /// opens records from the current epoch only. Feed it [`SealedRoom::add_links`] to reach
     /// the room's history — see [`crate::retention`] for why history needs feeding.
     pub fn new(room_id: impl Into<String>, group: RoomGroup) -> Self {
+        let room_id = room_id.into();
         Self {
-            room_id: room_id.into(),
+            chain: EpochKeyChain::new(&room_id),
+            room_id,
             group,
-            chain: EpochKeyChain::new(),
         }
     }
 
@@ -135,10 +136,15 @@ impl SealedRoom {
     /// epoch with the old key, and the room silently lost the ability to read everything
     /// written before the change — the exact defect the chain exists to fix, reintroduced
     /// one call site at a time. There is no accessor because there is no safe one.
-    pub fn add_member(&mut self, key_package: &[u8]) -> Result<MembershipChange, RoomKeyError> {
+    pub fn add_member(
+        &mut self,
+        key_package: &[u8],
+    ) -> Result<(MembershipChange, Option<EpochLink>), RoomKeyError> {
+        let outgoing = self.group.storage_key()?;
         let change = self.group.add_member_from_bytes(key_package)?;
-        self.chain.add_links(change.link.clone());
-        Ok(change)
+        let link = self.mint_link(outgoing)?;
+        self.chain.add_links(link.clone());
+        Ok((change, link))
     }
 
     /// Remove a member and commit, keeping the chain intact.
@@ -148,20 +154,54 @@ impl SealedRoom {
     pub fn remove_member(
         &mut self,
         index: LeafNodeIndex,
-    ) -> Result<MembershipChange, RoomKeyError> {
+    ) -> Result<(MembershipChange, Option<EpochLink>), RoomKeyError> {
+        let outgoing = self.group.storage_key()?;
         let change = self.group.remove_member(index)?;
-        self.chain.add_links(change.link.clone());
-        Ok(change)
+        let link = self.mint_link(outgoing)?;
+        self.chain.add_links(link.clone());
+        Ok((change, link))
     }
 
     /// Apply a commit another member produced, keeping the chain intact.
     ///
     /// Returns the room epoch after the commit.
-    pub fn apply_commit(&mut self, commit: &[u8]) -> Result<u32, RoomKeyError> {
-        let (mls_epoch, link) = self.group.apply_commit(commit)?;
-        self.chain.add_links(link);
-        u32::try_from(mls_epoch + 1)
-            .map_err(|_| RoomKeyError::Group(format!("epoch {mls_epoch} exceeds u32")))
+    pub fn apply_commit(
+        &mut self,
+        commit: &[u8],
+    ) -> Result<(u32, Option<EpochLink>), RoomKeyError> {
+        let outgoing = self.group.storage_key()?;
+        let mls_epoch = self.group.apply_commit(commit)?;
+        let link = self.mint_link(outgoing)?;
+        self.chain.add_links(link.clone());
+        let epoch = u32::try_from(mls_epoch + 1)
+            .map_err(|_| RoomKeyError::Group(format!("epoch {mls_epoch} exceeds u32")))?;
+        Ok((epoch, link))
+    }
+
+    /// Seal the outgoing epoch's storage key under the incoming one, bound to this room.
+    ///
+    /// Called immediately after a merge, while the group is at the new epoch and `outgoing`
+    /// still holds the old key — the only moment any party knows both.
+    ///
+    /// **This lives here rather than on [`RoomGroup`] because a rung is bound to its room.**
+    /// `roomId` is in the associated data for the same reason it is in a record's
+    /// (`rooms/epoch/chain/0.1`, and `SealedRecord` before it): a rung served under the
+    /// wrong room must fail to open rather than rely on two rooms happening to derive
+    /// different keys. The group does not know which room it is for, and should not.
+    fn mint_link(
+        &self,
+        outgoing: retention::StorageKey,
+    ) -> Result<Option<EpochLink>, RoomKeyError> {
+        let epoch = self.room_epoch();
+        if epoch < 2 {
+            return Ok(None);
+        }
+        Ok(Some(retention::seal_link(
+            &self.room_id,
+            epoch,
+            &self.group.storage_key()?,
+            &outgoing,
+        )?))
     }
 
     /// The room's current epoch, as the host records it.

--- a/vti-rooms/tests/epoch_backfill.rs
+++ b/vti-rooms/tests/epoch_backfill.rs
@@ -50,7 +50,7 @@ fn a_new_member_can_read_what_was_already_in_the_room() {
     let sealed = alice.seal_record("k1", 1, b"the library").expect("seal");
 
     let (bob_snapshot, bob_kp) = IdentitySnapshot::mint("did:key:zBob").expect("mint bob");
-    let change = alice.add_member(&bob_kp).expect("add bob");
+    let (change, _link) = alice.add_member(&bob_kp).expect("add bob");
     let welcome = change.welcome.expect("an add produces a welcome");
 
     let mut bob = SealedRoom::new(
@@ -80,7 +80,7 @@ fn a_removed_member_still_cannot_read_what_came_after() {
     let mut alice = SealedRoom::new(ROOM, RoomGroup::create("did:key:zAlice").expect("group"));
 
     let (bob_snapshot, bob_kp) = IdentitySnapshot::mint("did:key:zBob").expect("mint bob");
-    let change = alice.add_member(&bob_kp).expect("add bob");
+    let (change, _link) = alice.add_member(&bob_kp).expect("add bob");
     let mut bob = SealedRoom::new(
         ROOM,
         RoomGroup::join_from_identity(&bob_snapshot, &change.welcome.expect("welcome"))


### PR DESCRIPTION
Conforms the implementation to [dtgwg-trust-tasks-tf#387](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/387), now merged.

## The binding

The specification requires a rung's AEAD associated data to name the room, matching what `SealedRecord` already does. This implementation bound only the epoch pair:

```diff
- epoch-link|{epoch}|{epoch-1}
+ {roomId}|epoch-link|{epoch}|{epoch-1}
```

**Cross-room substitution failed anyway**, because two rooms derive different storage keys from independent MLS groups. But that is an accident of key derivation rather than a statement — a later refactor is free to remove it and nothing goes red. The new test pins the stated reason instead of the accidental one:

```
a_link_served_under_another_room_does_not_open ... ok
```

It asserts both halves: the same rung, same key, presented under another room fails; presented under its own room it opens.

## Minting moved from `RoomGroup` to `SealedRoom`

A rung is bound to its room, and `RoomGroup` deliberately does not know which room it is for — that separation is exactly why `room_id` lives on `SealedRoom` for record sealing. Keeping link production in the group would have meant either teaching MLS state about room identity or leaving the binding out.

The VTA's commit path now restores through a `SealedRoom` for the same reason.

## Breaking

| | |
|---|---|
| `MembershipChange.link` | removed |
| `RoomGroup::apply_commit` | returns `u64`, not `(u64, Option<EpochLink>)` |
| `SealedRoom::{add_member, remove_member}` | return `(MembershipChange, Option<EpochLink>)` |
| `SealedRoom::apply_commit` | returns `(u32, Option<EpochLink>)` |
| `EpochKeyChain::new`, `retention::{seal_link, open_link}` | take the room id |

**No stored data migrates.** crates.io has `vti-rooms` 0.1.1, which predates the chain entirely, so no rung exists that was sealed under the old binding.

## Verification

- `cargo test -p vti-rooms --features mls` — 106 tests, including the new binding test
- `cargo build --workspace --all-features` / `cargo clippy --workspace --all-features --all-targets` — clean
- `cargo run -p room-host --example data_room` — step 13 still shows Alice, Bob and a joining Carol reading a record sealed before the membership change, and now reports the rung as room-bound

## Still to come

This is the half that needs no new bindings. Consuming `MintEpochPayload.link` and adding a `rooms/epoch/chain` handler waits on release-plz publishing `trust-tasks-rs` 0.18.4 — 0.18.3 shipped just before #387 merged. That follow-up is **additive rather than breaking**: generated payload types are `#[non_exhaustive]` with builders as of 0.14.0, so a new optional member arrives as one more builder setter.

## Unrelated flake found while verifying this

The full-workspace run surfaced `room-host` `a_member_without_a_nomination_cannot_claim` failing with `BadPrivateKey("private key seed must be 32 bytes")`. **Not caused by this change** — it passes 22/22 three times in isolation on this branch — but it is a real latent bug and worth its own fix, so I have deliberately left it out of this PR.

`vta_sdk::did_key::decode_private_key_multibase` strips a two-byte private-key multicodec prefix by matching the first two bytes. A **bare, unprefixed** 32-byte seed — which is what the `Party` test fixture encodes — whose first two bytes happen to equal `0x8026` (Ed25519), `0x8226` (X25519) or `0x8626` (P256) gets them stripped, leaving 30 bytes. Reproduced deterministically:

```
ed25519: Err(InvalidSeedLength)
```

3 in 65,536 per generated key: rare enough to look like noise, frequent enough to hit CI. The robust fix is in the decoder rather than the fixture — disambiguate by length (strip only when `raw.len() == 34`) so every caller storing a bare key is covered, not just this test.
