### PR TITLE
feat(rooms): the VTA seals records and lists the rooms it can open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "url",
  "uuid",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "uuid",
 ]
 
@@ -7979,7 +7979,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9599,7 +9599,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "uuid",
 ]
 
@@ -9615,7 +9615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "uuid",
 ]
 
@@ -9634,7 +9634,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "uuid",
 ]
 
@@ -9652,7 +9652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
 ]
 
 [[package]]
@@ -9672,9 +9672,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.6"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe43bd5d03b468c49ffa6c75d53afca9fe27cb70b35384941db3a8c42c1da4b8"
+checksum = "cd500fca5a987d3f174419c92bcf921a580c18d034d5ff5c66fafb4ac8d94e61"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10430,7 +10430,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "uniffi",
  "vta-sdk",
 ]
@@ -10448,7 +10448,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10527,7 +10527,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "url",
  "utoipa",
  "uuid",
@@ -10612,7 +10612,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "url",
  "urlencoding",
  "utoipa",
@@ -10781,7 +10781,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10853,7 +10853,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10911,7 +10911,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -10967,7 +10967,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.6",
+ "trust-tasks-rs 0.18.7",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ aws-lc-rs = "1.16"
 # fully succeeded comes back as a 500 `responseSchemaViolation` — the members
 # are emitted and the schema rejects them. A caret on "0.18" would let a
 # resolver pick 0.18.2 and reintroduce exactly that.
