### PR TITLE
feat(rooms): a browser can be a room member

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -796,6 +796,18 @@ jobs:
           rustup target add wasm32-unknown-unknown
           cargo check -p vti-rooms --lib --no-default-features --features mls \
             --target wasm32-unknown-unknown
+      # The artifact itself, and its size. The size is reported rather than
+      # gated: a threshold picked today would either be slack enough to be
+      # meaningless or tight enough to fail on a dependency's patch release, and
+      # what a reviewer needs is the number in the log next to the diff that
+      # moved it.
+      - name: vti-rooms-wasm artifact
+        run: |
+          cargo build -p vti-rooms-wasm --profile wasm-release \
+            --target wasm32-unknown-unknown
+          f=target/wasm32-unknown-unknown/wasm-release/vti_rooms_wasm.wasm
+          echo "raw:      $(( $(wc -c < "$f") / 1024 )) KB"
+          echo "gzipped:  $(( $(gzip -9 -c "$f" | wc -c) / 1024 )) KB"
 
       - name: vta-sdk attest-verify
         run: cargo check -p vta-sdk --features attest-verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -781,6 +781,22 @@ jobs:
         run: cargo check -p vta-service --no-default-features --features azure-secrets,keyring,rest
       - name: vta-service tsp transport
         run: cargo check -p vta-service --features tsp
+      # A room's member half must not need a server. `vti-common` is optional
+      # behind `host`, and it is what pulls axum, fjall and tokio — so this is
+      # the check that `mls`/`sealed`/`retention` have not quietly acquired a
+      # dependency on one. It is also the *whole* precondition for the browser
+      # member: no store, no `AppError`, no runtime.
+      - name: vti-rooms member half (no host)
+        run: cargo clippy -p vti-rooms --no-default-features --features mls --all-targets -- -D warnings
+      # …and that the member half still reaches wasm, which is the property the
+      # feature exists for. `--lib` because the dev-dependencies (tokio) are
+      # native and do not need to reach wasm for this to hold.
+      - name: vti-rooms member half on wasm32
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo check -p vti-rooms --lib --no-default-features --features mls \
+            --target wasm32-unknown-unknown
+
       - name: vta-sdk attest-verify
         run: cargo check -p vta-sdk --features attest-verify
       - name: vta-sdk client + sealed-transfer + provision-integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,24 +3512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtg-credentials"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249ac520c8e0ebe2616af85ecb9377c9be49541267060c3157f906e4ce214445"
