### PR TITLE
feat(persona): serve the claim-type registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,11 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "uuid",
 ]
@@ -492,7 +496,11 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "uuid",
 ]
@@ -617,7 +625,11 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -8117,7 +8129,11 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9737,7 +9753,11 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -9753,7 +9773,11 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -9772,7 +9796,11 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -9790,7 +9818,11 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
 ]
 
 [[package]]
@@ -9810,9 +9842,15 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
+<<<<<<< HEAD
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a64b51eb2da3d74dadcb76d2d9a5ee983043194e5adebb364e7f6d8ba04164"
+=======
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2368308f6278f03c43dce6aee58c75f8815f8d8709540a7424a51dbe10bddc"
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
 dependencies = [
  "async-trait",
  "chrono",
@@ -10568,7 +10606,11 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uniffi",
  "vta-sdk",
 ]
@@ -10586,7 +10628,11 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10665,7 +10711,11 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "utoipa",
  "uuid",
@@ -10750,7 +10800,11 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "urlencoding",
  "utoipa",
@@ -10919,7 +10973,11 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10991,7 +11049,11 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "unicode-normalization",
  "url",
  "utoipa",
@@ -11049,7 +11111,11 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "utoipa",
  "utoipa-axum",
@@ -11105,7 +11171,11 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
+<<<<<<< HEAD
  "trust-tasks-rs 0.18.4",
+=======
+ "trust-tasks-rs 0.18.5",
+>>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "vti-common",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,11 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "uuid",
 ]
@@ -496,11 +492,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "uuid",
 ]
@@ -625,11 +617,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -8129,11 +8117,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9753,11 +9737,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -9773,11 +9753,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -9796,11 +9772,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uuid",
 ]
 
@@ -9818,11 +9790,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
 ]
 
 [[package]]
@@ -9842,15 +9810,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-<<<<<<< HEAD
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a64b51eb2da3d74dadcb76d2d9a5ee983043194e5adebb364e7f6d8ba04164"
-=======
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2368308f6278f03c43dce6aee58c75f8815f8d8709540a7424a51dbe10bddc"
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
 dependencies = [
  "async-trait",
  "chrono",
@@ -10606,11 +10568,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "uniffi",
  "vta-sdk",
 ]
@@ -10628,11 +10586,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10711,11 +10665,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "utoipa",
  "uuid",
@@ -10800,11 +10750,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "urlencoding",
  "utoipa",
@@ -10973,11 +10919,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "vta-sdk",
  "vti-rooms",
 ]
@@ -11049,11 +10991,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "unicode-normalization",
  "url",
  "utoipa",
@@ -11111,11 +11049,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "url",
  "utoipa",
  "utoipa-axum",
@@ -11171,11 +11105,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
-<<<<<<< HEAD
- "trust-tasks-rs 0.18.4",
-=======
  "trust-tasks-rs 0.18.5",
->>>>>>> 283f6bbb (feat(persona): serve the claim-type registry)
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ aws-lc-rs = "1.16"
 # fully succeeded comes back as a 500 `responseSchemaViolation` — the members
 # are emitted and the schema rejects them. A caret on "0.18" would let a
 # resolver pick 0.18.2 and reintroduce exactly that.
