### PR TITLE
fix(rooms)!: bind an invitation's proof to its issuer

### DIFF
--- a/vta-service/src/operations/room_invitation.rs
+++ b/vta-service/src/operations/room_invitation.rs
@@ -9,21 +9,28 @@
 //! stops being ceremonial. A VTA that accepted an uninvited Welcome would have made the
 //! invitation decorative.
 //!
-//! # Five checks, and none of them is optional
+//! # Six checks, and none of them is optional
 //!
 //! 1. It parses as a DTG credential, and it is an **invitation** — not some other credential
 //!    the sender had lying around.
-//! 2. Its **proof verifies**. Everything below is a claim until this holds; a well-formed
-//!    invitation naming anyone is trivial to write.
-//! 3. The **issuer is the room**. An invitation to a different room is not an invitation to
+//! 2. The **issuer is the room**. An invitation to a different room is not an invitation to
 //!    this one, however valid.
-//! 4. The **subject is us**. An invitation issued to somebody else is not transferable, and
+//! 3. The **subject is us**. An invitation issued to somebody else is not transferable, and
 //!    accepting one would let a third party place a member into a room they were invited to.
-//! 5. It is **within its validity window**, and **not already consumed**.
+//! 4. The proof's key **belongs to the issuer**. A proof that verifies only means *somebody*
+//!    signed it, which is equally true of a forgery; this is what makes that somebody the
+//!    room.
+//! 5. Its **proof verifies**. Everything above is a claim until this holds; a well-formed
+//!    invitation naming anyone is trivial to write.
+//! 6. It is **within its validity window**, and **not already consumed**.
 //!
 //! Dropping any one of them leaves a way in. The order is deliberate too: the cheap
 //! structural checks come before the signature verification, which comes before the storage
 //! read, so a malformed or irrelevant credential costs nothing.
+//!
+//! Check 4 was absent until it was found by porting this module to a browser and writing a
+//! test per clause rather than one "a bad invitation is refused" case — which passes with
+//! any five of six, and did.
 
 use chrono::Utc;
 use dtg_credentials::{DTGCredential, DTGCredentialType};
