### PR TITLE
fix(sdk): a mock VTA has to sign, now that the client checks

### DIFF
--- a/vta-sdk/src/provision_client/authz.rs
+++ b/vta-sdk/src/provision_client/authz.rs
@@ -68,7 +68,25 @@ pub(super) async fn verify_authorization(
 ) -> Result<(), String> {
     let _ = tx.send(VtaEvent::CheckStart(DiagCheck::VerifyAuthorization));
 
-    let served = match client.supported_trust_tasks(&["*"]).await {
+    // The probe tolerates an UNSIGNED reply, and only an unsigned one.
+    //
+    // This is a diagnostic and deliberately not a gate — see the module docs:
+    // refusing to provision a VTA that cannot answer it "would turn a
+    // diagnostic into an outage, which is the one way this module could be
+    // worse than not existing". Reply verification (#1341) put a second way to
+    // fail into a path whose failures are all swallowed below, so an agent that
+    // does not sign its replies stopped producing the two findings this module
+    // exists for — a missing grant and a version skew — and produced "could not
+    // ask" instead. The skew then surfaced as a bare 404 from the mint call,
+    // which is the exact failure the module was written to replace.
+    //
+    // `trusting_unsigned_replies` is the narrow tool for it: a *present* proof
+    // is still verified and still bound to this VTA, so a rewritten reply is
+    // still refused. Only the absence of a proof is tolerated, which is what an
+    // agent predating #1334/#1335 sends. Every task that is not this advisory
+    // probe keeps the full check.
+    let probe = client.clone().trusting_unsigned_replies();
+    let served = match probe.supported_trust_tasks(&["*"]).await {
         Ok(resp) => resp.supported_types,
 
         // No grant for this DID on this VTA. The two things worth naming are

--- a/vta-sdk/src/provision_client/runner_rest.rs
+++ b/vta-sdk/src/provision_client/runner_rest.rs
@@ -752,6 +752,69 @@ mod tests {
     /// A VTA on the previous provisioning version is stopped before any key is
     /// minted, and told which version it is on.
     ///
+    /// The other half of the probe's tolerance, and the half worth pinning:
+    /// an unsigned reply is accepted, a **badly signed** one is not.
+    ///
+    /// `trusting_unsigned_replies` is narrow on purpose — a *present* proof is
+    /// still verified and still bound to this VTA — so a rewritten reply cannot
+    /// steer the diagnostic. Without this test the fix for the regression below
+    /// reads exactly like "verification was turned off for the probe", which is
+    /// what it must not be: the skew message here would prove a forged task
+    /// list had been believed.
+    #[tokio::test]
+    async fn a_reply_with_a_broken_proof_does_not_steer_the_diagnostic() {
+        let server = MockServer::start().await;
+        mount_auth(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/trust-tasks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "urn:uuid:11111111-1111-4111-8111-111111111111",
+                "type": "https://trusttasks.org/spec/trust-task-discovery/0.1#response",
+                "payload": {
+                    "frameworkVersion": "0.2",
+                    "supportedTypes": [
+                        "https://trusttasks.org/spec/provision/integration/0.2"
+                    ]
+                },
+                // Present, and nonsense. The narrow tolerance must reject this.
+                "proof": {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "eddsa-jcs-2022",
+                    "created": "2026-01-01T00:00:00Z",
+                    "verificationMethod": "did:key:zNotTheAgent#zNotTheAgent",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let key = EphemeralSetupKey::generate().unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let ask = ProvisionAsk::didcomm_mediator("mediator", "https://mediator.example.com");
+
+        let outcome = run_rest_attempt_full_setup(
+            &server.uri(),
+            &test_vta_did_key(),
+            key.did.clone(),
+            key.private_key_multibase().to_string(),
+            ask,
+            &tx,
+        )
+        .await;
+
+        // The forged list said 0.2 and only 0.2. If it had been believed, the
+        // run would stop with the version-skew message naming it.
+        if let AttemptOutcome::PostAuthFailure(reason) = &outcome {
+            assert!(
+                !reason.contains("version skew"),
+                "a reply with a broken proof steered the diagnostic: {reason}"
+            );
+        }
+        drop(tx);
+        let _ = drain(&mut rx);
+    }
+
     /// REGRESSION (2026-08-31). #1147 cut `provision/integration` 0.2 -> 0.3
     /// with no dual-accept window; a current client against a VTA still on 0.2
     /// signed its VP, dispatched, and got back

--- a/vta-sdk/tests/auth_light_rest.rs
+++ b/vta-sdk/tests/auth_light_rest.rs
@@ -49,6 +49,28 @@ fn did_key_from_seed(seed_byte: u8) -> (String, String) {
     (did, priv_mb)
 }
 
+/// A `config/show` `#response` signed as `vta_did`, the way a real VTA answers.
+///
+/// The three token-refresh tests below care about the *order* of the auth calls
+/// and not about the reply, so their fixture used to be a placeholder:
+/// `urn:test:response`, unsigned. Since #1341 that is two separate refusals —
+/// `urn:` is not a Trust-Task type URI, and an unsigned reply from a client that
+/// holds an identity is rejected on principle. Both are the client being right,
+/// so the mock has to answer the way the thing it is standing in for does.
+async fn signed_config_reply(vta_did: &str, vta_priv: &str) -> serde_json::Value {
+    let mut doc: trust_tasks_rs::TrustTask<serde_json::Value> = serde_json::from_value(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": "https://trusttasks.org/spec/config/show/0.1#response",
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "payload": {"fields": []}
+    }))
+    .expect("a well-formed Trust-Task document");
+    vta_sdk::trust_task_sign::sign_in_place(&mut doc, vta_did, vta_priv)
+        .await
+        .expect("sign the mock VTA's reply");
+    serde_json::to_value(doc).expect("serialise the signed reply")
+}
+
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -491,6 +513,10 @@ async fn from_credential_url_override_wins_over_bundle() {
 #[tokio::test]
 async fn ensure_token_valid_refreshes_expired_access_token() {
     let server = MockServer::start().await;
+    // Hoisted above the mocks: one of them now signs as this VTA, so the key has
+    // to exist before it is mounted — and its private half is no longer discarded.
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, vta_priv) = did_key_from_seed(0x22);
     mount_challenge(&server).await;
 
     // Initial auth: access already expired, refresh still good.
@@ -552,18 +578,14 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
             "authorization",
             "Bearer fresh-access",
         ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
-            "type": "urn:test:response",
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": {"fields": []}
-        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(signed_config_reply(&vta_did, &vta_priv).await),
+        )
         .expect(1)
         .mount(&server)
         .await;
 
-    let (client_did, client_priv) = did_key_from_seed(0x11);
-    let (vta_did, _) = did_key_from_seed(0x22);
     let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
     let client = VtaClient::from_credential(&cred, None).await.unwrap();
 
@@ -579,6 +601,10 @@ async fn ensure_token_valid_refreshes_expired_access_token() {
 #[tokio::test]
 async fn ensure_token_valid_full_reauth_when_refresh_expired() {
     let server = MockServer::start().await;
+    // Hoisted above the mocks: one of them now signs as this VTA, so the key has
+    // to exist before it is mounted — and its private half is no longer discarded.
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, vta_priv) = did_key_from_seed(0x22);
 
     // Two sequential challenge calls expected (initial + re-auth).
     Mock::given(method("POST"))
@@ -650,18 +676,14 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
             "authorization",
             "Bearer reauth-access",
         ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
-            "type": "urn:test:response",
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": {"fields": []}
-        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(signed_config_reply(&vta_did, &vta_priv).await),
+        )
         .expect(1)
         .mount(&server)
         .await;
 
-    let (client_did, client_priv) = did_key_from_seed(0x11);
-    let (vta_did, _) = did_key_from_seed(0x22);
     let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
     let client = VtaClient::from_credential(&cred, None).await.unwrap();
     client.get_config().await.unwrap();
@@ -672,6 +694,10 @@ async fn ensure_token_valid_full_reauth_when_refresh_expired() {
 #[tokio::test]
 async fn ensure_token_valid_falls_through_when_refresh_fails() {
     let server = MockServer::start().await;
+    // Hoisted above the mocks: one of them now signs as this VTA, so the key has
+    // to exist before it is mounted — and its private half is no longer discarded.
+    let (client_did, client_priv) = did_key_from_seed(0x11);
+    let (vta_did, vta_priv) = did_key_from_seed(0x22);
 
     Mock::given(method("POST"))
         .and(path("/auth/challenge"))
@@ -747,18 +773,14 @@ async fn ensure_token_valid_falls_through_when_refresh_fails() {
             "authorization",
             "Bearer fallback-access",
         ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
-            "type": "urn:test:response",
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": {"fields": []}
-        })))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(signed_config_reply(&vta_did, &vta_priv).await),
+        )
         .expect(1)
         .mount(&server)
         .await;
 
-    let (client_did, client_priv) = did_key_from_seed(0x11);
-    let (vta_did, _) = did_key_from_seed(0x22);
     let cred = CredentialBundle::new(client_did, client_priv, vta_did).vta_url(server.uri());
     let client = VtaClient::from_credential(&cred, None).await.unwrap();
     client.get_config().await.unwrap();

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -41,13 +41,8 @@ const TASK_SEEDS_EXPORT_MNEMONIC: &str =
 const TASK_WEBVH_DIDS_LIST: &str = "https://trusttasks.org/spec/vta/webvh/dids/list/1.0";
 
 /// A success response document carrying `payload`.
-fn tt_ok(payload: Value) -> ResponseTemplate {
-    ResponseTemplate::new(200).set_body_json(json!({
-        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
-        "type": "urn:test:response",
-        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "payload": payload,
-    }))
+async fn tt_ok(payload: Value) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(signed_response(payload).await)
 }
 
 /// Assert a key is *absent* from the payload.
@@ -91,9 +86,59 @@ fn test_identity() -> vta_sdk::client::ClientIdentity {
             multibase::Base::Base58Btc,
             sk.to_bytes().as_slice(),
         ),
-        vta_did: "did:key:z6MkTestVta".into(),
+        vta_did: test_vta_key().0,
         verification_method: None,
     }
+}
+
+/// The VTA this file's mocks answer as: a real `did:key` and its private half.
+///
+/// It used to be the literal `did:key:z6MkTestVta`, which is not a decodable
+/// `did:key` at all and did not need to be — nothing checked who replied. Since
+/// #1341 the client verifies the proof on every reply **and** binds its signer to
+/// the VTA it believes it is talking to, so the stub has to be able to sign as
+/// itself. Every test in this file therefore exercises that check rather than
+/// opting out of it, which is worth the two helpers it costs.
+fn test_vta_key() -> (String, String) {
+    let sk = ed25519_dalek::SigningKey::from_bytes(&[0xC2; 32]);
+    let mut mc = vec![0xed, 0x01];
+    mc.extend_from_slice(sk.verifying_key().as_bytes());
+    let did = format!(
+        "did:key:{}",
+        multibase::encode(multibase::Base::Base58Btc, mc)
+    );
+    let mut priv_mc = vec![0x80, 0x26];
+    priv_mc.extend_from_slice(sk.to_bytes().as_slice());
+    (did, multibase::encode(multibase::Base::Base58Btc, &priv_mc))
+}
+
+/// Wrap a payload in a `#response` document and sign it as the mock VTA.
+///
+/// The type is a stand-in: nothing on the reply path matches it against the
+/// request, and these tests assert on the payload. Where a test names its own
+/// response type deliberately, it uses [`signed_response_typed`].
+async fn signed_response(payload: Value) -> Value {
+    signed_response_typed(
+        "https://trusttasks.org/spec/config/show/0.1#response",
+        payload,
+    )
+    .await
+}
+
+/// [`signed_response`], keeping the caller's own response type.
+async fn signed_response_typed(type_uri: &str, payload: Value) -> Value {
+    let (vta_did, vta_priv) = test_vta_key();
+    let mut doc: trust_tasks_rs::TrustTask<Value> = serde_json::from_value(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": type_uri,
+        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "payload": payload,
+    }))
+    .expect("a well-formed Trust-Task document");
+    vta_sdk::trust_task_sign::sign_in_place(&mut doc, &vta_did, &vta_priv)
+        .await
+        .expect("sign the mock VTA's reply");
+    serde_json::to_value(doc).expect("serialise the signed reply")
 }
 
 async fn client(server: &MockServer) -> VtaClient {
@@ -132,12 +177,7 @@ async fn mount_json(
     status: u16,
     body: Value,
 ) -> wiremock::MockGuard {
-    let resp = ResponseTemplate::new(status).set_body_json(json!({
-        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
-        "type": "urn:test:response",
-        "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        "payload": body,
-    }));
+    let resp = ResponseTemplate::new(status).set_body_json(signed_response(body).await);
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
@@ -494,10 +534,13 @@ async fn list_keys_paginates_query_params() {
                 "status": "active", "contextId": "ctx-a"
             }
         })))
