### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,7 +2552,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -7080,7 +7080,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10294,7 +10294,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10437,7 +10437,7 @@ dependencies = [
 
 [[package]]
 name = "vta-persona"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -10476,7 +10476,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10540,7 +10540,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -10773,7 +10773,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10875,7 +10875,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.14.0...cnm-cli-v0.14.1) — 2026-09-08
+
+
 ## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.13.6...cnm-cli-v0.14.0) — 2026-09-07
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.15.0...pnm-cli-v0.15.1) — 2026-09-08
+
+
+### Documentation
+
+- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))
+
+`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
+  everything a person reads. That was wrong in two independent ways.
+
+  It asserts what the model cannot promise. What a holder keeps in the pool is
+  self-asserted until a credential backs it, and a face exists so a person can
+  choose what to show — an old value, a pinned version, a value overridden for one
+  context, or a value that is simply not true. The step-up card said "Approve
+  disclosing 1 fact" about exactly that.
+
+  And the word was already spent: `fact` is the VTC ceremony engine's term for a
+  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
+  every `.rego`) — very nearly the opposite meaning, in the same product.
+
+  `detail` is the persona audit envelope's own field, `trait` is a keyword,
+  `entry` names an entry in a face and `value` is the field inside an attribute,
+  so the spec word comes to the screen instead and that row stops translating.
+  Truth is carried by the provenance beneath the value, never by the noun.
+
+  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
+    on their phone)
+  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
+    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
+  - `vta-persona` doc comments that define the model in the old word
+
+  Commands, flags, task URIs and wire records are untouched — they always said
+  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
+  the other meaning.
+
+  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
+
+
+
 ## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.14.6...pnm-cli-v0.15.0) — 2026-09-07
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.15.0"
+version = "0.15.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.14.0...vta-cli-common-v0.14.1) — 2026-09-08
+
+
+### Documentation
+
+- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))
+
+`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
+  everything a person reads. That was wrong in two independent ways.
+
+  It asserts what the model cannot promise. What a holder keeps in the pool is
+  self-asserted until a credential backs it, and a face exists so a person can
+  choose what to show — an old value, a pinned version, a value overridden for one
+  context, or a value that is simply not true. The step-up card said "Approve
+  disclosing 1 fact" about exactly that.
+
+  And the word was already spent: `fact` is the VTC ceremony engine's term for a
+  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
+  every `.rego`) — very nearly the opposite meaning, in the same product.
+
+  `detail` is the persona audit envelope's own field, `trait` is a keyword,
+  `entry` names an entry in a face and `value` is the field inside an attribute,
+  so the spec word comes to the screen instead and that row stops translating.
+  Truth is carried by the provenance beneath the value, never by the noun.
+
+  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
+    on their phone)
+  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
+    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
+  - `vta-persona` doc comments that define the model in the old word
+
+  Commands, flags, task URIs and wire records are untouched — they always said
+  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
+  the other meaning.
+
+  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
+
+
+
 ## [0.14.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.13.0...vta-cli-common-v0.14.0) — 2026-09-07
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-persona/CHANGELOG.md
+++ b/vta-persona/CHANGELOG.md
@@ -2,6 +2,227 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.2.0...vta-persona-v0.3.0) — 2026-09-08
+
+
+### Added
+
+- **persona**: Let a deployment declare its own claim types ([#1327](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1327))
+
+Teaching an agent one word cost five steps across two repositories: a pull
+  request against the specification, a publish, a hand-transcription into
+  `vta-persona`'s table, a release, a deploy. So nobody did it, every local token
+  — `profile.github`, `employer`, whatever an ecosystem actually keeps about its
+  people — resolved to the unregistered floor, and holders were shown their own
+  values masked as though each were a passport number.
+
+  `CLAIM-TYPES.md` §6 anticipated exactly this: the served-table task was "worth
+  doing when the first extension type ships, not before". It ships now.
+
+  `VTA_CLAIM_TYPE_EXTENSIONS` names a JSON file of rows in the shape the agent
+  already serves, so an operator can copy a row out of
+  `persona/claim-types/list`, change it, and put it back.
+
+  **Extensions feed the same lookup the resolution uses.** `declared()` is one
+  iterator over core plus extensions, and `defaults_for`, the family walk and
+  `registry_listing` all read it. That is the task's central MUST — what is served
+  and what is enforced cannot disagree — and two tables walked separately are two
+  tables that resolve differently. The family step is where it would have shown:
+  an extension family the exact lookup knew about and the walk did not.
+
+  **What an operator may declare, and why the line falls there:**
+
+  - Anything core does not cover. A token core has never heard of resolves to the
+    floor *because nobody has reasoned about it* — §4 rule 3 says so — and an
+    operator declaring it is that reasoning arriving.
+  - Tightenings of anything core does cover. That direction takes nothing from
+    anyone.
+  - Not loosenings, compared against what core resolves — exactly (`email.work`)
+    or through a family (`payment.giftCard` under `payment`). Otherwise a
+    deployment could declare a passport unremarkable, or escape a gated family by
+    inventing a member of it, which is the hole rule 3 exists to close.
+  - Never an `x:` token. §4's last rule makes that namespace unregistered by
+    construction; a row declaring one is a row no conforming client would honour.
+
+  **A bad file stops the agent starting**, rather than dropping the offending row.
+  Serving a table the operator did not write means a tightening they believe is in
+  force is not, and the values it was meant to protect are the ones they would
+  hear about last. An unknown axis value is refused rather than defaulted for the
+  same reason — `"hgih"` reading as `normal` looks exactly like a rule that works.
+  Loaded rows are logged with the path and the count, because "why is this masked"
+  is the question an operator will actually have.
+
+  Configured rather than administered, and the reason is upstream: serving an
+  admin task to edit the registry live needs a published task specification first,
+  since the dispatcher refuses a URI the registry does not declare. A file is
+  diffable, reviewable, and belongs to whoever owns the deployment.
+
+  Nine new tests over the rules, plus `docs/02-vta/claim-type-registry.md` for the
+  operator. 99 vta-persona and 1047 vta-service unit tests pass; `cargo fmt
+  --check` and `cargo clippy --all-features` clean.
+
+- **persona**: Serve the claim-type registry ([#1315](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1315))
+
+* feat(persona): serve the claim-type registry
+
+  The agent side of trust-tasks #390, now that trust-tasks-rs 0.18.5 is
+  published. Bumps the pin and implements `persona/claim-types/list/1.0`.
+
+  Served from `vta_persona::claim_types` — the same REGISTRY and UNREGISTERED
+  that `defaults_for` resolves through — because the task's central MUST is that
+  a maintainer serves the table it actually applies. A served table that differs
+  from the enforced one is worse than serving nothing: a client would mask and
+  gate by one rule while the agent disclosed by another, and nothing would report
+  it. The end-to-end test asserts that behaviourally, not by comparison: the
+  agent serves `payment.card: stepUp` and then refuses a `payment.card`
+  disclosure for want of one.
+
+  `strictness` is carried because §4 rule 3 is not computable without it. The
+  orderings come from new MOST_PROTECTIVE_FIRST constants, which are hand-written
+  — Rust cannot enumerate variants — so a unit test asserts each agrees with
+  `Ord`, the ordering the module actually resolves by. A disagreement would be
+  silent and served to every client as the rule.
+
+  `minimumSet` and `oidc` are omitted: both optional, and this agent's table does
+  not carry them. Transcribing them at the serving layer would be a second copy
+  of data nothing here resolves against.
+
+- **persona**: Honour a holder's release override at disclosure ([#1310](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1310))
+
+#1304 enforced `release: stepUp` from the claim-type registry only; a holder's
+  per-attribute override was ignored. `Attribute` carried a comment explaining
+  why the field had been withheld — "a stored override for a gate that does not
+  exist is a promise the holder would be entitled to rely on". The gate now
+  exists, so the field can be stored honestly.
+
+  The override is set above the boundary and enforced below it, so it travels
+  with the projection: Attribute.release → ResolvedClaim → MaterialisedClaim →
+  the gate. Nothing reads up. Re-materialisation on an attribute edit already
+  propagates, so changing the override changes what every bound context enforces.
+
+  Resolved once at preview creation onto `Preview.step_up_required` rather than
+  derived at read like `sensitivity`, because `PreviewClaim` is serialised
+  straight into the preview response and that schema declares
+  `additionalProperties: false` — this is an at-rest decision, not something a
+  verifier is owed. A preview is a single-use snapshot expiring in minutes, so
+  freezing it for that window is also the honest reading.
+
+  An override wins in both directions, per CLAIM-TYPES §4 rule 1. Loosening is
+  not a hole because `attribute/put` is holder-scoped: no verifier and no
+  context-scoped caller can reach it. The audit row records the decision either
+  way, since relaxing a card from stepUp to consent is the most consequential
+  thing this task can do.
+
+
+
+### Changed
+
+- **persona**: Attribute is not exhaustively constructible from outside ([#1328](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1328))
+
+`Attribute` grew `sensitivity` in #1299 and `release` in #1310. Each was a
+  `pub` field added to a struct any consumer could write as a literal, so each
+  was a compatibility break — the informational semver report has been carrying
+  `constructible_struct_adds_field` for the second one since it landed, which is
+  how this was noticed.
+
+  The record is not finished growing. The persona specification keeps adding
+  members and this crate keeps following it, so without `#[non_exhaustive]` every
+  one of those is another break for the same reason. Marked now, in a release that
+  already carries a break, so the next member is an addition instead.
+
+  `release-plz` has `semver_check = true` for this crate, so the bump was never
+  going to be missed — this is about how many breaks get paid, not whether one is
+  noticed. `cargo semver-checks` now reports two majors where it reported one, and
+  both belong to the same release.
+
+  Nothing outside this crate constructs an `Attribute`: it arrives from the store
+  or from a deserialised document. Inside the crate, literal construction is
+  unaffected, so the eight construction sites are untouched.
+
+  Also corrects `claim_types`'s module header, which said "nothing consults
+  `ReleaseRequirement`: `persona/disclosure/present` does not yet demand a fresh
+  authentication for a `stepUp` attribute, and a holder **cannot** record a
+  `release` override". Both halves stopped being true in #1310. The paragraph is
+  "what this module decides, and what it does not" — the first thing a reader
+  looks at, and the easiest to leave describing a version of the crate that no
+  longer exists.
+
+  99 vta-persona tests pass; `cargo fmt --check` and `cargo clippy --all-targets
+  --all-features` clean.
+
+
+
+### Documentation
+
+- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))
+
+`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
+  everything a person reads. That was wrong in two independent ways.
+
+  It asserts what the model cannot promise. What a holder keeps in the pool is
+  self-asserted until a credential backs it, and a face exists so a person can
+  choose what to show — an old value, a pinned version, a value overridden for one
+  context, or a value that is simply not true. The step-up card said "Approve
+  disclosing 1 fact" about exactly that.
+
+  And the word was already spent: `fact` is the VTC ceremony engine's term for a
+  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
+  every `.rego`) — very nearly the opposite meaning, in the same product.
+
+  `detail` is the persona audit envelope's own field, `trait` is a keyword,
+  `entry` names an entry in a face and `value` is the field inside an attribute,
+  so the spec word comes to the screen instead and that row stops translating.
+  Truth is carried by the provenance beneath the value, never by the noun.
+
+  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
+    on their phone)
+  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
+    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
+  - `vta-persona` doc comments that define the model in the old word
+
+  Commands, flags, task URIs and wire records are untouched — they always said
+  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
+  the other meaning.
+
+  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
+
+
+
+### Fixed
+
+- **persona**: A bad claim-type row is refused, not fatal ([#1331](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1331))
+
+The first version exited on a bad extension file, on the reasoning that serving
+  a table the operator did not write is worse than not serving at all. That is
+  right for a laptop and wrong for a hosted agent: refusing to boot takes out
+  sessions, credentials and mediation over a mis-typed claim type, and in a hosted
+  deployment nobody is reading stderr.
+
+  Rejection is per row now. The good rows apply, the agent starts, and every
+  refusal is reported — an ERROR log line each, and carried on
+  `persona/claim-types/list` under `ext["org.openvtc.claim-types"]` as
+  `rejected: [{type, reason}]`, with `fileError` beside it when the file itself
+  could not be read. `ext` is the specification's vendor-namespaced member, so
+  this needs no spec change and a client that does not know the key ignores it.
+
+  **The direction it fails in is stated rather than assumed.** A refused row is
+  not applied, so its token resolves as if the file had never mentioned it. For a
+  word core has never heard of that is the most protective answer. For a row that
+  meant to *tighten* a core type it is not — the looser answer stays in force,
+  which is the case the old behaviour existed to prevent. Nothing makes that safe
+  except somebody seeing it, which is why the reasons travel to a screen instead
+  of stopping at a log line, and why a test pins the resolution rather than only
+  the refusal.
+
+  A duplicated token disqualifies **every** row naming it rather than letting the
+  first win: applying one of two conflicting declarations is a guess at what the
+  operator meant, and an invisible one.
+
+  102 vta-persona tests pass (3 new), `cargo fmt --check` and `cargo clippy
+  --all-features` clean.
+
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.1.0...vta-persona-v0.2.0) — 2026-09-07
 
 

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-persona"
 description = "VTA persona store — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose"
 readme = "README.md"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 # Published for the same reason vta-vault is: `vta-service` is published, and a
 # crate cannot go to crates.io without its whole dependency closure. Nothing

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,347 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.34.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.34.0...vta-sdk-v0.34.1) — 2026-09-08
+
+
+### Added
+
+- **rooms**: A VTA mints the credentials that make a room joinable ([#1329](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1329))
+
+* feat(rooms): sign a room's credentials through the key oracle
+
+  The seam the owner tasks need, and the one design question scoping this work
+  flagged as its biggest unknown: how a VTA signs AS a room without holding the
+  room's key in a way that breaks the property the rooms family rests on.
+
+- **rooms**: The VTA seals records and lists the rooms it can open ([#1326](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1326))
+
+* feat(rooms): the VTA seals records and lists the rooms it can open
+
+  Implements rooms/keys/seal/0.1 and rooms/keys/list/0.1
+  (dtgwg-trust-tasks-tf#399), which are the two gaps that made a room UI
+  impossible.
+
+  ## seal — the mirror of open
+
+  A client could read a sealed room and not write to one, because sealing needs
+  the epoch's storage key and the key never leaves the VTA. Plaintext in,
+  ciphertext out.
+
+  It does not write, and does not reach the room's host. The caller presents its
+  own authority there. Sealing and being allowed to store are different questions
+  asked of different parties — this VTA knows the key and nothing about the room's
+  ACL; the host knows the credentials and cannot read a byte. Doing both here
+  would make the VTA the party that decides what a room contains.
+
+  ## list — where a roomId comes from
+
+  Every other room task took an identifier the caller already knew.
+
+  It restores each group to answer rather than reading the epoch out of the
+  snapshot, because `earliestReadableEpoch` is only knowable by *walking* the
+  chain — and a number derived two different ways is a number that will eventually
+  disagree with itself.
+
+  Custody, not membership: a room whose Welcome never arrived is absent even where
+  a good VMC is held, and a VTA not yet told of a removal still lists a room it can
+  open but can no longer write to. A caller MUST NOT read it as authority.
+
+  ## Six census sites, located before writing any code
+
+  The URI constants, ALL_URIS, retry_safety, dispatch, the conformance witnesses,
+  and the vta-mcp guard. The last is invisible to a
+  `grep TASK_ROOMS_KEYS_CHAIN_0_1` sweep because it classifies by SLUG — which is
+  exactly how it was missed on #1320, so it was checked by name this time.
+
+  `seal` is Sensitive there, beside `open`: it is the same exchange run the other
+  way, and the one direction where cleartext room material travels INTO the
+  oracle. `list` is ReadOnly, named rather than defaulted because what it returns
+  is the principal's room membership as key custody sees it.
+
+  trust-tasks-rs moves 0.18.6 → 0.18.7.
+
+- **rooms**: A joined member's agent can read the room's history ([#1320](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1320))
+
+* feat(rooms): a joined member's agent can read the room's history
+
+  The last leg. `rooms/epoch/chain` ([#1314](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1314)) gets the rungs from the room's host to
+  the member; this is `rooms/keys/chain/0.1`, which gets them from the member into
+  their own VTA — the party that actually opens records for their agent.
+
+  Until now a member who joined read the room's history in their client and their
+  agent did not: `rooms/keys/open` resolves from the chain the VTA accrued by
+  applying commits, and a joiner's was empty.
+
+  ## The response is the interesting part
+
+  `earliestReadableEpoch` is not a count of what arrived. A rung extends reach only
+  if every rung above it is present too, so the number worth returning is the one
+  this VTA can only get by walking what it holds. A host serving the same rungs
+  could not have answered it — which is why the specification puts it here.
+
+  A rung already held is never replaced, so a redelivery stores nothing and
+  reports the same reachability. That is why it is `RetrySafe`.
+
+  ## Five censuses
+
+  Adding a task to `vta-service` owes all of them, and they were done up front
+  rather than one CI run at a time: the URI constant, `ALL_URIS`, `retry_safety`,
+  dispatch, and the conformance witness. No `vta-mcp` guard verb — this is
+  inbound from the principal, like `commit` and `welcome`, not an agent-facing
+  verb.
+
+  An epoch outside `u32` is refused rather than saturated: clamping it to
+  `u32::MAX` would store a rung under an epoch nobody will ever ask for, which is
+  a delivery that reports success and extends nothing.
+
+  trust-tasks-rs moves 0.18.5 → 0.18.6, the release carrying the spec.
+
+- **auth/step-up**: Record a bound approval without elevating the session ([#1316](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1316))
+
+* feat(auth/step-up): record a bound approval without elevating the session
+
+  Closes the compromise #1304 stated and could not avoid: a `release: stepUp`
+  approval marked the preview it was bound to AND raised the session's assurance,
+  because 0.2's acknowledgement has exactly two statuses — `elevated` was untrue
+  and `rejected` was worse, since the approval had been applied.
+
+- **persona**: Serve the claim-type registry ([#1315](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1315))
+
+* feat(persona): serve the claim-type registry
+
+  The agent side of trust-tasks #390, now that trust-tasks-rs 0.18.5 is
+  published. Bumps the pin and implements `persona/claim-types/list/1.0`.
+
+  Served from `vta_persona::claim_types` — the same REGISTRY and UNREGISTERED
+  that `defaults_for` resolves through — because the task's central MUST is that
+  a maintainer serves the table it actually applies. A served table that differs
+  from the enforced one is worse than serving nothing: a client would mask and
+  gate by one rule while the agent disclosed by another, and nothing would report
+  it. The end-to-end test asserts that behaviourally, not by comparison: the
+  agent serves `payment.card: stepUp` and then refuses a `payment.card`
+  disclosure for want of one.
+
+  `strictness` is carried because §4 rule 3 is not computable without it. The
+  orderings come from new MOST_PROTECTIVE_FIRST constants, which are hand-written
+  — Rust cannot enumerate variants — so a unit test asserts each agrees with
+  `Ord`, the ordering the module actually resolves by. A disagreement would be
+  silent and served to every client as the rule.
+
+  `minimumSet` and `oidc` are omitted: both optional, and this agent's table does
+  not carry them. Transcribing them at the serving layer would be a second copy
+  of data nothing here resolves against.
+
+- **sdk**: Open the rotated DID's mediator account over TSP too ([#1312](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1312))
+
+#1309 left the mediator-account pass DIDComm-only and documented why: the
+  mediator's management dispatch (`MessageType::process` →
+  `trust_tasks::process`) was `#[cfg(feature = "didcomm")]` and took a
+  DIDComm `Message`, so a TSP message addressed to it was filed for pickup
+  rather than answered. There was no packet a TSP-only client could send to
+  set its own account ACL, over any transport.
+
+  affinidi-tdk-rs#783 added the TSP wrapper. This is its client half, and
+  it makes that documented limitation false — which is the point, since it
+  would otherwise have quietly outlived the constraint that justified it.
+
+  `acl_setup` gains `set_client_acl_over_tsp`, sending the same
+  `messaging/account/update/0.1` task as a TSP Direct message addressed to
+  the mediator. Same task, same allow-all ACL, same account key
+  (`sha256(did)`), so whichever arm runs the account ends up authorised for
+  both transports — the mediator keys its ACL on the DID, not the protocol.
+
+  `rotate_key_over_client` now routes the pass by transport instead of
+  skipping:
+
+  - DIDComm available, including dual-transport → the DIDComm arm. It is
+    what every deployed mediator understands, so on a VTA offering both it
+    is the one certain to be acted on.
+  - TSP-only → the TSP arm. Previously skipped, because it had to be.
+
+  Two things it deliberately does not do.
+
+  It never claims delivery. A TSP send resolving `Ok` means the mediator
+  accepted the frame, not that it applied the ACL (R1.1), and a mediator
+  predating #783 files it silently. The success log says what was *sent*,
+  with delivery unconfirmed; a guard asserts the word "opened" never
+  appears there.
+
+  It does not wait for a reply. The mediator applies the ACL before
+  responding, so a reply carries no information — the same reasoning that
+  makes the DIDComm arm log its errors rather than propagate them — while
+  waiting for one would stall for the full timeout against a mediator that
+  is never going to send it. Against such a mediator this degrades to
+  exactly the previous behaviour: the account keeps the `global_acl_default`
+  it was created with at authentication.
+
+  Also declares `dep:uuid` on the `acl-setup` feature. It was compiling
+  only because another enabled feature happened to supply it, which builds
+  in the workspace and fails under `cargo publish`'s isolated verification
+  — a class this workspace has been bitten by before.
+
+  Verified across all four relevant feature combinations rather than
+  `--all-features` alone. A helper whose only caller sits behind a `cfg` is
+  live in one build and dead in the other, and testing the first says
+  nothing about the second; that exact miss failed CI on the mediator side
+  of this pair an hour earlier.
+
+  Not covered end-to-end: the workspace's transitive test-mediator is
+  pinned at 0.20.11 and the TSP management arm ships in 0.22.3, so there is
+  no live mediator here to exercise it against yet. The guards pin the
+  routing and the honesty of the logging, not the wire exchange.
+
+- **sdk**: One key rotation for every transport, TSP included ([#1309](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1309))
+
+* feat(sdk): one key rotation for every transport, TSP included
+
+  A `needs_rotation` session on a TSP-only VTA could never retire its temp
+  did:key: rotation ran over DIDComm, and a VTA that advertises only `#tsp`
+  has no DIDComm mediator to run it on. The cold-start temp DID is meant to
+  be short-lived, so it stayed indefinitely.
+
+  `acl/swap-key/0.1` is a dispatched Trust Task, and TSP carries the
+  Trust-Task surface, so the VTA could already service this — TSP inbound
+  reaches `dispatch_trust_task_core`, the same spine DIDComm uses. The gap
+  was entirely client-side. Rather than add a third rotation path, this
+  collapses the two that existed into one: `rotate_key_over_client` issues
+  the swap through whatever transport the client holds, so REST, DIDComm
+  and TSP share an implementation and TSP comes free.
+
+  That also closes a divergence. REST rotated with the atomic
+  `acl/swap-key`; DIDComm used create-then-delete, minting an entry for the
+  new DID while the temp still held the same grant — the over-privilege
+  window `acl/swap-key` exists to avoid. The old code said so in a comment
+  and deferred it. One entry now exists at every instant.
+
+  What the swap cannot prove is that the new DID can *reach* its mediator,
+  and a rotation that commits to an unreachable DID is unrecoverable: the
+  temp entry is gone. So the new DID is probed first, while a failure is
+  still free. Two things kept separate there, because conflating them is a
+  bug:
+
+  - **Reachability** is proven over the transport the caller reconnects on.
+    A DIDComm trust-ping against a TSP-only mediator proves the wrong thing
+    and fails outright, which would have refused good DIDs on exactly the
+    deployments this change is for. The TSP arm probes with
+    `TspPingSession`.
+  - **The mediator account** is keyed on `sha256(did)` rather than a
+    protocol, so one pass authorises both transports — but it is issued
+    through the ATM, so it needs a DIDComm mediator and is attempted only
+    where one exists. Always best-effort: a closed account costs a dropped
+    forwarded reply on the next connect, never a credential.
+
+  Fatality follows need. A REST client never touches the mediator, so
+  failing its rotation on one would make `--transport rest` depend on
+  DIDComm infrastructure it does not use; there the probe is best-effort.
+
+  Transport selection follows the workspace order — TSP where advertised,
+  else DIDComm, else REST — so a dual-transport VTA rotates over TSP.
+
+  Eight source-level guards pin the ordering and the transport matching,
+  which live across several functions with nothing type-level holding them.
+  They read this file's own source, truncated at the test module so a guard
+  cannot match its own string literal. Six were mutation-checked to fail on
+  exactly the regression they target; the seventh is redundant with the
+  type system, which rejects the substitution outright.
+
+  `docs/02-vta/cold-start.md` described the create-then-delete flow, which
+  was already wrong for REST before this change.
+
+  No public API changes: every function this touches is private, and
+  `SessionStore::ensure_authenticated{,_didcomm}` and
+  `connect_with_transport` keep their signatures. `cargo semver-checks`
+  against the merge base reports no required update.
+
+
+
+### Documentation
+
+- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))
+
+`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
+  everything a person reads. That was wrong in two independent ways.
+
+  It asserts what the model cannot promise. What a holder keeps in the pool is
+  self-asserted until a credential backs it, and a face exists so a person can
+  choose what to show — an old value, a pinned version, a value overridden for one
+  context, or a value that is simply not true. The step-up card said "Approve
+  disclosing 1 fact" about exactly that.
+
+  And the word was already spent: `fact` is the VTC ceremony engine's term for a
+  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
+  every `.rego`) — very nearly the opposite meaning, in the same product.
+
+  `detail` is the persona audit envelope's own field, `trait` is a keyword,
+  `entry` names an entry in a face and `value` is the field inside an attribute,
+  so the spec word comes to the screen instead and that row stops translating.
+  Truth is carried by the provenance beneath the value, never by the noun.
+
+  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
+    on their phone)
+  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
+    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
+  - `vta-persona` doc comments that define the model in the old word
+
+  Commands, flags, task URIs and wire records are untouched — they always said
+  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
+  the other meaning.
+
+  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
+
+
+
+### Fixed
+
+- **sdk**: Finish the rotation test's migration to the Trust-Task binding ([#1313](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1313))
+
+main has been red since #1309, whose own Feature combos failed before it merged.
+  Every PR opened since inherits it.
+
+  #1309 moved rotation off a hand-rolled `POST /acl/swap` onto the dispatched
+  `acl/swap-key`, and the test file's header already describes that world — but
+  one of its four stubs never moved. The request went to an unmocked path and
+  404'd.
+
+  Two halves, and the second is why a permissive mock would have been worse than
+  the red: the response shape also changed, because `AclEntryResponse` renames
+  `subject` to `did` and `scopes` to `allowed_contexts`, so a stub written from
+  the Rust field names decodes to "missing field `subject`". A mock matched on the
+  path alone would have gone green while exercising neither half. This one matches
+  on the document `type` and `payload.currentSubject`, as the correctly-migrated
+  `config/show` stub in the same file already does.
+
+  Both halves probed: pointing the matcher at another task type fails, and using
+  the old REST field names fails. 24 passed, 0 failed.
+
+- **sdk**: A bare key whose first bytes spell a multicodec prefix is not truncated ([#1308](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1308))
+
+Both key decoders accept two encodings — a 2-byte multicodec prefix followed by
+  32 key bytes, or 32 bare key bytes — and told them apart by looking at the
+  leading bytes. A bare key is free to begin with any two bytes at all, including
+  a prefix's, so such a key had its first two stripped and arrived as 30:
+  `InvalidSeedLength`, for a key that was perfectly valid.
+
+  For randomly generated keys that is 3 chances in 65536 (0x8026 Ed25519, 0x8226
+  X25519, 0x8626 P256, plus 0xed01 on the public side) — rare enough to read as
+  noise, frequent enough to fail CI. It did, on room-host's
+  `a_member_without_a_nomination_cannot_claim`, which is what surfaced it. That
+  test's fixture is not at fault: it encodes a bare seed, which both functions
+  document as supported.
+
+  Length is the only sound disambiguator, because the leading bytes carry no
+  information a bare key is obliged to respect. A prefix is stripped only from a
+  34-byte input.
+
+  Both directions are pinned. Two tests fail without this change; two more pass
+  with or without it and exist to stop the wrong fix — simply not stripping would
+  satisfy the first pair and break every real caller.
+
+  These are public `vta-sdk` functions, so the exposure was never limited to the
+  test fixture: any caller storing a bare key could hit it.
+
+
+
 ## [0.34.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.33.0...vta-sdk-v0.34.0) — 2026-09-07
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.34.0"
+version = "0.34.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,311 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.24.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.24.0...vta-service-v0.24.1) — 2026-09-08
+
+
+### Added
+
+- **rooms**: A VTA mints the credentials that make a room joinable ([#1329](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1329))
+
+* feat(rooms): sign a room's credentials through the key oracle
+
+  The seam the owner tasks need, and the one design question scoping this work
+  flagged as its biggest unknown: how a VTA signs AS a room without holding the
+  room's key in a way that breaks the property the rooms family rests on.
+
+- **rooms**: The VTA seals records and lists the rooms it can open ([#1326](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1326))
+
+* feat(rooms): the VTA seals records and lists the rooms it can open
+
+  Implements rooms/keys/seal/0.1 and rooms/keys/list/0.1
+  (dtgwg-trust-tasks-tf#399), which are the two gaps that made a room UI
+  impossible.
+
+  ## seal — the mirror of open
+
+  A client could read a sealed room and not write to one, because sealing needs
+  the epoch's storage key and the key never leaves the VTA. Plaintext in,
+  ciphertext out.
+
+  It does not write, and does not reach the room's host. The caller presents its
+  own authority there. Sealing and being allowed to store are different questions
+  asked of different parties — this VTA knows the key and nothing about the room's
+  ACL; the host knows the credentials and cannot read a byte. Doing both here
+  would make the VTA the party that decides what a room contains.
+
+  ## list — where a roomId comes from
+
+  Every other room task took an identifier the caller already knew.
+
+  It restores each group to answer rather than reading the epoch out of the
+  snapshot, because `earliestReadableEpoch` is only knowable by *walking* the
+  chain — and a number derived two different ways is a number that will eventually
+  disagree with itself.
+
+  Custody, not membership: a room whose Welcome never arrived is absent even where
+  a good VMC is held, and a VTA not yet told of a removal still lists a room it can
+  open but can no longer write to. A caller MUST NOT read it as authority.
+
+  ## Six census sites, located before writing any code
+
+  The URI constants, ALL_URIS, retry_safety, dispatch, the conformance witnesses,
+  and the vta-mcp guard. The last is invisible to a
+  `grep TASK_ROOMS_KEYS_CHAIN_0_1` sweep because it classifies by SLUG — which is
+  exactly how it was missed on #1320, so it was checked by name this time.
+
+  `seal` is Sensitive there, beside `open`: it is the same exchange run the other
+  way, and the one direction where cleartext room material travels INTO the
+  oracle. `list` is ReadOnly, named rather than defaulted because what it returns
+  is the principal's room membership as key custody sees it.
+
+  trust-tasks-rs moves 0.18.6 → 0.18.7.
+
+- **persona**: Let a deployment declare its own claim types ([#1327](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1327))
+
+Teaching an agent one word cost five steps across two repositories: a pull
+  request against the specification, a publish, a hand-transcription into
+  `vta-persona`'s table, a release, a deploy. So nobody did it, every local token
+  — `profile.github`, `employer`, whatever an ecosystem actually keeps about its
+  people — resolved to the unregistered floor, and holders were shown their own
+  values masked as though each were a passport number.
+
+  `CLAIM-TYPES.md` §6 anticipated exactly this: the served-table task was "worth
+  doing when the first extension type ships, not before". It ships now.
+
+  `VTA_CLAIM_TYPE_EXTENSIONS` names a JSON file of rows in the shape the agent
+  already serves, so an operator can copy a row out of
+  `persona/claim-types/list`, change it, and put it back.
+
+  **Extensions feed the same lookup the resolution uses.** `declared()` is one
+  iterator over core plus extensions, and `defaults_for`, the family walk and
+  `registry_listing` all read it. That is the task's central MUST — what is served
+  and what is enforced cannot disagree — and two tables walked separately are two
+  tables that resolve differently. The family step is where it would have shown:
+  an extension family the exact lookup knew about and the walk did not.
+
+  **What an operator may declare, and why the line falls there:**
+
+  - Anything core does not cover. A token core has never heard of resolves to the
+    floor *because nobody has reasoned about it* — §4 rule 3 says so — and an
+    operator declaring it is that reasoning arriving.
+  - Tightenings of anything core does cover. That direction takes nothing from
+    anyone.
+  - Not loosenings, compared against what core resolves — exactly (`email.work`)
+    or through a family (`payment.giftCard` under `payment`). Otherwise a
+    deployment could declare a passport unremarkable, or escape a gated family by
+    inventing a member of it, which is the hole rule 3 exists to close.
+  - Never an `x:` token. §4's last rule makes that namespace unregistered by
+    construction; a row declaring one is a row no conforming client would honour.
+
+  **A bad file stops the agent starting**, rather than dropping the offending row.
+  Serving a table the operator did not write means a tightening they believe is in
+  force is not, and the values it was meant to protect are the ones they would
+  hear about last. An unknown axis value is refused rather than defaulted for the
+  same reason — `"hgih"` reading as `normal` looks exactly like a rule that works.
+  Loaded rows are logged with the path and the count, because "why is this masked"
+  is the question an operator will actually have.
+
+  Configured rather than administered, and the reason is upstream: serving an
+  admin task to edit the registry live needs a published task specification first,
+  since the dispatcher refuses a URI the registry does not declare. A file is
+  diffable, reviewable, and belongs to whoever owns the deployment.
+
+  Nine new tests over the rules, plus `docs/02-vta/claim-type-registry.md` for the
+  operator. 99 vta-persona and 1047 vta-service unit tests pass; `cargo fmt
+  --check` and `cargo clippy --all-features` clean.
+
+- **rooms**: A joined member's agent can read the room's history ([#1320](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1320))
+
+* feat(rooms): a joined member's agent can read the room's history
+
+  The last leg. `rooms/epoch/chain` ([#1314](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1314)) gets the rungs from the room's host to
+  the member; this is `rooms/keys/chain/0.1`, which gets them from the member into
+  their own VTA — the party that actually opens records for their agent.
+
+  Until now a member who joined read the room's history in their client and their
+  agent did not: `rooms/keys/open` resolves from the chain the VTA accrued by
+  applying commits, and a joiner's was empty.
+
+  ## The response is the interesting part
+
+  `earliestReadableEpoch` is not a count of what arrived. A rung extends reach only
+  if every rung above it is present too, so the number worth returning is the one
+  this VTA can only get by walking what it holds. A host serving the same rungs
+  could not have answered it — which is why the specification puts it here.
+
+  A rung already held is never replaced, so a redelivery stores nothing and
+  reports the same reachability. That is why it is `RetrySafe`.
+
+  ## Five censuses
+
+  Adding a task to `vta-service` owes all of them, and they were done up front
+  rather than one CI run at a time: the URI constant, `ALL_URIS`, `retry_safety`,
+  dispatch, and the conformance witness. No `vta-mcp` guard verb — this is
+  inbound from the principal, like `commit` and `welcome`, not an agent-facing
+  verb.
+
+  An epoch outside `u32` is refused rather than saturated: clamping it to
+  `u32::MAX` would store a rung under an epoch nobody will ever ask for, which is
+  a delivery that reports success and extends nothing.
+
+  trust-tasks-rs moves 0.18.5 → 0.18.6, the release carrying the spec.
+
+- **auth/step-up**: Record a bound approval without elevating the session ([#1316](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1316))
+
+* feat(auth/step-up): record a bound approval without elevating the session
+
+  Closes the compromise #1304 stated and could not avoid: a `release: stepUp`
+  approval marked the preview it was bound to AND raised the session's assurance,
+  because 0.2's acknowledgement has exactly two statuses — `elevated` was untrue
+  and `rejected` was worse, since the approval had been applied.
+
+- **persona**: Serve the claim-type registry ([#1315](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1315))
+
+* feat(persona): serve the claim-type registry
+
+  The agent side of trust-tasks #390, now that trust-tasks-rs 0.18.5 is
+  published. Bumps the pin and implements `persona/claim-types/list/1.0`.
+
+  Served from `vta_persona::claim_types` — the same REGISTRY and UNREGISTERED
+  that `defaults_for` resolves through — because the task's central MUST is that
+  a maintainer serves the table it actually applies. A served table that differs
+  from the enforced one is worse than serving nothing: a client would mask and
+  gate by one rule while the agent disclosed by another, and nothing would report
+  it. The end-to-end test asserts that behaviourally, not by comparison: the
+  agent serves `payment.card: stepUp` and then refuses a `payment.card`
+  disclosure for want of one.
+
+  `strictness` is carried because §4 rule 3 is not computable without it. The
+  orderings come from new MOST_PROTECTIVE_FIRST constants, which are hand-written
+  — Rust cannot enumerate variants — so a unit test asserts each agrees with
+  `Ord`, the ordering the module actually resolves by. A disagreement would be
+  silent and served to every client as the rule.
+
+  `minimumSet` and `oidc` are omitted: both optional, and this agent's table does
+  not carry them. Transcribing them at the serving layer would be a second copy
+  of data nothing here resolves against.
+
+- **persona**: Honour a holder's release override at disclosure ([#1310](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1310))
+
+#1304 enforced `release: stepUp` from the claim-type registry only; a holder's
+  per-attribute override was ignored. `Attribute` carried a comment explaining
+  why the field had been withheld — "a stored override for a gate that does not
+  exist is a promise the holder would be entitled to rely on". The gate now
+  exists, so the field can be stored honestly.
+
+  The override is set above the boundary and enforced below it, so it travels
+  with the projection: Attribute.release → ResolvedClaim → MaterialisedClaim →
+  the gate. Nothing reads up. Re-materialisation on an attribute edit already
+  propagates, so changing the override changes what every bound context enforces.
+
+  Resolved once at preview creation onto `Preview.step_up_required` rather than
+  derived at read like `sensitivity`, because `PreviewClaim` is serialised
+  straight into the preview response and that schema declares
+  `additionalProperties: false` — this is an at-rest decision, not something a
+  verifier is owed. A preview is a single-use snapshot expiring in minutes, so
+  freezing it for that window is also the honest reading.
+
+  An override wins in both directions, per CLAIM-TYPES §4 rule 1. Loosening is
+  not a hole because `attribute/put` is holder-scoped: no verifier and no
+  context-scoped caller can reach it. The audit row records the decision either
+  way, since relaxing a card from stepUp to consent is the most consequential
+  thing this task can do.
+
+
+
+### Documentation
+
+- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))
+
+`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
+  everything a person reads. That was wrong in two independent ways.
+
+  It asserts what the model cannot promise. What a holder keeps in the pool is
+  self-asserted until a credential backs it, and a face exists so a person can
+  choose what to show — an old value, a pinned version, a value overridden for one
+  context, or a value that is simply not true. The step-up card said "Approve
+  disclosing 1 fact" about exactly that.
+
+  And the word was already spent: `fact` is the VTC ceremony engine's term for a
+  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
+  every `.rego`) — very nearly the opposite meaning, in the same product.
+
+  `detail` is the persona audit envelope's own field, `trait` is a keyword,
+  `entry` names an entry in a face and `value` is the field inside an attribute,
+  so the spec word comes to the screen instead and that row stops translating.
+  Truth is carried by the provenance beneath the value, never by the noun.
+
+  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
+    on their phone)
+  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
+    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
+  - `vta-persona` doc comments that define the model in the old word
+
+  Commands, flags, task URIs and wire records are untouched — they always said
+  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
+  the other meaning.
+
+  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
+
+
+
+### Fixed
+
+- **persona**: A bad claim-type row is refused, not fatal ([#1331](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1331))
+
+The first version exited on a bad extension file, on the reasoning that serving
+  a table the operator did not write is worse than not serving at all. That is
+  right for a laptop and wrong for a hosted agent: refusing to boot takes out
+  sessions, credentials and mediation over a mis-typed claim type, and in a hosted
+  deployment nobody is reading stderr.
+
+  Rejection is per row now. The good rows apply, the agent starts, and every
+  refusal is reported — an ERROR log line each, and carried on
+  `persona/claim-types/list` under `ext["org.openvtc.claim-types"]` as
+  `rejected: [{type, reason}]`, with `fileError` beside it when the file itself
+  could not be read. `ext` is the specification's vendor-namespaced member, so
+  this needs no spec change and a client that does not know the key ignores it.
+
+  **The direction it fails in is stated rather than assumed.** A refused row is
+  not applied, so its token resolves as if the file had never mentioned it. For a
+  word core has never heard of that is the most protective answer. For a row that
+  meant to *tighten* a core type it is not — the looser answer stays in force,
+  which is the case the old behaviour existed to prevent. Nothing makes that safe
+  except somebody seeing it, which is why the reasons travel to a screen instead
+  of stopping at a log line, and why a test pins the resolution rather than only
+  the refusal.
+
+  A duplicated token disqualifies **every** row naming it rather than letting the
+  first win: applying one of two conflicting declarations is a guess at what the
+  operator meant, and an invisible one.
+
+  102 vta-persona tests pass (3 new), `cargo fmt --check` and `cargo clippy
+  --all-features` clean.
+
+- **persona**: Give the disclosure step-up context a type an approver can render ([#1306](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1306))
+
+`initiate_disclosure_step_up` emitted a flat bag of members with no `type`.
+  `vta-mobile-core` passes the authorization context to the native layer to
+  "decode and render as the approval card", and that card discriminates on a
+  `type` URI — so the context that exists to show the approver what would leave
+  was one no card could be chosen for.
+
+  Now the shape every authorization context uses: `{type, summary, risk,
+  action}`, with the specifics under `action` keyed by `kind`.
+
+  `summary` is the same string as `reason` on purpose — `reason_and_context`
+  reads `summary` back out as the reason, so two sentences would put two accounts
+  of one act in a single signed document. `risk: "high"` restates the claim-type
+  registry's judgement rather than making a fresh one: everything reaching this
+  gate is a type the registry marked `release: stepUp`.
+
+  Cuts over with OpenVTC/vta-browser-plugin#189, which reads the new shape and
+  refuses a context whose `type` is not this one — a share ask travels under the
+  same `ext` key and must never be shown in a disclosure's words.
+
+
+
 ## [0.24.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.23.5...vta-service-v0.24.0) — 2026-09-07
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.24.0"
+version = "0.24.1"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -160,7 +160,7 @@ vta-keys = { path = "../vta-keys", version = "0.4" }
 # Holder credential vault (storage/query/receive/present/status), extracted to
 # its own crate and re-exported as `crate::vault`. Feature edges: this crate's
 # `bbs` / `webvh` features enable `vta-vault/bbs` / `vta-vault/webvh`.
-vta-persona = { path = "../vta-persona", version = "0.2" }
+vta-persona = { path = "../vta-persona", version = "0.3" }
 vta-vault = { path = "../vta-vault", version = "0.5" }
 
 # The room presentation oracle attenuates a member VAC and signs it.

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.4...vtc-client-v0.5.5) — 2026-09-08
+
+
+### Added
+
+- **rooms**: Serve the epoch key chain, so a joining member can read the room ([#1314](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1314))
+
+* feat(rooms): serve the epoch key chain, so a joining member can read the room
+
+  Completes the mechanism #1300 built and #1305 made conformant. Wires the two
+  Trust Tasks published in dtgwg-trust-tasks-tf#387.
+
+  `rooms/epoch/mint` now carries the rung the advance produced. Minting is the
+  only moment one party holds both the outgoing and incoming epoch keys, so it is
+  the only call that can carry it — and a room that advances without one keeps
+  working while silently losing the ability to read everything written before.
+
+  `rooms/epoch/chain` serves the accumulated rungs, gated on `read`: reading the
+  room and reading the parts written earlier are the same act. What leaves is
+  ciphertext, since the key that opens a rung is a storage key no host holds — a
+  caller with the whole chain and no epoch key learns only how many epochs the
+  room has had, which its epoch number told them. That property is what lets a
+  *host* answer this at all, rather than requiring the owner to be online whenever
+  somebody joins.
+
+  Both hosts implement both. Two MUSTs from the spec are enforced: a rung whose
+  epoch does not match the advance is refused outright, and a rung already held
+  for an epoch is never replaced — a second one is either a replay or a
+  re-pointing of the room's history at key material of somebody else's choosing.
+
+  The keyspace is BACKED_UP, and not optionally: a restore that brings back a
+  room's records without its chain hands the members a room they can see the shape
+  of and cannot read.
+
+  ## What this does not finish
+
+  A joined member's *agent* still cannot read history. `rooms/keys/open` resolves
+  from the chain the member's VTA accrued by applying commits, and a joiner's is
+  empty; no task delivers rungs into a VTA. The mechanism, the storage and the
+  wire all exist — what is missing is the leg from a member's client into their
+  own VTA, which needs another spec round. Recorded in the design note §12.2 and
+  the operator guide rather than left implied by a passing demo.
+
+
+
 ## [0.5.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.3...vtc-client-v0.5.4) — 2026-09-07
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.18.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.0...vti-common-v0.18.1) — 2026-09-08
+
+
 ## [0.18.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.17.0...vti-common-v0.18.0) — 2026-09-07
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.18.0"
+version = "0.18.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vti-rooms/CHANGELOG.md
+++ b/vti-rooms/CHANGELOG.md
@@ -2,6 +2,121 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.2...vti-rooms-v0.1.3) — 2026-09-08
+
+
+### Added
+
+- **vtc**: An operator can see the rooms their community hosts ([#1325](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1325))
+
+* feat(vtc): an operator can see the rooms their community hosts
+
+  A VTC stores rooms and had no way to show its operator which ones. That is not
+  a small gap for a host: §9 obliges it to notify a room's owner before reclaiming
+  storage, and an operator who cannot list their rooms cannot send that notice.
+
+  `GET /v1/rooms`, admin-gated, plus `vti_rooms::storage::list_rooms` under it.
+
+  ## What a host may honestly say about a room it cannot read
+
+  The row, and nothing derived from the room's contents. Owner, tier, retention
+  policy, epoch, lifecycle state, expiry, retention days, mirror-of, timestamps.
+
+  Invariant I1 makes the owner visible at EVERY tier, including `private`,
+  precisely so a host has a party it can reach about quota, abuse and lifecycle —
+  so listing discloses nothing the design withheld. There is no records endpoint
+  here and no member list to return, because no host has one.
+
+  ## Plain REST, deliberately not a Trust Task
+
+  Every `rooms/*` task is authorized by credentials the ROOM issued, verified
+  against the room's own identifier — invariant I5, and what lets a room move
+  hosts. This asks the opposite question: what is this OPERATOR storing. It is
+  answered from the host's own admin authority, so pairing it with a room task
+  would claim a room governs an answer it has no view of.
+
+  ## Not paginated, and the comment says when that expires
+
+  A host's room count is bounded by what its operator agreed to store, not by
+  anything a caller controls. If that stops being true, `list_records` already has
+  the cursor shape to copy.
+
+- **rooms**: Serve the epoch key chain, so a joining member can read the room ([#1314](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1314))
+
+* feat(rooms): serve the epoch key chain, so a joining member can read the room
+
+  Completes the mechanism #1300 built and #1305 made conformant. Wires the two
+  Trust Tasks published in dtgwg-trust-tasks-tf#387.
+
+  `rooms/epoch/mint` now carries the rung the advance produced. Minting is the
+  only moment one party holds both the outgoing and incoming epoch keys, so it is
+  the only call that can carry it — and a room that advances without one keeps
+  working while silently losing the ability to read everything written before.
+
+  `rooms/epoch/chain` serves the accumulated rungs, gated on `read`: reading the
+  room and reading the parts written earlier are the same act. What leaves is
+  ciphertext, since the key that opens a rung is a storage key no host holds — a
+  caller with the whole chain and no epoch key learns only how many epochs the
+  room has had, which its epoch number told them. That property is what lets a
+  *host* answer this at all, rather than requiring the owner to be online whenever
+  somebody joins.
+
+  Both hosts implement both. Two MUSTs from the spec are enforced: a rung whose
+  epoch does not match the advance is refused outright, and a rung already held
+  for an epoch is never replaced — a second one is either a replay or a
+  re-pointing of the room's history at key material of somebody else's choosing.
+
+  The keyspace is BACKED_UP, and not optionally: a restore that brings back a
+  room's records without its chain hands the members a room they can see the shape
+  of and cannot read.
+
+  ## What this does not finish
+
+  A joined member's *agent* still cannot read history. `rooms/keys/open` resolves
+  from the chain the member's VTA accrued by applying commits, and a joiner's is
+  empty; no task delivers rungs into a VTA. The mechanism, the storage and the
+  wire all exist — what is missing is the leg from a member's client into their
+  own VTA, which needs another spec round. Recorded in the design note §12.2 and
+  the operator guide rather than left implied by a passing demo.
+
+
+
+### Fixed
+
+- **rooms**: Make the retention policy govern something ([#1318](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1318))
+
+`RetentionPolicy` shipped in #1300 as a field that was set and never read, and
+  `links_epochs()` was defined and never called. A room declared `FromJoin` would
+  have had rungs stored for it anyway — the policy was documentation.
+
+  ## The default was also wrong
+
+  It defaulted to `FromJoin`, reasoning that a room stored before the chain
+  existed "actually has no links". That confuses what a room *has* with what it
+  will *do*. A pre-chain room holds no rungs and never can for the epochs it has
+  already left behind — but it can chain from here, and because this policy is
+  immutable, defaulting it the other way would condemn every legacy room to keep
+  losing its history at every membership change. Which is the defect the chain
+  exists to fix.
+
+  So the default is `Chained`, and its unreachable early epochs are a fact about
+  its past rather than a policy about its future.
+
+  ## Enforced, not dropped
+
+  Both hosts now refuse a rung for a room that does not chain, rather than
+  silently discarding it. Storing it would give the room a chain it declared it
+  would not have; discarding it quietly would let a client believe history was
+  being retained when it was not.
+
+  `FromJoin` is not reachable over the wire — `rooms/create` has no member for it
+  until that spec lands — which is exactly why the guard is worth a test now. An
+  unreachable branch is the kind that rots, and this one was inert code until the
+  test existed. The room-host test writes the room straight to the store, the same
+  technique its succession tests use for states no handler can produce.
+
+
+
 ## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.1...vti-rooms-v0.1.2) — 2026-09-07
 
 

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.34.0 -> 0.34.1 (✓ API compatible changes)
* `vti-common`: 0.18.0 -> 0.18.1 (✓ API compatible changes)
* `vti-rooms`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `vtc-client`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `vta-cli-common`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `cnm-cli`: 0.14.0 -> 0.14.1
* `pnm-cli`: 0.15.0 -> 0.15.1
* `vta-persona`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `vta-service`: 0.24.0 -> 0.24.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.34.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.34.0...vta-sdk-v0.34.1) — 2026-09-08

### Added

- **rooms**: A VTA mints the credentials that make a room joinable ([#1329](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1329))

* feat(rooms): sign a room's credentials through the key oracle

  The seam the owner tasks need, and the one design question scoping this work
  flagged as its biggest unknown: how a VTA signs AS a room without holding the
  room's key in a way that breaks the property the rooms family rests on.

- **rooms**: The VTA seals records and lists the rooms it can open ([#1326](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1326))

* feat(rooms): the VTA seals records and lists the rooms it can open

  Implements rooms/keys/seal/0.1 and rooms/keys/list/0.1
  (dtgwg-trust-tasks-tf#399), which are the two gaps that made a room UI
  impossible.
</blockquote>


## `vti-rooms`

<blockquote>

## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.2...vti-rooms-v0.1.3) — 2026-09-08

### Added

- **vtc**: An operator can see the rooms their community hosts ([#1325](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1325))

* feat(vtc): an operator can see the rooms their community hosts

  A VTC stores rooms and had no way to show its operator which ones. That is not
  a small gap for a host: §9 obliges it to notify a room's owner before reclaiming
  storage, and an operator who cannot list their rooms cannot send that notice.

  `GET /v1/rooms`, admin-gated, plus `vti_rooms::storage::list_rooms` under it.
</blockquote>

## `vtc-client`

<blockquote>

## [0.5.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.4...vtc-client-v0.5.5) — 2026-09-08

### Added

- **rooms**: Serve the epoch key chain, so a joining member can read the room ([#1314](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1314))

* feat(rooms): serve the epoch key chain, so a joining member can read the room

  Completes the mechanism #1300 built and #1305 made conformant. Wires the two
  Trust Tasks published in dtgwg-trust-tasks-tf#387.

  `rooms/epoch/mint` now carries the rung the advance produced. Minting is the
  only moment one party holds both the outgoing and incoming epoch keys, so it is
  the only call that can carry it — and a room that advances without one keeps
  working while silently losing the ability to read everything written before.

  `rooms/epoch/chain` serves the accumulated rungs, gated on `read`: reading the
  room and reading the parts written earlier are the same act. What leaves is
  ciphertext, since the key that opens a rung is a storage key no host holds — a
  caller with the whole chain and no epoch key learns only how many epochs the
  room has had, which its epoch number told them. That property is what lets a
  *host* answer this at all, rather than requiring the owner to be online whenever
  somebody joins.

  Both hosts implement both. Two MUSTs from the spec are enforced: a rung whose
  epoch does not match the advance is refused outright, and a rung already held
  for an epoch is never replaced — a second one is either a replay or a
  re-pointing of the room's history at key material of somebody else's choosing.

  The keyspace is BACKED_UP, and not optionally: a restore that brings back a
  room's records without its chain hands the members a room they can see the shape
  of and cannot read.
</blockquote>

## `vta-cli-common`

<blockquote>

## [0.14.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.14.0...vta-cli-common-v0.14.1) — 2026-09-08

### Documentation

- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))

`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
  everything a person reads. That was wrong in two independent ways.

  It asserts what the model cannot promise. What a holder keeps in the pool is
  self-asserted until a credential backs it, and a face exists so a person can
  choose what to show — an old value, a pinned version, a value overridden for one
  context, or a value that is simply not true. The step-up card said "Approve
  disclosing 1 fact" about exactly that.

  And the word was already spent: `fact` is the VTC ceremony engine's term for a
  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
  every `.rego`) — very nearly the opposite meaning, in the same product.

  `detail` is the persona audit envelope's own field, `trait` is a keyword,
  `entry` names an entry in a face and `value` is the field inside an attribute,
  so the spec word comes to the screen instead and that row stops translating.
  Truth is carried by the provenance beneath the value, never by the noun.

  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
    on their phone)
  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
  - `vta-persona` doc comments that define the model in the old word

  Commands, flags, task URIs and wire records are untouched — they always said
  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
  the other meaning.

  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
</blockquote>


## `pnm-cli`

<blockquote>

## [0.15.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.15.0...pnm-cli-v0.15.1) — 2026-09-08

### Documentation

- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))

`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
  everything a person reads. That was wrong in two independent ways.

  It asserts what the model cannot promise. What a holder keeps in the pool is
  self-asserted until a credential backs it, and a face exists so a person can
  choose what to show — an old value, a pinned version, a value overridden for one
  context, or a value that is simply not true. The step-up card said "Approve
  disclosing 1 fact" about exactly that.

  And the word was already spent: `fact` is the VTC ceremony engine's term for a
  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
  every `.rego`) — very nearly the opposite meaning, in the same product.

  `detail` is the persona audit envelope's own field, `trait` is a keyword,
  `entry` names an entry in a face and `value` is the field inside an attribute,
  so the spec word comes to the screen instead and that row stops translating.
  Truth is carried by the provenance beneath the value, never by the noun.

  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
    on their phone)
  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
  - `vta-persona` doc comments that define the model in the old word

  Commands, flags, task URIs and wire records are untouched — they always said
  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
  the other meaning.

  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.
</blockquote>

## `vta-persona`

<blockquote>

## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.2.0...vta-persona-v0.3.0) — 2026-09-08

### Added

- **persona**: Let a deployment declare its own claim types ([#1327](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1327))

Teaching an agent one word cost five steps across two repositories: a pull
  request against the specification, a publish, a hand-transcription into
  `vta-persona`'s table, a release, a deploy. So nobody did it, every local token
  — `profile.github`, `employer`, whatever an ecosystem actually keeps about its
  people — resolved to the unregistered floor, and holders were shown their own
  values masked as though each were a passport number.

  `CLAIM-TYPES.md` §6 anticipated exactly this: the served-table task was "worth
  doing when the first extension type ships, not before". It ships now.

  `VTA_CLAIM_TYPE_EXTENSIONS` names a JSON file of rows in the shape the agent
  already serves, so an operator can copy a row out of
  `persona/claim-types/list`, change it, and put it back.

  **Extensions feed the same lookup the resolution uses.** `declared()` is one
  iterator over core plus extensions, and `defaults_for`, the family walk and
  `registry_listing` all read it. That is the task's central MUST — what is served
  and what is enforced cannot disagree — and two tables walked separately are two
  tables that resolve differently. The family step is where it would have shown:
  an extension family the exact lookup knew about and the walk did not.

  **What an operator may declare, and why the line falls there:**

  - Anything core does not cover. A token core has never heard of resolves to the
    floor *because nobody has reasoned about it* — §4 rule 3 says so — and an
    operator declaring it is that reasoning arriving.
  - Tightenings of anything core does cover. That direction takes nothing from
    anyone.
  - Not loosenings, compared against what core resolves — exactly (`email.work`)
    or through a family (`payment.giftCard` under `payment`). Otherwise a
    deployment could declare a passport unremarkable, or escape a gated family by
    inventing a member of it, which is the hole rule 3 exists to close.
  - Never an `x:` token. §4's last rule makes that namespace unregistered by
    construction; a row declaring one is a row no conforming client would honour.

  **A bad file stops the agent starting**, rather than dropping the offending row.
  Serving a table the operator did not write means a tightening they believe is in
  force is not, and the values it was meant to protect are the ones they would
  hear about last. An unknown axis value is refused rather than defaulted for the
  same reason — `"hgih"` reading as `normal` looks exactly like a rule that works.
  Loaded rows are logged with the path and the count, because "why is this masked"
  is the question an operator will actually have.

  Configured rather than administered, and the reason is upstream: serving an
  admin task to edit the registry live needs a published task specification first,
  since the dispatcher refuses a URI the registry does not declare. A file is
  diffable, reviewable, and belongs to whoever owns the deployment.

  Nine new tests over the rules, plus `docs/02-vta/claim-type-registry.md` for the
  operator. 99 vta-persona and 1047 vta-service unit tests pass; `cargo fmt
  --check` and `cargo clippy --all-features` clean.

- **persona**: Serve the claim-type registry ([#1315](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1315))

* feat(persona): serve the claim-type registry

  The agent side of trust-tasks #390, now that trust-tasks-rs 0.18.5 is
  published. Bumps the pin and implements `persona/claim-types/list/1.0`.

  Served from `vta_persona::claim_types` — the same REGISTRY and UNREGISTERED
  that `defaults_for` resolves through — because the task's central MUST is that
  a maintainer serves the table it actually applies. A served table that differs
  from the enforced one is worse than serving nothing: a client would mask and
  gate by one rule while the agent disclosed by another, and nothing would report
  it. The end-to-end test asserts that behaviourally, not by comparison: the
  agent serves `payment.card: stepUp` and then refuses a `payment.card`
  disclosure for want of one.

  `strictness` is carried because §4 rule 3 is not computable without it. The
  orderings come from new MOST_PROTECTIVE_FIRST constants, which are hand-written
  — Rust cannot enumerate variants — so a unit test asserts each agrees with
  `Ord`, the ordering the module actually resolves by. A disagreement would be
  silent and served to every client as the rule.

  `minimumSet` and `oidc` are omitted: both optional, and this agent's table does
  not carry them. Transcribing them at the serving layer would be a second copy
  of data nothing here resolves against.

- **persona**: Honour a holder's release override at disclosure ([#1310](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1310))

#1304 enforced `release: stepUp` from the claim-type registry only; a holder's
  per-attribute override was ignored. `Attribute` carried a comment explaining
  why the field had been withheld — "a stored override for a gate that does not
  exist is a promise the holder would be entitled to rely on". The gate now
  exists, so the field can be stored honestly.

  The override is set above the boundary and enforced below it, so it travels
  with the projection: Attribute.release → ResolvedClaim → MaterialisedClaim →
  the gate. Nothing reads up. Re-materialisation on an attribute edit already
  propagates, so changing the override changes what every bound context enforces.

  Resolved once at preview creation onto `Preview.step_up_required` rather than
  derived at read like `sensitivity`, because `PreviewClaim` is serialised
  straight into the preview response and that schema declares
  `additionalProperties: false` — this is an at-rest decision, not something a
  verifier is owed. A preview is a single-use snapshot expiring in minutes, so
  freezing it for that window is also the honest reading.

  An override wins in both directions, per CLAIM-TYPES §4 rule 1. Loosening is
  not a hole because `attribute/put` is holder-scoped: no verifier and no
  context-scoped caller can reach it. The audit row records the decision either
  way, since relaxing a card from stepUp to consent is the most consequential
  thing this task can do.



### Changed

- **persona**: Attribute is not exhaustively constructible from outside ([#1328](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1328))

`Attribute` grew `sensitivity` in #1299 and `release` in #1310. Each was a
  `pub` field added to a struct any consumer could write as a literal, so each
  was a compatibility break — the informational semver report has been carrying
  `constructible_struct_adds_field` for the second one since it landed, which is
  how this was noticed.

  The record is not finished growing. The persona specification keeps adding
  members and this crate keeps following it, so without `#[non_exhaustive]` every
  one of those is another break for the same reason. Marked now, in a release that
  already carries a break, so the next member is an addition instead.

  `release-plz` has `semver_check = true` for this crate, so the bump was never
  going to be missed — this is about how many breaks get paid, not whether one is
  noticed. `cargo semver-checks` now reports two majors where it reported one, and
  both belong to the same release.

  Nothing outside this crate constructs an `Attribute`: it arrives from the store
  or from a deserialised document. Inside the crate, literal construction is
  unaffected, so the eight construction sites are untouched.

  Also corrects `claim_types`'s module header, which said "nothing consults
  `ReleaseRequirement`: `persona/disclosure/present` does not yet demand a fresh
  authentication for a `stepUp` attribute, and a holder **cannot** record a
  `release` override". Both halves stopped being true in #1310. The paragraph is
  "what this module decides, and what it does not" — the first thing a reader
  looks at, and the easiest to leave describing a version of the crate that no
  longer exists.

  99 vta-persona tests pass; `cargo fmt --check` and `cargo clippy --all-targets
  --all-features` clean.



### Documentation

- **persona**: Say "attribute" on screen, not "fact" ([#1319](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1319))

`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for
  everything a person reads. That was wrong in two independent ways.

  It asserts what the model cannot promise. What a holder keeps in the pool is
  self-asserted until a credential backs it, and a face exists so a person can
  choose what to show — an old value, a pinned version, a value overridden for one
  context, or a value that is simply not true. The step-up card said "Approve
  disclosing 1 fact" about exactly that.

  And the word was already spent: `fact` is the VTC ceremony engine's term for a
  *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly,
  every `.rego`) — very nearly the opposite meaning, in the same product.

  `detail` is the persona audit envelope's own field, `trait` is a keyword,
  `entry` names an entry in a face and `value` is the field inside an attribute,
  so the spec word comes to the screen instead and that row stops translating.
  Truth is carried by the provenance beneath the value, never by the noun.

  - step-up approval card: "1 fact" → "1 attribute" (the string an approver reads
    on their phone)
  - `pnm persona …` help text and `vta-cli-common` printed output: "Your facts:"
    → "Your attributes:", "Fact:" → "Attribute:", and the surrounding guidance
  - `vta-persona` doc comments that define the model in the old word

  Commands, flags, task URIs and wire records are untouched — they always said
  `attribute`. Nothing in `vtc-service/src/ceremony/` is touched; that `Facts` is
  the other meaning.

  vta-persona 88 tests and vta-service persona_trust_task 23 tests pass.



### Fixed

- **persona**: A bad claim-type row is refused, not fatal ([#1331](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1331))

The first version exited on a bad extension file, on the reasoning that serving
  a table the operator did not write is worse than not serving at all. That is
  right for a laptop and wrong for a hosted agent: refusing to boot takes out
  sessions, credentials and mediation over a mis-typed claim type, and in a hosted
  deployment nobody is reading stderr.

  Rejection is per row now. The good rows apply, the agent starts, and every
  refusal is reported — an ERROR log line each, and carried on
  `persona/claim-types/list` under `ext["org.openvtc.claim-types"]` as
  `rejected: [{type, reason}]`, with `fileError` beside it when the file itself
  could not be read. `ext` is the specification's vendor-namespaced member, so
  this needs no spec change and a client that does not know the key ignores it.

  **The direction it fails in is stated rather than assumed.** A refused row is
  not applied, so its token resolves as if the file had never mentioned it. For a
  word core has never heard of that is the most protective answer. For a row that
  meant to *tighten* a core type it is not — the looser answer stays in force,
  which is the case the old behaviour existed to prevent. Nothing makes that safe
  except somebody seeing it, which is why the reasons travel to a screen instead
  of stopping at a log line, and why a test pins the resolution rather than only
  the refusal.

  A duplicated token disqualifies **every** row naming it rather than letting the
  first win: applying one of two conflicting declarations is a guess at what the
  operator meant, and an invisible one.

  102 vta-persona tests pass (3 new), `cargo fmt --check` and `cargo clippy
  --all-features` clean.
</blockquote>

## `vta-service`

<blockquote>

## [0.24.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.24.0...vta-service-v0.24.1) — 2026-09-08

### Added

- **rooms**: A VTA mints the credentials that make a room joinable ([#1329](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1329))

* feat(rooms): sign a room's credentials through the key oracle

  The seam the owner tasks need, and the one design question scoping this work
  flagged as its biggest unknown: how a VTA signs AS a room without holding the
  room's key in a way that breaks the property the rooms family rests on.

- **rooms**: The VTA seals records and lists the rooms it can open ([#1326](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1326))

* feat(rooms): the VTA seals records and lists the rooms it can open

  Implements rooms/keys/seal/0.1 and rooms/keys/list/0.1
  (dtgwg-trust-tasks-tf#399), which are the two gaps that made a room UI
  impossible.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).