### PR TITLE
docs: design note for the data-rooms demo site

### DIFF
--- a/docs/05-design-notes/data-rooms-demo-site.md
+++ b/docs/05-design-notes/data-rooms-demo-site.md
@@ -1,0 +1,364 @@
+# Data rooms — the demo site
+
+Status: **design, revision 1.** Nothing built. The feasibility question this
+design turns on — can a browser be a real room member — was answered by
+building, and §3.1 records what compiled.
+
+Parent design: [`data-rooms.md`](data-rooms.md) (rev 3). Operator guide:
+[`../02-vta/data-rooms.md`](../02-vta/data-rooms.md).
+
+A **single public website** where somebody with no wallet, no agent and no
+account can mint their own `did:key` in the browser, be admitted to a data room
+named by a DID, and read, write and curate its records — for **any** room, not a
+room the site was built around.
+
+---
+
+## 1. What this is for, and what it is not
+
+Rooms are built. What is missing is a way for a person to *encounter* one. Every
+existing client presumes a great deal: `pnm-cli` presumes a provisioned VTA and
+a shell; the browser plugin presumes an installed extension and a wallet already
+bound to an agent. Neither is something you can put in a link.
+
+The demo site is the missing front door. Its job is to make the room's actual
+properties visible in a browser tab within a minute of arriving:
+
+- the visitor holds their own key, and the room's decisions are made about *that
+  key*;
+- the host stores ciphertext it cannot read;
+- authority is a credential the room issued, not a row in the host's table;
+- and access is scoped, expiring and revocable.
+
+It is **not** a wallet, not a replacement for the plugin, and not a product
+surface. It is a demonstration that has to be honest, because a demo that fakes
+the properties demonstrates nothing.
+
+---
+
+## 2. The constraint everything follows from
+
+A room member is defined by two things, and neither is a credential you can hold
+in a cookie.
+
+**One: the MLS group.** The key that opens a sealed record is derived from group
+state at the epoch the record was written. Today that state lives in a VTA
+keyspace — `vta-service/src/server.rs:458`, rows at `room-group:{roomId}`
+(`vta-service/src/operations/room_groups.rs:43`).
+
+**Two: an authority presentation.** Every host task takes one and nothing else
+produces one. It is a `{membership, authority: [leaf, root]}` document where the
+leaf is the member's *own* root VAC attenuated to a single action, bound to an
+audience and a nonce, signed by the member's key, and good for four hours
+(`vta-service/src/operations/room_oracle.rs:85`).
+
+`pnm-cli` shows the client shape that follows (`pnm-cli/src/cli.rs:332`): it
+holds nothing, takes `--room`, `--host` and `--host-did`, asks *its VTA* for
+present/open/seal, and calls the *host* directly over REST. A website is the
+same client. Unlike the plugin console it can talk to a host directly — the
+console cannot, because `carrierParams` drops the recipient and every call lands
+at the wallet's own agent, which is why `rooms/keys/backfill` and
+`rooms/owner/register` had to exist at all.
+
+So the only real question is **where the visitor's member-side capability comes
+from**. Three answers were on the table: a VTA per visitor, a shared custodial
+VTA, or the browser itself.
+
+---
+
+## 3. The decision: the browser is the member
+
+A custodial VTA — one agent holding every visitor's room keys — is both a
+demonstration of the wrong thing and **broken today**. `rooms/keys/open` is gated
+on `Capability::RoomOpen` and nothing else
+(`vta-service/src/trust_tasks/room_group.rs:562`), and the storage key carries no
+principal. Two visitors in one VTA can open each other's rooms; two members of
+the *same* room collide on one row. A VTA is one principal's agent, and rooms
+are stored as though that is true, because it is.
+
+A VTA per visitor is honest and unusable: minutes to provision, a container per
+curious stranger.
+
+**So the tab is the key holder.** This was the option that looked like weeks of
+porting. It is not, and the reason is a property of the existing crate rather
+than luck.
+
+### 3.1 What was verified, and how
+
+`vti-rooms` divides cleanly along exactly the line this needs. Its member half —
+`mls.rs`, `sealed.rs`, `retention.rs`, plus `wire.rs`, `error.rs`,
+`lifecycle.rs` — **imports nothing from `vti-common`**. Only `storage.rs`,
+`authz.rs` and `audit.rs` do, and those are the *host's* concerns, which a member
+never runs. `error.rs` says why in its own module doc: key material is
+deliberately not a service concern, so `RoomKeyError` is deliberately not
+`AppError`.
+
+Three builds against `wasm32-unknown-unknown`:
+
+| Probe | Result |
+|---|---|
+| `openmls` 0.9 + `openmls_rust_crypto` + `chacha20poly1305` + `chrono` | **builds** |
+| `dtg-credentials` 0.7 (`default-features = false`) + `affinidi-data-integrity` 0.7 | **builds** |
+| `vti-rooms`' member half, **sources unmodified**, host modules and `vti-common` removed | **builds** — 465 KB `.wasm` |
+
+Three facts worth not re-deriving:
+
+- **`openmls` 0.9 ships a first-class `js` feature** (`dep:web-time`,
+  `getrandom/wasm_js`). Without it the build fails on `use web_time::SystemTime`
+  in `key_packages/lifetime.rs`, which reads like an unsupported target and is
+  not.
+- **Three `getrandom` majors are live in one graph** (0.2 via `rand 0.8`, 0.3,
+  0.4), and each needs its own opt-in: `features = ["js"]` on 0.2,
+  `features = ["wasm_js"]` on 0.3/0.4, *and*
+  `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`. Every failure here reports as
+  a `compile_error!` naming one version, so it is fixed three times.
+- **`dtg-credentials`' `affinidi-signing` feature is optional and default-on.**
+  Turning it off drops `affinidi-secrets-resolver`, and `DTGCredential::sign`
+  still works because `affinidi-data-integrity` takes a `Signer` **trait
+  object** — the same seam `RoomKeySigner` uses server-side. The browser supplies
+  its own.
+
+This is a feature-gate change to `vti-rooms` plus a binding crate. It is not a
+port.
+
+### 3.2 The split: what is Rust, what is TypeScript
+
+**In wasm (`vti-rooms-wasm`, a new crate):**
+
+- MLS: mint a KeyPackage, join from a Welcome, apply a commit, current epoch.
+- Sealing: seal and open a record at an epoch.
+- The epoch key chain: store rungs, walk backwards, report
+  `earliestReadableEpoch`.
+- **Presentation minting**: `DTGCredential::attenuate` + sign. This belongs in
+  Rust and not in TypeScript, because `attenuate` is what refuses to *widen*.
+  Reimplementing that rule in JS would duplicate the one check that stops a
+  member presenting more authority than the room gave them.
+
+**In TypeScript (`@openvtc/pnm-core`, already written):**
+
+- Trust Task documents and their `eddsa-jcs-2022` proofs
+  (`trust-tasks/sign.ts`, `canonical.ts`).
+- The `rooms/*` host calls (`rooms/index.ts`) — pointed at the host rather than
+  a VTA, which is what `RoomsCaller.service` was always for.
+- `did:key` derivation and verification-method shape (`did/`).
+
+The seam is: **wasm holds secrets and produces bytes; TypeScript speaks the
+wire.** Nothing that crosses the boundary is a private key.
+
+### 3.3 Persistence
+
+`IdentitySnapshot` and `GroupSnapshot` already externalise the whole OpenMLS
+provider store as an opaque blob — a decision made server-side because OpenMLS
+persists a group *through* its provider, and picking out "just the group" means
+reimplementing its layout. That decision is what makes a browser member cheap:
+the tab keeps the blob in IndexedDB and hands it back. No storage adapter, no
+`openmls_sqlite_storage`, no new trait.
+
+Kept per visitor, in IndexedDB:
+
+| | |
+|---|---|
+| Ed25519 key | non-extractable `CryptoKey` where the browser allows it |
+| `did:key` | derived, lexical — no resolution, no network |
+| group snapshot | one blob per room |
+| epoch-link rungs | the chain, per room |
+| VMC + VAC | the room-issued credentials |
+
+A cleared browser is a lost identity. The site must say so on the first screen
+and offer an export, because a person who loses a demo identity silently learns
+the wrong lesson about self-custody.
+
+### 3.4 What this buys beyond the demo
+
+The same artifact is the missing member-side library for any browser client, and
+it removes a real limitation: `pnm-cli rooms put` is documented as `open` rooms
+only, because sealing needed a VTA. A browser-native member seals locally and
+writes to sealed rooms without asking anyone.
+
+---
+
+## 4. Three gaps that must be closed
+
+These are not demo scaffolding. Each is a hole the demo is simply the first
+thing to fall into.
+
+### 4.1 A room DID does not say where its room is
+
+`vta-sdk/templates/room.json` gives a room exactly one service entry:
+DIDComm, pointing at a mediator. Nothing in `HeldRoom` carries a host either
+(`room_groups.rs:318` — `roomId`, `epoch`, `earliestReadableEpoch`), which is
+precisely why `pnm-cli` needs a separate `--host`.
+
+The template's own description says a room is portable because you can
+"re-point its service endpoint and the room has moved". **There is no host
+service endpoint to re-point.** Portability is asserted by a document that
+cannot express it.
+
+- *Now*: the site takes both, in one link — `/#/room/<did>?host=<base-url>`.
+- *Right*: add a host service entry to the `room` template so resolving a room
+  DID yields its host, and the invite link degrades to a DID. This is worth
+  raising against the template regardless of whether the demo is built.
+
+### 4.2 Admission assumes the member is addressable
+
+Today's ceremony is push-shaped, and every step presumes the member is an agent
+the owner can reach: the owner calls `rooms/keys/key-package` **on the member's
+VTA**, then sends the Welcome to it. A browser tab has no DIDComm address and no
+inbox.
+
+A browser member must **pull**. The ceremony inverts:
+
+```
+browser: mint KeyPackage locally (wasm)
+browser → broker:  POST /join { did, keyPackage }
+broker (as owner): rooms/owner/invite      → VIC for that did:key
+broker (as owner): add the KeyPackage to the group, commit
+broker → browser:  { welcome, epochLinks, membershipVc, authorityVc, roomDid, host, hostDid }
+browser: apply the Welcome (wasm), store the chain and both credentials
+```
+
+Every credential is real and issued by the room; only the *carriage* changed.
+
+### 4.3 Rooms have no join ceremony
+
+The `rooms/*` family runs to twenty-two tasks — thirteen served by a member's
+VTA, nine by a host — and not one of them is a join request. A VTC has
+`join-requests/{submit,manifest,status}`; a room's admission is owner-only —
+`owner/invite`, `keys/key-package`, `keys/welcome`, `owner/issue-membership`,
+`owner/issue-authority`.
+
+The broker's `POST /join` above is, in effect, an unspecified `rooms/join/*`
+ceremony. Building it as a demo endpoint is fine; **pretending it is not a spec
+gap is not.** The pull-shaped join is what any non-agent member needs — a
+browser, a mobile app, a CI job — and it should go upstream as a Trust Task
+family once the demo has shown its shape.
+
+---
+
+## 5. The broker — the only backend, and how small it is
+
+Because the browser is the member, the visitor needs **no VTA and no ACL entry**.
+The self-enrolment problem disappears: `acl.rs:530` requires admin to grant, and
+nothing needs granting.
+
+What remains is the *owner* side, which is a real agent and must be:
+
+- holds the demo rooms' owner identity (a VTA it drives);
+- serves `POST /join` (§4.2) and auto-admits, per the room's policy;
+- serves `GET /rooms` — the catalogue of demo rooms, each `{roomDid, host,
+  hostDid, admission}`.
+
+That is all. Every other call in the site is browser→host, direct.
+
+**Auto-admit with the approval shown.** The site displays each of the five owner
+acts as it happens — invitation issued, key package added, commit, membership
+issued, authority issued — with the credential each produced. A demo that hides
+admission behind a spinner demonstrates a login form. The governance *is* the
+product.
+
+The broker must be the only thing that can widen access. A visitor asks for a
+room in the catalogue and gets exactly the authority that room's policy grants;
+it never proxies an arbitrary host, and it never signs anything on a visitor's
+behalf.
+
+---
+
+## 6. The site
+
+A static SPA. One page per concern, nothing hardcoded per room.
+
+| Route | What |
+|---|---|
+| `/` | who you are — mint or import a `did:key`, export it, the honest warning |
+| `/rooms` | rooms this browser holds keys for, from local state + the catalogue |
+| `/room/<did>?host=…` | records: list, read, write, curate |
+| `/room/<did>/join` | the admission ceremony, step by step |
+| `/room/<did>/keys` | epochs, `earliestReadableEpoch`, the chain, what it means |
+
+Two epoch numbers belong on screen wherever a room does, because they are
+different repairs: an `epoch` behind the room's own means an undelivered commit;
+`earliestReadableEpoch` equal to `epoch` means the chain has not arrived. Shown
+as one number, "less history than I expected" reads as loss rather than as a
+delivery that has not happened yet.
+
+**A room is addressed, never configured.** The room list comes from local group
+state; a room is `{roomDid, host}` off the URL. That is the whole of "one site,
+any number of rooms" — including a room the site has never seen, hosted by a VTC
+the site does not know, provided the visitor holds credentials for it.
+
+**CORS is a deployment step, not a code change.** Both services already build a
+configurable allow-origin layer — `vta-service/src/routes/mod.rs:233`,
+`vtc-service/src/server.rs:1427`. The demo origin goes in both lists. A host
+that has not added it is simply not reachable from the site, which is the
+correct default and should be reported as such rather than as a network error.
+
+**Reading a host's refusal correctly.** A host's `trust-task-error` is its
+*answer*. Surface its code and reason as a refusal — "the room did not grant you
+`curate`" — never as a failed request. This is the single most instructive thing
+the demo can show, and rendering it as a 502 wastes it.
+
+---
+
+## 7. What the site must say out loud
+
+- **Your key is in this browser.** Clearing site data destroys it. Export it.
+- **This is a demo room.** Its owner admits anyone who asks. Real rooms do not.
+- **The host cannot read this.** Show the ciphertext next to the plaintext once,
+  on one record, because that is the claim everything else rests on.
+- **Your authority expires.** The presentation is minted per action, for one
+  action, for four hours. Show it, and show it being re-minted.
+
+Deliberately *not* demonstrated: the `private` tier. Its subject-binding
+verifier is a seam with no implementation and the ZK profile is still a
+working-group decision. A demo tier that silently behaves like `sealed` would
+misrepresent it.
+
+---
+
+## 8. Delivery sequence
+
+| # | Repo | What | Depends on |
+|---|---|---|---|
+| 1 | vti | Gate `storage`/`authz`/`audit` behind a default-on `host` feature; `vti-common` becomes optional. `--no-default-features --features mls` builds for wasm32 | — |
+| 2 | vti | `vti-rooms-wasm`: wasm-bindgen bindings — identity, key package, welcome, commit, seal, open, chain, present | 1 |
+| 3 | vti | Host service entry on the `room` DID template (§4.1) | — |
+| 4 | plugin | `@openvtc/pnm-core/rooms` host calls usable against a host base URL (they are already shaped for it); publish | — |
+| 5 | new | The broker: catalogue + `POST /join` (§4.2), driving a demo-owner VTA | 3 |
+| 6 | new | The site: identity → catalogue → join → read | 2, 4, 5 |
+| 7 | new | Write, curate, and the keys/epoch pane | 6 |
+| 8 | spec | `rooms/join/*` as a Trust Task family, from what §4.2 turned out to need | 5 |
+
+1–3 are the ones with real risk and none of it is unknown. 6–7 are the demo.
+
+**Where the site lives** is undecided: a new repo under OpenVTC, or `demo/`
+inside vti. A new repo, on the grounds that it deploys on its own cadence and
+depends on published artifacts rather than the workspace — but that is a call
+worth making explicitly rather than by whoever runs `cargo new` first.
+
+---
+
+## 9. Open questions
+
+- **Does the epoch key chain reach a browser member?** The three deliveries are
+  owner→host, host→member (`rooms/epoch/chain`), member→their own VTA
+  (`rooms/keys/chain`). A browser member has no third leg — it *is* the key
+  holder. The rungs must arrive in the join response and from
+  `rooms/epoch/chain`, which is host-served — so the leg exists. What needs
+  confirming is that a host accepts it from a member presenting `read` with no
+  VTA anywhere in the path, and that `rooms/keys/chain` then has no counterpart
+  here at all rather than a browser-side stand-in.
+- **Commit delivery.** A member who misses a commit is stuck at their last epoch
+  and every later record fails to open — the symptom reads as corruption. Today
+  commits reach a member's VTA. A browser member that has been closed for a week
+  needs to catch up on open; where it fetches missed commits from is not
+  designed.
+- **Bundle size.** 465 KB is the crate before wasm-bindgen glue, `wasm-opt` or
+  the credential half. Measure the real thing before promising a fast first
+  paint.
+- **Non-extractable keys and export are in tension.** Both matter here. Probably
+  two modes, chosen at mint, and the choice explained rather than defaulted.
+- **Does anything about a browser member weaken the pooling defence?** The rule
+  is that the chain's *root* subject is what a host compares, and the root is
+  the grant the room made. A browser member's root and leaf subject are the same
+  DID, which is a case the server-side path never produces. Worth a test, not a
+  redesign.

