### PR TITLE
feat(auth/step-up): record a bound approval without elevating the session

### DIFF
--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -118,6 +118,9 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // without the caller learning it was granted.
     (trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1, Keyed),
     (trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2, Keyed),
+    // Same, and no looser for being answerable with `recorded`: a bound
+    // approval is still a one-shot, and a lost reply still spends it.
+    (trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_3, Keyed),
     // ── Device ──────────────────────────────────────────────────────────
     // Registration is keyed by a caller-supplied device identity, so a repeat
     // lands on the same record — but it also mints device credentials, and

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -135,6 +135,19 @@ pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1: &str =
 pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2: &str =
     "https://trusttasks.org/spec/auth/step-up/approve-response/0.2";
 
+/// `spec/auth/step-up/approve-response/0.3` — successor to
+/// [`TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2`]; adds the `recorded`
+/// acknowledgement for an approval bound to a single operation.
+///
+/// **A relying party cannot reach for this on its own.** A response document's
+/// `type` is the request's `type` plus `#response`, so an approver that mints
+/// 0.2 gets a 0.2 answer, which has no word for "applied, nothing elevated".
+/// The maintainer must accept 0.3 *before* any approver mints it, never the
+/// other way round — an approver that moved first would have every step-up
+/// refused as an unsupported type.
+pub const TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_3: &str =
+    "https://trusttasks.org/spec/auth/step-up/approve-response/0.3";
+
 // ─── Device slice (spec/device/*) ────────────────────────────────────────
 // Canonical Trust Task registry shapes (dtgwg `device/*`). Companion/Service
 // lifecycle on the VTA: register a device, heartbeat, list, disable, wipe, and
@@ -1691,6 +1704,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_AUTH_PASSKEY_LOGIN_FINISH_0_2,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1,
     TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
+    TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_3,
     // Device slice
     TASK_DEVICE_REGISTER_0_1,
     TASK_DEVICE_REGISTER_0_2,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -592,6 +592,29 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
