### PR TITLE
fix(rooms): make the retention policy govern something

### DIFF
--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -655,6 +655,20 @@ async fn mint(
         Ok(a) => a,
         Err(e) => return from_app_error(doc, &e),
     };
+    // The room's policy governs whether it has a chain at all, so a rung for a room that
+    // does not chain is refused rather than dropped. Storing it would give the room a chain
+    // it declared it would not have; dropping it silently would let a client believe the
+    // room's history was being retained when it was not.
+    if req.link.is_some() && !room.retention_policy.links_epochs() {
+        return from_app_error(
+            doc,
+            &vti_common::error::AppError::Validation(format!(
+                "room `{}` does not keep an epoch key chain, so it accepts no epoch link",
+                req.room_id
+            )),
+        );
+    }
+
     // A rung that does not describe *this* advance is refused rather than stored beside it:
     // accepting a mismatched one would launder someone else's key material into this room's
     // history, and the members who walked the original would never see the difference.
@@ -1539,6 +1553,72 @@ mod tests {
         storage::create_room(&st.rooms, &room)
             .await
             .expect("register the room");
+    }
+
+    /// A room that does not chain refuses a rung, rather than storing one it said it would
+    /// not have.
+    ///
+    /// Written straight to the store because `FromJoin` is not reachable over the wire —
+    /// `rooms/create` has no member for it yet. That is the same reason this guard is worth
+    /// a test now: an unreachable branch is exactly the kind that rots, and the policy it
+    /// enforces was inert code until this test existed.
+    #[tokio::test]
+    async fn a_room_that_does_not_chain_refuses_an_epoch_link() {
+        let (_d, st) = state();
+        let app = router(st.clone());
+        let f = RoomFixture::new(Visibility::Attributed).await;
+
+        let room = Room {
+            retention_policy: vti_rooms::RetentionPolicy::FromJoin,
+            ..f.room.clone()
+        };
+        storage::create_room(&st.rooms, &room)
+            .await
+            .expect("register the room");
+
+        let (status, body) = call(
+            &app,
+            ROOMS_EPOCH_MINT_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "epoch": f.room.epoch + 1,
+                "presentation": f.as_owner(),
+                "link": {
+                    "epoch": f.room.epoch + 1,
+                    "wrapped": "9jK2_QhV1sVvR0m5xAqZ7A",
+                    "nonce": "b0Zt8Qm2Yq1sVvR0"
+                }
+            }),
+            &f.owner,
+        )
+        .await;
+
+        assert_ne!(status, StatusCode::OK, "a rung must be refused: {body}");
+        assert!(
+            body.to_string()
+                .contains("does not keep an epoch key chain"),
+            "expected a policy refusal, got: {body}"
+        );
+
+        // And the same mint without a rung is fine: the policy refuses the link, not the
+        // advance. A room that does not chain still advances its epochs.
+        let (status, body) = call(
+            &app,
+            ROOMS_EPOCH_MINT_TYPE,
+            serde_json::json!({
+                "roomId": f.room.room_id,
+                "epoch": f.room.epoch + 1,
+                "presentation": f.as_owner(),
+            }),
+            &f.owner,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(
+            body["epoch"].as_u64(),
+            Some(u64::from(f.room.epoch + 1)),
+            "an unlinked advance must still work: {body}"
+        );
     }
 
     fn days_ago(n: u64) -> Option<u64> {

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -493,6 +493,20 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
         Err(e) => return app_error_to_reject(&doc, &e),
     };
 
