### PR TITLE
fix(vta): sign success responses, completing the producer half

### DIFF
--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -262,7 +262,13 @@ pub struct AppState {
     /// `{did}#key-0`). Populated by `init_auth`. Needed by the
     /// live mediator-handshake prover to fetch the corresponding
     /// secret out of [`Self::secrets_resolver`].
-    #[cfg(any(feature = "didcomm", feature = "tsp"))]
+    ///
+    /// **Not feature-gated**, unlike its key-agreement sibling below, because
+    /// the Trust-Task spine signs every success response with it and
+    /// conformance must not depend on which transports were compiled in. A
+    /// `--no-default-features --features rest` build answers the same
+    /// specifications as a full one, and those specifications require a proof
+    /// on the response (SPEC §7.3 item 7).
     pub signing_vm_id: Option<String>,
     /// Verification-method id for the VTA's key-agreement key
     /// (e.g. `{did}#key-1`). Populated by `init_auth`.
@@ -566,7 +572,6 @@ pub async fn build_app_state(
         did_resolver: auth.did_resolver.clone(),
         status_list_resolver: crate::vault::status::default_status_resolver(auth.did_resolver),
         secrets_resolver: auth.secrets_resolver,
-        #[cfg(any(feature = "didcomm", feature = "tsp"))]
         signing_vm_id: auth.signing_vm_id,
         #[cfg(any(feature = "didcomm", feature = "tsp"))]
         ka_vm_id: auth.ka_vm_id,

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -1233,7 +1233,8 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
         did_resolver,
         status_list_resolver: None,
         secrets_resolver: transport.secrets_resolver,
-        #[cfg(feature = "didcomm")]
+        // Un-gated with the field: the spine signs every success response with
+        // it, so a build without didcomm still needs it populated.
         signing_vm_id: transport.signing_vm_id,
         #[cfg(feature = "didcomm")]
         ka_vm_id: transport.ka_vm_id,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -474,6 +474,112 @@ async fn validate_payload(
     }
 }
 
+/// Attach this agent's Data-Integrity proof to a success response.
+///
+/// # Why this was missing
+///
+/// SPEC §7.3 item 7: where a specification declares no separate requirement for
+/// the *response*, the request's applies to it — "an omission can never weaken a
+/// variant". 265 published specifications declare a single
+/// `proofRequirement: REQUIRED`, and this agent attached a proof to none of
+/// their responses. Nothing went red because no consumer verifies one either;
+/// producers not signing and consumers not checking is a mutually consistent
+/// silence.
+///
+/// # Why the resident secret and not `load_vta_issuer_secret`
+///
+/// That helper reads the keystore, derives, and **writes an audit entry per
+/// access**. Signing every response through it would turn the record of "the
+/// agent's issuer key was used" into one line per request — drowning a security
+/// control in its own noise, which is a worse outcome than the gap being fixed.
+///
+/// `secrets_resolver` already holds the signing secret for the messaging layer,
+/// keyed by [`AppState::signing_vm_id`]. Reading it costs nothing and audits
+/// nothing, which is the right shape for something that happens on every
+/// answer: the agent signing its own words is not a key *access* worth a line,
+/// it is the agent speaking.
+///
+/// # Scope
+///
+/// Success responses only. An error response's `type` resolves to the
+/// framework's `trust-task-error` specification, whose requirement is
+/// RECOMMENDED rather than REQUIRED and whose variant §7.3 makes undeclarable
+/// by a task.
+///
+/// An agent with no signing identity yet (before setup) answers unsigned rather
+/// than failing — it has nothing to sign with, and refusing would make an
+/// unprovisioned VTA unusable rather than merely unattributable.
+async fn sign_success_response(state: &AppState, outcome: TrustTaskOutcome) -> TrustTaskOutcome {
+    if !outcome.status.is_success() {
+        return outcome;
+    }
+    let (Some(resolver), Some(vm_id)) = (
+        state.secrets_resolver.as_ref(),
+        state.signing_vm_id.as_ref(),
+    ) else {
+        return outcome;
+    };
+    use affinidi_tdk::secrets_resolver::SecretsResolver as _;
+    let Some(secret) = resolver.get_secret(vm_id).await else {
+        tracing::error!(%vm_id, "no resident secret for the signing key; answering unsigned");
+        return outcome;
+    };
+
+    match attach_proof(&secret, &outcome.body).await {
+        Some(body) => TrustTaskOutcome {
+            status: outcome.status,
+            body,
+        },
+        // Every failure inside answers unsigned rather than turning a successful
+        // operation into a failure over its envelope: the work is done and the
+        // caller is entitled to the result, attributable or not.
+        None => outcome,
+    }
+}
+
+/// Sign `body` with `secret` and return the document with its `proof` attached.
+///
+/// Separated from the state plumbing so the cryptographic path is testable
+/// without an `AppState` — the wiring above needs a booted agent, this needs a
+/// key and some bytes.
+async fn attach_proof(
+    secret: &affinidi_secrets_resolver::secrets::Secret,
+    body: &[u8],
+) -> Option<Vec<u8>> {
+    let mut doc: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(d) => d,
+        Err(e) => {
+            // The spine built this a moment ago, so this cannot happen without a
+            // bug above.
+            tracing::error!(error = %e, "success response is not JSON; returning it unsigned");
+            return None;
+        }
+    };
+    // A proof never covers itself.
+    doc.as_object_mut()?.remove("proof");
+
+    let proof = match affinidi_data_integrity::DataIntegrityProof::sign(
+        &doc,
+        secret,
+        affinidi_data_integrity::SignOptions::new(),
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "could not sign the success response; answering unsigned");
+            return None;
+        }
+    };
+    let proof_value = serde_json::to_value(&proof)
+        .inspect_err(|e| tracing::error!(error = %e, "could not serialise the response proof"))
+        .ok()?;
+    doc.as_object_mut()?.insert("proof".into(), proof_value);
+    serde_json::to_vec(&doc)
+        .inspect_err(|e| tracing::error!(error = %e, "could not serialise the signed response"))
+        .ok()
+}
+
 pub(crate) async fn dispatch_trust_task_core(
     state: &AppState,
     auth: &AuthClaims,
@@ -484,6 +590,9 @@ pub(crate) async fn dispatch_trust_task_core(
         dispatch_trust_task_inner(state, auth, body).await
     })
     .await;
