### PR TITLE
feat(persona): serve persona/facet — the holder's arrangement of their identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "url",
  "uuid",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "uuid",
 ]
 
@@ -7979,7 +7979,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9599,7 +9599,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "uuid",
 ]
 
@@ -9615,7 +9615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "uuid",
 ]
 
@@ -9634,7 +9634,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "uuid",
 ]
 
@@ -9652,7 +9652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
 ]
 
 [[package]]
@@ -9672,9 +9672,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.8"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35197fd73d1a0e6b4147081139f054875c945ce1e38e6ee8800ab7db66084dc5"
+checksum = "762f669091e95f1eb5e735d9f24ac2408a6cfab3ce6543aa86226b3dac1d312f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10430,7 +10430,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "uniffi",
  "vta-sdk",
 ]
@@ -10448,7 +10448,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10527,7 +10527,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "url",
  "utoipa",
  "uuid",
@@ -10612,7 +10612,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "url",
  "urlencoding",
  "utoipa",
@@ -10781,7 +10781,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10853,7 +10853,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10911,7 +10911,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -10967,7 +10967,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.8",
+ "trust-tasks-rs 0.18.9",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,15 @@ aws-lc-rs = "1.16"
 # fully succeeded comes back as a 500 `responseSchemaViolation` — the members
 # are emitted and the schema rejects them. A caret on "0.18" would let a
 # resolver pick 0.18.2 and reintroduce exactly that.