+    // The room's policy governs whether it has a chain at all, so a rung for a room that
+    // does not chain is refused rather than dropped. Storing it would give the room a chain
+    // it declared it would not have; dropping it silently would let a client believe the
+    // room's history was being retained when it was not.
+    if req.link.is_some() && !room.retention_policy.links_epochs() {
+        return app_error_to_reject(
+            &doc,
+            &vti_common::error::AppError::Validation(format!(
+                "room `{}` does not keep an epoch key chain, so it accepts no epoch link",
+                req.room_id
+            )),
+        );
+    }
+
     // The rung, before the advance. A link that does not describe *this* advance is refused
     // outright rather than stored beside it: a host that accepted a mismatched one would be
     // laundering someone else's key material into this room's history, and the members who

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -110,6 +110,14 @@ pub enum RetentionPolicy {
     /// What a **library** wants: joining a room means being able to read it. The cost is
     /// post-compromise security for record content — a compromised current key reaches every
     /// retained epoch.
+    ///
+    /// **The default on deserialisation**, which is a statement about what a room will *do*
+    /// rather than what it already *has*. A room stored before the chain existed holds no
+    /// rungs, and nothing can give it any for the epochs it has already left behind — but it
+    /// can chain from here, and since this policy is immutable, defaulting it the other way
+    /// would condemn it to keep losing its history at every membership change. Its
+    /// unreachable early epochs are a fact about its past, not a policy about its future.
+    #[default]
     Chained,
 
     /// A member reads only from the epoch their group state is at. No links are produced,
@@ -124,15 +132,21 @@ pub enum RetentionPolicy {
     /// because a key they have read is a key they have. What this policy withholds is the
     /// means to derive one again — after a restart, on another device, or on joining.
     ///
-    /// The default on deserialisation, because it is what a room stored before the chain
-    /// existed actually has: no links. New rooms are created [`Chained`](Self::Chained)
-    /// unless they ask otherwise.
-    #[default]
+    /// Never reached by deserialisation, and not yet reachable over the wire: choosing it
+    /// needs a member on `rooms/create`, which is a spec change. It exists so that
+    /// [`links_epochs`](Self::links_epochs) has something to mean, and so a host that is one
+    /// day told a room does not chain refuses rungs for it rather than storing them anyway.
     FromJoin,
 }
 
 impl RetentionPolicy {
-    /// Whether a commit under this policy must produce a link.
+    /// Whether a commit under this policy produces a link, and therefore whether a host
+    /// **may store one**.
+    ///
+    /// A host that ignored this would give a room a chain it declared it would not have, and
+    /// its members would be able to read history the room told them they could not. Silently
+    /// — which is why the hosts refuse a rung here rather than dropping it: a client whose
+    /// configuration disagrees with the room should be told, not quietly accommodated.
     pub fn links_epochs(&self) -> bool {
         matches!(self, RetentionPolicy::Chained)
     }
@@ -396,5 +410,46 @@ impl Record {
             }
         }
         serde_json::Value::Object(map)
+    }
+}
+
+#[cfg(test)]
+mod retention_policy_tests {
+    use super::*;
+
+    /// The default is a statement about what a room will *do*, not what it already has.
+    ///
+    /// A room stored before the chain existed deserialises here. Defaulting it to
+    /// `FromJoin` — which an earlier version of this enum did — would have been the more
+    /// literal description of its contents and the wrong policy: the choice is immutable,
+    /// so it would have condemned every pre-chain room to keep losing its history at every
+    /// membership change, which is the defect the chain exists to fix.
+    #[test]
+    fn a_room_stored_before_the_chain_existed_chains_from_here() {
+        let json = r#"{
+            "roomId": "did:webvh:example.com:rooms:legacy",
+            "ownerDid": "did:key:zOwner",
+            "visibility": "attributed",
+            "epoch": 4,
+            "nextVersion": 9,
+            "retentionDays": 90,
+            "createdAt": 0,
+            "updatedAt": 0
+        }"#;
+        let room: Room = serde_json::from_str(json).expect("a pre-chain room deserialises");
+        assert_eq!(room.retention_policy, RetentionPolicy::Chained);
+        assert!(
+            room.retention_policy.links_epochs(),
+            "a legacy room must be able to chain from here, whatever it lost before"
+        );
+    }
+
+    /// The method exists so a host can refuse a rung for a room that does not chain. If this
+    /// ever stops being consulted, the policy is documentation and the hosts store rungs for
+    /// rooms that declared they would have none.
+    #[test]
+    fn only_a_chained_room_accepts_rungs() {
+        assert!(RetentionPolicy::Chained.links_epochs());
+        assert!(!RetentionPolicy::FromJoin.links_epochs());
     }
 }


### PR DESCRIPTION
`RetentionPolicy` shipped in #1300 as **a field that was set and never read**, and `links_epochs()` was defined and never called. A room declared `FromJoin` would have had rungs stored for it anyway — the policy was documentation, not behaviour.

Same class as the `rematerialise`-called-from-nowhere defect the persona work turned up. `pub` methods don't trip dead-code warnings, so nothing said so.

## The default was also wrong

It defaulted to `FromJoin`, on the reasoning that a room stored before the chain existed "actually has no links". **That confuses what a room *has* with what it will *do*.**

A pre-chain room holds no rungs, and never can for the epochs it has already left behind. But it can chain from here — and because this policy is **immutable**, defaulting it the other way would have condemned every legacy room to keep losing its history at every membership change. Which is precisely the defect the chain exists to fix.

So the default is `Chained`. A legacy room's unreachable early epochs are a fact about its past, not a policy about its future.

## Enforced, not dropped

Both hosts now **refuse** a rung for a room that does not chain:

- Storing it would give the room a chain it declared it would not have, and its members could read history the room told them they could not.
- Discarding it silently would let a client believe history was being retained when it was not.

A client whose configuration disagrees with the room should be told, not quietly accommodated.

## Why test an unreachable branch

`FromJoin` is not reachable over the wire — `rooms/create` has no member for it until that spec lands. That is exactly why the guard is worth a test *now*: an unreachable branch is the kind that rots, and this one was inert code until the test existed.

The room-host test writes the room straight to the store, the same technique its succession tests use for states no handler can produce. It asserts both halves:

- a rung is refused, naming the policy
- **the advance itself still succeeds** — the policy refuses the link, not the epoch

## Verification

- `cargo test -p vti-rooms --all-features` — 94 pass (2 new)
- `cargo test -p room-host --all-features` — 23 pass (1 new)
- `cargo test -p vtc-service --lib` — 956 pass
- `cargo test --workspace --all-features --no-run` — every test target compiles, which is the check that caught three separate `AppState` literals in #1314 one run at a time
- `cargo clippy --workspace --all-features --all-targets` — clean
