### PR TITLE
fix(persona): give the disclosure step-up context a type an approver can render

### DIFF
--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -569,6 +569,14 @@ const DEFAULT_STEP_UP_REASON: &str = "this operation requires a stepped-up (AAL2
 /// the same key.
 const EXT_KEY_AUTHZ_CONTEXT: &str = "org.openvtc.authorization-context";
 
+/// `type` of the authorization context a `release: stepUp` disclosure carries.
+///
+/// The context is passed through to the approver's device untouched, and the
+/// card that renders it discriminates on this member — the Cierge share ask
+/// (`https://openvtc.org/cierge/authorization-context/0.1`) is the exemplar.
+/// A context without one is a card the approver cannot choose.
+const PERSONA_AUTHZ_CONTEXT_TYPE: &str = "https://openvtc.org/persona/authorization-context/0.1";
+
 /// Pick the reason string + optional structured authorization context from a
 /// gated request's payload. A request MAY carry a `payload.authorizationContext`
 /// (e.g. a Cierge share/spend/tool ask); when it does, its human `summary`
@@ -1087,15 +1095,35 @@ pub(super) async fn initiate_disclosure_step_up(
             n => format!("{n} facts"),
         }
     );
-    let mut context = json!({
-        "operation": "persona/disclosure/present",
+    // The shape an approver's card already knows how to render:
+    // `{type, summary, risk, action}`, with the specifics under `action` keyed
+    // by `kind`. The first version of this emitted a flat bag of members with
+    // no `type`, which a native layer that discriminates on `type` cannot pick
+    // a card for — so the context that exists to show the approver what would
+    // leave would have shown them nothing.
+    //
+    // `summary` is the same string as `reason` on purpose, not by coincidence:
+    // `reason_and_context` reads `summary` back out as the reason for any
+    // context that carries one, so two different sentences here would put two
+    // different accounts of the same act in one document.
+    let mut action = json!({
+        "kind": "disclose",
         "previewId": preview_id,
         "verifierDid": verifier_did,
         "claimTypes": claim_types,
     });
     if let Some(p) = purpose {
-        context["purpose"] = json!(p);
+        action["purpose"] = json!(p);
     }
+    let context = json!({
+        "type": PERSONA_AUTHZ_CONTEXT_TYPE,
+        "summary": reason,
+        // Every disclosure that reaches this gate is one the claim-type
+        // registry marked `release: stepUp`. That is what `high` means here —
+        // it is the registry's judgement restated, not a fresh one.
+        "risk": "high",
+        "action": action,
+    });
 
     match mint_pending_step_up(
         &state.sessions_ks,

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -1830,11 +1830,24 @@ async fn a_step_up_claim_needs_an_approval_bound_to_that_preview() {
     // second device, and the approver authorises a release rather than reading
     // one.
     let context = &approve_request["payload"]["ext"]["org.openvtc.authorization-context"];
-    assert_eq!(context["operation"], "persona/disclosure/present", "{body}");
-    assert_eq!(context["previewId"], preview_id, "{body}");
-    assert_eq!(context["verifierDid"], "did:key:z6MkVerifier", "{body}");
-    assert_eq!(context["claimTypes"][0], "payment.card", "{body}");
-    assert_eq!(context["purpose"], "checkout", "{body}");
+    // The `{type, summary, risk, action}` shape an approver's card renders. The
+    // `type` is the half a native layer discriminates on, so a context without
+    // one is a context that shows the approver nothing.
+    assert_eq!(
+        context["type"], "https://openvtc.org/persona/authorization-context/0.1",
+        "the context carries no type, so no approval card can be chosen for it: {body}"
+    );
+    assert_eq!(context["risk"], "high", "{body}");
+    assert_eq!(
+        context["summary"], approve_request["payload"]["reason"],
+        "the summary and the reason are two accounts of one act and must not differ: {body}"
+    );
+    let action = &context["action"];
+    assert_eq!(action["kind"], "disclose", "{body}");
+    assert_eq!(action["previewId"], preview_id, "{body}");
+    assert_eq!(action["verifierDid"], "did:key:z6MkVerifier", "{body}");
+    assert_eq!(action["claimTypes"][0], "payment.card", "{body}");
+    assert_eq!(action["purpose"], "checkout", "{body}");
     assert!(
         !serde_json::to_string(&approve_request)
             .unwrap()


### PR DESCRIPTION
A defect in #1304, found by reading the approver side rather than the agent
side.

`initiate_disclosure_step_up` builds an authorization context so the approver
can see **what would leave** — the verifier, the claim types, the purpose. It
emitted a flat bag:

```json
{ "operation": "persona/disclosure/present", "previewId": "…",
  "verifierDid": "…", "claimTypes": ["payment.card"], "purpose": "checkout" }
```

That is not the shape an approver renders. `vta-mobile-core`'s
`parse_step_up_request` surfaces the context as raw JSON "for the native layer
to decode and render as the approval card", and the card discriminates on a
**`type`** URI — the Cierge share ask
(`https://openvtc.org/cierge/authorization-context/0.1`) is the only exemplar
and carries `{type, summary, risk, action}`.

So a context with no `type` is a card the approver cannot choose. The member
that exists precisely so the holder is not answering "approve a disclosure?"
blind would have shown them nothing.

## The fix

```json
{ "type": "https://openvtc.org/persona/authorization-context/0.1",
  "summary": "Approve disclosing 1 fact to did:key:z…",
  "risk": "high",
  "action": { "kind": "disclose", "previewId": "…", "verifierDid": "…",
              "claimTypes": ["payment.card"], "purpose": "checkout" } }
```

- **`summary` is the same string as `reason`, deliberately.**
  `reason_and_context` reads `summary` back out as the reason for any context
  that carries one, so two different sentences would put two accounts of one
  act in a single signed document.
- **`risk: "high"`** is the claim-type registry's judgement restated, not a
  fresh one: everything reaching this gate is a type the registry marked
  `release: stepUp`.
- The specifics move under `action` keyed by `kind`, so one renderer serves
  every context.

`vta-mobile-core` needs no change — it passes the context through untouched,
and its test pins the Cierge shape, not this one.

## Cuts over with the plugin

OpenVTC/vta-browser-plugin#190 reads the new shape, and adds the check this
change makes possible: **a context whose `type` is not the disclosure one is
refused**, so a share ask travelling under the same `ext` key can never be
shown to a holder in a disclosure's words. Per that repo's "nothing is
deployed — do not write compatibility folds" rule, the two land together and
neither carries a dual-accept arm.

## Tests

The end-to-end assertion in `persona_trust_task.rs` now pins the `type`, the
`risk`, and **that `summary` equals the request's `reason`** — the last being
the one a future edit is most likely to break by rewording one of them. The
existing assertion that the card number never reaches the approver's device is
unchanged and still passes.

`persona_trust_task` 22/22; `cargo clippy --workspace --all-targets --locked
-- -D warnings` clean.

## Guide checklist (§9)

- [x] R1.2/R1.3/R1.4/R1.5/R1.6 — no client, lock, retry, loop or ack touched
- [x] R2.1 — no mutation added
- [x] **R3.* — a wire shape changed**, and both consumers cut over in the same
      cycle: the plugin in #189, `vta-mobile-core` unaffected (pass-through).
      camelCase throughout; the `type` URI is the discriminator
- [x] R5.* — a context with no recognised `type` is refused by the consumer
      rather than guessed at
- [x] R6.* — `risk` restates the registry rather than asserting a fresh judgement
- [x] Deviations — none