-        .respond_with(tt_ok(json!({
-            "keys": [key_record_json("k1")],
-            "total": 1
-        })))
+        .respond_with(
+            tt_ok(json!({
+                "keys": [key_record_json("k1")],
+                "total": 1
+            }))
+            .await,
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -758,7 +801,7 @@ async fn list_acl_with_context_query() {
             "type": TASK_ACL_LIST,
             "payload": {"scope": "ctx-a"}
         })))
-        .respond_with(tt_ok(json!({"entries": []})))
+        .respond_with(tt_ok(json!({"entries": []})).await)
         .expect(1)
         .mount(&server)
         .await;
@@ -781,7 +824,7 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
         .and(body_partial_json(json!({
             "payload": {"scope": "acme/eng", "direction": "subtree"}
         })))
-        .respond_with(tt_ok(json!({"entries": []})))
+        .respond_with(tt_ok(json!({"entries": []})).await)
         .expect(1)
         .mount(&server)
         .await;
@@ -798,7 +841,7 @@ async fn list_acl_sends_the_direction_only_when_it_is_not_the_default() {
         // An old VTA rejects an unknown field, so the default direction must
         // be omitted rather than spelled out.
         .and(no_payload_key("direction"))
-        .respond_with(tt_ok(json!({"entries": []})))
+        .respond_with(tt_ok(json!({"entries": []})).await)
         .expect(2)
         .mount(&server)
         .await;
@@ -829,15 +872,18 @@ async fn swap_acl_sends_the_canonical_task_over_rest() {
                 "newSubject": "did:key:zNew",
             },
         })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:0000",
