### PR TITLE
feat(rooms): the VTA calls a room's host on its principal's behalf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "url",
  "uuid",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "uuid",
 ]
 
@@ -7979,7 +7979,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9599,7 +9599,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "uuid",
 ]
 
@@ -9615,7 +9615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "uuid",
 ]
 
@@ -9634,7 +9634,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "uuid",
 ]
 
@@ -9652,7 +9652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
 ]
 
 [[package]]
@@ -9672,9 +9672,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.7"
+version = "0.18.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd500fca5a987d3f174419c92bcf921a580c18d034d5ff5c66fafb4ac8d94e61"
+checksum = "35197fd73d1a0e6b4147081139f054875c945ce1e38e6ee8800ab7db66084dc5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10430,7 +10430,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "uniffi",
  "vta-sdk",
 ]
@@ -10448,7 +10448,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10527,7 +10527,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "url",
  "utoipa",
  "uuid",
@@ -10612,7 +10612,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "url",
  "urlencoding",
  "utoipa",
@@ -10781,7 +10781,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10853,7 +10853,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10911,7 +10911,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -10967,7 +10967,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.7",
+ "trust-tasks-rs 0.18.8",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ aws-lc-rs = "1.16"
 # fully succeeded comes back as a 500 `responseSchemaViolation` — the members
 # are emitted and the schema rejects them. A caret on "0.18" would let a
 # resolver pick 0.18.2 and reintroduce exactly that.
