### PR TITLE
feat(rooms): let a browser reach room-host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7976,6 +7976,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
+ "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -25,6 +25,8 @@ vti-rooms-dtg = { path = "../vti-rooms-dtg" }
 vtc-client = { path = "../vtc-client", version = "0.5" }
 
 axum = { workspace = true }
+# CORS only, and only when an operator asks for it — see `router_with_origins`.
+tower-http = { workspace = true, features = ["cors"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -946,6 +946,66 @@ pub fn router(state: Arc<HostState>) -> Router {
         .with_state(state)
 }
 
+/// [`router`], reachable from a browser at the named origins.
+///
+/// A room's own client may be a web page — a member is a party holding credentials, not a
+/// party running a server, and increasingly that means a tab. Without a CORS layer a
+/// browser cannot reach this host at all: the request is made and the response is discarded
+/// before any script sees it, so the failure surfaces as a network error with nothing in it
+/// about origins, and the page's author goes looking at the wrong end.
+///
+/// Off unless asked for, and by explicit origin rather than `*`. This host stores rooms it
+/// does not govern; which sites may talk to it from a user's browser is an operator's
+/// decision, and a wildcard is the one answer that cannot be reviewed. Mirrors
+/// `vta-service`'s layer, including its refusal to partially apply: a half-configured CORS
+/// surface is worse than none, because it looks configured.
+///
+/// Note this changes nothing about **authorization**. A browser reaching this host is still
+/// a request carrying a proof and a chain, refused exactly as any other would be. CORS
+/// decides who may ask, never what the answer is.
+pub fn router_with_origins(state: Arc<HostState>, allowed_origins: &[String]) -> Router {
+    let router = router(state);
+    match cors_layer(allowed_origins) {
+        Some(layer) => router.layer(layer),
+        None => router,
+    }
+}
+
+/// The CORS layer for `allowed_origins`, or `None` when there is nothing usable to apply.
+fn cors_layer(allowed_origins: &[String]) -> Option<tower_http::cors::CorsLayer> {
+    use axum::http::{HeaderName, HeaderValue, Method};
+    use tower_http::cors::{AllowOrigin, CorsLayer};
+
+    if allowed_origins.is_empty() {
+        return None;
+    }
+    // `AllowOrigin::list` panics on a wildcard, and falling through to `any()` is not the
+    // intent — an operator who wants every origin can say so in a proxy, where it is
+    // visible. Malformed entries are dropped for the same reason a typo should show up in
+    // the startup log rather than silently widen anything.
+    let parsed: Vec<HeaderValue> = allowed_origins
+        .iter()
+        .filter(|o| !o.is_empty() && *o != "*")
+        .filter_map(|o| HeaderValue::from_str(o).ok())
+        .collect();
+    if parsed.is_empty() {
+        tracing::warn!(
+            "every --allow-origin value was empty, a wildcard, or unparseable; serving with \
+             no CORS layer rather than a partial one"
+        );
+        return None;
+    }
+    Some(
+        CorsLayer::new()
+            .allow_origin(AllowOrigin::list(parsed))
+            // One route takes a body, and it is a POST. Nothing here is a GET a browser
+            // would send credentials with.
+            .allow_methods([Method::GET, Method::POST])
+            .allow_headers([HeaderName::from_static("content-type")])
+            .max_age(std::time::Duration::from_secs(60)),
+    )
+}
+
 /// Open the store with a `did:key`-only verifier.
 ///
 /// The conservative construction, and what a test or the example wants: no network

--- a/room-host/src/main.rs
+++ b/room-host/src/main.rs
@@ -4,7 +4,7 @@
 //! test or the `data_room` example without a socket.
 
 use clap::Parser;
-use room_host::{open_state_with_resolver, router};
+use room_host::{open_state_with_resolver, router_with_origins};
 
 #[derive(Parser, Debug)]
 #[command(name = "room-host", about = "Store and serve data-room records")]
@@ -23,6 +23,15 @@ struct Args {
     /// makes rather than a default they inherit.
     #[arg(long)]
     resolve_dids: bool,
+    /// Origins allowed to reach this host from a browser. Repeatable.
+    ///
+    /// Off by default, and explicit origins only — no wildcard. A room's member may be a
+    /// web page, and without this a browser cannot reach this host at all: the response is
+    /// discarded before any script sees it, so the failure reads as a network error with
+    /// nothing in it about origins. Which sites may ask is an operator's decision; what the
+    /// answer is remains the credentials'.
+    #[arg(long = "allow-origin")]
+    allow_origin: Vec<String>,
     /// Rooms this host **mirrors**: a JSON file naming each room's write-primary
     /// and the read credentials this mirror presents to it.
     ///
@@ -84,6 +93,6 @@ async fn main() -> anyhow::Result<()> {
         network_resolution = args.resolve_dids,
         "room host ready — storing records for rooms it does not govern"
     );
-    axum::serve(listener, router(state)).await?;
+    axum::serve(listener, router_with_origins(state, &args.allow_origin)).await?;
     Ok(())
 }


### PR DESCRIPTION
A room's member may be a web page. A member is a party holding credentials, not a party
running a server, and increasingly that means a tab — which until now could not reach this
host **at all**.

Without a CORS layer the request goes out, the response is discarded before any script
sees it, and the failure surfaces as a network error carrying nothing about origins. The
page's author then goes looking at the wrong end of the connection.

## `--allow-origin`, repeatable

Off by default, explicit origins only, no wildcard. This host stores rooms it does not
govern, so which sites may talk to it from somebody's browser is an operator's decision,
and a wildcard is the one answer that cannot be reviewed.

Mirrors `vta-service`'s layer, including its refusal to partially apply: every entry
empty, wildcard or unparseable means no layer and a warning, rather than a half-configured
CORS surface — which is worse than none, because it looks configured.

`router()` is unchanged for embedders; `router_with_origins()` is the new entry point and
`main` uses it.

## It changes nothing about authorization

A browser reaching this host is still a request carrying a proof and a chain, refused
exactly as any other would be. CORS decides who may ask, never what the answer is. Worth
stating because "we opened CORS on the record store" reads alarming until you remember
this host has no ambient authority to leak: it authorises against credentials the *room*
issued and holds no ACL of its own.

Found while pointing a browser-native room member at it — the demo in
`docs/05-design-notes/data-rooms-demo-site.md`.

## Verified

- `cargo test -p room-host` — 23 passed
- `cargo clippy -p room-host --all-targets -- -D warnings` — clean