--- a/docs/05-design-notes/data-rooms-demo-site.md
+++ b/docs/05-design-notes/data-rooms-demo-site.md
@@ -177,27 +177,53 @@ writes to sealed rooms without asking anyone.
 
 ---
 
-## 4. Three gaps that must be closed
+## 4. What the design actually runs into
 
-These are not demo scaffolding. Each is a hole the demo is simply the first
-thing to fall into.
+Three things looked like gaps. **One was not** (§4.1) — the correction is kept
+because the mistake is instructive and a reader will make it too. The other two
+are real, and neither is demo scaffolding: each is a hole the demo is simply the
+first thing to fall into.
 
-### 4.1 A room DID does not say where its room is
+### 4.1 Host addressing is out-of-band, and that is deliberate
 
-`vta-sdk/templates/room.json` gives a room exactly one service entry:
-DIDComm, pointing at a mediator. Nothing in `HeldRoom` carries a host either
-(`room_groups.rs:318` — `roomId`, `epoch`, `earliestReadableEpoch`), which is
-precisely why `pnm-cli` needs a separate `--host`.
+*This section began as a claimed gap. It is not one, and the correction matters
+enough to keep rather than delete.*
 
-The template's own description says a room is portable because you can
-"re-point its service endpoint and the room has moved". **There is no host
-service endpoint to re-point.** Portability is asserted by a document that
-cannot express it.
+A room's DID document names a mediator and nothing else
+(`vta-sdk/templates/room.json`), so resolving a room DID does not yield a host.
+That is **by design**, and the specification says so in as many words. From
+`rooms/keys/backfill/0.1`:
 