-            "type": "https://trusttasks.org/spec/acl/swap-key/0.1#response",
-            "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            "payload": {
-                "entry": acl_entry_json("did:key:zNew"),
-                "previousSubject": "did:key:zOld",
-            },
-        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(
+                signed_response_typed(
+                    "https://trusttasks.org/spec/acl/swap-key/0.1#response",
+                    json!({
+                        "entry": acl_entry_json("did:key:zNew"),
+                        "previousSubject": "did:key:zOld",
+                    }),
+                )
+                .await,
+            ),
+        )
         .expect(1)
         .mount_as_scoped(&server)
         .await;
@@ -958,7 +1004,7 @@ async fn delete_acl_returns_unit() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1109,7 +1155,7 @@ async fn delete_context_with_force_query() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1123,7 +1169,7 @@ async fn delete_context_no_force_omits_query() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1259,7 +1305,7 @@ async fn remove_webvh_server_deletes() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1347,9 +1393,12 @@ async fn list_dids_webvh_filters_by_context() {
             // literal happened to say.
             "payload": {"contextId": "primary", "serverId": "s1"}
         })))
-        .respond_with(tt_ok(json!({
-            "dids": [webvh_did_record_json("did:webvh:Qabc:server.example.com:primary")]
-        })))
+        .respond_with(
+            tt_ok(json!({
+                "dids": [webvh_did_record_json("did:webvh:Qabc:server.example.com:primary")]
+            }))
+            .await,
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -1406,7 +1455,7 @@ async fn delete_did_webvh_returns_unit() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1431,18 +1480,22 @@ async fn update_did_webvh_by_did_sends_the_canonical_task() {
                 "document": {"id": "did:webvh:Qabc:host:slug"},
             },
         })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:0000",