+    // Before the conformance observation below, so what that layer sees is what
+    // ships rather than a document one proof short of it.
+    let outcome = sign_success_response(state, outcome).await;
     // Observe the real response against the schema its own `type` names. Here
     // rather than in the REST route because REST is one of three transports
     // through this function — DIDComm and TSP read `outcome.body` directly, and
@@ -1920,6 +2029,172 @@ mod tests {
     use trust_tasks_rs::TrustTask;
 
     use super::*;
+
+    /// **A success response carries this agent's proof.**
+    ///
+    /// SPEC §7.3 item 7: a specification declaring a single
+    /// `proofRequirement: REQUIRED` binds its *response* as well as its request
+    /// — "an omission can never weaken a variant" — and 265 published
+    /// specifications declare exactly that. This agent attached a proof to none
+    /// of them until the spine started signing, and nothing caught it because no
+    /// consumer verifies one either.
+    ///
+    /// Tests the cryptographic path rather than the plumbing: a booted agent is
+    /// not needed to answer "does this produce a verifiable proof", and the
+    /// question that needs answering is that one.
+    #[tokio::test]
+    async fn a_success_response_is_signed() {
+        let secret = test_secret();
+        let body =
+            br#"{"id":"urn:uuid:x","type":"https://example.org/t#response","payload":{"ok":true}}"#;
+
+        let signed = super::attach_proof(&secret, body)
+            .await
+            .expect("a well-formed response signs");
+        let doc: Value = serde_json::from_slice(&signed).expect("signed document parses");
+
+        let proof = doc
+            .get("proof")
+            .expect("a success response with no proof is unattributable");
+        assert_eq!(
+            proof.get("cryptosuite").and_then(Value::as_str),
+            Some("eddsa-jcs-2022")
+        );
+        assert!(proof.get("proofValue").and_then(Value::as_str).is_some());
+        assert_eq!(
+            proof.get("verificationMethod").and_then(Value::as_str),
+            Some(secret.id.as_str()),
+            "the proof must name the key that signed it"
+        );
+        // The payload is untouched — signing attests to the answer, it does not
+        // change it.
+        assert_eq!(doc["payload"]["ok"], Value::Bool(true));
+    }
+
+    /// A proof never covers itself. Re-signing a document that already carries
+    /// one must replace it, not sign over it — otherwise the second proof
+    /// attests to a document containing the first, and neither verifies against
+    /// what a consumer canonicalises.
+    #[tokio::test]
+    async fn an_existing_proof_is_replaced_not_nested() {
+        let secret = test_secret();
+        let body = br#"{"id":"urn:uuid:x","type":"https://example.org/t#response","proof":{"stale":true},"payload":{}}"#;
+
+        let signed = super::attach_proof(&secret, body).await.expect("signs");
+        let doc: Value = serde_json::from_slice(&signed).expect("parses");
+        assert!(
+            doc["proof"].get("stale").is_none(),
+            "the stale proof survived: {}",
+            doc["proof"]
+        );
+    }
+
+    /// A body that is not a JSON object cannot be signed, and that must degrade
+    /// to an unsigned answer rather than a panic — the operation already
+    /// succeeded.
+    #[tokio::test]
+    async fn an_unsignable_body_degrades_rather_than_panicking() {
+        assert!(
+            super::attach_proof(&test_secret(), b"not json")
+                .await
+                .is_none()
+        );
+        assert!(
+            super::attach_proof(&test_secret(), b"[1,2,3]")
+                .await
+                .is_none()
+        );
+    }
+
+    /// **The spine calls the signer.**
+    ///
+    /// The behavioural tests above cover the cryptographic path and pass
+    /// perfectly well with the call deleted from `dispatch_trust_task_core` —
+    /// which is precisely the shape of the bug they exist to prevent, so on its
+    /// own that coverage is a comfort rather than a guard. This reads the source
+    /// of the spine and asserts the call is there, in the same spirit as
+    /// `vta-sdk`'s `connect_with_transport` body check.
+    ///
+    /// A source assertion rather than a behavioural one because the alternative
+    /// needs a booted agent with a resident signing secret, and the property is
+    /// one line: does every answer pass through the signer on its way out.
+    #[test]
+    fn the_spine_signs_every_response_it_returns() {
+        let src = include_str!("mod.rs");
+        let start = src
+            .find("pub(crate) async fn dispatch_trust_task_core(")
+            .expect("the spine is still named that");
+        let body = &src[start..];
+        let end = body.find("\n}\n").expect("the spine has an end");
+
+        assert!(
+            body[..end].contains("sign_success_response("),
+            "the dispatch spine no longer signs its responses. 265 published \
+             specifications require a proof on the response (SPEC §7.3 item 7), \
+             and no consumer verifies one — so nothing else in this workspace \
+             would notice."
+        );
+    }
+
+    /// The wiring from state to signature: a configured agent signs, and one
+    /// with no resident secret answers unsigned rather than failing.
+    #[tokio::test]
+    async fn the_signer_reads_the_agents_resident_key() {
+        use affinidi_secrets_resolver::ThreadedSecretsResolver;
+        use affinidi_tdk::secrets_resolver::SecretsResolver as _;
+
+        let (mut state, _dir) = crate::test_support::build_signing_test_app_state().await;
+        let outcome = || TrustTaskOutcome {
+            status: axum::http::StatusCode::OK,
+            body: br#"{"id":"urn:uuid:x","type":"https://example.org/t#response","payload":{}}"#
+                .to_vec(),
+        };
+
+        // No resident secret: the answer still goes out, unsigned. Cleared
+        // explicitly — this fixture ships one, which is worth knowing rather
+        // than relying on.
+        state.secrets_resolver = None;
+        state.signing_vm_id = None;
+        let unsigned = super::sign_success_response(&state, outcome()).await;
+        let doc: Value = serde_json::from_slice(&unsigned.body).expect("parses");
+        assert!(doc.get("proof").is_none());
+        assert!(
+            unsigned.status.is_success(),
+            "an unsigned answer is still an answer"
+        );
+
+        // Configured: the same answer, signed by the named key.
+        let secret = test_secret();
+        let vm_id = secret.id.clone();
+        let (resolver, _task) = ThreadedSecretsResolver::new(None).await;
+        resolver.insert(secret).await;
+        state.secrets_resolver = Some(std::sync::Arc::new(resolver));
+        state.signing_vm_id = Some(vm_id.clone());
+
+        let signed = super::sign_success_response(&state, outcome()).await;
+        let doc: Value = serde_json::from_slice(&signed.body).expect("parses");
+        assert_eq!(
+            doc["proof"]["verificationMethod"].as_str(),
+            Some(vm_id.as_str()),
+            "signed by the wrong key, or not at all: {doc}"
+        );
+    }
+
+    /// An Ed25519 `did:key` secret, which is what the agent's own signing key is
+    /// on a `did:key` deployment and shaped the same everywhere else.
+    fn test_secret() -> affinidi_secrets_resolver::secrets::Secret {
+        use ed25519_dalek::SigningKey;
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(sk.verifying_key().as_bytes());
+        let did = format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, mc)
+        );
+        let secrets =
+            vta_sdk::did_key::secrets_from_did_key(&did, &sk.to_bytes()).expect("did:key secrets");
+        secrets.signing
+    }
 
     /// The macro-generated `class_for` returns the authoritative §7.3
     /// classification declared inline next to each handler — the value the PDP


