### PR TITLE
feat(rooms): a `host` feature, so a room's member half reaches wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -781,6 +781,22 @@ jobs:
         run: cargo check -p vta-service --no-default-features --features azure-secrets,keyring,rest
       - name: vta-service tsp transport
         run: cargo check -p vta-service --features tsp
+      # A room's member half must not need a server. `vti-common` is optional
+      # behind `host`, and it is what pulls axum, fjall and tokio — so this is
+      # the check that `mls`/`sealed`/`retention` have not quietly acquired a
+      # dependency on one. It is also the *whole* precondition for the browser
+      # member: no store, no `AppError`, no runtime.
+      - name: vti-rooms member half (no host)
+        run: cargo clippy -p vti-rooms --no-default-features --features mls --all-targets -- -D warnings
+      # …and that the member half still reaches wasm, which is the property the
+      # feature exists for. `--lib` because the dev-dependencies (tokio) are
+      # native and do not need to reach wasm for this to hold.
+      - name: vti-rooms member half on wasm32
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo check -p vti-rooms --lib --no-default-features --features mls \
+            --target wasm32-unknown-unknown
+
       - name: vta-sdk attest-verify
         run: cargo check -p vta-sdk --features attest-verify
       - name: vta-sdk client + sealed-transfer + provision-integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6484,6 +6484,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b08d90fc020cb5354d5f08ca17711b84c82e2bcc7331753fd94f000d99a8c8"
 dependencies = [
+ "getrandom 0.4.3",
  "log",
  "openmls_serialization_helpers",
  "openmls_traits",
@@ -6492,6 +6493,7 @@ dependencies = [
  "serde_bytes",
  "thiserror 2.0.20",
  "tls_codec",
+ "web-time",
  "zeroize",
 ]
 
@@ -10957,6 +10959,7 @@ dependencies = [
  "base64 0.23.1",
  "chacha20poly1305 0.10.1",
  "chrono",
+ "getrandom 0.2.17",
  "getrandom 0.4.3",
  "openmls",
  "openmls_basic_credential",
@@ -11182,6 +11185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -168,7 +168,12 @@ dtg-credentials = { workspace = true }
 
 # The room MLS layer (custody, sealing) and the credential verifier whose
 # `VerificationKeys` an invitation check resolves through.
-vti-rooms = { path = "../vti-rooms", version = "0.1", features = ["mls"] }
+# The member half only. A VTA holds room keys, seals and opens records; it is
+# never a room's host, so it has no use for `storage`, `authz` or `audit` and
+# does not compile them. `default-features = false` is what says so.
+vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, features = [
+  "mls",
+] }
 vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.1" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -9,7 +9,23 @@ repository.workspace = true
 publish.workspace = true
 
 [features]
-default = []
+default = ["host"]
+# Everything a room's **host** needs, and the only reason this crate depends on
+# `vti-common`. On by default, because a host is what this crate was extracted
+# for; off, what remains is the member half — the group keys, sealing, the epoch
+# chain and the wire types — which needs no store, no `AppError`, and no server.
+#
+# The split is not new here, it was only unnamed: `vta-service` already uses
+# `mls`/`sealed`/`wire` and nothing else, while `vtc-service`, `room-host` and
+# `vti-rooms-dtg` use `storage`/`authz`/`audit`. Naming it is what lets the member
+# half build for `wasm32-unknown-unknown`, and so lets a browser be a real member
+# rather than a client of one. See `docs/05-design-notes/data-rooms-demo-site.md`.
+#
+# `lifecycle` is deliberately **not** gated. Only hosts consume it today, but it
+# needs nothing from `vti-common`, and a member computing a room's lifecycle
+# state to explain it on screen is a thing that should not require a host's
+# dependencies.
+host = ["dep:vti-common"]
 # The room's group-key layer (`mls`) and record sealing (`sealed`). Off by
 # default: a host that only stores ciphertext needs none of it, and OpenMLS is a
 # substantial dependency to make such a host carry. Mirrors how `vtc-service`
@@ -23,13 +39,18 @@ mls = [
   "dep:chacha20poly1305",
   "dep:base64",
   "dep:getrandom",
+  "dep:getrandom_02",
 ]
 
 [dependencies]
 # The store abstraction and AppError. This crate's only internal dependency:
 # a room's storage and authorization need nothing from a community service,
 # which is the whole reason they are extractable.
-vti-common = { path = "../vti-common", version = "0.18" }
+#
+# Optional, and load-bearing that it is: `vti-common` is server-side by its own
+# description and pulls axum, fjall and tokio, none of which build for wasm. It
+# is the `host` feature's whole content.
+vti-common = { path = "../vti-common", version = "0.18", optional = true }
 
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -51,6 +72,32 @@ getrandom = { version = "0.4", optional = true }
 # Verification may resolve a DID, so ChainVerifier is async; async-trait keeps it
 # dyn-compatible, as it does for vti_common::auth::backend.
 async-trait = "0.1"
+
+# On wasm, OpenMLS needs its `js` feature: it swaps `std::time` for `web-time`
+# (there is no `SystemTime` on `wasm32-unknown-unknown`) and routes randomness
+# through `getrandom`'s JS backend. Declared per-target rather than as a feature
+# of this crate so that building for wasm simply works, with nothing for a
+# consumer to remember — cargo unions these onto the general declaration above.
+#
+# **This is not sufficient on its own.** Two things the artifact crate must also
+# do, because neither can be set from here:
+#
+# `getrandom_02` is a **feature shim, not a dependency this crate calls**. There
+# are two getrandom majors in the graph: the 0.4 above, which `mls` uses
+# directly, and an 0.2 that RustCrypto's elliptic-curve stack pulls in under
+# `openmls_rust_crypto`. The second is transitive, so no feature declared for the
+# first can reach it — and without `js` it fails with a `compile_error!` saying
+# wasm "is not supported by default", which reads like an unsupported target and
+# is not. Naming it here turns the feature on for the whole graph.
+#
+# Doing it in this crate rather than leaving it to each artifact crate is
+# deliberate. The choice is target-specific and, on wasm32, there is only one
+# correct answer; the `cfg` means no native build can see it. The alternative is
+# a footgun in a doc comment, paid for once per consumer.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+openmls = { version = "0.9", features = ["js"], optional = true }
+getrandom = { version = "0.4", features = ["wasm_js"], optional = true }
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -49,17 +49,41 @@
 //!
 //! Three layers:
 //!
-//! - [`storage`] — the keyspaces and their invariants.
+//! - `storage` — the keyspaces and their invariants.
 //! - [`wire`] — the Trust-Task payload types, hand-written against the schemas in
 //!   `trustoverip/dtgwg-trust-tasks-tf#346` until the generated bindings publish.
-//! - [`authz`] — deciding whether an operation is allowed, **without reading any host's ACL
+//! - `authz` — deciding whether an operation is allowed, **without reading any host's ACL
 //!   or roster**. The invariant the whole design rests on.
+//!
+//! # Two halves, and the feature that names them
+//!
+//! A room has a host and it has members, and they need disjoint code. The `host` feature
+//! (on by default) carries `storage`, `authz` and `audit`; the `mls` feature carries the
+//! member's group keys, sealing and the epoch chain. `wire`, `error` and `lifecycle` are
+//! common to both.
+//!
+//! The division already existed and was simply unnamed — `vta-service` imports
+//! `mls`/`sealed`/`wire` and nothing else, while `vtc-service`, `room-host` and
+//! `vti-rooms-dtg` import `storage`/`authz`/`audit`. What naming it buys is that
+//! **`vti-common` becomes optional**, and with it every server dependency it carries:
+//! axum, fjall, tokio. `--no-default-features --features mls` therefore builds for
+//! `wasm32-unknown-unknown`, which is what lets a browser hold a room's keys itself
+//! instead of asking an agent to. See `docs/05-design-notes/data-rooms-demo-site.md`.
+//!
+//! That the member half needed **no source changes** to get there is a property of
+//! [`error`], which deliberately does not use `vti_common::error::AppError`: key material
+//! is not a service's concern, and a record that fails to open is an outcome rather than a
+//! fault. That decision was made for its own reasons and paid for itself here.
 //!
 //! The Trust-Task **handlers** are deliberately *not* here. Dispatch is a service's spine,
 //! and a spine is not extractable — see `docs/05-design-notes/vta-service-decomposition.md`.
 //! Each host writes its own thin handlers over these three layers.
 
+/// A room's audit trail, behind the `host` feature.
+#[cfg(feature = "host")]
 pub mod audit;
+/// Deciding whether a room operation is allowed, behind the `host` feature.
+#[cfg(feature = "host")]
 pub mod authz;
 pub mod error;
 pub mod lifecycle;
@@ -74,6 +98,8 @@ pub mod mls;
 pub mod retention;
 #[cfg(feature = "mls")]
 pub mod sealed;
+/// The room and record keyspaces, behind the `host` feature.
+#[cfg(feature = "host")]
 pub mod storage;
 pub mod wire;
 


### PR DESCRIPTION
`vti-rooms` already had two halves and no name for them:

| Consumer | Imports |
|---|---|
| `vta-service` (a member) | `mls`, `sealed`, `wire` |
| `vtc-service`, `room-host`, `vti-rooms-dtg` (hosts) | `storage`, `authz`, `audit`, `wire` |

This names the second half `host`, on by default, and makes `vti-common`
optional behind it.

`vti-common` describes itself as server-side infrastructure and pulls axum,
fjall and tokio — it was the whole of what kept a room's member code off
`wasm32-unknown-unknown`. With it optional, `--no-default-features --features
mls` builds there, which is what lets a browser hold a room's keys itself rather
than ask an agent to. Design: #1344.

**The member half needed no source changes.** That is a property of `error.rs`,
which deliberately does not use `vti_common::error::AppError` because key
material is not a service's concern — a decision made for its own reasons that
paid for itself here.

`lifecycle` is deliberately left ungated. Only hosts consume it today, but it
needs nothing from `vti-common`, and a member computing a room's lifecycle state
to explain it on screen should not need a host's dependencies.

## The wasm plumbing, and why it is per-target

Three things, each of which reports as a `compile_error!` that reads like an
unsupported target and is not:

- **OpenMLS 0.9 has a first-class `js` feature** — `web-time` for the
  `SystemTime` wasm lacks, plus getrandom's JS backend. Declared per-target
  rather than as a feature of this crate, so building for wasm just works with
  nothing for a consumer to remember. Verified wasm-only: `web-time` is in the
  wasm dependency tree and absent from the native one.
- **Two getrandom majors are in the graph.** The 0.4 is ours; the 0.2 arrives
  transitively under `openmls_rust_crypto` through RustCrypto's elliptic-curve
  stack, so no feature declared here could reach it. `getrandom_02` is a feature
  shim, not a dependency this crate calls — done here rather than left to each
  artifact crate because the choice is target-specific and on wasm32 there is
  only one right answer.
- **No `RUSTFLAGS` are needed.** With both declared per-target with their
  features, `--cfg getrandom_backend="wasm_js"` is unnecessary.

## Guards

Two steps in CI's `features` job, so neither property rots silently:

- clippy on the member half with no host (`-D warnings`);
- a wasm32 `--lib` check.

## Note for the version bump

Possibly breaking for an external consumer that already sets
`default-features = false` on `vti-rooms 0.1.x`: they previously got
`storage`/`authz`/`audit` and now get the member half. Consumers on default
features are unaffected — `default = ["host"]` gives them exactly what
`default = []` did. cargo-semver-checks builds with default features, so it will
not see this; flagging it rather than touching a `version =` field.

## Verified locally

- `cargo check --workspace --all-targets` — clean
- `cargo test -p vti-rooms` — 81 passed
- `cargo clippy -p vti-rooms --no-default-features --features mls --all-targets -- -D warnings` — clean
- `cargo check -p vti-rooms --lib --no-default-features --features mls --target wasm32-unknown-unknown` — clean