### PR TITLE
feat(sdk): open the rotated DID's mediator account over TSP too

### DIFF
--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -195,6 +195,11 @@ acl-setup = [
   "dep:sha2",
   "dep:tracing",
   "dep:tokio",
+  # The TSP arm mints a document id. Declared here rather than relied on from
+  # another feature: `cargo publish` verifies each crate in isolation, where
+  # nothing else supplies it, so unification hiding a missing `dep:` is a
+  # publish-time failure that no workspace build can reveal.
+  "dep:uuid",
 ]
 # DCQL credential selection + holder-bound OID4VP `vp_token` assembly
 # (`vp` module). `select_credentials` wraps the always-compiled

--- a/vta-sdk/src/acl_setup.rs
+++ b/vta-sdk/src/acl_setup.rs
@@ -29,41 +29,44 @@
 //! against an `ExplicitAllow` mediator is expected to require its DID be
 //! pre-authorised.
 //!
-//! ## Why this is issued over DIDComm, and what that costs a TSP-only mediator
+//! ## Both transports, and why the TSP arm looks different
 //!
-//! Everything here goes through the ATM — `account_update` is a DIDComm
-//! message to the mediator — so it needs a DIDComm mediator to issue it to.
-//! That is not an oversight in this crate; **the mediator has no TSP route for
-//! its own management tasks**. In affinidi-messaging-mediator 0.21.0 the
-//! dispatcher that turns a `TrustTaskEnvelope` into `account/update`
-//! (`messages/mod.rs`, `MessageType::process` → `trust_tasks::process`) is
-//! wholly `#[cfg(feature = "didcomm")]` and takes a DIDComm `Message`. A TSP
-//! `Direct`/`Control` message addressed to the mediator does not reach it: it
-//! goes to `deliver_tsp_local` → `deliver_opaque`, which *stores it for
-//! pickup*. There is no packet a TSP-only client can send to set its own ACL.
+//! [`set_client_acl_with_profile`] issues `account/update` through the ATM,
+//! i.e. over DIDComm. [`set_client_acl_over_tsp`] issues the same task as a TSP
+//! **Direct** message addressed to the mediator itself. Either one authorises
+//! the account for *both* transports — the mediator keys its ACL on
+//! `sha256(did)`, not on a protocol — so a client needs whichever it can reach
+//! the mediator on, not both.
 //!
-//! What saves a TSP-only deployment is that it usually does not need to. The
-//! account is created at **authentication**, not at first message, and that
-//! path is transport-agnostic: `handlers/authenticate/challenge.rs` carries no
-//! `cfg` gate and calls `account_add(did_hash, global_acl_default, None)`. So a
-//! TSP client that authenticates has an account with the mediator's default
-//! ACL, and where that default is permissive it can send and receive with no
-//! provisioning at all.
+//! The TSP arm exists because for a while there was no way to do this at all on
+//! a TSP-only mediator. The mediator's management dispatch
+//! (`MessageType::process` → `trust_tasks::process`) was `#[cfg(feature =
+//! "didcomm")]` and took a DIDComm `Message`, so a TSP message addressed to it
+//! was filed for pickup rather than answered — no packet a TSP-only client
+//! could send would set its own ACL. affinidi-tdk-rs#783 added the TSP wrapper;
+//! this is its client half.
 //!
-//! The gap is therefore narrow and precise: **a TSP-only mediator whose
-//! `global_acl_default` is restrictive cannot have client ACLs provisioned by
-//! the client at all, over any transport.** Not a client-side bug, and not one
-//! a client-side change can close — it needs a TSP arm on the mediator's
-//! management dispatch. Until then such a deployment must set account ACLs
-//! administratively. This matters increasingly as TSP displaces DIDComm; see
-//! `docs/05-design-notes/tsp-enablement.md`.
+//! **A mediator predating that fix files the request as mail instead of acting
+//! on it, and says nothing.** That is why the TSP arm does not report success:
+//! `send` returning `Ok` means the frame was accepted for delivery, never that
+//! the ACL was applied (R1.1). It logs what it sent, not what happened. The
+//! cost of being wrong is bounded — an account left on the mediator's
+//! `global_acl_default`, exactly where it would have been anyway.
 //!
