### PR TITLE
fix(sdk): the provisioning probe tolerates an unsigned reply again

### DIFF
--- a/vta-sdk/src/provision_client/authz.rs
+++ b/vta-sdk/src/provision_client/authz.rs
@@ -68,7 +68,25 @@ pub(super) async fn verify_authorization(
 ) -> Result<(), String> {
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::VerifyAuthorization));
 
-    let served = match client.supported_trust_tasks(&["*"]).await {
+    // The probe tolerates an UNSIGNED reply, and only an unsigned one.
+    //
+    // This is a diagnostic and deliberately not a gate — see the module docs:
+    // refusing to provision a VTA that cannot answer it "would turn a
+    // diagnostic into an outage, which is the one way this module could be
+    // worse than not existing". Reply verification (#1341) put a second way to
+    // fail into a path whose failures are all swallowed below, so an agent that
+    // does not sign its replies stopped producing the two findings this module
+    // exists for — a missing grant and a version skew — and produced "could not
+    // ask" instead. The skew then surfaced as a bare 404 from the mint call,
+    // which is the exact failure the module was written to replace.
+    //
+    // `trusting_unsigned_replies` is the narrow tool for it: a *present* proof
+    // is still verified and still bound to this VTA, so a rewritten reply is
+    // still refused. Only the absence of a proof is tolerated, which is what an
+    // agent predating #1334/#1335 sends. Every task that is not this advisory
+    // probe keeps the full check.
+    let probe = client.clone().trusting_unsigned_replies();
+    let served = match probe.supported_trust_tasks(&["*"]).await {
         Ok(resp) => resp.supported_types,
 
         // No grant for this DID on this VTA. The two things worth naming are

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -752,6 +752,69 @@ mod tests {
     /// A VTA on the previous provisioning version is stopped before any key is
     /// minted, and told which version it is on.
     ///
+    /// The other half of the probe's tolerance, and the half worth pinning:
+    /// an unsigned reply is accepted, a **badly signed** one is not.
+    ///
+    /// `trusting_unsigned_replies` is narrow on purpose — a *present* proof is
+    /// still verified and still bound to this VTA — so a rewritten reply cannot
+    /// steer the diagnostic. Without this test the fix for the regression below
+    /// reads exactly like "verification was turned off for the probe", which is
+    /// what it must not be: the skew message here would prove a forged task
+    /// list had been believed.
+    #[tokio::test]
+    async fn a_reply_with_a_broken_proof_does_not_steer_the_diagnostic() {
+        let server = MockServer::start().await;
+        mount_auth(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/trust-tasks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "urn:uuid:11111111-1111-4111-8111-111111111111",
+                "type": "https://trusttasks.org/spec/trust-task-discovery/0.1#response",
+                "payload": {
+                    "frameworkVersion": "0.2",
+                    "supportedTypes": [
+                        "https://trusttasks.org/spec/provision/integration/0.2"
+                    ]
+                },
+                // Present, and nonsense. The narrow tolerance must reject this.
+                "proof": {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "eddsa-jcs-2022",
+                    "created": "2026-01-01T00:00:00Z",
+                    "verificationMethod": "did:key:zNotTheAgent#zNotTheAgent",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let key = EphemeralSetupKey::generate().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let ask = ProvisionAsk::didcomm_mediator("mediator", "https://mediator.example.com");
+
+        let outcome = run_rest_attempt_full_setup(
+            &server.uri(),
+            &test_vta_did_key(),
+            key.did.clone(),
+            key.private_key_multibase().to_string(),
+            ask,
+            &tx,
+        )
+        .await;
+
+        // The forged list said 0.2 and only 0.2. If it had been believed, the
+        // run would stop with the version-skew message naming it.
+        if let AttemptOutcome::PostAuthFailure(reason) = &outcome {
+            assert!(
+                !reason.contains("version skew"),
+                "a reply with a broken proof steered the diagnostic: {reason}"
+            );
+        }
+        drop(tx);
+        let _ = drain(&mut rx);
+    }
+
     /// REGRESSION (2026-08-31). #1147 cut `provision/integration` 0.2 -> 0.3
     /// with no dual-accept window; a current client against a VTA still on 0.2
     /// signed its VP, dispatched, and got back


### PR DESCRIPTION
**Main is red** on `a_vta_on_the_previous_provision_version_is_named_before_minting`, and has been since #1341. The test is right — the behaviour regressed.

**Stacked below #1350**, which fixes the 67 test stubs the same PR left behind. The two are deliberately different fixes; see the split at the end.

## What broke

`verify_authorization` asks `trust-task-discovery/0.1` before anything is minted, and it is **a diagnostic, not a gate**. Its own module docs say why:

> A VTA that does not serve it is not a VTA we should refuse to provision — that would turn a diagnostic into an outage, which is the one way this module could be worse than not existing.

So every failure of the probe is swallowed into `Skipped`, except the two findings that name a concrete fix: **no grant**, and a **version skew**.

#1341 added a new way for the probe to fail — the reply must now verify — and it lands in that same catch-all. An agent that does not sign its replies stopped producing either finding and produced *"could not ask"* instead. The skew then surfaced where it always used to: as a bare 404 from the mint call, naming the version the *client* wanted and never the one the VTA has. That is the exact failure this module was written to replace.

## The fix, and why it is narrow

`trusting_unsigned_replies` — #1341's own method, for exactly this case ("an agent that predates #1334 and #1335 sends none"). It tolerates only the **absence** of a proof:

> A *present* proof is still verified and still bound to the expected agent.

So a rewritten or wrong-signer reply is still refused, and every task that is not this advisory probe keeps the full check.

**A second test pins that half deliberately.** `a_reply_with_a_broken_proof_does_not_steer_the_diagnostic` mocks a discovery reply carrying a present-but-nonsense proof and asserts the version-skew message does *not* appear. Without it this change reads exactly like "verification was turned off for the probe" — and a forged task list would prove it had been.

## Why this is a product fix and #1350 is a test fix

The difference is what is under test. Here, a real VTA that predates response signing must still get its version skew diagnosed — so the tolerance belongs **in the product**. In #1350, nothing wants an unsigned reply; the stubs had simply never represented a VTA (`test_identity`'s `vta_did` was the literal `did:key:z6MkTestVta`, not a decodable key), so they are made to sign and now *exercise* verification rather than sidestep it.

I first fixed the three `auth_light_rest` fixtures the weaker way here. #1350's reading is better and that commit has been dropped from this branch, so the stack applies cleanly.

## Verification

`vta-sdk --lib` 742/742 under `--all-features`; green under the default features CI runs. Clippy clean. The remaining integration-target failures are #1350's, and with both applied every `vta-sdk` target is green — `client_rest` 86/86.

Unblocks #1342.