### PR TITLE
test(sdk): prove the TSP mediator-account pass against a real mediator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,73 +371,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.20.11"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c77b2b9f46bc72ecace00d2a72a36587406dccdfd0257377a7d0d6278314e3f"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-common",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-encoding",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-mediator-common",
- "affinidi-messaging-mediator-config",
- "affinidi-messaging-sdk 0.21.1",
- "affinidi-rate-limit",
- "affinidi-secrets-resolver",
- "affinidi-task-utils",
- "affinidi-tsp",
- "ahash",
- "async-convert",
- "async-trait",
- "axum",
- "axum-extra",
- "axum-server",
- "base64 0.23.1",
- "chrono",
- "clap",
- "dashmap",
- "didwebvh-rs",
- "futures-util",
- "governor",
- "hostname",
- "http 1.5.0",
- "humantime",
- "itertools 0.15.0",
- "jsonwebtoken 10.4.0",
- "metrics",
- "metrics-exporter-prometheus",
- "num-format",
- "rand 0.10.2",
- "redis",
- "regex",
- "reqwest",
- "ring",
- "rustls",
- "semver",
- "serde",
- "serde_json",
- "sha256",
- "subtle",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite 0.30.0",
- "tokio-util",
- "toml",
- "tower",
- "tower-http 0.7.1",
- "tracing",
- "tracing-subscriber",
- "trust-tasks-rs 0.18.5",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "affinidi-messaging-mediator"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10a383a317d43c624b34fbfd1659170101660574d90eb8697ea5d85e9438f4b"
+checksum = "be1185f26910648388327dea8997e3e62531b50c9a0dd9cd750a32c46d0f7c0f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -468,7 +404,7 @@ dependencies = [
  "http 1.5.0",
  "humantime",
  "itertools 0.15.0",
- "jsonwebtoken 10.4.0",
+ "jsonwebtoken 11.0.0",
  "metrics",
  "metrics-exporter-prometheus",
  "num-format",