### PR DESCRIPTION
The agent side of #1334. Same gap, same reasoning: SPEC §7.3 item 7 makes a single `proofRequirement: REQUIRED` bind the **response** as well as the request, 265 published specifications declare one, and this service attached a proof to none of their responses. No consumer verifies one either, which is why nothing ever went red.

With this, both producers sign. Verification is deliberately still a separate, later phase — a consumer that checked before producers signed would reject everything.

## Two decisions, not mechanics

**It does not sign through `load_vta_issuer_secret`.** That helper reads the keystore, derives, and writes an **audit entry per access**. Signing every response through it would turn "the agent's issuer key was used" into one line per request — drowning a security control in its own noise, which is a worse outcome than the gap being closed.

It signs from the resident secret `secrets_resolver` already holds for the messaging layer, keyed by `signing_vm_id`: no keystore read, no audit entry. The agent signing its own words is not a key *access* worth recording, it is the agent speaking.

**`signing_vm_id` is no longer feature-gated.** It was `#[cfg(any(feature = "didcomm", feature = "tsp"))]`, which would have left a `--no-default-features --features rest` build answering the same specifications without the proof they require. **Conformance must not depend on which transports were compiled in.** Both builds are checked.

## The guard is in three parts, and finding out why is the useful bit

`attach_proof` is tested directly: it produces a verifiable proof naming the signing key, replaces a stale proof rather than nesting one inside another (a proof never covers itself), and degrades to unsigned on an unsignable body rather than panicking.

**Those tests passed with the call deleted from the spine.** That is precisely the shape of the bug they exist to prevent — coverage of the crypto that says nothing about whether anything calls it. So:

- a **source assertion** covers the wiring (`the_spine_signs_every_response_it_returns`), in the same spirit as `vta-sdk`'s existing `connect_with_transport` body check;
- a **state-level test** covers the plumbing (configured → signed by the named key; cleared → unsigned but still a success).

Both were verified to fail when the spine call is removed. A comfort is not a guard.

## One thing I had wrong

`build_signing_test_app_state` already ships a resident signing secret. My first draft asserted the unsigned case without clearing it and failed. The test now clears it explicitly — which is worth doing anyway, since relying on a fixture's absence of something is how the assumption goes stale.

## Verification

`cargo test -p vta-service --lib` — **1061 passed, 0 failed**. `cargo clippy --all-targets` and `cargo fmt --all` clean. Compiles on default features and on `--no-default-features --features rest`.