-            "type": "https://trusttasks.org/spec/vta/webvh/dids/update/1.0#response",
-            "payload": {
-                "did": "did:webvh:Qabc:host:slug",
-                "newVersionId": "2-z",
-                "newScid": "Qabc",
-                "newLogEntry": "{}",
-                "updateKeysCount": 1,
-                "preRotationKeyCount": 0
-            },
-        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(
+                signed_response_typed(
+                    "https://trusttasks.org/spec/vta/webvh/dids/update/1.0#response",
+                    json!({
+                        "did": "did:webvh:Qabc:host:slug",
+                        "newVersionId": "2-z",
+                        "newScid": "Qabc",
+                        "newLogEntry": "{}",
+                        "updateKeysCount": 1,
+                        "preRotationKeyCount": 0
+                    }),
+                )
+                .await,
+            ),
+        )
         .expect(1)
         .mount_as_scoped(&server)
         .await;
@@ -1537,17 +1590,20 @@ async fn list_audit_logs_paginates() {
                 "cursor": "opaque-token"
             }
         })))
-        .respond_with(tt_ok(json!({
-            "entries": [{
-                "eventId": "e1",
-                "recordedAt": "2026-07-01T00:00:00+00:00",
-                "action": "key.create",
-                "outcome": "success",
-                "actor": "did:key:zActor",
-            }],
-            "truncated": true,
-            "cursor": "next-token"
-        })))
+        .respond_with(
+            tt_ok(json!({
+                "entries": [{
+                    "eventId": "e1",
+                    "recordedAt": "2026-07-01T00:00:00+00:00",
+                    "action": "key.create",
+                    "outcome": "success",
+                    "actor": "did:key:zActor",
+                }],
+                "truncated": true,
+                "cursor": "next-token"
+            }))
+            .await,
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -1578,7 +1634,7 @@ async fn audit_list_percent_encodes_rfc3339_bounds() {
         .and(body_partial_json(json!({
             "payload": {"from": "2026-07-01T00:00:00Z"}
         })))
-        .respond_with(tt_ok(json!({"entries": [], "truncated": false})))
+        .respond_with(tt_ok(json!({"entries": [], "truncated": false})).await)
         .expect(1)
         .mount(&server)
         .await;
@@ -1724,7 +1780,7 @@ async fn delete_did_template_returns_unit() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1828,7 +1884,7 @@ async fn delete_context_did_template_returns_unit() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"payload": {}})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(signed_response(json!({})).await))
         .expect(1)
         .mount(&server)
         .await;