-trust-tasks-rs = { version = "0.18.4", default-features = false, features = [
+trust-tasks-rs = { version = "0.18.5", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/vta-persona/src/claim_types.rs
+++ b/vta-persona/src/claim_types.rs
@@ -108,6 +108,33 @@ pub enum MaskStyle {
     None,
 }
 
+impl Sensitivity {
+    /// Every variant, most protective first — the declaration order, which is
+    /// what makes `Ord` mean "more protective" on this axis.
+    ///
+    /// Written out rather than derived because Rust has no reflection over
+    /// variants; the test below walks it against `Ord` so a variant added
+    /// without being listed, or listed out of order, fails rather than being
+    /// served as a quietly wrong ordering to every client.
+    pub const MOST_PROTECTIVE_FIRST: &'static [Self] = &[Self::High, Self::Normal];
+}
+
+impl ReleaseRequirement {
+    /// Every variant, most protective first. See [`Sensitivity::MOST_PROTECTIVE_FIRST`].
+    pub const MOST_PROTECTIVE_FIRST: &'static [Self] = &[Self::StepUp, Self::Consent];
+}
+
+impl MaskStyle {
+    /// Every variant, most protective first. See [`Sensitivity::MOST_PROTECTIVE_FIRST`].
+    pub const MOST_PROTECTIVE_FIRST: &'static [Self] = &[
+        Self::Full,
+        Self::Last2,
+        Self::Last4,
+        Self::EmailLocal,
+        Self::None,
+    ];
+}
+
 /// The three axes as they resolve for one claim type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Axes {
@@ -467,6 +494,81 @@ fn longest_registered_family(claim_type: &str) -> Option<&'static Entry> {
         .next_back()
 }
 
+/// The registry as a client needs to receive it: every row, the floor, and the
+/// per-axis strictness ordering.
+///
+/// Served by `persona/claim-types/list` so a client resolves against **this**
+/// agent's table rather than a copy compiled into its own build. The three
+/// parts are inseparable: §4 rule 3 takes the longest registered prefix and the
+/// unregistered floor and keeps whichever is *more protective*, which a client
+/// cannot compute from the rows alone.
+///
+/// Rows are returned exactly as this crate holds them, in table order. Family
+/// prefixes (`payment`, `gov`) and exact tokens (`name.legal`) are
+/// undistinguished, because which one a row is depends on the token being
+/// resolved — and marking them would invite a client to walk only one kind,
+/// which is the hole that let a gated family be escaped by inventing a member.
+///
+/// **`minimumSet` and `oidc` are deliberately absent.** The spec makes both
+/// optional, and this agent's table does not carry them: nothing here resolves
+/// against either. Transcribing them in at the serving layer would be a second
+/// copy of data this crate does not use — which is the thing this task exists
+/// to end, one layer down.
+#[must_use]
+pub fn registry_listing() -> RegistryListing {
+    RegistryListing {
+        registry_version: REGISTRY_VERSION,
+        entries: REGISTRY
+            .iter()
+            .map(|e| RegistryRow {
+                claim_type: e.token,
+                axes: e.axes,
+            })
+            .collect(),
+        unregistered: UNREGISTERED,
+        strictness: Strictness {
+            // Each axis most protective first — the same order the enums are
+            // declared in, which is what makes `min()` mean "more protective"
+            // throughout this module. Derived from the enums rather than
+            // written out again, so the served ordering cannot disagree with
+            // the one the resolution actually uses.
+            sensitivity: Sensitivity::MOST_PROTECTIVE_FIRST,
+            release: ReleaseRequirement::MOST_PROTECTIVE_FIRST,
+            mask: MaskStyle::MOST_PROTECTIVE_FIRST,
+        },
+    }
+}
+
+/// One row of [`registry_listing`].
+#[derive(Clone, Copy, Debug)]
+pub struct RegistryRow {
+    pub claim_type: &'static str,
+    pub axes: Axes,
+}
+
+/// The per-axis orderings, most protective first.
+#[derive(Clone, Copy, Debug)]
+pub struct Strictness {
+    pub sensitivity: &'static [Sensitivity],
+    pub release: &'static [ReleaseRequirement],
+    pub mask: &'static [MaskStyle],
+}
+
+/// Everything `persona/claim-types/list` returns.
+#[derive(Clone, Debug)]
+pub struct RegistryListing {
+    pub registry_version: &'static str,
+    pub entries: Vec<RegistryRow>,
+    pub unregistered: Axes,
+    pub strictness: Strictness,
+}
+
+/// The version of `claim-types.json` this table was transcribed from.
+///
+/// A client caches on this, so it moves when the table moves — not when this
+/// crate is released.
+const REGISTRY_VERSION: &str = "0.1";
+
 /// The sensitivity of one attribute — §4 in full, rule 1 included.
 ///
 /// **Store the override; derive the default.** Only a holder's deliberate
@@ -528,6 +630,63 @@ pub fn release_of_claim(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The served ordering IS the resolution ordering.
+    ///
+    /// `MOST_PROTECTIVE_FIRST` is hand-written — Rust cannot enumerate variants
+    /// — so it can disagree with `Ord`, which is what every "more protective
+    /// wins" comparison in this module actually uses. A disagreement would be
+    /// silent and would be *served to every client* as the rule to resolve by.
+    /// So: each list must be sorted ascending under `Ord`, and must be
+    /// complete.
+    #[test]
+    fn the_served_strictness_matches_the_ordering_resolution_uses() {
+        fn ascending<T: Ord + std::fmt::Debug + Copy>(xs: &[T], axis: &str) {
+            let mut sorted = xs.to_vec();
+            sorted.sort();
+            assert_eq!(
+                xs.to_vec(),
+                sorted,
+                "{axis}: MOST_PROTECTIVE_FIRST disagrees with Ord, so the ordering served to \
+                 clients is not the one this module resolves by"
+            );
+        }
+        ascending(Sensitivity::MOST_PROTECTIVE_FIRST, "sensitivity");
+        ascending(ReleaseRequirement::MOST_PROTECTIVE_FIRST, "release");
+        ascending(MaskStyle::MOST_PROTECTIVE_FIRST, "mask");
+
+        // Completeness: the floor is the most protective value on every axis,
+        // so it must be the first element. A variant added above it and not
+        // listed would fail here.
+        assert_eq!(
+            Sensitivity::MOST_PROTECTIVE_FIRST[0],
+            UNREGISTERED.sensitivity
+        );
+        assert_eq!(MaskStyle::MOST_PROTECTIVE_FIRST[0], UNREGISTERED.mask);
+    }
+
+    /// The listing carries the three parts a client needs, and every row of the
+    /// table it actually resolves against.
+    #[test]
+    fn the_listing_serves_the_table_this_agent_resolves_by() {
+        let l = registry_listing();
+        assert_eq!(
+            l.entries.len(),
+            REGISTRY.len(),
+            "rows dropped on the way out"
+        );
+        for (row, entry) in l.entries.iter().zip(REGISTRY.iter()) {
+            assert_eq!(row.claim_type, entry.token);
+            assert_eq!(row.axes, entry.axes);
+        }
+        assert_eq!(l.unregistered, UNREGISTERED);
+        assert_eq!(l.registry_version, "0.1");
+
+        // The family rows are present and undistinguished — a client walking
+        // prefixes needs them, and nothing marks them as different.
+        assert!(l.entries.iter().any(|r| r.claim_type == "payment"));
+        assert!(l.entries.iter().any(|r| r.claim_type == "gov"));
+    }
     use crate::model::{Provenance, ValueType};
     use crate::store::new_attribute;
 

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -551,6 +551,12 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
         trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0,
         RetrySafety::ReadOnly,
     ),
+    // A compile-time table describing the agent's vocabulary. Reads nothing,
+    // writes nothing, and returns the same answer to every caller.
+    (
+        trust_tasks::TASK_PERSONA_CLAIM_TYPES_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
     (
         trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
         RetrySafety::Keyed,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -892,6 +892,10 @@ pub const TASK_PERSONA_DISCLOSURE_HISTORY_1_0: &str =
 pub const TASK_PERSONA_CORRELATION_ANALYZE_1_0: &str =
     "https://trusttasks.org/spec/persona/correlation/analyze/1.0";
 
+/// `spec/persona/claim-types/list/1.0`
+pub const TASK_PERSONA_CLAIM_TYPES_LIST_1_0: &str =
+    "https://trusttasks.org/spec/persona/claim-types/list/1.0";
+
 /// `spec/persona/renderers/list/1.0`
 pub const TASK_PERSONA_RENDERERS_LIST_1_0: &str =
     "https://trusttasks.org/spec/persona/renderers/list/1.0";
@@ -1891,6 +1895,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_PERSONA_DISCLOSURE_HISTORY_1_0,
     TASK_PERSONA_CORRELATION_ANALYZE_1_0,
     TASK_PERSONA_RENDERERS_LIST_1_0,
+    TASK_PERSONA_CLAIM_TYPES_LIST_1_0,
     TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
     TASK_PERSONA_LOCAL_PROFILE_GET_1_0,
     TASK_PERSONA_LOCAL_PROFILE_LIST_1_0,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2952,6 +2952,37 @@ fn persona_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
             ),
         ),
         (
+            u::TASK_PERSONA_CLAIM_TYPES_LIST_1_0,
+            (
+                json!({}),
+                parses::<specs::persona::claim_types::list::v1_0::Payload>,
+                validates::<specs::persona::claim_types::list::v1_0::Payload>,
+            ),
+            (
+                // The three parts are all REQUIRED, because §4 rule 3 —
+                // longest registered prefix vs the floor, more protective wins
+                // — is not computable from the rows alone.
+                json!({
+                    "registryVersion": "0.1",
+                    "entries": [
+                        // A family row and an exact row, undistinguished: which
+                        // one an entry is depends on the token being resolved.
+                        { "type": "payment", "sensitivity": "high",
+                          "release": "stepUp", "mask": "full" },
+                        { "type": "name.display", "sensitivity": "normal",
+                          "release": "consent", "mask": "none" }
+                    ],
+                    "unregistered": { "sensitivity": "high", "release": "consent", "mask": "full" },
+                    "strictness": {
+                        "sensitivity": ["high", "normal"],
+                        "release": ["stepUp", "consent"],
+                        "mask": ["full", "last2", "last4", "emailLocal", "none"]
+                    }
+                }),
+                parses::<specs::persona::claim_types::list::v1_0::Response>,
+            ),
+        ),
+        (
             u::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0,
             (
                 // Inline only. A reference is unrepresentable here rather than

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1711,6 +1711,9 @@ dispatch_table! {
     // Describes the agent's capabilities, not the holder. Discloses nothing.
     vta_sdk::trust_tasks::TASK_PERSONA_RENDERERS_LIST_1_0 => persona::handle_renderers_list
         [ None None false ],
+    // Describes the agent's vocabulary, not the holder. Discloses nothing.
+    vta_sdk::trust_tasks::TASK_PERSONA_CLAIM_TYPES_LIST_1_0 => persona::handle_claim_types_list
+        [ None None false ],
     // The context-local surface. Context-callable because authoring below the
     // boundary is safe; the rule exists to stop reading across it.
     vta_sdk::trust_tasks::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0 => persona::handle_local_profile_put

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -129,6 +129,7 @@ pub const REACH: &[(&str, Reach)] = &[
     (uris::TASK_PERSONA_DISCLOSURE_PRESENT_1_0, Reach::Context),
     // ── Neither side: the agent's own advertised capabilities ─────────────
     (uris::TASK_PERSONA_RENDERERS_LIST_1_0, Reach::Any),
+    (uris::TASK_PERSONA_CLAIM_TYPES_LIST_1_0, Reach::Any),
     // Authoring below the boundary is safe; the rule stops reading across it.
     (uris::TASK_PERSONA_LOCAL_PROFILE_PUT_1_0, Reach::Context),
     (uris::TASK_PERSONA_LOCAL_PROFILE_GET_1_0, Reach::Context),
@@ -1506,6 +1507,59 @@ pub(super) async fn handle_renderers_list(
                 "drops": if r.carries_provenance { vec![] } else { vec!["provenance"] },
                 "canCarryPredicates": r.carries_predicates,
             })).collect::<Vec<_>>()
+        }),
+    )
+}
+
+/// Serve the claim-type registry this agent resolves against.
+pub(super) async fn handle_claim_types_list(
+    // Unused for the same reason as `handle_renderers_list`: the table is a
+    // compile-time constant, not stored state.
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let _req: spec::claim_types::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    // `Reach::Any`, and neither of the other two would do. An unscoped holder
+    // only would refuse the application that needs this most — one inside a
+    // context, deciding how to render a preview it was just shown. A context
+    // requirement would refuse the holder's own tooling, which has no context
+    // to name. The response describes a vocabulary and carries nothing about
+    // the holder, any context, or any stored state.
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_CLAIM_TYPES_LIST_1_0, None).await {
+        return reject(&doc, e);
+    }
+
+    // Sourced from `vta_persona::claim_types` — the same table `defaults_for`
+    // resolves against — so what is served and what is enforced cannot
+    // disagree. That is the task's central MUST, and building the response
+    // from a second literal here would break it on day one.
+    let l = vta_persona::claim_types::registry_listing();
+    let axes = |a: &vta_persona::Axes| {
+        json!({
+            "sensitivity": wire_name(a.sensitivity),
+            "release": wire_name(a.release),
+            "mask": wire_name(a.mask),
+        })
+    };
+    success_response(
+        &doc,
+        json!({
+            "registryVersion": l.registry_version,
+            "entries": l.entries.iter().map(|r| {
+                let mut e = axes(&r.axes);
+                e["type"] = json!(r.claim_type);
+                e
+            }).collect::<Vec<_>>(),
+            "unregistered": axes(&l.unregistered),
+            "strictness": {
+                "sensitivity": l.strictness.sensitivity.iter().map(|v| wire_name(*v)).collect::<Vec<_>>(),
+                "release": l.strictness.release.iter().map(|v| wire_name(*v)).collect::<Vec<_>>(),
+                "mask": l.strictness.mask.iter().map(|v| wire_name(*v)).collect::<Vec<_>>(),
+            },
         }),
     )
 }

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -43,6 +43,7 @@ const BINDING_GET: &str = "https://trusttasks.org/spec/persona/binding/get/1.0";
 const BINDING_LIST: &str = "https://trusttasks.org/spec/persona/binding/list/1.0";
 const CORRELATION: &str = "https://trusttasks.org/spec/persona/correlation/analyze/1.0";
 const RENDERERS: &str = "https://trusttasks.org/spec/persona/renderers/list/1.0";
