### PR TITLE
feat(mobile): verify the consent prompt, not just the step-up one

### DIFF
--- a/vta-mobile-core/src/error.rs
+++ b/vta-mobile-core/src/error.rs
@@ -34,4 +34,17 @@ pub enum FfiError {
     /// logging `reason`).
     #[error("untrusted issuer: {reason}")]
     UntrustedIssuer { reason: String },
+
+    /// The request is authentic and from an enrolled issuer, but it is
+    /// addressed to a different approver. The device MUST NOT prompt.
+    ///
+    /// **Separate from [`FfiError::UntrustedIssuer`] on purpose.** Nothing is
+    /// wrong with the signature or the enrolment, so folding the two together
+    /// would send whoever reads the log to check an allowlist that is correct.
+    /// What failed is addressing: a document signed for one approver arriving
+    /// at another is either misrouting or a valid prompt being replayed
+    /// somewhere it can be answered by the wrong person, and the `recipient`
+    /// member exists to make that refusable.
+    #[error("addressed to {recipient}, not to this approver")]
+    NotForThisApprover { recipient: String },
 }

--- a/vta-mobile-core/src/task.rs
+++ b/vta-mobile-core/src/task.rs
@@ -1,16 +1,24 @@
 //! Trust Task parsing — wraps `trust-tasks-rs` generated types.
 //!
-//! Parses an inbound `auth/step-up/approve-request` (`0.1` or `0.2`) so the
-//! native app can show the user the reason and decide which evidence gate to
-//! satisfy. Before anything is surfaced, the request's own `eddsa-jcs-2022`
-//! Data Integrity proof is verified against the caller-supplied
-//! enrolled-executor allowlist ([`crate::proof::verify_signed_request`]) — an
-//! unverifiable request returns [`FfiError::UntrustedIssuer`] and the device
-//! MUST NOT prompt. The signed/passkey-backed `approve-response` builders live
-//! in [`crate::stepup`].
+//! Parses the two inbound documents a person is shown and asked to answer:
+//! `auth/step-up/approve-request` (`0.1` or `0.2`), so the native app can show
+//! the reason and decide which evidence gate to satisfy, and
+//! `consent/approve-request/0.1`, the prompt asking whether an agent may read
+//! or take part in one conversation.
+//!
+//! **Both go through the same gate, and that is the point of this module.**
+//! Before anything is surfaced, the document's own `eddsa-jcs-2022` Data
+//! Integrity proof is verified against the caller-supplied enrolled-executor
+//! allowlist ([`crate::proof::verify_signed_request`]) — an unverifiable
+//! request returns [`FfiError::UntrustedIssuer`] and the device MUST NOT
+//! prompt. Step-up had this from the start; the consent prompt did not, and
+//! for a while was neither signed by the VTA (#1177) nor checked here (#1323).
+//! The signed/passkey-backed `approve-response` builders live in
+//! [`crate::stepup`].
 
 use trust_tasks_rs::TrustTask;
 use trust_tasks_rs::specs::auth::step_up::approve_request::{v0_1, v0_2};
+use trust_tasks_rs::specs::consent::approve_request::v0_1 as consent_v0_1;
 
 use crate::error::FfiError;
 
@@ -139,6 +147,126 @@ pub async fn parse_step_up_request(
     })
 }
 
