### PR TITLE
feat(vtc): an operator can see the rooms their community hosts

### DIFF
--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -3840,6 +3840,41 @@
         ]
       }
     },
+    "/v1/rooms": {
+      "get": {
+        "tags": [
+          "rooms"
+        ],
+        "summary": "`GET /v1/rooms` — every room this community hosts.",
+        "operationId": "list_rooms",
+        "responses": {
+          "200": {
+            "description": "Rooms hosted here",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HostedRoom"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "403": {
+            "description": "Caller is not an admin"
+          }
+        },
+        "security": [
+          {
+            "bearer_jwt": []
+          }
+        ]
+      }
+    },
     "/v1/schemas": {
       "get": {
         "tags": [
@@ -5842,6 +5877,77 @@
           "active",
           "degraded"
         ]
+      },
+      "HostedRoom": {
+        "type": "object",
+        "description": "One room, as its host can honestly describe it.",
+        "required": [
+          "roomId",
+          "ownerDid",
+          "visibility",
+          "retentionPolicy",
+          "epoch",
+          "lifecycle",
+          "retentionDays",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "createdAt": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "epoch": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "epochExpiresAt": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "When the current epoch expires. Absent means the room never lapses.",
+            "minimum": 0
+          },
+          "lifecycle": {
+            "type": "string",
+            "description": "Where the room sits on the lifecycle clock: `live`, `lapsed`, `dormant`\nor `reclaimable`. Computed, never stored — minting an epoch *is* the\nrenewal, so a stored state would be a second thing to keep true."
+          },
+          "mirrorOf": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present when this host serves a read-only copy rather than the room\nitself, naming the primary it pulls from."
+          },
+          "ownerDid": {
+            "type": "string",
+            "description": "The accountable party — visible at every tier, which is what makes the\nlifecycle notice deliverable."
+          },
+          "retentionDays": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "retentionPolicy": {
+            "type": "string",
+            "description": "Whether the room keeps its history readable across a membership change."
+          },
+          "roomId": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "visibility": {
+            "type": "string"
+          }
+        }
       },
       "ImportRequest": {
         "type": "object",

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -1473,6 +1473,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/rooms": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** `GET /v1/rooms` — every room this community hosts. */
+        get: operations["list_rooms"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/schemas": {
         parameters: {
             query?: never;
@@ -2601,6 +2618,42 @@ export interface components {
          * @enum {string}
          */
         HealthStatus: "active" | "degraded";
+        /** @description One room, as its host can honestly describe it. */
+        HostedRoom: {
+            /** Format: int64 */
+            createdAt: number;
+            /** Format: int32 */
+            epoch: number;
+            /**
+             * Format: int64
+             * @description When the current epoch expires. Absent means the room never lapses.
+             */
+            epochExpiresAt?: number | null;
+            /**
+             * @description Where the room sits on the lifecycle clock: `live`, `lapsed`, `dormant`
+             *     or `reclaimable`. Computed, never stored — minting an epoch *is* the
+             *     renewal, so a stored state would be a second thing to keep true.
+             */
+            lifecycle: string;
+            /**
+             * @description Present when this host serves a read-only copy rather than the room
+             *     itself, naming the primary it pulls from.
+             */
+            mirrorOf?: string | null;
+            /**
+             * @description The accountable party — visible at every tier, which is what makes the
+             *     lifecycle notice deliverable.
+             */
+            ownerDid: string;
+            /** Format: int32 */
+            retentionDays: number;
+            /** @description Whether the room keeps its history readable across a membership change. */
+            retentionPolicy: string;
+            roomId: string;
+            /** Format: int64 */
+            updatedAt: number;
+            visibility: string;
+        };
         /**
          * @description `POST /v1/admin/config/import` request — canonical
          *     `vtc/config/import/0.1`.
@@ -7997,6 +8050,40 @@ export interface operations {
             };
             /** @description Edge is already suspended, superseded or withdrawn */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_rooms: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Rooms hosted here */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HostedRoom"][];
+                };
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not an admin */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod policies;
 pub mod recognise;
 mod recognition_admin;
 pub(crate) mod relationships;
+pub(crate) mod rooms;
 mod schemas;
 pub(crate) mod status_lists;
 pub mod trust_tasks;
@@ -821,6 +822,14 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(policies::read::list_policies),
             "https://trusttasks.org/spec/policy/list/0.2",
         ))
+        // Plain REST, and deliberately not a Trust Task. Every `rooms/*` task is
+        // authorized by credentials the ROOM issued, against the room's own
+        // identifier — that is invariant I5, and it is what lets a room move
+        // hosts. This is the opposite question: what is this *operator* storing.
+        // It is answered from the host's own admin authority, so pairing it with
+        // a room task would be claiming a room governs an answer it has no view
+        // of.
+        .routes(routes!(rooms::list_rooms))
         .routes(tt(
             routes!(policies::admin::upload),
             "https://trusttasks.org/spec/policy/upsert/0.2",
@@ -1379,6 +1388,7 @@ mod openapi_tests {
             "/v1/community/profile",
             "/v1/join-requests",
             "/v1/policies",
+            "/v1/rooms",
             "/v1/credentials/endorsements",
             "/v1/endorsement-types",
             "/v1/schemas",

--- a/vtc-service/src/routes/rooms.rs
+++ b/vtc-service/src/routes/rooms.rs
@@ -1,0 +1,103 @@
+//! Operator read surface for the rooms this community hosts.
+//!
+//! # What an operator may see, and why it is not a contradiction
+//!
+//! A host cannot read a room's records and holds no member list — both by construction, and
+//! the rest of the rooms design exists to keep it that way. What it *does* hold about each
+//! room it stores is exactly what operating one requires: who is accountable for it, which
+//! tier it was created at, which epoch it is on, and where it sits on the lifecycle clock.
+//!
+//! Invariant I1 makes the owner visible at **every** tier, including `private`, for this
+//! reason: a room whose contents nobody here can read still has a party this operator must
+//! be able to reach about quota, abuse, and the reclamation notice §9 obliges them to send.
+//! An operator who cannot list their rooms cannot send it.
+//!
+//! So this returns the row and nothing derived from the room's contents. There is no
+//! endpoint here that returns records, and there is no member list to return.
+
+use axum::Json;
+use axum::extract::State;
+use serde::Serialize;
+use vti_common::error::AppError;
+
+use crate::auth::AdminAuth;
+use crate::server::AppState;
+
+/// One room, as its host can honestly describe it.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedRoom {
+    pub room_id: String,
+    /// The accountable party — visible at every tier, which is what makes the
+    /// lifecycle notice deliverable.
+    pub owner_did: String,
+    pub visibility: String,
+    /// Whether the room keeps its history readable across a membership change.
+    pub retention_policy: String,
+    pub epoch: u32,
+    /// Where the room sits on the lifecycle clock: `live`, `lapsed`, `dormant`
+    /// or `reclaimable`. Computed, never stored — minting an epoch *is* the
+    /// renewal, so a stored state would be a second thing to keep true.
+    pub lifecycle: String,
+    /// When the current epoch expires. Absent means the room never lapses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epoch_expires_at: Option<u64>,
+    pub retention_days: u32,
+    /// Present when this host serves a read-only copy rather than the room
+    /// itself, naming the primary it pulls from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirror_of: Option<String>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+/// `GET /v1/rooms` — every room this community hosts.
+#[utoipa::path(
+    get,
+    path = "/rooms",
+    tag = "rooms",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "Rooms hosted here", body = [HostedRoom]),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn list_rooms(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<HostedRoom>>, AppError> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let rooms = vti_rooms::storage::list_rooms(&state.rooms_ks).await?;
+    Ok(Json(
+        rooms
+            .into_iter()
+            .map(|r| HostedRoom {
+                lifecycle: r.lifecycle(now).as_str().to_string(),
+                room_id: r.room_id,
+                owner_did: r.owner_did,
+                visibility: match r.visibility {
+                    vti_rooms::Visibility::Open => "open",
+                    vti_rooms::Visibility::Attributed => "attributed",
+                    vti_rooms::Visibility::Private => "private",
+                }
+                .to_string(),
+                retention_policy: match r.retention_policy {
+                    vti_rooms::RetentionPolicy::Chained => "chained",
+                    vti_rooms::RetentionPolicy::FromJoin => "fromJoin",
+                }
+                .to_string(),
+                epoch: r.epoch,
+                epoch_expires_at: r.epoch_expires_at,
+                retention_days: r.retention_days,
+                mirror_of: r.mirror_of,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            })
+            .collect(),
+    ))
+}

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -424,6 +424,37 @@ pub async fn get_record(
         .map_err(|e| AppError::Internal(format!("decode record `{key}`: {e}")))
 }
 
+/// Every room this host holds, for its operator.
+///
+/// # Why a host may enumerate what it cannot read
+///
+/// A room's *contents* and *membership* are withheld from a host by construction. What it
+/// stores about the room itself — the owner, the tier, the epoch number, the lifecycle clock
+/// — it stores precisely so it can be operated: quota, abuse, and the reclamation notice
+/// §9 requires it to send. Invariant I1 makes the owner visible at **every** tier for this
+/// reason, so an operator listing their rooms learns nothing the design withheld.
+///
+/// What this deliberately cannot return is a member list, because no host has one.
+///
+/// # Not paginated, and that is a decision with a shelf life
+///
+/// A host's room count is bounded by what its operator agreed to store, not by anything a
+/// caller controls. If that stops being true this needs the cursor treatment
+/// [`list_records`] already has — the shape to copy is there.
+pub async fn list_rooms(rooms: &KeyspaceHandle) -> Result<Vec<Room>, AppError> {
+    let pairs = rooms.prefix_iter_raw(ROOMS_PREFIX.to_string()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+    for (k, v) in pairs {
+        let room: Room = serde_json::from_slice(&v).map_err(|e| {
+            let which = String::from_utf8_lossy(&k).to_string();
+            AppError::Internal(format!("decode room at `{which}`: {e}"))
+        })?;
+        out.push(room);
+    }
+    out.sort_by(|a, b| a.room_id.cmp(&b.room_id));
+    Ok(out)
+}
+
 /// List a room's records, optionally filtered by key prefix and a `since_version`
 /// watermark.
 ///
@@ -1308,5 +1339,30 @@ mod tests {
                 .expect("list")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn listing_rooms_returns_every_room_in_identifier_order() {
+        let (_d, rooms, _r) = open().await;
+        for id in ["r3", "r1", "r2"] {
+            create_room(&rooms, &room(id, Visibility::Attributed))
+                .await
+                .expect("create");
+        }
+
+        let got = list_rooms(&rooms).await.expect("list");
+        assert_eq!(
+            got.iter().map(|r| r.room_id.as_str()).collect::<Vec<_>>(),
+            vec!["r1", "r2", "r3"],
+            "an operator's list is stable, or two reads disagree about nothing"
+        );
+    }
+
+    /// The scan is prefix-bound to the rooms keyspace, so nothing else it may share a
+    /// store with can appear in an operator's room list.
+    #[tokio::test]
+    async fn listing_rooms_is_empty_on_a_host_that_holds_none() {
+        let (_d, rooms, _r) = open().await;
+        assert!(list_rooms(&rooms).await.expect("list").is_empty());
     }
 }


### PR DESCRIPTION
A VTC stores rooms and had no way to show its operator which ones.

That is not a small gap for a host. §9 obliges it to notify a room's owner before reclaiming storage — and an operator who cannot list their rooms cannot send that notice.

`GET /v1/rooms`, admin-gated, with `vti_rooms::storage::list_rooms` under it.

## What a host may honestly say about a room it cannot read

The row, and nothing derived from the room's contents: owner, tier, retention policy, epoch, lifecycle state, expiry, retention days, mirror-of, timestamps.

**Invariant I1 makes the owner visible at every tier**, including `private`, precisely so a host has a party it can reach about quota, abuse and lifecycle. So listing discloses nothing the design withheld. There is no records endpoint here, and no member list to return — no host has one.

`lifecycle` is computed rather than stored, because minting an epoch *is* the renewal and a stored state would be a second thing to keep true.

## Plain REST, deliberately not a Trust Task

Worth stating, since 80 of the VTC's 90 routes are paired with a canonical task URI.

Every `rooms/*` task is authorized by credentials the **room** issued, verified against the room's own identifier — invariant I5, and what lets a room move hosts. This asks the opposite question: *what is this operator storing.* It is answered from the host's own admin authority, so pairing it with a room task would claim a room governs an answer it has no view of.

## Not paginated, and the comment says when that expires

A host's room count is bounded by what its operator agreed to store, not by anything a caller controls. If that stops being true, `list_records` already has the cursor shape to copy.

## Two censuses caught real mistakes

- `openapi_spec_covers_the_route_groups` — my `#[utoipa::path]` said `/v1/rooms` where the router already nests under `/v1`, producing `/v1/v1/rooms`.
- `every_unauthenticated_route_is_classified` — the doubled path had no `security(("bearer_jwt" = []))`, so it read as an unauthenticated route landing on the no-limiter main chain. That backstop is doing exactly what its comment says it is for.

## Verification

- `cargo test -p vti-rooms --all-features` — 96 pass (2 new: ordering, and the empty case)
- `cargo test -p vtc-service --lib` — 956 pass, including both censuses above
- `cargo test --workspace --all-features --no-run` — every target compiles
- `cargo clippy --workspace --all-features --all-targets` — clean

## Next

This is the read half of the VTC's rooms UX. The governance half is `rooms.rego`, which already ships a default and has a complete policy REST surface (`list`/`show`/`active`/`upload`/`activate`/`test`) — the admin-ui simply has no policy plugin yet.