@@ -103,6 +110,35 @@ pub async fn verify(
         .proof
         .as_ref()
         .ok_or_else(|| AppError::Validation("the invitation carries no proof".into()))?;
+
+    // The proof's key must belong to the **issuer**, and nothing above implies it.
+    //
+    // Resolving whatever verification method the proof names and verifying against it
+    // proves only that *somebody* signed the credential — which is equally true of a
+    // forgery. Without this, an attacker mints an invitation naming the room as issuer,
+    // signs it with their own key, points the proof at their own verification method, and
+    // checks 1–4 above all pass: the room is right, the subject is right, the window is
+    // right, and the signature verifies against the attacker's own key.
+    //
+    // Cheap, and deliberately before the resolver call: a credential that cannot be the
+    // room's own is refused without a network round trip.
+    let vm_controller = proof
+        .verification_method
+        .split('#')
+        .next()
+        .unwrap_or(&proof.verification_method);
+    if vm_controller != credential.issuer() {
+        tracing::warn!(
+            issuer = %credential.issuer(),
+            signer = %vm_controller,
+            "an invitation claiming a room as issuer was signed by another party"
+        );
+        return Err(AppError::Validation(format!(
+            "the invitation says room `{}` issued it but is signed by `{vm_controller}`",
+            credential.issuer()
+        )));
+    }
+
     let key = keys
         .public_key(&proof.verification_method)
         .await
@@ -165,4 +201,143 @@ pub async fn is_consumed(
         .await
         .map_err(|e| AppError::Internal(format!("read the invitation record: {e}")))?
         .is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+
+    /// Resolves a `did:key` verification method lexically — the key is the identifier, so
+    /// there is nothing to look up. Enough to exercise this module without a network or a
+    /// resolver cache, which is why it had no unit tests before.
+    struct DidKeyOnly;
+
+    #[async_trait::async_trait]
+    impl vti_rooms_dtg::VerificationKeys for DidKeyOnly {
+        async fn public_key(&self, verification_method: &str) -> Result<Vec<u8>, AppError> {
+            let did = verification_method
+                .split('#')
+                .next()
+                .unwrap_or(verification_method);
+            let mb = did
+                .strip_prefix("did:key:")
+                .ok_or_else(|| AppError::Validation(format!("not a did:key: {did}")))?;
+            let (_, bytes) = multibase::decode(mb)
+                .map_err(|e| AppError::Validation(format!("decode {did}: {e}")))?;
+            Ok(bytes[2..].to_vec())
+        }
+    }
+
+    /// A `did:key` and the secret behind it.
+    fn a_party(seed: u8) -> (String, affinidi_secrets_resolver::secrets::Secret) {
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let pk = sk.verifying_key().to_bytes();
+        let mut mc = vec![0xed, 0x01];
+        mc.extend_from_slice(&pk);
+        let did = format!(
+            "did:key:{}",
+            multibase::encode(multibase::Base::Base58Btc, &mc)
+        );
+        let secret = affinidi_secrets_resolver::secrets::Secret::from_str(
+            &format!("{did}#{}", did.trim_start_matches("did:key:")),
+            &serde_json::json!({
+                "crv": "Ed25519",
+                "d": B64.encode(sk.to_bytes()),
+                "kty": "OKP",
+                "x": B64.encode(pk),
+            }),
+        )
+        .expect("build a signing secret");
+        (did, secret)
+    }
+
+    /// An invitation from `issuer` to `subject`, signed by `signer`.
+    ///
+    /// `signer` is separate from `issuer` on purpose: a forgery is exactly the case where
+    /// they differ, and a helper that could not express it could not test for it.
+    async fn an_invitation(
+        issuer: &str,
+        signer: &affinidi_secrets_resolver::secrets::Secret,
+        subject: &str,
+        id: &str,
+    ) -> String {
+        let now = Utc::now();
+        let mut vic = DTGCredential::new_vic(
+            issuer.to_string(),
+            subject.to_string(),
+            now - chrono::Duration::minutes(1),
+            Some(now + chrono::Duration::hours(1)),
+        )
+        .with_id(id);
+        vic.sign(signer, None).await.expect("sign the invitation");
+        serde_json::to_string(vic.credential()).expect("serialise")
+    }
+
+    #[tokio::test]
+    async fn a_genuine_invitation_verifies() {
+        let (room, room_secret) = a_party(0x41);
+        let vic = an_invitation(&room, &room_secret, "did:key:zMember", "urn:uuid:i-1").await;
+
+        let verified = verify(&vic, &room, "did:key:zMember", &DidKeyOnly)
+            .await
+            .expect("a genuine invitation must verify");
+        assert_eq!(verified.credential_id(), "urn:uuid:i-1");
+    }
+
+    /// The check that was missing: an invitation naming the room as issuer but signed by
+    /// somebody else.
+    ///
+    /// Every other clause passes here — it is an invitation, the issuer field is the room,
+    /// the subject is the member, the window is open, and the proof verifies perfectly
+    /// against the key it names. The only thing wrong is *whose* key that is, and without
+    /// this check nothing looks at it: anyone could mint themselves an invitation to any
+    /// room, join it, and hold its group keys.
+    #[tokio::test]
+    async fn an_invitation_signed_by_anyone_but_the_room_is_refused() {
+        let (room, _room_secret) = a_party(0x42);
+        let (_attacker, attacker_secret) = a_party(0x43);
+
+        // Issuer says the room; the signature is the attacker's own.
+        let forged =
+            an_invitation(&room, &attacker_secret, "did:key:zMember", "urn:uuid:i-2").await;
+
+        let err = verify(&forged, &room, "did:key:zMember", &DidKeyOnly)
+            .await
+            .expect_err("a forged invitation must be refused");
+        assert!(
+            format!("{err}").contains("is signed by"),
+            "the refusal must name the mismatch rather than read as a bad signature: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_invitation_to_another_room_is_refused() {
+        let (room, _) = a_party(0x44);
+        let (elsewhere, elsewhere_secret) = a_party(0x45);
+        let vic = an_invitation(
+            &elsewhere,
+            &elsewhere_secret,
+            "did:key:zMember",
+            "urn:uuid:i-3",
+        )
+        .await;
+
+        let err = verify(&vic, &room, "did:key:zMember", &DidKeyOnly)
+            .await
+            .expect_err("an invitation to another room is not one to this one");
+        assert!(format!("{err}").contains("issued by"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn an_invitation_to_somebody_else_is_refused() {
+        let (room, room_secret) = a_party(0x46);
+        let vic = an_invitation(&room, &room_secret, "did:key:zSomeoneElse", "urn:uuid:i-4").await;
+
+        let err = verify(&vic, &room, "did:key:zMember", &DidKeyOnly)
+            .await
+            .expect_err("an invitation is not transferable");
+        assert!(format!("{err}").contains("not transferable"), "{err}");
+    }
 }


### PR DESCRIPTION
**An invitation naming a room as issuer, signed by anybody at all, was accepted.**

Every other clause in `room_invitation::verify` passes for a forgery: it *is* an
invitation, the issuer field *is* the room, the subject *is* the member, the window *is*
open, and the proof *does* verify — against the attacker's own key, which is the one the
proof named and the one this module went and resolved.

Nothing looked at whose key it was. So anyone could mint themselves an invitation to any
room, hand it to their agent, mint a KeyPackage against it, accept the Welcome, and hold
that room's group keys. The invitation is the consent artefact for joining — "joining a
room is a two-party act, and the invitation is the other party's half" — and without this
check it consented to nothing.

## The fix

Four lines, placed *before* the resolver call rather than after: a credential that cannot
be the room's own is refused without a network round trip.

```rust
if vm_controller != credential.issuer() { … }
```

The refusal names the mismatch rather than reading as a bad signature, because the chain
is perfectly valid — it is just not the room's.

## How it was found

By porting this module to a browser (`vti-rooms-wasm`, for the data-room demo) and writing
**a test per clause** instead of one "a bad invitation is refused" case. That shape passes
with any five of six, and did.

The module had **no unit tests at all**, which is most of why this survived. `verify()` is
async and takes `&dyn VerificationKeys`, so it reads as needing a resolver and a network —
when a fifteen-line `did:key` resolver exercises the whole of it, because a `did:key`
carries its key in its own name. Four tests added on that basis: a genuine invitation, the
forgery, another room's invitation, and somebody else's.

The doc comment's check list is renumbered five to six. A doc comment that counts its own
checks is load-bearing — it is how the next reader knows whether one went missing.

## Marked `!`

A previously-accepted credential is now refused. That is the point, but it is a behaviour
change for anyone who was relying on it, and the only parties who could be are forgeries.

## Related

Two more findings from the same port, filed separately: `room-host` had no CORS layer
(#1354), and `vta-cli-common` passes the wrong party as a presentation's
`audience` — which turns out to be a spec/implementation conflict rather than a plain bug,
written up in that PR.

## Verified

- `cargo test -p vta-service --lib operations::room_invitation` — 4 passed
- `cargo clippy -p vta-service --all-targets -- -D warnings` — clean