@@ -499,20 +435,20 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.39"
+version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c600af26f03a3322fffc64e79413fb48ea2aa6c059f5245c7cc5d1365ceb0fc8"
+checksum = "f7a8d75667f60abd3a3cf57cada307744333187032cee74235daeff93f8471a0"
 dependencies = [
- "aes-gcm 0.10.3",
+ "aes-gcm 0.11.1",
  "ahash",
- "argon2 0.5.3",
+ "argon2",
  "async-trait",
  "axum",
  "base64 0.23.1",
  "futures-util",
  "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "humantime",
  "metrics",
  "num-format",
@@ -522,7 +458,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sha256",
  "thiserror 2.0.20",
  "tokio",
@@ -623,46 +559,18 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86145b4ea466c2bfdae0a0c104cbfa2a5b284f87e2b1bf18e64fc8ce0b30876"
+checksum = "07c5f50dfcde03a3b9ee6d7d4282e6fcf18700fc67e6324fca551d7583bb20dd"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-mediator 0.20.11",
- "affinidi-messaging-mediator-common",
- "affinidi-messaging-sdk 0.21.1",
- "affinidi-secrets-resolver",
- "affinidi-tdk 0.11.0",
- "async-trait",
- "jsonwebtoken 10.4.0",
- "ring",
- "rustls",
- "serde_json",
- "sha256",
- "thiserror 2.0.20",
- "tokio",
- "tokio-util",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "affinidi-messaging-test-mediator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0351d50c9bcb6ea460b390a55233ccfd7fd7b71bf1dcb9295b6adf97cc93e8"
-dependencies = [
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-mediator 0.21.0",
+ "affinidi-messaging-mediator",
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-sdk 0.22.0",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "async-trait",
- "jsonwebtoken 10.4.0",
  "ring",
  "rustls",
  "serde_json",
@@ -824,27 +732,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "affinidi-tdk"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abceec2e934dfffbc31924d970d650c972660125cd26fe7ecd14e4552713f43f"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-authentication",
- "affinidi-did-common",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-secrets-resolver",
- "affinidi-tdk-common",
- "clap",
- "rustls",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1109,18 +996,6 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
-dependencies = [
- "base64ct",
- "blake2 0.10.6",
- "cpufeatures 0.2.17",
- "password-hash 0.5.0",
-]
-
-[[package]]
-name = "argon2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
@@ -1128,7 +1003,7 @@ dependencies = [
  "base64ct",
  "blake2 0.11.0",
  "cpufeatures 0.3.1",
- "password-hash 0.6.1",
+ "password-hash",
 ]
 
 [[package]]
@@ -3512,7 +3387,7 @@ name = "didcomm-test"
 version = "0.6.9"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "clap",
  "ed25519-dalek 3.0.0",
  "hex",
@@ -5554,11 +5429,9 @@ dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
- "pem 3.0.6",
  "serde",
  "serde_json",
  "signature 2.2.0",
- "simple_asn1",
  "zeroize",
 ]
 
@@ -6944,17 +6817,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -8473,7 +8335,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -10405,7 +10267,7 @@ name = "vta-backup"
 version = "0.3.4"
 dependencies = [
  "aes-gcm 0.11.1",
- "argon2 0.6.0",
+ "argon2",
  "async-trait",
  "base64 0.23.1",
  "chrono",
@@ -10495,7 +10357,7 @@ version = "0.4.4"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "base64 0.23.1",
  "bip39",
  "chrono",
@@ -10630,7 +10492,7 @@ dependencies = [
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "affinidi-vc",
  "agent-names",
  "apple-native-keyring-store",
@@ -10690,17 +10552,17 @@ dependencies = [
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk 0.21.1",
- "affinidi-messaging-test-mediator 0.4.5",
+ "affinidi-messaging-test-mediator",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "affinidi-tdk-common",
  "agent-names",
- "argon2 0.6.0",
+ "argon2",
  "async-trait",
  "aws-lc-rs",
  "axum",
@@ -10892,7 +10754,7 @@ dependencies = [
 name = "vta-webvh"
 version = "0.2.5"
 dependencies = [
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "chrono",
  "ed25519-dalek 3.0.0",
  "reqwest",
@@ -10936,15 +10798,15 @@ dependencies = [
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-test-mediator 0.4.5",
+ "affinidi-messaging-test-mediator",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "affinidi-vc",
- "argon2 0.6.0",
+ "argon2",
  "async-trait",
  "axum",
  "axum-extra",
@@ -11020,7 +10882,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "async-trait",
  "axum",
  "axum-extra",
@@ -11066,9 +10928,9 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk 0.21.1",
- "affinidi-messaging-test-mediator 0.5.0",
+ "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "chrono",
  "ed25519-dalek 3.0.0",
  "multibase",
@@ -11115,7 +10977,7 @@ version = "0.1.2"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.12.0",
+ "affinidi-tdk",
  "async-trait",
  "base64 0.23.1",
  "chrono",

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -332,7 +332,7 @@ tempfile = { version = "3", optional = true }
 # A real dependency rather than a dev-dependency: `test-support` exists to serve
 # *external* consumers, and a dev-dependency would not be available to them.
 # `tsp` so the mediator routes raw-TSP frames, not just DIDComm.
-affinidi-messaging-test-mediator = { version = "0.4", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.5", optional = true, features = [
     "tsp",
 ] }
 libc = { workspace = true, optional = true }

--- a/vta-service/tests/tsp_mediator_account_acl.rs
+++ b/vta-service/tests/tsp_mediator_account_acl.rs
@@ -1,0 +1,224 @@
+//! The client's own mediator-account ACL, set over **TSP**, against a real
+//! mediator.
+//!
+//! This is the one thing the TSP account pass could never be tested on until
+//! now, and the reason it is worth a live mediator rather than a guard.
+//!
+//! The mediator's management dispatch used to be DIDComm-only: `MessageType::
+//! process` → `trust_tasks::process` was `#[cfg(feature = "didcomm")]` and took
+//! a DIDComm `Message`, so a TSP message addressed to the mediator was filed for
+//! pickup rather than answered. There was no packet a TSP-only client could send
+//! to open its own account. affinidi-tdk-rs#783 added the TSP wrapper (mediator
+//! 0.22.3) and VTI #1312 the client half.
+//!
+//! **Why a live mediator is the only honest check.** Both halves of that pair
+//! ship with source-level guards, and guards cannot see the thing that actually
+//! goes wrong here: a mediator without the TSP arm accepts the frame, files it
+//! as mail, and answers nothing. The send resolves `Ok` either way. Success and
+//! silent failure are identical from the client — which is exactly why the
+//! client is careful to log only what it *sent* — so the only way to know the
+//! ACL was applied is to ask the mediator.
+//!
+//! The fixture therefore starts from a **restrictive** `global_acl_default`, so
+//! a freshly authenticated account is genuinely closed. Against a mediator
+//! predating the TSP arm, this test fails on the post-condition rather than
+//! passing vacuously.
+
+#![cfg(feature = "transport-harness")]
+
+use affinidi_messaging_test_mediator::TestMediator;
+use affinidi_messaging_test_mediator::acl;
+
+/// The realistic restrictive default: an account that can connect and
+/// authenticate, but is **closed for forwarded delivery** until something opens
+/// it.
+///
+/// Not `acl::deny_all()`, which is the wrong shape for this test in an
+/// instructive way: it sets `local = false` and clears `NotBlocked`, so the
+/// client is refused at the websocket with a 403 and never authenticates. It
+/// would never reach the code under test — and a deployment configured that way
+/// has no clients at all, so it is not the case worth covering.
+///
+/// `receive_forwarded` off with everything else on *is* the case worth
+/// covering: the client connects, gets an account, and still cannot receive a
+/// forwarded reply until its `account/update` lands.
+fn closed_for_forwarded() -> affinidi_messaging_test_mediator::MediatorACLSet {
+    let mut acls = acl::allow_all();
+    // (value, self_change, admin). `self_change = true` is the whole point: a
+    // client opens its *own* account, so the flag has to be self-manageable.
+    // With `false` the mediator answers
+    // `e.p.authorization.acl.not_self_manageable` — correctly, and see
+    // `a_default_that_forbids_self_management_refuses_the_client` below, which
+    // pins that as behaviour rather than leaving it as a fixture footgun.
+    acls.set_receive_forwarded(false, true, true)
+        .expect("admin=true may always set this bit");
+    acls
+}
+
+/// Mint a fresh Ed25519 `did:key` and its base58btc-encoded seed.
+fn mint_did_key() -> (String, String) {
+    // `rand` rather than `getrandom` directly: this crate already carries it,
+    // and the key only has to be unique per test, not production-grade.
+    let seed: [u8; 32] = rand::random();
+    let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let did = format!(
+        "did:key:{}",
+        vta_sdk::did_key::ed25519_multibase_pubkey(&signing.verifying_key().to_bytes())
+    );
+    (did, multibase::encode(multibase::Base::Base58Btc, seed))
+}
+
+#[tokio::test]
+async fn a_tsp_client_opens_its_own_mediator_account() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "vta_sdk=debug".into()),
+        )
+        .with_test_writer()
+        .try_init();
+    affinidi_messaging_test_mediator::install_default_crypto_provider();
+
+    // The default every new account inherits. Closed for forwarded delivery,
+    // because a permissive default is indistinguishable from a successful
+    // update — the test would pass against a mediator that ignored the request.
+    let mediator = TestMediator::builder()
+        .global_acl_default(closed_for_forwarded())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+    let mediator_did = mediator.did().to_string();
+
+    let (client_did, client_key) = mint_did_key();
+
+    // Authenticating is what creates the account, carrying `global_acl_default`.
+    // It is also the rotation path's reachability probe, so this mirrors the
+    // real sequence rather than a contrived one.
+    let session = vta_sdk::session::TspPingSession::new(&client_did, &client_key, &mediator_did)
+        .await
+        .expect("client reaches the mediator over TSP");
+
+    // Pre-condition. If this is already open the assertion below proves nothing,
+    // so state it rather than assume it.
+    let before = mediator
+        .get_acl(&client_did)
+        .await
+        .expect("read ACL")
+        .expect("authenticating registers the account");
+    assert!(
+        !before.get_receive_forwarded().0,
+        "fixture is wrong: a new account must start closed for forwarded delivery, \
+         otherwise this test cannot distinguish a successful update from a mediator \
+         that ignored the request"
+    );
+
+    // The thing under test: one `messaging/account/update/0.1`, over TSP,
+    // addressed to the mediator itself.
+    session.provision_client_acl("tsp-acl-e2e").await;
+    session.shutdown().await;
+
+    let after = mediator
+        .get_acl(&client_did)
+        .await
+        .expect("read ACL")
+        .expect("account still registered");
+
+    assert!(
+        after.get_receive_forwarded().0,
+        "the mediator did not apply the ACL sent over TSP. On a mediator without the TSP \
+         management arm (< 0.22.3) the request is filed as mail and answered with nothing, \
+         which looks exactly like this — check the mediator version before the client."
+    );
+    assert!(
+        after.get_receive_messages().0,
+        "receive_messages must be open too — TSP delivery checks it via `delivery_decision`, \
+         so an account without it is refused before `receive_forwarded` is ever consulted"
+    );
+}
+
+/// The same DID, provisioned twice. The rotation path can retry, and a mediator
+/// that refused a repeat would turn a safe retry into a failure.
+#[tokio::test]
+async fn provisioning_the_same_account_twice_is_harmless() {
+    affinidi_messaging_test_mediator::install_default_crypto_provider();
+
+    let mediator = TestMediator::builder()
+        .global_acl_default(closed_for_forwarded())
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+    let mediator_did = mediator.did().to_string();
+    let (client_did, client_key) = mint_did_key();
+
+    for _ in 0..2 {
+        let session =
+            vta_sdk::session::TspPingSession::new(&client_did, &client_key, &mediator_did)
+                .await
+                .expect("client reaches the mediator over TSP");
+        session.provision_client_acl("tsp-acl-e2e").await;
+        session.shutdown().await;
+    }
+
+    let acls = mediator
+        .get_acl(&client_did)
+        .await
+        .expect("read ACL")
+        .expect("account registered");
+    assert!(
+        acls.get_receive_forwarded().0,
+        "a second pass must leave the account open, not revert it"
+    );
+}
+
+/// A `global_acl_default` that marks `receiveForwarded` **not self-manageable**
+/// refuses the client's own update — and the client carries on regardless.
+///
+/// Found by getting the fixture above wrong, and worth keeping for two reasons.
+///
+/// It is a real deployment shape: an operator who wants forwarded delivery
+/// granted only by an admin sets exactly this, and the effect is that
+/// self-provisioning silently does nothing. The account stays closed, so a
+/// rotated DID never receives a forwarded reply, and nothing in the client's
+/// output says why — it is a `debug` line on a best-effort path.
+///
+/// And it pins the *client's* half of that contract: refusing must stay
+/// non-fatal. This runs on the rotation path immediately before the key swap,
+/// so propagating the error would turn "your mediator has a strict default"
+/// into "your rotation failed", which is a much worse outcome than an account
+/// that opens later.
+#[tokio::test]
+async fn a_default_that_forbids_self_management_refuses_the_client() {
+    affinidi_messaging_test_mediator::install_default_crypto_provider();
+
+    let mut acls = acl::allow_all();
+    // Closed *and* admin-only — the difference from `closed_for_forwarded`.
+    acls.set_receive_forwarded(false, false, true)
+        .expect("admin=true may always set this bit");
+
+    let mediator = TestMediator::builder()
+        .global_acl_default(acls)
+        .spawn()
+        .await
+        .expect("spawn test mediator");
+    let mediator_did = mediator.did().to_string();
+    let (client_did, client_key) = mint_did_key();
+
+    let session = vta_sdk::session::TspPingSession::new(&client_did, &client_key, &mediator_did)
+        .await
+        .expect("client reaches the mediator over TSP");
+
+    // Must not panic, and must not propagate: the caller is mid-rotation.
+    session.provision_client_acl("tsp-acl-e2e").await;
+    session.shutdown().await;
+
+    let acls = mediator
+        .get_acl(&client_did)
+        .await
+        .expect("read ACL")
+        .expect("account registered");
+    assert!(
+        !acls.get_receive_forwarded().0,
+        "the mediator must refuse a self-update of a flag it marked admin-only — if this \
+         starts passing, the mediator has stopped enforcing `not_self_manageable`"
+    );
+}

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -221,7 +221,7 @@ affinidi-messaging-didcomm = "0.15"
 # mediator-side twin of the client-side failure this crate's TSP work is about.
 # Always on (not conditioned on this crate's `tsp`): the harness is test-only,
 # and a mediator that can route TSP is harmless to the DIDComm suite.
-affinidi-messaging-test-mediator = { version = "0.4", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.5", optional = true, features = [
     "tsp",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }


### PR DESCRIPTION
#1312 shipped the client half of the TSP mediator-account pass with **no end-to-end coverage**: the workspace's transitive test-mediator was pinned at 0.20.11, and the mediator's TSP management arm ships in 0.22.3 (affinidi-tdk-rs#783). Both halves of that pair were guarded only at the source level.

Guards cannot see what actually goes wrong here. A mediator without the TSP arm accepts the frame, files it as mail and answers nothing — and the send resolves `Ok` either way. Success and silent failure are **identical from the client**, which is exactly why the client is careful to log only what it *sent*. The only way to know the ACL was applied is to ask the mediator.

So this bumps the pin to `"0.5"` (mediator 0.20.11 → 0.22.3, no breakage) and asserts on `TestMediatorHandle::get_acl` after a real `messaging/account/update/0.1` goes over TSP.

## What the first run proved before it passed

It failed — with a `403`:

```
e.p.authorization.acl.not_self_manageable
"this account may not change `receiveForwarded`"
```

That is the mediator **receiving, parsing, dispatching and answering** a Trust Task over TSP. The plumbing was already right; the fixture was wrong. `set_receive_forwarded(false, false, true)` — the middle argument is `self_change`, so I had built an account forbidden from managing its own flag, and the mediator correctly refused it.

## Three tests

| Test | What it pins |
|---|---|
| `a_tsp_client_opens_its_own_mediator_account` | The account pass actually applies over TSP: closed before, open after, read from the mediator's own store |
| `provisioning_the_same_account_twice_is_harmless` | A repeat leaves the account open rather than reverting it — the rotation path can retry |
| `a_default_that_forbids_self_management_refuses_the_client` | The deployment shape the fixture mistake exposed (below) |

The fixture starts from a default that is **closed for forwarded delivery but still connectable**. `acl::deny_all()` is the wrong shape, and wrong instructively: it clears `local` and `NotBlocked`, so the client is refused at the websocket with a 403 and never reaches the code under test. A deployment configured that way has no clients at all, so it is not the case worth covering.

## The operational finding

The fixture mistake is a real deployment shape, so it is kept as a test rather than just fixed. **An operator who grants forwarded delivery admin-only makes client self-provisioning silently do nothing**: the account stays closed, a rotated DID never receives a forwarded reply, and the only trace is a `debug` line on a best-effort path.

That test also pins the client's half of the contract — refusal must stay **non-fatal**. This runs on the rotation path immediately before the key swap, so propagating the error would turn "your mediator has a strict default" into "your rotation failed", which is a far worse outcome than an account that opens later.

## Non-vacuity

Checked by downgrading the lock to mediator 0.21.0, which has no TSP management arm:

| Mediator | Result |
|---|---|
| 0.21.0 | both positive tests **fail**, with the diagnostic they carry (*"On a mediator without the TSP management arm (< 0.22.3) the request is filed as mail and answered with nothing"*) |
| 0.22.3 | all three pass |

One honest caveat: the third test also passes on 0.21.0. It asserts the ACL is *not* changed, which holds whether the mediator refused it or ignored it — inherent to a negative assertion. Its load-bearing part is the no-panic/no-propagate check, which is valid on both.

`cargo clippy`, `cargo fmt --all --check` and `cargo check --workspace --all-targets` are clean. No production code changes — this is the test and the dependency bump that makes it possible.