-dependencies = [
- "affinidi-data-integrity",
- "affinidi-secrets-resolver",
- "chrono",
- "multibase",
- "serde",
- "serde_json",
- "serde_json_canonicalizer",
- "sha2 0.11.0",
- "thiserror 2.0.20",
- "tracing",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10609,7 +10591,7 @@ dependencies = [
  "dialoguer",
  "didwebvh-rs",
  "dirs",
- "dtg-credentials 0.6.0",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "fjall",
  "futures-util",
@@ -10851,7 +10833,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "didwebvh-rs",
- "dtg-credentials 0.6.0",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "fjall",
  "flate2",
@@ -11016,7 +10998,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "chrono",
- "dtg-credentials 0.6.0",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "multibase",
@@ -11037,7 +11019,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "base64 0.23.1",
  "chrono",
- "dtg-credentials 0.7.0",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "futures-lite",
  "getrandom 0.4.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtg-credentials"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249ac520c8e0ebe2616af85ecb9377c9be49541267060c3157f906e4ce214445"
+dependencies = [
+ "affinidi-data-integrity",
+ "affinidi-secrets-resolver",
+ "chrono",
+ "multibase",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,6 +4064,19 @@ name = "futures-io"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -10578,7 +10609,7 @@ dependencies = [
  "dialoguer",
  "didwebvh-rs",
  "dirs",
- "dtg-credentials",
+ "dtg-credentials 0.6.0",
  "ed25519-dalek 3.0.0",
  "fjall",
  "futures-util",
@@ -10820,7 +10851,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "didwebvh-rs",
- "dtg-credentials",
+ "dtg-credentials 0.6.0",
  "ed25519-dalek 3.0.0",
  "fjall",
  "flate2",
@@ -10985,7 +11016,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "chrono",
- "dtg-credentials",
+ "dtg-credentials 0.6.0",
  "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "multibase",
@@ -11002,7 +11033,13 @@ dependencies = [
 name = "vti-rooms-wasm"
 version = "0.1.0"
 dependencies = [
+ "affinidi-secrets-resolver",
  "base64 0.23.1",
+ "chrono",
+ "dtg-credentials 0.7.0",
+ "ed25519-dalek 3.0.0",
+ "futures-lite",
+ "multibase",
  "serde",
  "serde_json",
  "vti-rooms",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6484,6 +6484,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b08d90fc020cb5354d5f08ca17711b84c82e2bcc7331753fd94f000d99a8c8"
 dependencies = [
+ "getrandom 0.4.3",
  "log",
  "openmls_serialization_helpers",
  "openmls_traits",
@@ -6492,6 +6493,7 @@ dependencies = [
  "serde_bytes",
  "thiserror 2.0.20",
  "tls_codec",
+ "web-time",
  "zeroize",
 ]
 
@@ -10957,6 +10959,7 @@ dependencies = [
  "base64 0.23.1",
  "chacha20poly1305 0.10.1",
  "chrono",
+ "getrandom 0.2.17",
  "getrandom 0.4.3",
  "openmls",
  "openmls_basic_credential",
@@ -11182,6 +11185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10999,6 +10999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "vti-rooms-wasm"
+version = "0.1.0"
+dependencies = [
+ "base64 0.23.1",
+ "serde",
+ "serde_json",
+ "vti-rooms",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vti-secrets"
 version = "0.3.3"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11033,12 +11033,14 @@ dependencies = [
 name = "vti-rooms-wasm"
 version = "0.1.0"
 dependencies = [
+ "affinidi-data-integrity",
  "affinidi-secrets-resolver",
  "base64 0.23.1",
  "chrono",
  "dtg-credentials 0.7.0",
  "ed25519-dalek 3.0.0",
  "futures-lite",
+ "getrandom 0.4.3",
  "multibase",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "vti-common",
   "vti-rooms",
   "vti-rooms-dtg",
+  "vti-rooms-wasm",
   "vti-secrets",
   "vti-webauthn",
 ]
@@ -448,6 +449,21 @@ debug = false
 lto = "thin"
 codegen-units = 1
 strip = true
+
+# The browser member's artifact, which is downloaded rather than installed, so
+# its size is a page-load cost paid by every visitor. Separate from `release`
+# because these settings trade compile time and native performance for bytes,
+# which is the right trade for one wasm module and the wrong one for the
+# services.
+#
+# Build with `cargo build -p vti-rooms-wasm --profile wasm-release --target
+# wasm32-unknown-unknown`. `wasm-opt -Oz` on top is worth another slice again,
+# but it is a separate tool and not a cargo concern.
+[profile.wasm-release]
+inherits = "release"
+opt-level = "z"
+lto = "fat"
+panic = "abort"
 
 # Workspace-wide lint policy. Each crate inherits via `lints.workspace = true`
 # in its own Cargo.toml. Per-crate `#[allow(...)]` overrides are still possible

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -168,7 +168,12 @@ dtg-credentials = { workspace = true }
 
 # The room MLS layer (custody, sealing) and the credential verifier whose
 # `VerificationKeys` an invitation check resolves through.
-vti-rooms = { path = "../vti-rooms", version = "0.1", features = ["mls"] }
+# The member half only. A VTA holds room keys, seals and opens records; it is
+# never a room's host, so it has no use for `storage`, `authz` or `audit` and
+# does not compile them. `default-features = false` is what says so.
+vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, features = [
+  "mls",
+] }
 vti-rooms-dtg = { path = "../vti-rooms-dtg", version = "0.1" }
 # Background TTL sweepers (acl/consent/vault), extracted and re-exported as
 # crate::{acl_sweeper,consent_sweeper,vault_sweeper}.

--- a/vti-rooms-wasm/Cargo.toml
+++ b/vti-rooms-wasm/Cargo.toml
@@ -33,6 +33,17 @@ vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, 
 # the verifying side with it. `affinidi-secrets-resolver` comes along and builds
 # for wasm regardless, since `affinidi-data-integrity` depends on it anyway.
 dtg-credentials = "0.7"
+# The member's own signing key lives here rather than in JavaScript, so the
+# private half never crosses the boundary. Both already arrive through OpenMLS
+# and data-integrity respectively; naming them is honesty about what is used.
+ed25519-dalek = { workspace = true }
+affinidi-secrets-resolver = { workspace = true }
+affinidi-data-integrity = { workspace = true }
+getrandom = { version = "0.4", features = ["wasm_js"] }
+# `sign` is async and this boundary is not; the future is CPU-bound with no I/O
+# in it, so blocking on it is exact rather than a workaround.
+futures-lite = "2"
+
 chrono = { workspace = true }
 multibase = { workspace = true }
 

--- a/vti-rooms-wasm/Cargo.toml
+++ b/vti-rooms-wasm/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "vti-rooms-wasm"
+description = "A data room's member half, for the browser — MLS group custody, record sealing, and the epoch key chain, compiled to WebAssembly"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# Not published to crates.io. This crate's artifact is a `.wasm` module and the
+# JS glue beside it; its distribution channel is npm, via `wasm-pack`, and a
+# crates.io release would ship source nobody consumes from there. `vti-rooms`
+# stays published — that is the reusable half.
+publish = false
+
+[lib]
+# `cdylib` is the wasm artifact; `rlib` keeps the crate testable natively, which
+# matters more than it looks: the round-trip tests below are the only place the
+# member half is exercised end to end outside a browser.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# The member half, and nothing else from the workspace. `default-features =
+# false` is the whole point: with `host` on, this would pull `vti-common` and
+# with it axum, fjall and tokio, none of which reach wasm.
+vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, features = [
+  "mls",
+] }
+
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+wasm-bindgen = "0.2"

--- a/vti-rooms-wasm/Cargo.toml
+++ b/vti-rooms-wasm/Cargo.toml
@@ -32,7 +32,17 @@ vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, 
 # behind `affinidi-signing`. Dropping the feature to avoid the signing side takes
 # the verifying side with it. `affinidi-secrets-resolver` comes along and builds
 # for wasm regardless, since `affinidi-data-integrity` depends on it anyway.
-dtg-credentials = "0.7"
+# **The workspace's pin, not one of this crate's own.**
+#
+# A browser member and the hosts it talks to must agree about how an authority chain
+# links, and they have already disagreed once: 0.7 changed a link's `parent` from the
+# parent's `id` to a digest of its claims, so a 0.7 `attenuate` against a 0.6
+# `verify_chain` is refused — worded as a broken chain rather than a version skew
+# ("names parent `zQm…`, but was presented after `urn:uuid:…`"). Taking the workspace
+# dependency makes that drift impossible to reintroduce: this crate cannot fall out of
+# step with `vtc-service`, `room-host` or `vti-rooms-dtg` without the workspace moving
+# too. See OpenVTC/dtg-credentials#22.
+dtg-credentials = { workspace = true }
 # The member's own signing key lives here rather than in JavaScript, so the
 # private half never crosses the boundary. Both already arrive through OpenMLS
 # and data-integrity respectively; naming them is honesty about what is used.

--- a/vti-rooms-wasm/Cargo.toml
+++ b/vti-rooms-wasm/Cargo.toml
@@ -27,7 +27,21 @@ vti-rooms = { path = "../vti-rooms", version = "0.1", default-features = false, 
   "mls",
 ] }
 
+# The invitation gate. Default features on, which is not what it looks like:
+# `verify_proof_with_public_key` — the whole of what a member needs — is itself
+# behind `affinidi-signing`. Dropping the feature to avoid the signing side takes
+# the verifying side with it. `affinidi-secrets-resolver` comes along and builds
+# for wasm regardless, since `affinidi-data-integrity` depends on it anyway.
+dtg-credentials = "0.7"
+chrono = { workspace = true }
+multibase = { workspace = true }
+
 base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = "0.2"
+
+[dev-dependencies]
+ed25519-dalek = { workspace = true }
+affinidi-secrets-resolver = { workspace = true }
+futures-lite = "2"

--- a/vti-rooms-wasm/src/identity.rs
+++ b/vti-rooms-wasm/src/identity.rs
@@ -203,8 +203,8 @@ impl MemberIdentity {
     ) -> Result<String, String> {
         let root: DTGCredential =
             serde_json::from_str(vac).map_err(|e| format!("authority credential: {e}"))?;
-        let membership: Value =
-            serde_json::from_str(vmc).map_err(|e| format!("membership credential: {e}"))?;
+        // Parsed only to fail early on something malformed — the *string* is what travels.
+        serde_json::from_str::<Value>(vmc).map_err(|e| format!("membership credential: {e}"))?;
 
         let now = Utc::now();
         let expires = now + PRESENTATION_LIFETIME;
@@ -225,16 +225,22 @@ impl MemberIdentity {
         futures_lite::future::block_on(leaf.sign(&secret, None))
             .map_err(|e| format!("sign the attenuated credential: {e}"))?;
 
-        let leaf_json = serde_json::to_value(leaf.credential())
+        let leaf_json = serde_json::to_string(leaf.credential())
             .map_err(|e| format!("serialise the attenuated credential: {e}"))?;
-        let root_json = serde_json::to_value(root.credential())
-            .map_err(|e| format!("serialise the authority credential: {e}"))?;
 
-        // Leaf first, then the credential the room issued. Every link the host will rely on
-        // is present, because the host will not fetch one.
+        // **Strings, not objects.** `AuthorityPresentation` types `membership` as a
+        // `String` and `authority` as `Vec<String>`; a host handed objects refuses the
+        // whole request as "invalid type: map, expected a string", which reads as a
+        // malformed payload rather than as a shape mismatch. The credential text is the
+        // wire form — `vti-rooms-dtg` decodes base64url or bare JSON — and the root is
+        // passed through exactly as received rather than re-serialised, so nothing this
+        // side can do to its bytes can affect whether its proof still verifies.
+        //
+        // Leaf first, then the credential the room issued. Every link the host will rely
+        // on is present, because the host will not fetch one.
         let mut presentation = serde_json::json!({
-            "membership": membership,
-            "authority": [leaf_json, root_json],
+            "membership": vmc,
+            "authority": [leaf_json, vac],
         });
         if let Some(nonce) = nonce {
             presentation["nonce"] = Value::String(nonce.to_string());

--- a/vti-rooms-wasm/src/identity.rs
+++ b/vti-rooms-wasm/src/identity.rs
@@ -213,7 +213,10 @@ impl MemberIdentity {
                 self.did.clone(),
                 vec![action.to_string()],
                 now,
-                expires,
+                // 0.6 takes an `Option` here; 0.7 made it required. Always `Some`: a
+                // presentation that does not expire is a standing grant, which is the one
+                // thing a presentation exists not to be.
+                Some(expires),
                 // Bound to us: the leaf may be presented by this member and nobody else.
                 Some(self.did.clone()),
             )

--- a/vti-rooms-wasm/src/identity.rs
+++ b/vti-rooms-wasm/src/identity.rs
@@ -1,0 +1,253 @@
+//! The member's own signing identity, held in wasm.
+//!
+//! Everything a member signs — the authority presentation's leaf, and the Trust-Task
+//! documents a host authenticates them by — is signed here, so the private key never
+//! crosses into JavaScript at all.
+//!
+//! That is a change from where this started. The first cut minted the key with WebCrypto
+//! and kept the JWK in `localStorage`, which put a raw private key in a page's heap and in
+//! a string store any script on the origin can read — and contradicted this crate's own
+//! rule that secrets do not cross the boundary. Minting it here costs nothing (the crate
+//! already links `ed25519-dalek` through OpenMLS) and means one place owns every secret the
+//! member has.
+//!
+//! The snapshot is the one exception, and the same exception the group snapshot is: it *is*
+//! key material, and the caller's job is to put it somewhere per-origin and per-device and
+//! nowhere else.
+//!
+//! # Why `did:key`
+//!
+//! Self-certifying: the verification key is the identifier, so a counterparty verifies a
+//! signature without resolving anything. A member who is a stranger with a link has no
+//! infrastructure to be reachable at, and needs none — which is exactly the case this whole
+//! demo exists for. It is also what lets `room-host` run its conservative `did:key`-only
+//! verifier, where no unauthenticated request can trigger a network lookup.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use chrono::{Duration, Utc};
+use dtg_credentials::DTGCredential;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// How long a minted presentation is good for.
+///
+/// Deliberately not a parameter. A caller that could ask for a year would be asking for the
+/// standing credential a presentation exists not to be — "the page needed longer" is a
+/// reason to mint again, not to mint longer. Matches `vta-service`'s oracle.
+const PRESENTATION_LIFETIME: Duration = Duration::hours(4);
+
+/// A member's signing identity: an Ed25519 key and the `did:key` it names.
+///
+/// `Debug` is hand-written rather than derived, and deliberately: a derived one prints the
+/// signing key, and the places a `Debug` reaches — a log line, a panic message, a test
+/// failure — are exactly the places key material must not turn up.
+pub struct MemberIdentity {
+    did: String,
+    signing: ed25519_dalek::SigningKey,
+}
+
+/// The stored form. **Key material** — see the module docs.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IdentityFile {
+    did: String,
+    /// The Ed25519 seed, base64url.
+    seed: String,
+}
+
+impl MemberIdentity {
+    /// Mint a fresh identity.
+    pub fn mint() -> Result<Self, String> {
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed).map_err(|e| format!("no randomness available: {e}"))?;
+        Ok(Self::from_seed(seed))
+    }
+
+    fn from_seed(seed: [u8; 32]) -> Self {
+        let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let mut multicodec = vec![0xed, 0x01];
+        multicodec.extend_from_slice(signing.verifying_key().as_bytes());
+        let did = format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, &multicodec)
+        );
+        Self { did, signing }
+    }
+
+    pub fn restore(snapshot: &str) -> Result<Self, String> {
+        let file: IdentityFile =
+            serde_json::from_str(snapshot).map_err(|e| format!("identity snapshot: {e}"))?;
+        let bytes = B64
+            .decode(file.seed.as_bytes())
+            .map_err(|e| format!("identity seed: {e}"))?;
+        let seed: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| "identity seed is not 32 bytes".to_string())?;
+        let restored = Self::from_seed(seed);
+        // A `did:key` is derived from its key, so a snapshot whose DID does not match its
+        // seed was edited or swapped. Cheap to check and it fails here rather than as an
+        // unexplained refusal from a host later.
+        if restored.did != file.did {
+            return Err("the identity snapshot's DID does not match its key".into());
+        }
+        Ok(restored)
+    }
+
+    pub fn snapshot(&self) -> Result<String, String> {
+        serde_json::to_string(&IdentityFile {
+            did: self.did.clone(),
+            seed: B64.encode(self.signing.to_bytes()),
+        })
+        .map_err(|e| e.to_string())
+    }
+
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    /// The `did:key` verification method: the multibase tag IS the fragment, by convention.
+    fn verification_method(&self) -> String {
+        format!("{}#{}", self.did, &self.did["did:key:".len()..])
+    }
+
+    fn secret(&self) -> Result<affinidi_secrets_resolver::secrets::Secret, String> {
+        affinidi_secrets_resolver::secrets::Secret::from_str(
+            &self.verification_method(),
+            &serde_json::json!({
+                "crv": "Ed25519",
+                "d": B64.encode(self.signing.to_bytes()),
+                "kty": "OKP",
+                "x": B64.encode(self.signing.verifying_key().as_bytes()),
+            }),
+        )
+        .map_err(|e| format!("build the signing secret: {e}"))
+    }
+
+    /// Attach this member's `eddsa-jcs-2022` proof to a JSON document.
+    ///
+    /// What a host authenticates a request by: it takes the presenter from the document's
+    /// own proof and never from a payload field, because a presentation says what may be
+    /// done and not who is doing it — an unbound one is a bearer token anyone observing it
+    /// inherits.
+    pub fn sign_document(&self, document: &str) -> Result<String, String> {
+        let mut doc: Value =
+            serde_json::from_str(document).map_err(|e| format!("document is not JSON: {e}"))?;
+        // A proof never covers itself.
+        doc.as_object_mut()
+            .ok_or("a signable document must be a JSON object")?
+            .remove("proof");
+
+        let secret = self.secret()?;
+        let proof =
+            futures_lite::future::block_on(affinidi_data_integrity::DataIntegrityProof::sign(
+                &doc,
+                &secret,
+                affinidi_data_integrity::SignOptions::new(),
+            ))
+            .map_err(|e| format!("sign the document: {e}"))?;
+
+        doc.as_object_mut()
+            .ok_or("a signable document must be a JSON object")?
+            .insert(
+                "proof".into(),
+                serde_json::to_value(&proof).map_err(|e| e.to_string())?,
+            );
+        serde_json::to_string(&doc).map_err(|e| e.to_string())
+    }
+
+    /// Mint an authority presentation for one action on one room.
+    ///
+    /// `vac` is the authority credential the room issued this member; `vmc` its membership
+    /// credential. The result is `{ membership, authority: [leaf, root], nonce }` — the
+    /// shape every host task takes and nothing else produces.
+    ///
+    /// # Attenuation, not issuance
+    ///
+    /// The leaf is derived from the root by `attenuate`, which refuses to widen. So asking
+    /// for an action this member does not hold fails in the credential library rather than
+    /// at a check here that somebody could forget to write — and it fails on *this* side,
+    /// where the member can be told why, rather than as a refusal from the host.
+    ///
+    /// # The subject is us, and that is the unusual part
+    ///
+    /// Server-side this attenuates to a separate agent, so the leaf's subject and the
+    /// chain root's differ. A browser member is its own agent, so here they are the same
+    /// DID — a shape the VTA's path never produces. The pooling defence compares the
+    /// chain's **root** subject rather than its leaf, so it holds either way; it is
+    /// asserted in the tests rather than assumed.
+    ///
+    /// # There is no `audience` parameter, and that is deliberate
+    ///
+    /// `audience` is not "who this is addressed to". `verify_chain` compares it to the
+    /// **presenter** — "the leaf must be presentable by whoever is presenting it" — so it is
+    /// holder binding, and its whole job is to make a captured presentation worthless to
+    /// anyone else. A browser member always presents its own, so the only correct value is
+    /// this member's DID, and offering the choice is offering a way to get it wrong.
+    ///
+    /// Which is not hypothetical. `vta-cli-common`'s `RoomTarget` passes the **host's** DID
+    /// as the audience, so `pnm-cli rooms --host-did …` mints a leaf bound to an audience
+    /// no presenter can ever match: the host refuses it as `WrongAudience` every time, while
+    /// omitting the flag leaves the presentation bearer-shaped for its four-hour life. Its
+    /// doc comment states the intent exactly — "with it, a captured presentation is
+    /// worthless to anyone else" — and names the wrong party to bind to.
+    ///
+    /// The `nonce` is the verifier's, echoed rather than interpreted: its value to them is
+    /// that it came back unchanged.
+    pub fn present(
+        &self,
+        vac: &str,
+        vmc: &str,
+        action: &str,
+        nonce: Option<&str>,
+    ) -> Result<String, String> {
+        let root: DTGCredential =
+            serde_json::from_str(vac).map_err(|e| format!("authority credential: {e}"))?;
+        let membership: Value =
+            serde_json::from_str(vmc).map_err(|e| format!("membership credential: {e}"))?;
+
+        let now = Utc::now();
+        let expires = now + PRESENTATION_LIFETIME;
+        let mut leaf = root
+            .attenuate(
+                self.did.clone(),
+                vec![action.to_string()],
+                now,
+                expires,
+                // Bound to us: the leaf may be presented by this member and nobody else.
+                Some(self.did.clone()),
+            )
+            .map_err(|e| {
+                format!("cannot narrow your authority for this room to `{action}`: {e}")
+            })?;
+
+        let secret = self.secret()?;
+        futures_lite::future::block_on(leaf.sign(&secret, None))
+            .map_err(|e| format!("sign the attenuated credential: {e}"))?;
+
+        let leaf_json = serde_json::to_value(leaf.credential())
+            .map_err(|e| format!("serialise the attenuated credential: {e}"))?;
+        let root_json = serde_json::to_value(root.credential())
+            .map_err(|e| format!("serialise the authority credential: {e}"))?;
+
+        // Leaf first, then the credential the room issued. Every link the host will rely on
+        // is present, because the host will not fetch one.
+        let mut presentation = serde_json::json!({
+            "membership": membership,
+            "authority": [leaf_json, root_json],
+        });
+        if let Some(nonce) = nonce {
+            presentation["nonce"] = Value::String(nonce.to_string());
+        }
+        serde_json::to_string(&presentation).map_err(|e| e.to_string())
+    }
+}
+
+impl std::fmt::Debug for MemberIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemberIdentity")
+            .field("did", &self.did)
+            .field("signing", &"<redacted>")
+            .finish()
+    }
+}

--- a/vti-rooms-wasm/src/invitation.rs
+++ b/vti-rooms-wasm/src/invitation.rs
@@ -1,0 +1,188 @@
+//! Verifying a room invitation, in the browser.
+//!
+//! A **VIC** is the consent artefact: joining a room is a two-party act, and this is the
+//! other party's half. The gate belongs on the *member's* side, which is the part that looks
+//! wrong at first — an attacker would simply not check — so it is worth stating what it
+//! actually defends.
+//!
+//! It is not defending the room. It defends **this key holder**:
+//!
+//! - Minting a KeyPackage retains a private key against a Welcome that may never come. A
+//!   key holder that minted for anyone is one anyone can fill.
+//! - A Welcome carries a group's secrets. A key holder that accepted an uninvited one would
+//!   hold keys for a room nobody agreed to join — and would have made the invitation
+//!   decorative.
+//!
+//! The room's own protection is separate and lives at the owner, who refuses to add a
+//! KeyPackage from a DID it never invited. Two checks, two parties, two different threats;
+//! neither substitutes for the other.
+//!
+//! # Five checks, and none is optional
+//!
+//! Ported from `vta-service`'s `operations::room_invitation`, deliberately including its
+//! order — the cheap structural checks first, then the signature, then the spent-set — so a
+//! malformed or irrelevant credential costs nothing.
+//!
+//! 1. It parses, and it is an **invitation** rather than some other credential the sender
+//!    had lying around.
+//! 2. The **issuer is this room**. An invitation to a different room is not one to this one,
+//!    however valid.
+//! 3. The **subject is us**. An invitation is not transferable.
+//! 4. It is **within its validity window**, its proof's key **belongs to the issuer**, and
+//!    the **proof verifies**. Everything above is a claim until this holds: a well-formed
+//!    invitation naming anyone is trivial to write, and a proof that verifies only means
+//!    *somebody* signed it — the binding to the issuer is what makes it the room.
+//! 5. It is **not already spent**.
+//!
+//! Dropping any one leaves a way in. This is a second copy of a gate that already exists in
+//! `vta-service`, which is exactly how one of them ends up a check short — it belongs in
+//! `vti-rooms` where both can share it, and that is a follow-up rather than a demo concern.
+//!
+//! # Why no resolver
+//!
+//! The proof is checked against raw public-key bytes, and a room identified by a `did:key`
+//! carries its own key in its identifier. So verification is lexical: no network, no cache,
+//! nothing to be offline. A `did:webvh` room — what production mints — would need real
+//! resolution, and that is the one thing this module would grow.
+
+use chrono::Utc;
+use dtg_credentials::{DTGCredential, DTGCredentialType};
+
+/// What a verified invitation yields: the id to record as spent, and nothing else worth
+/// carrying. Constructible only by [`verify`], so a caller cannot reach the spending step
+/// with an invitation nobody checked.
+#[derive(Debug)]
+pub struct VerifiedInvitation {
+    pub credential_id: String,
+}
+
+/// The Ed25519 public key a `did:key` verification method names.
+///
+/// `did:key:z6Mk…#z6Mk…` — the fragment is the identifier, so the key is *in* the name. The
+/// multibase decodes to a two-byte multicodec prefix (`0xed 0x01`, Ed25519) and 32 bytes of
+/// key.
+fn did_key_public_key(verification_method: &str) -> Result<Vec<u8>, String> {
+    let did = verification_method
+        .split('#')
+        .next()
+        .unwrap_or(verification_method);
+    let multibase = did
+        .strip_prefix("did:key:")
+        .ok_or_else(|| format!("`{did}` is not a did:key, and this build resolves nothing else"))?;
+    let (_base, bytes) =
+        multibase::decode(multibase).map_err(|e| format!("decode `{did}`: {e}"))?;
+    match bytes.split_at_checked(2) {
+        Some(([0xed, 0x01], key)) if key.len() == 32 => Ok(key.to_vec()),
+        _ => Err(format!(
+            "`{did}` does not name an Ed25519 key; a room signs with Ed25519"
+        )),
+    }
+}
+
+/// Run the five checks. `spent` is the set of credential ids this key holder has already
+/// consumed — held by the caller because that is where storage belongs, and passed in rather
+/// than checked afterwards so that all five live in one place.
+pub fn verify(
+    encoded: &str,
+    room_id: &str,
+    expected_subject: &str,
+    spent: &[String],
+) -> Result<VerifiedInvitation, String> {
+    // 1. It parses, and it is an invitation.
+    let credential: DTGCredential = decode(encoded)?;
+    if !matches!(credential.type_(), DTGCredentialType::Invitation) {
+        return Err(format!(
+            "the presented credential is a {}, not an invitation",
+            credential.type_()
+        ));
+    }
+
+    // 2. The issuer is this room.
+    if credential.issuer() != room_id {
+        return Err(format!(
+            "the invitation was issued by `{}`, not by room `{room_id}`",
+            credential.issuer()
+        ));
+    }
+
+    // 3. The subject is us.
+    if credential.subject() != expected_subject {
+        return Err(format!(
+            "the invitation names `{}`, not you — an invitation is not transferable",
+            credential.subject()
+        ));
+    }
+
+    // 4. In window, and the proof verifies.
+    let now = Utc::now();
+    let common = credential.credential();
+    if common.valid_from > now {
+        return Err("the invitation is not valid yet".into());
+    }
+    if let Some(until) = common.valid_until
+        && until < now
+    {
+        return Err("the invitation has expired".into());
+    }
+    let proof = common
+        .proof
+        .as_ref()
+        .ok_or("the invitation carries no proof")?;
+
+    // The proof's key must belong to the **issuer**, and this is not implied by
+    // anything above it.
+    //
+    // `verify_proof_with_public_key` checks a signature against whatever bytes it is
+    // handed; resolving the verification method the proof names and verifying against
+    // *that* proves only that somebody signed it — which is true of a forgery. Without
+    // this line an attacker mints an invitation naming the room as issuer, signs it with
+    // their own key, points the proof at their own verification method, and every other
+    // check here passes.
+    //
+    // Found by writing a test per clause rather than one "a bad invitation is refused"
+    // case: the forgery clause was the only one that did not bite.
+    let vm_controller = proof
+        .verification_method
+        .split('#')
+        .next()
+        .unwrap_or(&proof.verification_method);
+    if vm_controller != credential.issuer() {
+        return Err(format!(
+            "the invitation says room `{}` issued it but is signed by `{vm_controller}` — a \
+             proof that verifies only means somebody signed it, not that the issuer did",
+            credential.issuer()
+        ));
+    }
+
+    let key = did_key_public_key(&proof.verification_method)?;
+    credential
+        .verify_proof_with_public_key(&key)
+        .map_err(|e| format!("the invitation's proof did not verify: {e}"))?;
+
+    // 5. Not already spent. Without an id there is nothing to record, and an invitation
+    //    that cannot be spent is one that can be spent forever.
+    let credential_id = credential
+        .id()
+        .ok_or("the invitation carries no id, so it cannot be recorded as used")?
+        .to_string();
+    if spent.contains(&credential_id) {
+        return Err(format!(
+            "invitation `{credential_id}` has already been used"
+        ));
+    }
+
+    Ok(VerifiedInvitation { credential_id })
+}
+
+/// Accept base64url or bare JSON — the same profile the room verifier reads.
+fn decode(encoded: &str) -> Result<DTGCredential, String> {
+    let trimmed = encoded.trim();
+    if trimmed.starts_with('{') {
+        return serde_json::from_str(trimmed).map_err(|e| format!("invitation JSON: {e}"));
+    }
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(trimmed.as_bytes())
+        .map_err(|e| format!("invitation base64: {e}"))?;
+    serde_json::from_slice(&bytes).map_err(|e| format!("invitation JSON: {e}"))
+}

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -54,6 +54,7 @@
 //! whose leaf nobody added, which fails at the first read looking like a bad Welcome rather
 //! than a wrong identity.
 
+pub mod identity;
 pub mod invitation;
 
 use base64::Engine as _;
@@ -145,6 +146,67 @@ pub fn mint_key_package_js(
     spent: &str,
 ) -> Result<String, JsError> {
     mint_key_package(member_did, room_id, invitation, spent).map_err(js)
+}
+
+/// A member's signing identity — the JS boundary over [`identity::MemberIdentity`].
+///
+/// Every secret this member has now lives on this side: the Ed25519 key that names their
+/// `did:key` and signs, and the MLS keys inside [`RoomMember`]. JavaScript holds two opaque
+/// snapshots and no key.
+#[wasm_bindgen]
+pub struct Identity {
+    inner: identity::MemberIdentity,
+}
+
+#[wasm_bindgen]
+impl Identity {
+    /// Mint a fresh `did:key`.
+    #[wasm_bindgen(js_name = mint)]
+    pub fn mint_js() -> Result<Identity, JsError> {
+        identity::MemberIdentity::mint()
+            .map(|inner| Identity { inner })
+            .map_err(js)
+    }
+
+    /// Restore one from [`Identity::snapshot`].
+    #[wasm_bindgen(js_name = restore)]
+    pub fn restore_js(snapshot: &str) -> Result<Identity, JsError> {
+        identity::MemberIdentity::restore(snapshot)
+            .map(|inner| Identity { inner })
+            .map_err(js)
+    }
+
+    /// **Key material.** Per-origin, per-device storage and nowhere else — anyone holding
+    /// this is this member.
+    #[wasm_bindgen(js_name = snapshot)]
+    pub fn snapshot_js(&self) -> Result<String, JsError> {
+        self.inner.snapshot().map_err(js)
+    }
+
+    #[wasm_bindgen(getter, js_name = did)]
+    pub fn did_js(&self) -> String {
+        self.inner.did().to_string()
+    }
+
+    /// See [`identity::MemberIdentity::sign_document`].
+    #[wasm_bindgen(js_name = signDocument)]
+    pub fn sign_document_js(&self, document: &str) -> Result<String, JsError> {
+        self.inner.sign_document(document).map_err(js)
+    }
+
+    /// See [`identity::MemberIdentity::present`].
+    #[wasm_bindgen(js_name = present)]
+    pub fn present_js(
+        &self,
+        vac: &str,
+        vmc: &str,
+        action: &str,
+        nonce: Option<String>,
+    ) -> Result<String, JsError> {
+        self.inner
+            .present(vac, vmc, action, nonce.as_deref())
+            .map_err(js)
+    }
 }
 
 /// Run the five invitation checks and return the credential id to record as spent.
@@ -512,6 +574,187 @@ mod tests {
             restored.epoch(),
             "with no links, the earliest readable epoch is the current one"
         );
+    }
+
+    /// A room grants a member `read`; the browser narrows it to one action and signs; the
+    /// **real chain verifier** accepts it.
+    ///
+    /// This is the assertion the whole authority slice rests on, and it is deliberately
+    /// made against `dtg_credentials::authority::verify_chain` — the same function a host
+    /// runs — rather than against a restatement of what it ought to do.
+    ///
+    /// It also pins the shape that is unusual here. Server-side, a presentation attenuates
+    /// to a *separate agent*, so the leaf's subject differs from the chain root's. A browser
+    /// member is its own agent, so they are the same DID: a case the VTA's path never
+    /// produces. The pooling defence compares the chain's **root** subject rather than its
+    /// leaf, so it should hold — asserted here rather than assumed.
+    #[test]
+    fn a_browser_minted_presentation_verifies_against_the_real_chain_verifier() {
+        use dtg_credentials::authority::verify_chain;
+
+        let (room, room_secret) = a_room(0x31);
+        let me = crate::identity::MemberIdentity::mint().unwrap();
+        let now = chrono::Utc::now();
+
+        // The room grants this member `read` and `curate` at its own scope.
+        let mut vac = dtg_credentials::DTGCredential::new_vac(
+            room.clone(),
+            me.did().to_string(),
+            room.clone(),
+            vec!["read".into(), "curate".into()],
+            now - chrono::Duration::minutes(1),
+            now + chrono::Duration::days(30),
+        )
+        .expect("mint the room's authority credential")
+        .with_id("urn:uuid:vac-1");
+        futures_lite::future::block_on(vac.sign(&room_secret, None)).unwrap();
+        let vac_json = serde_json::to_string(vac.credential()).unwrap();
+        let vmc_json = serde_json::json!({ "id": "urn:uuid:vmc-1" }).to_string();
+
+        let presentation: serde_json::Value = serde_json::from_str(
+            &me.present(&vac_json, &vmc_json, "read", Some("n-1"))
+                .expect("mint a presentation"),
+        )
+        .unwrap();
+
+        // Echoed unchanged: its value to the verifier is that it came back as sent.
+        assert_eq!(presentation["nonce"], "n-1");
+
+        let chain: Vec<dtg_credentials::DTGCredential> =
+            serde_json::from_value(presentation["authority"].clone()).unwrap();
+        assert_eq!(
+            chain.len(),
+            2,
+            "leaf first, then the credential the room issued"
+        );
+
+        verify_chain(&chain, &room, &room, "read", me.did(), chrono::Utc::now())
+            .expect("the host's own verifier must accept what the browser minted");
+
+        // The narrowing is real: `curate` is held at the root but was not asked for, so the
+        // leaf does not carry it. A presentation is for one action.
+        assert!(
+            verify_chain(&chain, &room, &room, "curate", me.did(), chrono::Utc::now()).is_err(),
+            "a presentation minted for `read` must not authorise `curate`"
+        );
+    }
+
+    /// A captured presentation is worthless to anyone else.
+    ///
+    /// This is what the `audience` binding buys, and the reason [`identity::MemberIdentity::present`]
+    /// takes no audience parameter: bound to the member, a presentation somebody observes on
+    /// the wire authorises nothing when they present it themselves.
+    ///
+    /// Worth pinning because the same field, filled with the *host's* DID instead, refuses
+    /// the legitimate presenter and protects nobody — which is what `vta-cli-common` does
+    /// today.
+    #[test]
+    fn a_captured_presentation_does_not_work_for_whoever_captured_it() {
+        use dtg_credentials::authority::verify_chain;
+
+        let (room, room_secret) = a_room(0x33);
+        let me = crate::identity::MemberIdentity::mint().unwrap();
+        let thief = crate::identity::MemberIdentity::mint().unwrap();
+        let now = chrono::Utc::now();
+
+        let mut vac = dtg_credentials::DTGCredential::new_vac(
+            room.clone(),
+            me.did().to_string(),
+            room.clone(),
+            vec!["read".into()],
+            now - chrono::Duration::minutes(1),
+            now + chrono::Duration::days(30),
+        )
+        .unwrap()
+        .with_id("urn:uuid:vac-3");
+        futures_lite::future::block_on(vac.sign(&room_secret, None)).unwrap();
+
+        let presentation: serde_json::Value = serde_json::from_str(
+            &me.present(
+                &serde_json::to_string(vac.credential()).unwrap(),
+                "{}",
+                "read",
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let chain: Vec<dtg_credentials::DTGCredential> =
+            serde_json::from_value(presentation["authority"].clone()).unwrap();
+
+        // The rightful member: accepted.
+        verify_chain(&chain, &room, &room, "read", me.did(), chrono::Utc::now()).unwrap();
+
+        // Whoever lifted it off the wire: refused, and refused as a wrong audience rather
+        // than as a bad signature — the chain is perfectly valid, it is just not theirs.
+        let err = verify_chain(
+            &chain,
+            &room,
+            &room,
+            "read",
+            thief.did(),
+            chrono::Utc::now(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                dtg_credentials::authority::AuthorityError::WrongAudience { .. }
+            ),
+            "expected a WrongAudience refusal, got {err:?}"
+        );
+    }
+
+    /// `attenuate` refuses to widen, and it refuses on *this* side.
+    ///
+    /// Asking for an action the member does not hold fails in the credential library, where
+    /// the member can be told why — rather than as a refusal from a host, which arrives
+    /// worded as though the member were at fault.
+    #[test]
+    fn a_member_cannot_ask_for_more_than_the_room_gave_them() {
+        let (room, room_secret) = a_room(0x32);
+        let me = crate::identity::MemberIdentity::mint().unwrap();
+        let now = chrono::Utc::now();
+
+        let mut vac = dtg_credentials::DTGCredential::new_vac(
+            room.clone(),
+            me.did().to_string(),
+            room.clone(),
+            vec!["read".into()],
+            now - chrono::Duration::minutes(1),
+            now + chrono::Duration::days(30),
+        )
+        .unwrap()
+        .with_id("urn:uuid:vac-2");
+        futures_lite::future::block_on(vac.sign(&room_secret, None)).unwrap();
+        let vac_json = serde_json::to_string(vac.credential()).unwrap();
+        let vmc_json = "{}".to_string();
+
+        let refused = me.present(&vac_json, &vmc_json, "write", None).unwrap_err();
+        assert!(
+            refused.contains("cannot narrow your authority"),
+            "{refused}"
+        );
+    }
+
+    /// An identity survives a restart, and a tampered snapshot does not load.
+    #[test]
+    fn an_identity_round_trips_and_refuses_a_mismatched_snapshot() {
+        let me = crate::identity::MemberIdentity::mint().unwrap();
+        let snapshot = me.snapshot().unwrap();
+        let back = crate::identity::MemberIdentity::restore(&snapshot).unwrap();
+        assert_eq!(back.did(), me.did());
+
+        // A `did:key` is derived from its key, so a snapshot naming a different DID is one
+        // that was edited. It fails here rather than as an unexplained refusal from a host.
+        let other = crate::identity::MemberIdentity::mint().unwrap();
+        let swapped: serde_json::Value = serde_json::from_str(&snapshot).unwrap();
+        let mut swapped = swapped.as_object().unwrap().clone();
+        swapped.insert("did".into(), other.did().into());
+        let err =
+            crate::identity::MemberIdentity::restore(&serde_json::to_string(&swapped).unwrap())
+                .unwrap_err();
+        assert!(err.contains("does not match its key"), "{err}");
     }
 
     /// Each of the five checks, made to bite.

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -1,0 +1,448 @@
+//! A data room's **member half**, for a browser.
+//!
+//! Everything a member does with a room's keys — holding the MLS group, sealing a record,
+//! opening one, and walking the epoch key chain — with none of what a host does. The
+//! implementation is [`vti_rooms`]; this crate is the boundary, and its whole job is to
+//! decide what crosses it.
+//!
+//! # Why this exists at all
+//!
+//! Until now a member's keys lived in a VTA, and every browser surface was a *client* of
+//! one: the wallet plugin drives an agent, `pnm-cli` drives an agent. That is right for an
+//! agent's principal and wrong for a stranger with a link, who has no agent and should not
+//! need one to look inside a room. With this, a tab is a member — it holds the group,
+//! opens what it is entitled to, and asks a host for nothing it could compute itself.
+//!
+//! # The rule at the boundary
+//!
+//! **Secrets do not cross.** Everything that leaves this module is either public (a
+//! KeyPackage, ciphertext, an epoch number) or a snapshot that is opaque to JavaScript and
+//! meant only to be handed back. Nothing returns a group key, a signature key, or a leaf
+//! secret, and no method takes one — because a key that crosses into JS is a key in a
+//! string, in a heap the page shares with everything else on it.
+//!
+//! A snapshot is the exception that proves it: it *is* key material, base64 inside JSON,
+//! and it exists because OpenMLS persists a group through its provider rather than as a
+//! value. The caller's job is to put it in IndexedDB and nowhere else. It is not a
+//! backup format and must never be sent anywhere.
+//!
+//! # Two layers, and why the inner one exists
+//!
+//! Every method appears twice: a plain Rust one carrying the logic, and a thin
+//! `#[wasm_bindgen]` wrapper that only converts the error. That is not ceremony —
+//! `JsError` and `JsValue` are *imported JS functions*, so constructing one on a native
+//! target panics outright. A crate whose only entry points were wrapped would therefore
+//! have no reachable native tests at all, and the tests worth having here are exactly the
+//! ones that assert a failure: a record that must not open at the wrong version, a stale
+//! snapshot that must refuse rather than return garbage. Those are unreachable through the
+//! wrapper, so the logic lives below it.
+//!
+//! # Shape of the API
+//!
+//! JSON strings in and out, `Uint8Array` for record bodies. Deliberately not
+//! `serde-wasm-bindgen`: the structures crossing here are small, they are the published
+//! `rooms/*` wire types, and a JSON string is the form they already travel in over the
+//! network — so the boundary speaks the same language as the transport and there is one
+//! fewer representation to get wrong.
+//!
+//! # Joining is two calls, and they are days apart
+//!
+//! [`mint_key_package`] produces an identity and the KeyPackage to send; [`RoomMember::join`]
+//! consumes both when the Welcome comes back. Between them the identity snapshot **is
+//! retained private key material** — that is why minting is not free and why a member who
+//! never joins should discard it. Joining with a *fresh* identity instead produces a group
+//! whose leaf nobody added, which fails at the first read looking like a bad Welcome rather
+//! than a wrong identity.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use serde::{Deserialize, Serialize};
+use vti_rooms::mls::{GroupSnapshot, IdentitySnapshot, RoomGroup};
+use vti_rooms::sealed::SealedRoom;
+use vti_rooms::wire::{EpochLink, SealedContent};
+use wasm_bindgen::prelude::*;
+
+/// What [`mint_key_package`] returns: the half to keep, and the half to send.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MintedIdentity {
+    /// Retain this — privately. The Welcome will be sealed to it.
+    identity: IdentitySnapshot,
+    /// Send this to the room's owner. Public.
+    key_package: String,
+}
+
+/// What [`RoomMember::apply_commit`] returns.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CommitApplied {
+    /// The room epoch after the commit.
+    epoch: u32,
+    /// The rung this commit produced, or `null` for the first one.
+    link: Option<EpochLink>,
+}
+
+/// Everything needed to reconstruct a [`RoomMember`].
+///
+/// Three parts because they have three different lifetimes: the room id never changes, the
+/// group advances with every commit, and the links only ever accumulate.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MemberSnapshot {
+    room_id: String,
+    group: GroupSnapshot,
+    /// Ascending. Ciphertext — a party holding no epoch key learns nothing from them.
+    #[serde(default)]
+    links: Vec<EpochLink>,
+}
+
+fn err(e: impl std::fmt::Display) -> String {
+    e.to_string()
+}
+
+/// The only place a JS error is constructed. See the module docs on why it is only here.
+fn js(e: String) -> JsError {
+    JsError::new(&e)
+}
+
+/// Mint an identity and a KeyPackage for **one** room.
+///
+/// Returns `{ identity, keyPackage }` as JSON. Send `keyPackage` to the room's owner and
+/// keep `identity` until the Welcome arrives.
+///
+/// **One per room, never reused.** A KeyPackage is a stable public identifier, so offering
+/// the same one to two rooms tells anybody who sees both that one party is in both — the
+/// correlation a `private` room exists to deny, arriving through the door rather than
+/// through the wall.
+pub fn mint_key_package(member_did: &str) -> Result<String, String> {
+    let (identity, key_package) = IdentitySnapshot::mint(member_did).map_err(err)?;
+    serde_json::to_string(&MintedIdentity {
+        identity,
+        key_package: B64.encode(key_package),
+    })
+    .map_err(err)
+}
+
+/// See [`mint_key_package`].
+#[wasm_bindgen(js_name = mintKeyPackage)]
+pub fn mint_key_package_js(member_did: &str) -> Result<String, JsError> {
+    mint_key_package(member_did).map_err(js)
+}
+
+/// One room this browser can open.
+///
+/// Holds the MLS group and the epoch key chain. Every method that resolves a key takes
+/// `&mut self`, because walking the chain memoises what it derives — opening a room's
+/// history is one walk, not one per record.
+#[wasm_bindgen]
+pub struct RoomMember {
+    inner: SealedRoom,
+}
+
+impl RoomMember {
+    /// Accept a Welcome, using the identity whose KeyPackage the owner added.
+    ///
+    /// `minted` is the JSON from [`mint_key_package`]; `welcome` is the Welcome bytes the
+    /// owner sent. The identity is consumed here and should be discarded afterwards.
+    ///
+    /// Fails rather than half-joining if the Welcome was not sealed to this identity.
+    pub fn join(room_id: &str, minted: &str, welcome: &[u8]) -> Result<RoomMember, String> {
+        let minted: MintedIdentity = serde_json::from_str(minted).map_err(err)?;
+        let group = RoomGroup::join_from_identity(&minted.identity, welcome).map_err(err)?;
+        Ok(RoomMember {
+            inner: SealedRoom::new(room_id, group),
+        })
+    }
+
+    /// Reconstruct from a snapshot previously returned by [`RoomMember::snapshot`].
+    pub fn restore(snapshot: &str) -> Result<RoomMember, String> {
+        let snap: MemberSnapshot = serde_json::from_str(snapshot).map_err(err)?;
+        let group = RoomGroup::restore(&snap.group).map_err(err)?;
+        let mut inner = SealedRoom::new(snap.room_id, group);
+        inner.add_links(snap.links);
+        Ok(RoomMember { inner })
+    }
+
+    /// Everything needed to reconstruct this member, as JSON.
+    ///
+    /// **This is key material.** It belongs in IndexedDB on this device and nowhere else:
+    /// not in `localStorage` a script can read as a string, not in a URL, not in a
+    /// "backup" sent anywhere. Anyone holding it can read every record this member can.
+    ///
+    /// Take a fresh one after every call that advances the group — [`RoomMember::join`],
+    /// [`RoomMember::apply_commit`] — or the next restore comes back at the old epoch and
+    /// every record written since fails to open, which reads as corruption rather than as
+    /// a snapshot that was not saved.
+    pub fn snapshot(&self) -> Result<String, String> {
+        serde_json::to_string(&MemberSnapshot {
+            room_id: self.inner.room_id().to_string(),
+            group: self.inner.group().snapshot().map_err(err)?,
+            links: self.inner.links(),
+        })
+        .map_err(err)
+    }
+
+    /// The room this member belongs to.
+    pub fn room_id(&self) -> String {
+        self.inner.room_id().to_string()
+    }
+
+    /// The epoch this member is at.
+    ///
+    /// Behind the room's own epoch means a commit has not been delivered — not that
+    /// anything is lost. Show it beside [`RoomMember::earliest_readable_epoch`]: they are
+    /// different repairs, and collapsing them into one number makes "less history than I
+    /// expected" read as loss rather than as a delivery that has not happened yet.
+    pub fn epoch(&self) -> u32 {
+        self.inner.room_epoch()
+    }
+
+    /// The earliest epoch this member can currently open.
+    ///
+    /// On a chained room this should be 1. Anything else means either links that have not
+    /// been delivered, or history that was deliberately severed at the join — and only the
+    /// party that *walks* the chain can answer it, which is why no host serves this number.
+    pub fn earliest_readable_epoch(&mut self) -> Result<u32, String> {
+        self.inner.earliest_readable_epoch().map_err(err)
+    }
+
+    /// Apply a commit — a membership change somebody else made.
+    ///
+    /// **Not optional.** A member who misses one is stuck at their last epoch and can open
+    /// nothing sealed after it; the symptom is "this record does not open", which reads
+    /// like corruption rather than a missed message.
+    ///
+    /// Returns `{ epoch, link }`. The link is a rung of the epoch key chain, minted in the
+    /// one moment any party knows both the outgoing key and the incoming one, and it has
+    /// already been added to this member's chain — it is returned because it is also what a
+    /// host stores on the member's behalf, and because a member who never uploads one keeps
+    /// their history only as long as this browser does. `null` on the first commit, which
+    /// has no predecessor epoch to wrap.
+    pub fn apply_commit(&mut self, commit: &[u8]) -> Result<String, String> {
+        let (epoch, link) = self.inner.apply_commit(commit).map_err(err)?;
+        serde_json::to_string(&CommitApplied { epoch, link }).map_err(err)
+    }
+
+    /// Add epoch links, extending how far back this member can read.
+    ///
+    /// Takes the JSON array a host's `rooms/epoch/chain` returns. Idempotent and
+    /// order-independent — a rung already held is never replaced, because a second rung for
+    /// an epoch is either a replay (which must be a no-op, or a retried delivery becomes a
+    /// failure) or an attempt to re-point this member's history at somebody else's key
+    /// material.
+    pub fn add_links(&mut self, links: &str) -> Result<(), String> {
+        let links: Vec<EpochLink> = serde_json::from_str(links).map_err(err)?;
+        self.inner.add_links(links);
+        Ok(())
+    }
+
+    /// Seal a record for writing. Returns `{ ciphertext, nonce, epoch }` as JSON.
+    ///
+    /// `version` **must** be the version the write will be stored at: it is bound into the
+    /// ciphertext along with the room, the key and the epoch. Get it wrong and the record
+    /// stores fine and never opens.
+    pub fn seal_record(&self, key: &str, version: u64, plaintext: &[u8]) -> Result<String, String> {
+        let sealed = self
+            .inner
+            .seal_record(key, version, plaintext)
+            .map_err(err)?;
+        serde_json::to_string(&sealed).map_err(err)
+    }
+
+    /// Open a record a host returned.
+    ///
+    /// Fails rather than returning wrong bytes if the record was relocated, if its epoch
+    /// was relabelled, or if the key for that epoch is not one this member can reach. The
+    /// key used is the one for the *record's* epoch, walked out of the chain — never the
+    /// group's current key.
+    pub fn open_record(
+        &mut self,
+        key: &str,
+        version: u64,
+        sealed: &str,
+    ) -> Result<Vec<u8>, String> {
+        let sealed: SealedContent = serde_json::from_str(sealed).map_err(err)?;
+        self.inner.open_record(key, version, &sealed).map_err(err)
+    }
+}
+
+/// The JS boundary: error conversion and nothing else.
+///
+/// Every method here is one line over its namesake above. Keeping it that way is the point
+/// — a wrapper that grew logic would be logic no native test could reach.
+#[wasm_bindgen]
+impl RoomMember {
+    /// See [`RoomMember::join`].
+    #[wasm_bindgen(js_name = join)]
+    pub fn join_js(room_id: &str, minted: &str, welcome: &[u8]) -> Result<RoomMember, JsError> {
+        Self::join(room_id, minted, welcome).map_err(js)
+    }
+
+    /// See [`RoomMember::restore`].
+    #[wasm_bindgen(js_name = restore)]
+    pub fn restore_js(snapshot: &str) -> Result<RoomMember, JsError> {
+        Self::restore(snapshot).map_err(js)
+    }
+
+    /// See [`RoomMember::snapshot`].
+    #[wasm_bindgen(js_name = snapshot)]
+    pub fn snapshot_js(&self) -> Result<String, JsError> {
+        self.snapshot().map_err(js)
+    }
+
+    /// See [`RoomMember::room_id`].
+    #[wasm_bindgen(getter, js_name = roomId)]
+    pub fn room_id_js(&self) -> String {
+        self.room_id()
+    }
+
+    /// See [`RoomMember::epoch`].
+    #[wasm_bindgen(getter, js_name = epoch)]
+    pub fn epoch_js(&self) -> u32 {
+        self.epoch()
+    }
+
+    /// See [`RoomMember::earliest_readable_epoch`].
+    #[wasm_bindgen(js_name = earliestReadableEpoch)]
+    pub fn earliest_readable_epoch_js(&mut self) -> Result<u32, JsError> {
+        self.earliest_readable_epoch().map_err(js)
+    }
+
+    /// See [`RoomMember::apply_commit`].
+    #[wasm_bindgen(js_name = applyCommit)]
+    pub fn apply_commit_js(&mut self, commit: &[u8]) -> Result<String, JsError> {
+        self.apply_commit(commit).map_err(js)
+    }
+
+    /// See [`RoomMember::add_links`].
+    #[wasm_bindgen(js_name = addLinks)]
+    pub fn add_links_js(&mut self, links: &str) -> Result<(), JsError> {
+        self.add_links(links).map_err(js)
+    }
+
+    /// See [`RoomMember::seal_record`].
+    #[wasm_bindgen(js_name = sealRecord)]
+    pub fn seal_record_js(
+        &self,
+        key: &str,
+        version: u64,
+        plaintext: &[u8],
+    ) -> Result<String, JsError> {
+        self.seal_record(key, version, plaintext).map_err(js)
+    }
+
+    /// See [`RoomMember::open_record`].
+    #[wasm_bindgen(js_name = openRecord)]
+    pub fn open_record_js(
+        &mut self,
+        key: &str,
+        version: u64,
+        sealed: &str,
+    ) -> Result<Vec<u8>, JsError> {
+        self.open_record(key, version, sealed).map_err(js)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vti_rooms::mls::RoomGroup;
+
+    /// The whole member story in one test, because the failures worth catching are all
+    /// *between* the steps: a snapshot taken before a commit, a version bound into
+    /// ciphertext that the write then disagrees with, a chain that was never fed.
+    #[test]
+    fn a_member_joins_reads_and_survives_a_restart() {
+        // The owner's side. Not part of this crate's API — a browser member is never an
+        // owner — but a Welcome has to come from somewhere.
+        let mut owner = RoomGroup::create("did:key:zOwner").unwrap();
+        let owner_room_id = "did:webvh:example.com:room";
+
+        let minted = mint_key_package("did:key:zJoiner").unwrap();
+        let parsed: MintedIdentity = serde_json::from_str(&minted).unwrap();
+        let key_package = B64.decode(&parsed.key_package).unwrap();
+
+        let change = owner.add_member_from_bytes(&key_package).unwrap();
+        let welcome = change
+            .welcome
+            .clone()
+            .expect("adding a member makes a Welcome");
+
+        let mut member = RoomMember::join(owner_room_id, &minted, &welcome).unwrap();
+        assert_eq!(member.room_id(), owner_room_id);
+
+        // A record the member writes and reads back.
+        let sealed = member.seal_record("rec-1", 7, b"hello").unwrap();
+        let opened = member.open_record("rec-1", 7, &sealed).unwrap();
+        assert_eq!(opened, b"hello");
+
+        // The version is bound into the ciphertext, not merely alongside it.
+        assert!(
+            member.open_record("rec-1", 8, &sealed).is_err(),
+            "a record must not open at a version it was not sealed for"
+        );
+
+        // …and so is the record key.
+        assert!(
+            member.open_record("rec-2", 7, &sealed).is_err(),
+            "a record must not open under a key it was not sealed for"
+        );
+
+        // A restart: everything the browser keeps is this string.
+        let snapshot = member.snapshot().unwrap();
+        let mut restored = RoomMember::restore(&snapshot).unwrap();
+        assert_eq!(restored.epoch(), member.epoch());
+        assert_eq!(
+            restored.open_record("rec-1", 7, &sealed).unwrap(),
+            b"hello",
+            "a restored member reads what it wrote before the restart"
+        );
+
+        // Nothing was fed to the chain, so this member reads from its join epoch only.
+        assert_eq!(
+            restored.earliest_readable_epoch().unwrap(),
+            restored.epoch(),
+            "with no links, the earliest readable epoch is the current one"
+        );
+    }
+
+    /// The failure this crate exists to make impossible to hit silently: a snapshot taken
+    /// before a commit restores to a member who cannot read what came after it.
+    #[test]
+    fn a_snapshot_taken_before_a_commit_is_stale() {
+        let mut owner = RoomGroup::create("did:key:zOwner").unwrap();
+        let minted = mint_key_package("did:key:zJoiner").unwrap();
+        let parsed: MintedIdentity = serde_json::from_str(&minted).unwrap();
+        let change = owner
+            .add_member_from_bytes(&B64.decode(&parsed.key_package).unwrap())
+            .unwrap();
+        let mut member = RoomMember::join(
+            "did:webvh:example.com:room",
+            &minted,
+            &change.welcome.unwrap(),
+        )
+        .unwrap();
+
+        let stale = member.snapshot().unwrap();
+
+        // Somebody else joins; the commit advances everyone's epoch.
+        let other = mint_key_package("did:key:zOther").unwrap();
+        let other_parsed: MintedIdentity = serde_json::from_str(&other).unwrap();
+        let change = owner
+            .add_member_from_bytes(&B64.decode(&other_parsed.key_package).unwrap())
+            .unwrap();
+        let applied: CommitApplied =
+            serde_json::from_str(&member.apply_commit(&change.commit).unwrap()).unwrap();
+        assert!(applied.epoch > RoomMember::restore(&stale).unwrap().epoch());
+        assert!(
+            applied.link.is_some(),
+            "a commit past the first mints a rung, which is what keeps history readable"
+        );
+
+        // A record written at the new epoch does not open for the stale snapshot — and
+        // fails as a refusal, not as garbage.
+        let sealed = member.seal_record("rec-1", 1, b"after").unwrap();
+        let mut stale = RoomMember::restore(&stale).unwrap();
+        assert!(stale.open_record("rec-1", 1, &sealed).is_err());
+    }
+}

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -54,6 +54,8 @@
 //! whose leaf nobody added, which fails at the first read looking like a bad Welcome rather
 //! than a wrong identity.
 
+pub mod invitation;
+
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
 use serde::{Deserialize, Serialize};
@@ -114,7 +116,18 @@ fn js(e: String) -> JsError {
 /// the same one to two rooms tells anybody who sees both that one party is in both — the
 /// correlation a `private` room exists to deny, arriving through the door rather than
 /// through the wall.
-pub fn mint_key_package(member_did: &str) -> Result<String, String> {
+pub fn mint_key_package(
+    member_did: &str,
+    room_id: &str,
+    invitation: &str,
+    spent: &str,
+) -> Result<String, String> {
+    // Gated, and gated *here* rather than only at the Welcome, because minting is
+    // not free: it retains a private key against a Welcome that may never come. A
+    // key holder that minted for anyone is one anyone can fill.
+    let spent: Vec<String> = serde_json::from_str(spent).map_err(err)?;
+    invitation::verify(invitation, room_id, member_did, &spent)?;
+
     let (identity, key_package) = IdentitySnapshot::mint(member_did).map_err(err)?;
     serde_json::to_string(&MintedIdentity {
         identity,
@@ -125,8 +138,30 @@ pub fn mint_key_package(member_did: &str) -> Result<String, String> {
 
 /// See [`mint_key_package`].
 #[wasm_bindgen(js_name = mintKeyPackage)]
-pub fn mint_key_package_js(member_did: &str) -> Result<String, JsError> {
-    mint_key_package(member_did).map_err(js)
+pub fn mint_key_package_js(
+    member_did: &str,
+    room_id: &str,
+    invitation: &str,
+    spent: &str,
+) -> Result<String, JsError> {
+    mint_key_package(member_did, room_id, invitation, spent).map_err(js)
+}
+
+/// Run the five invitation checks and return the credential id to record as spent.
+///
+/// Exposed separately from [`mint_key_package`] so a surface can *show* the checks — which
+/// is most of what a person needs to understand about a room they are being let into.
+#[wasm_bindgen(js_name = verifyInvitation)]
+pub fn verify_invitation_js(
+    invitation: &str,
+    room_id: &str,
+    member_did: &str,
+    spent: &str,
+) -> Result<String, JsError> {
+    let spent: Vec<String> = serde_json::from_str(spent).map_err(|e| js(e.to_string()))?;
+    invitation::verify(invitation, room_id, member_did, &spent)
+        .map(|v| v.credential_id)
+        .map_err(js)
 }
 
 /// One room this browser can open.
@@ -146,8 +181,22 @@ impl RoomMember {
     /// owner sent. The identity is consumed here and should be discarded afterwards.
     ///
     /// Fails rather than half-joining if the Welcome was not sealed to this identity.
-    pub fn join(room_id: &str, minted: &str, welcome: &[u8]) -> Result<RoomMember, String> {
+    pub fn join(
+        room_id: &str,
+        minted: &str,
+        welcome: &[u8],
+        invitation: &str,
+        spent: &str,
+    ) -> Result<RoomMember, String> {
         let minted: MintedIdentity = serde_json::from_str(minted).map_err(err)?;
+
+        // The same invitation, checked again and consumed by the caller after this
+        // returns. A Welcome carries a group's secrets, so a key holder that
+        // accepted an uninvited one would hold keys for a room nobody agreed to
+        // join — and would have made the invitation decorative.
+        let spent: Vec<String> = serde_json::from_str(spent).map_err(err)?;
+        invitation::verify(invitation, room_id, minted.identity.member_did(), &spent)?;
+
         let group = RoomGroup::join_from_identity(&minted.identity, welcome).map_err(err)?;
         Ok(RoomMember {
             inner: SealedRoom::new(room_id, group),
@@ -274,8 +323,14 @@ impl RoomMember {
 impl RoomMember {
     /// See [`RoomMember::join`].
     #[wasm_bindgen(js_name = join)]
-    pub fn join_js(room_id: &str, minted: &str, welcome: &[u8]) -> Result<RoomMember, JsError> {
-        Self::join(room_id, minted, welcome).map_err(js)
+    pub fn join_js(
+        room_id: &str,
+        minted: &str,
+        welcome: &[u8],
+        invitation: &str,
+        spent: &str,
+    ) -> Result<RoomMember, JsError> {
+        Self::join(room_id, minted, welcome, invitation, spent).map_err(js)
     }
 
     /// See [`RoomMember::restore`].
@@ -346,6 +401,57 @@ impl RoomMember {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::invitation::verify;
+    /// A room with a real `did:key` identity, and the secret it signs invitations with.
+    ///
+    /// `did:key` because the whole invitation check has to be lexical here: a browser
+    /// verifying a proof cannot go and resolve something, and a room that carries its key
+    /// in its own name means it does not have to.
+    fn a_room(seed: u8) -> (String, affinidi_secrets_resolver::secrets::Secret) {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64U;
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let pk = sk.verifying_key().to_bytes();
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(&pk);
+        let did = format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, &mc)
+        );
+        let secret = affinidi_secrets_resolver::secrets::Secret::from_str(
+            // The `did:key` convention: the multibase tag IS the fragment.
+            &format!("{did}#{}", did.trim_start_matches("did:key:")),
+            &serde_json::json!({
+                "crv": "Ed25519",
+                "d": B64U.encode(sk.to_bytes()),
+                "kty": "OKP",
+                "x": B64U.encode(pk),
+            }),
+        )
+        .expect("build the room's signing secret");
+        (did, secret)
+    }
+
+    /// An invitation from `room` to `subject`, signed.
+    fn an_invitation(
+        room: &str,
+        secret: &affinidi_secrets_resolver::secrets::Secret,
+        subject: &str,
+        id: &str,
+    ) -> String {
+        let now = chrono::Utc::now();
+        let mut vic = dtg_credentials::DTGCredential::new_vic(
+            room.to_string(),
+            subject.to_string(),
+            now - chrono::Duration::minutes(1),
+            Some(now + chrono::Duration::hours(1)),
+        )
+        .with_id(id);
+        futures_lite::future::block_on(vic.sign(secret, None)).expect("sign the invitation");
+        serde_json::to_string(vic.credential()).expect("serialise the invitation")
+    }
+
+    const NONE_SPENT: &str = "[]";
+
     use vti_rooms::mls::RoomGroup;
 
     /// The whole member story in one test, because the failures worth catching are all
@@ -356,9 +462,11 @@ mod tests {
         // The owner's side. Not part of this crate's API — a browser member is never an
         // owner — but a Welcome has to come from somewhere.
         let mut owner = RoomGroup::create("did:key:zOwner").unwrap();
-        let owner_room_id = "did:webvh:example.com:room";
 
-        let minted = mint_key_package("did:key:zJoiner").unwrap();
+        let (room_did, room_secret) = a_room(0x11);
+        let joiner = "did:key:zJoiner";
+        let vic = an_invitation(&room_did, &room_secret, joiner, "urn:uuid:invite-1");
+        let minted = mint_key_package(joiner, &room_did, &vic, NONE_SPENT).unwrap();
         let parsed: MintedIdentity = serde_json::from_str(&minted).unwrap();
         let key_package = B64.decode(&parsed.key_package).unwrap();
 
@@ -368,8 +476,8 @@ mod tests {
             .clone()
             .expect("adding a member makes a Welcome");
 
-        let mut member = RoomMember::join(owner_room_id, &minted, &welcome).unwrap();
-        assert_eq!(member.room_id(), owner_room_id);
+        let mut member = RoomMember::join(&room_did, &minted, &welcome, &vic, NONE_SPENT).unwrap();
+        assert_eq!(member.room_id(), room_did);
 
         // A record the member writes and reads back.
         let sealed = member.seal_record("rec-1", 7, b"hello").unwrap();
@@ -406,27 +514,113 @@ mod tests {
         );
     }
 
+    /// Each of the five checks, made to bite.
+    ///
+    /// A gate is only worth having if every clause of it refuses something, and a five-check
+    /// gate is exactly the shape that quietly becomes a four-check one. So each is asserted
+    /// separately rather than through one "a bad invitation is refused" case, which would
+    /// still pass with any four of them.
+    #[test]
+    fn every_invitation_check_refuses_something() {
+        let (room, secret) = a_room(0x21);
+        let (other_room, other_secret) = a_room(0x22);
+        let me = "did:key:zMe";
+
+        let good = an_invitation(&room, &secret, me, "urn:uuid:i-1");
+        assert!(
+            verify(&good, &room, me, &[]).is_ok(),
+            "the control must pass"
+        );
+
+        // 1. Not an invitation at all.
+        let now = chrono::Utc::now();
+        let mut vrc = dtg_credentials::DTGCredential::new_vac(
+            room.clone(),
+            me.to_string(),
+            "room".into(),
+            vec!["read".into()],
+            now,
+            now + chrono::Duration::hours(1),
+        )
+        .expect("build an authority credential")
+        .with_id("urn:uuid:i-2");
+        futures_lite::future::block_on(vrc.sign(&secret, None)).unwrap();
+        let as_json = serde_json::to_string(vrc.credential()).unwrap();
+        assert!(
+            verify(&as_json, &room, me, &[])
+                .unwrap_err()
+                .contains("not an invitation")
+        );
+
+        // 2. Issued by a different room. Valid, and not an invitation to *this* one.
+        let elsewhere = an_invitation(&other_room, &other_secret, me, "urn:uuid:i-3");
+        assert!(
+            verify(&elsewhere, &room, me, &[])
+                .unwrap_err()
+                .contains("issued by")
+        );
+
+        // 3. Issued to somebody else. An invitation is not transferable — without this a
+        //    third party could place a member into a room they were invited to.
+        let theirs = an_invitation(&room, &secret, "did:key:zSomeoneElse", "urn:uuid:i-4");
+        assert!(
+            verify(&theirs, &room, me, &[])
+                .unwrap_err()
+                .contains("not transferable")
+        );
+
+        // 4. Signed by the wrong key. Everything above is a claim until the proof holds: a
+        //    well-formed invitation naming anyone is trivial to write, and this is the one
+        //    check that makes the other four mean anything.
+        let forged = an_invitation(&room, &other_secret, me, "urn:uuid:i-5");
+        assert!(
+            verify(&forged, &room, me, &[])
+                .unwrap_err()
+                .contains("is signed by")
+        );
+
+        // 5. Already spent. Single-use is what stops an invitation being a standing
+        //    entitlement to rejoin a room you were removed from.
+        let spent = vec!["urn:uuid:i-1".to_string()];
+        assert!(
+            verify(&good, &room, me, &spent)
+                .unwrap_err()
+                .contains("already been used")
+        );
+    }
+
     /// The failure this crate exists to make impossible to hit silently: a snapshot taken
     /// before a commit restores to a member who cannot read what came after it.
     #[test]
     fn a_snapshot_taken_before_a_commit_is_stale() {
         let mut owner = RoomGroup::create("did:key:zOwner").unwrap();
-        let minted = mint_key_package("did:key:zJoiner").unwrap();
+        let (room_did, room_secret) = a_room(0x11);
+        let joiner = "did:key:zJoiner";
+        let vic = an_invitation(&room_did, &room_secret, joiner, "urn:uuid:invite-1");
+        let minted = mint_key_package(joiner, &room_did, &vic, NONE_SPENT).unwrap();
         let parsed: MintedIdentity = serde_json::from_str(&minted).unwrap();
         let change = owner
             .add_member_from_bytes(&B64.decode(&parsed.key_package).unwrap())
             .unwrap();
         let mut member = RoomMember::join(
-            "did:webvh:example.com:room",
+            &room_did,
             &minted,
             &change.welcome.unwrap(),
+            &vic,
+            NONE_SPENT,
         )
         .unwrap();
 
         let stale = member.snapshot().unwrap();
 
         // Somebody else joins; the commit advances everyone's epoch.
-        let other = mint_key_package("did:key:zOther").unwrap();
+        let other_vic = an_invitation(
+            &room_did,
+            &room_secret,
+            "did:key:zOther",
+            "urn:uuid:invite-2",
+        );
+        let other = mint_key_package("did:key:zOther", &room_did, &other_vic, NONE_SPENT).unwrap();
         let other_parsed: MintedIdentity = serde_json::from_str(&other).unwrap();
         let change = owner
             .add_member_from_bytes(&B64.decode(&other_parsed.key_package).unwrap())

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -620,12 +620,26 @@ mod tests {
         // Echoed unchanged: its value to the verifier is that it came back as sent.
         assert_eq!(presentation["nonce"], "n-1");
 
-        let chain: Vec<dtg_credentials::DTGCredential> =
-            serde_json::from_value(presentation["authority"].clone()).unwrap();
+        // The wire form is strings, so a verifier parses each link before checking it.
+        // Asserted rather than assumed: a host handed objects instead refuses the whole
+        // request as "invalid type: map, expected a string", which reads as a malformed
+        // payload rather than as the shape mismatch it is.
+        let chain: Vec<dtg_credentials::DTGCredential> = presentation["authority"]
+            .as_array()
+            .expect("authority is an array")
+            .iter()
+            .map(|link| {
+                serde_json::from_str(link.as_str().expect("each link is a string")).unwrap()
+            })
+            .collect();
         assert_eq!(
             chain.len(),
             2,
             "leaf first, then the credential the room issued"
+        );
+        assert!(
+            presentation["membership"].is_string(),
+            "membership travels as a string too"
         );
 
         verify_chain(&chain, &room, &room, "read", me.did(), chrono::Utc::now())
@@ -679,8 +693,12 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        let chain: Vec<dtg_credentials::DTGCredential> =
-            serde_json::from_value(presentation["authority"].clone()).unwrap();
+        let chain: Vec<dtg_credentials::DTGCredential> = presentation["authority"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|link| serde_json::from_str(link.as_str().unwrap()).unwrap())
+            .collect();
 
         // The rightful member: accepted.
         verify_chain(&chain, &room, &room, "read", me.did(), chrono::Utc::now()).unwrap();
@@ -755,6 +773,29 @@ mod tests {
             crate::identity::MemberIdentity::restore(&serde_json::to_string(&swapped).unwrap())
                 .unwrap_err();
         assert!(err.contains("does not match its key"), "{err}");
+    }
+
+    /// An invitation issued with `valid_from = now` — exactly what the demo's owner mints.
+    ///
+    /// Separate from the fixture above, which back-dates by a minute. A credential minted
+    /// and checked in the same instant is the normal case for an interactive join, and a
+    /// window check that is off by a rounding is a check that fails only in production.
+    #[test]
+    fn an_invitation_valid_from_this_instant_verifies() {
+        let (room, secret) = a_room(0x51);
+        let me = "did:key:zMe";
+        let now = chrono::Utc::now();
+        let mut vic = dtg_credentials::DTGCredential::new_vic(
+            room.clone(),
+            me.to_string(),
+            now,
+            Some(now + chrono::Duration::hours(1)),
+        )
+        .with_id("urn:uuid:now-1");
+        futures_lite::future::block_on(vic.sign(&secret, None)).unwrap();
+        let json = serde_json::to_string(vic.credential()).unwrap();
+
+        verify(&json, &room, me, &[]).expect("an invitation valid from now must verify now");
     }
 
     /// Each of the five checks, made to bite.

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -603,7 +603,7 @@ mod tests {
             room.clone(),
             vec!["read".into(), "curate".into()],
             now - chrono::Duration::minutes(1),
-            now + chrono::Duration::days(30),
+            Some(now + chrono::Duration::days(30)),
         )
         .expect("mint the room's authority credential")
         .with_id("urn:uuid:vac-1");
@@ -677,7 +677,7 @@ mod tests {
             room.clone(),
             vec!["read".into()],
             now - chrono::Duration::minutes(1),
-            now + chrono::Duration::days(30),
+            Some(now + chrono::Duration::days(30)),
         )
         .unwrap()
         .with_id("urn:uuid:vac-3");
@@ -740,7 +740,7 @@ mod tests {
             room.clone(),
             vec!["read".into()],
             now - chrono::Duration::minutes(1),
-            now + chrono::Duration::days(30),
+            Some(now + chrono::Duration::days(30)),
         )
         .unwrap()
         .with_id("urn:uuid:vac-2");
@@ -824,7 +824,7 @@ mod tests {
             "room".into(),
             vec!["read".into()],
             now,
-            now + chrono::Duration::hours(1),
+            Some(now + chrono::Duration::hours(1)),
         )
         .expect("build an authority credential")
         .with_id("urn:uuid:i-2");

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -9,7 +9,23 @@ repository.workspace = true
 publish.workspace = true
 
 [features]
-default = []
+default = ["host"]
+# Everything a room's **host** needs, and the only reason this crate depends on
+# `vti-common`. On by default, because a host is what this crate was extracted
+# for; off, what remains is the member half — the group keys, sealing, the epoch
+# chain and the wire types — which needs no store, no `AppError`, and no server.
+#
+# The split is not new here, it was only unnamed: `vta-service` already uses
+# `mls`/`sealed`/`wire` and nothing else, while `vtc-service`, `room-host` and
+# `vti-rooms-dtg` use `storage`/`authz`/`audit`. Naming it is what lets the member
+# half build for `wasm32-unknown-unknown`, and so lets a browser be a real member
+# rather than a client of one. See `docs/05-design-notes/data-rooms-demo-site.md`.
+#
+# `lifecycle` is deliberately **not** gated. Only hosts consume it today, but it
+# needs nothing from `vti-common`, and a member computing a room's lifecycle
+# state to explain it on screen is a thing that should not require a host's
+# dependencies.
+host = ["dep:vti-common"]
 # The room's group-key layer (`mls`) and record sealing (`sealed`). Off by
 # default: a host that only stores ciphertext needs none of it, and OpenMLS is a
 # substantial dependency to make such a host carry. Mirrors how `vtc-service`
@@ -23,13 +39,18 @@ mls = [
   "dep:chacha20poly1305",
   "dep:base64",
   "dep:getrandom",
+  "dep:getrandom_02",
 ]
 
 [dependencies]
 # The store abstraction and AppError. This crate's only internal dependency:
 # a room's storage and authorization need nothing from a community service,
 # which is the whole reason they are extractable.
-vti-common = { path = "../vti-common", version = "0.18" }
+#
+# Optional, and load-bearing that it is: `vti-common` is server-side by its own
+# description and pulls axum, fjall and tokio, none of which build for wasm. It
+# is the `host` feature's whole content.
+vti-common = { path = "../vti-common", version = "0.18", optional = true }
 
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -51,6 +72,32 @@ getrandom = { version = "0.4", optional = true }
 # Verification may resolve a DID, so ChainVerifier is async; async-trait keeps it
 # dyn-compatible, as it does for vti_common::auth::backend.
 async-trait = "0.1"
+
+# On wasm, OpenMLS needs its `js` feature: it swaps `std::time` for `web-time`
+# (there is no `SystemTime` on `wasm32-unknown-unknown`) and routes randomness
+# through `getrandom`'s JS backend. Declared per-target rather than as a feature
+# of this crate so that building for wasm simply works, with nothing for a
+# consumer to remember — cargo unions these onto the general declaration above.
+#
+# **This is not sufficient on its own.** Two things the artifact crate must also
+# do, because neither can be set from here:
+#
+# `getrandom_02` is a **feature shim, not a dependency this crate calls**. There
+# are two getrandom majors in the graph: the 0.4 above, which `mls` uses
+# directly, and an 0.2 that RustCrypto's elliptic-curve stack pulls in under
+# `openmls_rust_crypto`. The second is transitive, so no feature declared for the
+# first can reach it — and without `js` it fails with a `compile_error!` saying
+# wasm "is not supported by default", which reads like an unsupported target and
+# is not. Naming it here turns the feature on for the whole graph.
+#
+# Doing it in this crate rather than leaving it to each artifact crate is
+# deliberate. The choice is target-specific and, on wasm32, there is only one
+# correct answer; the `cfg` means no native build can see it. The alternative is
+# a footgun in a doc comment, paid for once per consumer.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+openmls = { version = "0.9", features = ["js"], optional = true }
+getrandom = { version = "0.4", features = ["wasm_js"], optional = true }
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -49,17 +49,41 @@
 //!
 //! Three layers:
 //!
-//! - [`storage`] — the keyspaces and their invariants.
+//! - `storage` — the keyspaces and their invariants.
 //! - [`wire`] — the Trust-Task payload types, hand-written against the schemas in
 //!   `trustoverip/dtgwg-trust-tasks-tf#346` until the generated bindings publish.
-//! - [`authz`] — deciding whether an operation is allowed, **without reading any host's ACL
+//! - `authz` — deciding whether an operation is allowed, **without reading any host's ACL
 //!   or roster**. The invariant the whole design rests on.
+//!
+//! # Two halves, and the feature that names them
+//!
+//! A room has a host and it has members, and they need disjoint code. The `host` feature
+//! (on by default) carries `storage`, `authz` and `audit`; the `mls` feature carries the
+//! member's group keys, sealing and the epoch chain. `wire`, `error` and `lifecycle` are
+//! common to both.
+//!
+//! The division already existed and was simply unnamed — `vta-service` imports
+//! `mls`/`sealed`/`wire` and nothing else, while `vtc-service`, `room-host` and
+//! `vti-rooms-dtg` import `storage`/`authz`/`audit`. What naming it buys is that
+//! **`vti-common` becomes optional**, and with it every server dependency it carries:
+//! axum, fjall, tokio. `--no-default-features --features mls` therefore builds for
+//! `wasm32-unknown-unknown`, which is what lets a browser hold a room's keys itself
+//! instead of asking an agent to. See `docs/05-design-notes/data-rooms-demo-site.md`.
+//!
+//! That the member half needed **no source changes** to get there is a property of
+//! [`error`], which deliberately does not use `vti_common::error::AppError`: key material
+//! is not a service's concern, and a record that fails to open is an outcome rather than a
+//! fault. That decision was made for its own reasons and paid for itself here.
 //!
 //! The Trust-Task **handlers** are deliberately *not* here. Dispatch is a service's spine,
 //! and a spine is not extractable — see `docs/05-design-notes/vta-service-decomposition.md`.
 //! Each host writes its own thin handlers over these three layers.
 
+/// A room's audit trail, behind the `host` feature.
+#[cfg(feature = "host")]
 pub mod audit;
+/// Deciding whether a room operation is allowed, behind the `host` feature.
+#[cfg(feature = "host")]
 pub mod authz;
 pub mod error;
 pub mod lifecycle;
@@ -74,6 +98,8 @@ pub mod mls;
 pub mod retention;
 #[cfg(feature = "mls")]
 pub mod sealed;
+/// The room and record keyspaces, behind the `host` feature.
+#[cfg(feature = "host")]
 pub mod storage;
 pub mod wire;
 


### PR DESCRIPTION
**Absorbs #1345**, which was the feature-gate precondition and is only useful with this.

A data room's member half, compiled to `wasm32-unknown-unknown`, so a tab holds its own
keys instead of driving an agent that does. Design: #1344.

## Five commits, and each one was forced by something

**1 · A `host` feature.** `vti-rooms` already had two halves and no name for them:
`vta-service` imports `mls`/`sealed`/`wire`, while `vtc-service`, `room-host` and
`vti-rooms-dtg` import `storage`/`authz`/`audit`. Naming the second half makes
`vti-common` optional — and it was the whole of what kept a room's member code off wasm,
since it pulls axum, fjall and tokio.

**The member half needed no source changes.** That is a property of `error.rs`, which
deliberately does not use `AppError` because key material is not a service's concern.

**2 · The crate.** The MLS group, record sealing, the epoch chain. Every method appears
twice — a plain Rust one with the logic, a one-line `#[wasm_bindgen]` wrapper that converts
the error — because `JsError` is an *imported JS function* and constructing one on a native
target panics. A crate whose only entry points were wrapped would have no reachable native
tests, and the tests worth having are the ones asserting a failure.

**3 · The invitation gate.** Six clauses before this member will mint a KeyPackage or accept
a Welcome. The gate is on the *member's* side, which looks wrong until you ask what it
defends: not the room, this key holder. Minting retains a private key against a Welcome that
may never come; accepting an uninvited Welcome holds keys for a room nobody agreed to join.

Writing a test per clause — rather than one "a bad invitation is refused" case, which passes
with any five of six — found that **nothing bound the proof's verification method to the
issuer**. Forged invitations were accepted. Fixed upstream in #1353.

**4 · The member's key and its presentation.** The key is minted and held here, so JS holds
two opaque snapshots and no key; the first cut kept a JWK in `localStorage`, which
contradicted this crate's own rule. `present()` attenuates the room's VAC to one action and
signs it.

It takes **no audience parameter**, deliberately — which is the thread that became #1356 and
then a `dtg-credentials` release: `audience` was compared to the *presenter*, so binding it
to a host refused the legitimate holder and protected nobody.

**5 · Linking a chain the way its hosts verify one.** `dtg-credentials` is taken from the
**workspace**, not pinned here. A browser member and its hosts must agree how a chain links,
and they already disagreed once — 0.7 moved `parent` from an id to a digest, and a 0.7
issuer against a 0.6 verifier is refused with wording that blames the chain. Taking the
workspace dependency makes that drift impossible to reintroduce. See
OpenVTC/dtg-credentials#22.

## Verified

- 8 tests, asserted against `dtg_credentials::authority::verify_chain` itself rather than a
  restatement of it: the presentation verifies, a narrowing to `read` does not authorise
  `curate`, over-asking is refused locally, and a captured presentation fails for the thief
  as a wrong-presenter refusal rather than a bad signature.
- Also pinned: the shape the server path never produces — a browser member is its own agent,
  so the leaf's subject and the chain root's are the same DID.
- `cargo clippy -p vti-rooms-wasm --all-targets -- -D warnings` clean, natively and for
  `wasm32-unknown-unknown`.
- CI gains three steps in `features`: the member half with no host, a wasm32 `--lib` check,
  and the artifact's size reported rather than gated.

**Driven end to end in a browser**, not only in tests: mint a `did:key`, be admitted, seal a
record, write it to the real `room-host`, and read it back. That is what found four of the
five commits above.