-//! TSP delivery is *not* exempt from ACLs, so this is a real constraint rather
-//! than a theoretical one: `deliver_opaque` applies "existence, RECEIVE_MESSAGES
-//! and the access-list verdict" via `delivery_decision`, and a recipient that is
-//! not a local account is refused outright. It is only `receive_forwarded` that
-//! is DIDComm-specific — that gate lives in the DIDComm forward protocol
-//! (`messages/protocols/routing.rs`) and TSP never traverses it.
+//! Why a fire-and-forget send rather than a request/response: the mediator
+//! applies the ACL *before* responding, so a lost or late reply does not mean
+//! the update failed — the same reasoning that makes the DIDComm arm log its
+//! errors instead of propagating them. Awaiting a reply here would buy nothing
+//! and would stall for the full timeout against a mediator that is never going
+//! to answer.
+//!
+//! TSP delivery is *not* exempt from ACLs, which is why this matters rather
+//! than being theoretical: `deliver_opaque` applies "existence,
+//! RECEIVE_MESSAGES and the access-list verdict" via `delivery_decision`, and a
+//! recipient that is not a local account is refused outright. Only
+//! `receive_forwarded` is DIDComm-specific — that gate lives in the DIDComm
+//! forward protocol (`messages/protocols/routing.rs`), which TSP never
+//! traverses.
 
 use std::sync::Arc;
 
@@ -254,6 +257,95 @@ pub async fn set_client_acl_with_profile(
             "client ACL request timed out (mediator may still process asynchronously)"
         ),
     }
+}
+
+/// Provision a client's own allow-all mediator ACL over **TSP**, as a Direct
+/// message addressed to the mediator.
+///
+/// The TSP twin of [`set_client_acl_with_profile`], for a client whose mediator
+/// it reaches over TSP — including a TSP-only mediator, which no DIDComm-issued
+/// task can reach at all. Same task (`messaging/account/update/0.1`), same
+/// allow-all ACL, same account key (`sha256(did)`), so whichever arm runs, the
+/// account ends up authorised for both transports.
+///
+/// **Reports what it sent, not what happened.** A successful send means the
+/// mediator accepted the frame, not that it applied the ACL (R1.1) — and a
+/// mediator predating affinidi-tdk-rs#783 will file it as mail and answer
+/// nothing. Deliberately fire-and-forget: the mediator applies the ACL before
+/// responding, so a reply adds no information, while waiting for one would
+/// stall for the full timeout against a mediator that will never send it.
+///
+/// Best-effort like its twin — errors are logged, never propagated. The worst
+/// case is an account left on the mediator's `global_acl_default`.
+#[cfg(feature = "tsp")]
+pub async fn set_client_acl_over_tsp(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    client_did: &str,
+    mediator_did: &str,
+    channel: &str,
+    client_name: &str,
+) {
+    let doc = match build_account_update_document(client_did, mediator_did) {
+        Ok(doc) => doc,
+        Err(e) => {
+            debug!(
+                channel,
+                client_did = %client_did,
+                error = %e,
+                client = client_name,
+                "could not build the account/update document for TSP (ACL unchanged)"
+            );
+            return;
+        }
+    };
+
+    match atm.tsp().send(profile, mediator_did, &doc).await {
+        // Note the wording: *sent*, not *configured*. See the module docs.
+        Ok(()) => debug!(
+            channel,
+            client_did = %client_did,
+            client = client_name,
+            "sent account/update to the mediator over TSP (delivery not confirmed)"
+        ),
+        Err(e) => debug!(
+            channel,
+            client_did = %client_did,
+            error = %e,
+            client = client_name,
+            "could not send account/update over TSP (ACL unchanged)"
+        ),
+    }
+}
+
+/// The `messaging/account/update/0.1` request that opens `client_did`'s account,
+/// serialised as the bare Trust Task document TSP carries.
+///
+/// Bare on purpose: the TSP binding puts the document on the wire directly,
+/// where DIDComm wraps it in a binding envelope whose `body` is the document.
+/// The mediator's TSP arm recognises a request by parsing the payload and
+/// matching its type, so what goes here has to be the document itself.
+#[cfg(feature = "tsp")]
+fn build_account_update_document(
+    client_did: &str,
+    mediator_did: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    use trust_tasks_rs::TrustTask;
+
+    let payload: account::update::v0_1::Payload = account::update::v0_1::Payload::builder()
+        .did(client_acl_hash(client_did))
+        .acl(Some(build_allow_all_acl()))
+        .try_into()
+        .map_err(|e| format!("account/update payload: {e:?}"))?;
+
+    // `issuer`/`recipient` are set explicitly: the mediator's
+    // `validate_basic` checks the document is addressed to it, and the TSP
+    // envelope's sender is what authorises the change, so both have to be on
+    // the document rather than inferred.
+    let mut doc = TrustTask::for_payload(format!("urn:uuid:{}", uuid::Uuid::new_v4()), payload);
+    doc.issuer = Some(client_did.to_string());
+    doc.recipient = Some(mediator_did.to_string());
+    Ok(serde_json::to_vec(&doc)?)
 }
 
 /// SHA-256 hex of a DID — the mediator's per-account ACL key

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -1349,17 +1349,66 @@ impl<'a> MediatorProbe<'a> {
         })
     }
 