@@ -1902,10 +1958,13 @@ async fn fetch_context_secrets_walks_all_pages() {
             "type": TASK_KEYS_LIST,
             "payload": {"offset": 0}
         })))
-        .respond_with(tt_ok(json!({
-            "keys": page1_keys,
-            "total": 101
-        })))
+        .respond_with(
+            tt_ok(json!({
+                "keys": page1_keys,
+                "total": 101
+            }))
+            .await,
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -1918,10 +1977,13 @@ async fn fetch_context_secrets_walks_all_pages() {
             "type": TASK_KEYS_LIST,
             "payload": {"offset": 100}
         })))
-        .respond_with(tt_ok(json!({
-            "keys": [key_record_json("k100")],
-            "total": 101
-        })))
+        .respond_with(
+            tt_ok(json!({
+                "keys": [key_record_json("k100")],
+                "total": 101
+            }))
+            .await,
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -1937,12 +1999,15 @@ async fn fetch_context_secrets_walks_all_pages() {
         .and(body_partial_json(
             json!({"type": TASK_SEEDS_EXPORT_MNEMONIC}),
         ))
-        .respond_with(tt_ok(json!({
-            "key_id": "k",
-            "key_type": "x25519",
-            "public_key_multibase": "z6LSqHQEbN8eMpx9NhMTXmxqYDhtbW5kqwQYWN9y91vxqMtq",
-            "private_key_multibase": "z3wei5qxuQ8mvebtP4WQiK3CsPuiL6XvfVmuhXKfzKKAwgvY"
-        })))
+        .respond_with(
+            tt_ok(json!({
+                "key_id": "k",
+                "key_type": "x25519",
+                "public_key_multibase": "z6LSqHQEbN8eMpx9NhMTXmxqYDhtbW5kqwQYWN9y91vxqMtq",
+                "private_key_multibase": "z3wei5qxuQ8mvebtP4WQiK3CsPuiL6XvfVmuhXKfzKKAwgvY"
+            }))
+            .await,
+        )
         .expect(101)
         .mount(&server)
         .await;

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -60,6 +60,28 @@ fn did_key_from_seed(seed_byte: u8) -> (String, String) {
     (did, priv_mb)
 }
 
+/// A `#response` document signed as the VTA these tests talk to.
+///
+/// Every test in this file points its client at `did_key_from_seed(0x20)`, and
+/// since #1341 the client verifies the proof on each reply and binds its signer
+/// to that DID. So the stub has to sign as the VTA it is standing in for — which
+/// is what a real one does, and what makes these tests exercise the check rather
+/// than sidestep it.
+async fn signed_reply(type_uri: &str, payload: serde_json::Value) -> serde_json::Value {
+    let (vta_did, vta_priv) = did_key_from_seed(0x20);
+    let mut doc: trust_tasks_rs::TrustTask<serde_json::Value> = serde_json::from_value(json!({
+        "id": "urn:uuid:00000000-0000-4000-8000-000000000000",
+        "type": type_uri,
+        "issuedAt": "2026-01-01T00:00:00Z",
+        "payload": payload,
+    }))
+    .expect("a well-formed Trust-Task document");
+    vta_sdk::trust_task_sign::sign_in_place(&mut doc, &vta_did, &vta_priv)
+        .await
+        .expect("sign the mock VTA's reply");
+    serde_json::to_value(doc).expect("serialise the signed reply")
+}
+
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -469,27 +491,31 @@ async fn ensure_authenticated_runs_full_rotation_flow() {
             "type": "https://trusttasks.org/spec/acl/swap-key/0.1",
             "payload": { "currentSubject": temp_did.clone() },
         })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:stub-swap-response",
-            "type": "https://trusttasks.org/spec/acl/swap-key/0.1#response",
-            "issuedAt": "2026-01-01T00:00:00Z",
-            // The canonical wire spelling, which is NOT the old REST body:
-            // `subject`/`scopes`, not `did`/`allowed_contexts`.
-            // `AclEntryResponse` renames both, so a stub written from the field
-            // names decodes to "missing field `subject`" — which is the second
-            // half of the same migration, and the reason a mock matched only on
-            // the path would have been worse than the red it replaced.
-            "payload": {
-                "entry": {
-                    "subject": "did:key:zNew",
-                    "role": "admin",
-                    "label": "ops",
-                    "scopes": ["primary"],
-                    "created_at": 1_700_000_000_u64,
-                    "created_by": "did:web:vta",
-                }
-            },
-        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(
+                signed_reply(
+                    "https://trusttasks.org/spec/acl/swap-key/0.1#response",
+                    // The canonical wire spelling, which is NOT the old REST body:
+                    // `subject`/`scopes`, not `did`/`allowed_contexts`.
+                    // `AclEntryResponse` renames both, so a stub written from the
+                    // field names decodes to "missing field `subject`" — which is
+                    // the second half of the same migration, and the reason a mock
+                    // matched only on the path would have been worse than the red
+                    // it replaced.
+                    json!({
+                        "entry": {
+                            "subject": "did:key:zNew",
+                            "role": "admin",
+                            "label": "ops",
+                            "scopes": ["primary"],
+                            "created_at": 1_700_000_000_u64,
+                            "created_by": "did:web:vta",
+                        }
+                    }),
+                )
+                .await,
+            ),
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -593,12 +619,15 @@ async fn connect_with_url_override_uses_rest_and_attaches_token() {
             "authorization",
             "Bearer connect-token",
         ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:stub-response",
-            "type": "https://trusttasks.org/spec/config/show/0.1#response",
-            "issuedAt": "2026-01-01T00:00:00Z",
-            "payload": { "fields": [] },
-        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(
+                signed_reply(
+                    "https://trusttasks.org/spec/config/show/0.1#response",
+                    json!({ "fields": [] }),
+                )
+                .await,
+            ),
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -701,12 +730,15 @@ async fn connect_url_override_falls_back_to_rest() {
         .and(wiremock::matchers::body_partial_json(json!({
             "type": "https://trusttasks.org/spec/config/show/0.1"
         })))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:stub-response",
-            "type": "https://trusttasks.org/spec/config/show/0.1#response",
-            "issuedAt": "2026-01-01T00:00:00Z",
-            "payload": { "fields": [] },
-        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(
+                signed_reply(
+                    "https://trusttasks.org/spec/config/show/0.1#response",
+                    json!({ "fields": [] }),
+                )
+                .await,
+            ),
+        )
         .expect(1)
         .mount(&server)
         .await;
@@ -755,12 +787,15 @@ async fn connect_auto_rest_authenticates_and_returns_token() {
             "authorization",
             "Bearer access-jwt",
         ))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "urn:uuid:stub-response",
-            "type": "https://trusttasks.org/spec/config/show/0.1#response",
-            "issuedAt": "2026-01-01T00:00:00Z",
-            "payload": { "fields": [] },
-        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(
+                signed_reply(
+                    "https://trusttasks.org/spec/config/show/0.1#response",
+                    json!({ "fields": [] }),
+                )
+                .await,
+            ),
+        )
         .expect(1)
         .mount(&server)
         .await;