-trust-tasks-rs = { version = "0.18.7", default-features = false, features = [
+trust-tasks-rs = { version = "0.18.8", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -136,6 +136,10 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // to the room's whole retained history. A blanket `vta_call` approval must
     // not silently cover widening what the principal's key holder can decrypt.
     ("rooms/keys/chain", Risk::Sensitive),
+    // Fetches key material from a named host and keeps it. Sensitive for the
+    // same reason `chain` is — it extends what this agent can decrypt — with the
+    // addition that it makes an outbound call to a party the caller names.
+    ("rooms/keys/backfill", Risk::Sensitive),
     // Secret material, accepted AND emitted. `seal` takes a record's plaintext and
     // returns it encrypted under the room's key — the one direction in this family
     // where cleartext room material travels INTO the oracle. It belongs beside
@@ -155,6 +159,10 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     ("rooms/owner/invite", Risk::Sensitive),
     ("rooms/owner/issue-membership", Risk::Sensitive),
     ("rooms/owner/issue-authority", Risk::Sensitive),
+    // Announces a room, and its owner, to a host the caller names. Nothing
+    // secret leaves — the disclosure is the room's existence and who answers for
+    // it — but it creates durable state at a third party.
+    ("rooms/owner/register", Risk::Sensitive),
     // The holder's own identity, emitted. `disclosure/present` is the one
     // persona task that hands claims to a named verifier, under a persona DID,
     // and writes the record saying it did. It sits beside `rooms/keys/present`

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -430,6 +430,10 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // redelivery stores nothing and reports the same reachability. A lost reply
     // costs the caller the answer, never the state.
     (trust_tasks::TASK_ROOMS_KEYS_CHAIN_0_1, RetrySafe),
+    // Idempotent by epoch on both halves: a rung already held is never replaced,
+    // and re-fetching from the host yields the same rungs. A retry that arrives
+    // after the first succeeded stores nothing and reports the same reach.
+    (trust_tasks::TASK_ROOMS_KEYS_BACKFILL_0_1, RetrySafe),
     // Sealing is a pure function of the key and the bytes, and it stores nothing:
     // a lost reply costs the caller a round trip, never any state. Re-sealing the
     // same body yields a different nonce, which is correct and changes nothing.
@@ -443,6 +447,17 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // response is exactly what a caller who lost the reply wants — the same
     // credential rather than another one.
     (trust_tasks::TASK_ROOMS_OWNER_INVITE_0_1, Keyed),
+    // Convergent, unlike its `Keyed` neighbours here: the issuance verbs each
+    // mint a fresh credential, so a second execution leaves a second durable
+    // artefact — this one mints nothing. A host keys a room by its `roomId`, so
+    // registering the same room twice converges on the one row rather than
+    // creating a second.
+    //
+    // A host MAY answer the repeat as a conflict rather than a no-op, so a
+    // retry can report an error over a registration that in fact succeeded.
+    // That is a worse *message*, not a worse world, which is the distinction
+    // this axis is about.
+    (trust_tasks::TASK_ROOMS_OWNER_REGISTER_0_1, RetrySafe),
     (trust_tasks::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1, Keyed),
     (trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1, Keyed),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -826,6 +826,16 @@ pub const TASK_ROOMS_KEYS_COMMIT_0_1: &str = "https://trusttasks.org/spec/rooms/
 /// through; this covers the history it did not.
 pub const TASK_ROOMS_KEYS_CHAIN_0_1: &str = "https://trusttasks.org/spec/rooms/keys/chain/0.1";
 
+/// `spec/rooms/keys/backfill/0.1` — fetch the room's epoch key chain from its host
+/// and keep it, so history written before the principal joined becomes readable.
+///
+/// The agent-side counterpart to [`TASK_ROOMS_EPOCH_CHAIN_0_1`]-at-a-host: it
+/// mints the presentation, makes the call, and stores what comes back. A surface
+/// that reaches only its own agent cannot do the middle hop, which is why this
+/// exists.
+pub const TASK_ROOMS_KEYS_BACKFILL_0_1: &str =
+    "https://trusttasks.org/spec/rooms/keys/backfill/0.1";
+
 /// `spec/rooms/keys/seal/0.1` — seal one record body with the room's current
 /// epoch key. The mirror of `open`: plaintext in, ciphertext out, key stays put.
 /// Auth: `roomOpen` capability. It does not write — the caller takes the result
@@ -842,6 +852,12 @@ pub const TASK_ROOMS_KEYS_LIST_0_1: &str = "https://trusttasks.org/spec/rooms/ke
 /// Auth: `credentialWrite` capability, plus whatever the key oracle says about
 /// naming the room's signing key.
 pub const TASK_ROOMS_OWNER_INVITE_0_1: &str = "https://trusttasks.org/spec/rooms/owner/invite/0.1";
+
+/// `spec/rooms/owner/register/0.1` — ask this agent to register a room with a
+/// host. `rooms/create` performed by the agent, for the surfaces that cannot
+/// reach a host themselves.
+pub const TASK_ROOMS_OWNER_REGISTER_0_1: &str =
+    "https://trusttasks.org/spec/rooms/owner/register/0.1";
 
 /// `spec/rooms/owner/issue-membership/0.1` — mint the membership credential a member
 /// presents on every subsequent room operation. The room has no roster; this
@@ -1920,9 +1936,11 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ROOMS_KEYS_WELCOME_0_1,
     TASK_ROOMS_KEYS_COMMIT_0_1,
     TASK_ROOMS_KEYS_CHAIN_0_1,
+    TASK_ROOMS_KEYS_BACKFILL_0_1,
     TASK_ROOMS_KEYS_SEAL_0_1,
     TASK_ROOMS_KEYS_LIST_0_1,
     TASK_ROOMS_OWNER_INVITE_0_1,
+    TASK_ROOMS_OWNER_REGISTER_0_1,
     TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1,
     TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1,
     TASK_VTA_MEMORY_DELETE_0_1,

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -68,6 +68,7 @@ pub mod protocol;
 #[cfg(feature = "webvh")]
 pub mod provision_integration;
 pub mod room_groups;
+pub mod room_host;
 pub mod room_invitation;
 pub mod room_issuance;
 pub mod room_oracle;

--- a/vta-service/src/operations/room_host.rs
+++ b/vta-service/src/operations/room_host.rs
@@ -1,0 +1,350 @@
+//! Calling a room's host, as the member's agent.
+//!
+//! # Why this exists at all
+//!
+//! Every host-served room verb — `rooms/create`, `rooms/records/*`,
+//! `rooms/epoch/*` — needs a channel to the host. The surfaces people actually
+//! use hold a channel to their own agent and to no third party: a browser
+//! extension's bridge passes a task type and a payload and addresses everything
+//! to the wallet's own VTA, so a document naming a host is simply not sendable
+//! from there. `rooms/keys/backfill` and `rooms/owner/register` move that call
+//! to the party that *can* make it, and this module is how it makes it.
+//!
+//! # What this is not
+//!
+//! It is **not** a second Trust-Task client. The document layer is already
+//! transport-agnostic — that is what a Trust Task is — and `vta-sdk` already
+//! owns the selection: [`ServiceCapabilities::from_did_document`] reads what a
+//! peer advertises by service **type**, and [`Protocol::PREFERENCE_ORDER`] is
+//! the workspace's TSP > DIDComm > REST. This module composes those with the
+//! one thing the SDK's own client cannot do here.
+//!
+//! That one thing is signing. [`vta_sdk::client::VtaClient`] signs from a
+//! `ClientIdentity` carrying a raw `private_key_multibase`, and **a VTA never
+//! holds its own keys in that shape** — it derives, signs and zeroizes behind
+//! [`crate::operations::keys::sign_payload`], where the context gates live. So
+//! the document is built and signed here, through the same `Signer` seam
+//! `RoomKeySigner` uses, and only the bytes travel.
+//!
+//! # Transport: an intersection, not a downgrade
+//!
+//! The rule is that the protocol used is the highest-preference one present in
+//! **both** parties' advertisements. [`OUTBOUND_SUPPORTED`] is this VTA's half,
+//! and it is deliberately a named constant rather than an implicit assumption:
+//! today it holds REST alone, because initiating TSP or DIDComm needs a
+//! correlated reply this service does not yet keep for outbound requests (it has
+//! `send_routed`, but only reply-side, and no pending-reply waiter of the kind
+//! `vtc-service` keeps).
+//!
+//! A host advertising nothing in that intersection is therefore a **loud typed
+//! refusal naming both sets**, never a quiet fallback. That distinction is the
+//! whole of the workspace rule: downgrading past what a peer advertises is
+//! forbidden; being honest that this VTA cannot yet initiate on a protocol is
+//! not the same thing, and the error says which it is.
+
+use serde_json::Value;
+use vta_sdk::protocol::matching::{Protocol, ServiceCapabilities};
+use vti_common::error::{AppError, bad_gateway_error};
+
+use crate::operations::room_issuance::{SigningContext, VtaKeySigner};
+
+/// The protocols this VTA can **initiate** a Trust-Task request on, in
+/// preference order.
+///
+/// Adding TSP here takes one thing: a pending-reply registry keyed by the
+/// document's `threadId`, so a `send_routed` can be awaited. `vtc-service`'s
+/// `state.pending_replies` is the shape. Until that exists, naming TSP here
+/// would produce a request that is sent and never answered.
+pub const OUTBOUND_SUPPORTED: [Protocol; 1] = [Protocol::Rest];
+
+/// The highest-preference protocol both this VTA and `host` can do, with the
+/// endpoint to reach it on.
+fn pick_transport(caps: &ServiceCapabilities, host: &str) -> Result<(Protocol, String), AppError> {
+    for protocol in Protocol::PREFERENCE_ORDER {
+        if !OUTBOUND_SUPPORTED.contains(&protocol) {
+            continue;
+        }
+        if let Some(endpoint) = caps.endpoint(protocol) {
+            return Ok((protocol, endpoint.to_string()));
+        }
+    }
+
+    let advertised: Vec<&str> = Protocol::PREFERENCE_ORDER
+        .iter()
+        .filter(|p| caps.endpoint(**p).is_some())
+        .map(|p| p.as_str())
+        .collect();
+    let ours: Vec<&str> = OUTBOUND_SUPPORTED.iter().map(|p| p.as_str()).collect();
+
+    Err(AppError::Validation(format!(
+        "no transport in common with room host `{host}`: it advertises [{}] and this agent can \
+         initiate [{}]. This is not a host that cannot be reached — it is one this agent cannot \
+         yet start a conversation with, which is a gap in the agent rather than in the host.",
+        if advertised.is_empty() {
+            "nothing".to_string()
+        } else {
+            advertised.join(", ")
+        },
+        ours.join(", "),
+    )))
+}
+
+/// Build the Trust-Task document that carries `task` to a host.
+///
+/// Extracted so the outbound shape is assertable without a live host — the same
+/// reason `webvh_didcomm::build_envelope_document` exists, and for the same
+/// class of bug: a malformed document is refused by the far side in words about
+/// the *payload*, and nothing local would have caught it.
+pub fn build_room_task(task: &str, host: &str, issuer: &str, payload: Value) -> Value {
+    serde_json::json!({
+        "id": format!("urn:uuid:{}", uuid::Uuid::new_v4()),
+        "type": task,
+        // Addressed to the host per SPEC §4.8. A host authorizes from the
+        // document's own proof, but an unaddressed document is one a stricter
+        // peer is entitled to refuse.
+        "recipient": host,
+        "issuer": issuer,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "payload": payload,
+    })
+}
+
+/// Read a host's reply, distinguishing the three things it can be.
+///
+/// A room host answers a Trust Task with the task's own `#response`, or with a
+/// `trust-task-error` document carrying its refusal. The second is **not** a
+/// transport failure and must not be flattened into one: the host's own code and
+/// reason are the operator-facing half of every `hostRefused` this family
+/// declares, and a 502 in their place tells an operator their network is broken
+/// when their room policy declined.
+pub fn read_reply(doc: &Value, expected: &str, host: &str) -> Result<Value, AppError> {
+    let doc_type = doc.get("type").and_then(Value::as_str).unwrap_or_default();
+
+    if doc_type == expected {
+        return Ok(doc.get("payload").cloned().unwrap_or(Value::Null));
+    }
+
+    if doc_type.starts_with("https://trusttasks.org/spec/trust-task-error/") {
+        let payload = doc.get("payload").cloned().unwrap_or(Value::Null);
+        let code = payload
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("unspecified");
+        let reason = payload
+            .get("reason")
+            .or_else(|| payload.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or("no reason given");
+        return Err(AppError::Forbidden(format!(
+            "room host `{host}` refused: {code}: {reason}"
+        )));
+    }
+
+    Err(AppError::Internal(format!(
+        "room host `{host}` answered `{doc_type}` where `{expected}` was expected; a reply that \
+         threads to our request but answers a different task is a contract break rather than a \
+         task failure"
+    )))
+}
+
+/// Send one room task to `host` and return the response document's `payload`.
+///
+/// `signing_key_id` and `issuer` name the identity this VTA signs as. For a
+/// member's backfill that is the agent itself — the host binds the presentation
+/// to the DID that signed the envelope, so the presentation must have been
+/// minted for this same DID or the host will (correctly) refuse it.
+pub async fn send_room_task(
+    ctx: SigningContext<'_>,
+    resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
+    host: &str,
+    signing_key_id: &str,
+    issuer: &str,
+    verification_method: &str,
+    task: &str,
+    response_task: &str,
+    payload: Value,
+) -> Result<Value, AppError> {
+    let resolved = resolver.resolve(host).await.map_err(|e| {
+        AppError::Validation(format!(
+            "the room host `{host}` does not resolve, so there is nothing to send to: {e}"
+        ))
+    })?;
+    let doc_value = serde_json::to_value(&resolved.doc)
+        .map_err(|e| AppError::Internal(format!("serialise the host's DID document: {e}")))?;
+
+    let caps = ServiceCapabilities::from_did_document(&doc_value);
+    let (protocol, endpoint) = pick_transport(&caps, host)?;
+
+    let mut document = build_room_task(task, host, issuer, payload);
+    let signer = VtaKeySigner::new(ctx, signing_key_id, verification_method);
+    let proof = affinidi_data_integrity::DataIntegrityProof::sign(
+        &document,
+        &signer,
+        affinidi_data_integrity::SignOptions::new(),
+    )
+    .await
+    .map_err(|e| {
+        // The cause, not just "signing failed" — every refusal worth acting on
+        // (an unknown key, a context the caller may not reach, a policy limit
+        // spent) lives in the source chain and `DataIntegrityError` renders
+        // only its own outer message.
+        let mut cause = String::new();
+        let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(&e);
+        while let Some(inner) = src {
+            cause = format!("{cause}: {inner}");
+            src = inner.source();
+        }
+        AppError::Internal(format!(
+            "sign the request to room host `{host}`: {e}{cause}"
+        ))
+    })?;
+    document["proof"] = serde_json::to_value(proof)
+        .map_err(|e| AppError::Internal(format!("serialise the proof: {e}")))?;
+
+    match protocol {
+        Protocol::Rest => {
+            let url = format!("{}/trust-tasks", endpoint.trim_end_matches('/'));
+            let response = vta_sdk::http::rest_client()
+                .post(&url)
+                .header("content-type", "application/json")
+                .json(&document)
+                .send()
+                .await
+                .map_err(|e| {
+                    bad_gateway_error(format!("room host `{host}` at {url} did not answer: {e}"))
+                })?;
+
+            // The body is read once, and before the status is judged: a refusal
+            // arrives as a `trust-task-error` document with a code an operator
+            // can act on, and throwing on the status first would discard it
+            // (guide rule R3.7).
+            let body = response.text().await.map_err(|e| {
+                bad_gateway_error(format!("room host `{host}` sent an unreadable body: {e}"))
+            })?;
+            let reply: Value = serde_json::from_str(&body).map_err(|e| {
+                bad_gateway_error(format!(
+                    "room host `{host}` sent a body that is not a Trust-Task document: {e}: {body}"
+                ))
+            })?;
+            read_reply(&reply, response_task, host)
+        }
+        // Unreachable while `OUTBOUND_SUPPORTED` holds REST alone; kept as an
+        // arm rather than a catch-all so adding a protocol there fails to
+        // compile here instead of silently doing nothing.
+        Protocol::Tsp | Protocol::Didcomm => Err(AppError::Internal(format!(
+            "{} is named in OUTBOUND_SUPPORTED but has no send path here",
+            protocol.as_str()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn caps_from(services: Value) -> ServiceCapabilities {
+        ServiceCapabilities::from_did_document(&serde_json::json!({ "service": services }))
+    }
+
+    #[test]
+    fn a_host_serving_rest_is_reachable() {
+        let caps = caps_from(serde_json::json!([{
+            "id": "#rest", "type": "VTARest", "serviceEndpoint": "https://host.example"
+        }]));
+        let (protocol, endpoint) = pick_transport(&caps, "did:example:host").expect("reachable");
+        assert_eq!(protocol, Protocol::Rest);
+        assert_eq!(endpoint, "https://host.example");
+    }
+
+    /// The honest refusal. A host that speaks only TSP is not unreachable in
+    /// principle — this agent cannot start the conversation — and the message
+    /// has to say which, or an operator goes looking at the host.
+    #[test]
+    fn a_tsp_only_host_is_refused_naming_both_sides() {
+        let caps = caps_from(serde_json::json!([{
+            "id": "#tsp", "type": "TSPTransport", "serviceEndpoint": "did:example:mediator"
+        }]));
+        let err = pick_transport(&caps, "did:example:host").expect_err("no common transport");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("tsp"),
+            "must name what the host advertises: {msg}"
+        );
+        assert!(
+            msg.contains("rest"),
+            "must name what this agent can do: {msg}"
+        );
+        assert!(
+            msg.contains("gap in the agent"),
+            "must say whose limitation it is: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_host_advertising_nothing_says_so() {
+        let err = pick_transport(&caps_from(serde_json::json!([])), "did:example:host")
+            .expect_err("nothing advertised");
+        assert!(err.to_string().contains("nothing"));
+    }
+
+    #[test]
+    fn the_document_is_addressed_and_attributed() {
+        let doc = build_room_task(
+            "https://trusttasks.org/spec/rooms/epoch/chain/0.1",
+            "did:example:host",
+            "did:example:agent",
+            serde_json::json!({ "roomId": "did:example:room" }),
+        );
+        assert_eq!(doc["recipient"], "did:example:host");
+        assert_eq!(doc["issuer"], "did:example:agent");
+        assert_eq!(doc["payload"]["roomId"], "did:example:room");
+        assert!(doc["id"].as_str().unwrap().starts_with("urn:uuid:"));
+    }
+
+    #[test]
+    fn a_response_yields_its_payload() {
+        let reply = serde_json::json!({
+            "type": "https://trusttasks.org/spec/rooms/epoch/chain/0.1#response",
+            "payload": { "links": [] }
+        });
+        let got = read_reply(
+            &reply,
+            "https://trusttasks.org/spec/rooms/epoch/chain/0.1#response",
+            "did:example:host",
+        )
+        .expect("a response");
+        assert_eq!(got["links"], serde_json::json!([]));
+    }
+
+    /// A refusal is the host's answer, not a broken network. Flattening it to a
+    /// gateway error tells an operator to check their connection when their
+    /// room policy declined.
+    #[test]
+    fn a_refusal_carries_the_hosts_own_code_and_reason() {
+        let reply = serde_json::json!({
+            "type": "https://trusttasks.org/spec/trust-task-error/0.5",
+            "payload": { "code": "private-tier-not-enabled", "reason": "this community has not enabled private rooms" }
+        });
+        let err = read_reply(&reply, "irrelevant", "did:example:host").expect_err("a refusal");
+        let msg = err.to_string();
+        assert!(msg.contains("private-tier-not-enabled"), "{msg}");
+        assert!(msg.contains("has not enabled private rooms"), "{msg}");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "a refusal, not a 502"
+        );
+    }
+
+    #[test]
+    fn a_reply_answering_a_different_task_is_a_contract_break() {
+        let reply =
+            serde_json::json!({ "type": "https://trusttasks.org/spec/rooms/create/0.1#response" });
+        let err = read_reply(
+            &reply,
+            "https://trusttasks.org/spec/rooms/epoch/chain/0.1#response",
+            "did:example:host",
+        )
+        .expect_err("wrong task");
+        assert!(err.to_string().contains("contract break"));
+    }
+}

--- a/vta-service/src/operations/room_issuance.rs
+++ b/vta-service/src/operations/room_issuance.rs
@@ -136,6 +136,57 @@ impl Signer for RoomKeySigner<'_> {
     }
 }
 
+/// Signs with one of **this VTA's own** keys, through the same gated oracle.
+///
+/// The same mechanism as [`RoomKeySigner`] pointed at a different identity, and
+/// worth its own type rather than a bare-string constructor: the two are not
+/// interchangeable and confusing them is silent. Signing an outbound host
+/// request as a *room* would present credentials the room issued under a proof
+/// naming the room as presenter, and the host binds the presentation to whoever
+/// signed — so the mismatch surfaces at the far side as "this presentation is
+/// not yours", which reads like a credential problem and is not one.
+pub struct VtaKeySigner<'a> {
+    inner: RoomKeySigner<'a>,
+}
+
+impl<'a> VtaKeySigner<'a> {
+    /// `verification_method` is named rather than derived. A VTA's DID is
+    /// normally a `did:webvh`, whose document decides what its keys are called;
+    /// `#key-1` is the room template's convention and guessing it for an agent
+    /// would produce a proof nothing resolves.
+    pub fn new(
+        ctx: SigningContext<'a>,
+        key_id: impl Into<String>,
+        verification_method: impl Into<String>,
+    ) -> Self {
+        Self {
+            inner: RoomKeySigner {
+                ctx,
+                key_id: key_id.into(),
+                verification_method: verification_method.into(),
+            },
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Signer for VtaKeySigner<'_> {
+    fn key_type(&self) -> KeyType {
+        self.inner.key_type()
+    }
+
+    fn verification_method(&self) -> &str {
+        self.inner.verification_method()
+    }
+
+    async fn sign(
+        &self,
+        data: &[u8],
+    ) -> Result<Vec<u8>, affinidi_data_integrity::DataIntegrityError> {
+        self.inner.sign(data).await
+    }
+}
+
 /// Sign `credential` as the room, returning it serialised with its proof attached.
 pub async fn sign_as_room(
     ctx: SigningContext<'_>,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2060,6 +2060,27 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
+            uris::TASK_ROOMS_KEYS_BACKFILL_0_1,
+            checked!(
+                specs::rooms::keys::backfill::v0_1::Payload,
+                specs::rooms::keys::backfill::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "host": "did:webvh:example.com:northwind-community",
+                    "fromEpoch": 6
+                }),
+                // All three numbers, because the response's whole point is that
+                // they come apart: two rungs arrived, both were new, and the
+                // reach moved to the room's first epoch.
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "earliestReadableEpoch": 1,
+                    "fetched": 2,
+                    "stored": 2
+                })
+            ),
+        ),
+        (
             uris::TASK_ROOMS_KEYS_SEAL_0_1,
             checked!(
                 specs::rooms::keys::seal::v0_1::Payload,
@@ -2109,6 +2130,26 @@ fn table() -> Vec<(&'static str, Conformance)> {
                 }),
                 json!({ "credential": "eyJhbGciOiJFZERTQSJ9.room-credential",
                     "credentialId": "urn:uuid:11111111-1111-4111-8111-111111111111" })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_OWNER_REGISTER_0_1,
+            checked!(
+                specs::rooms::owner::register::v0_1::Payload,
+                specs::rooms::owner::register::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "host": "did:webvh:example.com:northwind-community",
+                    "visibility": "private",
+                    "retentionDays": 90
+                }),
+                // `host` echoed, per the specification: a caller records where
+                // its room actually landed rather than where it asked for.
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "host": "did:webvh:example.com:northwind-community",
+                    "epoch": 1
+                })
             ),
         ),
         (

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1643,12 +1643,22 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_CHAIN_0_1 => room_group::handle_chain
         [ Mutating None false ],
+    // `actsAsSubject`, unlike every other `rooms/keys/*`: this one presents the
+    // principal's credentials to a third party as them. The response discloses
+    // only how far back the agent can now read.
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_BACKFILL_0_1 => room_group::handle_backfill
+        [ Mutating Metadata true ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_SEAL_0_1 => room_group::handle_seal
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_LIST_0_1 => room_group::handle_list
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_OWNER_INVITE_0_1 => room_owner::handle_invite
         [ Mutating Metadata false ],
+    // `actsAsSubject`, unlike the issuance verbs beside it: those sign as the
+    // room and return the credential to the caller, while this one speaks to a
+    // third party as its principal.
+    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_REGISTER_0_1 => room_owner::handle_register
+        [ Mutating Metadata true ],
     vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1 => room_owner::handle_issue_membership
         [ Mutating Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1 => room_owner::handle_issue_authority

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -392,6 +392,167 @@ pub(super) async fn handle_chain(
     )
 }
 
+/// Everything the gated signer needs, gathered from the running service.
+///
+/// A copy of `room_owner`'s rather than a shared one: the two modules sign as
+/// different identities and the struct is the argument list, not the policy.
+fn signing_context<'a>(
+    state: &'a AppState,
+    auth: &'a AuthClaims,
+) -> crate::operations::room_issuance::SigningContext<'a> {
+    crate::operations::room_issuance::SigningContext {
+        keys_ks: &state.keys_ks,
+        imported_ks: &state.imported_ks,
+        internal_ks: &state.internal_ks,
+        contexts_ks: &state.contexts_ks,
+        acl_ks: &state.acl_ks,
+        seed_store: &state.seed_store,
+        auth,
+    }
+}
+
+/// `rooms/keys/backfill/0.1` — fetch the chain from the host and keep it.
+///
+/// Three hops folded into one, performed by the party that can perform all three:
+/// mint a presentation, ask the host for the rungs, store what comes back. The
+/// member could do the first and third and not the second — a browser reaches its
+/// own agent and no third party — which is the whole reason this task exists.
+///
+/// **The presentation is minted for this VTA's own DID**, not the caller's, and
+/// that is load-bearing rather than incidental. `room_oracle::present` attenuates
+/// the principal's authority to whichever agent is named, and a host binds the
+/// presentation to the DID that signed the request envelope. This VTA is what
+/// signs the outbound document, so a presentation minted for anyone else is one
+/// the host is right to refuse — and the refusal would read as the member lacking
+/// authority rather than as an agent presenting somebody else's grant.
+pub(super) async fn handle_backfill(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::RoomOpen,
+        "fetching a room's readable history",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::keys::backfill::v0_1::Payload = match parse_payload(&doc)
+    {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let vta_did = match state.config.read().await.vta_did.clone() {
+        Some(d) => d,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                vti_common::error::AppError::Validation(
+                    "this agent has no DID of its own, so it cannot present to a host as itself"
+                        .into(),
+                ),
+            );
+        }
+    };
+    let Some(resolver) = state.did_resolver.clone() else {
+        return app_error_to_reject(
+            &doc,
+            vti_common::error::AppError::Validation(
+                "this agent has no DID resolver configured, so it cannot find the host".into(),
+            ),
+        );
+    };
+
+    // `read`, and only `read`. Reading the room and reading the parts of it
+    // written earlier are the same act, so they take the same grant; asking for
+    // more would hand the host authority the operation never needed.
+    let minted = match crate::operations::room_oracle::present(
+        state,
+        auth,
+        &vta_did,
+        &req.room_id,
+        "read",
+        Some(req.host.as_str()),
+        None,
+    )
+    .await
+    {
+        Ok(m) => m,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    let mut payload = serde_json::json!({
+        "roomId": req.room_id,
+        "presentation": minted.presentation,
+    });
+    if let Some(from) = req.from_epoch {
+        payload["fromEpoch"] = serde_json::json!(u64::from(from));
+    }
+    if let Some(limit) = req.limit {
+        payload["limit"] = serde_json::json!(u64::from(limit));
+    }
+
+    let key = format!("{vta_did}#key-0");
+    let reply = match crate::operations::room_host::send_room_task(
+        signing_context(state, auth),
+        &resolver,
+        &req.host,
+        &key,
+        &vta_did,
+        &key,
+        vti_rooms::wire::ROOMS_EPOCH_CHAIN_TYPE,
+        &format!("{}#response", vti_rooms::wire::ROOMS_EPOCH_CHAIN_TYPE),
+        payload,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    let links: Vec<vti_rooms::wire::EpochLink> =
+        match serde_json::from_value(reply.get("links").cloned().unwrap_or(Value::Array(vec![]))) {
+            Ok(l) => l,
+            Err(e) => {
+                return app_error_to_reject(
+                    &doc,
+                    vti_common::error::AppError::Internal(format!(
+                        "room host `{}` served rungs this agent cannot read: {e}",
+                        req.host
+                    )),
+                );
+            }
+        };
+    let fetched = links.len();
+
+    // Nothing served is a real answer rather than an error — the host holds no
+    // rungs below what this agent already reads — and it needs no special case:
+    // `store_links` with an empty delivery stores nothing and still walks what
+    // is held, which is the reach this must report either way.
+    let (earliest, stored) =
+        match room_groups::store_links(&state.room_groups_ks, &req.room_id, links, now()).await {
+            Ok(r) => r,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+
+    record(state, "rooms.keys.backfill", auth, &req.room_id).await;
+    success_response(
+        &doc,
+        serde_json::json!({
+            "roomId": req.room_id,
+            "earliestReadableEpoch": earliest,
+            "fetched": fetched,
+            "stored": stored,
+        }),
+    )
+}
+
 /// `rooms/keys/open/0.1`.
 pub(super) async fn handle_open(
     state: &AppState,

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -234,3 +234,114 @@ pub(super) async fn handle_issue_authority(
     )
     .await
 }
+
+/// `rooms/owner/register/0.1` — tell a host about a room that already exists.
+///
+/// `rooms/create` performed by the agent, for the same reason as
+/// [`super::room_group::handle_backfill`]: the surfaces owners create rooms from
+/// hold a channel to their own agent and to no third party.
+///
+/// **The order is unchanged and still forced.** The room's identity is minted
+/// first — that is a separate act, and this does not perform it — and a host is
+/// then told about a room that already exists. A host that named the room would
+/// be a host the room could not leave.
+///
+/// This signs as the **agent**, not as the room. A registration is a request to
+/// store something, authorised by the host's own creation policy against the
+/// party asking; signing as the room would claim the room is asking to be stored,
+/// which is neither true nor something the host can check.
+pub(super) async fn handle_register(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::CredentialWrite,
+        "registering a room with a host",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::owner::register::v0_1::Payload =
+        match parse_payload(&doc) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
+
+    let vta_did = match state.config.read().await.vta_did.clone() {
+        Some(d) => d,
+        None => {
+            return app_error_to_reject(
+                &doc,
+                vti_common::error::AppError::Validation(
+                    "this agent has no DID of its own, so it cannot speak to a host as itself"
+                        .into(),
+                ),
+            );
+        }
+    };
+    let Some(resolver) = state.did_resolver.clone() else {
+        return app_error_to_reject(
+            &doc,
+            vti_common::error::AppError::Validation(
+                "this agent has no DID resolver configured, so it cannot find the host".into(),
+            ),
+        );
+    };
+
+    // Absent `ownerDid` means the caller, per the specification. Defaulted here
+    // rather than at the host, because the host has no view of who asked this
+    // agent — it sees the agent.
+    let owner_did = req.owner_did.clone().unwrap_or_else(|| auth.did.clone());
+
+    let mut payload = serde_json::json!({
+        "roomId": req.room_id,
+        "visibility": req.visibility,
+        "ownerDid": owner_did,
+    });
+    if let Some(policy) = &req.retention_policy {
+        payload["retentionPolicy"] = serde_json::to_value(policy).unwrap_or(Value::Null);
+    }
+    if let Some(days) = req.retention_days {
+        payload["retentionDays"] = serde_json::json!(u64::from(days));
+    }
+
+    let key = format!("{vta_did}#key-0");
+    let reply = match crate::operations::room_host::send_room_task(
+        signing_context(state, auth),
+        &resolver,
+        &req.host,
+        &key,
+        &vta_did,
+        &key,
+        vti_rooms::wire::ROOMS_CREATE_TYPE,
+        &format!("{}#response", vti_rooms::wire::ROOMS_CREATE_TYPE),
+        payload,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // The host's own answer for the epoch, not an assumption that a new room
+    // starts at 1: a host that already held this room reports where it actually
+    // stands, and a caller recording 1 over a live room would be recording a
+    // fiction.
+    let epoch = reply.get("epoch").and_then(Value::as_u64).unwrap_or(1);
+
+    success_response(
+        &doc,
+        serde_json::json!({
+            "roomId": req.room_id,
+            // Echoed from what was reached, per the specification.
+            "host": req.host,
+            "epoch": epoch,
+        }),
+    )
+}

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -281,9 +281,13 @@ export const deleteJson = <T>(
 export const getJsonExempt = <T>(path: string): Promise<T> =>
   request<T>(path, { method: "GET" });
 
-// `/health` is the daemon's single Trust-Task-exempt endpoint.
+// `/health` and `GET /v1/rooms` are the daemon's two Trust-Task-exempt
+// endpoints, for unrelated reasons: `/health` predates the router, and the
+// rooms listing is the host's own view of what it stores — every `rooms/*`
+// task is authorised by a credential the ROOM issued, so naming one here
+// would claim a room governs an answer it has no view of.
 // `/admin/build-info.json` lives on the admin router (not the
-// TrustTaskRouter). Both are header-less by design.
+// TrustTaskRouter). All are header-less by design.
 export const fetchHealth = (): Promise<HealthResponse> =>
   getJsonExempt<HealthResponse>("/health");
 

--- a/vtc-service/admin-ui/src/lib/policies-api.ts
+++ b/vtc-service/admin-ui/src/lib/policies-api.ts
@@ -6,6 +6,7 @@
 // defaults for. The Ceremonies plugin manages all of them.
 
 import { getJson, postJson } from "@/lib/api";
+import type { PolicyPurpose } from "@/lib/wire-types";
 
 // One canonical task per verb (the shared upload/1.0 mount was retired
 // in phase 2a).
@@ -19,20 +20,39 @@ const TRUST_TASK_ACTIVATE = "https://trusttasks.org/spec/policy/activate/0.1";
 /// purpose is fixed by the module's Rego package), so it travels here.
 const PURPOSE_EXT = "org.openvtc.purpose";
 
-export const ALL_PURPOSES = [
-  "join",
-  "removal",
-  "personhood",
-  "registry",
-  "directory",
-  "roleDefinitions",
-  "crossCommunityRoles",
-  "crossCommunityRelationships",
-  "relationships",
-  "roleChange",
-] as const;
+/**
+ * Every purpose, in the order the console shows them.
+ *
+ * **Derived from the daemon, not described beside it.** This was a hand-written
+ * literal and it had already drifted: it named ten purposes while the daemon
+ * served eleven, so the `rooms` policy — which decides whether this community
+ * lends its disk to a data room, and whose shipped default **denies** the
+ * private tier — had no tab in the console and could not be read, tested or
+ * replaced from here. Nothing failed. The tab was simply absent, which is the
+ * quietest way for a policy to go unmanaged.
+ *
+ * The `Record<Purpose, true>` is what stops it happening again: a purpose added
+ * to the Rust enum reaches `wire.ts` on the next `wire:generate`, and this
+ * object then fails to compile until someone places it. Ordering is the
+ * object's, so a new purpose lands where it is put rather than at the end.
+ */
+export type Purpose = PolicyPurpose;
 
-export type Purpose = (typeof ALL_PURPOSES)[number];
+const PURPOSE_ORDER: Record<Purpose, true> = {
+  join: true,
+  removal: true,
+  personhood: true,
+  registry: true,
+  directory: true,
+  roleDefinitions: true,
+  crossCommunityRoles: true,
+  crossCommunityRelationships: true,
+  relationships: true,
+  roleChange: true,
+  rooms: true,
+};
+
+export const ALL_PURPOSES = Object.keys(PURPOSE_ORDER) as Purpose[];
 
 /// Purposes that are first-class ceremonies (have a flow + simulator).
 export const CEREMONY_PURPOSES: Purpose[] = [

--- a/vtc-service/admin-ui/src/lib/wire-types.ts
+++ b/vtc-service/admin-ui/src/lib/wire-types.ts
@@ -72,6 +72,19 @@ export type PoliciesPage = Schemas["PolicyListResponse"];
 export type ActiveBindingsResponse = Schemas["ActiveBindingsResponse"];
 export type PolicyUpsertResponse = Schemas["UploadResponse"];
 export type PolicyTestResponse = Schemas["TestResponse"];
+/**
+ * What a policy decides.
+ *
+ * Aliased rather than re-listed because the console's own copy had gone stale:
+ * it named ten purposes while the daemon served eleven, so the `rooms` policy —
+ * the one deciding whether this community lends its disk, and whose shipped
+ * default **denies** private rooms — was unreachable from the console entirely.
+ * Nothing failed; the tab was simply not there.
+ */
+export type PolicyPurpose = Schemas["PolicyPurpose"];
+
+// ── Rooms ───────────────────────────────────────────────────────────────
+export type HostedRoom = Schemas["HostedRoom"];
 
 // ── Community profile + ceremonies ──────────────────────────────────────
 export type Profile = Schemas["ProfileWithStatus"];

--- a/vtc-service/admin-ui/src/plugins/index.ts
+++ b/vtc-service/admin-ui/src/plugins/index.ts
@@ -13,6 +13,7 @@
 
 import {
   ClipboardList,
+  DoorOpen,
   Inbox,
   KeyRound,
   LayoutDashboard,
@@ -38,6 +39,7 @@ import { MyPasskeys } from "@/plugins/myPasskeys";
 import { Profile } from "@/plugins/profile";
 import { Recognition } from "@/plugins/recognition";
 import { Relationships } from "@/plugins/relationshipsGraph";
+import { Rooms } from "@/plugins/rooms";
 import { Sessions } from "@/plugins/sessions";
 
 export function registerBuiltinPlugins(): void {
@@ -95,6 +97,14 @@ export function registerBuiltinPlugins(): void {
     path: "/members",
     iconComponent: Users,
     reactComponent: Members,
+  });
+
+  registerPlugin({
+    id: "rooms",
+    label: "Data rooms",
+    path: "/rooms",
+    iconComponent: DoorOpen,
+    reactComponent: Rooms,
   });
 
   registerPlugin({

--- a/vtc-service/admin-ui/src/plugins/rooms.tsx
+++ b/vtc-service/admin-ui/src/plugins/rooms.tsx
@@ -1,0 +1,444 @@
+// Rooms plugin — the data rooms this community hosts, and the one decision it
+// gets to make about them.
+//
+// ## What a host knows, and why so little is not a bug
+//
+// A host cannot read a room's records and holds no member list. Both are by
+// construction: records arrive sealed under a key the host never sees, and
+// authorisation for every operation is a credential the *room* issued, checked
+// against the room's own DID rather than against anything stored here. That is
+// invariant I5, and it is what lets a room change hosts without reissuing a
+// single credential.
+//
+// So this screen shows the row and nothing derived from a room's contents.
+// There is no records view to add later and no member list to fetch — an
+// operator asking for either is asking for the property the tier removed.
+//
+// **The owner is visible at every tier, including `private`, on purpose.** A
+// room whose contents nobody here can read still has a party this operator must
+// be able to reach about quota, abuse, and the reclamation notice the lifecycle
+// obliges them to send. An operator who cannot list their rooms cannot send it,
+// which is why invariant I1 exists.
+//
+// ## The lifecycle column, and what each state actually means
+//
+// `live` → `lapsed` → `dormant` → `reclaimable`, computed from the epoch's
+// expiry and never stored — **minting an epoch is the renewal**, so a room in
+// use renews itself in the course of being used and a stored state would be a
+// second thing to keep true. A single renewal returns a room to `live` from any
+// of the three.
+//
+// **None of them is an outage, and the screen must not read like one.** A
+// lapsed room is read-only: nothing is destroyed, nothing is hidden, and reads
+// keep working right up to the moment a reclaimed room's bytes are deleted —
+// because the members’ choice at every stage is renew or take it with you.
+//
+// The two that mean something to an operator:
+//
+//   - **dormant** is where the owner is owed the notice, and where a nominated
+//     successor may claim the room. Not `lapsed` — an expired epoch is
+//     frequently somebody on holiday, and admitting a claim there would make
+//     every holiday a takeover window.
+//   - **reclaimable** is past the retention period stated at creation. The
+//     notice has already been sent; deletion is a separate, deliberate act this
+//     screen does not perform.
+//
+// ## The decision this community actually makes
+//
+// Creation, and only creation. The `rooms` policy decides whether to lend the
+// disk; once a room exists this community's roster has no say. The shipped
+// default permits `open` and `attributed` to members and **denies `private`** —
+// not because a private room is dangerous, but because a community that has not
+// decided should not discover it is hosting rooms whose membership it cannot
+// see.
+//
+// That default is a surprise worth putting on screen rather than leaving in a
+// Rego file, so the second card asks the live policy the question directly, per
+// tier, using the same `data.vtc.rooms.decision` query and the same input shape
+// the real creation path builds. A probe against a different input would answer
+// a different question, which is worse than not asking.
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { DoorOpen, RefreshCw } from "lucide-react";
+
+import { getJsonExempt, postJson } from "@/lib/api";
+import { fetchActivePolicy } from "@/lib/policies-api";
+import { formatEpoch, shorten } from "@/lib/format";
+import { NamedDid } from "@/components/NamedDid";
+import { useNameBook } from "@/lib/names";
+import type { HostedRoom, PolicyTestResponse } from "@/lib/wire-types";
+
+const TRUST_TASK_TEST = "https://trusttasks.org/spec/vtc/policies/test/0.1";
+
+/** The query the real creation path evaluates. Anything else probes a different rule. */
+const DECISION_QUERY = "data.vtc.rooms.decision";
+
+const TIERS = ["open", "attributed", "private"] as const;
+type Tier = (typeof TIERS)[number];
+
+const TIER_BLURB: Record<Tier, string> = {
+  open: "Records are stored in the clear. This host can read every one of them.",
+  attributed: "Records are sealed, and this host sees who wrote which.",
+  private: "Records are sealed and this host cannot see the membership at all.",
+};
+
+/**
+ * The rooms this community hosts.
+ *
+ * **Exempt on purpose, and the one place in a plugin where that is not a
+ * smell.** Every `rooms/*` Trust Task is authorised by a credential the ROOM
+ * issued, checked against the room's own identifier — invariant I5, and what
+ * lets a room change hosts. This asks the opposite question: what is this
+ * *operator* storing. It is answered from the host's own admin authority, so
+ * pairing it with a room task would claim a room governs an answer it has no
+ * view of. The daemon mounts it off the Trust-Task router for exactly that
+ * reason, so sending a header here would be inventing a task URI that names
+ * nothing.
+ */
+async function fetchRooms(): Promise<HostedRoom[]> {
+  return getJsonExempt<HostedRoom[]>("/v1/rooms");
+}
+
+/**
+ * Ask the active `rooms` policy what it would say.
+ *
+ * The input is the shape `RoomCreationFacts` serialises to, because a probe
+ * built from a guess answers about a policy nobody runs. `member: true` with no
+ * role is the ordinary case the default policy is written around; a stranger is
+ * denied by the `default decision` and tells the operator nothing they did not
+ * already know.
+ */
+async function probeTier(policyId: string, tier: Tier): Promise<PolicyTestResponse> {
+  return postJson<PolicyTestResponse>(
+    `/v1/policies/${policyId}/test`,
+    {
+      query: DECISION_QUERY,
+      input: {
+        now: new Date().toISOString(),
+        actor: { did: "did:example:a-member-of-this-community", member: true },
+        room: {
+          roomId: "did:example:a-room",
+          visibility: tier,
+          ownerDid: "did:example:a-member-of-this-community",
+        },
+      },
+    },
+    { trustTask: TRUST_TASK_TEST },
+  );
+}
+
+interface Verdict {
+  effect: string;
+  code?: string;
+  reason?: string;
+}
+
+function pluckDecision(resp: PolicyTestResponse): Verdict | null {
+  const value = (
+    resp as unknown as {
+      result?: { result?: { expressions?: { value?: unknown }[] }[] };
+    }
+  ).result?.result?.[0]?.expressions?.[0]?.value;
+  if (!value || typeof value !== "object") return null;
+  const v = value as { effect?: unknown; with?: { code?: unknown; reason?: unknown } };
+  if (typeof v.effect !== "string") return null;
+  return {
+    effect: v.effect,
+    code: typeof v.with?.code === "string" ? v.with.code : undefined,
+    reason: typeof v.with?.reason === "string" ? v.with.reason : undefined,
+  };
+}
+
+const LIFECYCLE_MEANS: Record<string, string> = {
+  live: "Renewed. Accepting writes.",
+  lapsed:
+    "The epoch expired, so the room is read-only. Nothing is destroyed or hidden, and one renewal returns it to live \u2014 often this is just somebody on holiday.",
+  dormant:
+    "Still unrenewed after the grace window. The owner is owed the notice, and a successor the room nominated may claim it from here.",
+  reclaimable:
+    "Past the retention period agreed at creation. The host may delete it; reads keep working until it does.",
+};
+
+function LifecyclePill({ value }: { value: string }) {
+  // `lapsed` must not read as a failure — the room is intact and one renewal
+  // fixes it. `reclaimable` is the only state where anything is at risk.
+  const tone =
+    value === "live" ? "success" : value === "reclaimable" ? "danger" : "warning";
+  return (
+    <span className={`chip ${tone}`} title={LIFECYCLE_MEANS[value] ?? value}>
+      {value}
+    </span>
+  );
+}
+
+function RoomsTable({ rooms }: { rooms: HostedRoom[] }) {
+  const nameBook = useNameBook();
+  return (
+    <table className="data-table">
+      <thead>
+        <tr>
+          <th>Room</th>
+          <th>Owner</th>
+          <th>Tier</th>
+          <th>Epoch</th>
+          <th>Lifecycle</th>
+          <th>Retention</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rooms.map((r) => (
+          <tr key={r.roomId}>
+            <td>
+              <code title={r.roomId}>{shorten(r.roomId)}</code>
+              {r.mirrorOf && (
+                <div className="muted" style={{ fontSize: "0.85em" }}>
+                  read-only copy of {shorten(r.mirrorOf)}
+                </div>
+              )}
+            </td>
+            <td>
+              <NamedDid did={r.ownerDid} book={nameBook} />
+            </td>
+            <td>{r.visibility}</td>
+            <td>
+              {r.epoch}
+              {r.epochExpiresAt ? (
+                <div className="muted" style={{ fontSize: "0.85em" }}>
+                  expires {formatEpoch(r.epochExpiresAt)}
+                </div>
+              ) : null}
+            </td>
+            <td>
+              <LifecyclePill value={r.lifecycle} />
+            </td>
+            <td>
+              {r.retentionDays}d
+              <div className="muted" style={{ fontSize: "0.85em" }}>
+                {r.retentionPolicy === "chained" ? "history kept" : "from join"}
+              </div>
+            </td>
+            <td>{formatEpoch(r.createdAt)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/**
+ * What the live policy says, per tier.
+ *
+ * Three questions rather than a rendering of the Rego, because the question an
+ * operator has is a yes/no about a tier and the answer is whatever the module
+ * actually returns — including for a policy they wrote themselves, which no
+ * amount of reading the shipped default would predict.
+ */
+function CreationPolicy() {
+  const [ran, setRan] = useState(false);
+
+  const activeQuery = useQuery({
+    queryKey: ["policies", "active", "rooms"],
+    queryFn: () => fetchActivePolicy("rooms"),
+  });
+
+  const policyId = activeQuery.data?.id;
+
+  const probesQuery = useQuery({
+    queryKey: ["rooms", "policy-probe", policyId],
+    enabled: ran && Boolean(policyId),
+    queryFn: async () => {
+      const out: Record<Tier, Verdict | null> = {
+        open: null,
+        attributed: null,
+        private: null,
+      };
+      for (const tier of TIERS) {
+        out[tier] = pluckDecision(await probeTier(policyId!, tier));
+      }
+      return out;
+    },
+  });
+
+  return (
+    <section className="card">
+      <h3>Who may create a room here</h3>
+      <p className="lead">
+        Creation is the only part of a room's life this community decides. Once a
+        room exists every operation on it is authorised by credentials the room
+        itself issued, and this community's roster has no say — which is what
+        lets a room move to another host without a credential being reissued.
+      </p>
+
+      {activeQuery.isPending && <p>Reading the active rooms policy…</p>}
+
+      {activeQuery.isError && (
+        <p className="muted">
+          The active rooms policy could not be read, so this cannot say what the
+          community permits. That is a failure to ask, not a community with no
+          policy — creation is still being decided by whatever is active.
+        </p>
+      )}
+
+      {!activeQuery.isPending && !activeQuery.isError && !policyId && (
+        <p className="muted">
+          No rooms policy is active. A room creation evaluated against nothing is
+          a <b>deny</b>: a missing rule is not read as consent here, so nobody can
+          create a room until one is activated.
+        </p>
+      )}
+
+      {policyId && (
+        <>
+          <p className="muted">
+            Asked of the module actually in force, using the same query and input
+            shape a real registration builds — for an ordinary member of this
+            community.
+          </p>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => setRan(true)}
+            disabled={probesQuery.isFetching}
+          >
+            <RefreshCw aria-hidden="true" />
+            {probesQuery.isFetching ? "Asking…" : ran ? "Ask again" : "Ask the policy"}
+          </button>
+
+          {probesQuery.isError && (
+            <p className="muted">The policy could not be evaluated.</p>
+          )}
+
+          {probesQuery.data && (
+            <table className="data-table" style={{ marginTop: "var(--space-4)" }}>
+              <thead>
+                <tr>
+                  <th>Tier</th>
+                  <th>A member may create</th>
+                  <th>What the policy said</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TIERS.map((tier) => {
+                  const v = probesQuery.data[tier];
+                  const allowed = v?.effect === "allow";
+                  return (
+                    <tr key={tier}>
+                      <td>
+                        {tier}
+                        <div className="muted" style={{ fontSize: "0.85em" }}>
+                          {TIER_BLURB[tier]}
+                        </div>
+                      </td>
+                      <td>
+                        <span className={`chip ${allowed ? "success" : "warning"}`}>
+                          {v ? (allowed ? "yes" : "no") : "no decision"}
+                        </span>
+                      </td>
+                      <td className="muted">
+                        {v
+                          ? (v.reason ?? v.code ?? v.effect)
+                          : "The module returned nothing for this input, which this host treats as a deny."}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+
+      <p className="muted" style={{ marginTop: "var(--space-4)" }}>
+        To change any of it, edit the <b>rooms</b> policy under Ceremonies. The
+        shipped default denies the private tier deliberately: a community that has
+        not decided should not find out it is hosting rooms whose membership it
+        cannot see.
+      </p>
+    </section>
+  );
+}
+
+export function Rooms() {
+  const roomsQuery = useQuery({ queryKey: ["rooms"], queryFn: fetchRooms });
+  const rooms = roomsQuery.data ?? [];
+
+  // Worth surfacing above the table: these two are the states that ask the
+  // operator to do something, and they are invisible in a long list.
+  const { dormant, reclaimable } = useMemo(
+    () => ({
+      dormant: rooms.filter((r) => r.lifecycle === "dormant").length,
+      reclaimable: rooms.filter((r) => r.lifecycle === "reclaimable").length,
+    }),
+    [rooms],
+  );
+
+  return (
+    <section className="page">
+      <h2>Data rooms</h2>
+      <p className="lead">
+        Rooms this community stores. It cannot read their records and holds no
+        member list — both by construction — so this is the row and nothing
+        derived from a room's contents. The owner is shown at every tier,
+        including private, because they are the party a quota or reclamation
+        notice has to reach.
+      </p>
+
+      {roomsQuery.isPending && (
+        <section className="card">
+          <p>Loading rooms…</p>
+        </section>
+      )}
+
+      {roomsQuery.isError && (
+        <section className="card">
+          <p className="muted">
+            The room list could not be read. This is a failure to ask — not a
+            community hosting none.
+          </p>
+        </section>
+      )}
+
+      {!roomsQuery.isPending && !roomsQuery.isError && rooms.length === 0 && (
+        <section className="card">
+          <div className="empty-state">
+            <span className="empty-icon" aria-hidden="true">
+              <DoorOpen />
+            </span>
+            <h4>No rooms hosted here</h4>
+            <p>
+              A room appears once its owner registers it with this community. The
+              policy below decides who may.
+            </p>
+          </div>
+        </section>
+      )}
+
+      {rooms.length > 0 && (
+        <section className="card">
+          {dormant > 0 && (
+            <p className="muted">
+              {dormant} {dormant === 1 ? "room is" : "rooms are"} <b>dormant</b> —
+              unrenewed past the grace window. This is where the owner is owed the
+              notice, and where a successor the room nominated may claim it.
+            </p>
+          )}
+          {reclaimable > 0 && (
+            <p className="muted">
+              {reclaimable} {reclaimable === 1 ? "room is" : "rooms are"}{" "}
+              <b>reclaimable</b> — past the retention agreed at creation, so this
+              host may delete {reclaimable === 1 ? "it" : "them"}. Deletion is a
+              separate, deliberate act and does not happen from this screen; until
+              it does, {reclaimable === 1 ? "the room" : "they"} still read
+              normally.
+            </p>
+          )}
+          <RoomsTable rooms={rooms} />
+        </section>
+      )}
+
+      <CreationPolicy />
+    </section>
+  );
+}


### PR DESCRIPTION
Implements `rooms/keys/backfill` and `rooms/owner/register` from trustoverip/dtgwg-trust-tasks-tf#402, and bumps `trust-tasks-rs` to 0.18.8 to get them.

## Why these exist

The surfaces people use hold a channel to their own agent and to no third party. A browser console's bridge passes a task type and a payload and addresses everything to the wallet's own VTA — so every host-served room verb was unreachable from it, and the create flow merged in the plugin repo minted a room's identity and could then never register it.

## `operations/room_host.rs` is not a second Trust-Task client

That was my first instinct and it was wrong. The document layer is already transport-agnostic — that is what a Trust Task *is* — and `vta-sdk` already owns the selection:

- `ServiceCapabilities::from_did_document` reads what a peer advertises by service **type**,
- `Protocol::PREFERENCE_ORDER` is the workspace's TSP > DIDComm > REST.

So this module composes those with the one thing `VtaClient` cannot do here. `VtaClient` signs from a `ClientIdentity` carrying a raw `private_key_multibase`, and **a VTA never holds its own keys in that shape** — it derives, signs and zeroizes behind `operations::keys::sign_payload`, where the context gates live. `VtaKeySigner` reuses that seam, so only bytes travel.

(`webvh_didcomm.rs` is *also* the wrong template, for a different reason: the VTC's DIDComm `route` handles seven legacy message types and never reaches `dispatch_trust_task_core`, so room tasks are not reachable over DIDComm at all.)

## Transport is an intersection, not a downgrade

`OUTBOUND_SUPPORTED` names this VTA's half and today holds **REST alone**, because initiating TSP needs a correlated reply this service does not keep for outbound requests — it has `send_routed`, reply-side only, and no pending-reply waiter of the kind `vtc-service` keeps. Adding TSP is one thing: that registry, keyed by `threadId`. The constant says so.

A host advertising nothing in the intersection gets a typed refusal **naming both sets and saying whose limitation it is**:

> no transport in common with room host `did:…`: it advertises [tsp] and this agent can initiate [rest]. This is not a host that cannot be reached — it is one this agent cannot yet start a conversation with, which is a gap in the agent rather than in the host.

That is the distinction the rule draws. Downgrading past what a peer advertises is forbidden; being honest that this agent cannot yet initiate on a protocol is not the same thing, and the error says which.

## Two details that decide whether it works at all

**The presentation is minted for this VTA's own DID, not the caller's.** `room_oracle::present` attenuates the principal's authority to whichever agent is named, and a host binds the presentation to the DID that signed the envelope. A presentation minted for anyone else is one the host is right to refuse — and the refusal would read as *the member lacking authority* rather than as an agent presenting somebody else's grant.

**A host's `trust-task-error` is its answer, not a broken network.** Flattening it to a 502 would tell an operator to check their connection when their room policy declined, so `read_reply` surfaces the host's own code and reason as a `Forbidden` — which is what makes the `hostRefused` code the spec declares actually useful.

## Classification

`register` is `RetrySafe`, not `Keyed` like the issuance verbs beside it. Those mint a fresh credential each time, so a second execution leaves a second durable artefact; this mints nothing, and a host keys a room by `roomId`, so a repeat converges on one row. A host may still answer the repeat as a conflict — a worse *message*, not a worse world, which is what that axis measures. The comment says so rather than leaving it to be re-derived.

Both are `actsAsSubject: true` in the dispatch table, unlike every neighbour in their families: these are the two that speak to a third party *as* the principal.

## Verification

- `cargo test -p vta-service --lib` — 1056 passed, 0 failed.
- `cargo test -p vta-mcp -p vta-sdk` — all green.
- `cargo build --workspace --all-targets`, `cargo clippy --all-targets`, `cargo fmt --all` — clean.
- 7 new unit tests on the transport pick and reply reading, including that a TSP-only host is refused naming both sides, and that a refusal keeps the host's code rather than becoming a gateway error.
- **Census non-vacuity proven, not assumed**: deleting the `vta-mcp` guard entry makes `every_dispatchable_uri_has_a_known_verb` fail on the URI. That guard classifies by *slug*, which is invisible to a URI grep and is the site I got wrong last time.

All six sites per task: URI constant, `ALL_URIS`, `retry_safety`, dispatch, conformance witness, MCP guard.

## Next

The browser console can now finish the create flow and offer the history repair its rooms pane already names — one call each, to the agent it can already reach.