-- *Now*: the site takes both, in one link — `/#/room/<did>?host=<base-url>`.
-- *Right*: add a host service entry to the `room` template so resolving a room
-  DID yields its host, and the invite link degrades to a DID. This is worth
-  raising against the template regardless of whether the demo is built.
+> The host to fetch from, as a DID. **Named by the caller because nothing maps a
+> room to its host**: a room is portable — re-point it and it has moved — so a
+> remembered host is a value that goes stale […] A caller who names the wrong
+> host learns so as a refusal from a party that does not serve this room, which
+> is loud and immediate.
+
+And from `rooms/owner/register/0.1`, the stronger reason: **a room may be
+registered with more than one host** — "a mirror serves reads while its primary
+takes writes". A single host pointer in the DID document would not be merely
+stale; it would be *wrong*.
+
+Host **endpoint** discovery does exist and is the normal mechanism: a caller
+names the host by DID, and that DID resolves to a service endpoint
+(`operations/room_host.rs`'s `send_room_task`, over `vta-sdk`'s
+`ServiceCapabilities::from_did_document`). What is deliberately absent is only
+the room→host link.
+
+So `{roomDid, host}` in the site's URL is **not a workaround**. It is the same
+addressing `pnm-cli` takes as `--room` and `--host`, and it is what the spec
+asks a caller to supply. The demo carries the host in the invite link and in the
+broker's catalogue, and a visitor who types a room DID with the wrong host gets
+the refusal the spec designed for — which the site should render as "that host
+does not serve this room", because it is an answer.
+
+One genuine nit falls out of this. `room.json`'s description says a room is
+portable because you can "re-point its service endpoint and the room has moved".
+Given that nothing maps a room to its host, that sentence points at a mechanism
+the document does not have, and reads exactly the way it misled this design on
+its first pass. Worth rewording to say that portability comes from the room
+issuing its own credentials, so a member simply names a different host.
 
 ### 4.2 Admission assumes the member is addressable
 
@@ -271,7 +297,7 @@ A static SPA. One page per concern, nothing hardcoded per room.
 |---|---|
 | `/` | who you are — mint or import a `did:key`, export it, the honest warning |
 | `/rooms` | rooms this browser holds keys for, from local state + the catalogue |
-| `/room/<did>?host=…` | records: list, read, write, curate |
+| `/room/<did>?host=<hostDid>&at=<url>` | records: list, read, write, curate |
 | `/room/<did>/join` | the admission ceremony, step by step |
 | `/room/<did>/keys` | epochs, `earliestReadableEpoch`, the chain, what it means |
 
@@ -282,9 +308,21 @@ as one number, "less history than I expected" reads as loss rather than as a
 delivery that has not happened yet.
 
 **A room is addressed, never configured.** The room list comes from local group
-state; a room is `{roomDid, host}` off the URL. That is the whole of "one site,
-any number of rooms" — including a room the site has never seen, hosted by a VTC
-the site does not know, provided the visitor holds credentials for it.
+state; a room is `{roomDid, hostDid, endpoint}` off the URL. That is the whole
+of "one site, any number of rooms" — including a room the site has never seen,
+hosted by a VTC the site does not know, provided the visitor holds credentials
+for it.
+
+The host appears **twice** for the reason `pnm-cli` takes both `--host` and
+`--host-did`: the DID is what a presentation is bound to, and the URL is where
+the bytes go. Server-side, `send_room_task` derives the second from the first by
+resolving the host's DID. A browser could do the same — `did:webvh` resolution
+is plain HTTPS — and should, eventually, so a link carries one identifier rather
+than an identifier plus a location. Until then the catalogue supplies both, and
+`at=` is an override for a host the catalogue has never heard of. **A
+presentation bound to no host is usable by anyone who observes it until it
+expires**, so the site must never let `host` go unset merely because it only had
+a URL.
 
 **CORS is a deployment step, not a code change.** Both services already build a
 configurable allow-origin layer — `vta-service/src/routes/mod.rs:233`,