+const CLAIM_TYPES: &str = "https://trusttasks.org/spec/persona/claim-types/list/1.0";
 const DISCLOSURE_HISTORY: &str = "https://trusttasks.org/spec/persona/disclosure/history/1.0";
 const PREVIEW: &str = "https://trusttasks.org/spec/persona/disclosure/preview/1.0";
 const PRESENT: &str = "https://trusttasks.org/spec/persona/disclosure/present/1.0";
@@ -2214,4 +2215,141 @@ async fn a_holders_release_override_gates_a_type_the_registry_does_not() {
         "an ungated name.display was gated, so the override is not what decided it: \
          {status} {body}"
     );
+}
+
+/// The registry is served, and it is the one the agent resolves by.
+///
+/// The task's central MUST is that a maintainer serves the table it actually
+/// applies — a served table that differs from the enforced one is worse than
+/// serving nothing, because a client would mask and gate by one rule while the
+/// agent disclosed by another and nothing would report the disagreement.
+///
+/// So this does not check the response against a literal. It checks it against
+/// **observed agent behaviour**: `payment.card` is served as `release: stepUp`,
+/// and a disclosure of `payment.card` is in fact refused for want of a step-up.
+/// A response built from a second hard-coded table would pass a literal
+/// comparison and fail this.
+#[tokio::test]
+async fn the_served_registry_is_the_one_the_agent_enforces() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let vta = &ctx.vta_did;
+    let scoped = authed(&ctx, "ct-scoped", "admin", &[CTX]).await;
+
+    let (status, body) = post_to(&router, &scoped, vta, CLAIM_TYPES, json!({})).await;
+    assert!(!refused(status, &body), "claim-types/list: {status} {body}");
+    let p = payload_of(&body);
+
+    assert_eq!(p["registryVersion"], "0.1", "{body}");
+
+    // The three parts are inseparable: §4 rule 3 needs the floor and an
+    // ordering, not just the rows.
+    assert_eq!(p["unregistered"]["sensitivity"], "high", "{body}");
+    assert_eq!(p["unregistered"]["release"], "consent", "{body}");
+    assert_eq!(p["unregistered"]["mask"], "full", "{body}");
+    assert_eq!(
+        p["strictness"]["release"][0], "stepUp",
+        "the strictness ordering must be most-protective-first, or a client's \
+         'more protective wins' resolves backwards: {body}"
+    );
+    assert_eq!(p["strictness"]["sensitivity"][0], "high", "{body}");
+    assert_eq!(p["strictness"]["mask"][0], "full", "{body}");
+
+    let entries = p["entries"].as_array().expect("entries");
+    let find = |t: &str| {
+        entries
+            .iter()
+            .find(|e| e["type"] == t)
+            .unwrap_or_else(|| panic!("no entry for {t} in {p:#}"))
+    };
+
+    // The family rows are present and undistinguished. A client walking
+    // prefixes needs them, and nothing marks them as a different kind of row —
+    // which is what stopped a gated family being escapable by inventing a
+    // member.
+    assert_eq!(find("payment")["release"], "stepUp", "{p:#}");
+    assert_eq!(find("gov")["release"], "stepUp", "{p:#}");
+    assert_eq!(find("name")["release"], "consent", "{p:#}");
+
+    // And now the half that makes this more than a literal comparison: the
+    // agent must BEHAVE the way the table it just served says it will.
+    let served_card_release = find("payment.card")["release"].clone();
+    assert_eq!(served_card_release, "stepUp", "{p:#}");
+
+    let holder = authed(&ctx, "ct-holder", "admin", &[]).await;
+    let attr = put_attribute_at(&router, &holder, vta, "payment.card", "4242424242424242").await;
+    let (_, body) = post_to(
+        &router,
+        &holder,
+        vta,
+        PROFILE_PUT,
+        json!({ "name": "card", "entries": [{ "ref": attr }] }),
+    )
+    .await;
+    let profile = payload_of(&body)["profileId"]
+        .as_str()
+        .expect("profileId")
+        .to_string();
+    let persona = "did:key:z6MkPersonaClaimTypes";
+    let (status, body) = post_to(
+        &router,
+        &holder,
+        vta,
+        BINDING_SET,
+        json!({ "contextId": CTX, "personaDid": persona, "profileId": profile }),
+    )
+    .await;
+    assert!(!refused(status, &body), "binding/set: {status} {body}");
+    let (_, body) = post_to(
+        &router,
+        &scoped,
+        vta,
+        PREVIEW,
+        json!({ "contextId": CTX, "personaDid": persona, "verifierDid": "did:key:z6MkV" }),
+    )
+    .await;
+    let preview_id = payload_of(&body)["previewId"]
+        .as_str()
+        .expect("previewId")
+        .to_string();
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        vta,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(refused(status, &body), "{status} {body}");
+    assert_eq!(
+        payload_of(&body)["code"],
+        "persona/disclosure/present:stepUpRequired",
+        "the agent served `payment.card: stepUp` and then disclosed it without one — a served \
+         table that differs from the enforced one is worse than serving nothing: {body}"
+    );
+}
+
+/// Any authenticated caller may read it — scoped and unscoped alike.
+///
+/// Both of the usual answers are wrong here in opposite directions, so both
+/// are asserted: refusing the scoped caller would refuse the application that
+/// needs this most, and refusing the unscoped one would refuse the holder's own
+/// tooling, which has no context to name.
+#[tokio::test]
+async fn the_registry_is_readable_by_scoped_and_unscoped_callers_alike() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let vta = &ctx.vta_did;
+    for (tag, contexts) in [("ct-any-scoped", &[CTX][..]), ("ct-any-holder", &[][..])] {
+        let token = authed(&ctx, tag, "admin", contexts).await;
+        let (status, body) = post_to(&router, &token, vta, CLAIM_TYPES, json!({})).await;
+        assert!(
+            !refused(status, &body),
+            "{tag} was refused: {status} {body}"
+        );
+        assert!(
+            payload_of(&body)["entries"]
+                .as_array()
+                .is_some_and(|e| !e.is_empty()),
+            "{tag} got an empty table: {body}"
+        );
+    }
 }