+            uris::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_3,
+            checked!(
+                specs::auth::step_up::approve_response::v0_3::Payload,
+                specs::auth::step_up::approve_response::v0_3::Response,
+                // The request is field-for-field 0.2. Only the acknowledgement
+                // moved, which is the whole reason the version had to.
+                json!({
+                    "subject": SUBJECT,
+                    "sessionId": "sess-1",
+                    "challenge": "chal-0123456789abcdef",
+                    "decision": "approved",
+                    "grantedAcr": "aal2",
+                    "evidence": { "kind": "didSigned" },
+                }),
+                // The witness is the BOUND form deliberately: `elevated` is
+                // already witnessed by 0.2 above, and `recorded` is the member
+                // this version exists for. No `session` — it changes none, and
+                // a snapshot here would witness an elevation that does not
+                // happen.
+                json!({ "status": "recorded", "boundTo": "01J0000000000000000000000A" })
+            ),
+        ),
+        (
             uris::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2,
             checked!(
                 specs::auth::step_up::approve_response::v0_2::Payload,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1383,12 +1383,19 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_AUTH_SESSIONS_LIST_0_1 => auth::handle_sessions_list
         [ None Metadata false ],
-    // Dual-accept: both versions route to the same typed handler, which
-    // normalises the `evidence.kind` discriminator on a copy (the signed
-    // document is never mutated). Not edge-transformed in `wire_v0_2` because
-    // the payload carries the approver's signature.
+    // All three versions route to the same typed handler, which normalises the
+    // `evidence.kind` discriminator on a copy (the signed document is never
+    // mutated). Not edge-transformed in `wire_v0_2` because the payload carries
+    // the approver's signature.
+    //
+    // The REQUEST payloads are field-for-field identical across 0.1/0.2/0.3 —
+    // 0.3 changed only the acknowledgement, adding `recorded`. What differs is
+    // what the handler may ANSWER, and it reads `doc.type_uri` to decide: a
+    // bound approval can be acknowledged honestly only to a 0.3 request,
+    // because a response's type is the request's type plus `#response`.
     vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_1
         | vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_2
+        | vta_sdk::trust_tasks::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_3
         => step_up::handle_approve_response
         [ Mutating None false ],
     // ─── Policy slice (runtime PDP management) ────────────────────

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -35,6 +35,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose;
 use serde_json::{Value, json};
 use trust_tasks_rs::specs::auth::step_up::approve_response::v0_1 as approve_response;
+use vta_sdk::trust_tasks as uris;
 // Only the DIDComm sends name the envelope; TSP carries the document bytes
 // directly, so this is unused when the binding is compiled out. Imported from the
 // binding crate rather than copied — one source, no local literals (#900).
@@ -432,26 +433,12 @@ pub(super) async fn handle_approve_response(
 
     // 7a. A *bound* approval marks the operation it was taken for.
     //
-    // This is what authorises the disclosure — not the elevation below. The
-    // gate in `persona::handle_disclosure_present` reads the preview's own
+    // This is what authorises the disclosure — not any elevation. The gate in
+    // `persona::handle_disclosure_present` reads the preview's own
     // `approved_at` and never the session's `acr`, so the next `release:
     // stepUp` disclosure is refused however freshly the session authenticated:
     // its preview carries no approval. That is the whole of what "each time"
     // asks for, and it is why the binding is to the `previewId`.
-    //
-    // The session is then elevated as it always is, because that is what this
-    // ceremony *is*: the subject proved, freshly, that they are still
-    // themselves, and `aal2` is the name for having done so. Recording that
-    // fact and refusing to record it are not made different by which operation
-    // prompted it — every other `initiate_self_step_up` caller shows its own
-    // authorization context and yields the same session-wide `aal2`.
-    //
-    // What that costs, stated plainly: an approval taken to disclose a card
-    // number leaves a session that satisfies an unrelated `requireStepUp` rule
-    // for the elevation window. The narrower answer — record the approval and
-    // elevate nothing — needs a third `status` on the ack, and the ack's
-    // version is the one the approver's request named, so a maintainer cannot
-    // reach for a newer minor on its own. See the PR for the follow-up.
     //
     // Marking a preview that is no longer there is not an error. An approval
     // can arrive after its preview expired or was consumed; the disclosure it
@@ -476,6 +463,31 @@ pub(super) async fn handle_approve_response(
                     },
                 );
             }
+        }
+
+        // 7b. And, if the approver asked in 0.3, it elevates NOTHING.
+        //
+        // This is the whole reason 0.3 exists. An approval taken to disclose a
+        // card number is not a reason to raise the session's assurance for
+        // everything else it can reach, and #1304 could only elevate anyway
+        // because 0.2's acknowledgement has exactly two statuses: `elevated`
+        // was untrue and `rejected` was worse, since the approval *had* been
+        // applied.
+        //
+        // The version is read from the REQUEST, not chosen. A response's type
+        // is the request's type plus `#response`, so an approver that minted
+        // 0.2 must be answered in 0.2 — and 0.2 still has no word for this. So
+        // a 0.1/0.2 bound approval falls through and elevates, exactly as
+        // before; only a 0.3 one gets the honest answer. That is the cutover,
+        // and it moves per approver rather than per deployment.
+        if doc.type_uri.to_string() == uris::TASK_AUTH_STEP_UP_APPROVE_RESPONSE_0_3 {
+            audit!(
+                "auth.step_up.recorded",
+                actor = &pending.subject,
+                resource = preview_id,
+                outcome = "success"
+            );
+            return success_response(&doc, json!({ "status": "recorded", "boundTo": preview_id }));
         }
     }
 

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -1698,6 +1698,7 @@ async fn a_correlation_finding_names_where_the_shared_value_went() {
 // ---------------------------------------------------------------------------
 
 const APPROVE_RESPONSE: &str = "https://trusttasks.org/spec/auth/step-up/approve-response/0.2";
+const APPROVE_RESPONSE_0_3: &str = "https://trusttasks.org/spec/auth/step-up/approve-response/0.3";
 
 /// Build the face, bind it, preview it, and return `(scoped token, previewId)`.
 ///
@@ -2352,4 +2353,155 @@ async fn the_registry_is_readable_by_scoped_and_unscoped_callers_alike() {
             "{tag} got an empty table: {body}"
         );
     }
