### PR TITLE
feat(rooms): hosts compute and serve the data commitment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10975,6 +10975,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "getrandom 0.4.3",
+ "multibase",
  "openmls",
  "openmls_basic_credential",
  "openmls_rust_crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "url",
  "uuid",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "uuid",
 ]
 
@@ -7995,7 +7995,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9615,7 +9615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "uuid",
 ]
 
@@ -9631,7 +9631,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "uuid",
 ]
 
@@ -9650,7 +9650,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "uuid",
 ]
 
@@ -9668,7 +9668,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
 ]
 
 [[package]]
@@ -9688,9 +9688,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.9"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762f669091e95f1eb5e735d9f24ac2408a6cfab3ce6543aa86226b3dac1d312f"
+checksum = "e3b18725200227aa173e4c7b6b89450bf6d42ab4add65caf510464378f196356"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10446,7 +10446,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "uniffi",
  "vta-sdk",
 ]
@@ -10464,7 +10464,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10544,7 +10544,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "url",
  "utoipa",
  "uuid",
@@ -10629,7 +10629,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "url",
  "urlencoding",
  "utoipa",
@@ -10798,7 +10798,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10870,7 +10870,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10928,7 +10928,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -10988,7 +10988,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.9",
+ "trust-tasks-rs 0.18.11",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.18.9", default-features = false, features = [
+trust-tasks-rs = { version = "0.18.11", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -540,6 +540,25 @@ async fn list(
                 doc,
                 ListRecordsResponse {
                     records: records.iter().take(limit).map(|r| r.metadata()).collect(),
+                    // The reference host commits too. A host that served
+                    // listings without one would be a working example of the
+                    // thing the commitment exists to make detectable.
+                    data_commitment: match storage::data_commitment(&state.records, &req.room_id)
+                        .await
+                    {
+                        Ok(root) => Some(vti_rooms::merkle::to_multibase(&root)),
+                        Err(e) => {
+                            // Advisory, so it must not fail the read — a member
+                            // who asked for records and got an error because the
+                            // tree was unhappy has lost a working operation.
+                            tracing::error!(
+                                room = %req.room_id,
+                                error = %e,
+                                "could not compute the data commitment; answering without one"
+                            );
+                            None
+                        }
+                    },
                 },
             )
         }

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -393,7 +393,28 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
                 Some(&req.key),
             )
             .await;
-            success_response(&doc, record)
+            // Serialised then extended rather than wrapped in a new type: the
+            // shape this has always returned is what consumers parse, and the
+            // commitment is one more member on it.
+            let mut payload = match serde_json::to_value(&record) {
+                Ok(v) => v,
+                Err(e) => {
+                    return app_error_to_reject(
+                        &doc,
+                        &vti_common::error::AppError::Internal(format!(
+                            "serialise record `{}`: {e}",
+                            req.key
+                        )),
+                    );
+                }
+            };
+            if let (Some(obj), Some(root)) = (
+                payload.as_object_mut(),
+                room_commitment(state, &req.room_id).await,
+            ) {
+                obj.insert("dataCommitment".into(), Value::String(root));
+            }
+            success_response(&doc, payload)
         }
         Err(e) => app_error_to_reject(&doc, &e),
     }
@@ -454,8 +475,33 @@ pub(crate) async fn handle_list_records(
         &doc,
         ListRecordsResponse {
             records: records.iter().take(limit).map(|r| r.metadata()).collect(),
+            data_commitment: room_commitment(state, &req.room_id).await,
         },
     )
+}
+
+/// The room's data commitment, or `None` if it could not be computed.
+///
+/// **A failure here must not fail the read.** The commitment is an additional
+/// guarantee, and the specification makes it OPTIONAL precisely so a host that
+/// cannot assert one says nothing rather than something false — a member who
+/// asked for records and got an error because the *tree* was unhappy has lost a
+/// working operation to an advisory one.
+///
+/// Logged rather than swallowed silently: a host that has quietly stopped
+/// committing looks, to a member, exactly like a host that never did.
+async fn room_commitment(state: &AppState, room_id: &str) -> Option<String> {
+    match storage::data_commitment(&state.room_records_ks, room_id).await {
+        Ok(root) => Some(vti_rooms::merkle::to_multibase(&root)),
+        Err(e) => {
+            tracing::error!(
+                room = %room_id,
+                error = %e,
+                "could not compute the room's data commitment; answering without one"
+            );
+            None
+        }
+    }
 }
 
 /// `rooms/epoch/mint/0.1`.

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -63,6 +63,8 @@ chrono = { workspace = true }
 # SHA-256 with RFC 6962's domain separation.
 serde_json_canonicalizer = { workspace = true }
 sha2 = { workspace = true }
