### PR TITLE
feat(persona): honour a holder's release override at disclosure

### DIFF
--- a/vta-persona/src/binding.rs
+++ b/vta-persona/src/binding.rs
@@ -44,6 +44,19 @@ pub struct MaterialisedClaim {
     /// short, and MUST NOT be disclosed.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub stale: bool,
+    /// The holder's `release` override, copied down with the value.
+    ///
+    /// **This is the whole mechanism for honouring an override below the
+    /// boundary.** A context cannot read the pool to ask what the holder
+    /// decided, so the decision travels with the projection or it does not
+    /// travel at all — copies go down, nothing reads up. Re-materialisation on
+    /// an attribute edit refreshes it, so changing the override changes what
+    /// every bound context enforces without any of them reading anything.
+    ///
+    /// `None` on a binding written before this field existed, which resolves to
+    /// the registry default — the behaviour those bindings already had.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release: Option<crate::ReleaseRequirement>,
 }
 
 /// The binding plus the claims it pushed into the context.
@@ -172,6 +185,7 @@ impl PersonaStore {
                 value: c.value,
                 provenance: c.provenance,
                 stale: c.stale,
+                release: c.release,
             })
             .collect())
     }

--- a/vta-persona/src/claim_types.rs
+++ b/vta-persona/src/claim_types.rs
@@ -486,6 +486,45 @@ pub fn sensitivity_of(attribute: &Attribute) -> Sensitivity {
         .unwrap_or_else(|| defaults_for(&attribute.r#type).sensitivity)
 }
 
+/// What it takes to let one attribute leave — §4 per the `release` axis.
+///
+/// Same shape as [`sensitivity_of`], and an override wins in **both**
+/// directions for the same reason: the holder is the principal, and an agent
+/// that kept gating a value its owner had decided needed no gate would be
+/// overruling the person the control exists to serve.
+///
+/// That the loosening direction is available is not a hole, because of where
+/// the write happens. `release` is set through `persona/attribute/put`, which
+/// is **holder-scoped** — above the boundary, refused to every context-scoped
+/// caller and to every application inside a context. A verifier cannot reach
+/// it, and neither can the site asking for the disclosure. The only party who
+/// can relax the gate is the one it protects.
+///
+/// Worth considering separately: whether *loosening* should itself require a
+/// step-up, so the act of turning a gate off is gated. That is a real idea and
+/// deliberately not built here — it is a new gate, not this one.
+#[must_use]
+pub fn release_of(attribute: &Attribute) -> ReleaseRequirement {
+    attribute
+        .release
+        .unwrap_or_else(|| defaults_for(&attribute.r#type).release)
+}
+
+/// The `release` of a claim that has already been pushed into a context.
+///
+/// The pool is not readable from here — that is the boundary — so the holder's
+/// override has to have travelled *down* with the value when the binding was
+/// written. `None` means the projection carries no decision and the registry
+/// default answers, which is also what every binding written before this field
+/// existed says.
+#[must_use]
+pub fn release_of_claim(
+    claim_type: &str,
+    override_: Option<ReleaseRequirement>,
+) -> ReleaseRequirement {
+    override_.unwrap_or_else(|| defaults_for(claim_type).release)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -16,7 +16,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::claim_types::Sensitivity;
+use crate::claim_types::{ReleaseRequirement, Sensitivity};
 
 /// A ULID in Crockford base32. Record identity for attributes and profiles.
 ///
@@ -195,12 +195,22 @@ pub struct Attribute {
     /// instead would freeze it — a later tightening of the registry would then
     /// protect new attributes and leave this one exposed.
     ///
-    /// There is deliberately no `release` counterpart. The published schema
-    /// defines one, and nothing in this workspace enforces a `stepUp` at
-    /// disclosure yet; a stored override for a gate that does not exist is a
-    /// promise the holder would be entitled to rely on.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sensitivity: Option<Sensitivity>,
+    /// What it takes to let this attribute **leave**, where the holder decided
+    /// it explicitly. Same rule as `sensitivity`: absent means no decision, and
+    /// the default is derived from the registry at read.
+    ///
+    /// This field was deliberately withheld until there was a gate to honour
+    /// it — "a stored override for a gate that does not exist is a promise the
+    /// holder would be entitled to rely on". `persona/disclosure/present` now
+    /// enforces `release: stepUp`, so the promise is one the agent keeps.
+    ///
+    /// Like `sensitivity`, an override wins in **both** directions — see
+    /// [`crate::claim_types::release_of`] for why loosening is honoured rather
+    /// than quietly refused.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release: Option<ReleaseRequirement>,
     pub version: Version,
     pub created_at: String,
     pub updated_at: String,

--- a/vta-persona/src/present.rs
+++ b/vta-persona/src/present.rs
@@ -124,6 +124,25 @@ pub struct Preview {
     pub renderer_drops: Vec<String>,
     pub purpose: Option<String>,
     pub expires_at: String,
+    /// Whether any claim in this preview needs a fresh approval to leave.
+    ///
+    /// **Resolved once, here, and stored** — unlike `sensitivity`, which is
+    /// derived at every read. The reason is where the inputs live: the answer
+    /// depends on the holder's per-attribute `release` override, which travels
+    /// down with the materialised claim and is *not* on `PreviewClaim`. The
+    /// preview response's schema declares `additionalProperties: false` on its
+    /// claims, so putting it there would put it on the wire, and this is an
+    /// at-rest decision rather than something a verifier is owed.
+    ///
+    /// Freezing it for the preview's lifetime is also the honest reading: a
+    /// preview is a snapshot of what the holder was shown, it is single-use,
+    /// and it expires in minutes. A holder who changes the override afterwards
+    /// previews again.
+    ///
+    /// `false` on a preview written before this field existed — which is what
+    /// those previews enforced.
+    #[serde(default)]
+    pub step_up_required: bool,
     /// When a step-up approval bound to this preview was recorded, if one was.
     ///
     /// **On the preview, not beside it.** An approval authorises one disclosure
@@ -169,7 +188,13 @@ impl PersonaStore {
         // can rank by what is new rather than listing everything equally.
         let seen = self.claim_types_seen_by(verifier_did).await?;
 
+        // The included originals are kept alongside, because the `release`
+        // decision is read from them and `PreviewClaim` deliberately does not
+        // carry it (see `Preview::step_up_required`). Filtered by `requested`
+        // exactly as `claims` is: a verifier asking for only a name must not be
+        // gated by a card the profile also holds but that is not being sent.
         let mut claims = Vec::new();
+        let mut included: Vec<crate::MaterialisedClaim> = Vec::new();
         for m in &materialised {
             if let Some(want) = requested
                 && !want.iter().any(|t| t == &m.r#type)
@@ -177,6 +202,7 @@ impl PersonaStore {
                 continue;
             }
             claims.push(preview_claim(m, &seen));
+            included.push(m.clone());
         }
 
         if claims.is_empty() {
@@ -213,6 +239,7 @@ impl PersonaStore {
             purpose: purpose.map(str::to_string),
             expires_at: (chrono::Utc::now() + chrono::Duration::seconds(PREVIEW_TTL_SECONDS))
                 .to_rfc3339(),
+            step_up_required: Self::any_claim_requires_step_up(&included),
             approved_at: None,
         };
 
@@ -259,18 +286,30 @@ impl PersonaStore {
     /// Whether this preview would disclose anything the holder has to approve
     /// afresh — any claim whose type resolves to [`ReleaseRequirement::StepUp`].
     ///
-    /// Resolved from the claim **type**, which is all this side of the boundary
-    /// has. A preview is built from the *materialised* copy in the context, and
-    /// a materialised claim deliberately carries no pool identifier — so a
-    /// holder's per-attribute `release` override cannot be read from here. It
-    /// would have to be carried down with the value when the binding is
-    /// written, which is the same direction everything else travels: copies go
-    /// down, nothing reads up. Until it is, no override is stored, so the
-    /// registry default is the whole answer rather than most of it.
+    /// Whether this preview needs a fresh approval before it may be presented.
+    ///
+    /// Reads the decision [`create_preview`](Self::create_preview) recorded.
+    /// See [`Preview::step_up_required`] for why it is stored rather than
+    /// re-derived here.
     #[must_use]
     pub fn requires_step_up(preview: &Preview) -> bool {
-        preview.claims.iter().any(|c| {
-            crate::claim_types::defaults_for(&c.r#type).release
+        preview.step_up_required
+    }
+
+    /// Does any of these materialised claims need a fresh approval to leave?
+    ///
+    /// Per claim: **the holder's override where one travelled down**, and the
+    /// claim-type registry otherwise. The override cannot be looked up from
+    /// here — nothing below the boundary may read the pool — so it is carried
+    /// down with the value at bind time and read off the copy. Copies go down;
+    /// nothing reads up.
+    ///
+    /// A binding written before that field existed carries `None` on every
+    /// claim and resolves entirely from the registry, which is what it did
+    /// before.
+    fn any_claim_requires_step_up(claims: &[crate::MaterialisedClaim]) -> bool {
+        claims.iter().any(|m| {
+            crate::claim_types::release_of_claim(&m.r#type, m.release)
                 == crate::claim_types::ReleaseRequirement::StepUp
         })
     }
@@ -509,6 +548,159 @@ mod tests {
             .await
             .unwrap();
         p.profile_id
+    }
+
+    /// As `bound_with_type`, returning the attribute id too, so a test can
+    /// reach back into the pool and set an override on it.
+    async fn bound_returning_ids(s: &PersonaStore, claim_type: &str) -> (String, String) {
+        let a = new_attribute(
+            claim_type,
+            ValueType::String,
+            serde_json::json!("4111111111111111"),
+            Provenance::SelfAsserted,
+        );
+        s.put(a.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Work",
+            vec![ProfileEntry::Ref {
+                r#ref: a.attribute_id.clone(),
+            }],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+        s.set_binding("ctx", "did:persona:a", Some(&p.profile_id), vec![], None)
+            .await
+            .unwrap();
+        (p.profile_id, a.attribute_id)
+    }
+
+    /// A holder's override reaches the gate, in both directions.
+    ///
+    /// This is the whole of what "carry it down at bind time" buys: the
+    /// override is set on the pool attribute, above the boundary, and the
+    /// decision has to arrive at a preview built entirely from the context's
+    /// copy — which cannot read the pool to ask.
+    ///
+    /// Both directions, because both are the holder's to make. Tightening an
+    /// ungated name is the easy case to get right; **loosening a card is the
+    /// one worth pinning**, since an agent that quietly kept gating it would be
+    /// overruling the person the gate exists to serve.
+    #[tokio::test]
+    async fn a_holders_release_override_reaches_the_gate() {
+        // Tighten: a display name the registry does not gate.
+        let (_d, s) = fresh().await;
+        let (p, id) = bound_returning_ids(&s, "name.display").await;
+        let ungated = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            !PersonaStore::requires_step_up(&ungated),
+            "registry default"
+        );
+
+        let mut a = s.get(&id).await.unwrap().unwrap();
+        a.release = Some(crate::claim_types::ReleaseRequirement::StepUp);
+        s.put(a, None).await.unwrap();
+        s.set_binding("ctx", "did:persona:a", Some(&p), vec![], None)
+            .await
+            .unwrap();
+        let now_gated = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            PersonaStore::requires_step_up(&now_gated),
+            "the holder asked for a fresh approval on their display name and did not get one"
+        );
+
+        // Loosen: a card the registry does gate.
+        let (_d2, s2) = fresh().await;
+        let (p2, id2) = bound_returning_ids(&s2, "payment.card").await;
+        let gated = s2
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(PersonaStore::requires_step_up(&gated), "registry default");
+
+        let mut a2 = s2.get(&id2).await.unwrap().unwrap();
+        a2.release = Some(crate::claim_types::ReleaseRequirement::Consent);
+        s2.put(a2, None).await.unwrap();
+        s2.set_binding("ctx", "did:persona:a", Some(&p2), vec![], None)
+            .await
+            .unwrap();
+        let now_open = s2
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            !PersonaStore::requires_step_up(&now_open),
+            "the holder's own decision about their own pool was overruled"
+        );
+    }
+
+    /// A claim the verifier did not ask for does not gate the disclosure.
+    ///
+    /// The preview is filtered by `requestedClaims`; the gate must be filtered
+    /// the same way. A profile holding a card and a name, asked only for the
+    /// name, is a `consent` disclosure — gating it on the card would demand a
+    /// fresh approval for something that is not being sent.
+    #[tokio::test]
+    async fn a_claim_not_being_sent_does_not_gate_the_one_that_is() {
+        let (_d, s) = fresh().await;
+        let card = new_attribute(
+            "payment.card",
+            ValueType::String,
+            serde_json::json!("4111111111111111"),
+            Provenance::SelfAsserted,
+        );
+        let name = new_attribute(
+            "name.display",
+            ValueType::String,
+            serde_json::json!("Ada"),
+            Provenance::SelfAsserted,
+        );
+        s.put(card.clone(), None).await.unwrap();
+        s.put(name.clone(), None).await.unwrap();
+        let p = new_profile(
+            "Both",
+            vec![
+                ProfileEntry::Ref {
+                    r#ref: card.attribute_id.clone(),
+                },
+                ProfileEntry::Ref {
+                    r#ref: name.attribute_id.clone(),
+                },
+            ],
+        );
+        s.put_profile(p.clone(), None).await.unwrap();
+        s.set_binding("ctx", "did:persona:a", Some(&p.profile_id), vec![], None)
+            .await
+            .unwrap();
+
+        let name_only = s
+            .create_preview(
+                "ctx",
+                "did:persona:a",
+                "did:verifier:v",
+                None,
+                Some(&["name.display".to_string()]),
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !PersonaStore::requires_step_up(&name_only),
+            "a card that is not being disclosed gated a disclosure of a display name"
+        );
+
+        let everything = s
+            .create_preview("ctx", "did:persona:a", "did:verifier:v", None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            PersonaStore::requires_step_up(&everything),
+            "the card IS being disclosed here and must gate it"
+        );
     }
 
     /// A card number needs a fresh approval; a display name does not. The pair

--- a/vta-persona/src/profile.rs
+++ b/vta-persona/src/profile.rs
@@ -57,6 +57,11 @@ pub struct ResolvedClaim {
     /// MUST NOT be disclosed; it is surfaced so a holder learns their profile
     /// has quietly stopped being fully presentable.
     pub stale: bool,
+    /// The holder's `release` override on the pool attribute behind this claim,
+    /// where they set one. `None` for an inline entry — it has no pool record,
+    /// so there is nowhere for a decision to have been recorded and the
+    /// registry default answers.
+    pub release: Option<crate::ReleaseRequirement>,
 }
 
 impl PersonaStore {
@@ -186,6 +191,7 @@ impl PersonaStore {
                     version: None,
                     updated_at: None,
                     stale: false,
+                    release: None,
                 },
             });
         }
@@ -211,6 +217,7 @@ impl PersonaStore {
                 version: None,
                 updated_at: None,
                 stale: true,
+                release: None,
             });
         };
 
@@ -229,6 +236,11 @@ impl PersonaStore {
             version: Some(a.version),
             updated_at: Some(a.updated_at.clone()),
             stale: stale || a.stale.unwrap_or(false),
+            // Carried down with the value, because nothing below the boundary
+            // can read the pool to ask. An `override` entry replaces the value
+            // and inherits everything else, this included — the holder's
+            // decision is about the attribute, not about one presentation of it.
+            release: a.release,
         })
     }
 
@@ -664,6 +676,10 @@ impl PersonaStore {
                                 value: Some(inline.value.clone()),
                                 provenance: inline.provenance.clone(),
                                 stale: false,
+                                // A context-local profile is inline-only, so
+                                // there is no pool attribute and no override to
+                                // carry — the registry default answers.
+                                release: None,
                             }),
                             // Unreachable: `put_local_profile` refuses anything
                             // else, and the schema cannot express it. Skipped

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -537,6 +537,8 @@ pub fn new_attribute(
         // Unset, not `normal`: a new attribute records no holder decision, so
         // its sensitivity resolves from the registry every time it is read.
         sensitivity: None,
+        // Same, for the same reason.
+        release: None,
         version: 0,
         created_at: now.clone(),
         updated_at: now,

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -260,7 +260,10 @@ fn decide(
 // noticing. The generated types cannot.
 
 use trust_tasks_rs::specs::persona as spec;
-use vta_persona::{Listing, PersonaStore, Sensitivity, ValueType, ValueVisibility, new_attribute};
+use vta_persona::{
+    Listing, PersonaStore, ReleaseRequirement, Sensitivity, ValueType, ValueVisibility,
+    new_attribute,
+};
 
 /// Open the store for this request.
 ///
@@ -499,6 +502,23 @@ pub(super) async fn handle_attribute_put(
         },
     };
 
+    // Same route as `sensitivity` above, and for the same reason: through the
+    // wire spelling rather than a match, because the generated enum is
+    // `#[non_exhaustive]` and a wildcard arm is where a variant added upstream
+    // would land silently.
+    let release: Option<ReleaseRequirement> = match req.release.as_ref() {
+        None => None,
+        Some(r) => match serde_json::to_value(r)
+            .ok()
+            .and_then(|v| serde_json::from_value(v).ok())
+        {
+            Some(parsed) => Some(parsed),
+            None => {
+                return reject(&doc, AppError::Validation("unrecognised release".into()));
+            }
+        },
+    };
+
     let mut attribute = new_attribute(
         req.type_.to_string(),
         value_type,
@@ -510,6 +530,7 @@ pub(super) async fn handle_attribute_put(
     }
     attribute.label = req.label.as_ref().map(|l| (**l).clone());
     attribute.sensitivity = sensitivity;
+    attribute.release = release;
 
     let attribute_id = attribute.attribute_id.clone();
     let value = attribute.value.clone();
@@ -537,11 +558,21 @@ pub(super) async fn handle_attribute_put(
         None => String::new(),
     };
 
+    // Recorded for the same reason, and it matters more here: `release` decides
+    // what it takes to let the value LEAVE, so a holder relaxing their own card
+    // from `stepUp` to `consent` is the single most consequential thing this
+    // task can do. A trail that showed only "attribute updated" would not let
+    // them find the moment the gate came off.
+    let release_note = match release {
+        Some(r) => format!(", release {} set by the holder", wire_name(r)),
+        None => String::new(),
+    };
+
     // Type, value TYPE, provenance kind and version — never `value`. See
     // `audit_persona` for why that line is drawn on lifetime rather than on
     // who may read the row.
     let detail = format!(
-        "{} attribute {attribute_id}: claim type {}, valueType {}, provenance {}{}, now at \
+        "{} attribute {attribute_id}: claim type {}, valueType {}, provenance {}{}{}, now at \
          version {}",
         if written.created {
             "created"
@@ -552,6 +583,7 @@ pub(super) async fn handle_attribute_put(
         wire_name(value_type),
         provenance_kind,
         sensitivity_note,
+        release_note,
         written.version,
     );
     audit_persona(

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -2040,3 +2040,178 @@ async fn an_ungated_claim_is_not_gated() {
         "a name.display disclosure was gated behind a step-up: {status} {body}"
     );
 }
+
+/// A holder's `release` override survives the wire and reaches the gate.
+///
+/// The store test beside `requires_step_up` asserts the resolution. This
+/// asserts the *system*: that `attribute/put` accepts the member, stores it,
+/// carries it across the boundary at bind time, and that `present` then
+/// enforces it — four layers, none of which the unit test can see.
+///
+/// Uses `name.display`, which the registry does **not** gate, so a pass cannot
+/// come from the registry default. The gate here exists only because the
+/// holder asked for it.
+#[tokio::test]
+async fn a_holders_release_override_gates_a_type_the_registry_does_not() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let vta = &ctx.vta_did;
+    let holder = authed(&ctx, "rel-holder", "admin", &[]).await;
+    let scoped = authed(&ctx, "rel-scoped", "admin", &[CTX]).await;
+
+    let (status, body) = post_to(
+        &router,
+        &holder,
+        vta,
+        ATTR_PUT,
+        json!({
+            "type": "name.display",
+            "value": "Ada",
+            "valueType": "string",
+            "provenance": { "kind": "selfAsserted" },
+            "release": "stepUp",
+        }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "attribute/put with release: {status} {body}"
+    );
+    let attr = payload_of(&body)["attributeId"]
+        .as_str()
+        .expect("attributeId")
+        .to_string();
+
+    let (status, body) = post_to(
+        &router,
+        &holder,
+        vta,
+        PROFILE_PUT,
+        json!({ "name": "gated-name", "entries": [{ "ref": attr }] }),
+    )
+    .await;
+    assert!(!refused(status, &body), "profile/put: {status} {body}");
+    let profile = payload_of(&body)["profileId"]
+        .as_str()
+        .expect("profileId")
+        .to_string();
+
+    let persona = "did:key:z6MkPersonaRelease";
+    let (status, body) = post_to(
+        &router,
+        &holder,
+        vta,
+        BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona, "profileId": profile }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/set: {status} {body}");
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        vta,
+        PREVIEW,
+        json!({
+            "contextId": CTX,
+            "personaDid": persona,
+            "verifierDid": "did:key:z6MkVerifier",
+        }),
+    )
+    .await;
+    assert!(!refused(status, &body), "preview: {status} {body}");
+    let preview_id = payload_of(&body)["previewId"]
+        .as_str()
+        .expect("previewId")
+        .to_string();
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        vta,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(
+        refused(status, &body),
+        "the holder asked for a fresh approval on this attribute and the disclosure went \
+         through without one: {status} {body}"
+    );
+    assert_eq!(
+        payload_of(&body)["code"],
+        "persona/disclosure/present:stepUpRequired",
+        "refused, but not for the reason the holder asked for: {body}"
+    );
+
+    // And the override is what did it — the same type with no override is not
+    // gated. Without this the test passes for a gate that fires on everything.
+    let plain = authed(&ctx, "rel-plain", "admin", &[]).await;
+    let (_, body) = post_to(
+        &router,
+        &plain,
+        vta,
+        ATTR_PUT,
+        json!({
+            "type": "name.display",
+            "value": "Grace",
+            "valueType": "string",
+            "provenance": { "kind": "selfAsserted" },
+        }),
+    )
+    .await;
+    let attr2 = payload_of(&body)["attributeId"]
+        .as_str()
+        .expect("attributeId")
+        .to_string();
+    let (_, body) = post_to(
+        &router,
+        &plain,
+        vta,
+        PROFILE_PUT,
+        json!({ "name": "plain-name", "entries": [{ "ref": attr2 }] }),
+    )
+    .await;
+    let profile2 = payload_of(&body)["profileId"]
+        .as_str()
+        .expect("profileId")
+        .to_string();
+    let persona2 = "did:key:z6MkPersonaPlain";
+    let (status, body) = post_to(
+        &router,
+        &plain,
+        vta,
+        BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona2, "profileId": profile2 }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/set: {status} {body}");
+    let (_, body) = post_to(
+        &router,
+        &scoped,
+        vta,
+        PREVIEW,
+        json!({
+            "contextId": CTX,
+            "personaDid": persona2,
+            "verifierDid": "did:key:z6MkVerifier",
+        }),
+    )
+    .await;
+    let preview2 = payload_of(&body)["previewId"]
+        .as_str()
+        .expect("previewId")
+        .to_string();
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        vta,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview2 }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "an ungated name.display was gated, so the override is not what decided it: \
+         {status} {body}"
+    );
+}


### PR DESCRIPTION
Closes the known limitation stated in #1304: only the claim-type registry's
default `release` was enforced, and a holder's per-attribute override was
ignored.

## The comment that said not to build this yet

`Attribute` carried a deliberate absence:

> There is deliberately no `release` counterpart. The published schema defines
> one, and nothing in this workspace enforces a `stepUp` at disclosure yet; a
> stored override for a gate that does not exist is a promise the holder would
> be entitled to rely on.

#1304 built the gate. The precondition that comment named is satisfied, so the
field can be stored honestly — and this PR is that comment being cashed in
rather than a new idea.

## Copies go down; nothing reads up

The override is set on the **pool** attribute, above the boundary. A preview is
built from the **materialised copy** inside a context, which deliberately
carries no pool identifier and cannot read the pool to ask what the holder
decided.

So the decision travels *with* the projection or not at all:

```
Attribute.release  →  ResolvedClaim.release  →  MaterialisedClaim.release  →  the gate
   (pool)              (profile resolve)          (stored in the binding)
```

Re-materialisation on an attribute edit already exists — "edit once,
everywhere" — so changing the override changes what every bound context
enforces without any of them reading anything.

Inline profile entries and context-local profiles carry `None`: they have no
pool record, so there is nowhere a decision could have been recorded, and the
registry default answers.

## Where the resolution is stored, and why that differs from `sensitivity`

`sensitivity` is derived at every read — *store the override, derive the
default* — so tightening the registry protects attributes already written.
`release` is resolved **once, at preview creation**, onto `Preview.step_up_required`.

The reason is the wire. `persona/disclosure/preview`'s response schema declares
`additionalProperties: false` on its claims, so putting `release` on
`PreviewClaim` would put it on the wire — and `PreviewClaim` *is* serialised
straight into the response. (This is the same trap that caught `elevated` in
the #1304 branch, and the response-conformance layer catches it either way.)
`Preview` itself is not serialised wholesale — the handler picks members out —
so the decision lives there instead.

Freezing it for a preview's lifetime is also the honest reading: a preview is a
snapshot of what the holder was shown, single-use, expiring in minutes. A
holder who changes the override afterwards previews again.

## An override wins in both directions

Following `CLAIM-TYPES.md` §4 rule 1 — *"If the holder set the value explicitly
on the attribute, that wins"* — and matching `sensitivity_of`, which already
argues the case: an agent that kept gating a value its owner had decided needed
no gate would be overruling the person the control exists to serve.

**Loosening is available, and the reason that is not a hole is where the write
happens.** `release` is set through `persona/attribute/put`, which is
holder-scoped — refused to every context-scoped caller and every application
inside a context. A verifier cannot reach it; neither can the site asking for
the disclosure. The only party who can relax the gate is the one it protects.

The audit row records the decision either way, and says so in the trail, because
a holder relaxing their own card from `stepUp` to `consent` is the most
consequential thing this task can do and "attribute updated" would not let them
find the moment the gate came off.

**Deliberately not built:** making the *loosening* itself require a step-up, so
turning a gate off is gated. It is a good idea and it is a new gate, not this
one.

## Tests

`vta-persona` (2 new, 88 total):
- **an override reaches the gate in both directions** — tighten `name.display`
  (which the registry does *not* gate, so a pass cannot come from the default)
  and loosen `payment.card`;
- **a claim not being sent does not gate the one that is** — a profile holding
  a card and a name, previewed for the name only, is a `consent` disclosure.
  The gate is filtered by `requestedClaims` exactly as the preview is.

`vta-service` (1 new, 23 total), end to end through the real dispatch spine:
`attribute/put` accepts `release`, stores it, carries it across the boundary at
bind time, and `present` refuses with `stepUpRequired` — four layers the unit
tests cannot see between. Uses `name.display` so the registry default cannot
account for it, and asserts the same type *without* an override is **not**
gated, so a gate that fired on everything would fail.

`cargo clippy --workspace --all-targets --locked -- -D warnings` clean;
`vta-service --lib` 1045 pass.

## Guide checklist (§9)

- [x] R1.2/R1.3/R1.4/R1.5/R1.6 — no client, lock, retry, loop or ack touched
- [x] R2.1 — the override is written by the existing `put` path; re-materialisation is the existing edit-propagation path
- [x] R3.* — **no wire change**: `MaterialisedClaim` and `Preview` are at-rest types; `release` on `attribute/put` is an already-published optional member
- [x] R5.* — absent override ⇒ registry default; a binding or preview written before these fields deserialises to exactly its previous behaviour (`#[serde(default)]` on both)
- [x] R6.* — the audit row states the holder's decision rather than only that a write happened
- [x] "Process dies on the next line" — no new multi-step mutation
- [x] Deviations — the stored-vs-derived difference from `sensitivity` is explained above and in the field's own docs
