### PR TITLE
fix(vtc): sign success responses — 265 specs require it and none got one

### DIFF
--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -134,9 +134,90 @@ pub(crate) async fn dispatch_trust_task_core(
         return reject_with(&doc, reason);
     }
 
-    // 3. Dispatch by type URI.
+    // 3. Dispatch by type URI, then sign what comes back.
     let type_uri = doc.type_uri.to_string();
-    match type_uri.as_str() {
+    let outcome = dispatch_typed(state, ctx, doc, &type_uri).await;
+    sign_success_response(state, outcome).await
+}
+
+/// Attach this community's Data-Integrity proof to a success response.
+///
+/// # Why here and not at each `success_response`
+///
+/// Signing is the same decision taken once per handler, and there are twenty-one
+/// of them. Forgetting once is a task whose response is unattributable, and
+/// nothing downstream would notice — which is exactly how every response came to
+/// be unsigned in the first place. The spine is where the framework's inbound
+/// checks already live; the outbound one belongs beside them.
+///
+/// # Why this was missing, and what it cost
+///
+/// SPEC §7.3 item 7: where a specification declares no separate requirement for
+/// the *response*, the request's applies to it — "an omission can never weaken a
+/// variant". 265 published specifications declare a single
+/// `proofRequirement: REQUIRED`, so their responses require a proof, and this
+/// service attached none to any of them.
+///
+/// Nothing went red because no consumer verifies one either. Producers not
+/// signing and consumers not checking is a mutually consistent silence, and the
+/// cost is that **no answer this service has ever given is evidence of
+/// anything**: a member cannot show a third party what the host told them, and
+/// cannot be contradicted when they misreport it.
+///
+/// # Scope
+///
+/// Success responses only. An *error response*'s `type` resolves to the
+/// framework's `trust-task-error` specification, whose own requirement is
+/// RECOMMENDED rather than REQUIRED (SPEC §8.1, and §7.3's note that the error
+/// variant is deliberately not declarable by a task). Signing those is a
+/// separate decision with its own rationale — a retained compliance refusal is
+/// the case that argues for it — and is not smuggled in here.
+///
+/// A community with no signer configured (setup, before provisioning) returns
+/// the document unsigned rather than failing: it has nothing to sign with, and
+/// refusing to answer would make an unprovisioned VTC unusable rather than
+/// merely unattributable.
+async fn sign_success_response(state: &AppState, outcome: TrustTaskOutcome) -> TrustTaskOutcome {
+    if !outcome.status.is_success() {
+        return outcome;
+    }
+    let Some(signer) = state.credential_signer.clone() else {
+        return outcome;
+    };
+
+    let mut doc: Value = match serde_json::from_slice(&outcome.body) {
+        Ok(d) => d,
+        Err(e) => {
+            // The spine built this document a moment ago, so this cannot happen
+            // without a bug above. Answer unsigned rather than turning a
+            // successful operation into a failure over its envelope.
+            tracing::error!(error = %e, "success response is not JSON; returning it unsigned");
+            return outcome;
+        }
+    };
+    if let Err(e) = signer.sign_doc(&mut doc).await {
+        tracing::error!(error = %e, "could not sign the success response; returning it unsigned");
+        return outcome;
+    }
+    match serde_json::to_vec(&doc) {
+        Ok(body) => TrustTaskOutcome {
+            status: outcome.status,
+            body,
+        },
+        Err(e) => {
+            tracing::error!(error = %e, "could not serialise the signed response");
+            outcome
+        }
+    }
+}
+
+async fn dispatch_typed(
+    state: &AppState,
+    ctx: &JoinAuthCtx,
+    doc: TrustTask<Value>,
+    type_uri: &str,
+) -> TrustTaskOutcome {
+    match type_uri {
         jr::JOIN_REQUEST_SUBMIT_TYPE => handle_submit(state, ctx, doc).await,
         jr::JOIN_REQUEST_MANIFEST_TYPE => handle_manifest(state, doc).await,
         jr::JOIN_REQUEST_STATUS_TYPE => handle_status(state, ctx, doc).await,
@@ -980,6 +1061,89 @@ mod tests {
                 body.contains(crate::members::match_code::MATCH_CODE_EXT_KEY),
                 "the messaging reply must carry the match code the REST reply does, got: {body}"
             );
+        }
+
+        /// **Every success response carries this community's proof.**
+        ///
+        /// SPEC §7.3 item 7: a specification declaring a single
+        /// `proofRequirement: REQUIRED` binds its *response* as well as its
+        /// request — "an omission can never weaken a variant" — and 265
+        /// published specifications declare exactly that. This service attached
+        /// a proof to none of them until the spine started signing.
+        ///
+        /// Nothing caught it because no consumer verifies one either, which is
+        /// why the guard is here rather than left to a client: a mutually
+        /// consistent silence between producer and consumer stays silent.
+        #[tokio::test]
+        async fn a_success_response_is_signed() {
+            let vtc = fixture().await;
+            let out = dispatch_trust_task_core(
+                &vtc.state,
+                &JoinAuthCtx::didcomm(MEMBER.into()),
+                &document(PERSONHOOD_CHALLENGE_TYPE, json!({ "did": MEMBER })),
+            )
+            .await;
+
+            let doc: serde_json::Value =
+                serde_json::from_slice(&out.body).expect("the reply is a JSON document");
+            let proof = doc.get("proof").unwrap_or_else(|| {
+                panic!(
+                    "a success response carries no proof, so nothing this community says is \
+                     attributable: {}",
+                    rendered(&out)
+                )
+            });
+            assert_eq!(
+                proof.get("cryptosuite").and_then(|v| v.as_str()),
+                Some("eddsa-jcs-2022"),
+                "unexpected cryptosuite: {proof}"
+            );
+            assert!(
+                proof.get("proofValue").and_then(|v| v.as_str()).is_some(),
+                "the proof carries no signature: {proof}"
+            );
+        }
+
+        /// A community with no signer answers **unsigned rather than failing**.
+        ///
+        /// It has nothing to sign with, and refusing would make an
+        /// unprovisioned VTC unusable rather than merely unattributable — the
+        /// wrong direction to err in, since the operation itself succeeded.
+        #[tokio::test]
+        async fn a_community_with_no_signer_still_answers() {
+            let vtc = TestVtc::builder().with_signers(false).build().await;
+            store_acl_entry(
+                &vtc.state.acl_ks,
+                &VtcAclEntry {
+                    did: MEMBER.into(),
+                    role: VtcRole::Member,
+                    label: None,
+                    allowed_contexts: vec![],
+                    created_at: 0,
+                    created_by: "did:key:vtc-install".into(),
+                    updated_at: None,
+                    updated_by: None,
+                    expires_at: None,
+                },
+            )
+            .await
+            .expect("seed the member");
+
+            let out = dispatch_trust_task_core(
+                &vtc.state,
+                &JoinAuthCtx::didcomm(MEMBER.into()),
+                &document(PERSONHOOD_CHALLENGE_TYPE, json!({ "did": MEMBER })),
+            )
+            .await;
+
+            assert!(
+                out.status.is_success(),
+                "an unsigned answer is still an answer: {}",
+                rendered(&out)
+            );
+            let doc: serde_json::Value =
+                serde_json::from_slice(&out.body).expect("the reply is a JSON document");
+            assert!(doc.get("proof").is_none(), "signed without a signer");
         }
 
         /// The membership check standing in for the REST route's session.


### PR DESCRIPTION
Found while working out verified reads (#1333). That note described an unsigned put acknowledgement as a rooms problem. It is not a rooms problem.

## The gap

SPEC §7.3 item 7:

> *Where a specification declares no requirement for the **response**, the **request**'s applies to it, so an omission can never weaken a variant.*

**265 published specifications declare a single `proofRequirement: REQUIRED`.** Only 10 use the per-variant form that could relax it. So 265 task types require a proof on their response — and this service attached one to none of them. `success_response` built the document with `respond_with` and serialised it; nothing signed anything on the way out.

## Why nothing caught it

**No consumer verifies a response proof either** — not `vta-sdk`, not the browser client. Producers not signing and consumers not checking is a mutually consistent silence, and it is how this survived:

- the conformance ledger (checks hand-typed example documents),
- `test_support::response_conformance` (validates every observed body against its published schema — but the **payload's shape**; the proof is on the envelope),
- 35 integration binaries.

Each was looking at something adjacent to it.

## What it cost

No answer this community has ever given is evidence of anything. A member cannot show a third party what the host told them, and cannot be contradicted when they misreport it. For rooms specifically that is the whole basis of a write receipt — but it is true of every join decision, every VMC issuance, every credential the VTC has ever acknowledged.

## Signed at the spine

There are twenty-one `success_response` call sites. Signing is the same decision taken twenty-one times, and forgetting once is a task whose response is unattributable with nothing downstream to notice — which is exactly how every response came to be unsigned. The spine is where the framework's inbound checks already live; the outbound one belongs beside them.

**Success responses only.** An error response's `type` resolves to `trust-task-error`, whose own requirement is RECOMMENDED rather than REQUIRED, and whose variant §7.3 makes undeclarable by a task. Signing those is a separate decision with its own rationale — a retained compliance refusal is the case that argues for it — and is not smuggled in here.

**A community with no signer answers unsigned rather than failing.** It has nothing to sign with, and refusing would make an unprovisioned VTC unusable rather than merely unattributable — the wrong direction to err in, since the operation itself succeeded.

## Verification

- `cargo test -p vtc-service --lib` — 956 passed, 0 failed, plus the two new guards.
- **Guard proven non-vacuous**: removing the `sign_success_response` call makes `a_success_response_is_signed` fail, printing the real unsigned challenge response it now catches.
- `cargo clippy --all-targets`, `cargo fmt --all` — clean.
- The 35 integration binaries were still running locally when I opened this; CI is the authoritative check on them and I have not claimed a result I did not see.

## The VTA half is owed, and is not here

`vta-service` has the identical gap and needs a decision this one did not.

`load_vta_issuer_secret` writes an **audit entry per key access**, so signing every response through it would drown the audit trail — and the audit trail is a security control, so that is a real cost rather than a performance note. The resident path (`secrets_resolver` + `signing_vm_id`) exists and avoids it, but is `#[cfg(any(feature = "didcomm", feature = "tsp"))]`, and **conformance must not depend on feature flags**.

So the fix there is a non-gated response signer populated at init. Worth its own PR rather than bolted onto this one.