### PR DESCRIPTION
**Stacked on #1348.** That PR fixes the provisioning probe; this fixes the other 67 tests
#1341 left behind — the whole of CI's **Feature combos** job.

## These are the same regression, not the same fix

#1341 made `VtaClient` verify the proof on every reply and bind its signer to the VTA it
is talking to. Right, and the point of the #1334/#1335 arc. What it left behind is a set
of stubs answering the way a VTA used to: unsigned, and often with a placeholder
`urn:test:response` that is not a Trust-Task type URI at all.

#1348 and this PR treat two different situations, and the difference is *what is under
test*:

| | |
|---|---|
| **#1348** — the provisioning probe | A real product property. The probe is a diagnostic, not a gate, and it genuinely must tolerate an agent predating #1334/#1335 — otherwise a VTA that does not sign loses the version-skew diagnosis and the operator gets a bare 404 from the mint. `trusting_unsigned_replies` belongs *in the product*. |
| **this PR** — 67 unit tests | Nothing about these wants an unsigned reply. Their stub simply lagged the client. So the stub is made to answer the way the thing it stands in for does, and each test now **exercises** the new verification rather than sidestepping it. |

I originally fixed the probe test the second way too. #1348's reading is better: making
the mock sign fixes the test and leaves the real old-VTA case broken. That half is
dropped here in favour of theirs.