+# `dataCommitment` travels as a multibase-encoded multihash, never bare hex.
+multibase = { workspace = true }
 
 # MLS (RFC 9420) for room group keys, behind the `mls` feature. The design note
 # adopts MLS rather than a hand-rolled epoch scheme: post-compromise security and

--- a/vti-rooms/src/merkle.rs
+++ b/vti-rooms/src/merkle.rs
@@ -63,6 +63,9 @@ pub enum MerkleError {
         #[source]
         source: serde_json::Error,
     },
+    /// A wire value is not a commitment this build can compare against.
+    #[error("`{value}` is not a usable data commitment: {why}")]
+    NotACommitment { value: String, why: &'static str },
 }
 
 /// Hash one record into a leaf.
@@ -250,10 +253,45 @@ mod hex_hash {
     }
 }
 
-/// Hex-encode a commitment for the wire.
+/// Encode a commitment as the wire carries it: a `DigestMultibase`.
+///
+/// `0x12 0x20` (sha2-256, 32 bytes) followed by the digest, base58btc with the
+/// `z` prefix — the same shape `sealed_transfer::bundle_digest_multibase`
+/// produces, and what `rooms/records/{list,get}`'s `dataCommitment` is typed as.
+///
+/// **Not hex.** A bare hex string hard-codes SHA-256 into the wire contract,
+/// which is exactly what the framework's `DigestMultibase` exists to avoid:
+/// multihash names the algorithm in-band, so moving off SHA-256 later is a
+/// change of value rather than another schema revision.
 #[must_use]
-pub fn to_hex(hash: &Hash) -> String {
-    hash.iter().map(|b| format!("{b:02x}")).collect()
+pub fn to_multibase(hash: &Hash) -> String {
+    let mut mh = Vec::with_capacity(34);
+    mh.extend_from_slice(&[0x12, 0x20]);
+    mh.extend_from_slice(hash);
+    multibase::encode(multibase::Base::Base58Btc, mh)
+}
+
+/// Read a wire `dataCommitment` back to a [`Hash`].
+///
+/// Refuses anything that is not a sha2-256 multihash. A commitment is what a
+/// comparison turns on, so silently accepting an algorithm this build cannot
+/// compute would turn "these two roots differ" into "these two roots are not
+/// comparable" without saying so.
+pub fn from_multibase(value: &str) -> Result<Hash, MerkleError> {
+    let (_, bytes) = multibase::decode(value).map_err(|_| MerkleError::NotACommitment {
+        value: value.to_string(),
+        why: "not valid multibase",
+    })?;
+    let Some((&[0x12, 0x20], digest)) = bytes.split_at_checked(2) else {
+        return Err(MerkleError::NotACommitment {
+            value: value.to_string(),
+            why: "not a sha2-256 multihash (expected the 0x12 0x20 prefix)",
+        });
+    };
+    digest.try_into().map_err(|_| MerkleError::NotACommitment {
+        value: value.to_string(),
+        why: "a sha2-256 multihash carries exactly 32 bytes",
+    })
 }
 
 #[cfg(test)]
@@ -466,6 +504,48 @@ mod tests {
         let leaves = [leaf_hash(&record("a", 1)).expect("hashes")];
         assert!(inclusion_proof(&leaves, 1).is_none());
         assert!(inclusion_proof(&[], 0).is_none());
+    }
+
+    /// The wire encoding is `DigestMultibase`, not hex. A bare hex string
+    /// hard-codes SHA-256 into the contract, which is what the framework's
+    /// definition exists to prevent.
+    #[test]
+    fn a_commitment_encodes_as_a_sha2_256_multihash() {
+        let root = commit_records(&mut [record("a", 1)]).expect("commits");
+        let encoded = to_multibase(&root);
+
+        assert!(
+            encoded.starts_with('z'),
+            "base58btc is RECOMMENDED: {encoded}"
+        );
+        let (_, bytes) = multibase::decode(&encoded).expect("valid multibase");
+        assert_eq!(&bytes[..2], &[0x12, 0x20], "sha2-256 multihash prefix");
+        assert_eq!(bytes.len(), 34);
+        assert_eq!(from_multibase(&encoded).expect("round-trips"), root);
+    }
+
+    /// A commitment is what a comparison turns on, so an unreadable one must be
+    /// an error rather than a value that quietly fails to match.
+    #[test]
+    fn something_that_is_not_a_commitment_is_refused() {
+        // Bare hex — the encoding this replaced.
+        assert!(from_multibase(&to_hex_for_test(&empty_root())).is_err());
+        // A multihash naming another algorithm.
+        let mut other = vec![0x13, 0x20];
+        other.extend_from_slice(&[7u8; 32]);
+        let encoded = multibase::encode(multibase::Base::Base58Btc, other);
+        assert!(
+            from_multibase(&encoded).is_err(),
+            "accepted a non-sha2-256 digest"
+        );
+        // Right prefix, wrong length.
+        let short = multibase::encode(multibase::Base::Base58Btc, vec![0x12, 0x20, 1, 2, 3]);
+        assert!(from_multibase(&short).is_err());
+        assert!(from_multibase("not multibase at all").is_err());
+    }
+
+    fn to_hex_for_test(hash: &Hash) -> String {
+        hash.iter().map(|b| format!("{b:02x}")).collect()
     }
 
     #[test]

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -488,6 +488,32 @@ pub async fn list_records(
     Ok(out)
 }
 
+/// The room's data commitment — the root of its record tree.
+///
+/// Over **every** record the room holds, never the page being returned: a
+/// page-scoped root is one a host satisfies by construction and could never
+/// fail, which would let a member feel checked while checking nothing.
+///
+/// # Why this is not cached
+///
+/// It scans and hashes the room on every call, which is real work a cache would
+/// avoid. A cache would also have to be invalidated by every put, curate and
+/// prune, and **a stale root is worse than a slow one**: it is a *wrong*
+/// commitment, and the failure it produces is an honest host appearing to
+/// equivocate — the exact accusation this machinery exists to make credible.
+///
+/// So: correct first, and cache when there is a measurement saying where. The
+/// natural shape is a root kept beside the room row and updated on write, which
+/// is a different change with its own invariant to hold.
+pub async fn data_commitment(
+    records: &KeyspaceHandle,
+    room_id: &str,
+) -> Result<crate::merkle::Hash, AppError> {
+    let mut all = list_records(records, room_id, None, None).await?;
+    crate::merkle::commit_records(&mut all)
+        .map_err(|e| AppError::Internal(format!("commit the records of `{room_id}`: {e}")))
+}
+
 /// What one curation changes.
 ///
 /// A struct rather than three parameters because they are one *decision* — a curator
@@ -700,6 +726,70 @@ mod tests {
         assert!(
             matches!(err, AppError::Conflict(_)),
             "re-registering would reset the epoch and version counter: {err:?}"
+        );
+    }
+
+    /// The property the commitment exists for, at the storage layer: a host that
+    /// serves a listing missing a record commits to a different room than the
+    /// one it holds. Without this the value is decoration.
+    #[tokio::test]
+    async fn a_missing_record_changes_the_rooms_commitment() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for (i, key) in ["a", "b", "c"].iter().enumerate() {
+            put_record(&rooms, &rec, "r1", open_record(key), None, i as u64 + 1)
+                .await
+                .unwrap();
+        }
+
+        let whole_room = data_commitment(&rec, "r1").await.unwrap();
+
+        // What a host serving two of the three records would be committing to.
+        let mut short = list_records(&rec, "r1", None, None).await.unwrap();
+        short.retain(|r| r.key != "b");
+        let partial = crate::merkle::commit_records(&mut short).unwrap();
+
+        assert_ne!(
+            whole_room, partial,
+            "dropping a record left the commitment unchanged"
+        );
+    }
+
+    /// The commitment covers the room, not a query. A prefix or `sinceVersion`
+    /// narrows what a caller *sees*; a root that narrowed with it would be one
+    /// the host satisfies by construction.
+    #[tokio::test]
+    async fn the_commitment_ignores_the_filters_a_listing_applies() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for (i, key) in ["alpha", "beta", "gamma"].iter().enumerate() {
+            put_record(&rooms, &rec, "r1", open_record(key), None, i as u64 + 1)
+                .await
+                .unwrap();
+        }
+
+        let root = data_commitment(&rec, "r1").await.unwrap();
+        // A filtered listing returns fewer records; the room is unchanged, so
+        // the commitment must be too.
+        let filtered = list_records(&rec, "r1", Some("a"), None).await.unwrap();
+        assert!(filtered.len() < 3, "the fixture must actually filter");
+        assert_eq!(data_commitment(&rec, "r1").await.unwrap(), root);
+    }
+
+    /// An empty room has an honest commitment rather than no commitment.
+    #[tokio::test]
+    async fn an_empty_room_commits_to_the_empty_root() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        assert_eq!(
+            data_commitment(&rec, "r1").await.unwrap(),
+            crate::merkle::empty_root()
         );
     }
 

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -235,6 +235,13 @@ pub struct ListRecordsBody {
 pub struct ListRecordsResponse {
     /// Metadata only — never bodies.
     pub records: Vec<serde_json::Value>,
+    /// The room's data commitment, as a `DigestMultibase`.
+    ///
+    /// Optional on the wire because a host that maintains no tree must not
+    /// invent a root: its absence honestly says "no completeness guarantee
+    /// here", and a fabricated one would say the opposite while meaning less.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_commitment: Option<String>,
 }
 
 /// `rooms/records/curate/0.1` request.


### PR DESCRIPTION
Third of the verified-reads pieces, and the one that makes the first two do anything: the tree (#1346), the wire member (trustoverip/dtgwg-trust-tasks-tf#411, released in `trust-tasks-rs` 0.18.11), and now a host that actually asserts a root.

`storage::data_commitment` scans the room and returns the root. **Both hosts serve it** — the VTC on `rooms/records/{list,get}`, and `room-host` on its listing, because a reference host that served listings without one would be a working example of the thing the commitment exists to make detectable.

## Over the whole room, never the page

A filtered listing narrows what a caller *sees*; a root that narrowed with it would be one the host satisfies by construction and could never fail — it would let a member feel checked while checking nothing.

There is a test for exactly that: a prefix filter returns fewer records and leaves the commitment unchanged.

## Deliberately not cached

The comment says why rather than leaving it to be asked in review. A cache needs invalidating on every put, curate and prune, and **a stale root is worse than a slow one**: it is a *wrong* commitment, and the failure it produces is an honest host appearing to equivocate — the exact accusation this machinery exists to make credible.

Correct first; cache when a measurement says where. The natural shape is a root kept beside the room row and updated on write, which is a different change with its own invariant to hold.

## A commitment failure must not fail the read

The specification makes the member OPTIONAL precisely so a host that cannot assert a root says nothing rather than something false. A member who asked for *records* and got an error because the **tree** was unhappy has lost a working operation to an advisory one.

Logged rather than swallowed silently, because a host that has quietly stopped committing looks — to a member — exactly like one that never did.

## Tests

Three at the storage layer, each an attack rather than a mechanism:

- dropping a record changes the room's commitment (without this the value is decoration);
- a filtered listing does **not** change it;
- an empty room commits to the empty root rather than to nothing.

## Verification

`cargo clippy --workspace --all-targets -- -D warnings` clean — run with CI's exact flags, which is what caught the `room-host` constructor before pushing rather than after. `cargo test -p vti-rooms -p room-host` green (111 + 23). `cargo test -p vtc-service --lib` — 958 passed, 0 failed. `cargo build --workspace --all-targets` clean. The VTC integration suites were still running when I opened this; CI covers them.

## What is left

Traces. A commitment lets a reader compare roots and catch a host that equivocates; a trace is what proves a *particular* record sits under a particular root. `rooms/records/get` already carries the commitment, so that addition needs no new member and no version bump there.