### PR TITLE
ci: keep authorization-context type constants unique and named

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,24 @@ jobs:
       - name: Lockfile self-pin guard
         run: bash scripts/check-lockfile-self-pins.sh
 
+  authz-context-types:
+    # An approver's device chooses which approval card to render by
+    # discriminating on the authorization context's `type` URI. Two producers
+    # sharing one means an approver reads a prompt describing an act that is not
+    # the one they are authorising — so each must be unique, and each must be a
+    # named constant rather than a literal inside a `json!`, because a literal
+    # is invisible to the uniqueness check.
+    #
+    # Cheap and independent of the build, so it runs on its own rather than
+    # behind the compile jobs: a naming mistake should be reported in seconds.
+    name: authorization-context types
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Authorization-context type uniqueness guard
+        run: bash scripts/check-authz-context-types.sh
+
   lockfile-resolves:
     # The sibling of the job above, and the same misattribution failure it
     # describes — arrived at from the other direction. There, Cargo.lock pins a

--- a/scripts/check-authz-context-types.sh
+++ b/scripts/check-authz-context-types.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Every authorization-context `type` URI this workspace emits must be declared
+# exactly once, as a named constant.
+#
+# ## What this is protecting
+#
+# The context under `payload.ext["org.openvtc.authorization-context"]` is what
+# an approver's device renders as the approval card, and the card is chosen by
+# discriminating on `type`. Two producers sharing a `type` therefore means one
+# of them gets the other's card: the approver reads a prompt describing an act
+# that is not the one they are authorising.
+#
+# The consumer side of that is already guarded — the browser plugin refuses a
+# context whose `type` is not the one it expects, and there is a test that
+# drives a correctly-signed Cierge share ask through the disclosure path and
+# requires it to be refused. This is the producer side: it does not stop a
+# collision between repositories, which no single repository can, but it stops
+# the version of the mistake that happens here, and it makes a new producer's
+# `type` a visible, named thing rather than a literal inside a `json!`.
+#
+# ## What it checks
+#
+# 1. No two constants declare the same URI.
+# 2. No production source inlines the URI pattern outside a constant. A literal
+#    is invisible to check 1, so the second producer added that way would
+#    collide silently — which is precisely the case this exists for.
+#
+# Tests are exempt: a fixture asserting the wire value is the point of a
+# fixture, and a test that could not name the URI could not check it. That
+# means `tests/` directories AND the inline `#[cfg(test)] mod tests` at the foot
+# of a `src/` file — two of which already carry the Cierge type as a fixture, so
+# without this the guard would fail on day one against code that is correct.
+#
+# Run it: bash scripts/check-authz-context-types.sh
+set -euo pipefail
+
+pattern='https://openvtc\.org/[a-z0-9-]+/authorization-context/[0-9]+\.[0-9]+'
+fail=0
+
+# Production Rust only: `*/src/**`, with `tests/` and `benches/` excluded by
+# construction rather than by name.
+files=$(find . -path ./target -prune -o -path '*/src/*' -name '*.rs' -print 2>/dev/null | sort)
+
+# Strip comments before looking at anything: a doc comment naming another
+# producer's type as an example is documentation, not a declaration, and this
+# file's own header would otherwise trip its own guard.
+# Cut the file at its first module-level `#[cfg(test)]`, then strip comments.
+#
+# Truncation relies on the Rust convention that the test module comes last. A
+# file that put one in the middle would have the rest of it skipped, so the line
+# count that was scanned is printed on success — a file that suddenly scans
+# almost nothing is visible rather than silently unguarded.
+production_part() { sed -e '/^#\[cfg(test)\]/q' "$1" | sed -e 's://[^"]*$::' -e 's:^[[:space:]]*//.*::'; }
+
+declare -a decl_names=() decl_uris=() decl_files=()
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    name=$(printf '%s' "$line" | sed -E 's/.*const[[:space:]]+([A-Z0-9_]+)[[:space:]]*:.*/\1/')
+    uri=$(printf '%s' "$line" | grep -oE "$pattern" | head -1)
+    [ -n "$uri" ] || continue
+    decl_names+=("$name"); decl_uris+=("$uri"); decl_files+=("$f")
+  done < <(production_part "$f" | grep -E "const[[:space:]]+[A-Z0-9_]+[[:space:]]*:[[:space:]]*&('static[[:space:]]+)?str[[:space:]]*=.*$pattern" || true)
+done <<< "$files"
+
+# 1. No two constants declare the same URI.
+for i in "${!decl_uris[@]}"; do
+  for j in "${!decl_uris[@]}"; do
+    [ "$i" -lt "$j" ] || continue
+    if [ "${decl_uris[$i]}" = "${decl_uris[$j]}" ]; then
+      echo "::error::${decl_names[$i]} (${decl_files[$i]}) and ${decl_names[$j]} (${decl_files[$j]}) both declare ${decl_uris[$i]}. An approver's card is chosen by discriminating on this URI, so two producers sharing one means one of them renders the other's card — the approver reads a prompt describing an act that is not the one they are authorising. Give the new producer its own namespace segment."
+      fail=1
+    fi
+  done
+done
+
+# 2. No inlined literals in production source.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    echo "::error::$f: authorization-context type URI inlined outside a constant — $hit. Declare it as a \`const\` so a collision with another producer is visible to this check; a literal inside a \`json!\` is not."
+    fail=1
+  done < <(production_part "$f" \
+      | grep -vE "const[[:space:]]+[A-Z0-9_]+[[:space:]]*:[[:space:]]*&('static[[:space:]]+)?str[[:space:]]*=" \
+      | grep -oE "$pattern" || true)
+done <<< "$files"
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+
+scanned=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  scanned=$(( scanned + $(production_part "$f" | wc -l) ))
+done <<< "$files"
+
+echo "OK: ${#decl_uris[@]} authorization-context type constant(s) across $(printf '%s\n' "$files" | grep -c . ) production file(s) ($scanned lines scanned), each declared once and named:"
+for i in "${!decl_uris[@]}"; do
+  echo "  ${decl_names[$i]} = ${decl_uris[$i]}  (${decl_files[$i]})"
+done


