### PR TITLE
fix(sdk): finish the rotation test's migration to the Trust-Task binding

### DIFF
--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -401,6 +401,9 @@ async fn ensure_authenticated_runs_full_rotation_flow() {
     let server = MockServer::start().await;
     mount_challenge(&server).await;
 
+    let (temp_did, temp_pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+
     let future = now_secs() + 3600;
     Mock::given(method("POST"))
         .and(path("/auth/"))
@@ -442,25 +445,50 @@ async fn ensure_authenticated_runs_full_rotation_flow() {
         .mount(&server)
         .await;
 
-    let (temp_did, temp_pk) = did_key_from_seed(0x10);
-    let (vta_did, _) = did_key_from_seed(0x20);
-
-    // `POST /acl/swap` — one atomic operation, and the reason this stub is a
-    // single mock where it used to be three. Rotation was read-the-entry,
-    // create-under-the-new-DID, delete-the-temp; `acl/swap-key` moves the
-    // entry's role and contexts onto the new DID in one step, so there is no
-    // window in which both DIDs are privileged. The new DID is minted inside
-    // `rotate_key` and unknown here, which is exactly why the swap carries a
-    // VP-JWT proving control of it rather than the caller naming it.
+    // `acl/swap-key/0.1`, dispatched on the Trust-Task binding — **not** a
+    // bespoke `POST /acl/swap`, which the SDK stopped calling in #1309 when
+    // rotation was unified across REST, DIDComm and TSP. This stub was the one
+    // the migration missed; the rest of the file had already moved, and the
+    // header above describes the world it did not reach.
+    //
+    // One atomic operation, and the reason this is a single mock where it used
+    // to be three. Rotation was read-the-entry, create-under-the-new-DID,
+    // delete-the-temp; `acl/swap-key` moves the entry's role and contexts onto
+    // the new DID in one step, so there is no window in which both DIDs are
+    // privileged. The new DID is minted inside `rotate_key` and unknown here,
+    // which is exactly why the swap carries a VP-JWT proving control of it
+    // rather than the caller naming it.
+    //
+    // Matched on the document `type` and on `payload.currentSubject`, not on
+    // the path alone. A mock that answered any POST to the binding would go
+    // green while rotation dispatched the wrong task entirely — which is the
+    // failure that reached `main` here, one layer up.
     Mock::given(method("POST"))
-        .and(path("/acl/swap"))
+        .and(path("/trust-tasks"))
+        .and(wiremock::matchers::body_partial_json(json!({
+            "type": "https://trusttasks.org/spec/acl/swap-key/0.1",
+            "payload": { "currentSubject": temp_did.clone() },
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "did": "did:key:zNew",
-            "role": "admin",
-            "label": "ops",
-            "allowed_contexts": ["primary"],
-            "created_at": 1_700_000_000_u64,
-            "created_by": "did:web:vta",
+            "id": "urn:uuid:stub-swap-response",
+            "type": "https://trusttasks.org/spec/acl/swap-key/0.1#response",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            // The canonical wire spelling, which is NOT the old REST body:
+            // `subject`/`scopes`, not `did`/`allowed_contexts`.
+            // `AclEntryResponse` renames both, so a stub written from the field
+            // names decodes to "missing field `subject`" — which is the second
+            // half of the same migration, and the reason a mock matched only on
+            // the path would have been worse than the red it replaced.
+            "payload": {
+                "entry": {
+                    "subject": "did:key:zNew",
+                    "role": "admin",
+                    "label": "ops",
+                    "scopes": ["primary"],
+                    "created_at": 1_700_000_000_u64,
+                    "created_by": "did:web:vta",
+                }
+            },
         })))
         .expect(1)
         .mount(&server)


### PR DESCRIPTION
`main` has been red since #1309 merged. This fixes it.

## What is broken

`cargo test -p vta-sdk --all-features` — the `Feature combos` step — fails on
`vta-sdk/tests/session_store.rs::ensure_authenticated_runs_full_rotation_flow`:

```
"rotate: acl/swap-key failed: not found: unknown error —
 has your admin run `vta import-did --did did:key:z6Mkkgmu… --role admin` yet?"
```

#1309's own `Feature combos` failed too
([run 34191224870](https://github.com/OpenVTC/verifiable-trust-infrastructure/actions/runs/34191224870/job/101949526357))
and it merged anyway, so every PR opened since inherits it — #1310 and #1311
are both red for this and nothing else. #1311 changes **no Rust at all**, which
is the cleanest proof available that the break is `main`'s.

## The implementation is right; the migration was half-finished

#1309 deliberately moved rotation off a hand-rolled REST call, and says so:

> The swap rides `acl/swap-key` like every other transport's does, so it needs a
> client — **not a hand-rolled `POST /acl/swap`**.

The test file's own header describes the new world too — *"The layer-3 stubs
serve `POST /trust-tasks` … They used to serve bespoke REST routes, which the
SDK no longer calls"*. **One stub did not get the memo.** Of the four mocked
paths in the file, three had moved; `/acl/swap` had not.

## Two halves, and the second is why a lazy mock would have been worse

Pointing the stub at `/trust-tasks` was not enough. The response also had to
change shape: `AclEntryResponse` renames its fields (`subject` → `did`,
`scopes` → `allowed_contexts`), so a stub written from the Rust field names
decodes to `missing field 'subject'`.

A mock matched only on the path, answering something permissive, would have gone
green while testing neither half. That is why this matches on the **document
`type`** and on `payload.currentSubject`, exactly as the correctly-migrated
`config/show` stub a few lines below already does.

## Verified non-vacuous

Both halves probed, not assumed:

```
matcher expects acl/grant instead of acl/swap-key   → FAILED
response uses the old REST field names (`did`)      → FAILED
restored                                            → 24 passed; 0 failed
```

Full step green: `cargo test -p vta-sdk --all-features` — 731 + 86 + 24 + … all
suites pass, 0 failures.

## The gap that let this through

The test file is gated on `session` + `test-support`, and its header says a CI
step was added "for exactly this class of rot" — that step is
`cargo test -p vta-sdk --all-features` inside `Feature combos`. **It worked.**
It reported on #1309 and the PR merged regardless.

So there is nothing to add here; the guard already exists and already fired. The
only thing worth changing is not merging past it — which is a habit, not a
workflow file.

## Guide checklist (§9)

- [x] R1.*/R2.1/R3.* — test-only change; no runtime code, no wire format, no mutation
- [x] R5.* — the stub now fails closed: a wrong task type or wrong response shape does not match, so the test fails rather than passing permissively
- [x] R6.* — probed both branches rather than asserting the fix works
- [x] Deviations — none