@@ -321,14 +359,15 @@ misrepresent it.
 |---|---|---|---|
 | 1 | vti | Gate `storage`/`authz`/`audit` behind a default-on `host` feature; `vti-common` becomes optional. `--no-default-features --features mls` builds for wasm32 | — |
 | 2 | vti | `vti-rooms-wasm`: wasm-bindgen bindings — identity, key package, welcome, commit, seal, open, chain, present | 1 |
-| 3 | vti | Host service entry on the `room` DID template (§4.1) | — |
+| 3 | vti | Reword `room.json`'s portability sentence (§4.1) — a doc fix, not a schema change | — |
 | 4 | plugin | `@openvtc/pnm-core/rooms` host calls usable against a host base URL (they are already shaped for it); publish | — |
-| 5 | new | The broker: catalogue + `POST /join` (§4.2), driving a demo-owner VTA | 3 |
+| 5 | new | The broker: catalogue + `POST /join` (§4.2), driving a demo-owner VTA | — |
 | 6 | new | The site: identity → catalogue → join → read | 2, 4, 5 |
 | 7 | new | Write, curate, and the keys/epoch pane | 6 |
 | 8 | spec | `rooms/join/*` as a Trust Task family, from what §4.2 turned out to need | 5 |
 
-1–3 are the ones with real risk and none of it is unknown. 6–7 are the demo.
+1–2 are the ones with real risk and none of it is unknown; 3 is a paragraph.
+6–7 are the demo.
 
 **Where the site lives** is undecided: a new repo under OpenVTC, or `demo/`
 inside vti. A new repo, on the grounds that it deploys on its own cadence and

--- a/docs/05-design-notes/data-rooms-demo-site.md
+++ b/docs/05-design-notes/data-rooms-demo-site.md
@@ -101,17 +101,27 @@ Three builds against `wasm32-unknown-unknown`:
 | `dtg-credentials` 0.7 (`default-features = false`) + `affinidi-data-integrity` 0.7 | **builds** |
 | `vti-rooms`' member half, **sources unmodified**, host modules and `vti-common` removed | **builds** — 465 KB `.wasm` |
 
+Since shipped as the `host` feature: `cargo check -p vti-rooms --lib
+--no-default-features --features mls --target wasm32-unknown-unknown` passes in
+the workspace, guarded by two steps in CI's `features` job.
+
 Three facts worth not re-deriving:
 
 - **`openmls` 0.9 ships a first-class `js` feature** (`dep:web-time`,
   `getrandom/wasm_js`). Without it the build fails on `use web_time::SystemTime`
   in `key_packages/lifetime.rs`, which reads like an unsupported target and is
   not.
-- **Three `getrandom` majors are live in one graph** (0.2 via `rand 0.8`, 0.3,
-  0.4), and each needs its own opt-in: `features = ["js"]` on 0.2,
-  `features = ["wasm_js"]` on 0.3/0.4, *and*
-  `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`. Every failure here reports as
-  a `compile_error!` naming one version, so it is fixed three times.
+- **Two `getrandom` majors are live in one graph.** The 0.4 is `vti-rooms`' own;
+  the 0.2 arrives transitively under `openmls_rust_crypto`, through RustCrypto's
+  elliptic-curve stack, so no feature the crate declares can reach it — it needs
+  a direct `features = ["js"]` shim. Every failure here reports as a
+  `compile_error!` naming one version, which reads like an unsupported target and
+  is not.
+- **No `RUSTFLAGS` are needed.** An early probe set
+  `--cfg getrandom_backend="wasm_js"` and it was never removed to check; with
+  both getrandoms declared per-target with their features, the build is clean
+  without it. Worth stating because "you must also set RUSTFLAGS" is the kind of
+  detail that gets copied into a Dockerfile and never questioned.
 - **`dtg-credentials`' `affinidi-signing` feature is optional and default-on.**
   Turning it off drops `affinidi-secrets-resolver`, and `DTGCredential::sign`
   still works because `affinidi-data-integrity` takes a `Signer` **trait

