### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,7 +2515,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -7058,7 +7058,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10222,7 +10222,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "tokio",
@@ -10234,7 +10234,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2",
@@ -10264,7 +10264,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10290,7 +10290,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10323,7 +10323,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10407,7 +10407,7 @@ dependencies = [
 
 [[package]]
 name = "vta-persona"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -10426,7 +10426,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "hex",
  "multibase",
@@ -10446,7 +10446,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10512,7 +10512,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -10619,7 +10619,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -10690,7 +10690,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10724,7 +10724,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10745,7 +10745,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10847,7 +10847,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10922,7 +10922,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10949,7 +10949,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10994,7 +10994,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.14.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.14.1...cnm-cli-v0.14.2) — 2026-09-09
+
+
 ## [0.14.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.14.0...cnm-cli-v0.14.1) — 2026-09-08
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.14.1"
+version = "0.14.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,10 +21,10 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
-vta-cli-common = { path = "../vta-cli-common", version = "0.14", features = [
+vta-cli-common = { path = "../vta-cli-common", version = "0.15", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.15.1...pnm-cli-v0.16.0) — 2026-09-09
+
+
+### Fixed
+
+- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))
+
+* fix(rooms): bind a presentation to its presenter, not to the host
+
+  `pnm-cli rooms --host-did …` could never work. Every request it made was
+  refused as `WrongAudience`, and omitting the flag "worked" only by
+  skipping the check it exists to perform — so the flag's two states were
+  broken and unprotected.
+
+  `audience` is not who a presentation is addressed to.
+  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
+  "the leaf must be presentable by whoever is presenting it" — so it is
+  holder binding, and its whole job is to make a captured presentation
+  worthless to whoever captured it. Filled with the host's DID it named a
+  party no presenter can ever match.
+
+  The value to bind to was already named a few lines away: `RoomSigner`'s
+  doc says "a room request is signed by the party the presentation was
+  minted for". This passes exactly that. There is no unbound case left, so
+  the warning about one goes, and `--host-did` keeps its real job of naming
+  the document's recipient.
+
+  ## The spec says otherwise, and that is filed separately
+
+  `rooms/keys/present/0.1` describes `audience` as "the party the
+  presentation is for … a host's identifier, normally". The CLI implemented
+  the spec faithfully; the spec and the credential library it runs on
+  disagree, identically in dtg-credentials 0.6 and 0.7, so it is not
+  version drift.
+
+  This changes the CLI to match the verifier rather than the prose, because
+  a presentation that cannot verify protects nobody while being wrong in
+  the other direction. Which side should move is a working-group question —
+  0.7's own notes point at upstream PR #41, "a key-control demonstration at
+  invocation, which removes `audience` as redundant" — and is raised there.
+
+  * fix(rooms)!: stop sending `audience` and `nonce` on rooms/keys/present
+
+  Completes the previous commit, which repointed `audience` at the presenter so
+  it would at least verify. It should not be sent at all, and neither should
+  `nonce`. Both are removed from `rooms/keys/present` by spec 0.2.
+
+  `audience` named the party that had to PRESENT a credential, not the one it was
+  addressed to — so a host DID named somebody no presenter can ever be, and the
+  host refused every request. That is now moot: dtg-credentials 0.8.0 removed the
+  property and made the real rule explicit, which the VTA was already satisfying.
+  The leaf grants to the DID this VTA authenticated, and a host refuses a chain
+  whose leaf grants to anyone else. Who may present is established, not declared.
+
+  `nonce` was written into the presentation object, which is closed and has no
+  member for it — so a caller supplying one got a presentation the host rejects
+  as malformed. It could not have been made to work: every signature in a
+  presentation is an ISSUER's, never the presenter's, so a challenge inside it is
+  unauthenticated and a replay copies it along with everything else. Freshness is
+  the request's, via `issuedAt` and the duplicate-execution rule keyed on
+  document `id`.
+
+  ## A second live instance, found while doing this
+
+  `rooms/keys/backfill` passed the caller-named host as the audience in
+  `vta-service`, exactly as that spec's normative MUST instructed. Every backfill
+  this VTA attempted was refused for the same reason. What actually makes a
+  caller-named host safe is that the leaf grants to the VTA: naming a host
+  transfers no standing. It does hand that host sight of the principal's
+  credentials, which is a disclosure rather than an escalation, and the comment
+  now says so.
+
+  ## Nothing binds a presentation to a host, deliberately
+
+  A chain is scoped to the ROOM. One rooted in a room confers nothing anywhere
+  else, and any host serving that room would honour it — a room may have more
+  than one host, and moving between them without reissuing credentials is the
+  point. Binding a request to its destination is `recipient` on the document that
+  carries the presentation, per SPEC.md §4.8.2, which its proof covers.
+
+
+
 ## [0.15.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.15.0...pnm-cli-v0.15.1) — 2026-09-08
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,14 +28,14 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
-vta-cli-common = { path = "../vta-cli-common", version = "0.14", features = [
+vta-cli-common = { path = "../vta-cli-common", version = "0.15", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 # Storage, wire types and authorization. The whole of what hosting a room needs —
 # no member lifecycle, no policy engine, no credential issuance, no admin UI.
-vti-rooms = { path = "../vti-rooms", version = "0.1" }
+vti-rooms = { path = "../vti-rooms", version = "0.2" }
 # The store and AppError. Nothing else internal.
 vti-common = { path = "../vti-common", version = "0.18" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.4...vta-audit-v0.3.5) — 2026-09-09
+
+
 ## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.3...vta-audit-v0.3.4) — 2026-09-07
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,7 +21,7 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.18" }
-vta-sdk = { path = "../vta-sdk", version = "0.34" }
+vta-sdk = { path = "../vta-sdk", version = "0.35" }
 async-trait = "0.1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.4...vta-backup-v0.3.5) — 2026-09-09
+
+
 ## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.3...vta-backup-v0.3.4) — 2026-09-07
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -32,7 +32,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 # a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
 # own and was borrowing one from its cipher.
 rand = { workspace = true }
-vta-sdk = { path = "../vta-sdk", version = "0.34" }
+vta-sdk = { path = "../vta-sdk", version = "0.35" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.4" }
 vta-config = { path = "../vta-config", version = "0.4" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.14.1...vta-cli-common-v0.15.0) — 2026-09-09
+
+
+### Fixed
+
+- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))
+
+* fix(rooms): bind a presentation to its presenter, not to the host
+
+  `pnm-cli rooms --host-did …` could never work. Every request it made was
+  refused as `WrongAudience`, and omitting the flag "worked" only by
+  skipping the check it exists to perform — so the flag's two states were
+  broken and unprotected.
+
+  `audience` is not who a presentation is addressed to.
+  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
+  "the leaf must be presentable by whoever is presenting it" — so it is
+  holder binding, and its whole job is to make a captured presentation
+  worthless to whoever captured it. Filled with the host's DID it named a
+  party no presenter can ever match.
+
+  The value to bind to was already named a few lines away: `RoomSigner`'s
+  doc says "a room request is signed by the party the presentation was
+  minted for". This passes exactly that. There is no unbound case left, so
+  the warning about one goes, and `--host-did` keeps its real job of naming
+  the document's recipient.
+
+  ## The spec says otherwise, and that is filed separately
+
+  `rooms/keys/present/0.1` describes `audience` as "the party the
+  presentation is for … a host's identifier, normally". The CLI implemented
+  the spec faithfully; the spec and the credential library it runs on
+  disagree, identically in dtg-credentials 0.6 and 0.7, so it is not
+  version drift.
+
+  This changes the CLI to match the verifier rather than the prose, because
+  a presentation that cannot verify protects nobody while being wrong in
+  the other direction. Which side should move is a working-group question —
+  0.7's own notes point at upstream PR #41, "a key-control demonstration at
+  invocation, which removes `audience` as redundant" — and is raised there.
+
+  * fix(rooms)!: stop sending `audience` and `nonce` on rooms/keys/present
+
+  Completes the previous commit, which repointed `audience` at the presenter so
+  it would at least verify. It should not be sent at all, and neither should
+  `nonce`. Both are removed from `rooms/keys/present` by spec 0.2.
+
+  `audience` named the party that had to PRESENT a credential, not the one it was
+  addressed to — so a host DID named somebody no presenter can ever be, and the
+  host refused every request. That is now moot: dtg-credentials 0.8.0 removed the
+  property and made the real rule explicit, which the VTA was already satisfying.
+  The leaf grants to the DID this VTA authenticated, and a host refuses a chain
+  whose leaf grants to anyone else. Who may present is established, not declared.
+
+  `nonce` was written into the presentation object, which is closed and has no
+  member for it — so a caller supplying one got a presentation the host rejects
+  as malformed. It could not have been made to work: every signature in a
+  presentation is an ISSUER's, never the presenter's, so a challenge inside it is
+  unauthenticated and a replay copies it along with everything else. Freshness is
+  the request's, via `issuedAt` and the duplicate-execution rule keyed on
+  document `id`.
+
+  ## A second live instance, found while doing this
+
+  `rooms/keys/backfill` passed the caller-named host as the audience in
+  `vta-service`, exactly as that spec's normative MUST instructed. Every backfill
+  this VTA attempted was refused for the same reason. What actually makes a
+  caller-named host safe is that the leaf grants to the VTA: naming a host
+  transfers no standing. It does hand that host sight of the principal's
+  credentials, which is a disclosure rather than an escalation, and the comment
+  now says so.
+
+  ## Nothing binds a presentation to a host, deliberately
+
+  A chain is scoped to the ROOM. One rooted in a room confers nothing anywhere
+  else, and any host serving that room would honour it — a room may have more
+  than one host, and moving between them without reissuing credentials is the
+  point. Binding a request to its destination is `recipient` on the document that
+  carries the presentation, per SPEC.md §4.8.2, which its proof covers.
+
+
+
 ## [0.14.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.14.0...vta-cli-common-v0.14.1) — 2026-09-08
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.14.1"
+version = "0.15.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.4...vta-config-v0.4.5) — 2026-09-09
+
+
 ## [0.4.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.3...vta-config-v0.4.4) — 2026-09-07
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.34", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.35", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,7 +34,7 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.24", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.25", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.4...vta-keys-v0.4.5) — 2026-09-09
+
+
 ## [0.4.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.3...vta-keys-v0.4.4) — 2026-09-07
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -38,7 +38,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4" }
 vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-persona/CHANGELOG.md
+++ b/vta-persona/CHANGELOG.md
@@ -2,6 +2,81 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.3.0...vta-persona-v0.3.1) — 2026-09-09
+
+
+### Added
+
+- **persona**: Say whether a link crosses a part of the holder's life ([#1342](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1342))
+
+Serves the members added in dtgwg-trust-tasks-tf#408, published in
+  trust-tasks-rs 0.18.10: `crossesFacets` and `facetIds` on a finding,
+  `facetId` on each `sharedWith` location. This needs a floor of 0.18.10 —
+  the spine validates OUTGOING responses, so under an older schema an analysis
+  that fully succeeded would come back 500 `responseSchemaViolation` — and no
+  longer moves one: main reached 0.18.11 while this sat open, which satisfies
+  it. The bump this branch carried is dropped rather than resolved downward.
+
+  **Severity is how linkable. Facets are whether the holder minds.** Nothing
+  here touches `severity`, and that is the design rather than an omission. A
+  value shared between two profiles in one facet still links them for anyone
+  who sees both — the holder's filing changes nothing a counterparty can do —
+  so softening severity on intent would report a false all-clear. What the
+  facets add is a second axis: which of these findings the holder would
+  actually want to act on.
+
+  **Absent is unknown, not false.** `crosses_facets` is `Option<bool>` and is
+  `None` when the holder keeps no facets, because `false` asserts these
+  identities sit in one part of a life and an agent with no facets has made no
+  such finding. `FacetIndex::any` is what carries that distinction, which is
+  why the index is a struct rather than a map.
+
+  **An unarranged profile is not a second facet.** Only distinct, named facets
+  count toward a crossing. Counting "no facet" as one would make every holder
+  who has arranged one part of their life and not the rest see a crossing on
+  everything they own — the dismissal problem arriving from the other
+  direction.
+
+  `facet_index` is built once per analysis for the reason `disclosure_index`
+  is: `analyze_correlation` with no `attributeId` walks the whole pool, and
+  the per-finding shape re-lists every facet for every finding.
+
+  The conformance witness now exercises the three new members rather than
+  merely permitting them — they are the ones added last, and an outgoing
+  member the embedded schema has not caught up with is a 500 on a call that
+  succeeded.
+
+  vta-persona 118/118 (6 new, one per rule above), vta-service lib 1063/1063,
+  clippy --all-targets clean.
+
+- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))
+
+Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
+  in trust-tasks-rs 0.18.9.
+
+  A holder who uses this model for a while ends up with twenty profiles, and a
+  flat list of twenty is a list nobody reads. A facet is the arrangement over
+  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
+  the profiles it groups.
+
+  **An arrangement, not a container.** Nothing is stored inside a facet, and
+  `delete_facet` touches no profile and no attribute. There is no cascading
+  form because there is no cascading form of the idea: a grouping that could
+  take its members with it is a folder, and a holder who reads it as a folder
+  is right to be afraid of it. `releasedFaces` reports what now belongs
+  nowhere, which is what a screen needs to say what it will look like
+  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.
+
+  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
+  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
+  well-behaved consumer does not hold the values it would have to resend —
+  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
+  name. It would either request every sensitive value the holder owns to
+  perform an arrangement that has nothing to do with values, or send a put
+  without one and destroy them.
+
+
+
 ## [0.3.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.2.0...vta-persona-v0.3.0) — 2026-09-08
 
 

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-persona"
 description = "VTA persona store — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 # Published for the same reason vta-vault is: `vta-service` is published, and a
 # crate cannot go to crates.io without its whole dependency closure. Nothing

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.4...vta-policy-v0.3.5) — 2026-09-09
+
+
 ## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.3...vta-policy-v0.3.4) — 2026-09-07
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.4" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.34", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.35", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,335 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.35.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.34.1...vta-sdk-v0.35.0) — 2026-09-09
+
+
+### Added
+
+- **rooms**: Cut over to present/0.2 and issue-authority/0.2 ([#1365](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1365))
+
+The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked
+  by affinidi/affinidi-tdk-rs#784.
+
+  `trust-tasks-rs` 0.19 carries both new spec versions, but this workspace could
+  not take it: `affinidi-messaging-sdk 0.22.0` required 0.18, so pinning 0.19 put
+  two `trust-tasks-rs` nodes in the graph and broke `vta-sdk` on `expected
+  MediatorAcl, found a different MediatorAcl`. TDK #784 moved the messaging family
+  to 0.19 and 0.23.0.
+
+  Taking it exposed pins that had drifted apart underneath: `vta-sdk` was on
+  messaging-sdk 0.22 while `vta-service` and the e2e tests were on 0.21, and three
+  `trust-tasks-rs` versions were resolving at once. All of it is now consolidated:
+  the lockfile holds exactly ONE `trust-tasks-rs` and ONE `affinidi-messaging-sdk`,
+  where before it held three of each.
+
+  `rooms/keys/present` 0.1 -> 0.2 and `rooms/owner/issue-authority` 0.1 -> 0.2.
+  Both 0.1s are retired upstream. Neither is dual-accepted, deliberately: for
+  `present`, 0.1's extra members are exactly the two nothing could honour; for
+  `issue-authority`, accepting 0.1 means accepting a request with no `validUntil`,
+  which is the thing 0.2 exists to refuse.
+
+  The hand-rolled `validUntil` guard in `room_owner.rs` is deleted. 0.2 makes the
+  member REQUIRED, so the generated payload types it as a `DateTime` and the
+  envelope schema rejects a request without one before dispatch. Same rule, one
+  layer up, which is where a shape constraint belongs.
+
+  `every_witnessed_task_round_trips_through_its_generated_types` refused two
+  witnesses that had been green for as long as they existed:
+
+  1. The `issue-authority` witness carried no `validUntil` — a chain root with no
+     expiry, the exact request 0.2 forbids, and one this service could have sent.
+  2. The `present` witness carried `"audience": "did:key:z6MkHost"` — a HOST DID,
+     the precise shape #414 reported as impossible to satisfy, since the field
+     named the party that had to PRESENT the credential.
+
+  `room_oracle` emitted `membership` and `authority[]` as JSON **objects**;
+  `AuthorityPresentation` types both as strings, and the host's opener reads
+  base64url or bare JSON text. So the oracle's output could not deserialize at a
+  host at all — `rooms/keys/present` had never worked end to end. It went unseen
+  because 0.1's response typed `presentation` as an opaque object; 0.2 names the
+  shared component, which turned a runtime refusal nothing exercised into a type
+  error. The oracle now serialises each credential. That is the first half of
+  have caught all three of these years earlier.
+
+- **sdk**: A no-I/O verifier resolves did:peer too ([#1364](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1364))
+- **sdk**: The client verifies the replies it receives ([#1341](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1341))
+
+Completes the arc #1334 and #1335 began. Both services sign their responses;
+  until now nothing checked one, so the signature was decorative. This is the
+  surface that matters most — the CLI, cierge and the services all dispatch
+  Trust Tasks through `VtaClient`.
+
+  A reply is bytes off a socket. Nothing else in this path establishes who
+  produced them: the transport proves a connection, and over REST not even
+  that beyond TLS to a host name. Without the proof an intermediary can
+  rewrite an ACL listing, flip a policy decision, or answer for an agent that
+  never spoke, and every check downstream passes — because the checks
+  downstream are about shape.
+
+  Two checks, and the second is the one easy to omit: the proof must verify,
+  **and its proven signer must be the agent this client is talking to**. A
+  proof by somebody else's key verifies perfectly well, so skipping the
+  binding turns "signed by somebody" into "signed by the agent". The expected
+  signer is `ClientIdentity::vta_did`, which the client already holds.
+
+  A client with no identity does not verify, because there is nothing to bind
+  against — such a client cannot produce a conforming request either and is
+  refused at the agent for a missing `recipient`. A loopback client likewise:
+  its sink answers ahead of the transport and returns a value rather than a
+  signed document.
+
+  Error documents are exempt, from the specification rather than for
+  convenience: `trust-task-error`'s own proof requirement is RECOMMENDED
+  (SPEC §8.1), so demanding one would make every conforming refusal
+  unreadable, including the ones carrying the reason a caller needs.
+
+  `trusting_unsigned_replies()` is a staging control, not a preference. An
+  agent that predates #1334/#1335 sends nothing to verify, so a client
+  upgraded ahead of its agent would refuse every answer; this exists so that
+  ordering can be chosen rather than endured. It weakens the check to almost
+  nothing while set — an attacker who can rewrite a reply can also strip its
+  proof — so a present proof is still verified and still bound.
+
+  The resolver is built once per client and shared by clones. A
+  `DIDCacheClient` is a cache; one per call would defeat it.
+
+- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))
+
+Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
+  in trust-tasks-rs 0.18.9.
+
+  A holder who uses this model for a while ends up with twenty profiles, and a
+  flat list of twenty is a list nobody reads. A facet is the arrangement over
+  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
+  the profiles it groups.
+
+  **An arrangement, not a container.** Nothing is stored inside a facet, and
+  `delete_facet` touches no profile and no attribute. There is no cascading
+  form because there is no cascading form of the idea: a grouping that could
+  take its members with it is a folder, and a holder who reads it as a folder
+  is right to be afraid of it. `releasedFaces` reports what now belongs
+  nowhere, which is what a screen needs to say what it will look like
+  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.
+
+  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
+  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
+  well-behaved consumer does not hold the values it would have to resend —
+  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
+  name. It would either request every sensitive value the holder owns to
+  perform an arrangement that has nothing to do with values, or send a put
+  without one and destroy them.
+
+
+
+### Changed
+
+- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))
+
+Pure move plus re-exports; no behaviour changes. It exists so the next
+  change can be small: `VtaClient` needs to verify the responses it receives,
+  and the verifier it needs already exists one layer up where a client cannot
+  reach it.
+
+  `vti-common` was the right home while services verifying their *inbound*
+  requests were the only consumer. A client verifying its *replies* is the
+  same operation over the same document shape, and `vta-sdk` is the layer both
+  can see.
+
+  **The part worth not duplicating is the verification-method resolver.**
+  Resolving one looks trivial and is not: a DID document may name its methods
+  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
+  proof always names them absolutely, so a resolver accepting only the
+  spelling it expects refuses perfectly good documents from conforming peers.
+  A second copy would drift, and drift in a verifier means refusing honest
+  documents or accepting dishonest ones. Writing that copy is what this move
+  avoids.
+
+  Behind a new `proof-verify` feature rather than `client`, because
+  `vti-common` takes `vta-sdk` with `default-features = false` and must not
+  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
+  that crate already depended on `affinidi-data-integrity` and the DID
+  resolver directly. `client` enables it: a client that cannot verify its
+  replies is the gap being closed.
+
+  The resolver rides in the feature deliberately. Verification is only as good
+  as the party it resolves — a `did:key` signer needs no I/O, and a
+  `did:webvh` one, which is what a real agent is, cannot be verified without
+  resolving its document.
+
+  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
+  use the flat re-export, so there is one canonical path rather than an alias
+  to go stale. Two doc comments naming the old location updated with them.
+
+  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
+  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
+  tests that moved with the code.
+
+
+
+### Fixed
+
+- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))
+
+* fix(rooms): bind a presentation to its presenter, not to the host
+
+  `pnm-cli rooms --host-did …` could never work. Every request it made was
+  refused as `WrongAudience`, and omitting the flag "worked" only by
+  skipping the check it exists to perform — so the flag's two states were
+  broken and unprotected.
+
+  `audience` is not who a presentation is addressed to.
+  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
+  "the leaf must be presentable by whoever is presenting it" — so it is
+  holder binding, and its whole job is to make a captured presentation
+  worthless to whoever captured it. Filled with the host's DID it named a
+  party no presenter can ever match.
+
+  The value to bind to was already named a few lines away: `RoomSigner`'s
+  doc says "a room request is signed by the party the presentation was
+  minted for". This passes exactly that. There is no unbound case left, so
+  the warning about one goes, and `--host-did` keeps its real job of naming
+  the document's recipient.
+
+  ## The spec says otherwise, and that is filed separately
+
+  `rooms/keys/present/0.1` describes `audience` as "the party the
+  presentation is for … a host's identifier, normally". The CLI implemented
+  the spec faithfully; the spec and the credential library it runs on
+  disagree, identically in dtg-credentials 0.6 and 0.7, so it is not
+  version drift.
+
+  This changes the CLI to match the verifier rather than the prose, because
+  a presentation that cannot verify protects nobody while being wrong in
+  the other direction. Which side should move is a working-group question —
+  0.7's own notes point at upstream PR #41, "a key-control demonstration at
+  invocation, which removes `audience` as redundant" — and is raised there.
+
+  * fix(rooms)!: stop sending `audience` and `nonce` on rooms/keys/present
+
+  Completes the previous commit, which repointed `audience` at the presenter so
+  it would at least verify. It should not be sent at all, and neither should
+  `nonce`. Both are removed from `rooms/keys/present` by spec 0.2.
+
+  `audience` named the party that had to PRESENT a credential, not the one it was
+  addressed to — so a host DID named somebody no presenter can ever be, and the
+  host refused every request. That is now moot: dtg-credentials 0.8.0 removed the
+  property and made the real rule explicit, which the VTA was already satisfying.
+  The leaf grants to the DID this VTA authenticated, and a host refuses a chain
+  whose leaf grants to anyone else. Who may present is established, not declared.
+
+  `nonce` was written into the presentation object, which is closed and has no
+  member for it — so a caller supplying one got a presentation the host rejects
+  as malformed. It could not have been made to work: every signature in a
+  presentation is an ISSUER's, never the presenter's, so a challenge inside it is
+  unauthenticated and a replay copies it along with everything else. Freshness is
+  the request's, via `issuedAt` and the duplicate-execution rule keyed on
+  document `id`.
+
+  ## A second live instance, found while doing this
+
+  `rooms/keys/backfill` passed the caller-named host as the audience in
+  `vta-service`, exactly as that spec's normative MUST instructed. Every backfill
+  this VTA attempted was refused for the same reason. What actually makes a
+  caller-named host safe is that the leaf grants to the VTA: naming a host
+  transfers no standing. It does hand that host sight of the principal's
+  credentials, which is a disclosure rather than an escalation, and the comment
+  now says so.
+
+  ## Nothing binds a presentation to a host, deliberately
+
+  A chain is scoped to the ROOM. One rooted in a room confers nothing anywhere
+  else, and any host serving that room would honour it — a room may have more
+  than one host, and moving between them without reissuing credentials is the
+  point. Binding a request to its destination is `recipient` on the document that
+  carries the presentation, per SPEC.md §4.8.2, which its proof covers.
+
+- **sdk**: A mock VTA has to sign, now that the client checks ([#1350](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1350))
+
+* fix(sdk): the provisioning probe tolerates an unsigned reply again
+
+  Main has been red since #1341 on
+  `a_vta_on_the_previous_provision_version_is_named_before_minting`, and the
+  test is right — the behaviour regressed.
+
+  `verify_authorization` asks `trust-task-discovery/0.1` before anything is
+  minted, and it is **a diagnostic, not a gate**. Its own module says why:
+  refusing to provision a VTA that cannot answer it "would turn a diagnostic
+  into an outage, which is the one way this module could be worse than not
+  existing". Every failure of the probe is therefore swallowed into `Skipped`,
+  except the two findings that name a concrete fix — no grant, and a version
+  skew.
+
+  #1341 added a new way for the probe to fail: the reply must now verify. That
+  lands in the same catch-all, so an agent that does not sign its replies
+  stopped producing *either* finding and produced "could not ask" instead. The
+  skew then surfaced where it always used to — as a bare 404 from the mint
+  call, naming the version the client wanted and never the one the VTA has,
+  which is the exact failure this module was written to replace.
+
+  `trusting_unsigned_replies` is the narrow tool for it, and it is #1341's own:
+  a **present** proof is still verified and still bound to this VTA, so a
+  rewritten reply is still refused. Only the *absence* of a proof is tolerated
+  — which is what an agent predating #1334/#1335 sends, and precisely the case
+  that method documents itself for. Every task that is not this advisory probe
+  keeps the full check.
+
+  A second test pins the half that matters: a reply carrying a **broken** proof
+  must not steer the diagnostic. Without it the change reads exactly like
+  "verification was turned off for the probe", and a forged task list would
+  prove it had been.
+
+  Also worth recording, because it is how this reached main green: `cargo test
+  -p vta-sdk` runs 306 tests, the workspace run runs 741. The failing test is
+  in the half a per-crate run does not compile, so "the vta-sdk suite is green"
+  was true and insufficient.
+
+  vta-sdk 741/741 under --all-features, and green under the default features CI
+  actually runs. Clippy clean.
+
+- **sdk**: The provisioning probe tolerates an unsigned reply again ([#1348](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1348))
+
+Main has been red since #1341 on
+  `a_vta_on_the_previous_provision_version_is_named_before_minting`, and the
+  test is right — the behaviour regressed.
+
+  `verify_authorization` asks `trust-task-discovery/0.1` before anything is
+  minted, and it is **a diagnostic, not a gate**. Its own module says why:
+  refusing to provision a VTA that cannot answer it "would turn a diagnostic
+  into an outage, which is the one way this module could be worse than not
+  existing". Every failure of the probe is therefore swallowed into `Skipped`,
+  except the two findings that name a concrete fix — no grant, and a version
+  skew.
+
+  #1341 added a new way for the probe to fail: the reply must now verify. That
+  lands in the same catch-all, so an agent that does not sign its replies
+  stopped producing *either* finding and produced "could not ask" instead. The
+  skew then surfaced where it always used to — as a bare 404 from the mint
+  call, naming the version the client wanted and never the one the VTA has,
+  which is the exact failure this module was written to replace.
+
+  `trusting_unsigned_replies` is the narrow tool for it, and it is #1341's own:
+  a **present** proof is still verified and still bound to this VTA, so a
+  rewritten reply is still refused. Only the *absence* of a proof is tolerated
+  — which is what an agent predating #1334/#1335 sends, and precisely the case
+  that method documents itself for. Every task that is not this advisory probe
+  keeps the full check.
+
+  A second test pins the half that matters: a reply carrying a **broken** proof
+  must not steer the diagnostic. Without it the change reads exactly like
+  "verification was turned off for the probe", and a forged task list would
+  prove it had been.
+
+  Also worth recording, because it is how this reached main green: `cargo test
+  -p vta-sdk` runs 306 tests, the workspace run runs 741. The failing test is
+  in the half a per-crate run does not compile, so "the vta-sdk suite is green"
+  was true and insufficient.
+
+  vta-sdk 741/741 under --all-features, and green under the default features CI
+  actually runs. Clippy clean.
+
+
+
 ## [0.34.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.34.0...vta-sdk-v0.34.1) — 2026-09-08
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.34.1"
+version = "0.35.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,649 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.24.1...vta-service-v0.25.0) — 2026-09-09
+
+
+### Added
+
+- **persona**: Say whether a link crosses a part of the holder's life ([#1342](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1342))
+
+Serves the members added in dtgwg-trust-tasks-tf#408, published in
+  trust-tasks-rs 0.18.10: `crossesFacets` and `facetIds` on a finding,
+  `facetId` on each `sharedWith` location. This needs a floor of 0.18.10 —
+  the spine validates OUTGOING responses, so under an older schema an analysis
+  that fully succeeded would come back 500 `responseSchemaViolation` — and no
+  longer moves one: main reached 0.18.11 while this sat open, which satisfies
+  it. The bump this branch carried is dropped rather than resolved downward.
+
+  **Severity is how linkable. Facets are whether the holder minds.** Nothing
+  here touches `severity`, and that is the design rather than an omission. A
+  value shared between two profiles in one facet still links them for anyone
+  who sees both — the holder's filing changes nothing a counterparty can do —
+  so softening severity on intent would report a false all-clear. What the
+  facets add is a second axis: which of these findings the holder would
+  actually want to act on.
+
+  **Absent is unknown, not false.** `crosses_facets` is `Option<bool>` and is
+  `None` when the holder keeps no facets, because `false` asserts these
+  identities sit in one part of a life and an agent with no facets has made no
+  such finding. `FacetIndex::any` is what carries that distinction, which is
+  why the index is a struct rather than a map.
+
+  **An unarranged profile is not a second facet.** Only distinct, named facets
+  count toward a crossing. Counting "no facet" as one would make every holder
+  who has arranged one part of their life and not the rest see a crossing on
+  everything they own — the dismissal problem arriving from the other
+  direction.
+
+  `facet_index` is built once per analysis for the reason `disclosure_index`
+  is: `analyze_correlation` with no `attributeId` walks the whole pool, and
+  the per-finding shape re-lists every facet for every finding.
+
+  The conformance witness now exercises the three new members rather than
+  merely permitting them — they are the ones added last, and an outgoing
+  member the embedded schema has not caught up with is a 500 on a call that
+  succeeded.
+
+  vta-persona 118/118 (6 new, one per rule above), vta-service lib 1063/1063,
+  clippy --all-targets clean.
+
+- **rooms**: Cut over to present/0.2 and issue-authority/0.2 ([#1365](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1365))
+
+The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked
+  by affinidi/affinidi-tdk-rs#784.
+
+  `trust-tasks-rs` 0.19 carries both new spec versions, but this workspace could
+  not take it: `affinidi-messaging-sdk 0.22.0` required 0.18, so pinning 0.19 put
+  two `trust-tasks-rs` nodes in the graph and broke `vta-sdk` on `expected
+  MediatorAcl, found a different MediatorAcl`. TDK #784 moved the messaging family
+  to 0.19 and 0.23.0.
+
+  Taking it exposed pins that had drifted apart underneath: `vta-sdk` was on
+  messaging-sdk 0.22 while `vta-service` and the e2e tests were on 0.21, and three
+  `trust-tasks-rs` versions were resolving at once. All of it is now consolidated:
+  the lockfile holds exactly ONE `trust-tasks-rs` and ONE `affinidi-messaging-sdk`,
+  where before it held three of each.
+
+  `rooms/keys/present` 0.1 -> 0.2 and `rooms/owner/issue-authority` 0.1 -> 0.2.
+  Both 0.1s are retired upstream. Neither is dual-accepted, deliberately: for
+  `present`, 0.1's extra members are exactly the two nothing could honour; for
+  `issue-authority`, accepting 0.1 means accepting a request with no `validUntil`,
+  which is the thing 0.2 exists to refuse.
+
+  The hand-rolled `validUntil` guard in `room_owner.rs` is deleted. 0.2 makes the
+  member REQUIRED, so the generated payload types it as a `DateTime` and the
+  envelope schema rejects a request without one before dispatch. Same rule, one
+  layer up, which is where a shape constraint belongs.
+
+  `every_witnessed_task_round_trips_through_its_generated_types` refused two
+  witnesses that had been green for as long as they existed:
+
+  1. The `issue-authority` witness carried no `validUntil` — a chain root with no
+     expiry, the exact request 0.2 forbids, and one this service could have sent.
+  2. The `present` witness carried `"audience": "did:key:z6MkHost"` — a HOST DID,
+     the precise shape #414 reported as impossible to satisfy, since the field
+     named the party that had to PRESENT the credential.
+
+  `room_oracle` emitted `membership` and `authority[]` as JSON **objects**;
+  `AuthorityPresentation` types both as strings, and the host's opener reads
+  base64url or bare JSON text. So the oracle's output could not deserialize at a
+  host at all — `rooms/keys/present` had never worked end to end. It went unseen
+  because 0.1's response typed `presentation` as an opaque object; 0.2 names the
+  shared component, which turned a runtime refusal nothing exercised into a type
+  error. The oracle now serialises each credential. That is the first half of
+  have caught all three of these years earlier.
+
+- **rooms**: A browser can be a room member ([#1347](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1347))
+
+* feat(rooms): a `host` feature, so a room's member half reaches wasm
+
+  `vti-rooms` already had two halves and no name for them: `vta-service`
+  imports `mls`/`sealed`/`wire` and nothing else, while `vtc-service`,
+  `room-host` and `vti-rooms-dtg` import `storage`/`authz`/`audit`. This
+  names the second half `host`, on by default, and makes `vti-common`
+  optional behind it.
+
+  `vti-common` describes itself as server-side infrastructure and pulls
+  axum, fjall and tokio, so it was the whole of what kept a room's member
+  code off `wasm32-unknown-unknown`. With it optional,
+  `--no-default-features --features mls` builds there — which is what lets
+  a browser hold a room's keys itself rather than ask an agent to. See
+  `docs/05-design-notes/data-rooms-demo-site.md`.
+
+  The member half needed **no source changes** to get there. That is a
+  property of `error.rs`, which deliberately does not use
+  `vti_common::error::AppError` because key material is not a service's
+  concern; a decision made for its own reasons that paid for itself here.
+
+  `lifecycle` is deliberately left ungated: only hosts consume it today,
+  but it needs nothing from `vti-common`, and a member computing a room's
+  lifecycle state to explain it on screen should not need a host's
+  dependencies.
+
+  Three things about the wasm plumbing, each of which reports as a
+  `compile_error!` that reads like an unsupported target:
+
+  - OpenMLS 0.9 has a first-class `js` feature (`web-time` for the
+    `SystemTime` wasm lacks, plus getrandom's JS backend). Declared
+    per-target rather than as a feature of this crate, so building for
+    wasm just works — verified wasm-only: `web-time` appears in the wasm
+    tree and not the native one.
+  - There are two getrandom majors in the graph. The 0.4 is ours; the 0.2
+    arrives transitively under `openmls_rust_crypto` via RustCrypto's
+    elliptic-curve stack, so no feature declared here could reach it.
+    `getrandom_02` is a feature shim, not a dependency this crate calls.
+  - With both declared per-target, **no `RUSTFLAGS` are needed** — the
+    `wasm_js` feature alone selects the backend.
+
+  CI gains two steps in the `features` job: clippy on the member half with
+  no host, and a wasm32 `--lib` check, so neither property rots silently.
+
+  `vta-service` now takes `default-features = false`: a VTA holds room keys
+  and is never a room's host, so it no longer compiles one.
+
+  * feat(rooms): vti-rooms-wasm — a data room's member half, in a browser
+
+  The MLS group, record sealing and the epoch key chain, compiled to
+  WebAssembly, so a tab can *be* a member rather than drive an agent that
+  is one. `vti-rooms` supplies all of it; this crate is only the boundary,
+  and its job is deciding what crosses.
+
+  **Secrets do not cross.** Everything returned is public — a KeyPackage,
+  ciphertext, an epoch number — with one deliberate exception: the
+  snapshot, which is key material because OpenMLS persists a group through
+  its provider rather than as a value. It goes in IndexedDB and nowhere
+  else; the docs say so at the method, since it is the one thing here a
+  caller could reasonably mishandle.
+
+  ## Two layers, and why
+
+  Every method appears twice: a plain Rust one with the logic, and a
+  one-line `#[wasm_bindgen]` wrapper that converts the error. Not
+  ceremony — `JsError` and `JsValue` are imported JS functions, so
+  constructing one on a native target panics. A crate whose only entry
+  points were wrapped would have no reachable native tests at all, and the
+  tests worth having are exactly the ones asserting a *failure*.
+
+  Both tests are of that kind, and both are round-trips rather than unit
+  assertions, because everything worth catching happens between the steps:
+
+  - a record must not open at a version or under a key it was not sealed
+    for — the binding is in the AEAD's associated data, not merely
+    alongside it;
+  - a snapshot taken before a commit must *refuse* rather than return
+    garbage, which is the failure mode a browser member will actually hit
+    (a tab closed for a week, reopened after somebody else joined).
+
+  ## Two API decisions
+
+  - **JSON strings in and out**, not `serde-wasm-bindgen`. The structures
+    crossing are the published `rooms/*` wire types and JSON is the form
+    they already travel in, so the boundary speaks the transport's
+    language and there is one fewer representation to get wrong.
+  - **`applyCommit` returns `{ epoch, link }`**, not just the epoch. The
+    rung is minted in the one moment any party knows both the outgoing and
+    incoming keys; it is added to the member's own chain here, and
+    returned because it is also what a host stores on their behalf. A
+    member who never uploads one keeps their history only as long as this
+    browser does.
+
+  ## Size
+
+  A `wasm-release` profile (`opt-level = "z"`, fat LTO, `panic = "abort"`)
+  takes the artifact from 693 KB gzipped to **540 KB**. Separate from
+  `release` because it trades compile time and native performance for
+  bytes — right for one downloaded module, wrong for the services.
+  `wasm-opt -Oz` is worth another slice and is not a cargo concern.
+
+  CI reports both sizes rather than gating on a threshold: one picked today
+  would be either slack enough to mean nothing or tight enough to fail on a
+  dependency's patch release, and what a reviewer needs is the number in
+  the log beside the diff that moved it.
+
+  * feat(rooms): gate the browser member on a room invitation
+
+  A VIC is the consent artefact: joining a room is a two-party act and the
+  invitation is the other party's half. Ported from vta-service's
+  operations::room_invitation, including its check order.
+
+  The gate is on the MEMBER's side, which looks wrong until you ask what it
+  defends. Not the room — this key holder. Minting retains a private key
+  against a Welcome that may never come, so a key holder that minted for
+  anyone is one anyone can fill; and a Welcome carries a group's secrets,
+  so accepting an uninvited one holds keys for a room nobody agreed to
+  join. The room's own protection is the owner refusing an uninvited key
+  package. Two parties, two threats, neither substituting for the other.
+
+  Verification is lexical: the proof is checked against raw public-key
+  bytes and a did:key room carries its key in its own name, so a browser
+  needs no resolver and cannot be offline. A did:webvh room would need real
+  resolution, and that is the one thing this would grow.
+
+  ## A check the original is missing
+
+  Writing a test per clause — rather than one 'a bad invitation is refused'
+  case, which passes with any four of five — showed the forgery clause did
+  not bite. Nothing binds the proof's verification method to the ISSUER.
+  verify_proof_with_public_key checks a signature against whatever bytes it
+  is handed, so resolving the method the proof names and verifying against
+  that proves somebody signed it, which is also true of a forgery: mint an
+  invitation naming the room as issuer, sign it with your own key, point
+  the proof at your own verification method, and every other check passes.
+
+  Added here as its own clause. vta-service's copy has the same shape and
+  needs the same fix — reported separately; this is a second copy of a gate
+  that should live in vti-rooms where both can share it.
+
+  * feat(rooms): the member's key and its authority presentation, in wasm
+
+  Two halves of one thing: everything a member signs is signed in wasm, so
+  the private key never crosses into JavaScript.
+
+  The first cut minted the key with WebCrypto and kept the JWK in
+  `localStorage` — a raw private key in a page's heap and in a string store
+  any script on the origin can read, contradicting this crate's own rule
+  that secrets do not cross. Minting it here costs nothing (`ed25519-dalek`
+  already arrives through OpenMLS) and leaves JS holding two opaque
+  snapshots and no key. `Debug` is hand-written to redact: the places a
+  `Debug` reaches — a log line, a panic, a test failure — are exactly the
+  places key material must not turn up.
+
+  `present` mints the authority presentation every host task takes:
+  attenuate the room's VAC to one action, sign as the member, and return
+  `{membership, authority: [leaf, root], nonce}`. Attenuation refuses to
+  widen, so asking for more than the room granted fails here — where the
+  member can be told why — rather than as a refusal from a host worded as
+  though they were at fault.
+
+  ## It takes no `audience` parameter, and that is the point
+
+  `audience` is not who the presentation is addressed to. `verify_chain`
+  compares it to the PRESENTER — "the leaf must be presentable by whoever
+  is presenting it" — so it is holder binding, and its job is to make a
+  captured presentation worthless to anyone else. A browser member always
+  presents its own, so the only correct value is its own DID, and offering
+  the choice is offering a way to get it wrong.
+
+  Not hypothetical: `vta-cli-common`'s `RoomTarget` passes the HOST's DID
+  as the audience, so `pnm-cli rooms --host-did …` mints a leaf bound to an
+  audience no presenter can match — refused as `WrongAudience` every time —
+  while omitting the flag leaves the presentation bearer-shaped for four
+  hours. Its doc states the intent exactly ("with it, a captured
+  presentation is worthless to anyone else") and names the wrong party.
+  Reported separately.
+
+  Tests assert against `dtg_credentials::authority::verify_chain` itself,
+  not a restatement of it: the presentation verifies, a narrowing to `read`
+  does not authorise `curate`, over-asking is refused locally, and a
+  captured presentation fails for the thief as `WrongAudience` rather than
+  as a bad signature. Also pins the shape the server path never produces —
+  a browser member is its own agent, so the leaf's subject and the chain
+  root's are the same DID.
+
+  * fix(rooms): a presentation travels as strings, not objects
+
+  AuthorityPresentation types membership as a String and authority as a
+  Vec<String>: the credential TEXT is the wire form, and vti-rooms-dtg
+  decodes base64url or bare JSON on the way in. present() was emitting
+  parsed objects, so room-host refused the whole request as "invalid type:
+  map, expected a string" — which reads as a malformed payload rather than
+  as the shape mismatch it is, and points at the wrong field.
+
+  Found by sending one to a real host rather than by reading the type.
+
+  The root is now passed through exactly as received instead of being
+  re-serialised, so nothing on this side can touch the bytes its proof was
+  made over. Both tests assert the wire form — that each authority link is
+  a string and membership is one too — because a chain that verifies in a
+  test and is refused on the wire is the failure this cost an hour to.
+
+  * fix(rooms): the wasm member links a chain the way its hosts verify one
+
+  dtg-credentials 0.7 changed how an authority chain links — a link's
+  `parent` went from naming the parent's `id` to naming a *digest* of its
+  claims — so a 0.7 `attenuate` and a 0.6 `verify_chain` cannot
+  interoperate. The refusal reads as a broken chain rather than a version
+  skew:
+
+      chain link 0 names parent `zQmPvoS…`,
+      but was presented after `urn:uuid:0647…`
+
+  Found by pointing a browser member at `room-host` and watching a
+  perfectly good presentation be refused. Pinned to what the workspace
+  verifies with. Reported upstream as OpenVTC/dtg-credentials#22, which
+  asks for ordering guidance and a hint in that error message.
+
+- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))
+
+Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
+  in trust-tasks-rs 0.18.9.
+
+  A holder who uses this model for a while ends up with twenty profiles, and a
+  flat list of twenty is a list nobody reads. A facet is the arrangement over
+  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
+  the profiles it groups.
+
+  **An arrangement, not a container.** Nothing is stored inside a facet, and
+  `delete_facet` touches no profile and no attribute. There is no cascading
+  form because there is no cascading form of the idea: a grouping that could
+  take its members with it is a folder, and a holder who reads it as a folder
+  is right to be afraid of it. `releasedFaces` reports what now belongs
+  nowhere, which is what a screen needs to say what it will look like
+  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.
+
+  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
+  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
+  well-behaved consumer does not hold the values it would have to resend —
+  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
+  name. It would either request every sensitive value the holder owns to
+  perform an arrangement that has nothing to do with values, or send a put
+  without one and destroy them.
+
+
+
+### Changed
+
+- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))
+
+Pure move plus re-exports; no behaviour changes. It exists so the next
+  change can be small: `VtaClient` needs to verify the responses it receives,
+  and the verifier it needs already exists one layer up where a client cannot
+  reach it.
+
+  `vti-common` was the right home while services verifying their *inbound*
+  requests were the only consumer. A client verifying its *replies* is the
+  same operation over the same document shape, and `vta-sdk` is the layer both
+  can see.
+
+  **The part worth not duplicating is the verification-method resolver.**
+  Resolving one looks trivial and is not: a DID document may name its methods
+  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
+  proof always names them absolutely, so a resolver accepting only the
+  spelling it expects refuses perfectly good documents from conforming peers.
+  A second copy would drift, and drift in a verifier means refusing honest
+  documents or accepting dishonest ones. Writing that copy is what this move
+  avoids.
+
+  Behind a new `proof-verify` feature rather than `client`, because
+  `vti-common` takes `vta-sdk` with `default-features = false` and must not
+  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
+  that crate already depended on `affinidi-data-integrity` and the DID
+  resolver directly. `client` enables it: a client that cannot verify its
+  replies is the gap being closed.
+
+  The resolver rides in the feature deliberately. Verification is only as good
+  as the party it resolves — a `did:key` signer needs no I/O, and a
+  `did:webvh` one, which is what a real agent is, cannot be verified without
+  resolving its document.
+
+  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
+  use the flat re-export, so there is one canonical path rather than an alias
+  to go stale. Two doc comments naming the old location updated with them.
+
+  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
+  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
+  tests that moved with the code.
+
+
+
+### Fixed
+
+- **rooms**: Bind an invitation's proof to its issuer ([#1353](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1353))
+
+An invitation naming a room as issuer, signed by anybody at all, was
+  accepted. Every other clause passed: it is an invitation, the issuer
+  field is the room, the subject is the member, the window is open, and
+  the proof verifies — against the attacker's own key, which is the one
+  the proof named and the one this module went and resolved.
+
+  Nothing looked at *whose* key it was. So anyone could mint themselves an
+  invitation to any room, hand it to their own agent, mint a KeyPackage
+  against it, accept the Welcome, and hold that room's group keys. The
+  invitation is the consent artefact for joining; without this check it
+  consented to nothing.
+
+  The fix is four lines, before the resolver call rather than after: a
+  credential that cannot be the room's own is refused without a network
+  round trip.
+
+  ## How it was found, which is the part worth keeping
+
+  By porting this module to a browser and writing a test per clause instead
+  of one "a bad invitation is refused" case. That shape passes with any
+  five of six, and did. The module had no unit tests at all — verify() is
+  async and takes a `&dyn VerificationKeys`, which reads as needing a
+  resolver and a network, when a fifteen-line did:key resolver is enough to
+  exercise the whole of it. Four tests added on that.
+
+  The check list in the module docs is renumbered five to six. A doc
+  comment that counts its own checks is load-bearing: it is how the next
+  reader knows whether one went missing.
+
+- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))
+
+* fix(rooms): bind a presentation to its presenter, not to the host
+
+  `pnm-cli rooms --host-did …` could never work. Every request it made was
+  refused as `WrongAudience`, and omitting the flag "worked" only by
+  skipping the check it exists to perform — so the flag's two states were
+  broken and unprotected.
+
+  `audience` is not who a presentation is addressed to.
+  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
+  "the leaf must be presentable by whoever is presenting it" — so it is
+  holder binding, and its whole job is to make a captured presentation
+  worthless to whoever captured it. Filled with the host's DID it named a
+  party no presenter can ever match.
+
+  The value to bind to was already named a few lines away: `RoomSigner`'s
+  doc says "a room request is signed by the party the presentation was
+  minted for". This passes exactly that. There is no unbound case left, so
+  the warning about one goes, and `--host-did` keeps its real job of naming
+  the document's recipient.
+
+  ## The spec says otherwise, and that is filed separately
+
+  `rooms/keys/present/0.1` describes `audience` as "the party the
+  presentation is for … a host's identifier, normally". The CLI implemented
+  the spec faithfully; the spec and the credential library it runs on
+  disagree, identically in dtg-credentials 0.6 and 0.7, so it is not
+  version drift.
+
+  This changes the CLI to match the verifier rather than the prose, because
+  a presentation that cannot verify protects nobody while being wrong in
+  the other direction. Which side should move is a working-group question —
+  0.7's own notes point at upstream PR #41, "a key-control demonstration at
+  invocation, which removes `audience` as redundant" — and is raised there.
+
+  * fix(rooms)!: stop sending `audience` and `nonce` on rooms/keys/present
+
+  Completes the previous commit, which repointed `audience` at the presenter so
+  it would at least verify. It should not be sent at all, and neither should
+  `nonce`. Both are removed from `rooms/keys/present` by spec 0.2.
+
+  `audience` named the party that had to PRESENT a credential, not the one it was
+  addressed to — so a host DID named somebody no presenter can ever be, and the
+  host refused every request. That is now moot: dtg-credentials 0.8.0 removed the
+  property and made the real rule explicit, which the VTA was already satisfying.
+  The leaf grants to the DID this VTA authenticated, and a host refuses a chain
+  whose leaf grants to anyone else. Who may present is established, not declared.
+
+  `nonce` was written into the presentation object, which is closed and has no
+  member for it — so a caller supplying one got a presentation the host rejects
+  as malformed. It could not have been made to work: every signature in a
+  presentation is an ISSUER's, never the presenter's, so a challenge inside it is
+  unauthenticated and a replay copies it along with everything else. Freshness is
+  the request's, via `issuedAt` and the duplicate-execution rule keyed on
+  document `id`.
+
+  ## A second live instance, found while doing this
+
+  `rooms/keys/backfill` passed the caller-named host as the audience in
+  `vta-service`, exactly as that spec's normative MUST instructed. Every backfill
+  this VTA attempted was refused for the same reason. What actually makes a
+  caller-named host safe is that the leaf grants to the VTA: naming a host
+  transfers no standing. It does hand that host sight of the principal's
+  credentials, which is a disclosure rather than an escalation, and the comment
+  now says so.
+
+  ## Nothing binds a presentation to a host, deliberately
+
+  A chain is scoped to the ROOM. One rooted in a room confers nothing anywhere
+  else, and any host serving that room would honour it — a room may have more
+  than one host, and moving between them without reissuing credentials is the
+  point. Binding a request to its destination is `recipient` on the document that
+  carries the presentation, per SPEC.md §4.8.2, which its proof covers.
+
+- The last two #1341 fallout failures ([#1359](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1359))
+
+* fix(vta): the hosted-DID services test drives REST directly
+
+  `services_write_paths_against_a_hosted_vta_did` repoints `cfg.vta_did` at a
+  `did:webvh` the mock mints at runtime. The agent's response-signing identity
+  does not follow — `signing_vm_id` is computed once at boot — so the mock
+  answers signed as its `did:key` while claiming to be the hosted DID, and
+  `VtaClient` refuses every reply since #1341. The refusal is correct; the
+  fixture is what is inconsistent.
+
+  Booting the mock with the hosted identity, which is the obvious repair, fixes
+  the signer and not the verification. The DID is minted against `StubWebvhHost`,
+  which publishes nothing and answers on loopback under a domain that resolves
+  nowhere, so a reply signed as it is unverifiable by any client in any process.
+  There is no arrangement of this fixture in which a verifying client accepts an
+  answer from a stub-hosted DID.
+
+  The subject of the test is the agent's `services/*` write paths, so the four
+  dispatches go over the REST binding directly: the same signed document
+  `VtaClient` builds, to the same `/trust-tasks` route, with the same bearer
+  token. Everything server-side is unchanged — §7.2 admission, the dispatch
+  spine, the handlers, the response proof. Only the client's verification of the
+  reply is out of the picture, and it is not what this test covers.
+
+  Making `signing_vm_id` runtime-mutable was the other candidate and is worse: it
+  would reshape `AppState` to permit something production forbids, which
+  `config_registry_round_trips_and_identity_stays_read_only` exists to record.
+
+- **sdk**: The mock VTA signs its answers, as every real one does ([#1355](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1355))
+
+* fix(sdk): the mock VTA signs its answers, as every real one does
+
+  Third wave of the #1341 regression, and the first to be fixed at the cause
+  rather than per-test. Main is red on `vta-service`'s round-trip suite; this
+  takes it from 0/10 to 10/10 without touching a single test.
+
+  **The harness never did what production does.** `server.rs` sets
+  `signing_vm_id` to `{vta_did}#key-0` for every DID method that is not
+  `did:peer`, so a REST-only VTA signs its answers with its own key and needs
+  no transport identity to do it. `build_test_app` populated that slot *only*
+  from `build_transport_state`, which requires a `did:peer:2` — so a `MockVta`
+  answered unsigned where the real thing signs, and every round-trip test
+  failed with the client blaming the reply for something the harness had never
+  provided.
+
+  **The sentinel had to go, for the reason `TEST_ADMIN_SEED` records.** The
+  mock's `did:key:z6MkTestVTA` was not a `did:key` at all — the same mistake
+  that note describes fixing for the admin identity, and for the same reason:
+  nothing resolves it, so nothing it signs can carry a verifiable proof. It is
+  now derived from `TEST_VTA_SEED`, and the 28 references that named the
+  literal name the real one.
+
+  Deliberately *not* a full provisioning. The default mock gets a real identity
+  and the key behind it, and still no seed records or keystore, so a test that
+  asserts an unprovisioned VTA still gets one. Only enough to sign.
+
+  `secret_from_ed25519` carries the sharp edge: `Secret::from_multibase` needs
+  the multicodec prefix (`0x80 0x26`, ed25519-priv) and refuses raw bytes with
+  `Unsupported key type`, while `decode_private_key_multibase` accepts either.
+  The two encodings look interchangeable and are not.
+
+  Also, in the spine: a VTA **configured to sign and unable to** now answers
+  with a 500 naming the verification method, instead of silently answering
+  unsigned into a client that will refuse it and report the reply as the
+  problem. A VTA with no signing identity at all still answers unsigned —
+  unchanged, and correct for a pre-setup agent.
+
+  `client_round_trip` 10/10, `mock_vta` 12/13. Two known failures remain and
+  are the same regression in two more stand-ins; see the PR.
+
+- **rooms**: Verify a host's reply before believing it ([#1337](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1337))
+
+#1334 and #1335 made both services sign their responses. Nothing verified
+  one, so the property was not yet bought: producers signing and consumers not
+  checking leaves the signature decorative.
+
+  This is the first consumer to check, and it is the one the rooms work
+  introduced — the VTA calling a room's host on its principal's behalf.
+
+  **A reply is bytes off a socket.** Without a proof it attests to nothing: an
+  intermediary can rewrite a record listing, change the epoch a chain claims
+  to reach, or answer for a host that never spoke, and every check downstream
+  would pass — because the checks downstream are about shape.
+
+  Two things are required, and the second is the one easy to omit. The proof
+  must verify, and its proven signer must be **the host this agent addressed**.
+  `verify_trust_task_proof_with` says so in its own documentation: a proof by
+  `did:webvh:…:someone-else#key-0` verifies perfectly well, and that it is not
+  the party you expected is a separate check. Without the binding, "signed by
+  somebody" gets mistaken for "signed by the host", which is the entire
+  property.
+
+  Error documents are exempt, from the specification rather than for
+  convenience: a refusal's `type` resolves to `trust-task-error`, whose own
+  proof requirement is RECOMMENDED (SPEC §8.1). Demanding one would make every
+  conforming refusal unreadable — including the `hostRefused` this family
+  declares, whose whole purpose is carrying the host's reason to an operator.
+  A refusal confers nothing, which is why the framework asks less of it.
+
+  This rejects unsigned success replies outright rather than warning, so a
+  room host that predates #1334 will be refused. That is the intended
+  behaviour and it is a deployment-order constraint: hosts upgrade before
+  agents that talk to them.
+
+  `cargo test -p vta-service --lib`: 1063 passed, 0 failed.
+
+- **vta**: Sign success responses, completing the producer half ([#1335](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1335))
+
+The agent side of #1334. Same gap, same reasoning: SPEC §7.3 item 7 makes a
+  single `proofRequirement: REQUIRED` bind the response as well as the
+  request, 265 published specifications declare one, and this service attached
+  a proof to none of their responses. No consumer verifies one either, which
+  is why nothing ever went red.
+
+  Two things made the agent harder than the community, and both are decisions
+  rather than mechanics.
+
+  **It does not sign through `load_vta_issuer_secret`.** That helper reads the
+  keystore, derives, and writes an audit entry per access. Signing every
+  response through it would turn "the agent's issuer key was used" into one
+  line per request — drowning a security control in its own noise, which is a
+  worse outcome than the gap being closed. It signs from the resident secret
+  `secrets_resolver` already holds for the messaging layer: no keystore read,
+  no audit entry. The agent signing its own words is not a key access worth
+  recording, it is the agent speaking.
+
+  **`signing_vm_id` is no longer feature-gated.** It was
+  `#[cfg(any(feature = "didcomm", feature = "tsp"))]`, which would have made a
+  `--no-default-features --features rest` build answer the same specifications
+  without the proof they require. Conformance must not depend on which
+  transports were compiled in.
+
+  The guard is in three parts because the first two are not enough, and
+  finding that out is the useful part. `attach_proof` is tested directly — it
+  produces a verifiable proof, replaces a stale one rather than nesting, and
+  degrades on an unsignable body. Those tests **passed with the call deleted
+  from the spine**, which is exactly the shape of the bug they exist to
+  prevent, so a source assertion covers the wiring and a state-level test
+  covers the plumbing. A comfort is not a guard.
+
+  Worth recording: `build_signing_test_app_state` already ships a resident
+  signing secret. The degradation case clears it explicitly rather than
+  assuming its absence — the first draft assumed, and was wrong.
+
+  `cargo test -p vta-service --lib`: 1061 passed, 0 failed.
+
+
+
 ## [0.24.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.24.0...vta-service-v0.24.1) — 2026-09-08
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.24.1"
+version = "0.25.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -171,10 +171,10 @@ dtg-credentials = { workspace = true }
 # The member half only. A VTA holds room keys, seals and opens records; it is
 # never a room's host, so it has no use for `storage`, `authz` or `audit` and
 # does not compile them. `default-features = false` is what says so.
-vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, features = [
+vti-rooms = { path = "../vti-rooms", version = "0.2", default-features = false, features = [
   "mls",
 ] }
-vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.1" }
+vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.2" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.
 vta-sweepers = { path = "../vta-sweepers", version = "0.3" }
@@ -193,7 +193,7 @@ vta-policy = { path = "../vta-policy", version = "0.3" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.2", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -214,7 +214,7 @@ trust-tasks-proof = { workspace = true }
 # generation, bundle opening). Used by `vta bootstrap request` /
 # `vta bootstrap open` so cold-start clients can run the offline flow
 # without depending on `pnm`.
-vta-cli-common = { path = "../vta-cli-common", version = "0.14" }
+vta-cli-common = { path = "../vta-cli-common", version = "0.15" }
 affinidi-crypto = { workspace = true }
 # Low-level `Secret` type for loading the VTA's signing key at
 # provision time. Already transitively present via affinidi-tdk; made
@@ -360,7 +360,7 @@ aws-lc-rs = { version = "1", optional = true }
 # The signed room fixtures, for the oracle round-trip test. A dev-dependency so
 # the feature never reaches a release build — a permissive fixture is exactly
 # what should not ship, which is why the crate gates it.
-vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.1", features = ["test-support"] }
+vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.2", features = ["test-support"] }
 tempfile = "3"
 # The exact parser the DID-hosting server uses to read `alsoKnownAs` off a
 # published log. Dev-only: it lets the agent-name contract test assert that
@@ -393,7 +393,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.3...vta-support-v0.3.4) — 2026-09-09
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.2...vta-support-v0.3.3) — 2026-09-07
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vta-config = { path = "../vta-config", version = "0.4" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.4...vta-vault-v0.5.5) — 2026-09-09
+
+
 ## [0.5.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.3...vta-vault-v0.5.4) — 2026-09-07
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -34,7 +34,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.5...vta-webvh-v0.2.6) — 2026-09-09
+
+
 ## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.4...vta-webvh-v0.2.5) — 2026-09-07
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -22,7 +22,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18" }
-vta-sdk = { path = "../vta-sdk", version = "0.34" }
+vta-sdk = { path = "../vta-sdk", version = "0.35" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.5...vtc-client-v0.5.6) — 2026-09-09
+
+
 ## [0.5.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.5.4...vtc-client-v0.5.5) — 2026-09-08
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.5.5"
+version = "0.5.6"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,12 +21,12 @@ mls = ["vti-rooms/mls"]
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["session"] }
 
 # The room's wire types, and — under the `mls` feature — its group-key and
 # sealing layers, which this crate re-exports rather than owning. A VTA needs
 # both and must not depend on a VTC client, so they live in the shared leaf.
-vti-rooms = { path = "../vti-rooms", version = "0.1" }
+vti-rooms = { path = "../vti-rooms", version = "0.2" }
 
 # `TrustTask` — the join-submit document this client signs, and the `#response`
 # envelope the VTC answers it with. Same crate `vta-sdk` builds the document

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -117,7 +117,7 @@ name = "vtc"
 path = "src/main.rs"
 
 [dependencies]
-vti-rooms = { path = "../vti-rooms", version = "0.1" }
+vti-rooms = { path = "../vti-rooms", version = "0.2" }
 vti-rooms-dtg = { path = "../vti-rooms-dtg" }
 vti-common = { path = "../vti-common", version = "0.18", features = [
   "passkey",
@@ -136,7 +136,7 @@ vti-common = { path = "../vti-common", version = "0.18", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.18.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.1...vti-common-v0.18.2) — 2026-09-09
+
+
+### Changed
+
+- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))
+
+Pure move plus re-exports; no behaviour changes. It exists so the next
+  change can be small: `VtaClient` needs to verify the responses it receives,
+  and the verifier it needs already exists one layer up where a client cannot
+  reach it.
+
+  `vti-common` was the right home while services verifying their *inbound*
+  requests were the only consumer. A client verifying its *replies* is the
+  same operation over the same document shape, and `vta-sdk` is the layer both
+  can see.
+
+  **The part worth not duplicating is the verification-method resolver.**
+  Resolving one looks trivial and is not: a DID document may name its methods
+  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
+  proof always names them absolutely, so a resolver accepting only the
+  spelling it expects refuses perfectly good documents from conforming peers.
+  A second copy would drift, and drift in a verifier means refusing honest
+  documents or accepting dishonest ones. Writing that copy is what this move
+  avoids.
+
+  Behind a new `proof-verify` feature rather than `client`, because
+  `vti-common` takes `vta-sdk` with `default-features = false` and must not
+  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
+  that crate already depended on `affinidi-data-integrity` and the DID
+  resolver directly. `client` enables it: a client that cannot verify its
+  replies is the gap being closed.
+
+  The resolver rides in the feature deliberately. Verification is only as good
+  as the party it resolves — a `did:key` signer needs no I/O, and a
+  `did:webvh` one, which is what a real agent is, cannot be verified without
+  resolving its document.
+
+  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
+  use the flat re-export, so there is one canonical path rather than an alias
+  to go stale. Two doc comments naming the old location updated with them.
+
+  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
+  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
+  tests that moved with the code.
+
+
+
 ## [0.18.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.0...vti-common-v0.18.1) — 2026-09-08
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.18.1"
+version = "0.18.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.34", default-features = false, features = [
+vta-sdk = { path = "../vta-sdk", version = "0.35", default-features = false, features = [
   # The Trust-Task proof verifier lives there now; this crate re-exports it.
   "proof-verify",
 ] }

--- a/vti-rooms-dtg/CHANGELOG.md
+++ b/vti-rooms-dtg/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.2...vti-rooms-dtg-v0.2.0) — 2026-09-09
+
+
+### Fixed
+
+- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))
+
+* fix(rooms): bind a presentation to its presenter, not to the host
+
+  `pnm-cli rooms --host-did …` could never work. Every request it made was
+  refused as `WrongAudience`, and omitting the flag "worked" only by
+  skipping the check it exists to perform — so the flag's two states were
+  broken and unprotected.
+
+  `audience` is not who a presentation is addressed to.
+  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
+  "the leaf must be presentable by whoever is presenting it" — so it is
+  holder binding, and its whole job is to make a captured presentation
+  worthless to whoever captured it. Filled with the host's DID it named a
+  party no presenter can ever match.
+
+  The value to bind to was already named a few lines away: `RoomSigner`'s
+  doc says "a room request is signed by the party the presentation was
+  minted for". This passes exactly that. There is no unbound case left, so
+  the warning about one goes, and `--host-did` keeps its real job of naming
+  the document's recipient.
+
+  ## The spec says otherwise, and that is filed separately
+
+  `rooms/keys/present/0.1` describes `audience` as "the party the
+  presentation is for … a host's identifier, normally". The CLI implemented
+  the spec faithfully; the spec and the credential library it runs on
+  disagree, identically in dtg-credentials 0.6 and 0.7, so it is not
+  version drift.
+
+  This changes the CLI to match the verifier rather than the prose, because
+  a presentation that cannot verify protects nobody while being wrong in
+  the other direction. Which side should move is a working-group question —
+  0.7's own notes point at upstream PR #41, "a key-control demonstration at
+  invocation, which removes `audience` as redundant" — and is raised there.
+
+  * fix(rooms)!: stop sending `audience` and `nonce` on rooms/keys/present
+
+  Completes the previous commit, which repointed `audience` at the presenter so
+  it would at least verify. It should not be sent at all, and neither should
+  `nonce`. Both are removed from `rooms/keys/present` by spec 0.2.
+
+  `audience` named the party that had to PRESENT a credential, not the one it was
+  addressed to — so a host DID named somebody no presenter can ever be, and the
+  host refused every request. That is now moot: dtg-credentials 0.8.0 removed the
+  property and made the real rule explicit, which the VTA was already satisfying.
+  The leaf grants to the DID this VTA authenticated, and a host refuses a chain
+  whose leaf grants to anyone else. Who may present is established, not declared.
+
+  `nonce` was written into the presentation object, which is closed and has no
+  member for it — so a caller supplying one got a presentation the host rejects
+  as malformed. It could not have been made to work: every signature in a
+  presentation is an ISSUER's, never the presenter's, so a challenge inside it is
+  unauthenticated and a replay copies it along with everything else. Freshness is
+  the request's, via `issuedAt` and the duplicate-execution rule keyed on
+  document `id`.
+
+  ## A second live instance, found while doing this
+
+  `rooms/keys/backfill` passed the caller-named host as the audience in
+  `vta-service`, exactly as that spec's normative MUST instructed. Every backfill
+  this VTA attempted was refused for the same reason. What actually makes a
+  caller-named host safe is that the leaf grants to the VTA: naming a host
+  transfers no standing. It does hand that host sight of the principal's
+  credentials, which is a disclosure rather than an escalation, and the comment
+  now says so.
+
+  ## Nothing binds a presentation to a host, deliberately
+
+  A chain is scoped to the ROOM. One rooted in a room confers nothing anywhere
+  else, and any host serving that room would honour it — a room may have more
+  than one host, and moving between them without reissuing credentials is the
+  point. Binding a request to its destination is `recipient` on the document that
+  carries the presentation, per SPEC.md §4.8.2, which its proof covers.
+
+
+
 ## [0.1.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.1...vti-rooms-dtg-v0.1.2) — 2026-09-07
 
 

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms-dtg"
 description = "The DTG-credential chain verifier for data rooms"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -24,7 +24,7 @@ publish.workspace = true
 test-support = ["dep:ed25519-dalek", "dep:getrandom", "dep:multibase", "dep:vta-sdk", "dep:affinidi-tdk"]
 
 [dependencies]
-vti-rooms = { path = "../vti-rooms", version = "0.1" }
+vti-rooms = { path = "../vti-rooms", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18" }
 
 # `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
@@ -45,7 +45,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { version = "0.4", optional = true }
 multibase = { workspace = true, optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = ["didcomm"], optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm"], optional = true }
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/vti-rooms-wasm/Cargo.toml
+++ b/vti-rooms-wasm/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 # The member half, and nothing else from the workspace. `default-features =
 # false` is the whole point: with `host` on, this would pull `vti-common` and
 # with it axum, fjall and tokio, none of which reach wasm.
-vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, features = [
+vti-rooms = { path = "../vti-rooms", version = "0.2", default-features = false, features = [
   "mls",
 ] }
 

--- a/vti-rooms/CHANGELOG.md
+++ b/vti-rooms/CHANGELOG.md
@@ -2,6 +2,441 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.3...vti-rooms-v0.2.0) — 2026-09-09
+
+
+### Added
+
+- **rooms**: Traces, and a response type for the single-record read ([#1368](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1368))
+
+A commitment lets a reader catch a host that equivocates. A trace proves a
+  particular record sits under the root that host just asserted. This serves
+  them — and fixes the conformance defect that adding them uncovered.
+
+  Implements trust-tasks-tf#419, released as trust-tasks-rs 0.19.1.
+
+  `rooms/records/get` has never conformed to its published schema. Both hosts
+  answered a read by serialising `vti_rooms::Record` — the *storage* record — and
+  adding `dataCommitment` to whatever came out:
+
+      "c2VhbGVk" is not of type "object";
+      Additional properties are not allowed
+      ('author','epoch','nonce','pinned','status','updatedAt' were unexpected)
+
+  It survived because `vti_rooms::wire`'s rule — every wire type appears in
+  tests/schema_conformance.rs — can only be applied to types that exist. A
+  response that was never a type had no line to be missing from, and a storage
+  record reached the wire because nothing stood between them. The consumer is not
+  hypothetical: `@openvtc/pnm-core`'s `roomsRecordsGet` is typed on the generated
+  payload, so a caller reading `sealed.ciphertext` got `undefined` from a live
+  host, with a green type-check on both sides.
+
+  The leaf preimage was not reproducible either. `leaf_hash` canonicalised the
+  storage record, so every root it produced was unreachable by any reader:
+  `updatedAt` is unix seconds in storage and RFC 3339 on the wire, `epoch` and
+  `nonce` are flat in storage and inside `sealed` on the wire, and `epoch`
+  serialises as `null` on an open room where the wire has it absent. Survivable
+  while the only use was comparing two roots from the same build; not survivable
+  once a trace has to be computable by someone else.
+
+- **rooms**: Hosts compute and serve the data commitment ([#1351](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1351))
+
+* fix(rooms): a commitment is a DigestMultibase, not bare hex
+
+  Owed from #1346. The spec that landed with it
+  (trustoverip/dtgwg-trust-tasks-tf#411) types `dataCommitment` as the
+  framework's `DigestMultibase`, and the helper shipped emitting hex.
+
+  Bare hex hard-codes SHA-256 into the wire contract, which is precisely what
+  `DigestMultibase` exists to prevent: multihash names the algorithm in-band,
+  so moving off SHA-256 later is a change of value rather than another schema
+  revision. `0x12 0x20` then the digest, base58btc with the `z` prefix — the
+  same shape `sealed_transfer::bundle_digest_multibase` already produces, so
+  the two agree by construction rather than by memory.
+
+  `from_multibase` refuses anything that is not a sha2-256 multihash. A
+  commitment is what a comparison turns on, so silently accepting an algorithm
+  this build cannot compute would turn "these two roots differ" into "these
+  two roots are not comparable" without saying which.
+
+  Two tests, both about the encoding being a contract rather than a detail: a
+  commitment decodes to the 34-byte multihash and round-trips, and bare hex, a
+  foreign algorithm, a truncated digest and non-multibase are each refused.
+
+  The tree, the leaves and the proofs are untouched — this is the wire
+  boundary only.
+
+- **rooms**: A browser can be a room member ([#1347](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1347))
+
+* feat(rooms): a `host` feature, so a room's member half reaches wasm
+
+  `vti-rooms` already had two halves and no name for them: `vta-service`
+  imports `mls`/`sealed`/`wire` and nothing else, while `vtc-service`,
+  `room-host` and `vti-rooms-dtg` import `storage`/`authz`/`audit`. This
+  names the second half `host`, on by default, and makes `vti-common`
+  optional behind it.
+
+  `vti-common` describes itself as server-side infrastructure and pulls
+  axum, fjall and tokio, so it was the whole of what kept a room's member
+  code off `wasm32-unknown-unknown`. With it optional,
+  `--no-default-features --features mls` builds there — which is what lets
+  a browser hold a room's keys itself rather than ask an agent to. See
+  `docs/05-design-notes/data-rooms-demo-site.md`.
+
+  The member half needed **no source changes** to get there. That is a
+  property of `error.rs`, which deliberately does not use
+  `vti_common::error::AppError` because key material is not a service's
+  concern; a decision made for its own reasons that paid for itself here.
+
+  `lifecycle` is deliberately left ungated: only hosts consume it today,
+  but it needs nothing from `vti-common`, and a member computing a room's
+  lifecycle state to explain it on screen should not need a host's
+  dependencies.
+
+  Three things about the wasm plumbing, each of which reports as a
+  `compile_error!` that reads like an unsupported target:
+
+  - OpenMLS 0.9 has a first-class `js` feature (`web-time` for the
+    `SystemTime` wasm lacks, plus getrandom's JS backend). Declared
+    per-target rather than as a feature of this crate, so building for
+    wasm just works — verified wasm-only: `web-time` appears in the wasm
+    tree and not the native one.
+  - There are two getrandom majors in the graph. The 0.4 is ours; the 0.2
+    arrives transitively under `openmls_rust_crypto` via RustCrypto's
+    elliptic-curve stack, so no feature declared here could reach it.
+    `getrandom_02` is a feature shim, not a dependency this crate calls.
+  - With both declared per-target, **no `RUSTFLAGS` are needed** — the
+    `wasm_js` feature alone selects the backend.
+
+  CI gains two steps in the `features` job: clippy on the member half with
+  no host, and a wasm32 `--lib` check, so neither property rots silently.
+
+  `vta-service` now takes `default-features = false`: a VTA holds room keys
+  and is never a room's host, so it no longer compiles one.
+
+  * feat(rooms): vti-rooms-wasm — a data room's member half, in a browser
+
+  The MLS group, record sealing and the epoch key chain, compiled to
+  WebAssembly, so a tab can *be* a member rather than drive an agent that
+  is one. `vti-rooms` supplies all of it; this crate is only the boundary,
+  and its job is deciding what crosses.
+
+  **Secrets do not cross.** Everything returned is public — a KeyPackage,
+  ciphertext, an epoch number — with one deliberate exception: the
+  snapshot, which is key material because OpenMLS persists a group through
+  its provider rather than as a value. It goes in IndexedDB and nowhere
+  else; the docs say so at the method, since it is the one thing here a
+  caller could reasonably mishandle.
+
+  ## Two layers, and why
+
+  Every method appears twice: a plain Rust one with the logic, and a
+  one-line `#[wasm_bindgen]` wrapper that converts the error. Not
+  ceremony — `JsError` and `JsValue` are imported JS functions, so
+  constructing one on a native target panics. A crate whose only entry
+  points were wrapped would have no reachable native tests at all, and the
+  tests worth having are exactly the ones asserting a *failure*.
+
+  Both tests are of that kind, and both are round-trips rather than unit
+  assertions, because everything worth catching happens between the steps:
+
+  - a record must not open at a version or under a key it was not sealed
+    for — the binding is in the AEAD's associated data, not merely
+    alongside it;
+  - a snapshot taken before a commit must *refuse* rather than return
+    garbage, which is the failure mode a browser member will actually hit
+    (a tab closed for a week, reopened after somebody else joined).
+
+  ## Two API decisions
+
+  - **JSON strings in and out**, not `serde-wasm-bindgen`. The structures
+    crossing are the published `rooms/*` wire types and JSON is the form
+    they already travel in, so the boundary speaks the transport's
+    language and there is one fewer representation to get wrong.
+  - **`applyCommit` returns `{ epoch, link }`**, not just the epoch. The
+    rung is minted in the one moment any party knows both the outgoing and
+    incoming keys; it is added to the member's own chain here, and
+    returned because it is also what a host stores on their behalf. A
+    member who never uploads one keeps their history only as long as this
+    browser does.
+
+  ## Size
+
+  A `wasm-release` profile (`opt-level = "z"`, fat LTO, `panic = "abort"`)
+  takes the artifact from 693 KB gzipped to **540 KB**. Separate from
+  `release` because it trades compile time and native performance for
+  bytes — right for one downloaded module, wrong for the services.
+  `wasm-opt -Oz` is worth another slice and is not a cargo concern.
+
+  CI reports both sizes rather than gating on a threshold: one picked today
+  would be either slack enough to mean nothing or tight enough to fail on a
+  dependency's patch release, and what a reviewer needs is the number in
+  the log beside the diff that moved it.
+
+  * feat(rooms): gate the browser member on a room invitation
+
+  A VIC is the consent artefact: joining a room is a two-party act and the
+  invitation is the other party's half. Ported from vta-service's
+  operations::room_invitation, including its check order.
+
+  The gate is on the MEMBER's side, which looks wrong until you ask what it
+  defends. Not the room — this key holder. Minting retains a private key
+  against a Welcome that may never come, so a key holder that minted for
+  anyone is one anyone can fill; and a Welcome carries a group's secrets,
+  so accepting an uninvited one holds keys for a room nobody agreed to
+  join. The room's own protection is the owner refusing an uninvited key
+  package. Two parties, two threats, neither substituting for the other.
+
+  Verification is lexical: the proof is checked against raw public-key
+  bytes and a did:key room carries its key in its own name, so a browser
+  needs no resolver and cannot be offline. A did:webvh room would need real
+  resolution, and that is the one thing this would grow.
+
+  ## A check the original is missing
+
+  Writing a test per clause — rather than one 'a bad invitation is refused'
+  case, which passes with any four of five — showed the forgery clause did
+  not bite. Nothing binds the proof's verification method to the ISSUER.
+  verify_proof_with_public_key checks a signature against whatever bytes it
+  is handed, so resolving the method the proof names and verifying against
+  that proves somebody signed it, which is also true of a forgery: mint an
+  invitation naming the room as issuer, sign it with your own key, point
+  the proof at your own verification method, and every other check passes.
+
+  Added here as its own clause. vta-service's copy has the same shape and
+  needs the same fix — reported separately; this is a second copy of a gate
+  that should live in vti-rooms where both can share it.
+
+  * feat(rooms): the member's key and its authority presentation, in wasm
+
+  Two halves of one thing: everything a member signs is signed in wasm, so
+  the private key never crosses into JavaScript.
+
+  The first cut minted the key with WebCrypto and kept the JWK in
+  `localStorage` — a raw private key in a page's heap and in a string store
+  any script on the origin can read, contradicting this crate's own rule
+  that secrets do not cross. Minting it here costs nothing (`ed25519-dalek`
+  already arrives through OpenMLS) and leaves JS holding two opaque
+  snapshots and no key. `Debug` is hand-written to redact: the places a
+  `Debug` reaches — a log line, a panic, a test failure — are exactly the
+  places key material must not turn up.
+
+  `present` mints the authority presentation every host task takes:
+  attenuate the room's VAC to one action, sign as the member, and return
+  `{membership, authority: [leaf, root], nonce}`. Attenuation refuses to
+  widen, so asking for more than the room granted fails here — where the
+  member can be told why — rather than as a refusal from a host worded as
+  though they were at fault.
+
+  ## It takes no `audience` parameter, and that is the point
+
+  `audience` is not who the presentation is addressed to. `verify_chain`
+  compares it to the PRESENTER — "the leaf must be presentable by whoever
+  is presenting it" — so it is holder binding, and its job is to make a
+  captured presentation worthless to anyone else. A browser member always
+  presents its own, so the only correct value is its own DID, and offering
+  the choice is offering a way to get it wrong.
+
+  Not hypothetical: `vta-cli-common`'s `RoomTarget` passes the HOST's DID
+  as the audience, so `pnm-cli rooms --host-did …` mints a leaf bound to an
+  audience no presenter can match — refused as `WrongAudience` every time —
+  while omitting the flag leaves the presentation bearer-shaped for four
+  hours. Its doc states the intent exactly ("with it, a captured
+  presentation is worthless to anyone else") and names the wrong party.
+  Reported separately.
+
+  Tests assert against `dtg_credentials::authority::verify_chain` itself,
+  not a restatement of it: the presentation verifies, a narrowing to `read`
+  does not authorise `curate`, over-asking is refused locally, and a
+  captured presentation fails for the thief as `WrongAudience` rather than
+  as a bad signature. Also pins the shape the server path never produces —
+  a browser member is its own agent, so the leaf's subject and the chain
+  root's are the same DID.
+
+  * fix(rooms): a presentation travels as strings, not objects
+
+  AuthorityPresentation types membership as a String and authority as a
+  Vec<String>: the credential TEXT is the wire form, and vti-rooms-dtg
+  decodes base64url or bare JSON on the way in. present() was emitting
+  parsed objects, so room-host refused the whole request as "invalid type:
+  map, expected a string" — which reads as a malformed payload rather than
+  as the shape mismatch it is, and points at the wrong field.
+
+  Found by sending one to a real host rather than by reading the type.
+
+  The root is now passed through exactly as received instead of being
+  re-serialised, so nothing on this side can touch the bytes its proof was
+  made over. Both tests assert the wire form — that each authority link is
+  a string and membership is one too — because a chain that verifies in a
+  test and is refused on the wire is the failure this cost an hour to.
+
+  * fix(rooms): the wasm member links a chain the way its hosts verify one
+
+  dtg-credentials 0.7 changed how an authority chain links — a link's
+  `parent` went from naming the parent's `id` to naming a *digest* of its
+  claims — so a 0.7 `attenuate` and a 0.6 `verify_chain` cannot
+  interoperate. The refusal reads as a broken chain rather than a version
+  skew:
+
+      chain link 0 names parent `zQmPvoS…`,
+      but was presented after `urn:uuid:0647…`
+
+  Found by pointing a browser member at `room-host` and watching a
+  perfectly good presentation be refused. Pinned to what the workspace
+  verifies with. Reported upstream as OpenVTC/dtg-credentials#22, which
+  asks for ordering guidance and a hint in that error message.
+
+- **rooms**: The record commitment — a Merkle tree over a room's records ([#1346](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1346))
+
+* feat(rooms): the record commitment — a Merkle tree over a room's records
+
+  First of the verified-reads pieces (#1343's build order: the store, then the
+  commitment on read responses, then traces). Structure only — nothing serves
+  it yet, and no wire shape changes.
+
+  A room's records are signed and room-bound, so a host cannot forge, alter or
+  relocate one. **Silence is free**: `rooms/records/list` returns a set and
+  nothing says the set is complete, so a host serving nine records from a room
+  holding ten is indistinguishable from a room holding nine. This is the
+  structure that closes it.
+
+  Three decisions worth stating, because each has a wrong version that looks
+  identical from outside.
+
+  **Leaves are sorted by key**, because completeness is a range property. An
+  inclusion proof says "this record is here"; only the ordering lets a
+  consumer say "and there is nothing between these two keys". A tree over
+  unsorted leaves proves everything it contains and nothing about what it
+  omits — which is the property being bought. The sort is inside
+  `commit_records` rather than assumed of callers.
+
+  **A leaf commits to the whole record**, as canonical JSON (RFC 8785), not to
+  a chosen subset. A host that can flip `status` from active to retracted, or
+  move `pinned`, or rewrite `author` on an attributed room, rewrites what the
+  room means without touching a byte of ciphertext. Picking fields invites
+  picking wrongly; a field added to `Record` later is committed automatically.
+  The plaintext is never involved — on the sealed tiers the host holds
+  ciphertext and commits to what it actually stores.
+
+  **RFC 6962's domain separation and its odd-node rule.** Leaves are prefixed
+  `0x00` and nodes `0x01`, without which an internal node's preimage can be
+  offered as a leaf. An odd node is promoted rather than duplicated: promotion
+  avoids a tree of n leaves colliding with one of n+1 whose last is repeated.
+  `root_of` and `inclusion_proof` implement that rule twice and would drift
+  silently, so the tests walk every leaf of every tree size 1..=9.
+
+  Ten tests, each written against an attack rather than a mechanism: omitting
+  a record moves the root, changing any one field moves the leaf, input order
+  does not matter, a leaf and a node over the same bytes differ, a record the
+  room does not hold does not prove, and a tampered sibling — or a flipped
+  side — fails.
+
+
+
+### Fixed
+
+- **rooms**: A commitment is a DigestMultibase, not bare hex ([#1349](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1349))
+
+Owed from #1346. The spec that landed with it
+  (trustoverip/dtgwg-trust-tasks-tf#411) types `dataCommitment` as the
+  framework's `DigestMultibase`, and the helper shipped emitting hex.
+
+  Bare hex hard-codes SHA-256 into the wire contract, which is precisely what
+  `DigestMultibase` exists to prevent: multihash names the algorithm in-band,
+  so moving off SHA-256 later is a change of value rather than another schema
+  revision. `0x12 0x20` then the digest, base58btc with the `z` prefix — the
+  same shape `sealed_transfer::bundle_digest_multibase` already produces, so
+  the two agree by construction rather than by memory.
+
+  `from_multibase` refuses anything that is not a sha2-256 multihash. A
+  commitment is what a comparison turns on, so silently accepting an algorithm
+  this build cannot compute would turn "these two roots differ" into "these
+  two roots are not comparable" without saying which.
+
+  Two tests, both about the encoding being a contract rather than a detail: a
+  commitment decodes to the 34-byte multihash and round-trips, and bare hex, a
+  foreign algorithm, a truncated digest and non-multibase are each refused.
+
+  The tree, the leaves and the proofs are untouched — this is the wire
+  boundary only.
+
+- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))
+
+* fix(rooms): bind a presentation to its presenter, not to the host
+
+  `pnm-cli rooms --host-did …` could never work. Every request it made was
+  refused as `WrongAudience`, and omitting the flag "worked" only by
+  skipping the check it exists to perform — so the flag's two states were
+  broken and unprotected.
+
+  `audience` is not who a presentation is addressed to.
+  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
+  "the leaf must be presentable by whoever is presenting it" — so it is
+  holder binding, and its whole job is to make a captured presentation
+  worthless to whoever captured it. Filled with the host's DID it named a
+  party no presenter can ever match.
+
+  The value to bind to was already named a few lines away: `RoomSigner`'s
+  doc says "a room request is signed by the party the presentation was
+  minted for". This passes exactly that. There is no unbound case left, so
+  the warning about one goes, and `--host-did` keeps its real job of naming
+  the document's recipient.
+
+  ## The spec says otherwise, and that is filed separately
+
+  `rooms/keys/present/0.1` describes `audience` as "the party the
+  presentation is for … a host's identifier, normally". The CLI implemented
+  the spec faithfully; the spec and the credential library it runs on
+  disagree, identically in dtg-credentials 0.6 and 0.7, so it is not
+  version drift.
+
+  This changes the CLI to match the verifier rather than the prose, because
+  a presentation that cannot verify protects nobody while being wrong in
+  the other direction. Which side should move is a working-group question —
+  0.7's own notes point at upstream PR #41, "a key-control demonstration at
+  invocation, which removes `audience` as redundant" — and is raised there.
+
+  * fix(rooms)!: stop sending `audience` and `nonce` on rooms/keys/present
+
+  Completes the previous commit, which repointed `audience` at the presenter so
+  it would at least verify. It should not be sent at all, and neither should
+  `nonce`. Both are removed from `rooms/keys/present` by spec 0.2.
+
+  `audience` named the party that had to PRESENT a credential, not the one it was
+  addressed to — so a host DID named somebody no presenter can ever be, and the
+  host refused every request. That is now moot: dtg-credentials 0.8.0 removed the
+  property and made the real rule explicit, which the VTA was already satisfying.
+  The leaf grants to the DID this VTA authenticated, and a host refuses a chain
+  whose leaf grants to anyone else. Who may present is established, not declared.
+
+  `nonce` was written into the presentation object, which is closed and has no
+  member for it — so a caller supplying one got a presentation the host rejects
+  as malformed. It could not have been made to work: every signature in a
+  presentation is an ISSUER's, never the presenter's, so a challenge inside it is
+  unauthenticated and a replay copies it along with everything else. Freshness is
+  the request's, via `issuedAt` and the duplicate-execution rule keyed on
+  document `id`.
+
+  ## A second live instance, found while doing this
+
+  `rooms/keys/backfill` passed the caller-named host as the audience in
+  `vta-service`, exactly as that spec's normative MUST instructed. Every backfill
+  this VTA attempted was refused for the same reason. What actually makes a
+  caller-named host safe is that the leaf grants to the VTA: naming a host
+  transfers no standing. It does hand that host sight of the principal's
+  credentials, which is a disclosure rather than an escalation, and the comment
+  now says so.
+
+  ## Nothing binds a presentation to a host, deliberately
+
+  A chain is scoped to the ROOM. One rooted in a room confers nothing anywhere
+  else, and any host serving that room would honour it — a room may have more
+  than one host, and moving between them without reissuing credentials is the
+  point. Binding a request to its destination is `recipient` on the document that
+  carries the presentation, per SPEC.md §4.8.2, which its proof covers.
+
+
+
 ## [0.1.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.2...vti-rooms-v0.1.3) — 2026-09-08
 
 

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.3...vti-secrets-v0.3.4) — 2026-09-09
+
+
 ## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.2...vti-secrets-v0.3.3) — 2026-09-07
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ tokio = { workspace = true }
 zeroize = { version = "1" }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.34", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.34.1 -> 0.35.0 (✓ API compatible changes)
* `vti-common`: 0.18.1 -> 0.18.2 (✓ API compatible changes)
* `vti-rooms`: 0.1.3 -> 0.2.0 (✓ API compatible changes)
* `vtc-client`: 0.5.5 -> 0.5.6 (✓ API compatible changes)
* `vta-cli-common`: 0.14.1 -> 0.15.0 (✓ API compatible changes)
* `cnm-cli`: 0.14.1 -> 0.14.2
* `pnm-cli`: 0.15.1 -> 0.16.0
* `vti-rooms-dtg`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `vta-keys`: 0.4.4 -> 0.4.5
* `vta-persona`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `vta-webvh`: 0.2.5 -> 0.2.6
* `vta-service`: 0.24.1 -> 0.25.0 (✓ API compatible changes)
* `vta-audit`: 0.3.4 -> 0.3.5
* `vti-secrets`: 0.3.3 -> 0.3.4
* `vta-config`: 0.4.4 -> 0.4.5
* `vta-support`: 0.3.3 -> 0.3.4
* `vta-backup`: 0.3.4 -> 0.3.5
* `vta-policy`: 0.3.4 -> 0.3.5
* `vta-vault`: 0.5.4 -> 0.5.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.35.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.34.1...vta-sdk-v0.35.0) — 2026-09-09

### Added

- **rooms**: Cut over to present/0.2 and issue-authority/0.2 ([#1365](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1365))

The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked
  by affinidi/affinidi-tdk-rs#784.

  `trust-tasks-rs` 0.19 carries both new spec versions, but this workspace could
  not take it: `affinidi-messaging-sdk 0.22.0` required 0.18, so pinning 0.19 put
  two `trust-tasks-rs` nodes in the graph and broke `vta-sdk` on `expected
  MediatorAcl, found a different MediatorAcl`. TDK #784 moved the messaging family
  to 0.19 and 0.23.0.

  Taking it exposed pins that had drifted apart underneath: `vta-sdk` was on
  messaging-sdk 0.22 while `vta-service` and the e2e tests were on 0.21, and three
  `trust-tasks-rs` versions were resolving at once. All of it is now consolidated:
  the lockfile holds exactly ONE `trust-tasks-rs` and ONE `affinidi-messaging-sdk`,
  where before it held three of each.

  `rooms/keys/present` 0.1 -> 0.2 and `rooms/owner/issue-authority` 0.1 -> 0.2.
  Both 0.1s are retired upstream. Neither is dual-accepted, deliberately: for
  `present`, 0.1's extra members are exactly the two nothing could honour; for
  `issue-authority`, accepting 0.1 means accepting a request with no `validUntil`,
  which is the thing 0.2 exists to refuse.

  The hand-rolled `validUntil` guard in `room_owner.rs` is deleted. 0.2 makes the
  member REQUIRED, so the generated payload types it as a `DateTime` and the
  envelope schema rejects a request without one before dispatch. Same rule, one
  layer up, which is where a shape constraint belongs.

  `every_witnessed_task_round_trips_through_its_generated_types` refused two
  witnesses that had been green for as long as they existed:

  1. The `issue-authority` witness carried no `validUntil` — a chain root with no
     expiry, the exact request 0.2 forbids, and one this service could have sent.
  2. The `present` witness carried `"audience": "did:key:z6MkHost"` — a HOST DID,
     the precise shape #414 reported as impossible to satisfy, since the field
     named the party that had to PRESENT the credential.

  `room_oracle` emitted `membership` and `authority[]` as JSON **objects**;
  `AuthorityPresentation` types both as strings, and the host's opener reads
  base64url or bare JSON text. So the oracle's output could not deserialize at a
  host at all — `rooms/keys/present` had never worked end to end. It went unseen
  because 0.1's response typed `presentation` as an opaque object; 0.2 names the
  shared component, which turned a runtime refusal nothing exercised into a type
  error. The oracle now serialises each credential. That is the first half of
  have caught all three of these years earlier.

- **sdk**: A no-I/O verifier resolves did:peer too ([#1364](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1364))
- **sdk**: The client verifies the replies it receives ([#1341](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1341))

Completes the arc #1334 and #1335 began. Both services sign their responses;
  until now nothing checked one, so the signature was decorative. This is the
  surface that matters most — the CLI, cierge and the services all dispatch
  Trust Tasks through `VtaClient`.

  A reply is bytes off a socket. Nothing else in this path establishes who
  produced them: the transport proves a connection, and over REST not even
  that beyond TLS to a host name. Without the proof an intermediary can
  rewrite an ACL listing, flip a policy decision, or answer for an agent that
  never spoke, and every check downstream passes — because the checks
  downstream are about shape.

  Two checks, and the second is the one easy to omit: the proof must verify,
  **and its proven signer must be the agent this client is talking to**. A
  proof by somebody else's key verifies perfectly well, so skipping the
  binding turns "signed by somebody" into "signed by the agent". The expected
  signer is `ClientIdentity::vta_did`, which the client already holds.

  A client with no identity does not verify, because there is nothing to bind
  against — such a client cannot produce a conforming request either and is
  refused at the agent for a missing `recipient`. A loopback client likewise:
  its sink answers ahead of the transport and returns a value rather than a
  signed document.

  Error documents are exempt, from the specification rather than for
  convenience: `trust-task-error`'s own proof requirement is RECOMMENDED
  (SPEC §8.1), so demanding one would make every conforming refusal
  unreadable, including the ones carrying the reason a caller needs.

  `trusting_unsigned_replies()` is a staging control, not a preference. An
  agent that predates #1334/#1335 sends nothing to verify, so a client
  upgraded ahead of its agent would refuse every answer; this exists so that
  ordering can be chosen rather than endured. It weakens the check to almost
  nothing while set — an attacker who can rewrite a reply can also strip its
  proof — so a present proof is still verified and still bound.

  The resolver is built once per client and shared by clones. A
  `DIDCacheClient` is a cache; one per call would defeat it.

- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))

Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
  in trust-tasks-rs 0.18.9.

  A holder who uses this model for a while ends up with twenty profiles, and a
  flat list of twenty is a list nobody reads. A facet is the arrangement over
  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
  the profiles it groups.

  **An arrangement, not a container.** Nothing is stored inside a facet, and
  `delete_facet` touches no profile and no attribute. There is no cascading
  form because there is no cascading form of the idea: a grouping that could
  take its members with it is a folder, and a holder who reads it as a folder
  is right to be afraid of it. `releasedFaces` reports what now belongs
  nowhere, which is what a screen needs to say what it will look like
  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.

  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
  well-behaved consumer does not hold the values it would have to resend —
  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
  name. It would either request every sensitive value the holder owns to
  perform an arrangement that has nothing to do with values, or send a put
  without one and destroy them.



### Changed

- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))

Pure move plus re-exports; no behaviour changes. It exists so the next
  change can be small: `VtaClient` needs to verify the responses it receives,
  and the verifier it needs already exists one layer up where a client cannot
  reach it.

  `vti-common` was the right home while services verifying their *inbound*
  requests were the only consumer. A client verifying its *replies* is the
  same operation over the same document shape, and `vta-sdk` is the layer both
  can see.

  **The part worth not duplicating is the verification-method resolver.**
  Resolving one looks trivial and is not: a DID document may name its methods
  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
  proof always names them absolutely, so a resolver accepting only the
  spelling it expects refuses perfectly good documents from conforming peers.
  A second copy would drift, and drift in a verifier means refusing honest
  documents or accepting dishonest ones. Writing that copy is what this move
  avoids.

  Behind a new `proof-verify` feature rather than `client`, because
  `vti-common` takes `vta-sdk` with `default-features = false` and must not
  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
  that crate already depended on `affinidi-data-integrity` and the DID
  resolver directly. `client` enables it: a client that cannot verify its
  replies is the gap being closed.

  The resolver rides in the feature deliberately. Verification is only as good
  as the party it resolves — a `did:key` signer needs no I/O, and a
  `did:webvh` one, which is what a real agent is, cannot be verified without
  resolving its document.

  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
  use the flat re-export, so there is one canonical path rather than an alias
  to go stale. Two doc comments naming the old location updated with them.

  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
  tests that moved with the code.



### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>

## `vti-common`

<blockquote>

## [0.18.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.1...vti-common-v0.18.2) — 2026-09-09

### Changed

- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))

Pure move plus re-exports; no behaviour changes. It exists so the next
  change can be small: `VtaClient` needs to verify the responses it receives,
  and the verifier it needs already exists one layer up where a client cannot
  reach it.

  `vti-common` was the right home while services verifying their *inbound*
  requests were the only consumer. A client verifying its *replies* is the
  same operation over the same document shape, and `vta-sdk` is the layer both
  can see.

  **The part worth not duplicating is the verification-method resolver.**
  Resolving one looks trivial and is not: a DID document may name its methods
  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
  proof always names them absolutely, so a resolver accepting only the
  spelling it expects refuses perfectly good documents from conforming peers.
  A second copy would drift, and drift in a verifier means refusing honest
  documents or accepting dishonest ones. Writing that copy is what this move
  avoids.

  Behind a new `proof-verify` feature rather than `client`, because
  `vti-common` takes `vta-sdk` with `default-features = false` and must not
  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
  that crate already depended on `affinidi-data-integrity` and the DID
  resolver directly. `client` enables it: a client that cannot verify its
  replies is the gap being closed.

  The resolver rides in the feature deliberately. Verification is only as good
  as the party it resolves — a `did:key` signer needs no I/O, and a
  `did:webvh` one, which is what a real agent is, cannot be verified without
  resolving its document.

  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
  use the flat re-export, so there is one canonical path rather than an alias
  to go stale. Two doc comments naming the old location updated with them.

  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
  tests that moved with the code.
</blockquote>

## `vti-rooms`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.3...vti-rooms-v0.2.0) — 2026-09-09

### Added

- **rooms**: Traces, and a response type for the single-record read ([#1368](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1368))

A commitment lets a reader catch a host that equivocates. A trace proves a
  particular record sits under the root that host just asserted. This serves
  them — and fixes the conformance defect that adding them uncovered.

  Implements trust-tasks-tf#419, released as trust-tasks-rs 0.19.1.

  `rooms/records/get` has never conformed to its published schema. Both hosts
  answered a read by serialising `vti_rooms::Record` — the *storage* record — and
  adding `dataCommitment` to whatever came out:

      "c2VhbGVk" is not of type "object";
      Additional properties are not allowed
      ('author','epoch','nonce','pinned','status','updatedAt' were unexpected)

  It survived because `vti_rooms::wire`'s rule — every wire type appears in
  tests/schema_conformance.rs — can only be applied to types that exist. A
  response that was never a type had no line to be missing from, and a storage
  record reached the wire because nothing stood between them. The consumer is not
  hypothetical: `@openvtc/pnm-core`'s `roomsRecordsGet` is typed on the generated
  payload, so a caller reading `sealed.ciphertext` got `undefined` from a live
  host, with a green type-check on both sides.

  The leaf preimage was not reproducible either. `leaf_hash` canonicalised the
  storage record, so every root it produced was unreachable by any reader:
  `updatedAt` is unix seconds in storage and RFC 3339 on the wire, `epoch` and
  `nonce` are flat in storage and inside `sealed` on the wire, and `epoch`
  serialises as `null` on an open room where the wire has it absent. Survivable
  while the only use was comparing two roots from the same build; not survivable
  once a trace has to be computable by someone else.

- **rooms**: Hosts compute and serve the data commitment ([#1351](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1351))

* fix(rooms): a commitment is a DigestMultibase, not bare hex

  Owed from #1346. The spec that landed with it
  (trustoverip/dtgwg-trust-tasks-tf#411) types `dataCommitment` as the
  framework's `DigestMultibase`, and the helper shipped emitting hex.

  Bare hex hard-codes SHA-256 into the wire contract, which is precisely what
  `DigestMultibase` exists to prevent: multihash names the algorithm in-band,
  so moving off SHA-256 later is a change of value rather than another schema
  revision. `0x12 0x20` then the digest, base58btc with the `z` prefix — the
  same shape `sealed_transfer::bundle_digest_multibase` already produces, so
  the two agree by construction rather than by memory.

  `from_multibase` refuses anything that is not a sha2-256 multihash. A
  commitment is what a comparison turns on, so silently accepting an algorithm
  this build cannot compute would turn "these two roots differ" into "these
  two roots are not comparable" without saying which.

  Two tests, both about the encoding being a contract rather than a detail: a
  commitment decodes to the 34-byte multihash and round-trips, and bare hex, a
  foreign algorithm, a truncated digest and non-multibase are each refused.

  The tree, the leaves and the proofs are untouched — this is the wire
  boundary only.

- **rooms**: A browser can be a room member ([#1347](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1347))

* feat(rooms): a `host` feature, so a room's member half reaches wasm

  `vti-rooms` already had two halves and no name for them: `vta-service`
  imports `mls`/`sealed`/`wire` and nothing else, while `vtc-service`,
  `room-host` and `vti-rooms-dtg` import `storage`/`authz`/`audit`. This
  names the second half `host`, on by default, and makes `vti-common`
  optional behind it.

  `vti-common` describes itself as server-side infrastructure and pulls
  axum, fjall and tokio, so it was the whole of what kept a room's member
  code off `wasm32-unknown-unknown`. With it optional,
  `--no-default-features --features mls` builds there — which is what lets
  a browser hold a room's keys itself rather than ask an agent to. See
  `docs/05-design-notes/data-rooms-demo-site.md`.

  The member half needed **no source changes** to get there. That is a
  property of `error.rs`, which deliberately does not use
  `vti_common::error::AppError` because key material is not a service's
  concern; a decision made for its own reasons that paid for itself here.

  `lifecycle` is deliberately left ungated: only hosts consume it today,
  but it needs nothing from `vti-common`, and a member computing a room's
  lifecycle state to explain it on screen should not need a host's
  dependencies.

  Three things about the wasm plumbing, each of which reports as a
  `compile_error!` that reads like an unsupported target:

  - OpenMLS 0.9 has a first-class `js` feature (`web-time` for the
    `SystemTime` wasm lacks, plus getrandom's JS backend). Declared
    per-target rather than as a feature of this crate, so building for
    wasm just works — verified wasm-only: `web-time` appears in the wasm
    tree and not the native one.
  - There are two getrandom majors in the graph. The 0.4 is ours; the 0.2
    arrives transitively under `openmls_rust_crypto` via RustCrypto's
    elliptic-curve stack, so no feature declared here could reach it.
    `getrandom_02` is a feature shim, not a dependency this crate calls.
  - With both declared per-target, **no `RUSTFLAGS` are needed** — the
    `wasm_js` feature alone selects the backend.

  CI gains two steps in the `features` job: clippy on the member half with
  no host, and a wasm32 `--lib` check, so neither property rots silently.

  `vta-service` now takes `default-features = false`: a VTA holds room keys
  and is never a room's host, so it no longer compiles one.

  * feat(rooms): vti-rooms-wasm — a data room's member half, in a browser

  The MLS group, record sealing and the epoch key chain, compiled to
  WebAssembly, so a tab can *be* a member rather than drive an agent that
  is one. `vti-rooms` supplies all of it; this crate is only the boundary,
  and its job is deciding what crosses.

  **Secrets do not cross.** Everything returned is public — a KeyPackage,
  ciphertext, an epoch number — with one deliberate exception: the
  snapshot, which is key material because OpenMLS persists a group through
  its provider rather than as a value. It goes in IndexedDB and nowhere
  else; the docs say so at the method, since it is the one thing here a
  caller could reasonably mishandle.
</blockquote>


## `vta-cli-common`

<blockquote>

## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.14.1...vta-cli-common-v0.15.0) — 2026-09-09

### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>


## `pnm-cli`

<blockquote>

## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.15.1...pnm-cli-v0.16.0) — 2026-09-09

### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>

## `vti-rooms-dtg`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.2...vti-rooms-dtg-v0.2.0) — 2026-09-09

### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>


## `vta-persona`

<blockquote>

## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.3.0...vta-persona-v0.3.1) — 2026-09-09

### Added

- **persona**: Say whether a link crosses a part of the holder's life ([#1342](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1342))

Serves the members added in dtgwg-trust-tasks-tf#408, published in
  trust-tasks-rs 0.18.10: `crossesFacets` and `facetIds` on a finding,
  `facetId` on each `sharedWith` location. This needs a floor of 0.18.10 —
  the spine validates OUTGOING responses, so under an older schema an analysis
  that fully succeeded would come back 500 `responseSchemaViolation` — and no
  longer moves one: main reached 0.18.11 while this sat open, which satisfies
  it. The bump this branch carried is dropped rather than resolved downward.

  **Severity is how linkable. Facets are whether the holder minds.** Nothing
  here touches `severity`, and that is the design rather than an omission. A
  value shared between two profiles in one facet still links them for anyone
  who sees both — the holder's filing changes nothing a counterparty can do —
  so softening severity on intent would report a false all-clear. What the
  facets add is a second axis: which of these findings the holder would
  actually want to act on.

  **Absent is unknown, not false.** `crosses_facets` is `Option<bool>` and is
  `None` when the holder keeps no facets, because `false` asserts these
  identities sit in one part of a life and an agent with no facets has made no
  such finding. `FacetIndex::any` is what carries that distinction, which is
  why the index is a struct rather than a map.

  **An unarranged profile is not a second facet.** Only distinct, named facets
  count toward a crossing. Counting "no facet" as one would make every holder
  who has arranged one part of their life and not the rest see a crossing on
  everything they own — the dismissal problem arriving from the other
  direction.

  `facet_index` is built once per analysis for the reason `disclosure_index`
  is: `analyze_correlation` with no `attributeId` walks the whole pool, and
  the per-finding shape re-lists every facet for every finding.

  The conformance witness now exercises the three new members rather than
  merely permitting them — they are the ones added last, and an outgoing
  member the embedded schema has not caught up with is a 500 on a call that
  succeeded.

  vta-persona 118/118 (6 new, one per rule above), vta-service lib 1063/1063,
  clippy --all-targets clean.

- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))

Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
  in trust-tasks-rs 0.18.9.

  A holder who uses this model for a while ends up with twenty profiles, and a
  flat list of twenty is a list nobody reads. A facet is the arrangement over
  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
  the profiles it groups.

  **An arrangement, not a container.** Nothing is stored inside a facet, and
  `delete_facet` touches no profile and no attribute. There is no cascading
  form because there is no cascading form of the idea: a grouping that could
  take its members with it is a folder, and a holder who reads it as a folder
  is right to be afraid of it. `releasedFaces` reports what now belongs
  nowhere, which is what a screen needs to say what it will look like
  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.

  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
  well-behaved consumer does not hold the values it would have to resend —
  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
  name. It would either request every sensitive value the holder owns to
  perform an arrangement that has nothing to do with values, or send a put
  without one and destroy them.
</blockquote>


## `vta-service`

<blockquote>

## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.24.1...vta-service-v0.25.0) — 2026-09-09

### Added

- **persona**: Say whether a link crosses a part of the holder's life ([#1342](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1342))

Serves the members added in dtgwg-trust-tasks-tf#408, published in
  trust-tasks-rs 0.18.10: `crossesFacets` and `facetIds` on a finding,
  `facetId` on each `sharedWith` location. This needs a floor of 0.18.10 —
  the spine validates OUTGOING responses, so under an older schema an analysis
  that fully succeeded would come back 500 `responseSchemaViolation` — and no
  longer moves one: main reached 0.18.11 while this sat open, which satisfies
  it. The bump this branch carried is dropped rather than resolved downward.

  **Severity is how linkable. Facets are whether the holder minds.** Nothing
  here touches `severity`, and that is the design rather than an omission. A
  value shared between two profiles in one facet still links them for anyone
  who sees both — the holder's filing changes nothing a counterparty can do —
  so softening severity on intent would report a false all-clear. What the
  facets add is a second axis: which of these findings the holder would
  actually want to act on.

  **Absent is unknown, not false.** `crosses_facets` is `Option<bool>` and is
  `None` when the holder keeps no facets, because `false` asserts these
  identities sit in one part of a life and an agent with no facets has made no
  such finding. `FacetIndex::any` is what carries that distinction, which is
  why the index is a struct rather than a map.

  **An unarranged profile is not a second facet.** Only distinct, named facets
  count toward a crossing. Counting "no facet" as one would make every holder
  who has arranged one part of their life and not the rest see a crossing on
  everything they own — the dismissal problem arriving from the other
  direction.

  `facet_index` is built once per analysis for the reason `disclosure_index`
  is: `analyze_correlation` with no `attributeId` walks the whole pool, and
  the per-finding shape re-lists every facet for every finding.

  The conformance witness now exercises the three new members rather than
  merely permitting them — they are the ones added last, and an outgoing
  member the embedded schema has not caught up with is a 500 on a call that
  succeeded.

  vta-persona 118/118 (6 new, one per rule above), vta-service lib 1063/1063,
  clippy --all-targets clean.

- **rooms**: Cut over to present/0.2 and issue-authority/0.2 ([#1365](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1365))

The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked
  by affinidi/affinidi-tdk-rs#784.

  `trust-tasks-rs` 0.19 carries both new spec versions, but this workspace could
  not take it: `affinidi-messaging-sdk 0.22.0` required 0.18, so pinning 0.19 put
  two `trust-tasks-rs` nodes in the graph and broke `vta-sdk` on `expected
  MediatorAcl, found a different MediatorAcl`. TDK #784 moved the messaging family
  to 0.19 and 0.23.0.

  Taking it exposed pins that had drifted apart underneath: `vta-sdk` was on
  messaging-sdk 0.22 while `vta-service` and the e2e tests were on 0.21, and three
  `trust-tasks-rs` versions were resolving at once. All of it is now consolidated:
  the lockfile holds exactly ONE `trust-tasks-rs` and ONE `affinidi-messaging-sdk`,
  where before it held three of each.

  `rooms/keys/present` 0.1 -> 0.2 and `rooms/owner/issue-authority` 0.1 -> 0.2.
  Both 0.1s are retired upstream. Neither is dual-accepted, deliberately: for
  `present`, 0.1's extra members are exactly the two nothing could honour; for
  `issue-authority`, accepting 0.1 means accepting a request with no `validUntil`,
  which is the thing 0.2 exists to refuse.

  The hand-rolled `validUntil` guard in `room_owner.rs` is deleted. 0.2 makes the
  member REQUIRED, so the generated payload types it as a `DateTime` and the
  envelope schema rejects a request without one before dispatch. Same rule, one
  layer up, which is where a shape constraint belongs.

  `every_witnessed_task_round_trips_through_its_generated_types` refused two
  witnesses that had been green for as long as they existed:

  1. The `issue-authority` witness carried no `validUntil` — a chain root with no
     expiry, the exact request 0.2 forbids, and one this service could have sent.
  2. The `present` witness carried `"audience": "did:key:z6MkHost"` — a HOST DID,
     the precise shape #414 reported as impossible to satisfy, since the field
     named the party that had to PRESENT the credential.

  `room_oracle` emitted `membership` and `authority[]` as JSON **objects**;
  `AuthorityPresentation` types both as strings, and the host's opener reads
  base64url or bare JSON text. So the oracle's output could not deserialize at a
  host at all — `rooms/keys/present` had never worked end to end. It went unseen
  because 0.1's response typed `presentation` as an opaque object; 0.2 names the
  shared component, which turned a runtime refusal nothing exercised into a type
  error. The oracle now serialises each credential. That is the first half of
  have caught all three of these years earlier.

- **rooms**: A browser can be a room member ([#1347](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1347))

* feat(rooms): a `host` feature, so a room's member half reaches wasm

  `vti-rooms` already had two halves and no name for them: `vta-service`
  imports `mls`/`sealed`/`wire` and nothing else, while `vtc-service`,
  `room-host` and `vti-rooms-dtg` import `storage`/`authz`/`audit`. This
  names the second half `host`, on by default, and makes `vti-common`
  optional behind it.

  `vti-common` describes itself as server-side infrastructure and pulls
  axum, fjall and tokio, so it was the whole of what kept a room's member
  code off `wasm32-unknown-unknown`. With it optional,
  `--no-default-features --features mls` builds there — which is what lets
  a browser hold a room's keys itself rather than ask an agent to. See
  `docs/05-design-notes/data-rooms-demo-site.md`.

  The member half needed **no source changes** to get there. That is a
  property of `error.rs`, which deliberately does not use
  `vti_common::error::AppError` because key material is not a service's
  concern; a decision made for its own reasons that paid for itself here.

  `lifecycle` is deliberately left ungated: only hosts consume it today,
  but it needs nothing from `vti-common`, and a member computing a room's
  lifecycle state to explain it on screen should not need a host's
  dependencies.

  Three things about the wasm plumbing, each of which reports as a
  `compile_error!` that reads like an unsupported target:

  - OpenMLS 0.9 has a first-class `js` feature (`web-time` for the
    `SystemTime` wasm lacks, plus getrandom's JS backend). Declared
    per-target rather than as a feature of this crate, so building for
    wasm just works — verified wasm-only: `web-time` appears in the wasm
    tree and not the native one.
  - There are two getrandom majors in the graph. The 0.4 is ours; the 0.2
    arrives transitively under `openmls_rust_crypto` via RustCrypto's
    elliptic-curve stack, so no feature declared here could reach it.
    `getrandom_02` is a feature shim, not a dependency this crate calls.
  - With both declared per-target, **no `RUSTFLAGS` are needed** — the
    `wasm_js` feature alone selects the backend.

  CI gains two steps in the `features` job: clippy on the member half with
  no host, and a wasm32 `--lib` check, so neither property rots silently.

  `vta-service` now takes `default-features = false`: a VTA holds room keys
  and is never a room's host, so it no longer compiles one.

  * feat(rooms): vti-rooms-wasm — a data room's member half, in a browser

  The MLS group, record sealing and the epoch key chain, compiled to
  WebAssembly, so a tab can *be* a member rather than drive an agent that
  is one. `vti-rooms` supplies all of it; this crate is only the boundary,
  and its job is deciding what crosses.

  **Secrets do not cross.** Everything returned is public — a KeyPackage,
  ciphertext, an epoch number — with one deliberate exception: the
  snapshot, which is key material because OpenMLS persists a group through
  its provider rather than as a value. It goes in IndexedDB and nowhere
  else; the docs say so at the method, since it is the one thing here a
  caller could reasonably mishandle.
</blockquote>









</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).