-trust-tasks-rs = { version = "0.18.8", default-features = false, features = [
+#
+# 0.18.9 raises that floor for the same reason one version later: it is the
+# first release carrying the `persona/facet/*` schemas. The spine validates
+# outgoing responses against the embedded schema, so on 0.18.8 a facet write
+# that fully succeeded would come back 500 `responseSchemaViolation` — the
+# members are emitted and the schema has never heard of them. Same failure
+# shape as `adminScope` above, which is why the floor moves rather than the
+# feature being guarded.
+trust-tasks-rs = { version = "0.18.9", default-features = false, features = [
   "validate",
   "all-specs",
 ] }
@@ -491,4 +499,5 @@ type_complexity = "allow"
 # ever reports one, the fix is the same choice we faced here: patch it (fast,
 # and it will break again on the next minor bump) or cut the dependency edge
 # upstream (slower, permanent).
+
 

--- a/vta-persona/src/facet.rs
+++ b/vta-persona/src/facet.rs
@@ -1,0 +1,535 @@
+//! Facets — the holder's own arrangement of their own identity.
+//!
+//! A holder who uses this model for a while does not end up with three
+//! profiles. They end up with twenty, and a flat list of twenty is a list
+//! nobody reads. A facet is the arrangement over them: "Work", "Home", "Play".
+//!
+//! # An arrangement, not a container
+//!
+//! Nothing is stored *inside* a facet. It names profiles and attributes that
+//! exist perfectly well without it, and deleting one deletes the name and the
+//! statement about what belonged to it — nothing else. Every function here is
+//! written so that no path can touch a profile or an attribute, and
+//! [`PersonaStore::delete_facet`] has no cascading form on purpose: an
+//! arrangement that could take its members with it is a folder, and a holder
+//! who reads it as a folder is right to be afraid of it.
+//!
+//! # Why membership lives here and not on the records
+//!
+//! The obvious alternative is a `facet_id` on [`Attribute`](crate::Attribute).
+//! It is the wrong shape for a mechanical reason: `persona/attribute/put`
+//! **replaces** the attribute, and a well-behaved consumer does not hold the
+//! values it would have to resend — `attribute/list` withholds the plaintext of
+//! anything resolving to `sensitivity: high` unless it is asked for by name. So
+//! such a consumer would either request every sensitive value the holder owns
+//! in order to perform an arrangement that has nothing to do with values, or
+//! send a put without one and silently destroy them.
+//!
+//! Membership on the facet has neither problem: one record is written, no value
+//! is read, and the worst outcome of any error is an arrangement to redo.
+//!
+//! # Agent-scoped, and that is a control
+//!
+//! A facet states which of the holder's identities are, to them, parts of one
+//! life — precisely the join that multiple personas exist to deny a verifier.
+//! It is stored under [`storage::FACET_PREFIX`], which
+//! [`storage::scope_of`] reports as [`Scope::Agent`](storage::Scope::Agent),
+//! and nothing in this module reads or writes a context-scoped key.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{Facet, FacetColour, Ulid, Version};
+use crate::storage;
+use crate::store::{PersonaStore, Written};
+use vti_common::error::AppError;
+
+/// A live facet or the grave of one, so a delete is distinguishable from a
+/// record that never existed. Same shape as `ProfileSlot`, for the same reason:
+/// the version counter is monotonic per store, and a tombstone keeps a deleted
+/// id from being confused with an unused one.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) enum FacetSlot {
+    Live(Facet),
+    Tombstone {
+        facet_id: Ulid,
+        version: Version,
+        deleted_at: String,
+    },
+}
+
+/// Where a profile already sits, when a write tries to place it somewhere else.
+///
+/// Carries the facet holding it rather than only the fact of the clash, so a
+/// consumer can offer to *move* the profile. Told only that the write failed,
+/// the only thing a UI can do is ask the holder to go and find it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlacedElsewhere {
+    pub face_id: Ulid,
+    pub facet_id: Ulid,
+}
+
+/// The outcome of checking a proposed membership against what is already
+/// arranged.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FacetPlacement {
+    /// Profiles this write would place that another facet already holds.
+    pub placed: Vec<PlacedElsewhere>,
+}
+
+/// A new facet with a freshly minted id, at version 0 until it is written.
+///
+/// Minted here rather than at the dispatcher for the reason `new_profile` and
+/// `new_attribute` are: the id format is this store's business — a ULID, so a
+/// key-ordered scan is also creation-ordered — and a caller that formatted its
+/// own would be free to choose one that scans out of order.
+#[must_use]
+pub fn new_facet(
+    name: impl Into<String>,
+    colour: FacetColour,
+    icon: Option<String>,
+    face_ids: Vec<Ulid>,
+    attribute_ids: Vec<Ulid>,
+) -> Facet {
+    Facet {
+        facet_id: ulid::Ulid::generate().to_string(),
+        name: name.into(),
+        colour,
+        icon,
+        face_ids,
+        attribute_ids,
+        version: 0,
+        created_at: String::new(),
+        updated_at: String::new(),
+    }
+}
+
+impl PersonaStore {
+    /// Create or replace one facet.
+    ///
+    /// Refuses, without writing, when a listed profile belongs to another facet
+    /// or when any listed id names a record the holder does not hold. Both are
+    /// checked **before** a version is taken, so a refused write consumes
+    /// nothing from the counter.
+    pub async fn put_facet(
+        &self,
+        mut facet: Facet,
+        expected_version: Option<Version>,
+    ) -> Result<Written, AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        // Every id must name something the holder holds. An arrangement
+        // referring to a record that never existed is a typo, and accepting it
+        // silently makes the typo permanent.
+        let mut dangling_faces = Vec::new();
+        for id in &facet.face_ids {
+            if self.get_profile(id).await?.is_none() {
+                dangling_faces.push(id.clone());
+            }
+        }
+        let mut dangling_attributes = Vec::new();
+        for id in &facet.attribute_ids {
+            if !matches!(self.slot(id).await?, Some(crate::store::Slot::Live(_))) {
+                dangling_attributes.push(id.clone());
+            }
+        }
+        if !dangling_faces.is_empty() || !dangling_attributes.is_empty() {
+            return Err(AppError::Validation(format!(
+                "facet references {} face(s) and {} attribute(s) that do not exist: {}",
+                dangling_faces.len(),
+                dangling_attributes.len(),
+                dangling_faces
+                    .iter()
+                    .chain(dangling_attributes.iter())
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+
+        // A profile belongs to at most one facet. Checked against every other
+        // facet, excluding this one — a replace that keeps its own faces is not
+        // a clash with itself, and treating it as one would make a facet
+        // uneditable the moment it held anything.
+        let clash = self
+            .placement_conflicts(&facet.face_ids, Some(&facet.facet_id))
+            .await?;
+        if !clash.placed.is_empty() {
+            return Err(AppError::Validation(format!(
+                "{} face(s) already belong to another facet: {}",
+                clash.placed.len(),
+                clash
+                    .placed
+                    .iter()
+                    .map(|p| format!("{} in {}", p.face_id, p.facet_id))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+
+        let existing = self.facet_slot(&facet.facet_id).await?;
+        let current_version = match &existing {
+            Some(FacetSlot::Live(f)) => Some(f.version),
+            _ => None,
+        };
+        crate::store::check_precondition(expected_version, current_version)?;
+
+        let version = self.next_version().await?;
+        let created = current_version.is_none();
+        facet.version = version;
+        facet.updated_at = crate::store::now_rfc3339();
+        if created {
+            facet.created_at = facet.updated_at.clone();
+        } else if let Some(FacetSlot::Live(old)) = &existing {
+            facet.created_at = old.created_at.clone();
+        }
+
+        self.ks
+            .insert(storage::facet_key(&facet.facet_id), &FacetSlot::Live(facet))
+            .await?;
+
+        Ok(Written { version, created })
+    }
+
+    /// Every facet, creation-ordered by the key scan.
+    ///
+    /// Dangling membership is returned rather than pruned. A member whose
+    /// record has since been deleted is how a consumer can offer to tidy;
+    /// dropping it here would turn a deletion the holder may not have intended
+    /// into one they can never see.
+    pub async fn list_facets(&self) -> Result<Vec<Facet>, AppError> {
+        let rows = self
+            .ks
+            .prefix_iter_raw(storage::FACET_PREFIX.as_bytes().to_vec())
+            .await?;
+        let mut out = Vec::new();
+        for (_k, v) in rows {
+            if let Ok(FacetSlot::Live(f)) = serde_json::from_slice::<FacetSlot>(&v) {
+                out.push(f);
+            }
+        }
+        Ok(out)
+    }
+
+    pub async fn get_facet(&self, facet_id: &str) -> Result<Option<Facet>, AppError> {
+        Ok(match self.facet_slot(facet_id).await? {
+            Some(FacetSlot::Live(f)) => Some(f),
+            _ => None,
+        })
+    }
+
+    /// Delete one facet.
+    ///
+    /// **Touches no profile and no attribute**, and there is deliberately no
+    /// cascading variant. Returns how many profiles now belong to no facet at
+    /// all, which is what a consumer needs in order to say what the screen will
+    /// look like afterwards.
+    pub async fn delete_facet(
+        &self,
+        facet_id: &str,
+        expected_version: Option<Version>,
+    ) -> Result<(bool, usize), AppError> {
+        let _guard = self.write_lock.lock().await;
+
+        let existing = self.facet_slot(facet_id).await?;
+        let live = match &existing {
+            Some(FacetSlot::Live(f)) => Some(f.clone()),
+            _ => None,
+        };
+        crate::store::check_precondition(expected_version, live.as_ref().map(|f| f.version))?;
+
+        let Some(facet) = live else {
+            // A successful no-op. A producer retrying after a lost response has
+            // to be able to reach the state it wanted without having to tell a
+            // second delete apart from a first.
+            return Ok((false, 0));
+        };
+
+        let released = facet.face_ids.len();
+        let version = self.next_version().await?;
+        self.ks
+            .insert(
+                storage::facet_key(facet_id),
+                &FacetSlot::Tombstone {
+                    facet_id: facet_id.to_string(),
+                    version,
+                    deleted_at: crate::store::now_rfc3339(),
+                },
+            )
+            .await?;
+
+        Ok((true, released))
+    }
+
+    /// Which of `face_ids` another facet already holds.
+    ///
+    /// `excluding` is the facet being written, so a replace does not clash with
+    /// its own membership.
+    pub async fn placement_conflicts(
+        &self,
+        face_ids: &[Ulid],
+        excluding: Option<&str>,
+    ) -> Result<FacetPlacement, AppError> {
+        if face_ids.is_empty() {
+            return Ok(FacetPlacement::default());
+        }
+        let mut placed = Vec::new();
+        for other in self.list_facets().await? {
+            if excluding == Some(other.facet_id.as_str()) {
+                continue;
+            }
+            for id in face_ids {
+                if other.face_ids.contains(id) {
+                    placed.push(PlacedElsewhere {
+                        face_id: id.clone(),
+                        facet_id: other.facet_id.clone(),
+                    });
+                }
+            }
+        }
+        Ok(FacetPlacement { placed })
+    }
+
+    pub(crate) async fn facet_slot(&self, facet_id: &str) -> Result<Option<FacetSlot>, AppError> {
+        self.ks.get(storage::facet_key(facet_id)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{FacetColour, Provenance, ValueType};
+    use crate::store::new_attribute;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn fresh() -> (tempfile::TempDir, PersonaStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        (
+            dir,
+            PersonaStore::new(store.keyspace(vta_keyspaces::PERSONA).unwrap(), [9u8; 32]),
+        )
+    }
+
+    fn facet(name: &str, faces: Vec<Ulid>, attributes: Vec<Ulid>) -> Facet {
+        Facet {
+            facet_id: format!("01J8XR3QK9V00000000000{:04}", name.len()),
+            name: name.to_string(),
+            colour: FacetColour::Teal,
+            icon: None,
+            face_ids: faces,
+            attribute_ids: attributes,
+            version: 0,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    async fn a_profile(s: &PersonaStore, name: &str) -> Ulid {
+        let p = crate::profile::new_profile(name, vec![]);
+        let id = p.profile_id.clone();
+        s.put_profile(p, None).await.unwrap();
+        id
+    }
+
+    async fn an_attribute(s: &PersonaStore) -> Ulid {
+        let a = new_attribute(
+            "phone.mobile",
+            ValueType::String,
+            serde_json::json!("+61 400 000 000"),
+            Provenance::SelfAsserted,
+        );
+        let id = a.attribute_id.clone();
+        s.put(a, None).await.unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn a_facet_round_trips_with_its_membership() {
+        let (_d, s) = fresh().await;
+        let face = a_profile(&s, "Acme").await;
+        let attr = an_attribute(&s).await;
+
+        let written = s
+            .put_facet(
+                facet("Work", vec![face.clone()], vec![attr.clone()]),
+                Some(0),
+            )
+            .await
+            .unwrap();
+        assert!(written.created);
+
+        let listed = s.list_facets().await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "Work");
+        assert_eq!(listed[0].face_ids, vec![face]);
+        assert_eq!(listed[0].attribute_ids, vec![attr]);
+    }
+
+    /// The property the whole design turns on: a facet is an arrangement, not a
+    /// container. Deleting one must leave every record it named untouched.
+    #[tokio::test]
+    async fn deleting_a_facet_deletes_nothing_it_named() {
+        let (_d, s) = fresh().await;
+        let face = a_profile(&s, "Acme").await;
+        let attr = an_attribute(&s).await;
+        let f = facet("Work", vec![face.clone()], vec![attr.clone()]);
+        let facet_id = f.facet_id.clone();
+        s.put_facet(f, Some(0)).await.unwrap();
+
+        let (existed, released) = s.delete_facet(&facet_id, None).await.unwrap();
+        assert!(existed);
+        assert_eq!(
+            released, 1,
+            "the released-face count is what the screen reads"
+        );
+
+        assert!(
+            s.get_profile(&face).await.unwrap().is_some(),
+            "deleting a facet deleted a profile it merely named"
+        );
+        assert!(
+            s.get(&attr).await.unwrap().is_some(),
+            "deleting a facet deleted an attribute it merely named"
+        );
+        assert!(s.list_facets().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleting_what_is_not_there_is_a_successful_no_op() {
+        // A producer retrying after a lost response must reach the state it
+        // wanted without having to tell a second delete apart from a first.
+        let (_d, s) = fresh().await;
+        let (existed, released) = s
+            .delete_facet("01J8XR3QK9V0000000000000ZZ", None)
+            .await
+            .unwrap();
+        assert!(!existed);
+        assert_eq!(released, 0);
+    }
+
+    #[tokio::test]
+    async fn a_face_belongs_to_at_most_one_facet() {
+        let (_d, s) = fresh().await;
+        let face = a_profile(&s, "Acme").await;
+        s.put_facet(facet("Work", vec![face.clone()], vec![]), Some(0))
+            .await
+            .unwrap();
+
+        let err = s
+            .put_facet(facet("Home!", vec![face.clone()], vec![]), Some(0))
+            .await
+            .expect_err("a face was placed in two facets");
+        assert!(format!("{err}").contains("already belong"), "{err}");
+
+        // And the refusal names where it already is, so a consumer can offer to
+        // move it rather than sending the holder to look for it.
+        let clash = s.placement_conflicts(&[face], None).await.unwrap();
+        assert_eq!(clash.placed.len(), 1);
+        assert_eq!(
+            clash.placed[0].facet_id,
+            facet("Work", vec![], vec![]).facet_id
+        );
+    }
+
+    #[tokio::test]
+    async fn an_attribute_may_belong_to_several() {
+        // A mobile number is genuinely part of both a working life and a home
+        // one; a model that made the holder choose would be asking a question
+        // about their phone that has no answer.
+        let (_d, s) = fresh().await;
+        let attr = an_attribute(&s).await;
+        s.put_facet(facet("Work", vec![], vec![attr.clone()]), Some(0))
+            .await
+            .unwrap();
+        s.put_facet(facet("Home!", vec![], vec![attr]), Some(0))
+            .await
+            .expect("an attribute was refused a second facet");
+    }
+
+    #[tokio::test]
+    async fn a_replace_does_not_clash_with_its_own_faces() {
+        // Excluding the facet being written is what keeps it editable: without
+        // it, a facet becomes uneditable the moment it holds anything.
+        let (_d, s) = fresh().await;
+        let face = a_profile(&s, "Acme").await;
+        let first = facet("Work", vec![face.clone()], vec![]);
+        let id = first.facet_id.clone();
+        let v = s.put_facet(first, Some(0)).await.unwrap().version;
+
+        let mut again = facet("Work", vec![face], vec![]);
+        again.facet_id = id;
+        again.name = "Work life".into();
+        let written = s
+            .put_facet(again, Some(v))
+            .await
+            .expect("a replace clashed with itself");
+        assert!(!written.created);
+    }
+
+    #[tokio::test]
+    async fn a_dangling_reference_refuses_the_write() {
+        let (_d, s) = fresh().await;
+        let err = s
+            .put_facet(
+                facet("Work", vec!["01J8XR3QK9V0000000000000AA".into()], vec![]),
+                Some(0),
+            )
+            .await
+            .expect_err("a facet named a profile that does not exist");
+        assert!(format!("{err}").contains("do not exist"), "{err}");
+        assert!(
+            s.list_facets().await.unwrap().is_empty(),
+            "a refused write left a facet behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refused_write_consumes_no_version() {
+        // Validation runs before a version is taken, so a rejected document
+        // does not advance the store's change-feed watermark.
+        let (_d, s) = fresh().await;
+        let before = s.next_version().await.unwrap();
+        let _ = s
+            .put_facet(
+                facet("Work", vec!["01J8XR3QK9V0000000000000AA".into()], vec![]),
+                Some(0),
+            )
+            .await;
+        let after = s.next_version().await.unwrap();
+        assert_eq!(after, before + 1, "a refused write consumed a version");
+    }
+
+    #[tokio::test]
+    async fn membership_naming_a_deleted_record_is_returned_not_pruned() {
+        // A dangling member is how a consumer offers to tidy. Dropping it here
+        // turns a deletion the holder may not have intended into one they can
+        // never see.
+        let (_d, s) = fresh().await;
+        let face = a_profile(&s, "Acme").await;
+        s.put_facet(facet("Work", vec![face.clone()], vec![]), Some(0))
+            .await
+            .unwrap();
+        s.delete_profile(&face).await.unwrap();
+
+        let listed = s.list_facets().await.unwrap();
+        assert_eq!(
+            listed[0].face_ids,
+            vec![face],
+            "a dangling member was silently pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_facet_is_agent_scoped() {
+        // The security property, asserted on the key rather than the type.
+        assert_eq!(
+            storage::scope_of(&storage::facet_key("01J8")),
+            Some(storage::Scope::Agent)
+        );
+    }
+}

--- a/vta-persona/src/lib.rs
+++ b/vta-persona/src/lib.rs
@@ -42,6 +42,7 @@ pub mod claim_types;
 pub mod contact;
 pub mod correlation;
 pub mod disclosure;
+pub mod facet;
 pub mod model;
 pub mod present;
 pub mod profile;
@@ -55,9 +56,10 @@ pub use binding::{BindingSummary, Bound, MaterialisedClaim};
 pub use claim_types::{Axes, MaskStyle, ReleaseRequirement, Sensitivity};
 pub use contact::{Contact, ContactClaim, ContactDocument, ContactRevision, ContactSummary, Filed};
 pub use disclosure::{DisclosedClaim, DisclosureRecord, HistoryQuery, new_disclosure};
+pub use facet::{FacetPlacement, PlacedElsewhere, new_facet};
 pub use model::{
-    Attribute, Binding, InlineValue, OverrideValue, Profile, ProfileEntry, ProofRung, Provenance,
-    StaleReason, Ulid, ValueType, Version,
+    Attribute, Binding, Facet, FacetColour, InlineValue, OverrideValue, Profile, ProfileEntry,
+    ProofRung, Provenance, StaleReason, Ulid, ValueType, Version,
 };
 pub use present::{PREVIEW_TTL_SECONDS, Preview, PreviewClaim, Renderer, renderer};
 pub use profile::{ResolvedClaim, is_pool_free, new_profile};

--- a/vta-persona/src/model.rs
+++ b/vta-persona/src/model.rs
@@ -343,6 +343,73 @@ pub struct Profile {
     pub updated_at: String,
 }
 
+/// A colour **name**, resolved by each consumer against its own palette.
+///
+/// Never a literal. A hex value cannot be legible in a terminal, a light theme
+/// and a dark one at once, so a stored one is wrong somewhere and the holder
+/// has no way to know where — and a consumer that reserves colours to carry
+/// meaning (an error, a warning, an irreversible act) cannot keep a decorative
+/// choice out of that channel unless the set is closed.
+///
+/// None of the eight is named for success, warning or danger.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FacetColour {
+    Slate,
+    Indigo,
+    Teal,
+    Moss,
+    Sand,
+    Clay,
+    Rose,
+    Plum,
+}
+
+/// A named part of the holder's life, and what belongs to it. **Agent-scoped.**
+///
+/// An *arrangement*, not a container: nothing is stored inside a facet, and
+/// deleting one deletes nothing but the arrangement. That distinction is the
+/// whole of its design, and it is worth stating in the type because the
+/// intuitive reading is the other one — a grouping that looked like a folder,
+/// and behaved like one, would make `delete` the most dangerous call in this
+/// crate, and a holder cannot tell which kind they have from the button.
+///
+/// `#[non_exhaustive]` from the start, for the reason [`Attribute`] acquired it
+/// after two compatibility breaks: this record is going to grow as the persona
+/// specification does, and the next member should be an addition rather than a
+/// third break.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Facet {
+    pub facet_id: Ulid,
+    /// The holder's own word — "Work", "Home". Never disclosed, and never
+    /// interpreted: it is not a scope, a policy input, or a name a counterparty
+    /// sees. It is also the most revealing member in the record, which is easy
+    /// to miss because it carries no value *about* the holder: "Work" discloses
+    /// nothing and "the divorce" discloses a great deal. It MUST NOT reach an
+    /// operational log or a metric label.
+    pub name: String,
+    pub colour: FacetColour,
+    /// One or two emoji. Stored opaquely and never parsed; a consumer that
+    /// cannot render it shows the name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    /// Profiles belonging to this facet. A profile belongs to **at most one**,
+    /// because this is where a consumer reads its colour from and two answers
+    /// is no answer.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub face_ids: Vec<Ulid>,
+    /// Attributes belonging to this facet. An attribute **may** belong to
+    /// several — a mobile number is genuinely part of both a working life and a
+    /// home one — so no exclusivity is enforced here and none may be inferred.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attribute_ids: Vec<Ulid>,
+    pub version: Version,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 /// Assignment of a profile to a persona DID. **Context-scoped.**
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/vta-persona/src/storage.rs
+++ b/vta-persona/src/storage.rs
@@ -26,6 +26,21 @@ pub fn profile_key(profile_id: &str) -> String {
 
 pub const PROFILE_PREFIX: &str = "pp:";
 
+/// One facet — the holder's name for a part of their life, and what belongs
+/// to it.
+///
+/// **Agent-scoped, and that is the whole of its security story.** A facet says
+/// which of the holder's identities they consider parts of one life, which is
+/// precisely the join multiple personas exist to deny a verifier. A context
+/// that could address one would learn how the holder arranges every *other*
+/// context.
+#[must_use]
+pub fn facet_key(facet_id: &str) -> String {
+    format!("pf:{facet_id}")
+}
+
+pub const FACET_PREFIX: &str = "pf:";
+
 /// Correlation index, keyed by a keyed hash of the value so that exact-match
 /// lookup works with no plaintext index over the holder's personal data.
 #[must_use]
@@ -134,6 +149,7 @@ pub const CORRELATION_HMAC_KEY: &str = "pxkey";
 const PREFIX_SCOPES: &[(&str, Scope)] = &[
     ("pa:", Scope::Agent),
     ("pp:", Scope::Agent),
+    ("pf:", Scope::Agent),
     ("pxi:", Scope::Agent),
     ("pxr:", Scope::Agent),
     ("pb:", Scope::Context),

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -540,6 +540,15 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
         trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0,
         RetrySafety::RetrySafe,
     ),
+    (trust_tasks::TASK_PERSONA_FACET_PUT_1_0, RetrySafety::Keyed),
+    (
+        trust_tasks::TASK_PERSONA_FACET_LIST_1_0,
+        RetrySafety::ReadOnly,
+    ),
+    (
+        trust_tasks::TASK_PERSONA_FACET_DELETE_1_0,
+        RetrySafety::RetrySafe,
+    ),
     (
         trust_tasks::TASK_PERSONA_BINDING_SET_1_0,
         RetrySafety::Keyed,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -915,6 +915,16 @@ pub const TASK_PERSONA_PROFILE_LIST_1_0: &str =
 pub const TASK_PERSONA_PROFILE_DELETE_1_0: &str =
     "https://trusttasks.org/spec/persona/profile/delete/1.0";
 
+/// `spec/persona/facet/put/1.0`
+pub const TASK_PERSONA_FACET_PUT_1_0: &str = "https://trusttasks.org/spec/persona/facet/put/1.0";
+
+/// `spec/persona/facet/list/1.0`
+pub const TASK_PERSONA_FACET_LIST_1_0: &str = "https://trusttasks.org/spec/persona/facet/list/1.0";
+
+/// `spec/persona/facet/delete/1.0`
+pub const TASK_PERSONA_FACET_DELETE_1_0: &str =
+    "https://trusttasks.org/spec/persona/facet/delete/1.0";
+
 /// `spec/persona/binding/set/1.0`
 pub const TASK_PERSONA_BINDING_SET_1_0: &str =
     "https://trusttasks.org/spec/persona/binding/set/1.0";
@@ -1959,6 +1969,9 @@ pub const ALL_URIS: &[&str] = &[
     TASK_PERSONA_PROFILE_GET_1_0,
     TASK_PERSONA_PROFILE_LIST_1_0,
     TASK_PERSONA_PROFILE_DELETE_1_0,
+    TASK_PERSONA_FACET_PUT_1_0,
+    TASK_PERSONA_FACET_LIST_1_0,
+    TASK_PERSONA_FACET_DELETE_1_0,
     TASK_PERSONA_BINDING_SET_1_0,
     TASK_PERSONA_BINDING_GET_1_0,
     TASK_PERSONA_BINDING_LIST_1_0,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2775,6 +2775,7 @@ fn persona_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
     const PERSONA_DID: &str = "did:webvh:vta.test:persona-fixture";
     const VERIFIER: &str = "did:web:verifier.test";
     const SUBJECT: &str = "did:peer:0zfixturepairwisesubject";
+    const FACET: &str = "01J8ZQ2CCCCCCCCCCCCCCCCCCC";
     const NOW: &str = "2026-01-01T00:00:00Z";
 
     let self_asserted = json!({ "kind": "selfAsserted" });
@@ -2881,6 +2882,58 @@ fn persona_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
                     "profileId": PROFILE, "name": "Work", "entries": [], "version": 2, "updatedAt": NOW
                 }]}),
                 parses::<specs::persona::profile::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_FACET_PUT_1_0,
+            (
+                // Both membership lists populated and an icon present, so the
+                // witness covers every optional member rather than the shape a
+                // minimal create happens to take.
+                json!({
+                    "name": "Work",
+                    "colour": "teal",
+                    "icon": "\u{1F4BC}",
+                    "faceIds": [PROFILE],
+                    "attributeIds": [ATTR],
+                    "expectedVersion": 0
+                }),
+                parses::<specs::persona::facet::put::v1_0::Payload>,
+                validates::<specs::persona::facet::put::v1_0::Payload>,
+            ),
+            (
+                json!({ "facetId": FACET, "version": 2, "created": true, "updatedAt": NOW }),
+                parses::<specs::persona::facet::put::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_FACET_LIST_1_0,
+            (
+                json!({}),
+                parses::<specs::persona::facet::list::v1_0::Payload>,
+                validates::<specs::persona::facet::list::v1_0::Payload>,
+            ),
+            (
+                // No `nextCursor`: its absence is what says a listing is
+                // complete, so the witness is the complete-page shape.
+                json!({ "facets": [{
+                    "facetId": FACET, "name": "Work", "colour": "teal",
+                    "faceIds": [PROFILE], "attributeIds": [ATTR],
+                    "version": 2, "updatedAt": NOW
+                }]}),
+                parses::<specs::persona::facet::list::v1_0::Response>,
+            ),
+        ),
+        (
+            u::TASK_PERSONA_FACET_DELETE_1_0,
+            (
+                json!({ "facetId": FACET }),
+                parses::<specs::persona::facet::delete::v1_0::Payload>,
+                validates::<specs::persona::facet::delete::v1_0::Payload>,
+            ),
+            (
+                json!({ "existed": true, "releasedFaces": 1 }),
+                parses::<specs::persona::facet::delete::v1_0::Response>,
             ),
         ),
         (

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1702,6 +1702,16 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_PERSONA_PROFILE_LIST_1_0 => persona::handle_profile_list
         [ None Metadata false ],
+    // A facet arranges records; it never touches one. `put` is Mutating because
+    // it writes a record of its own, and `delete` Destructive for the same
+    // reason — neither reaches a profile or an attribute, which is the property
+    // `deleting_a_facet_deletes_nothing_it_named` pins in vta-persona.
+    vta_sdk::trust_tasks::TASK_PERSONA_FACET_PUT_1_0 => persona::handle_facet_put
+        [ Mutating None false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_FACET_LIST_1_0 => persona::handle_facet_list
+        [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_PERSONA_FACET_DELETE_1_0 => persona::handle_facet_delete
+        [ Destructive None false ],
     vta_sdk::trust_tasks::TASK_PERSONA_PROFILE_DELETE_1_0 => persona::handle_profile_delete
         [ Destructive None false ],
     // The critical gate. Holder-only, and Mutating because it materialises a

--- a/vta-service/src/trust_tasks/persona.rs
+++ b/vta-service/src/trust_tasks/persona.rs
@@ -39,7 +39,9 @@ use crate::audit;
 use crate::auth::AuthClaims;
 use crate::server::AppState;
 
-use super::helpers::{TrustTaskOutcome, error_response, parse_payload, success_response};
+use super::helpers::{
+    TrustTaskOutcome, error_response, parse_payload, reject_with_code, success_response,
+};
 
 /// The family namespace for codes shared across the slice. A proper path prefix
 /// of each task slug, which SPEC §8.5 permits so a family-wide meaning is
@@ -102,6 +104,14 @@ pub const REACH: &[(&str, Reach)] = &[
     (uris::TASK_PERSONA_PROFILE_GET_1_0, Reach::Holder),
     (uris::TASK_PERSONA_PROFILE_LIST_1_0, Reach::Holder),
     (uris::TASK_PERSONA_PROFILE_DELETE_1_0, Reach::Holder),
+    // A facet states which of the holder's identities are, to them, parts of
+    // one life — the linkage map the whole family exists to keep from being
+    // assembled by anyone else, written down by the only person entitled to
+    // write it. A context-scoped caller reading one would learn how the holder
+    // arranges every *other* context.
+    (uris::TASK_PERSONA_FACET_PUT_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_FACET_LIST_1_0, Reach::Holder),
+    (uris::TASK_PERSONA_FACET_DELETE_1_0, Reach::Holder),
     // The critical gate. An application able to call this could bind any
     // profile to a persona it controls and read the result back through a
     // disclosure it requests of itself. Every other read leaks; this one is
@@ -2173,6 +2183,177 @@ pub(super) async fn handle_disclosure_present(
 // ─────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────
+
+// ── Facets: the holder's own arrangement of their own identity ──────────────
+
+pub(super) async fn handle_facet_put(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::facet::put::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_FACET_PUT_1_0, None).await {
+        return reject(&doc, e);
+    }
+
+    let s = store(state);
+    // `.map(|u| u.to_string())` rather than `.map(ToString::to_string)`: the
+    // generated `Ulid` is a newtype with `Deref` and no `Display`, so the
+    // method call auto-derefs to `String` while the function path does not.
+    let face_ids: Vec<String> = req.face_ids.iter().map(|u| u.to_string()).collect();
+    let attribute_ids: Vec<String> = req.attribute_ids.iter().map(|u| u.to_string()).collect();
+    let Some(colour) = colour_of(&req.colour) else {
+        return reject_with_code(
+            &doc,
+            ext(&slug_from_doc(&doc), "unsupportedColour"),
+            "this agent does not know that colour",
+            Some(json!({ "colour": req.colour.to_string() })),
+        );
+    };
+    let mut facet = vta_persona::new_facet(
+        req.name.to_string(),
+        colour,
+        req.icon.as_ref().map(|i| i.to_string()),
+        face_ids,
+        attribute_ids,
+    );
+    // A supplied id addresses an existing record; an absent one keeps the
+    // minted ULID, which is what makes a create idempotent under retry only
+    // when the producer chose the id itself.
+    if let Some(id) = req.facet_id.as_ref() {
+        facet.facet_id = id.to_string();
+    }
+    let facet_id = facet.facet_id.clone();
+
+    // The exclusivity refusal is its own extended code rather than a validation
+    // string, because the details are what make it actionable: told only that
+    // the write failed, a consumer can do nothing but send the holder off to
+    // find where the face already is.
+    let clash = match s
+        .placement_conflicts(&facet.face_ids, Some(&facet_id))
+        .await
+    {
+        Ok(c) => c,
+        Err(e) => return reject(&doc, e),
+    };
+    if !clash.placed.is_empty() {
+        return reject_with_code(
+            &doc,
+            ext(&slug_from_doc(&doc), "faceAlreadyPlaced"),
+            "one or more faces already belong to another facet",
+            Some(json!({ "placed": clash.placed })),
+        );
+    }
+
+    let written = match s
+        .put_facet(facet, req.expected_version.map(u64::from))
+        .await
+    {
+        Ok(w) => w,
+        Err(e) => return reject(&doc, e),
+    };
+    // The name is the most revealing member in the record and never reaches an
+    // audit line: "Work" discloses nothing and "the divorce" discloses a great
+    // deal, and a holder naming a part of their life is not thinking about logs.
+    audit_persona(state, "persona.facet.put", auth, None, None, None).await;
+    success_response(
+        &doc,
+        json!({
+            "facetId": facet_id,
+            "version": written.version,
+            "created": written.created,
+            "updatedAt": chrono::Utc::now().to_rfc3339(),
+        }),
+    )
+}
+
+pub(super) async fn handle_facet_list(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let _req: spec::facet::list::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_FACET_LIST_1_0, None).await {
+        return reject(&doc, e);
+    }
+    let facets = match store(state).list_facets().await {
+        Ok(f) => f,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(state, "persona.facet.list", auth, None, None, None).await;
+    // No `nextCursor`: this maintainer returns every facet in one page. The
+    // member is absent rather than null, which is what says the listing is
+    // complete — a consumer following the cursor sees exactly one page.
+    success_response(&doc, json!({ "facets": facets }))
+}
+
+pub(super) async fn handle_facet_delete(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: spec::facet::delete::v1_0::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    if let Err(e) = authorize(state, auth, uris::TASK_PERSONA_FACET_DELETE_1_0, None).await {
+        return reject(&doc, e);
+    }
+    // Touches no profile and no attribute. There is no cascading form of this
+    // call because there is no cascading form of the idea: a facet is an
+    // arrangement, not a container.
+    let (existed, released) = match store(state)
+        .delete_facet(
+            &req.facet_id.to_string(),
+            req.expected_version.map(u64::from),
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return reject(&doc, e),
+    };
+    audit_persona(state, "persona.facet.delete", auth, None, None, None).await;
+    success_response(
+        &doc,
+        json!({ "existed": existed, "releasedFaces": released }),
+    )
+}
+
+/// The wire colour to the store's.
+///
+/// **Returns `None` for a colour this build does not know, and the caller
+/// refuses the document.** The generated enum is `#[non_exhaustive]`, so the
+/// compiler cannot make this match exhaustive across the crate boundary and a
+/// wildcard arm is mandatory — which means the choice is what the wildcard
+/// *does*. Mapping an unknown colour to a default would be a facet silently
+/// changing colour: a small thing the holder cannot explain and cannot fix,
+/// arriving with no error anywhere. Refusing says which member this build did
+/// not understand.
+///
+/// Unreachable from the wire today — serde rejects an unknown string before the
+/// payload parses — but reachable the moment `trust-tasks-rs` is bumped to a
+/// version declaring a ninth colour, which is exactly when it should be loud.
+fn colour_of(c: &spec::facet::put::v1_0::FacetColour) -> Option<vta_persona::FacetColour> {
+    use spec::facet::put::v1_0::FacetColour as W;
+    use vta_persona::FacetColour as S;
+    Some(match c {
+        W::Slate => S::Slate,
+        W::Indigo => S::Indigo,
+        W::Teal => S::Teal,
+        W::Moss => S::Moss,
+        W::Sand => S::Sand,
+        W::Clay => S::Clay,
+        W::Rose => S::Rose,
+        W::Plum => S::Plum,
+        _ => return None,
+    })
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Implements the three tasks specified in [dtgwg-trust-tasks-tf#405](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/405), published in `trust-tasks-rs` 0.18.9.

A holder who uses this model for a while ends up with twenty profiles, and a flat list of twenty is a list nobody reads. A **facet** is the arrangement over them — *Work*, *Home*, *Play* — agent-scoped like the pool and the profiles it groups.

## The property the whole thing turns on

**A facet is an arrangement, not a container.** Nothing is stored inside one. `delete_facet` touches no profile and no attribute, and there is deliberately no cascading form — an arrangement that could take its members with it is a folder, and a holder who reads it as a folder is right to be afraid of it. `releasedFaces` reports what now belongs nowhere, which is what a screen needs in order to say what it will look like afterwards.

`deleting_a_facet_deletes_nothing_it_named` asserts exactly that, on the records rather than on the return value.

## Why membership lives on the facet

The obvious alternative is a `facet_id` on `Attribute`. It is the wrong shape for a mechanical reason: `persona/attribute/put` **replaces**, and a well-behaved consumer does not hold the values it would have to resend — `attribute/list` withholds the plaintext of anything resolving to `sensitivity: high` unless asked for by name. Such a consumer would either request every sensitive value the holder owns in order to perform an arrangement that has nothing to do with values, or send a put without one and silently destroy them.

## Boundary

**`Reach::Holder` for all three**, and the census enforces it — a task cannot join the family without someone deciding which side it is on. A facet states which of the holder's identities are, to them, parts of one life: the linkage map this family exists to keep from being assembled by anyone else, written down by the only person entitled to write it. A context-scoped caller reading one would learn how the holder arranges every *other* context.

`pf:` is registered agent-scoped in the storage census, and `a_facet_is_agent_scoped` asserts it on the key rather than the type.

## Two refusals worth reviewing

**A face belongs to at most one facet; an attribute may belong to several.** The refusal is `persona/facet/put:faceAlreadyPlaced` and its details name the facet *already holding* the face, so a consumer can offer to move it rather than sending the holder off to look. A replace excludes itself from that check — without it a facet becomes uneditable the moment it holds anything.

**An unknown colour is refused, not defaulted.** The generated `FacetColour` is `#[non_exhaustive]`, so the compiler cannot make `colour_of` exhaustive across the crate boundary and a wildcard arm is mandatory — which makes what the wildcard *does* the actual decision. Mapping an unknown colour to a default would be a facet silently changing colour: a small thing the holder cannot explain and cannot fix, arriving with no error anywhere. Unreachable from the wire today (serde rejects the string before the payload parses), and loud the moment a ninth colour is published.

## The floor

`trust-tasks-rs` `0.18.8` → `0.18.9`, and it is a correctness constraint rather than a version preference — the same shape as the `adminScope` floor documented above it in `Cargo.toml`. The dispatch spine validates **outgoing** responses against the embedded schema, so on 0.18.8 a facet write that fully succeeded comes back `500 responseSchemaViolation`: the members are emitted and the schema has never heard of them.

## Verification

- `vta-persona` 112/112 (10 new)
- `vta-service --lib` 1056/1056, including the reach census, the storage scope census, the audit-coverage sweep and `every_published_dispatched_uri_has_a_witness` — the last needed three new `checked!` entries, which is the conformance sweep working as intended
- `cargo clippy --all-targets --all-features` clean

Developed against a local path patch while 0.18.9 was in flight; **the patch is not in this branch** — the build and every number above is against the published crate.