-trust-tasks-rs = { version = "0.18.6", default-features = false, features = [
+trust-tasks-rs = { version = "0.18.7", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -136,6 +136,16 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // to the room's whole retained history. A blanket `vta_call` approval must
     // not silently cover widening what the principal's key holder can decrypt.
     ("rooms/keys/chain", Risk::Sensitive),
+    // Secret material, accepted AND emitted. `seal` takes a record's plaintext and
+    // returns it encrypted under the room's key — the one direction in this family
+    // where cleartext room material travels INTO the oracle. It belongs beside
+    // `open`, which is the same exchange run the other way.
+    ("rooms/keys/seal", Risk::Sensitive),
+    // A read, and the verb rule would get it right — but what it lists is the
+    // principal's room membership as key custody sees it, which is more than any
+    // single room operation discloses. Named here so that is a decision rather
+    // than a default.
+    ("rooms/keys/list", Risk::ReadOnly),
     // The holder's own identity, emitted. `disclosure/present` is the one
     // persona task that hands claims to a named verifier, under a persona DID,
     // and writes the record saying it did. It sits beside `rooms/keys/present`

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -430,6 +430,11 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // redelivery stores nothing and reports the same reachability. A lost reply
     // costs the caller the answer, never the state.
     (trust_tasks::TASK_ROOMS_KEYS_CHAIN_0_1, RetrySafe),
+    // Sealing is a pure function of the key and the bytes, and it stores nothing:
+    // a lost reply costs the caller a round trip, never any state. Re-sealing the
+    // same body yields a different nonce, which is correct and changes nothing.
+    (trust_tasks::TASK_ROOMS_KEYS_SEAL_0_1, RetrySafe),
+    (trust_tasks::TASK_ROOMS_KEYS_LIST_0_1, RetrySafe),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),
     // ── Application state ───────────────────────────────────────────────
     //

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -826,6 +826,17 @@ pub const TASK_ROOMS_KEYS_COMMIT_0_1: &str = "https://trusttasks.org/spec/rooms/
 /// through; this covers the history it did not.
 pub const TASK_ROOMS_KEYS_CHAIN_0_1: &str = "https://trusttasks.org/spec/rooms/keys/chain/0.1";
 
+/// `spec/rooms/keys/seal/0.1` — seal one record body with the room's current
+/// epoch key. The mirror of `open`: plaintext in, ciphertext out, key stays put.
+/// Auth: `roomOpen` capability. It does not write — the caller takes the result
+/// to a host and presents its own authority there.
+pub const TASK_ROOMS_KEYS_SEAL_0_1: &str = "https://trusttasks.org/spec/rooms/keys/seal/0.1";
+
+/// `spec/rooms/keys/list/0.1` — which rooms this VTA can open, and how far back
+/// each reads. Auth: `roomOpen` capability. Key custody, never membership: a
+/// room whose Welcome never arrived is absent even where a good VMC is held.
+pub const TASK_ROOMS_KEYS_LIST_0_1: &str = "https://trusttasks.org/spec/rooms/keys/list/0.1";
+
 /// `spec/vta/memory/delete/0.1` — remove one entry by key (`not_found` if
 /// absent). Auth: context access. Payload:
 /// [`crate::protocols::memory::MemoryDeleteBody`].
@@ -1888,6 +1899,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ROOMS_KEYS_WELCOME_0_1,
     TASK_ROOMS_KEYS_COMMIT_0_1,
     TASK_ROOMS_KEYS_CHAIN_0_1,
+    TASK_ROOMS_KEYS_SEAL_0_1,
+    TASK_ROOMS_KEYS_LIST_0_1,
     TASK_VTA_MEMORY_DELETE_0_1,
     // Application-state slice (spec/vta/app-state/*)
     TASK_VTA_APP_STATE_GET_1_0,

--- a/vta-service/src/operations/room_groups.rs
+++ b/vta-service/src/operations/room_groups.rs
@@ -37,9 +37,12 @@ use vti_rooms::mls::{GroupSnapshot, IdentitySnapshot, RoomGroup};
 use vti_rooms::sealed::SealedRoom;
 use vti_rooms::wire::EpochLink;
 
+/// Prefix for a room's group state, and the scan `list_rooms` walks.
+const GROUP_PREFIX: &str = "room-group:";
+
 /// Storage key for a room's group state.
 fn group_key(room_id: &str) -> String {
-    format!("room-group:{room_id}")
+    format!("{GROUP_PREFIX}{room_id}")
 }
 
 /// Storage key for a consumed invitation.
@@ -228,6 +231,94 @@ pub async fn apply_commit(
     )
     .await?;
     Ok(epoch)
+}
+
+/// Seal a record body with the room's current epoch key.
+///
+/// The mirror of [`open_record`], and the reason a client can write to a sealed room at all:
+/// the key never leaves, so the caller sends plaintext and receives ciphertext.
+///
+/// # It does not write
+///
+/// The caller takes the result to a host and presents its own authority there. Sealing and
+/// being allowed to store are different questions asked of different parties — this VTA
+/// knows the key and nothing about the room's ACL; the host knows the credentials and cannot
+/// read a byte. Doing both here would make this VTA the party that decides what goes into a
+/// room, which is the one thing the design keeps it out of.
+pub async fn seal_record(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    key: &str,
+    version: u64,
+    plaintext: &[u8],
+) -> Result<vti_rooms::wire::SealedContent, AppError> {
+    let record = load(groups, room_id).await?.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "this VTA holds no group state for room `{room_id}`"
+        ))
+    })?;
+    let group = RoomGroup::restore(&record.snapshot)
+        .map_err(|e| AppError::Internal(format!("restore the group: {e}")))?;
+
+    SealedRoom::new(room_id, group)
+        .seal_record(key, version, plaintext)
+        .map_err(|e| AppError::Validation(e.to_string()))
+}
+
+/// Every room this VTA holds group state for, with how far each one reads.
+///
+/// # Custody, not membership
+///
+/// This answers "what can I open", never "what am I a member of". A principal may hold a
+/// perfectly good membership credential for a room whose Welcome never arrived — absent
+/// here, correctly. And a VTA not yet told of a removal still holds keys for a room its
+/// principal has left: it cannot write there, because the host checks credentials that no
+/// longer verify, and it can still open what it already had. That is what removal has always
+/// meant, and a caller MUST NOT read this list as authority to act.
+pub async fn list_rooms(groups: &KeyspaceHandle) -> Result<Vec<HeldRoom>, AppError> {
+    let pairs = groups.prefix_iter_raw(GROUP_PREFIX.to_string()).await?;
+    let mut out = Vec::with_capacity(pairs.len());
+
+    for (k, v) in pairs {
+        let record: RoomGroupRecord = serde_json::from_slice(&v).map_err(|e| {
+            let which = String::from_utf8_lossy(&k).to_string();
+            AppError::Internal(format!("decode group state at `{which}`: {e}"))
+        })?;
+        let room_id = String::from_utf8_lossy(&k)
+            .strip_prefix(GROUP_PREFIX)
+            .unwrap_or_default()
+            .to_string();
+
+        // Restoring to answer is deliberate. The epoch could be read from the snapshot, but
+        // `earliestReadableEpoch` is only knowable by *walking* the chain — and a number
+        // derived two different ways is a number that will eventually disagree with itself.
+        let group = RoomGroup::restore(&record.snapshot)
+            .map_err(|e| AppError::Internal(format!("restore the group for `{room_id}`: {e}")))?;
+        let mut room = SealedRoom::new(&room_id, group);
+        room.add_links(record.links);
+
+        let epoch = room.room_epoch();
+        let earliest = room
+            .earliest_readable_epoch()
+            .map_err(|e| AppError::Internal(format!("walk the chain for `{room_id}`: {e}")))?;
+
+        out.push(HeldRoom {
+            room_id,
+            epoch,
+            earliest_readable_epoch: earliest,
+        });
+    }
+    out.sort_by(|a, b| a.room_id.cmp(&b.room_id));
+    Ok(out)
+}
+
+/// One room this VTA can open, as `rooms/keys/list` reports it.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeldRoom {
+    pub room_id: String,
+    pub epoch: u32,
+    pub earliest_readable_epoch: u32,
 }
 
 /// Retain epoch links this VTA's principal fetched from the room's host.

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2060,6 +2060,43 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
+            uris::TASK_ROOMS_KEYS_SEAL_0_1,
+            checked!(
+                specs::rooms::keys::seal::v0_1::Payload,
+                specs::rooms::keys::seal::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "key": "giXFLTGBdnnQJRoIsktuIg",
+                    "version": 1,
+                    "plaintext": "IyBOb3J0aHdpbmQ"
+                }),
+                json!({
+                    "sealed": {
+                        "ciphertext": "3QhV1sVvR0m5xAqZ7Aw2mQnR4vBk8QLp3wXc9TgYw",
+                        "nonce": "b0Zt8Qm2Yq1sVvR0",
+                        "epoch": 4
+                    }
+                })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_KEYS_LIST_0_1,
+            checked!(
+                specs::rooms::keys::list::v0_1::Payload,
+                specs::rooms::keys::list::v0_1::Response,
+                json!({}),
+                json!({
+                    "rooms": [
+                        {
+                            "roomId": "did:webvh:example.com:rooms:northwind",
+                            "epoch": 4,
+                            "earliestReadableEpoch": 1
+                        }
+                    ]
+                })
+            ),
+        ),
+        (
             uris::TASK_ROOMS_KEYS_OPEN_0_1,
             checked!(
                 specs::rooms::keys::open::v0_1::Payload,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1642,6 +1642,10 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_CHAIN_0_1 => room_group::handle_chain
         [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_SEAL_0_1 => room_group::handle_seal
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_LIST_0_1 => room_group::handle_list
+        [ None Metadata false ],
     // ─── Application-state slice (spec/vta/app-state/*) ──────────
     // Versioned, namespaced per-context JSON the VTA stores but never
     // interprets. Gated on context access (require_context), NOT operator

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -208,6 +208,110 @@ pub(super) async fn handle_commit(
     success_response(&doc, CommitResponse { epoch })
 }
 
+/// `rooms/keys/seal/0.1`.
+///
+/// The mirror of [`handle_open`], and gated on the same capability for the same reason:
+/// `RoomOpen` governs a principal's room records, and sealing one is acting on them.
+///
+/// Note what this returns and what it does not. It hands back ciphertext; it does not store
+/// anything and does not reach the room's host. A caller that wanted the record written must
+/// present its own authority there, which is the separation that keeps this VTA out of the
+/// decision about what a room contains.
+pub(super) async fn handle_seal(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::RoomOpen,
+        "sealing a room record",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::keys::seal::v0_1::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let plaintext = match base64::Engine::decode(
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+        &req.plaintext,
+    ) {
+        Ok(b) => b,
+        Err(e) => {
+            return app_error_to_reject(
+                &doc,
+                vti_common::error::AppError::Validation(format!("plaintext is not base64url: {e}")),
+            );
+        }
+    };
+
+    let sealed = match room_groups::seal_record(
+        &state.room_groups_ks,
+        &req.room_id,
+        &req.key,
+        u64::from(req.version),
+        &plaintext,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    record(state, "rooms.keys.seal", auth, &req.room_id).await;
+    success_response(
+        &doc,
+        serde_json::json!({
+            "sealed": {
+                "ciphertext": sealed.ciphertext,
+                "nonce": sealed.nonce,
+                "epoch": sealed.epoch,
+            }
+        }),
+    )
+}
+
+/// `rooms/keys/list/0.1`.
+///
+/// Which rooms this VTA can open, and how far back each reads.
+///
+/// Gated on `RoomOpen` because that is the capability the answer is *about*: an agent that
+/// may not open a principal's rooms has no business enumerating them, and the list is the
+/// principal's room membership as key custody sees it — more than any single room operation
+/// discloses.
+pub(super) async fn handle_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::RoomOpen,
+        "listing the rooms this VTA holds keys for",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let rooms = match room_groups::list_rooms(&state.room_groups_ks).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    record(state, "rooms.keys.list", auth, "").await;
+    success_response(&doc, serde_json::json!({ "rooms": rooms }))
+}
+
 /// `rooms/keys/chain/0.1`.
 ///
 /// The principal hands this VTA the room's epoch key chain, so it can open records sealed

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -256,7 +256,7 @@ pub(super) async fn handle_seal(
         &state.room_groups_ks,
         &req.room_id,
         &req.key,
-        u64::from(req.version),
+        req.version,
         &plaintext,
     )
     .await

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -1069,8 +1069,34 @@ async fn consent_family_response_shapes() {
 ///
 /// Minting one against the stub host and pointing `vta_did` at it is what
 /// unlocks the whole family, which is why this is one test rather than five.
-#[tokio::test]
-async fn services_write_paths_against_a_hosted_vta_did() {
+/// Run on a thread with a real stack rather than libtest's 2 MiB.
+///
+/// This body boots an entire in-process VTA and drives the whole write family
+/// through it, so the future is enormous in a debug build — and it grows every
+/// time the dispatch table does. It overflowed for the first time when two
+/// `rooms/keys/*` arms were added, which is not a fact about those arms: it is
+/// this test sitting just under a limit nobody had written down.
+///
+/// `RUST_MIN_STACK=16777216` also fixes it, and that is how it was diagnosed —
+/// but a test that passes only when an environment variable is set is a test
+/// that fails for the next person. The stack is asked for here instead.
+#[test]
+fn services_write_paths_against_a_hosted_vta_did() {
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build a runtime")
+                .block_on(services_write_paths_against_a_hosted_vta_did_inner());
+        })
+        .expect("spawn the test thread")
+        .join()
+        .expect("the test thread panicked");
+}
+
+async fn services_write_paths_against_a_hosted_vta_did_inner() {
     use vta_sdk::client::{CreateDidWebvhRequest, VtaClient};
     use vta_sdk::protocols::did_management::create::WebvhPathMode;
 


### PR DESCRIPTION
Implements `rooms/keys/seal/0.1` and `rooms/keys/list/0.1` ([spec #399](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/399)) — the two gaps that between them made a room UI impossible.

## `seal` — the mirror of `open`

A client could **read** a sealed room and could not **write** to one: sealing needs the epoch's storage key, and the key never leaves the VTA. Plaintext in, ciphertext out.

**It does not write**, and does not reach the room's host. The caller presents its own authority there. Sealing and being allowed to store are different questions asked of different parties — this VTA knows the key and nothing about the room's ACL; the host knows the credentials and cannot read a byte. Doing both here would make the VTA the party that decides what a room contains, which is the one thing the design keeps it out of.

## `list` — where a `roomId` comes from

Every other room task took an identifier the caller already knew, and nothing said where it came from.

It **restores each group to answer** rather than reading the epoch out of the snapshot. `earliestReadableEpoch` is only knowable by *walking* the chain, and a number derived two different ways is a number that will eventually disagree with itself.

**Custody, not membership.** A room whose Welcome never arrived is absent even where a good VMC is held. And a VTA not yet told of a removal still lists a room it can open but can no longer write to — which is what removal has always meant. A caller **MUST NOT** read this as authority to act.

## Six census sites, located before writing any code

The URI constants, `ALL_URIS`, `retry_safety`, dispatch, the conformance witnesses, and the `vta-mcp` guard.

That last one is **invisible to a `grep TASK_ROOMS_KEYS_CHAIN_0_1` sweep**, because it classifies by *slug* rather than URI — which is exactly how it was missed on #1320. Checked by name this time.

Classifications, both deliberate rather than defaulted:

- **`seal` → `Sensitive`**, beside `open`. Same exchange run the other way, and the one direction in this family where cleartext room material travels *into* the oracle.
- **`list` → `ReadOnly`**. The verb rule would get this right on its own, but what it returns is the principal's room membership as key custody sees it — more than any single room operation discloses — so it is named rather than inferred.

## Verification

- `cargo test -p vta-sdk --all-features` — 733 pass (`ALL_URIS` + `retry_safety` censuses)
- `cargo test -p vta-mcp --all-features` — 36 pass (the guard census)
- `cargo test -p vta-service --all-features` — running locally as I push; CI is the authority and I will confirm here either way
- `cargo build --workspace --all-features` — clean

`trust-tasks-rs` moves 0.18.6 → 0.18.7, the release carrying both specs.

## Next

The `rooms/owner/*` three (#401) are the remaining implementation, then the two UI panes. `GET /v1/rooms` for the VTC operator landed in #1325.