+}
+
+/// A 0.3 bound approval authorises the disclosure and elevates **nothing**.
+///
+/// This is what `auth/step-up/approve-response/0.3` was added for, and the
+/// close of #1304's one stated compromise. The two halves both matter:
+///
+/// - the disclosure goes through, so the approval was really applied;
+/// - the session stays at `aal1`, so an approval taken to release a card
+///   number buys nothing else in the assurance window.
+#[tokio::test]
+async fn a_bound_approval_asked_in_0_3_records_without_elevating() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let (scoped, preview_id) =
+        preview_a_face_holding(&router, &ctx, "rec", "payment.card", "4242424242424242").await;
+
+    let (_, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    let ar = payload_of(&body)["details"]["approveRequest"].clone();
+    let session_id = ar["payload"]["sessionId"]
+        .as_str()
+        .expect("sessionId")
+        .to_string();
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        APPROVE_RESPONSE_0_3,
+        json!({
+            "subject": holder_did(),
+            "sessionId": session_id,
+            "challenge": ar["payload"]["challenge"],
+            "decision": "approved",
+            "grantedAcr": "aal2",
+        }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "approve-response/0.3: {status} {body}"
+    );
+    let p = payload_of(&body);
+    assert_eq!(
+        p["status"], "recorded",
+        "a bound approval asked in 0.3 must be acknowledged `recorded`: {body}"
+    );
+    assert_eq!(p["boundTo"], preview_id, "{body}");
+    assert!(
+        p.get("session").is_none(),
+        "`recorded` changes no session, so a session snapshot would report an elevation that \
+         did not happen: {body}"
+    );
+
+    // The session is untouched — the half that closes the compromise.
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .expect("session still there");
+    assert_eq!(
+        stored.acr, "aal1",
+        "the approval elevated the session, so it buys more than the disclosure it was taken \
+         for: {stored:?}"
+    );
+
+    // And the approval it WAS taken for went through.
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "recorded, but the disclosure it authorised was still refused: {status} {body}"
+    );
+}
+
+/// A 0.2 approver still gets the old behaviour, and that is deliberate.
+///
+/// The cutover moves per approver, not per deployment: a response's type is the
+/// request's type plus `#response`, so an approver that minted 0.2 must be
+/// answered in 0.2 — which has no word for "applied, nothing elevated". Until
+/// that approver moves, elevating is the only honest thing left.
+///
+/// Asserted so the fallback is a decision rather than an accident: if this
+/// starts returning `recorded` to a 0.2 request, the response no longer
+/// validates against the version the approver asked in.
+#[tokio::test]
+async fn a_bound_approval_asked_in_0_2_still_elevates() {
+    let (router, ctx) = build_provisionable_test_app().await;
+    let (scoped, preview_id) =
+        preview_a_face_holding(&router, &ctx, "old", "payment.card", "4242424242424242").await;
+
+    let (_, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        PRESENT,
+        json!({ "contextId": CTX, "previewId": preview_id }),
+    )
+    .await;
+    let ar = payload_of(&body)["details"]["approveRequest"].clone();
+    let session_id = ar["payload"]["sessionId"]
+        .as_str()
+        .expect("sessionId")
+        .to_string();
+
+    let (status, body) = post_to(
+        &router,
+        &scoped,
+        &ctx.vta_did,
+        APPROVE_RESPONSE,
+        json!({
+            "subject": holder_did(),
+            "sessionId": session_id,
+            "challenge": ar["payload"]["challenge"],
+            "decision": "approved",
+            "grantedAcr": "aal2",
+        }),
+    )
+    .await;
+    assert!(
+        !refused(status, &body),
+        "approve-response/0.2: {status} {body}"
+    );
+    assert_eq!(
+        payload_of(&body)["status"],
+        "elevated",
+        "0.2 has no `recorded`, so answering with one would not validate against the version \
+         the approver asked in: {body}"
+    );
+
+    // "Each time" survives the elevation regardless — a second preview of the
+    // same face is still gated, because the gate reads the preview and never
+    // the session. That is asserted at length in
+    // `an_approval_does_not_carry_to_the_next_disclosure`; this is the version
+    // that still elevates, so it is worth knowing the property holds here too.
+    let stored = vti_common::auth::session::get_session(&ctx.sessions_ks, &session_id)
+        .await
+        .unwrap()
+        .expect("session still there");
+    assert_eq!(stored.acr, "aal2", "{stored:?}");
 }


