### PR TITLE
docs(persona): say "attribute" on screen, not "fact"

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -214,11 +214,11 @@ pub(crate) enum Commands {
         command: CredVaultCommands,
     },
 
-    /// Your own identity — the facts you hold about yourself, the faces that
+    /// Your own identity — the attributes you hold about yourself, the faces that
     /// show a set of them together, which face each persona wears where, and
     /// what other people have told you.
     ///
-    /// Your facts and your faces sit ABOVE every trust context. Reaching them
+    /// Your attributes and your faces sit ABOVE every trust context. Reaching them
     /// needs an agent credential with no context restriction, or one granted
     /// `persona-holder`. Wearing, contacts and what leaves are context-scoped
     /// and take `--context`.
@@ -3125,7 +3125,7 @@ pub(crate) enum ProofRungOpt {
 /// `pnm persona …` — the holder's own identity.
 #[derive(Subcommand)]
 pub(crate) enum PersonaCommands {
-    /// Your facts — what you hold about yourself, each held once.
+    /// Your attributes — what you say about yourself, each held once.
     ///
     /// Sits above every context, so it needs an agent credential with no
     /// context restriction, or one granted `persona-holder`. A context admin
@@ -3134,8 +3134,8 @@ pub(crate) enum PersonaCommands {
         #[command(subcommand)]
         command: PersonaAttributeCommands,
     },
-    /// Faces — the sets of facts you show together. Same authority as your
-    /// facts: above every context.
+    /// Faces — the sets of attributes you show together. Same authority as your
+    /// attributes: above every context.
     Profile {
         #[command(subcommand)]
         command: PersonaProfileCommands,
@@ -3156,19 +3156,19 @@ pub(crate) enum PersonaCommands {
         command: PersonaDisclosureCommands,
     },
     /// Faces and wearing that live INSIDE one context, built only from values
-    /// typed there — they cannot reach your facts.
+    /// typed there — they cannot reach your attributes.
     Local {
         #[command(subcommand)]
         command: PersonaLocalCommands,
     },
-    /// Report how linkable a value, a fact or a face would make you — "same
+    /// Report how linkable a value, an attribute or a face would make you — "same
     /// person to anyone who sees both". Reads only; writes nothing.
     ///
     /// Note the inversion: a credential shown WHOLE links you more than a value
     /// you simply said, because the issuer's signature is identical everywhere
     /// it goes — while a derived proof links you less.
     Correlate {
-        /// Analyse one fact you hold.
+        /// Analyse one attribute you hold.
         #[arg(long = "attribute-id")]
         attribute_id: Option<String>,
         /// Analyse a whole face.
@@ -3180,7 +3180,7 @@ pub(crate) enum PersonaCommands {
         candidate_file: Option<String>,
     },
     /// List the output formats this VTA can produce, and what each DISCARDS.
-    /// Worth running before a preview: one that drops where a fact came from
+    /// Worth running before a preview: one that drops where an attribute came from
     /// turns "my employer attested this" into something you merely said.
     ///
     /// Open to any authenticated caller — it names nothing about you, and a
@@ -3191,7 +3191,7 @@ pub(crate) enum PersonaCommands {
 /// `pnm persona attribute …`
 #[derive(Subcommand)]
 pub(crate) enum PersonaAttributeCommands {
-    /// Store one fact about the holder. Omit `--attribute-id` to create.
+    /// Store one attribute about the holder. Omit `--attribute-id` to create.
     Put {
         /// Vocabulary token naming what this is — `name.legal`,
         /// `phone.mobile`, `address.postal`. Dotted, most-general first;

--- a/vta-cli-common/src/commands/persona.rs
+++ b/vta-cli-common/src/commands/persona.rs
@@ -8,9 +8,9 @@
 //! URI it sends and from every script already written against it.
 //!
 //! What an operator *reads* uses the words a person would
-//! (`design-docs/persona-vocabulary.md`): an attribute is a **fact**, a profile
-//! is a **face** — the set of facts you show together — and a persona **wears**
-//! a face in a context. So `persona profile list` prints `Faces:` above JSON
+//! (`design-docs/persona-vocabulary.md`): an attribute stays an **attribute**, a
+//! profile is a **face** — the set of attributes you show together — and a
+//! persona **wears** a face in a context. So `persona profile list` prints `Faces:` above JSON
 //! whose members are `profileId`. That pairing is deliberate: it is where an
 //! operator learns the mapping, once, in the one place both halves are on
 //! screen together.
@@ -59,7 +59,7 @@ fn print_result(label: &str, value: &Value) -> CmdResult {
 // The pool
 // ---------------------------------------------------------------------------
 
-/// `persona attribute put` — store one fact about the holder.
+/// `persona attribute put` — store one attribute about the holder.
 #[allow(clippy::too_many_arguments)]
 pub async fn cmd_attribute_put(
     client: &VtaClient,
@@ -82,7 +82,7 @@ pub async fn cmd_attribute_put(
             expected_version,
         )
         .await?;
-    print_result("Fact:", &result)
+    print_result("Attribute:", &result)
 }
 
 /// `persona attribute list` — enumerate the pool.
@@ -116,7 +116,7 @@ pub async fn cmd_attribute_list(
     if !is_json_output() {
         // Said only where it is true, and said once. The agent withholds a
         // sensitive value without saying so in the response — the row comes
-        // back with no `value`, which reads exactly like a fact that never had
+        // back with no `value`, which reads exactly like an attribute that never had
         // one — so the person is told here or not at all.
         if !include_values {
             println!("{DIM}Names only — add --values to include the values themselves.{RESET}");
@@ -127,7 +127,7 @@ pub async fn cmd_attribute_list(
             );
         }
     }
-    print_result("Your facts:", &result)
+    print_result("Your attributes:", &result)
 }
 
 /// `persona attribute delete` — remove one attribute.
@@ -179,7 +179,7 @@ pub async fn cmd_profile_get(client: &VtaClient, profile_id: String, resolve: bo
     let result = client.persona_profile_get(&profile_id, resolve).await?;
     if !is_json_output() && !resolve {
         println!(
-            "{DIM}Showing how the face is built — add --resolve to see the facts it would \
+            "{DIM}Showing how the face is built — add --resolve to see the attributes it would \
              show.{RESET}"
         );
     }
@@ -246,7 +246,7 @@ pub async fn cmd_binding_set(
         } else {
             println!(
                 "{DIM}A context only ever gets a copy: the face's values were written into \
-                 {context_id}. Editing a fact refreshes it; copies go down, and nothing reads \
+                 {context_id}. Editing an attribute refreshes it; copies go down, and nothing reads \
                  up.{RESET}"
             );
         }
@@ -469,7 +469,7 @@ fn render_preview(result: &Value, context_id: &str, verifier_did: &str, purpose:
 
     println!();
     if claims.is_empty() {
-        println!("  {DIM}No facts would leave.{RESET}");
+        println!("  {DIM}No attributes would leave.{RESET}");
     }
     for claim in claims {
         let ty = claim.get("type").and_then(Value::as_str).unwrap_or("?");

--- a/vta-persona/src/correlation.rs
+++ b/vta-persona/src/correlation.rs
@@ -37,7 +37,7 @@ type HmacSha256 = Hmac<Sha256>;
 /// Canonicalisation is JSON with sorted object members, so that two values a
 /// holder would consider identical hash identically regardless of how a producer
 /// happened to serialise them. Without it, `{"a":1,"b":2}` and `{"b":2,"a":1}`
-/// would be two different facts and the guard would miss the reuse it exists to
+/// would be two different attributes and the guard would miss the reuse it exists to
 /// catch.
 #[must_use]
 pub fn blind(agent_key: &[u8; 32], value: &serde_json::Value) -> String {
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn member_order_does_not_change_the_blinded_key() {
-        // Two serialisations of the same fact must hash identically, or the
+        // Two serialisations of the same attribute must hash identically, or the
         // guard misses the reuse it exists to catch.
         let a: serde_json::Value = serde_json::from_str(r#"{"a":1,"b":2}"#).unwrap();
         let b: serde_json::Value = serde_json::from_str(r#"{"b":2,"a":1}"#).unwrap();
@@ -260,7 +260,7 @@ pub struct Finding {
     /// holder learns to dismiss.
     ///
     /// Carries the count of other attributes holding the value, which is the
-    /// one fact [`Finding::shared_with`] does not restate: that list is keyed
+    /// one thing [`Finding::shared_with`] does not restate: that list is keyed
     /// on the *profiles and bindings* the value reaches, and two attributes
     /// referenced by one profile collapse to a single entry there.
     pub why: String,

--- a/vta-persona/src/disclosure.rs
+++ b/vta-persona/src/disclosure.rs
@@ -19,7 +19,7 @@
 //!
 //! Putting the pool above the context boundary bought a correlation check that
 //! can see across contexts. The cost is that a holder can no longer tell, by
-//! looking at one context, where a fact has gone. Filtering by claim type
+//! looking at one context, where an attribute has gone. Filtering by claim type
 //! settles that — *where has my home address reached* — and it is why this is a
 //! queryable record rather than an audit log line.
 
@@ -154,7 +154,7 @@ impl PersonaStore {
     /// Which contexts a claim type has reached.
     ///
     /// The specific question the agent-scoped pool owes the holder: having put
-    /// their facts above the context boundary, it must be able to say where
+    /// their attributes above the context boundary, it must be able to say where
     /// each one has gone.
     pub async fn contexts_reached_by(&self, claim_type: &str) -> Result<Vec<String>, AppError> {
         let mut contexts: Vec<String> = self
@@ -246,7 +246,7 @@ mod tests {
     #[tokio::test]
     async fn history_answers_where_a_fact_has_reached() {
         // The debt the scope split incurred: with the pool above the boundary,
-        // a holder cannot tell from one context where a fact has gone.
+        // a holder cannot tell from one context where an attribute has gone.
         let (_d, s) = fresh().await;
         s.record_disclosure(new_disclosure(
             "ctx-work",

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -2,7 +2,7 @@
 //!
 //! Two scopes, and the split is a security control rather than a filing
 //! decision. The **attribute pool and profiles are agent-scoped** — one person,
-//! one set of facts about themselves, above every trust context — so that the
+//! one set of attributes about themselves, above every trust context — so that the
 //! correlation index can see the risk it most needs to report: the same value
 //! presented by two personas in two different contexts, which a per-context
 //! index cannot see by construction. **Bindings, contacts and disclosure
@@ -160,10 +160,10 @@ pub enum StaleReason {
     NotFound,
 }
 
-/// One atomic fact a holder keeps about themselves. **Agent-scoped.**
+/// One atomic attribute a holder keeps about themselves. **Agent-scoped.**
 ///
 /// Several attributes may share a `type` — three phone numbers, a legal name and
-/// a preferred name — which is why `attribute_id` is the identity of a fact and
+/// a preferred name — which is why `attribute_id` is the identity of an attribute and
 /// `type` is not.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -259,7 +259,7 @@ pub enum ProfileEntry {
         #[serde(rename = "pinVersion")]
         pin_version: Version,
     },
-    /// The same fact, a different value here.
+    /// The same attribute, a different value here.
     ///
     /// Replaces value and label **only**: type, valueType and provenance are
     /// inherited. Letting an override replace provenance would let a

--- a/vta-persona/src/profile.rs
+++ b/vta-persona/src/profile.rs
@@ -2,7 +2,7 @@
 //! delete able to name what it would break.
 //!
 //! A profile **references** attributes rather than copying them, which is the
-//! property that lets a holder change a fact once. The cost is that the store
+//! property that lets a holder change an attribute once. The cost is that the store
 //! has to know who refers to what — hence the reverse index, written here and
 //! read by [`crate::PersonaStore::referring_profiles`].
 //!
@@ -247,7 +247,7 @@ impl PersonaStore {
     /// Remove a profile, dropping its reverse-index edges.
     ///
     /// The pool is untouched: a profile references rather than owns, so
-    /// deleting a composition destroys no facts. That is the asymmetry with
+    /// deleting a composition destroys no attributes. That is the asymmetry with
     /// deleting an attribute, where removal *does* change what compositions
     /// present.
     pub async fn delete_profile(&self, profile_id: &str) -> Result<bool, AppError> {
@@ -500,7 +500,7 @@ mod tests {
     #[tokio::test]
     async fn deleting_a_profile_leaves_the_pool_alone() {
         // The asymmetry with attribute deletion: a profile references rather
-        // than owns, so removing one destroys no facts.
+        // than owns, so removing one destroys no attributes.
         let (_d, s) = fresh().await;
         let a = attr("keep me");
         s.put(a.clone(), None).await.unwrap();
@@ -515,7 +515,7 @@ mod tests {
         assert!(s.delete_profile(&p.profile_id).await.unwrap());
         assert!(
             s.get(&a.attribute_id).await.unwrap().is_some(),
-            "the fact survives"
+            "the attribute survives"
         );
         assert!(
             s.referring_profiles(&a.attribute_id)

--- a/vta-persona/src/store.rs
+++ b/vta-persona/src/store.rs
@@ -281,7 +281,7 @@ impl PersonaStore {
     /// Remove one attribute, leaving a tombstone.
     ///
     /// Refuses while a profile refers to it unless `cascade`. Profiles reference
-    /// rather than copy, so removing a fact changes what every referring profile
+    /// rather than copy, so removing an attribute changes what every referring profile
     /// presents — and doing that silently is the surprise this store exists to
     /// prevent.
     ///
@@ -359,7 +359,7 @@ impl PersonaStore {
     ///
     /// A value withheld for sensitivity leaves its **row** in place: type,
     /// label, provenance, version and staleness all come back. This is
-    /// withholding a value, not hiding a fact — a holder listing their pool
+    /// withholding a value, not hiding an attribute — a holder listing their pool
     /// must still see that the card is there, or the control teaches them their
     /// own store has lost something.
     ///
@@ -849,7 +849,7 @@ mod list_tests {
         );
     }
 
-    /// Withholding a value is not hiding a fact. The row and everything about
+    /// Withholding a value is not hiding an attribute. The row and everything about
     /// it still come back, or a holder listing their own pool would conclude
     /// the store had lost the card.
     #[tokio::test]

--- a/vta-sdk/src/protocols/persona.rs
+++ b/vta-sdk/src/protocols/persona.rs
@@ -496,7 +496,7 @@ pub struct ContactClaim {
 ///
 /// Stored as received. The holder does not merge it into their own pool, and
 /// that separation is the point: a contact is somebody else's account of
-/// themselves, not a fact the holder is asserting.
+/// themselves, not an attribute the holder is asserting.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContactDocument {

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -363,7 +363,7 @@ async fn audit_persona(
 /// Matched rather than serialised because only the tag is wanted: serialising
 /// a `CredentialBacked` provenance would carry `credentialId`, `claimPath` and
 /// `issuerDid` into the audit row alongside it, and a claim path is a
-/// description of what an issuer attested about the holder — a fact with the
+/// description of what an issuer attested about the holder — an attribute with the
 /// same lifetime problem as the value itself.
 fn provenance_kind(p: &vta_persona::Provenance) -> &'static str {
     match p {

--- a/vta-service/src/trust_tasks/step_up.rs
+++ b/vta-service/src/trust_tasks/step_up.rs
@@ -1091,8 +1091,8 @@ pub(super) async fn initiate_disclosure_step_up(
     let reason = format!(
         "Approve disclosing {} to {verifier_did}",
         match claim_types.len() {
-            1 => "1 fact".to_string(),
-            n => format!("{n} facts"),
+            1 => "1 attribute".to_string(),
+            n => format!("{n} attributes"),
         }
     );
     // The shape an approver's card already knows how to render:

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -1247,7 +1247,7 @@ async fn a_persona_write_is_audited_with_what_changed_and_not_the_value() {
     );
     assert!(
         detail.contains("phone.mobile"),
-        "the detail does not name the claim type — the one fact that makes the row \
+        "the detail does not name the claim type — the one thing that makes the row \
          legible without resolving the id: {detail}"
     );
     assert!(
@@ -1338,7 +1338,7 @@ async fn details_for(ctx: &TestAppContext, action: &str) -> Vec<String> {
         .collect()
 }
 
-/// `includeValues` moves the ordinary facts and leaves the card behind;
+/// `includeValues` moves the ordinary attributes and leaves the card behind;
 /// `includeSensitive` is what moves the card.
 ///
 /// Asserted at the wire, because that is the only place the claim is about the
@@ -1392,7 +1392,7 @@ async fn a_listing_withholds_sensitive_values_and_says_so_in_the_audit_trail() {
         !serde_json::to_string(&body).unwrap().contains(CARD),
         "the card number is somewhere else in the response: {body}"
     );
-    // The row is still there. This is withholding a value, not hiding a fact:
+    // The row is still there. This is withholding a value, not hiding an attribute:
     // a holder must not conclude their agent has lost the card.
     assert_eq!(
         listed(&body, "payment.card")
@@ -1439,7 +1439,7 @@ async fn a_listing_withholds_sensitive_values_and_says_so_in_the_audit_trail() {
     // Three listings, three rows, and no two of them alike. The three ways this
     // task can behave are the three the holder most needs told apart, and the
     // response carries nothing that would let a reviewer reconstruct which was
-    // which — a withheld value and a fact that never had one look identical on
+    // which — a withheld value and an attribute that never had one look identical on
     // the wire.
     let details = details_for(&ctx, "persona.attribute.list").await;
     assert_eq!(details.len(), 3, "one row per listing: {details:#?}");


### PR DESCRIPTION
`design-docs/persona-vocabulary.md` translated `attribute` to **fact** for everything a person reads. That was wrong in two independent ways.

**It asserts what the model cannot promise.** What a holder keeps in the pool is self-asserted until a credential backs it, and a face exists precisely so a person can choose what to show — an old value, a pinned version, a value overridden for one context, or a value that is simply not true. The step-up card said *"Approve disclosing 1 fact"* about exactly that.

**And the word was already spent.** `fact` is the VTC ceremony engine's term for a *verified* policy input (`vtc-service/src/ceremony/facts.rs`, `Facts` assembly, every `.rego`) — very nearly the opposite meaning, in the same product.

`detail` is the persona audit envelope's own field (`detail.reason`), `trait` is a keyword, `entry` names an entry in a face and `value` is the field inside an attribute — so the spec word comes to the screen instead and that row stops translating. **Truth is carried by the provenance beneath the value, never by the noun.**

## What changed

| Surface | Before | After |
|---|---|---|
| step-up approval card (`vta-service`) | `Approve disclosing 1 fact to …` | `Approve disclosing 1 attribute to …` |
| `pnm persona attribute list` | `Your facts:` | `Your attributes:` |
| `pnm persona attribute put` | `Fact:` | `Attribute:` |
| `pnm persona …` help | "the facts you hold about yourself" | "the attributes you hold about yourself" |
| `vta-persona` doc comments | define the model as "facts" | define it as attributes |

Commands, flags, task URIs and wire records are untouched — they always said `attribute`. **Nothing in `vtc-service/src/ceremony/` is touched**; that `Facts` is the other meaning and must stay.

Companion changes: `design-docs/persona-vocabulary.md` (the table, plus a new *Why not "fact"* section explaining why a friendlier synonym should not be reintroduced) and OpenVTC/vta-browser-plugin#191, which carries the same rename through the console and the step-up fixture.

## Verification

`cargo check` clean for vta-persona / vta-cli-common / pnm-cli / vta-sdk / vta-service; `vta-persona` 88 tests and `vta-service --test persona_trust_task` 23 tests pass.