+/// Type URI of the consent prompt this approver renders.
+const CONSENT_REQUEST_0_1: &str = "https://trusttasks.org/spec/consent/approve-request/0.1";
+
+/// The fields of a `consent/approve-request` the native consent UI needs.
+///
+/// Every one of these comes out of the **verified** document. That is not a
+/// stylistic preference: the prompt asks a person to let an agent read a
+/// conversation, and a renderer that took the conversation's label from the
+/// raw JSON while taking the agent's DID from the verified copy would be
+/// showing a sentence that no single signer ever asserted.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct ConsentRequest {
+    /// The **proven** signer of the document's proof, guaranteed to be in the
+    /// caller's enrolled-executor allowlist.
+    pub issuer: String,
+    /// DID of the agent the decision is about. Consent is granted to one agent
+    /// rather than to the service hosting it, so this is the identity the
+    /// approver is deciding about and the one a later revocation names.
+    pub agent: String,
+    /// Messaging platform the conversation lives on, as the bridge names it.
+    pub platform: String,
+    /// The bridge's opaque handle for the conversation. Deliberately not a
+    /// phone number or a group link: it exists so a decision can be matched to
+    /// a conversation without the matching key being personal data.
+    pub conversation_ref: String,
+    /// `dm`, `group`, … — how the conversation is shaped.
+    pub kind: String,
+    /// What is being asked for: `receive` or `converse`.
+    pub scope: String,
+    /// Single-use value the approver's decision MUST echo. Without it a
+    /// decision is a free-floating assertion that cannot be shown to answer
+    /// *this* prompt rather than an earlier one.
+    pub challenge: String,
+    /// Human-readable label for the conversation — "Signal group 'Family'".
+    ///
+    /// **Chosen by the requesting party, so the native layer MUST treat it as
+    /// untrusted text**: escape it, bound its length, and never let it displace
+    /// `agent` / `platform` / `conversation_ref` as the basis of the decision.
+    /// It is here because `conversation_ref` is opaque by design, and an
+    /// approver asked to decide about an identifier that means nothing to them
+    /// will either always allow or always deny.
+    pub display_hint: Option<String>,
+    /// Digest of the message that prompted this request, when there is one, so
+    /// an approver deciding a `receive` scope can confirm a real message is
+    /// arriving. A digest rather than the content: showing the message in order
+    /// to ask would disclose the very thing the decision gates.
+    pub first_message_digest: Option<String>,
+}
+
+/// Verify and parse an inbound `consent/approve-request/0.1` document.
+///
+/// The sibling of [`parse_step_up_request`], and deliberately the same shape.
+/// `trusted_issuers` is the enrolled-executor allowlist the native layer holds;
+/// `approver` is this device's own approver identity.
+///
+/// Three refusals, in order, and each is a different fault:
+///
+/// 1. not a consent prompt → [`FfiError::Decode`];
+/// 2. no valid proof from an enrolled issuer → [`FfiError::UntrustedIssuer`],
+///    the spec's `untrusted_issuer` condition — **the device MUST NOT prompt**;
+/// 3. `recipient` is somebody else → [`FfiError::NotForThisApprover`]. An
+///    authentic prompt for another approver, arriving here, is misrouting or a
+///    replay aimed at whoever will tap first; the `recipient` member exists to
+///    be read, and until this function existed it was written and never read.
+///
+/// Async because verification resolves the issuer's DID for its key material,
+/// through the crate's shared resolver cache.
+#[uniffi::export(async_runtime = "tokio")]
+pub async fn parse_consent_request(
+    json: String,
+    trusted_issuers: Vec<String>,
+    approver: String,
+) -> Result<ConsentRequest, FfiError> {
+    let v: serde_json::Value = serde_json::from_str(&json).map_err(|e| FfiError::Decode {
+        reason: format!("not valid JSON: {e}"),
+    })?;
+
+    let type_uri = v.get("type").and_then(|t| t.as_str()).unwrap_or_default();
+    if type_uri != CONSENT_REQUEST_0_1 {
+        return Err(FfiError::Decode {
+            reason: "not a consent/approve-request/0.1 document".to_string(),
+        });
+    }
+
+    // The gate: no valid proof from an enrolled executor, no prompt.
+    let issuer = crate::proof::verify_signed_request(&v, &trusted_issuers).await?;
+
+    // Addressed here? Read after the proof rather than before it, so a
+    // document nobody signed is refused as unverifiable rather than as
+    // misaddressed — the more serious of the two, and the one whose `recipient`
+    // could say anything at all.
+    let recipient = v.get("recipient").and_then(|r| r.as_str()).ok_or_else(|| {
+        FfiError::NotForThisApprover {
+            recipient: "(absent)".to_string(),
+        }
+    })?;
+    if recipient != approver {
+        return Err(FfiError::NotForThisApprover {
+            recipient: recipient.to_string(),
+        });
+    }
+
+    let doc: TrustTask<consent_v0_1::Payload> =
+        serde_json::from_str(&json).map_err(|e| FfiError::Decode {
+            reason: format!("not a valid consent/approve-request document: {e}"),
+        })?;
+    let p = doc.payload;
+    Ok(ConsentRequest {
+        issuer,
+        agent: p.subject.agent.to_string(),
+        platform: p.subject.platform.to_string(),
+        conversation_ref: p.subject.conversation_ref.to_string(),
+        kind: p.subject.kind.to_string(),
+        scope: p.scope.to_string(),
+        challenge: p.challenge.to_string(),
+        display_hint: p.display_hint.map(|h| h.to_string()),
+        first_message_digest: p.first_message_digest.map(|d| d.to_string()),
+    })
+}
+
 /// Map the `0.2` camelCase evidence spelling onto the `0.1` form the native
 /// layers already switch on. `webauthn` is spelled identically in both.
 fn normalize_evidence(kind: String) -> String {
@@ -196,6 +324,114 @@ mod tests {
 
     fn enrolled() -> Vec<String> {
         vec![did_for(EXECUTOR)]
+    }
+
+    // ── consent/approve-request ────────────────────────────────────────────
+    //
+    // The same four questions the step-up cases ask, because the prompt is the
+    // same kind of thing: a person is shown a sentence and taps a button that
+    // grants an agent access to a conversation. Until #1323 the VTA signed this
+    // document and nothing here read the signature, so a prompt from anyone at
+    // all rendered identically to a real one.
+
+    /// This device's approver identity — what the VTA addresses a prompt to.
+    const APPROVER: &str = "did:web:alice.example";
+
+    /// Shaped as `vta-service`'s `consent.rs` builds it: the wire subject
+    /// (`platform` / `conversationRef` / `kind` / `agent`), the scope, the
+    /// challenge, and the two optional members.
+    const CONSENT_REQUEST: &str = r#"{
+      "id": "urn:uuid:5f0f6f1e-6f5a-4f2f-9a1e-8f2b6d2c0a11",
+      "type": "https://trusttasks.org/spec/consent/approve-request/0.1",
+      "issuer": "did:web:agent.example",
+      "recipient": "did:web:alice.example",
+      "issuedAt": "2026-09-08T12:00:00Z",
+      "payload": {
+        "subject": {
+          "platform": "signal",
+          "conversationRef": "conv-1",
+          "kind": "group",
+          "agent": "did:key:zAgent"
+        },
+        "scope": "receive",
+        "challenge": "Q29uc2VudENoYWxsZW5nZVhZ",
+        "displayHint": "Signal group 'Family'",
+        "firstMessageDigest": "zQmFakeDigest"
+      }
+    }"#;
+
+    #[tokio::test]
+    async fn a_signed_consent_prompt_from_an_enrolled_issuer_is_surfaced() {
+        let json = issued_by(CONSENT_REQUEST, EXECUTOR, Some(EXECUTOR)).await;
+        let r = parse_consent_request(json, enrolled(), APPROVER.to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            r.issuer,
+            did_for(EXECUTOR),
+            "the PROVEN signer, not the claimed one"
+        );
+        assert_eq!(r.agent, "did:key:zAgent");
+        assert_eq!(r.platform, "signal");
+        assert_eq!(r.conversation_ref, "conv-1");
+        assert_eq!(r.kind, "group");
+        assert_eq!(r.scope, "receive");
+        assert_eq!(r.challenge, "Q29uc2VudENoYWxsZW5nZVhZ");
+        assert_eq!(r.display_hint.as_deref(), Some("Signal group 'Family'"));
+        assert_eq!(r.first_message_digest.as_deref(), Some("zQmFakeDigest"));
+    }
+
+    #[tokio::test]
+    async fn an_unsigned_consent_prompt_is_refused() {
+        // #1177's document exactly: everything else in order, no proof. It
+        // reached a phone and rendered.
+        let json = issued_by(CONSENT_REQUEST, EXECUTOR, None).await;
+        let err = parse_consent_request(json, enrolled(), APPROVER.to_string())
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FfiError::UntrustedIssuer { .. }),
+            "an unsigned prompt must not reach a person: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_consent_prompt_from_an_unenrolled_issuer_is_refused() {
+        // Correctly signed, by someone this device has never enrolled. The
+        // signature proves who wrote it and says nothing about whether they may
+        // ask.
+        let json = issued_by(CONSENT_REQUEST, STRANGER, Some(STRANGER)).await;
+        let err = parse_consent_request(json, enrolled(), APPROVER.to_string())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FfiError::UntrustedIssuer { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_consent_prompt_addressed_to_another_approver_is_refused() {
+        // Authentic, enrolled, and not for this person. Refusing it is what
+        // stops a valid prompt being replayed wherever someone will tap first,
+        // and it is the only thing the `recipient` member was ever for.
+        let json = issued_by(CONSENT_REQUEST, EXECUTOR, Some(EXECUTOR)).await;
+        let err = parse_consent_request(json, enrolled(), "did:web:bob.example".to_string())
+            .await
+            .unwrap_err();
+        match err {
+            FfiError::NotForThisApprover { recipient } => assert_eq!(recipient, APPROVER),
+            other => panic!("expected a misaddressing refusal, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_step_up_request_is_not_a_consent_prompt() {
+        // The two parsers must not accept each other's documents: the fields a
+        // person is shown differ, and a step-up rendered as a consent card
+        // would ask about a conversation that is not what is being elevated.
+        let json = issued_by(PASSKEY_REQUEST, EXECUTOR, Some(EXECUTOR)).await;
+        let err = parse_consent_request(json, enrolled(), APPROVER.to_string())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FfiError::Decode { .. }), "{err:?}");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Closes #1323.

## A signature nobody verifies stops nothing

`vta-service` signs `consent/approve-request/0.1` before pushing it to an approver's phone (#1177), and #1322 keeps it that way. **The device never read it.** `vta-mobile-core` had exactly one parser, `parse_step_up_request`, whose gate is the point of the file:

```rust
// The gate: no valid proof from an enrolled executor, no prompt.
let relying_party = crate::proof::verify_signed_request(&v, &trusted_issuers).await?;
```

The consent prompt reached the native UI without it, so a document from anyone at all rendered identically to a real one, and the `recipient` binding that stops a prompt being answered by the wrong person was written and never read.

## `parse_consent_request`

Its sibling, and deliberately the same shape. Three refusals, in order, each a different fault:

| | condition | error |
| --- | --- | --- |
| 1 | not a consent prompt | `Decode` |
| 2 | no valid proof from an enrolled issuer | `UntrustedIssuer` — the spec's `untrusted_issuer` condition, the device MUST NOT prompt |
| 3 | `recipient` is somebody else | `NotForThisApprover` |

**The order is deliberate**: the proof is checked before the addressing, so an unsigned document is refused as unverifiable rather than as misaddressed — the more serious of the two, and the one whose `recipient` could say anything at all.

**Why the third is a new variant** rather than reusing `UntrustedIssuer`: nothing is wrong with the signature or the enrolment, so folding them together sends whoever reads the log to check an allowlist that is correct. What failed is addressing — a prompt signed for one approver arriving at another is misrouting, or a valid prompt replayed wherever someone will tap first.

## Everything shown comes out of the verified document

A renderer that took the conversation's label from the raw JSON while taking the agent's DID from the verified copy would be showing a sentence that no single signer ever asserted. So the whole `ConsentRequest` is built from the parsed document, and `issuer` is the **proven** signer rather than the claimed one.

`displayHint` is carried, because `conversationRef` is opaque by design and an approver asked to decide about a meaningless identifier will either always allow or always deny. It is documented at the FFI boundary as what it is: text chosen by the requesting party. Escape it, bound its length, and never let it displace the agent, platform and conversation reference as the basis of the decision.

The spec has been published since #1177 was written, so this parses through the generated `trust_tasks_rs::specs::consent::approve_request::v0_1` type rather than by hand, exactly as the step-up path does.

## Tests

Five, mirroring the step-up cases one for one:

- a signed prompt from an enrolled issuer surfaces every field, and `issuer` is the proven signer;
- an unsigned one — **#1177's document exactly** — is refused;
- a correctly-signed one from an issuer this device never enrolled is refused (the signature proves who wrote it and says nothing about whether they may ask);
- an authentic, enrolled prompt addressed to another approver is refused, with its recipient named;
- the two parsers do not accept each other's documents.

13 `task` tests pass; `cargo fmt --check` and `cargo clippy -p vta-mobile-core --all-targets` clean.

## For the iOS side

`FfiError` gains a variant, so an exhaustive `switch` over it in `vta-mobile-agent-ios` will need the new case. `NotForThisApprover` carries the recipient it was addressed to; treat it as "drop silently, log", the same disposition as `UntrustedIssuer` — in neither case may a prompt be shown.