-    /// The DIDComm mediator whose account should be opened, if any.
-    fn account_mediator(&self) -> Option<&'a str> {
+    /// The mediator whose account should be opened, and how to reach it.
+    ///
+    /// DIDComm is preferred when the VTA advertises it, for the plain reason
+    /// that it is the arm every deployed mediator understands: the TSP
+    /// management route is newer (affinidi-tdk-rs#783), so on a dual-transport
+    /// VTA the DIDComm pass is the one certain to be acted on. A TSP-only VTA
+    /// takes the TSP arm, which is the whole point — it is that or nothing.
+    fn account_transport(&self) -> Option<(&'a str, AccountTransport)> {
         match self {
             Self::None => None,
-            Self::Didcomm { mediator_did, .. } => Some(mediator_did),
+            Self::Didcomm { mediator_did, .. } => Some((mediator_did, AccountTransport::Didcomm)),
             Self::Tsp {
-                didcomm_mediator_did,
+                didcomm_mediator_did: Some(didcomm),
                 ..
-            } => *didcomm_mediator_did,
+            } => Some((didcomm, AccountTransport::Didcomm)),
+            #[cfg(feature = "tsp")]
+            Self::Tsp {
+                mediator_did,
+                didcomm_mediator_did: None,
+            } => Some((mediator_did, AccountTransport::Tsp)),
+            // Without the `tsp` feature there is no TSP arm to send on, so a
+            // TSP-only mediator has no account pass. Unreachable in practice —
+            // this build cannot have connected over TSP to get here.
+            #[cfg(not(feature = "tsp"))]
+            Self::Tsp {
+                didcomm_mediator_did: None,
+                ..
+            } => None,
         }
     }
+}
+
+/// How the mediator-account pass reaches the mediator.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum AccountTransport {
+    Didcomm,
+    #[cfg(feature = "tsp")]
+    Tsp,
+}
+
+/// Open `client_did`'s mediator account over TSP.
+///
+/// Opens a short-lived TSP session purely to carry one `account/update`. The
+/// rotation's reachability probe has already proven this DID can reach the
+/// mediator, so this is a second connect on a path known to work — kept
+/// separate because the probe's session is torn down before the swap, and
+/// holding it open across the commit is the thing the rotation ordering exists
+/// to avoid.
+#[cfg(feature = "tsp")]
+async fn send_account_update_over_tsp(
+    client_did: &str,
+    private_key: &str,
+    mediator_did: &str,
+) -> Result<(), String> {
+    let session = TspPingSession::new(client_did, private_key, mediator_did)
+        .await
+        .map_err(|e| e.to_string())?;
+    session.provision_client_acl("pnm-rotate").await;
+    session.shutdown().await;
+    Ok(())
 }
 
 /// Which transport a rotation reopens its socket on.
@@ -1457,39 +1506,65 @@ async fn rotate_key_over_client(
         debug!(%new_did, over_tsp, "rotation DID reached its mediator");
     }
 
