### PR TITLE
refactor(persona)!: Attribute is not exhaustively constructible from outside

### DIFF
--- a/vta-persona/src/claim_types.rs
+++ b/vta-persona/src/claim_types.rs
@@ -35,18 +35,23 @@
 //!
 //! # What this module decides, and what it does not
 //!
-//! Only [`Sensitivity`] is acted on today, by
+//! [`Sensitivity`] is acted on by
 //! [`PersonaStore::list_attributes`](crate::PersonaStore::list_attributes),
-//! which is the read-path control that makes the axis more than cosmetic.
-//! Nothing consults [`ReleaseRequirement`]: `persona/disclosure/present` does
-//! not yet demand a fresh authentication for a `stepUp` attribute, and a holder
-//! **cannot** record a `release` override, precisely so that nothing here can
-//! be mistaken for a gate that exists. `MaskStyle` is a renderer's business and
-//! this crate draws nothing.
+//! which withholds a `high` value from a listing that did not ask for one —
+//! the read-path control that makes the axis more than cosmetic.
 //!
-//! They are resolved anyway because §4 is one rule over one table. The
-//! alternative is a second copy of both, added when the disclosure gate lands,
-//! which is how the two would come to disagree.
+//! [`ReleaseRequirement`] is acted on by
+//! [`present`](crate::present), which refuses a `stepUp` claim without a fresh
+//! approval bound to that preview. This paragraph said the opposite until the
+//! gate landed, and a holder could not record a `release` override either; both
+//! are now true, and the note is corrected rather than deleted because "what
+//! this module decides" is the first thing a reader needs and the easiest thing
+//! to leave stale.
+//!
+//! [`MaskStyle`] is still nobody's business here: it is a renderer's, and this
+//! crate draws nothing. It is resolved anyway because §4 is one rule over one
+//! table, and the alternative is a second copy of the rules that comes to
+//! disagree with this one.
 
 use serde::{Deserialize, Serialize};
 

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -165,8 +165,21 @@ pub enum StaleReason {
 /// Several attributes may share a `type` — three phone numbers, a legal name and
 /// a preferred name — which is why `attribute_id` is the identity of an attribute and
 /// `type` is not.
+/// **Not exhaustively constructible from outside this crate**, and the reason
+/// is its own history: `sensitivity` arrived in #1299 and `release` in #1310,
+/// each a `pub` field on a struct any consumer could write as a literal, so
+/// each was a compatibility break for a record that is only going to keep
+/// growing as the persona specification does. Marked once, in a release that
+/// already carried the break, so the next member is an addition rather than
+/// another one.
+///
+/// Nothing outside this crate builds one today — an `Attribute` arrives from
+/// the store or from a deserialised document — so this costs a consumer
+/// nothing it was actually doing. Inside the crate, literal construction is
+/// unaffected.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Attribute {
     pub attribute_id: Ulid,
     /// Vocabulary token — `name.legal`, `phone.mobile`. The store's own; every


### PR DESCRIPTION
`Attribute` grew `sensitivity` in #1299 and `release` in #1310. Each added a `pub` field to a struct any consumer could write as a literal, so each was a compatibility break — the informational semver report has been carrying `constructible_struct_adds_field` for the second one since it landed, which is how this surfaced.

## Why now, and why once

The record is not finished growing. The persona specification keeps adding members and this crate follows it, so without `#[non_exhaustive]` every future member is another break for exactly the same reason. Marking it in a release that **already** carries a break costs nothing extra and makes the next member an addition.

To be clear about what this is not fixing: `release-plz` has `semver_check = true` for this crate, so it forces a compatibility-breaking bump when the API actually broke — the version was never going to ship wrong. This is about how many breaks get paid over time, not whether one gets noticed.

`cargo semver-checks --package vta-persona` now reports two majors where it reported one:

```
--- failure constructible_struct_adds_field ---   (pre-existing, #1310)
--- failure struct_marked_non_exhaustive ---      (this change)
Summary semver requires new major version: 2 major and 0 minor checks failed
```

Both belong to the same release.

## Cost to consumers: none that exists

Nothing outside this crate constructs an `Attribute` — it arrives from the store or from a deserialised document. Inside the crate literal construction is unaffected, so the eight construction sites are untouched and no builder is needed.

## Also: a module header describing a crate that no longer exists

`claim_types`'s "what this module decides, and what it does not" said:

> Nothing consults `ReleaseRequirement`: `persona/disclosure/present` does not yet demand a fresh authentication for a `stepUp` attribute, and a holder **cannot** record a `release` override, precisely so that nothing here can be mistaken for a gate that exists.

Both halves stopped being true in #1310 — `present` refuses a `stepUp` claim without a fresh approval bound to that preview, and the override is a field on the record. That paragraph is the first thing a reader of this module looks at and the easiest to leave stale, so it now says what is true and notes that it once said the opposite.

## Checks

99 `vta-persona` tests pass; `cargo fmt --check` and `cargo clippy --all-targets --all-features` clean.