--- a/vta-sdk/src/client/loopback.rs
+++ b/vta-sdk/src/client/loopback.rs
@@ -111,8 +111,13 @@ impl super::VtaClient {
     pub fn loopback(sink: Arc<dyn LoopbackSink>) -> Self {
         Self {
             // A loopback client never reaches a conforming consumer — the sink
-            // answers ahead of the transport — so there is nothing to sign for.
+            // answers ahead of the transport — so there is nothing to sign for,
+            // and by the same token nothing to verify: the sink returns a value,
+            // not a signed document, and it is intercepted before any reply
+            // verification could run.
             identity: None,
+            reply_resolver: Arc::new(tokio::sync::OnceCell::new()),
+            require_signed_replies: false,
             transport: super::Transport::Rest {
                 client: crate::http::rest_client(),
                 base_url: "http://loopback.invalid".to_string(),

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -259,6 +259,14 @@ pub struct VtaClient {
     /// identity yet fails at the VTA with a message naming the missing member,
     /// rather than at construction with one that does not.
     pub(super) identity: Option<std::sync::Arc<ClientIdentity>>,
+    /// Resolver for verifying reply proofs, built on first use and shared by
+    /// clones — a `DIDCacheClient` *is* a cache, so one per client is right and
+    /// one per call would defeat it.
+    pub(super) reply_resolver: std::sync::Arc<
+        tokio::sync::OnceCell<Option<affinidi_did_resolver_cache_sdk::DIDCacheClient>>,
+    >,
+    /// Whether an unsigned reply is refused. See [`VtaClient::trusting_unsigned_replies`].
+    pub(super) require_signed_replies: bool,
 }
 
 // ── Protocol response aliases ──────────────────────────────────────
@@ -426,6 +434,10 @@ impl VtaClient {
         Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            reply_resolver: std::sync::Arc::new(tokio::sync::OnceCell::new()),
+            // Refusing an unsigned reply is the default because a reply that
+            // attests to nothing is what this exists to stop being acceptable.
+            require_signed_replies: true,
             identity: None,
             transport: Transport::Rest {
                 client: crate::http::rest_client(),
@@ -472,6 +484,10 @@ impl VtaClient {
         Ok(Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            reply_resolver: std::sync::Arc::new(tokio::sync::OnceCell::new()),
+            // Refusing an unsigned reply is the default because a reply that
+            // attests to nothing is what this exists to stop being acceptable.
+            require_signed_replies: true,
             identity: Some(std::sync::Arc::new(identity)),
             transport: Transport::Rest {
                 client: http,
@@ -573,6 +589,10 @@ impl VtaClient {
         Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            reply_resolver: std::sync::Arc::new(tokio::sync::OnceCell::new()),
+            // Refusing an unsigned reply is the default because a reply that
+            // attests to nothing is what this exists to stop being acceptable.
+            require_signed_replies: true,
             identity: identity.map(std::sync::Arc::new),
             transport: Transport::DIDComm {
                 session,
@@ -843,6 +863,10 @@ impl VtaClient {
         Self {
             #[cfg(feature = "test-loopback")]
             loopback: None,
+            reply_resolver: std::sync::Arc::new(tokio::sync::OnceCell::new()),
+            // Refusing an unsigned reply is the default because a reply that
+            // attests to nothing is what this exists to stop being acceptable.
+            require_signed_replies: true,
             identity: identity.map(std::sync::Arc::new),
             transport: Transport::Tsp {
                 session: std::sync::Arc::new(session),
@@ -1772,7 +1796,7 @@ impl VtaClient {
                     ));
                 }
                 let response_doc: serde_json::Value = resp.json().await?;
-                Self::extract_trust_task_payload(response_doc)
+                self.finish_reply(response_doc).await
             }
             // The whole typed VTA surface over TSP. The VTA's inbound
             // dispatcher hands the unpacked payload straight to
@@ -1797,7 +1821,8 @@ impl VtaClient {
                     )
                     .await
                     .map_err(|e| VtaError::TspTransport(e.to_string()))?;
-                Self::extract_trust_task_payload(Self::decode_trust_task_reply(&reply)?)
+                self.finish_reply(Self::decode_trust_task_reply(&reply)?)
+                    .await
             }
             #[cfg(feature = "session")]
             Transport::DIDComm {
@@ -1832,9 +1857,9 @@ impl VtaClient {
                             .await
                             .map_err(|e| VtaError::TspTransport(e.to_string()))?,
                     };
-                    return Self::extract_trust_task_payload(Self::decode_trust_task_reply(
-                        &reply,
-                    )?);
+                    return self
+                        .finish_reply(Self::decode_trust_task_reply(&reply)?)
+                        .await;
                 }
 
                 const TRUST_TASK_ENVELOPE_TYPE: &str =
@@ -1847,7 +1872,7 @@ impl VtaClient {
                         timeout,
                     )
                     .await?;
-                Self::extract_trust_task_payload(response_doc)
+                self.finish_reply(response_doc).await
             }
         }
     }
@@ -1901,6 +1926,125 @@ impl VtaClient {
     fn decode_trust_task_reply(reply: &str) -> Result<serde_json::Value, VtaError> {
         serde_json::from_str(reply)
             .map_err(|e| VtaError::Protocol(format!("trust-task reply decode: {e}")))
+    }
+
+    /// Accept replies that carry no proof.
+    ///
+    /// **A staging control, not a preference.** 265 published specifications
+    /// require a proof on their response, and an agent that predates
+    /// OpenVTC/verifiable-trust-infrastructure#1334 and #1335 sends none — so a
+    /// client upgraded ahead of the agent it talks to would refuse every answer
+    /// it got. This exists so that ordering can be chosen rather than endured.
+    ///
+    /// It weakens the check to almost nothing while set: an attacker who can
+    /// rewrite a reply can also remove its proof, so this catches accidental
+    /// corruption and a wrong-signer reply and stops nobody. A *present* proof
+    /// is still verified and still bound to the expected agent.
+    ///
+    /// Turn it off again as soon as the agent is upgraded.
+    #[must_use]
+    pub fn trusting_unsigned_replies(mut self) -> Self {
+        self.require_signed_replies = false;
+        self
+    }
+
+    /// Verify the reply, then read it.
+    ///
+    /// # Why a client verifies at all
+    ///
+    /// A reply is bytes off a socket. Nothing else in this path establishes who
+    /// produced them: the transport proves a *connection*, and on REST it does
+    /// not even prove that much beyond TLS to a host name. Without the proof, an
+    /// intermediary can rewrite an ACL listing, flip a policy decision, or
+    /// answer for an agent that never spoke — and every check downstream passes,
+    /// because the checks downstream are about shape.
+    ///
+    /// SPEC §7.3 item 7 makes this the agent's obligation and this client's
+    /// business: a specification declaring a single `proofRequirement: REQUIRED`
+    /// binds its *response* as well as its request, and 265 of them do.
+    ///
+    /// # Two checks, and the second is the one easy to omit
+    ///
+    /// The proof must verify, **and its proven signer must be the agent this
+    /// client is talking to**. A proof by somebody else's key verifies perfectly
+    /// well; that it is not the party you expected is a separate comparison, and
+    /// skipping it turns "signed by somebody" into "signed by the agent".
+    ///
+    /// The expected signer is `ClientIdentity::vta_did`. A client with no
+    /// identity cannot produce conforming documents in the first place — it is
+    /// refused at the agent for a missing `recipient` — so there is nothing to
+    /// verify against and nothing worth verifying.
+    ///
+    /// # What is exempt
+    ///
+    /// An error document. Its `type` resolves to the framework's
+    /// `trust-task-error` specification, whose own proof requirement is
+    /// RECOMMENDED rather than REQUIRED (SPEC §8.1), so demanding one would make
+    /// every conforming refusal unreadable. A refusal confers nothing, which is
+    /// why the framework asks less of it.
+    async fn finish_reply(&self, doc: serde_json::Value) -> Result<serde_json::Value, VtaError> {
+        self.verify_reply(&doc).await?;
+        Self::extract_trust_task_payload(doc)
+    }
+
+    async fn verify_reply(&self, doc: &serde_json::Value) -> Result<(), VtaError> {
+        let Some(identity) = self.identity.as_ref() else {
+            return Ok(());
+        };
+        let doc_type = doc
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        if doc_type.starts_with("https://trusttasks.org/spec/trust-task-error/") {
+            return Ok(());
+        }
+
+        let parsed: trust_tasks_rs::TrustTask<serde_json::Value> =
+            serde_json::from_value(doc.clone()).map_err(|e| {
+                VtaError::Protocol(format!("reply is not a Trust-Task document: {e}"))
+            })?;
+
+        if parsed.proof.is_none() && !self.require_signed_replies {
+            return Ok(());
+        }
+
+        let resolver = self
+            .reply_resolver
+            .get_or_init(|| async {
+                affinidi_did_resolver_cache_sdk::DIDCacheClient::new(
+                    affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default()
+                        .build(),
+                )
+                .await
+                .ok()
+            })
+            .await;
+
+        // `None` means the resolver could not be built at all, which leaves a
+        // `did:key` signer verifiable and a `did:webvh` one refused by the
+        // resolver's own error — the honest outcome, and a legible one.
+        let vm_resolver =
+            crate::trust_task_proof::TrustTaskVmResolver::from_optional(resolver.clone());
+        let signer = crate::trust_task_proof::verify_trust_task_proof_with(&parsed, &vm_resolver)
+            .await
+            .map_err(|e| {
+                VtaError::Protocol(format!(
+                    "the reply from `{}` is unsigned or its proof does not verify ({e}). An \
+                     unsigned answer is bytes, not evidence — every specification that requires \
+                     a proof on its request requires one on its response too (SPEC §7.3 item 7)",
+                    identity.vta_did
+                ))
+            })?;
+
+        if signer != identity.vta_did {
+            return Err(VtaError::Protocol(format!(
+                "the reply claiming to come from `{}` is signed by `{signer}`. The proof \
+                 verifies, which means somebody really signed it — just not the agent this \
+                 client is talking to",
+                identity.vta_did
+            )));
+        }
+        Ok(())
     }
 
     /// Pull `payload` out of a framework trust-task response document. A success
@@ -2556,6 +2700,92 @@ mod tests {
             Some(VtaError::Forbidden(detail)) => assert!(detail.contains("did:key:zAlice")),
             other => panic!("expected Forbidden, got {other:?}"),
         }
+    }
+
+    // ── reply verification ──────────────────────────────────────────
+
+    /// A client with no identity has nothing to verify against — it cannot
+    /// produce a conforming request either, and is refused at the agent for a
+    /// missing `recipient`. Verifying would be checking a signature against an
+    /// expectation nobody holds.
+    #[tokio::test]
+    async fn a_client_with_no_identity_does_not_verify() {
+        let client = VtaClient::new("https://vta.example");
+        let doc = serde_json::json!({ "type": "https://trusttasks.org/spec/vta/contexts/list/1.0#response", "payload": {} });
+        client
+            .verify_reply(&doc)
+            .await
+            .expect("no identity, nothing to bind a signature to");
+    }
+
+    /// An unsigned success reply is refused by default, and the message says why
+    /// an unsigned answer is worthless rather than merely reporting a missing
+    /// field.
+    #[tokio::test]
+    async fn an_unsigned_reply_is_refused_by_default() {
+        let client = signed_reply_client();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000001",
+            "type": "https://trusttasks.org/spec/vta/contexts/list/1.0#response",
+            "issuer": "did:key:zAgent",
+            "recipient": "did:key:zClient",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            "payload": {}
+        });
+        let err = client
+            .verify_reply(&doc)
+            .await
+            .expect_err("an unsigned reply must not be believed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bytes, not evidence"),
+            "the refusal must say why, got: {msg}"
+        );
+    }
+
+    /// The staging control, which exists so an upgrade order can be chosen.
+    #[tokio::test]
+    async fn an_unsigned_reply_is_accepted_when_staging() {
+        let client = signed_reply_client().trusting_unsigned_replies();
+        let doc = serde_json::json!({
+            "id": "urn:uuid:00000000-0000-4000-8000-000000000001",
+            "type": "https://trusttasks.org/spec/vta/contexts/list/1.0#response",
+            "issuer": "did:key:zAgent",
+            "recipient": "did:key:zClient",
+            "issuedAt": "2026-01-01T00:00:00Z",
+            "payload": {}
+        });
+        client
+            .verify_reply(&doc)
+            .await
+            .expect("staging accepts an unsigned reply");
+    }
+
+    /// A refusal is exempt whatever the setting: `trust-task-error` declares its
+    /// proof RECOMMENDED, so requiring one would make every conforming refusal
+    /// unreadable — including the ones carrying the reason a caller needs.
+    #[tokio::test]
+    async fn an_error_document_needs_no_proof() {
+        let client = signed_reply_client();
+        let doc = serde_json::json!({
+            "type": "https://trusttasks.org/spec/trust-task-error/0.5",
+            "payload": { "code": "taskFailed", "message": "no" }
+        });
+        client
+            .verify_reply(&doc)
+            .await
+            .expect("a refusal needs no proof");
+    }
+
+    /// A client whose identity names the agent it talks to, so a reply has
+    /// something to be bound against.
+    fn signed_reply_client() -> VtaClient {
+        VtaClient::new("https://vta.example").with_identity(ClientIdentity {
+            client_did: "did:key:zClient".into(),
+            private_key_multibase: "z0".into(),
+            vta_did: "did:key:zAgent".into(),
+            verification_method: None,
+        })
     }
 
     // ── extract_trust_task_payload ──────────────────────────────────


### PR DESCRIPTION
A single public site where somebody with no wallet, no agent and no account can
mint their own `did:key` in the browser, be admitted to a data room named by a
DID, and read, write and curate its records — for **any** room, not a room the
site was built around.

Rooms are built; what is missing is a way for a person to *encounter* one. Every
existing client presumes a lot — `pnm-cli` presumes a provisioned VTA and a
shell, the browser plugin presumes an installed extension and a wallet already
bound to an agent. Neither is something you can put in a link.

## The decision

**The browser is the member**, not a client of one.

A shared custodial VTA holding every visitor's room keys demonstrates the wrong
thing, and is broken today besides: `rooms/keys/open` is gated on
`Capability::RoomOpen` and nothing else, and `room-group:{roomId}` carries no
principal — so co-tenants can open each other's rooms, and two members of one
room collide on a single row. A VTA is one principal's agent, and rooms are
stored as though that is true, because it is.

A VTA per visitor is honest and unusable: minutes to provision, a container per
curious stranger.

Browser-native looked like weeks of porting. It is not, and §3.1 records what was
built rather than argued: `vti-rooms`' member half compiles for
`wasm32-unknown-unknown` with its **sources unmodified**, because
`mls`/`sealed`/`retention` import nothing from `vti-common`. That is a property
of `error.rs` deliberately not using `AppError`. Shipped separately as
#1345.

## The section that is a correction, not a finding

§4.1 began as a claimed gap — "a room DID does not say where its host is" — and
it is not one. The specs state the absence and its reasons:
`rooms/keys/backfill/0.1` says the host is *"named by the caller because nothing
maps a room to its host"*, and `rooms/owner/register/0.1` notes a room may be
registered with more than one host, a mirror serving reads while its primary
takes writes. A single host pointer in the DID document would be **wrong**, not
merely stale.

The section is kept as a correction rather than deleted, because
`room.json`'s description claims portability by "re-point its service endpoint"
— pointing at a mechanism the document does not have, and the sentence that
caused the mistake. Rewording it is item 3 in §8.

## What is actually missing

Two things, and neither is demo scaffolding:

- **Admission is push-shaped.** The owner calls `rooms/keys/key-package` *on the
  member's VTA*. A browser tab has no DIDComm address and no inbox, so the
  ceremony has to invert to a pull.
- **Rooms have no join ceremony.** Twenty-two `rooms/*` tasks, not one a join
  request, where a VTC has `join-requests/*`. The demo's `POST /join` is an
  unspecified `rooms/join/*` worth upstreaming once its shape is known.

Because the browser is the member, a visitor needs **no VTA and no ACL entry** —
which deletes the self-enrolment problem entirely. The only backend is an
owner-side broker: a catalogue plus auto-admit, with each of the five owner acts
shown on screen rather than hidden behind a spinner.

§8 sequences the work as eight PRs. §9 lists what is still open, including the
one that matters most: a browser member that has been closed for a week needs to
catch up on missed commits, and where it fetches them from is not designed.

Docs only — no code.