-    // 2b. The mediator account. Always best-effort and always over DIDComm —
-    //     the ACL is keyed on the hashed DID rather than a protocol, so this one
-    //     pass authorises TSP too, but it is issued through the ATM and so needs
-    //     a DIDComm mediator to issue it to. A failure costs a dropped forwarded
-    //     reply on the next connect, never a credential.
+    // 2b. The mediator account, on whichever transport reaches the mediator.
+    //     Always best-effort: the ACL is keyed on the hashed DID rather than a
+    //     protocol, so one pass authorises both transports, and a failure costs
+    //     a dropped forwarded reply on the next connect, never a credential.
     //
-    //     Skipping it on a TSP-only mediator is correct, not a gap in this
-    //     rotation: the account is created by *authentication* — which the
-    //     reachability probe above just performed — carrying the mediator's
-    //     `global_acl_default`. A permissive default therefore needs nothing
-    //     from us. A restrictive one cannot be fixed from any client over TSP,
-    //     because the mediator's management-task dispatch is DIDComm-only. See
-    //     `crate::acl_setup`'s module docs for the mediator code that shows it.
-    if let Some(mediator_did) = probe.account_mediator() {
-        let opened = tokio::time::timeout(PROBE_TIMEOUT, async {
-            let s = TrustPingSession::new(&new_did, &new_private_key, mediator_did)
-                .await
-                .map_err(|e| e.to_string())?;
-            s.provision_client_acl("pnm-rotate").await;
-            s.shutdown().await;
-            Ok::<(), String>(())
-        })
-        .await
-        .unwrap_or_else(|_| Err(format!("timed out after {}s", PROBE_TIMEOUT.as_secs())));
+    //     A TSP-only mediator is served by the TSP arm rather than skipped. It
+    //     used to be skipped because it had to be — the mediator's management
+    //     dispatch was DIDComm-only, so no packet a TSP-only client could send
+    //     would set its own ACL (affinidi-tdk-rs#783 added the TSP wrapper).
+    //     Against a mediator predating that, the request is filed as mail and
+    //     nothing happens, which is exactly where skipping left us; the account
+    //     keeps the `global_acl_default` it was created with at authentication.
+    match probe.account_transport() {
+        Some((mediator_did, AccountTransport::Didcomm)) => {
+            let opened = tokio::time::timeout(PROBE_TIMEOUT, async {
+                let s = TrustPingSession::new(&new_did, &new_private_key, mediator_did)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                s.provision_client_acl("pnm-rotate").await;
+                s.shutdown().await;
+                Ok::<(), String>(())
+            })
+            .await
+            .unwrap_or_else(|_| Err(format!("timed out after {}s", PROBE_TIMEOUT.as_secs())));
 
-        match opened {
-            Ok(()) => debug!(%new_did, "opened the rotated DID's mediator account"),
-            Err(e) => tracing::debug!(
-                %new_did, error = %e,
-                "could not open the rotated DID's mediator account (non-fatal — it opens on \
-                 the next DIDComm connect)"
-            ),
+            match opened {
+                Ok(()) => debug!(%new_did, "opened the rotated DID's mediator account"),
+                Err(e) => tracing::debug!(
+                    %new_did, error = %e,
+                    "could not open the rotated DID's mediator account (non-fatal — it opens \
+                     on the next DIDComm connect)"
+                ),
+            }
         }
+        #[cfg(feature = "tsp")]
+        Some((mediator_did, AccountTransport::Tsp)) => {
+            let sent = tokio::time::timeout(
+                PROBE_TIMEOUT,
+                send_account_update_over_tsp(&new_did, &new_private_key, mediator_did),
+            )
+            .await
+            .unwrap_or_else(|_| Err(format!("timed out after {}s", PROBE_TIMEOUT.as_secs())));
+
+            match sent {
+                // *Sent*, not *opened*: a TSP send resolving `Ok` means the
+                // mediator accepted the frame, never that it applied the ACL
+                // (R1.1), and a mediator without the TSP management arm files it
+                // silently. Do not claim more than happened.
+                Ok(()) => debug!(
+                    %new_did,
+                    "sent the rotated DID's account/update over TSP (delivery not confirmed)"
+                ),
+                Err(e) => tracing::debug!(
+                    %new_did, error = %e,
+                    "could not send the rotated DID's account/update over TSP (non-fatal)"
+                ),
+            }
+        }
+        None => {}
     }
 
     // 3. Atomically move the ACL entry onto the new DID. The VP-JWT proves
@@ -2749,6 +2824,33 @@ impl TspPingSession {
     /// account (so the reply can't route back to it) — so waiting for a pong (as
     /// [`ping`](Self::ping) does) always times out and masks the send success.
     /// `Ok(())` means the relationship-free routed send worked (3c).
+    /// Open this client's own allow-all mediator account over the session's live
+    /// TSP socket.
+    ///
+    /// The TSP twin of [`TrustPingSession::provision_client_acl`]. Unlike that
+    /// one it cannot report whether the ACL was applied — see
+    /// [`crate::acl_setup::set_client_acl_over_tsp`]. No-op unless `acl-setup`
+    /// is enabled.
+    ///
+    /// Note this is deliberately *not* called on the `pnm health` TSP probe,
+    /// which runs on a throwaway DID: provisioning there would litter the
+    /// mediator with allow-all accounts for DIDs that never come back. It is for
+    /// a DID the caller is about to commit to.
+    pub async fn provision_client_acl(&self, client_name: &str) {
+        #[cfg(feature = "acl-setup")]
+        crate::acl_setup::set_client_acl_over_tsp(
+            self.identity.hub.atm(),
+            &self.identity.profile,
+            &self.client_did,
+            &self.mediator_did,
+            "tsp-ping-session",
+            client_name,
+        )
+        .await;
+        #[cfg(not(feature = "acl-setup"))]
+        let _ = client_name;
+    }
+
     pub async fn probe_send(&self, vta_did: &str) -> Result<(), Box<dyn std::error::Error>> {
         let body = serde_json::to_vec(&ping_document(&self.client_did, vta_did)?)?;
 
@@ -3843,6 +3945,61 @@ mod tests {
             reconnect.contains("required: true"),
             "a DIDComm rotation reconnects over the mediator, so its probe must be required: \
              the temp entry is gone by then, and an unreachable new DID is unrecoverable"
+        );
+    }
+
+    #[test]
+    fn a_tsp_only_mediator_still_gets_its_account_pass() {
+        // The reason this exists: a TSP-only mediator used to be skipped
+        // entirely, because the mediator's management dispatch was DIDComm-only
+        // and no packet a client could send would set its ACL
+        // (affinidi-tdk-rs#783 added the TSP arm). Skipping is no longer
+        // correct, and the way it would regress is by falling back to `None`
+        // rather than by failing — silent, and only on the deployments that
+        // depend on it.
+        let f = body_of("    fn account_transport(", "\n    }\n");
+
+        let tsp_only = f
+            .find("didcomm_mediator_did: None,")
+            .expect("a TSP-only mediator must be matched explicitly");
+        let arm = &f[tsp_only..];
+        assert!(
+            arm.contains("AccountTransport::Tsp"),
+            "a TSP-only mediator must take the TSP account pass, not `None` — that skip was \
+             only ever correct while the mediator had no TSP management route"
+        );
+
+        // Dual-transport prefers DIDComm: it is the arm every deployed mediator
+        // understands, so on a VTA offering both it is the one certain to act.
+        let dual = f
+            .find("didcomm_mediator_did: Some(didcomm)")
+            .expect("a dual-transport mediator must be matched");
+        let dual_arm = &f[dual..f[dual..].find("Self::Tsp").map_or(f.len(), |i| dual + i)];
+        assert!(
+            dual_arm.contains("AccountTransport::Didcomm"),
+            "a VTA advertising both transports must open its account over DIDComm"
+        );
+    }
+
+    #[test]
+    fn the_tsp_account_pass_never_claims_delivery() {
+        // R1.1: a TSP send resolving `Ok` means the mediator accepted the frame,
+        // not that it applied the ACL — and a mediator without the TSP
+        // management arm files it silently and answers nothing. Every
+        // "delivered" log in the ecosystem was built on that lie once already.
+        let rotate = body_of("async fn rotate_key_over_client(", "\n}\n");
+        let tsp_arm_start = rotate
+            .find("AccountTransport::Tsp")
+            .expect("the TSP account pass must exist");
+        let tsp_arm = &rotate[tsp_arm_start..];
+        let success_log = tsp_arm
+            .find("Ok(()) =>")
+            .map(|i| &tsp_arm[i..i + 300])
+            .expect("the TSP arm must log its success case");
+        assert!(
+            success_log.contains("sent") && !success_log.contains("opened"),
+            "the TSP success log must say what was *sent*, not what was opened — a send `Ok` \
+             is acceptance for delivery, never confirmation the ACL was applied"
         );
     }
 


### PR DESCRIPTION
Completes the pair started in #1309. That PR made key rotation work over TSP but had to leave the mediator-account pass DIDComm-only, and documented why: the mediator's management dispatch (`MessageType::process` → `trust_tasks::process`) was `#[cfg(feature = "didcomm")]` and took a DIDComm `Message`, so a TSP message addressed to it was filed for pickup rather than answered. **There was no packet a TSP-only client could send to set its own account ACL, over any transport.**

[affinidi-tdk-rs#783](https://github.com/affinidi/affinidi-tdk-rs/pull/783) added the TSP wrapper. This is its client half — and it makes that documented limitation false, which is the point: a comment explaining why something is impossible outlives the impossibility unless someone goes back for it.

## What changed

`acl_setup` gains `set_client_acl_over_tsp`, sending the same `messaging/account/update/0.1` task as a TSP **Direct** message addressed to the mediator. Same task, same allow-all ACL, same account key (`sha256(did)`) — the mediator keys its ACL on the DID, not the protocol, so whichever arm runs, the account ends up authorised for both transports. A client needs whichever one reaches its mediator, not both.

`rotate_key_over_client` routes the pass by transport instead of skipping:

| Mediator | Account pass |
|---|---|
| DIDComm, or dual-transport | DIDComm arm — what every deployed mediator understands, so on a VTA offering both it is the one certain to be acted on |
| TSP-only | TSP arm. Previously skipped, because it had to be |

## Two things it deliberately does not do

**It never claims delivery.** A TSP send resolving `Ok` means the mediator accepted the frame, not that it applied the ACL (R1.1) — and a mediator predating #783 files it silently and answers nothing. The success log says what was *sent*, delivery unconfirmed. `the_tsp_account_pass_never_claims_delivery` asserts the word "opened" never appears there.

**It does not wait for a reply.** The mediator applies the ACL before responding, so a reply carries no information — the same reasoning that makes the DIDComm arm log its errors rather than propagate them — while waiting for one would stall for the full timeout against a mediator that is never going to send it. Against such a mediator this degrades to exactly the previous behaviour: the account keeps the `global_acl_default` it was created with at authentication.

## Testing

Two new guards, both mutation-checked:

| Mutation | Guard that caught it |
|---|---|
| Revert TSP-only to `None` (i.e. skipped again) | `a_tsp_only_mediator_still_gets_its_account_pass` |
| Change the TSP success log from "sent" to "opened" | `the_tsp_account_pass_never_claims_delivery` |

`cargo test --workspace` green, clippy and `cargo fmt --all --check` clean, `cargo semver-checks --baseline-rev origin/main` reports **no semver update required**.

Checked across **all four** relevant feature combinations (`session`, `session,acl-setup`, `session,tsp`, `session,acl-setup,tsp`) rather than `--all-features` alone. That is not incidental: a helper whose only caller sits behind a `cfg` is live in one build and dead in the other, the pipeline compiles with `-D warnings`, and testing the first says nothing about the second. That exact miss failed CI on the mediator side of this pair an hour earlier; checking all four here caught a second instance of the same class before push.

Also declares `dep:uuid` on the `acl-setup` feature. It was compiling only because another enabled feature happened to supply it — which builds fine in the workspace and fails under `cargo publish`'s isolated verification, a class this workspace has been bitten by before.

## What is not covered

**No end-to-end coverage of the wire exchange.** The workspace's transitive test-mediator is pinned at 0.20.11 and the TSP management arm ships in 0.22.3, which is merged but not yet published — so there is no live mediator here to exercise this against. The guards pin the routing and the honesty of the logging, not that the mediator answers.

Real verification needs the mediator release plus a lock bump. Worth doing deliberately when that lands, because the failure mode is silent: a mediator that files the request as mail looks exactly like one that applied it.