### PR DESCRIPTION
The agent side of trust-tasks #390, now that `trust-tasks-rs` 0.18.5 is
published. Bumps the pin `0.18.3 → 0.18.5` and serves
`persona/claim-types/list/1.0`.

## Served from the table it resolves by, not a second copy

The task's central MUST: *"a maintainer MUST serve the registry it actually
resolves against. A table served here that differs from the one the agent
applies is worse than serving nothing."*

So the handler reads `vta_persona::claim_types::registry_listing()` — the same
`REGISTRY` and `UNREGISTERED` that `defaults_for` resolves through. Building the
response from a literal here would have broken that MUST on day one, and it is
the exact failure the whole task exists to end, one layer down.

**The test enforces it behaviourally rather than by comparison.** It asserts
the agent serves `payment.card: release stepUp` *and* that a `payment.card`
disclosure is then refused with `stepUpRequired`. A response built from a second
hard-coded table would pass a literal check and fail this one.

## `strictness` is derived, and guarded

The response carries the per-axis orderings because §4 rule 3 — longest
registered prefix vs the floor, more protective wins — is not computable
without one.

They come from new `MOST_PROTECTIVE_FIRST` constants on each enum. Rust cannot
enumerate variants, so those are hand-written and *can* disagree with `Ord`,
which is what every "more protective" comparison in the module actually uses. A
disagreement would be silent **and served to every client as the rule to
resolve by** — so a unit test asserts each list is sorted ascending under `Ord`
and that the floor is its first element. A variant added without being listed,
or listed out of order, fails there.