## Three files, three seams

| File | Tests | The seam |
|---|---|---|
| `client_rest.rs` | 60 | `test_identity`'s `vta_did` was the literal `did:key:z6MkTestVta` — not a decodable `did:key`, and it did not need to be while nothing checked who replied. Now a real key whose private half the file keeps; `mount_json` and `tt_ok` sign with it. |
| `session_store.rs` | 4 | The same, against the `0x20` seed every test in the file already points its client at. |
| `auth_light_rest.rs` | 3 | Three token-refresh tests whose reply was incidental; the VTA key moves above the mocks because one of them now signs as it. |

## Why nobody saw 67 of these

These three binaries have **no tests at all** under default features, so the workspace job
cannot see them. The all-features job can, but stops at the first failing binary — the lib
target #1348 fixes. One reported failure, sixty-eight real ones.

## Still red after both PRs

`Test (workspace)` — 51 tests in `vta-service` (`client_round_trip`, `mock_vta`) and
`vti-e2e-tests` (`client_didcomm`), verified failing on pristine `main` under default
features. CI never reached them.

Different shape again: they drive the **real router**, so the reply comes from the actual
service, which signs (#1335). It cannot here because `build_test_app()` sets `vta_did` to
`did:key:z6MkTestVTA` — a sentinel that, as its own doc comment says, "resolves nowhere
but satisfies the routes that just compare it as a string" — and holds no signing key.
`build_provisionable_test_app()` already exists with a real self-resolving identity and
signing keys, so the fix is probably to give the shared harness one — but that is 85 call
sites and 28 references to the sentinel, and wants its own PR.

## Verified on this stack (#1348 + this)

- `cargo test -p vta-sdk --all-features` — **19 binaries, all green**
- `cargo clippy -p vta-sdk --all-features --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean