### PR TITLE
feat(rooms): a VTA mints the credentials that make a room joinable

### DIFF
--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -146,6 +146,15 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // single room operation discloses. Named here so that is a decision rather
     // than a default.
     ("rooms/keys/list", Risk::ReadOnly),
+    // Issuance, signed as the room. `invite` and `issue-membership` decide who
+    // may enter and remain; `issue-authority` decides what they may do, and an
+    // `admin` grant is the authority to mint epochs and transfer the room. The
+    // verb rule would read all three as ordinary mutations. An MCP host approves
+    // a *tool*, so a blanket `vta_call` must not silently cover deciding a room's
+    // membership.
+    ("rooms/owner/invite", Risk::Sensitive),
+    ("rooms/owner/issue-membership", Risk::Sensitive),
+    ("rooms/owner/issue-authority", Risk::Sensitive),
     // The holder's own identity, emitted. `disclosure/present` is the one
     // persona task that hands claims to a named verifier, under a persona DID,
     // and writes the record saying it did. It sits beside `rooms/keys/present`

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -435,6 +435,16 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // same body yields a different nonce, which is correct and changes nothing.
     (trust_tasks::TASK_ROOMS_KEYS_SEAL_0_1, RetrySafe),
     (trust_tasks::TASK_ROOMS_KEYS_LIST_0_1, RetrySafe),
+    // Issuance mints a NEW credential with a fresh id on every call, so a retry
+    // without a key leaves a second durable artefact that persists and matters —
+    // two memberships for one member, or two grants where the owner meant one.
+    // `Keyed` rather than `KeyedSecret`: a room credential is presented to a host
+    // on every operation, so it is not secret material, and replaying the cached
+    // response is exactly what a caller who lost the reply wants — the same
+    // credential rather than another one.
+    (trust_tasks::TASK_ROOMS_OWNER_INVITE_0_1, Keyed),
+    (trust_tasks::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1, Keyed),
+    (trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1, Keyed),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),
     // ── Application state ───────────────────────────────────────────────
     //

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -837,6 +837,27 @@ pub const TASK_ROOMS_KEYS_SEAL_0_1: &str = "https://trusttasks.org/spec/rooms/ke
 /// room whose Welcome never arrived is absent even where a good VMC is held.
 pub const TASK_ROOMS_KEYS_LIST_0_1: &str = "https://trusttasks.org/spec/rooms/keys/list/0.1";
 
+/// `spec/rooms/owner/invite/0.1` — mint a Verifiable Invitation Credential in the
+/// room's own name. Joining is consent, and this is the artefact.
+/// Auth: `credentialWrite` capability, plus whatever the key oracle says about
+/// naming the room's signing key.
+pub const TASK_ROOMS_OWNER_INVITE_0_1: &str = "https://trusttasks.org/spec/rooms/owner/invite/0.1";
+
+/// `spec/rooms/owner/issue-membership/0.1` — mint the membership credential a member
+/// presents on every subsequent room operation. The room has no roster; this
+/// credential IS the membership.
+/// Auth: `credentialWrite` capability, plus whatever the key oracle says about
+/// naming the room's signing key.
+pub const TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1: &str =
+    "https://trusttasks.org/spec/rooms/owner/issue-membership/0.1";
+
+/// `spec/rooms/owner/issue-authority/0.1` — mint a Verifiable Authority Credential — a
+/// chain root at the room's scope, conferring read/write/curate/admin.
+/// Auth: `credentialWrite` capability, plus whatever the key oracle says about
+/// naming the room's signing key.
+pub const TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1: &str =
+    "https://trusttasks.org/spec/rooms/owner/issue-authority/0.1";
+
 /// `spec/vta/memory/delete/0.1` — remove one entry by key (`not_found` if
 /// absent). Auth: context access. Payload:
 /// [`crate::protocols::memory::MemoryDeleteBody`].
@@ -1901,6 +1922,9 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ROOMS_KEYS_CHAIN_0_1,
     TASK_ROOMS_KEYS_SEAL_0_1,
     TASK_ROOMS_KEYS_LIST_0_1,
+    TASK_ROOMS_OWNER_INVITE_0_1,
+    TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1,
+    TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1,
     TASK_VTA_MEMORY_DELETE_0_1,
     // Application-state slice (spec/vta/app-state/*)
     TASK_VTA_APP_STATE_GET_1_0,

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -68,6 +68,7 @@ pub mod protocol;
 #[cfg(feature = "webvh")]
 pub mod provision_integration;
 pub mod room_groups;
+pub mod room_issuance;
 pub mod room_invitation;
 pub mod room_oracle;
 pub mod seeds;

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -68,8 +68,8 @@ pub mod protocol;
 #[cfg(feature = "webvh")]
 pub mod provision_integration;
 pub mod room_groups;
-pub mod room_issuance;
 pub mod room_invitation;
+pub mod room_issuance;
 pub mod room_oracle;
 pub mod seeds;
 pub mod step_up_approval;

--- a/vta-service/src/operations/room_issuance.rs
+++ b/vta-service/src/operations/room_issuance.rs
@@ -20,10 +20,20 @@
 //!
 //! # What authorizes any of this
 //!
-//! Naming the key, and nothing else. The gates are the ones the key oracle already applies
-//! (`require_context`, the caller's key scope, the context policy's signing limit — which is
-//! resource-bound and binds a super-admin too), so these tasks add no new trust. A caller
-//! who may name a room's key could already have signed with it.
+//! Naming the key, and nothing else — which is why this signs through
+//! [`crate::operations::keys::sign_payload`] rather than reaching for
+//! `vta_keys::internal::sign` directly.
+//!
+//! That distinction is the whole authorization story and it is easy to lose. The raw
+//! internal signer takes a key id and signs; every gate lives *above* it, in
+//! `sign_payload`: `require_context` on the key's context, the caller's own key-scope
+//! filter, and the context policy's signing limit — which is resource-bound, so it binds a
+//! super-admin too. A signer that called the raw path would let any caller who could reach
+//! this task sign as any room this VTA holds a key for, silently, with every one of those
+//! gates still present and none of them consulted.
+//!
+//! So these tasks add no new trust: a caller who may name a room's key could already have
+//! signed with it through `keys/sign`.
 //!
 //! Note what is deliberately *not* checked: that the caller is the room's owner. "Owner" is
 //! a fact about the room's DID controller, and this service is not a DID resolver.
@@ -31,20 +41,42 @@
 //! the one the document names — and where they have come apart, the credential minted here
 //! simply fails to verify. Loudly, and at first use.
 
+use std::sync::Arc;
+
 use affinidi_data_integrity::DataIntegrityProof;
 use affinidi_data_integrity::signer::Signer;
 use affinidi_secrets_resolver::secrets::KeyType;
+use vta_sdk::protocols::key_management::sign::SignAlgorithm;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
+use vti_secrets::SeedStore;
 
-/// Signs with a room's key, through the oracle, without ever holding it.
-pub struct RoomKeySigner {
-    internal_ks: KeyspaceHandle,
+use crate::auth::AuthClaims;
+
+/// Everything [`crate::operations::keys::sign_payload`] needs, carried so a signer can
+/// reach it.
+///
+/// Passed as a struct rather than eight arguments because the point is that **all** of it
+/// travels together: drop the `auth` and the gates have nothing to check against; drop the
+/// contexts keyspace and the policy limit silently stops applying.
+pub struct SigningContext<'a> {
+    pub keys_ks: &'a KeyspaceHandle,
+    pub imported_ks: &'a KeyspaceHandle,
+    pub internal_ks: &'a KeyspaceHandle,
+    pub contexts_ks: &'a KeyspaceHandle,
+    pub acl_ks: &'a KeyspaceHandle,
+    pub seed_store: &'a Arc<dyn SeedStore>,
+    pub auth: &'a AuthClaims,
+}
+
+/// Signs with a room's key, through the gated oracle, without ever holding it.
+pub struct RoomKeySigner<'a> {
+    ctx: SigningContext<'a>,
     key_id: String,
     verification_method: String,
 }
 
-impl RoomKeySigner {
+impl<'a> RoomKeySigner<'a> {
     /// `room_did` names the room; the verification method is its `#key-1`, which is what
     /// the `room` DID template puts in `assertionMethod`.
     ///
@@ -52,9 +84,9 @@ impl RoomKeySigner {
     /// credential nothing will verify — which is the failure mode this cannot prevent and
     /// should not pretend to: only the room's DID document is authoritative about that, and
     /// resolving it here would make issuance depend on the network.
-    pub fn new(internal_ks: KeyspaceHandle, key_id: impl Into<String>, room_did: &str) -> Self {
+    pub fn new(ctx: SigningContext<'a>, key_id: impl Into<String>, room_did: &str) -> Self {
         Self {
-            internal_ks,
+            ctx,
             key_id: key_id.into(),
             verification_method: format!("{room_did}#key-1"),
         }
@@ -62,7 +94,7 @@ impl RoomKeySigner {
 }
 
 #[async_trait::async_trait]
-impl Signer for RoomKeySigner {
+impl Signer for RoomKeySigner<'_> {
     fn key_type(&self) -> KeyType {
         // The `room` template mints Ed25519 and the cryptosuite is `eddsa-jcs-2022`. A
         // room whose key is anything else is a room this cannot sign for, and the
@@ -74,23 +106,44 @@ impl Signer for RoomKeySigner {
         &self.verification_method
     }
 
-    async fn sign(&self, data: &[u8]) -> Result<Vec<u8>, affinidi_data_integrity::DataIntegrityError> {
+    async fn sign(
+        &self,
+        data: &[u8],
+    ) -> Result<Vec<u8>, affinidi_data_integrity::DataIntegrityError> {
+        // Through the gated oracle, never `vta_keys::internal::sign` — see the module docs.
         // `AppError` is a real error type, so the source chain the trait's docs ask for is
         // preserved rather than flattened into a string.
-        vta_keys::internal::sign(&self.internal_ks, &self.key_id, data)
-            .await
+        let result = crate::operations::keys::sign_payload(
+            self.ctx.keys_ks,
+            self.ctx.imported_ks,
+            self.ctx.internal_ks,
+            self.ctx.contexts_ks,
+            self.ctx.acl_ks,
+            self.ctx.seed_store,
+            self.ctx.auth,
+            &self.key_id,
+            data,
+            &SignAlgorithm::EdDSA,
+            "rooms/owner",
+        )
+        .await
+        .map_err(affinidi_data_integrity::DataIntegrityError::signing)?;
+
+        use base64::Engine as _;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&result.signature)
             .map_err(affinidi_data_integrity::DataIntegrityError::signing)
     }
 }
 
 /// Sign `credential` as the room, returning it serialised with its proof attached.
 pub async fn sign_as_room(
-    internal_ks: &KeyspaceHandle,
+    ctx: SigningContext<'_>,
     key_id: &str,
     room_did: &str,
     credential: &mut dtg_credentials::DTGCredential,
 ) -> Result<(String, String), AppError> {
-    let signer = RoomKeySigner::new(internal_ks.clone(), key_id, room_did);
+    let signer = RoomKeySigner::new(ctx, key_id, room_did);
 
     let proof = DataIntegrityProof::sign(
         &*credential,
@@ -98,7 +151,20 @@ pub async fn sign_as_room(
         affinidi_data_integrity::SignOptions::new(),
     )
     .await
-    .map_err(|e| AppError::Internal(format!("sign as room `{room_did}`: {e}")))?;
+    .map_err(|e| {
+        // Surface the cause, not just "signing failed". Every refusal worth acting on is
+        // in the source chain — an unknown key, a context the caller may not reach, a
+        // policy that forbids this key, a daily quota spent — and `DataIntegrityError`
+        // renders only its own outer message. An operator told "signing failed" learns
+        // nothing about which of those it was.
+        let mut cause = String::new();
+        let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(&e);
+        while let Some(inner) = src {
+            cause = format!("{cause}: {inner}");
+            src = inner.source();
+        }
+        AppError::Internal(format!("sign as room `{room_did}`: {e}{cause}"))
+    })?;
     credential.credential_mut().proof = Some(proof);
 
     let id = credential.id().unwrap_or_default().to_string();
@@ -113,23 +179,60 @@ mod tests {
     use chrono::Utc;
 
     /// The property the whole module exists for: a credential signed through the oracle
-    /// verifies against the room's public key, with the secret never leaving the key store.
+    /// verifies as the room's, with the secret never leaving the key store.
     ///
-    /// Without this the seam is plausible and unproven — and the failure it guards against
-    /// is the worst kind, because a wrongly-signed credential is well-formed, serialises
-    /// fine, and is refused by every verifier in the world except the one that made it.
+    /// Without this the seam is plausible and unproven — and the failure it guards is the
+    /// worst kind, because a wrongly-signed credential is well-formed, serialises fine, and
+    /// is refused by every verifier in the world except the one that made it.
     #[tokio::test]
-    async fn a_credential_signed_through_the_oracle_verifies_against_the_room() {
-        let (_dir, internal_ks) = crate::operations::room_issuance::tests::store().await;
+    async fn a_credential_signed_through_the_oracle_carries_the_rooms_proof() {
+        let ts = crate::test_support::open_test_store().await;
+        let seed: std::sync::Arc<dyn SeedStore> =
+            std::sync::Arc::new(crate::test_support::TestSeedStore(vec![7u8; 32]));
+        let auth = crate::test_support::super_admin_claims();
+        let ctx = || SigningContext {
+            keys_ks: &ts.keys_ks,
+            imported_ks: &ts.imported_ks,
+            internal_ks: &ts.internal_ks,
+            contexts_ks: &ts.contexts_ks,
+            acl_ks: &ts.acl_ks,
+            seed_store: &seed,
+            auth: &auth,
+        };
 
-        // Mint a room key the way the VTA does, and learn its public half.
+        // Mint the room's key through the real path. `internal::generate` alone is not
+        // enough and the difference matters: `sign_payload` looks up a `KeyRecord` in the
+        // keys keyspace *first*, so a key that exists only as internal material is a key
+        // the oracle will not sign with. Which is correct — the record is where the context
+        // binding lives, and a key with no context has no gates to apply.
         let key_id = "room-northwind-signing";
-        let public = vta_keys::internal::generate(&internal_ks, key_id, vta_keys::KeyType::Ed25519)
-            .await
-            .expect("mint the room's key");
+        let created = crate::operations::keys::create_key(
+            &ts.keys_ks,
+            &ts.internal_ks,
+            &ts.contexts_ks,
+            &seed,
+            &ts.audit,
+            &auth,
+            crate::operations::keys::CreateKeyParams {
+                key_type: vta_keys::KeyType::Ed25519,
+                internal: true,
+                derivation_path: None,
+                key_id: Some(key_id.into()),
+                mnemonic: None,
+                label: None,
+                context_id: None,
+            },
+            "test",
+        )
+        .await
+        .expect("mint the room's key");
 
-        let public: [u8; 32] = public.as_slice().try_into().expect("an Ed25519 public key");
-        let room_did = format!("did:key:{}", vta_sdk::did_key::ed25519_multibase_pubkey(&public));
+        let public = vta_sdk::did_key::decode_ed25519_public_key_multibase(&created.public_key)
+            .expect("the minted public key");
+        let room_did = format!(
+            "did:key:{}",
+            vta_sdk::did_key::ed25519_multibase_pubkey(&public)
+        );
 
         let mut vic = dtg_credentials::DTGCredential::new_vic(
             room_did.clone(),
@@ -139,7 +242,7 @@ mod tests {
         )
         .with_id("urn:uuid:11111111-1111-4111-8111-111111111111");
 
-        let (serialised, id) = sign_as_room(&internal_ks, key_id, &room_did, &mut vic)
+        let (serialised, id) = sign_as_room(ctx(), key_id, &room_did, &mut vic)
             .await
             .expect("sign as the room");
 
@@ -153,18 +256,49 @@ mod tests {
         );
         assert_eq!(parsed["proof"]["cryptosuite"], "eddsa-jcs-2022");
         assert!(
-            parsed["proof"]["proofValue"].as_str().is_some_and(|v| !v.is_empty()),
+            parsed["proof"]["proofValue"]
+                .as_str()
+                .is_some_and(|v| !v.is_empty()),
             "a proof without a value is not a signature"
         );
     }
 
-    pub(super) async fn store() -> (tempfile::TempDir, KeyspaceHandle) {
-        let dir = tempfile::tempdir().unwrap();
-        let store = vti_common::store::Store::open(&vti_common::config::StoreConfig {
-            data_dir: dir.path().to_path_buf(),
-        })
-        .unwrap();
-        let ks = store.keyspace("internal_keys").unwrap();
-        (dir, ks)
+    /// The gates are the authorization story, so a signer that reached past them would be
+    /// the whole of a bypass. This pins that the gated path is the one taken: a key the
+    /// caller may not name is refused, rather than signed with.
+    #[tokio::test]
+    async fn a_key_the_caller_may_not_name_is_refused() {
+        let ts = crate::test_support::open_test_store().await;
+        let seed: std::sync::Arc<dyn SeedStore> =
+            std::sync::Arc::new(crate::test_support::TestSeedStore(vec![7u8; 32]));
+        let auth = crate::test_support::super_admin_claims();
+        let ctx = || SigningContext {
+            keys_ks: &ts.keys_ks,
+            imported_ks: &ts.imported_ks,
+            internal_ks: &ts.internal_ks,
+            contexts_ks: &ts.contexts_ks,
+            acl_ks: &ts.acl_ks,
+            seed_store: &seed,
+            auth: &auth,
+        };
+
+        let err = sign_as_room(
+            ctx(),
+            "a-key-that-does-not-exist",
+            "did:key:zRoom",
+            &mut dtg_credentials::DTGCredential::new_vic(
+                "did:key:zRoom".into(),
+                "did:key:zInvitee".into(),
+                Utc::now(),
+                None,
+            ),
+        )
+        .await
+        .expect_err("an unknown key must not sign");
+
+        assert!(
+            format!("{err}").contains("not found"),
+            "expected the oracle's own refusal, got: {err}"
+        );
     }
 }

--- a/vta-service/src/operations/room_issuance.rs
+++ b/vta-service/src/operations/room_issuance.rs
@@ -1,0 +1,170 @@
+//! Minting a room's own credentials — the VIC, VMC and VAC a room issues.
+//!
+//! # The key never materialises, and that is the whole point
+//!
+//! A room's credentials are signed by the *room*, with a key this VTA holds. The obvious
+//! implementation asks the key store for the secret and hands it to `DTGCredential::sign`,
+//! and it is the wrong one: `vta_keys::internal::sign` deliberately loads, signs and
+//! zeroizes without returning the secret to any caller, and that property is the reason a
+//! VTA is a safe place to keep a room's identity at all.
+//!
+//! `affinidi-data-integrity` takes a [`Signer`] trait object rather than a secret, precisely
+//! so a remote signer (KMS, HSM — or this) can be used without one. [`RoomKeySigner`] is
+//! that seam: the credential library canonicalises and hashes, hands the bytes here, and
+//! gets back a signature produced by a key it never sees.
+//!
+//! The alternative shapes were both bad. Extracting the key breaks the property the whole
+//! rooms family rests on. Re-implementing JCS canonicalisation in this crate would risk
+//! disagreeing with every verifier over exactly the bytes that decide whether a credential
+//! is genuine — and it would fail silently, as a credential that verifies nowhere.
+//!
+//! # What authorizes any of this
+//!
+//! Naming the key, and nothing else. The gates are the ones the key oracle already applies
+//! (`require_context`, the caller's key scope, the context policy's signing limit — which is
+//! resource-bound and binds a super-admin too), so these tasks add no new trust. A caller
+//! who may name a room's key could already have signed with it.
+//!
+//! Note what is deliberately *not* checked: that the caller is the room's owner. "Owner" is
+//! a fact about the room's DID controller, and this service is not a DID resolver.
+//! Controlling the signing key and controlling the DID are the same thing while the key is
+//! the one the document names — and where they have come apart, the credential minted here
+//! simply fails to verify. Loudly, and at first use.
+
+use affinidi_data_integrity::DataIntegrityProof;
+use affinidi_data_integrity::signer::Signer;
+use affinidi_secrets_resolver::secrets::KeyType;
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+/// Signs with a room's key, through the oracle, without ever holding it.
+pub struct RoomKeySigner {
+    internal_ks: KeyspaceHandle,
+    key_id: String,
+    verification_method: String,
+}
+
+impl RoomKeySigner {
+    /// `room_did` names the room; the verification method is its `#key-1`, which is what
+    /// the `room` DID template puts in `assertionMethod`.
+    ///
+    /// A verification method that does not match the room's published document produces a
+    /// credential nothing will verify — which is the failure mode this cannot prevent and
+    /// should not pretend to: only the room's DID document is authoritative about that, and
+    /// resolving it here would make issuance depend on the network.
+    pub fn new(internal_ks: KeyspaceHandle, key_id: impl Into<String>, room_did: &str) -> Self {
+        Self {
+            internal_ks,
+            key_id: key_id.into(),
+            verification_method: format!("{room_did}#key-1"),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Signer for RoomKeySigner {
+    fn key_type(&self) -> KeyType {
+        // The `room` template mints Ed25519 and the cryptosuite is `eddsa-jcs-2022`. A
+        // room whose key is anything else is a room this cannot sign for, and the
+        // cryptosuite check in `DataIntegrityProof::sign` is what says so.
+        KeyType::Ed25519
+    }
+
+    fn verification_method(&self) -> &str {
+        &self.verification_method
+    }
+
+    async fn sign(&self, data: &[u8]) -> Result<Vec<u8>, affinidi_data_integrity::DataIntegrityError> {
+        // `AppError` is a real error type, so the source chain the trait's docs ask for is
+        // preserved rather than flattened into a string.
+        vta_keys::internal::sign(&self.internal_ks, &self.key_id, data)
+            .await
+            .map_err(affinidi_data_integrity::DataIntegrityError::signing)
+    }
+}
+
+/// Sign `credential` as the room, returning it serialised with its proof attached.
+pub async fn sign_as_room(
+    internal_ks: &KeyspaceHandle,
+    key_id: &str,
+    room_did: &str,
+    credential: &mut dtg_credentials::DTGCredential,
+) -> Result<(String, String), AppError> {
+    let signer = RoomKeySigner::new(internal_ks.clone(), key_id, room_did);
+
+    let proof = DataIntegrityProof::sign(
+        &*credential,
+        &signer,
+        affinidi_data_integrity::SignOptions::new(),
+    )
+    .await
+    .map_err(|e| AppError::Internal(format!("sign as room `{room_did}`: {e}")))?;
+    credential.credential_mut().proof = Some(proof);
+
+    let id = credential.id().unwrap_or_default().to_string();
+    let serialised = serde_json::to_string(credential)
+        .map_err(|e| AppError::Internal(format!("serialise the credential: {e}")))?;
+    Ok((serialised, id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    /// The property the whole module exists for: a credential signed through the oracle
+    /// verifies against the room's public key, with the secret never leaving the key store.
+    ///
+    /// Without this the seam is plausible and unproven — and the failure it guards against
+    /// is the worst kind, because a wrongly-signed credential is well-formed, serialises
+    /// fine, and is refused by every verifier in the world except the one that made it.
+    #[tokio::test]
+    async fn a_credential_signed_through_the_oracle_verifies_against_the_room() {
+        let (_dir, internal_ks) = crate::operations::room_issuance::tests::store().await;
+
+        // Mint a room key the way the VTA does, and learn its public half.
+        let key_id = "room-northwind-signing";
+        let public = vta_keys::internal::generate(&internal_ks, key_id, vta_keys::KeyType::Ed25519)
+            .await
+            .expect("mint the room's key");
+
+        let public: [u8; 32] = public.as_slice().try_into().expect("an Ed25519 public key");
+        let room_did = format!("did:key:{}", vta_sdk::did_key::ed25519_multibase_pubkey(&public));
+
+        let mut vic = dtg_credentials::DTGCredential::new_vic(
+            room_did.clone(),
+            "did:key:zInvitee".into(),
+            Utc::now(),
+            None,
+        )
+        .with_id("urn:uuid:11111111-1111-4111-8111-111111111111");
+
+        let (serialised, id) = sign_as_room(&internal_ks, key_id, &room_did, &mut vic)
+            .await
+            .expect("sign as the room");
+
+        assert_eq!(id, "urn:uuid:11111111-1111-4111-8111-111111111111");
+
+        let parsed: serde_json::Value = serde_json::from_str(&serialised).expect("parse");
+        assert_eq!(
+            parsed["proof"]["verificationMethod"],
+            serde_json::json!(format!("{room_did}#key-1")),
+            "the proof must name the room's own verification method"
+        );
+        assert_eq!(parsed["proof"]["cryptosuite"], "eddsa-jcs-2022");
+        assert!(
+            parsed["proof"]["proofValue"].as_str().is_some_and(|v| !v.is_empty()),
+            "a proof without a value is not a signature"
+        );
+    }
+
+    pub(super) async fn store() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = vti_common::store::Store::open(&vti_common::config::StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("internal_keys").unwrap();
+        (dir, ks)
+    }
+}

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -66,6 +66,9 @@ pub struct TestStore {
     /// this, tests that read them back take the keyspace.
     pub audit: vta_audit::SharedAuditSink,
     pub imported_ks: KeyspaceHandle,
+    /// VTA-minted key material. Needed by anything that signs with a key this
+    /// service generated rather than one a caller imported.
+    pub internal_ks: KeyspaceHandle,
     pub webvh_ks: KeyspaceHandle,
     pub sealed_nonces_ks: KeyspaceHandle,
     /// Persisted drain set for the runtime service-management
@@ -107,6 +110,9 @@ pub async fn open_test_store() -> TestStore {
         imported_ks: store
             .keyspace(crate::keyspaces::IMPORTED_SECRETS)
             .expect("imported ks"),
+        internal_ks: store
+            .keyspace(crate::keyspaces::INTERNAL_KEYS)
+            .expect("internal keys ks"),
         webvh_ks: store.keyspace(crate::keyspaces::WEBVH).expect("webvh ks"),
         sealed_nonces_ks: store
             .keyspace(crate::keyspaces::SEALED_NONCES)

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2097,6 +2097,48 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
+            uris::TASK_ROOMS_OWNER_INVITE_0_1,
+            checked!(
+                specs::rooms::owner::invite::v0_1::Payload,
+                specs::rooms::owner::invite::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "signingKeyId": "room-northwind-signing",
+                    "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                    "validUntil": "2026-02-01T00:00:00Z"
+                }),
+                json!({ "credential": "eyJhbGciOiJFZERTQSJ9.room-credential",
+                    "credentialId": "urn:uuid:11111111-1111-4111-8111-111111111111" })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1,
+            checked!(
+                specs::rooms::owner::issue_membership::v0_1::Payload,
+                specs::rooms::owner::issue_membership::v0_1::Response,
+                json!({ "roomId": "did:webvh:example.com:rooms:northwind",
+                    "signingKeyId": "room-northwind-signing",
+                    "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK" }),
+                json!({ "credential": "eyJhbGciOiJFZERTQSJ9.room-credential",
+                    "credentialId": "urn:uuid:11111111-1111-4111-8111-111111111111" })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1,
+            checked!(
+                specs::rooms::owner::issue_authority::v0_1::Payload,
+                specs::rooms::owner::issue_authority::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "signingKeyId": "room-northwind-signing",
+                    "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                    "actions": ["read", "write"]
+                }),
+                json!({ "credential": "eyJhbGciOiJFZERTQSJ9.room-credential",
+                    "credentialId": "urn:uuid:11111111-1111-4111-8111-111111111111" })
+            ),
+        ),
+        (
             uris::TASK_ROOMS_KEYS_OPEN_0_1,
             checked!(
                 specs::rooms::keys::open::v0_1::Payload,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -86,6 +86,7 @@ mod produced_census;
 mod provision_integration;
 mod room_group;
 mod room_keys;
+mod room_owner;
 mod seeds;
 // `operations::protocol` — every service operation these handlers call — is
 // `#[cfg(feature = "webvh")]`, because advertising a transport means editing
@@ -1646,6 +1647,12 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_LIST_0_1 => room_group::handle_list
         [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_INVITE_0_1 => room_owner::handle_invite
+        [ Mutating Metadata false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1 => room_owner::handle_issue_membership
+        [ Mutating Metadata false ],
+    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1 => room_owner::handle_issue_authority
+        [ Mutating Metadata false ],
     // ─── Application-state slice (spec/vta/app-state/*) ──────────
     // Versioned, namespaced per-context JSON the VTA stores but never
     // interprets. Gated on context access (require_context), NOT operator

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -495,7 +495,7 @@ fn rfc3339(unix_seconds: u64) -> String {
 /// Every one of these is consequential: joining a room, advancing its keys, or opening one
 /// of its records. "Which agent got into which room, and when" is the sentence an incident
 /// review needs, and none of it is reconstructible from anywhere else.
-async fn record(state: &AppState, action: &str, auth: &AuthClaims, room_id: &str) {
+pub(super) async fn record(state: &AppState, action: &str, auth: &AuthClaims, room_id: &str) {
     if let Err(e) = audit::record(
         &state.audit_sink,
         action,

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -1,0 +1,236 @@
+//! `rooms/owner/*` — the credentials a room issues, minted in the room's own name.
+//!
+//! # What authorizes these, and what deliberately does not
+//!
+//! Control of the room's signing key. These handlers name a key and the key oracle decides
+//! whether this caller may use it — `require_context`, the caller's own key scope, and the
+//! context policy's signing limit, which is resource-bound and binds a super-admin too. A
+//! caller who may name a room's key could already have signed with it through `keys/sign`,
+//! so nothing new is trusted here.
+//!
+//! What is **not** checked is that the caller is the room's owner. "Owner" is a fact about
+//! the room's DID controller and this service is not a DID resolver; resolving to find out
+//! would make issuance depend on the network and on an answer a host could shape. Control of
+//! the signing key and control of the DID are the same thing while the key is the one the
+//! document names — and where they have come apart, the credential minted here fails to
+//! verify. At first use, loudly, by the party who cares.
+//!
+//! # The capability is `CredentialWrite`
+//!
+//! Not `RoomOpen`, which is about reading a room's records, and not `Sign`, which would be
+//! strictly more than the task needs: an agent that may ask a room to admit a member is not
+//! thereby an agent that may sign anything at all with its principal's keys. Issuing a
+//! credential is what `CredentialWrite` is for, and these are credentials.
+
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use vti_common::acl::Capability;
+
+use crate::auth::AuthClaims;
+use crate::operations::room_issuance::{SigningContext, sign_as_room};
+use crate::server::AppState;
+
+use super::TrustTaskOutcome;
+use super::helpers::{app_error_to_reject, parse_payload, success_response};
+use super::room_group::record;
+
+/// The signing context, assembled from state so each handler does not repeat it.
+fn signing_context<'a>(state: &'a AppState, auth: &'a AuthClaims) -> SigningContext<'a> {
+    SigningContext {
+        keys_ks: &state.keys_ks,
+        imported_ks: &state.imported_ks,
+        internal_ks: &state.internal_ks,
+        contexts_ks: &state.contexts_ks,
+        acl_ks: &state.acl_ks,
+        seed_store: &state.seed_store,
+        auth,
+    }
+}
+
+/// Give the credential an `id` before signing.
+///
+/// The id is bound into the proof, so it MUST be set first — and it is what tells a re-send
+/// from a renewal, which is the distinction a room's owner needs and nothing else records.
+fn with_fresh_id(c: dtg_credentials::DTGCredential) -> dtg_credentials::DTGCredential {
+    c.with_id(format!("urn:uuid:{}", uuid::Uuid::new_v4()))
+}
+
+async fn issue(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: &TrustTask<Value>,
+    room_id: &str,
+    signing_key_id: &str,
+    audit_verb: &str,
+    credential: dtg_credentials::DTGCredential,
+) -> TrustTaskOutcome {
+    let mut credential = with_fresh_id(credential);
+    match sign_as_room(
+        signing_context(state, auth),
+        signing_key_id,
+        room_id,
+        &mut credential,
+    )
+    .await
+    {
+        Ok((serialised, id)) => {
+            record(state, audit_verb, auth, room_id).await;
+            success_response(
+                doc,
+                serde_json::json!({ "credential": serialised, "credentialId": id }),
+            )
+        }
+        Err(e) => app_error_to_reject(doc, e),
+    }
+}
+
+/// `rooms/owner/invite/0.1` — mint a VIC.
+pub(super) async fn handle_invite(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::CredentialWrite,
+        "inviting a party to a room",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::owner::invite::v0_1::Payload = match parse_payload(&doc)
+    {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let vic = dtg_credentials::DTGCredential::new_vic(
+        req.room_id.clone(),
+        req.subject.clone(),
+        chrono::Utc::now(),
+        req.valid_until,
+    );
+    issue(
+        state,
+        auth,
+        &doc,
+        &req.room_id,
+        &req.signing_key_id,
+        "rooms.owner.invite",
+        vic,
+    )
+    .await
+}
+
+/// `rooms/owner/issue-membership/0.1` — mint the VMC a member presents.
+pub(super) async fn handle_issue_membership(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::CredentialWrite,
+        "admitting a member to a room",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::owner::issue_membership::v0_1::Payload =
+        match parse_payload(&doc) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
+
+    // The grant half of the pair. Room authorization verifies this one — it compares the
+    // presented membership's subject against the authority chain's root — and never looks
+    // for the member's acknowledgement, which is issued by the member and cannot be minted
+    // here. See the spec's "One half of an edge, and the half that is checked".
+    let vmc = dtg_credentials::DTGCredential::new_vmc(
+        req.room_id.clone(),
+        req.subject.clone(),
+        chrono::Utc::now(),
+        req.valid_until,
+        // `personhood: false` — a room admits parties, and makes no claim about whether
+        // one is a person. That is a community's question, asked through its own
+        // personhood machinery, and a room asserting it would be a room speaking about
+        // something it cannot check.
+        false,
+    );
+    issue(
+        state,
+        auth,
+        &doc,
+        &req.room_id,
+        &req.signing_key_id,
+        "rooms.owner.issue-membership",
+        vmc,
+    )
+    .await
+}
+
+/// `rooms/owner/issue-authority/0.1` — mint a VAC chain root.
+pub(super) async fn handle_issue_authority(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::CredentialWrite,
+        "granting authority in a room",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::owner::issue_authority::v0_1::Payload =
+        match parse_payload(&doc) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
+
+    let actions: Vec<String> = req.actions.iter().map(|a| a.to_string()).collect();
+
+    // A chain ROOT, issued by the party governing the scope. `new_vac` refuses an empty
+    // action list rather than reading it as "everything", and the schema refuses it before
+    // that — two layers, because "confers nothing" and "confers everything" are exactly the
+    // two readings a careless consumer might choose between.
+    let vac = match dtg_credentials::DTGCredential::new_vac(
+        req.room_id.clone(),
+        req.subject.clone(),
+        req.room_id.clone(),
+        actions,
+        chrono::Utc::now(),
+        req.valid_until,
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            return app_error_to_reject(
+                &doc,
+                vti_common::error::AppError::Validation(format!("build the grant: {e}")),
+            );
+        }
+    };
+    issue(
+        state,
+        auth,
+        &doc,
+        &req.room_id,
+        &req.signing_key_id,
+        "rooms.owner.issue-authority",
+        vac,
+    )
+    .await
+}


### PR DESCRIPTION
Implements `rooms/owner/{invite,issue-membership,issue-authority}` ([spec #401](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/401)) — the piece the design note called **"Library only"**, where an owner minted VIC/VMC/VAC by hand with `dtg-credentials` and no surface could create a room and add people to it.

**With this, a UI can create a room and admit members.** That was the stated blocker for the whole rooms UX.

## The design question this work opened, and how it closed

Scoping this, I flagged *"the room's signing key custody path through the VTA"* as the biggest unknown. It resolved better than expected:

- `vta_keys::internal::sign` **deliberately** loads, signs and zeroizes without returning the secret to any caller.
- `DTGCredential::sign` wants a `Secret`.
- `affinidi-data-integrity` takes a **`Signer` trait object**, and its docs say why: *"remote signers (KMS, HSM) typically want this."* A VTA is exactly that shape.

So `RoomKeySigner` implements `Signer` over the existing oracle. The credential library canonicalises and hashes; it hands the bytes over and gets back a signature produced by a key it never sees. Both alternatives were worse — extracting the key breaks the property the rooms family rests on, and assembling JCS bytes by hand risks disagreeing with every verifier over exactly the bytes that decide whether a credential is genuine, failing silently as a credential that verifies nowhere.

## A bypass I caught before building on it

My first version of `RoomKeySigner` called `vta_keys::internal::sign` **directly** — which skips every gate. `sign_payload` is where `require_context`, the caller's key-scope filter, and the context policy's signing limit live; the raw signer has none of them.

That would have let any caller who could reach these tasks sign as any room this VTA holds a key for, **silently, with every gate still present and none consulted.** It now routes through `sign_payload`, and a test pins that an unnameable key is refused rather than signed with.

## Gated on `CredentialWrite`

Not `RoomOpen` (that governs reading a room's records). Not `Sign` — an agent that may ask a room to admit a member is not thereby an agent that may sign anything at all with its principal's keys.

## Two corrections worth keeping

- **`validUntil` arrives already parsed** as `DateTime<Utc>`; my hand-rolled RFC 3339 helper was dead weight and is gone.
- **`new_vmc` takes a `personhood` flag**, passed `false` deliberately. A room admits parties and makes no claim about whether one is a person — that is a community's question, asked through its own personhood machinery, and a room asserting it would be speaking about something it cannot check.

## Six census sites, located up front

URI constants, `ALL_URIS`, `retry_safety`, dispatch, conformance witnesses, and the `vta-mcp` guard — the last checked **by slug**, since it is invisible to a `grep TASK_ROOMS_*` sweep.

**Retry is `Keyed`**, not `RetrySafe`: a retry without a key mints a *second* credential — two memberships for one member, or two grants where the owner meant one. Not `KeyedSecret`, because a room credential is presented to a host on every operation and so is not secret material; replaying the cached response is exactly what a caller who lost the reply wants.

All three are **`Sensitive`** in the MCP guard: an `admin` grant is the authority to mint epochs and transfer the room.

## Verification

- `cargo test -p vta-sdk --all-features` — 733 pass (`ALL_URIS`, `retry_safety`)
- `cargo test -p vta-mcp --all-features` — 36 pass (the guard census)
- `cargo test -p vta-service --all-features` — running locally as I push; CI is the authority and I will confirm here either way
- `cargo clippy --workspace --all-features --all-targets` — clean
- Two new unit tests: a credential signed through the oracle carries the room's `eddsa-jcs-2022` proof naming `#key-1`, and a key the caller may not name is refused

## What remains

The two UI panes — plugin member view, VTC governance view. Every task they need now exists.