## `minimumSet` and `oidc` are deliberately absent

Both are optional in the schema, and this agent's table does not carry them —
nothing here resolves against either. Transcribing them in at the serving layer
would be a second copy of data this crate does not use, which is the thing this
task exists to end. If the agent starts resolving them, it serves them.

## Authorization: `Reach::Any`

Neither other answer works, and the sibling task's history is why the reasoning
is written out. Unscoped-holder-only refuses the application that needs it most
— one inside a context, deciding how to render a preview it was just shown. A
context requirement refuses the holder's own tooling, which has no context to
name. The response describes a vocabulary and carries nothing about the holder,
any context, or any stored state.

Both directions are asserted, so a gate that drifted either way fails.

## Verified

- `persona_trust_task` 24/24 (2 new), `vta-persona --lib` 88/88 (2 new)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` clean

## What this unblocks

The two vendored copies of the table can go — the plugin's
`manager/claim-sensitivity.ts` and, in time, the transcription in
`vta-persona/src/claim_types.rs` itself. Those are follow-ups; nothing in this
PR changes either.

**Not in this PR:** accepting `approve-response/0.3` and answering `recorded`.
That is the other half of the 0.18.5 bump and lands separately, because it is
the one that removes #1304's session-elevation compromise and deserves its own
review. Note the ordering constraint — the VTA must accept 0.3 **before** any
approver stack mints it, or every step-up through that approver breaks.

## Guide checklist (§9)

- [x] R1.2/R1.3/R1.4/R1.5/R1.6 — no client, lock, retry, loop or ack touched
- [x] R2.1 — read-only task, no mutation
- [x] R3.* — new task on the published schema; `wire_name` gives the camelCase spellings via serde, so the response cannot drift from the enums
- [x] R5.* — the served floor IS the enforced floor; an unrecognised token still resolves to it
- [x] R6.* — the response reports the table actually in force, asserted against behaviour
- [x] Deviations — `minimumSet`/`oidc` omitted, with the reason above