### PR DESCRIPTION
The one recommendation worth keeping from the security review on #1306/#190:
a check that authorization-context `type` constants stay unique.

## Why this is a real property and not tidiness

An approver's device chooses which approval card to render by discriminating on
the context's `type` URI. Two producers sharing one means an approver reads a
prompt describing an act that is not the one they are authorising.

The **consumer** side is already guarded: the browser plugin refuses a context
whose `type` is not the disclosure one, and a test drives a correctly-signed
Cierge share ask — from an enrolled agent, passing proof, issuer and tamper
checks — through the disclosure path and requires it to be refused. This is the
producer side.

It cannot stop a collision *between repositories*, which no single repository
can. It stops the version of the mistake that happens here.

## Two checks

1. **No two constants declare the same URI.**
2. **No production source inlines the URI pattern outside a constant.** This is
   the one that matters: a literal inside a `json!` is invisible to check 1, so
   a second producer added that way would collide silently — precisely the case
   the guard exists for. #1306 added exactly such a literal before it became
   `PERSONA_AUTHZ_CONTEXT_TYPE`.

## Verified non-vacuous, and the first attempt was wrong

Both branches were probed rather than assumed, and the first probe of check 1
**passed when it should have failed** — I appended the colliding constant to the
end of the file, which lands after the `#[cfg(test)]` module the scanner
truncates at. Re-probed with the constant in a realistic position and it fires.
Worth recording, because a guard that looks green against a bad probe is
indistinguishable from one that works.

```
PROBE 1  colliding constant, before the test module  → ::error:: … both declare … EXIT=1
PROBE 2  URI inlined in production code              → ::error:: … outside a constant … EXIT=1
restored                                             → EXIT=0
```

(The exit codes were also checked directly rather than through a pipe, which had
been masking them behind `head`.)

## Test code is exempt, and that had to be handled

Two inline `#[cfg(test)]` fixtures already carry the Cierge type —
`vta-mobile-core/src/task.rs` and `vta-service/src/trust_tasks/step_up.rs` — so
without an exemption the guard would have failed on day one against code that is
correct. A fixture asserting the wire value is the point of a fixture.

The scanner cuts each file at its first module-level `#[cfg(test)]`, which
relies on the Rust convention that the test module comes last. A file that put
one in the middle would have the rest of it skipped, so **the number of lines
actually scanned is printed on success** — a file that suddenly scans almost
nothing is visible rather than silently unguarded.

Comments are stripped before anything is matched, so a doc comment naming
another producer's type as an example is documentation rather than a
declaration. The script's own header would otherwise trip its own guard.

## Current state

```
OK: 1 authorization-context type constant(s) across 869 production file(s)
    (264909 lines scanned), each declared once and named:
  PERSONA_AUTHZ_CONTEXT_TYPE = https://openvtc.org/persona/authorization-context/0.1
```

Runs as its own job — cheap and independent of the build, so a naming mistake is
reported in seconds rather than behind the compile.

## Guide checklist (§9)

- [x] R1.*/R2.1 — CI only; no runtime code, no client, no mutation
- [x] R3.* — no wire change
- [x] R5.* — the guard fails closed: an unparseable or unexpected shape is an error, not a pass
- [x] R6.* — reports what was actually scanned, so a weakened scan is visible
- [x] Deviations — none
