### PR TITLE
fix(sdk): a bare key whose first bytes spell a multicodec prefix is not truncated

### DIFF
--- a/vta-sdk/src/did_key.rs
+++ b/vta-sdk/src/did_key.rs
@@ -12,9 +12,12 @@ const ED25519_PUB_CODEC: [u8; 2] = [0xed, 0x01];
 /// Decode an Ed25519 public key from its multibase form. Inverse of
 /// [`ed25519_multibase_pubkey`]. Accepts both multicodec-prefixed
 /// (`0xed01`) and raw-bytes encodings; returns the 32-byte key.
+///
+/// **Length disambiguates, not the leading bytes** — see
+/// [`decode_private_key_multibase`] for the failure that rule prevents.
 pub fn decode_ed25519_public_key_multibase(mb: &str) -> Result<[u8; 32], DidKeyError> {
     let (_, raw) = multibase::decode(mb).map_err(|e| DidKeyError::Multibase(e.to_string()))?;
-    let key_bytes = if raw.len() >= 2 && [raw[0], raw[1]] == ED25519_PUB_CODEC {
+    let key_bytes = if raw.len() == PREFIXED_KEY_LEN && [raw[0], raw[1]] == ED25519_PUB_CODEC {
         &raw[2..]
     } else {
         &raw[..]
@@ -23,6 +26,16 @@ pub fn decode_ed25519_public_key_multibase(mb: &str) -> Result<[u8; 32], DidKeyE
         .try_into()
         .map_err(|_| DidKeyError::InvalidSeedLength)
 }
+
+/// A 2-byte multicodec prefix followed by a 32-byte key.
+///
+/// The **only** thing that distinguishes a prefixed key from a bare one, because a bare key
+/// is free to begin with any two bytes at all — including a prefix's. Matching on the
+/// leading bytes alone truncated a bare 32-byte key to 30 whenever its first two happened to
+/// collide, which for randomly generated keys is 3 chances in 65536: rare enough to look
+/// like noise and frequent enough to fail CI. It did, on `room-host`'s
+/// `a_member_without_a_nomination_cannot_claim`.
+const PREFIXED_KEY_LEN: usize = 34;
 
 /// Known 2-byte multicodec varint prefixes for private keys.
 const ED25519_PRIV_CODEC: [u8; 2] = [0x80, 0x26]; // 0x1300
@@ -39,11 +52,12 @@ const P256_PRIV_CODEC: [u8; 2] = [0x86, 0x26]; // 0x1306
 /// before returning the raw key bytes.
 pub fn decode_private_key_multibase(mb: &str) -> Result<[u8; 32], DidKeyError> {
     let (_, raw) = multibase::decode(mb).map_err(|e| DidKeyError::Multibase(e.to_string()))?;
-    let key_bytes = if raw.len() >= 2 {
-        match [raw[0], raw[1]] {
-            ED25519_PRIV_CODEC | X25519_PRIV_CODEC | P256_PRIV_CODEC => &raw[2..],
-            _ => &raw[..],
-        }
+    let key_bytes = if raw.len() == PREFIXED_KEY_LEN
+        && matches!(
+            [raw[0], raw[1]],
+            ED25519_PRIV_CODEC | X25519_PRIV_CODEC | P256_PRIV_CODEC
+        ) {
+        &raw[2..]
     } else {
         &raw[..]
     };

--- a/vta-sdk/tests/bare_key_multicodec_collision.rs
+++ b/vta-sdk/tests/bare_key_multicodec_collision.rs
@@ -1,0 +1,95 @@
+//! A bare 32-byte key must survive decoding even when its first two bytes
+//! happen to spell a multicodec prefix.
+//!
+//! Both decoders accept two encodings — a 2-byte multicodec prefix plus 32 key
+//! bytes, or 32 bare key bytes — and originally told them apart by looking at
+//! the leading bytes. A bare key is free to begin with any two bytes at all,
+//! including a prefix's, so such a key had its first two stripped and arrived as
+//! 30 bytes: `InvalidSeedLength`, for a key that was perfectly valid.
+//!
+//! For randomly generated keys that is 3 chances in 65536 (`0x8026`, `0x8226`,
+//! `0x8626`) — rare enough to read as noise, frequent enough to fail CI, which
+//! it did on `room-host`'s `a_member_without_a_nomination_cannot_claim`.
+//!
+//! Length is the only sound disambiguator, and these tests pin both directions
+//! of it: a colliding bare key still decodes whole, and a genuinely prefixed key
+//! still has its prefix removed.
+
+use vta_sdk::did_key::{decode_ed25519_public_key_multibase, decode_private_key_multibase};
+
+const ED25519_PRIV: [u8; 2] = [0x80, 0x26];
+const X25519_PRIV: [u8; 2] = [0x82, 0x26];
+const P256_PRIV: [u8; 2] = [0x86, 0x26];
+const ED25519_PUB: [u8; 2] = [0xed, 0x01];
+
+fn mb(bytes: &[u8]) -> String {
+    multibase::encode(multibase::Base::Base58Btc, bytes)
+}
+
+/// A bare 32-byte key whose first two bytes collide with a private-key prefix.
+#[test]
+fn a_colliding_bare_private_key_decodes_whole() {
+    for (name, prefix) in [
+        ("ed25519", ED25519_PRIV),
+        ("x25519", X25519_PRIV),
+        ("p256", P256_PRIV),
+    ] {
+        let mut seed = [7u8; 32];
+        seed[0] = prefix[0];
+        seed[1] = prefix[1];
+
+        let got = decode_private_key_multibase(&mb(&seed))
+            .unwrap_or_else(|e| panic!("{name}: a valid 32-byte seed must decode, got {e}"));
+        assert_eq!(got, seed, "{name}: the key came back altered");
+    }
+}
+
+/// The same, for the public-key decoder.
+#[test]
+fn a_colliding_bare_public_key_decodes_whole() {
+    let mut key = [9u8; 32];
+    key[0] = ED25519_PUB[0];
+    key[1] = ED25519_PUB[1];
+
+    let got = decode_ed25519_public_key_multibase(&mb(&key)).expect("a valid 32-byte key decodes");
+    assert_eq!(got, key);
+}
+
+/// The other direction: a genuinely prefixed key still loses its prefix. Without
+/// this, "stop stripping" would pass the tests above and break every real caller.
+#[test]
+fn a_prefixed_key_still_has_its_prefix_removed() {
+    let key = [3u8; 32];
+
+    for prefix in [ED25519_PRIV, X25519_PRIV, P256_PRIV] {
+        let mut prefixed = Vec::with_capacity(34);
+        prefixed.extend_from_slice(&prefix);
+        prefixed.extend_from_slice(&key);
+
+        assert_eq!(
+            decode_private_key_multibase(&mb(&prefixed)).expect("prefixed key decodes"),
+            key,
+            "a 34-byte prefixed key must yield the 32 bytes after the prefix"
+        );
+    }
+
+    let mut prefixed = Vec::with_capacity(34);
+    prefixed.extend_from_slice(&ED25519_PUB);
+    prefixed.extend_from_slice(&key);
+    assert_eq!(
+        decode_ed25519_public_key_multibase(&mb(&prefixed)).expect("prefixed pubkey decodes"),
+        key
+    );
+}
+
+/// Anything that is neither 32 nor 34 bytes is still refused rather than coerced.
+#[test]
+fn a_wrong_length_key_is_still_refused() {
+    for len in [0usize, 2, 31, 33, 35, 64] {
+        let bytes = vec![1u8; len];
+        assert!(
+            decode_private_key_multibase(&mb(&bytes)).is_err(),
+            "{len} bytes must not decode as a key"
+        );
+    }
+}


### PR DESCRIPTION
A latent flake with a deterministic cause, found while verifying #1305.

## What happens

Both key decoders accept two encodings — a 2-byte multicodec prefix followed by 32 key bytes, or 32 bare key bytes — and told them apart by **looking at the leading bytes**:

```rust
let key_bytes = if raw.len() >= 2 {
    match [raw[0], raw[1]] {
        ED25519_PRIV_CODEC | X25519_PRIV_CODEC | P256_PRIV_CODEC => &raw[2..],
        _ => &raw[..],
    }
} else { &raw[..] };
```

A bare key is free to begin with any two bytes at all, **including a prefix's**. Such a key had its first two stripped and arrived as 30 bytes — `InvalidSeedLength`, for a key that was perfectly valid.

For randomly generated keys that is **3 chances in 65,536** (`0x8026` Ed25519, `0x8226` X25519, `0x8626` P256, plus `0xed01` on the public side): rare enough to read as cosmic rays, frequent enough to fail CI.

## How it surfaced

`room-host`'s `a_member_without_a_nomination_cannot_claim` failed once in a full-workspace run with `BadPrivateKey("private key seed must be 32 bytes")`, then passed 22/22 on three consecutive isolated runs and passed on `main`. Classic flake shape — and the sort that gets blamed on whichever PR is unlucky enough to be running.

**The fixture is not at fault.** `Party::new()` encodes a bare 32-byte seed, which both functions explicitly document as supported.

## The fix

Length is the only sound disambiguator, because the leading bytes carry no information a bare key is obliged to respect. A prefix is stripped only from a 34-byte input.

## Tests, and why four

| test | before | after |
|---|---|---|
| colliding bare **private** key decodes whole | **FAIL** | pass |
| colliding bare **public** key decodes whole | **FAIL** | pass |
| prefixed key still loses its prefix | pass | pass |
| lengths other than 32/34 still refused | pass | pass |

The bottom two pass either way **on purpose**. They exist to stop the wrong fix: simply not stripping would satisfy the first pair and break every real caller. I verified the split by stashing the source change and re-running — exactly two go red.

## Scope

These are public `vta-sdk` functions, so the exposure was never limited to a test fixture: any caller storing a bare key could hit it. Deliberately kept out of #1305, which was rooms conformance.

## Verification

- `cargo test --workspace --all-features` — **171 suites, 5574 tests, 0 failures**
- `cargo clippy --workspace --all-features --all-targets` — clean