### PR DESCRIPTION
**Closes the one compromise #1304 stated and could not avoid.**

That PR's own words: a `release: stepUp` approval marked the preview it was
bound to *and* raised the session's assurance, because 0.2's acknowledgement has
exactly two statuses — `elevated` was untrue and `rejected` was worse, since the
approval had in fact been applied. trust-tasks #391 added `recorded`. This
accepts 0.3 and answers with it.

A bound approval now marks its preview, returns `{status: "recorded", boundTo}`
with **no** `session` member, and elevates nothing.

## The version is read from the request, not chosen

A response document's `type` is the request's `type` plus `#response`, so an
approver that minted 0.2 must be answered in 0.2 — which still has no word for
this. A 0.1/0.2 bound approval therefore falls through and elevates exactly as
before.

Two consequences worth stating:

- **The cutover moves per approver, not per deployment.** Each approver stack
  gets the honest behaviour the moment it starts minting 0.3, independently.
- **The VTA had to accept 0.3 first.** An approver that moved before this landed
  would have had every step-up refused as `unsupportedType`. That ordering is
  now recorded on the SDK constant so the next person meets it before making the
  mistake.

## Both halves asserted

`a_bound_approval_asked_in_0_3_records_without_elevating`:
- the ack is `recorded`, `boundTo` names the preview, and there is **no**
  `session` member — a snapshot there would report an elevation that did not
  happen;
- the stored session is still `aal1`, which is the half that closes the
  compromise;
- and the disclosure it authorised goes through, so the approval was really
  applied rather than merely acknowledged.

`a_bound_approval_asked_in_0_2_still_elevates` pins the fallback as a decision
rather than an accident: if this ever answered `recorded` to a 0.2 request, the
response would not validate against the version the approver asked in — and the
response-conformance layer would catch it, as it caught the first attempt at
this in #1304.

## What is unchanged

"Each time" never depended on the elevation. The gate reads
`preview.approved_at` and never `acr`, which is why
`an_approval_does_not_carry_to_the_next_disclosure` passes on both paths — it
asserts a second disclosure is refused *while the session is at aal2*.

## Verified

- `persona_trust_task` 25/25 (2 new, alongside #1310's, which this rebases onto)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- Shares the `trust-tasks-rs 0.18.3 → 0.18.5` bump with #1315; whichever lands
  second needs no change

## What lands after this

The approver stacks can now mint 0.3 — the browser plugin's
`buildStepUpApproval` (currently pinned to 0.2) and `vta-mobile-core`. Only when
one of them does will a real flow stop elevating; until then this is capability
without effect, which is the correct order.

## Guide checklist (§9)

- [x] R1.2/R1.3/R1.4/R1.5/R1.6 — no client, lock, retry, loop or ack path touched
- [x] R2.1 — the preview mark happens before the response is returned, as before; the new branch removes a write rather than adding one
- [x] R3.* — new accepted version on the published schema; the response is validated by the conformance layer against the version the request named
- [x] R5.* — an unrecognised version is still refused; the 0.1/0.2 path is unchanged, so absence of 0.3 support anywhere downstream changes nothing
- [x] R6.* — the ack claims only what happened: `recorded` carries no session, and an audit row records the bound approval separately from an elevation
- [x] Deviations — none
