### PR TITLE
fix(sdk): the mock VTA signs its answers, as every real one does

### DIFF
--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -969,9 +969,9 @@ pub struct VtaTransportIdentity {
 /// `signing_vm_id` for every DID method that is not `did:peer`. Carried out of
 /// [`provision_vta_signing_identity`] rather than re-derived, so the harness
 /// signs with the key it actually provisioned.
-struct VtaOwnSigner {
-    vm_id: String,
-    secret: affinidi_tdk::secrets_resolver::secrets::Secret,
+pub(crate) struct VtaOwnSigner {
+    pub(crate) vm_id: String,
+    pub(crate) secret: affinidi_tdk::secrets_resolver::secrets::Secret,
 }
 
 /// What [`build_transport_state`] hands back — a struct rather than a tuple so

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -197,6 +197,62 @@ pub fn test_deps(ts: &TestStore) -> ProvisionIntegrationDeps {
 /// that cannot sign cannot exercise any of them.
 pub const TEST_ADMIN_SEED: [u8; 32] = [0x7A; 32];
 
+/// The mock VTA's own seed, and the reason it is no longer a sentinel.
+///
+/// It used to be the literal `"did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD"` — the same mistake
+/// `TEST_ADMIN_SEED` above records fixing for the *admin*: not a `did:key` at
+/// all, resolving nowhere, so nothing it signed could carry a verifiable proof.
+/// That was survivable while only requests were checked and a VTA's answers
+/// were taken on trust.
+///
+/// `VtaClient` verifies replies now
+/// (OpenVTC/verifiable-trust-infrastructure#1341), and production has always
+/// signed them with `{vta_did}#key-0` for every DID method that is not
+/// `did:peer` (`server.rs`). A mock that cannot sign is therefore not a cheap
+/// stand-in any more — it is a VTA that behaves in a way no real one does, and
+/// every test through it fails with the client blaming the reply.
+pub const TEST_VTA_SEED: [u8; 32] = [0x5A; 32];
+
+/// The mock VTA's `did:key` and its `#key-0` verification method.
+///
+/// Derived, not written down: a literal here is what the sentinel was.
+pub fn test_vta_did() -> (String, String) {
+    let (did, _vm) = did_for_seed(TEST_VTA_SEED[0]);
+    let vm = format!("{did}#key-0");
+    (did, vm)
+}
+
+/// The mock VTA's own signing secret, as production wires it into
+/// `signing_vm_id`.
+pub(crate) fn test_vta_signer() -> VtaOwnSigner {
+    use ed25519_dalek::SigningKey;
+    let sk = SigningKey::from_bytes(&[TEST_VTA_SEED[0]; 32]);
+    let (_did, vm_id) = test_vta_did();
+    VtaOwnSigner {
+        vm_id: vm_id.clone(),
+        secret: secret_from_ed25519(&sk, vm_id),
+    }
+}
+
+/// An ed25519 signing key as a `Secret`.
+///
+/// **Multicodec-prefixed** (`0x80 0x26`, ed25519-priv). `Secret::from_multibase`
+/// requires the prefix and refuses raw bytes with `Unsupported key type`, while
+/// `decode_private_key_multibase` accepts either — so the two encodings look
+/// interchangeable and are not.
+pub(crate) fn secret_from_ed25519(
+    sk: &ed25519_dalek::SigningKey,
+    id: String,
+) -> affinidi_tdk::secrets_resolver::secrets::Secret {
+    let mut prefixed = vec![0x80u8, 0x26];
+    prefixed.extend_from_slice(sk.to_bytes().as_slice());
+    let mb = multibase::encode(multibase::Base::Base58Btc, prefixed);
+    let mut secret = affinidi_tdk::secrets_resolver::secrets::Secret::from_multibase(&mb, None)
+        .expect("construct an ed25519 Secret");
+    secret.id = id;
+    secret
+}
+
 /// The test super-admin's `did:key`, and the verification method inside it.
 ///
 /// `did:key` encodes the public key in the identifier, so the DID document is
@@ -387,7 +443,7 @@ async fn provision_vta_signing_identity(
     keys_ks: &KeyspaceHandle,
     data_dir: &std::path::Path,
     vta_did_override: Option<&str>,
-) -> (String, Arc<PlaintextSeedStore>) {
+) -> (String, Arc<PlaintextSeedStore>, VtaOwnSigner) {
     use crate::keys::seeds::{SeedRecord, save_seed_record, set_active_seed_id};
 
     // Deterministic 64-byte seed (BIP-32 wants ≥16 bytes; 64 mirrors
@@ -431,6 +487,38 @@ async fn provision_vta_signing_identity(
     };
     let key_id = format!("{vta_did}#key-0");
 
+    // The same key, as a `Secret` the response signer can use.
+    //
+    // Production sets `signing_vm_id` to `{vta_did}#key-0` for did:webvh and
+    // did:key alike (`server.rs`, the non-`did:peer` branch of `AuthInit`), so
+    // a REST-only VTA signs its answers with its own key and needs no transport
+    // identity to do it. This harness never ran that path — it populated the
+    // signer only from `build_transport_state`, which requires a `did:peer:2` —
+    // so a `MockVta` answered unsigned where the real thing signs.
+    //
+    // That gap was invisible until `VtaClient` began verifying replies
+    // (#1341), at which point every round-trip test failed with the client
+    // blaming the reply for something the harness had never provided.
+    let own_signer = {
+        // Multicodec-prefixed, which is what `Secret::from_multibase` reads —
+        // `0x80 0x26` is ed25519-priv. The raw 32 bytes decode fine through
+        // `decode_private_key_multibase`, which tolerates an unprefixed key,
+        // and are refused here; the two are not interchangeable.
+        let mut prefixed = vec![0x80u8, 0x26];
+        prefixed.extend_from_slice(signing.to_bytes().as_slice());
+        let private_key_multibase = multibase::encode(multibase::Base::Base58Btc, prefixed);
+        let mut secret = affinidi_tdk::secrets_resolver::secrets::Secret::from_multibase(
+            &private_key_multibase,
+            None,
+        )
+        .expect("construct the VTA's own signing secret");
+        secret.id = key_id.clone();
+        VtaOwnSigner {
+            vm_id: key_id.clone(),
+            secret,
+        }
+    };
+
     save_key_record(
         keys_ks,
         &key_id,
@@ -468,11 +556,15 @@ async fn provision_vta_signing_identity(
     .await
     .expect("save VTA sealed-transfer key record");
 
-    (vta_did, Arc::new(PlaintextSeedStore::new(data_dir)))
+    (
+        vta_did,
+        Arc::new(PlaintextSeedStore::new(data_dir)),
+        own_signer,
+    )
 }
 
 pub async fn bootstrap_test_vta(ts: &TestStore) -> (String, ProvisionIntegrationDeps) {
-    let (vta_did, _seed_store) =
+    let (vta_did, _seed_store, _own_signer) =
         provision_vta_signing_identity(&ts.keys_ks, &ts.data_dir, None).await;
 
     let mut config = test_app_config(ts.data_dir.clone());
@@ -535,7 +627,8 @@ pub async fn build_signing_test_app_state_with_sink(
     // Provision the VTA's `{vta_did}#key-0` VC-issuance key into the keystore
     // and point the config at the resulting self-resolving did:key.
     let keys_ks = store.keyspace(crate::keyspaces::KEYS).expect("keys ks");
-    let (vta_did, seed_store) = provision_vta_signing_identity(&keys_ks, dir.path(), None).await;
+    let (vta_did, seed_store, _own_signer) =
+        provision_vta_signing_identity(&keys_ks, dir.path(), None).await;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> = seed_store;
 
     let mut config = test_app_config(dir.path().to_path_buf());
@@ -700,7 +793,7 @@ pub struct TestAppContext {
     /// The contexts keyspace — exposed so a harness can seed the trust context a
     /// DID mint requires, the way a provisioning flow would.
     pub contexts_ks: KeyspaceHandle,
-    /// The VTA DID this app is configured with — the `did:key:z6MkTestVTA`
+    /// The VTA DID this app is configured with — the `did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD`
     /// sentinel for [`build_test_app`], or a real, self-resolving `did:key`
     /// for [`build_provisionable_test_app`]. A harness driving a URL-direct
     /// provision passes this as the `vta_did` argument.
@@ -870,6 +963,17 @@ pub struct VtaTransportIdentity {
     pub mediator_did: String,
 }
 
+/// The VTA's own response-signing key, as production wires it.
+///
+/// `{vta_did}#key-0` — the same verification method `server.rs` puts in
+/// `signing_vm_id` for every DID method that is not `did:peer`. Carried out of
+/// [`provision_vta_signing_identity`] rather than re-derived, so the harness
+/// signs with the key it actually provisioned.
+struct VtaOwnSigner {
+    vm_id: String,
+    secret: affinidi_tdk::secrets_resolver::secrets::Secret,
+}
+
 /// What [`build_transport_state`] hands back — a struct rather than a tuple so
 /// the TSP slot can be `cfg`-gated (attributes are not allowed on tuple type
 /// elements) and so the five `Option`s stay distinguishable at the call site.
@@ -989,7 +1093,7 @@ pub async fn build_offline_atm() -> affinidi_tdk::messaging::ATM {
 /// `aws_lc` JWT provider via [`init_jwt_provider`], and the full
 /// `routes::router()` + `routes::health_router()` merged together.
 ///
-/// `vta_did` is `did:key:z6MkTestVTA` — a sentinel that resolves
+/// `vta_did` is `did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD` — a sentinel that resolves
 /// nowhere but satisfies the routes that just compare it as a string.
 /// `vta_name` and `public_url` are set so the JWT audience / DID
 /// document construction don't take their None branches in tests.
@@ -1091,21 +1195,29 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
     // Provisionable: a real signing identity (active seed + `#key-0` +
     // `#sealed-transfer-0`) derived into `keys_ks`, and `vta_did` set to the
     // resulting self-resolving `did:key`.
-    let (vta_did, seed_store): (String, Arc<dyn crate::keys::seed_store::SeedStore>) =
-        if opts.provisionable_vta {
-            let (did, ps) = provision_vta_signing_identity(
-                &keys_ks,
-                dir.path(),
-                opts.vta_transport.as_ref().map(|t| t.did.as_str()),
-            )
-            .await;
-            let store: Arc<dyn crate::keys::seed_store::SeedStore> = ps;
-            (did, store)
-        } else {
-            let store: Arc<dyn crate::keys::seed_store::SeedStore> =
-                Arc::new(TestSeedStore(vec![0xABu8; 32]));
-            ("did:key:z6MkTestVTA".to_string(), store)
-        };
+    let (vta_did, seed_store, own_signer): (
+        String,
+        Arc<dyn crate::keys::seed_store::SeedStore>,
+        Option<VtaOwnSigner>,
+    ) = if opts.provisionable_vta {
+        let (did, ps, signer) = provision_vta_signing_identity(
+            &keys_ks,
+            dir.path(),
+            opts.vta_transport.as_ref().map(|t| t.did.as_str()),
+        )
+        .await;
+        let store: Arc<dyn crate::keys::seed_store::SeedStore> = ps;
+        (did, store, Some(signer))
+    } else {
+        // A real `did:key` and the key behind it — but no seed records and no
+        // keystore, so a test that asserts an *unprovisioned* VTA still gets
+        // one. The identity is only as real as it must be for the mock to sign
+        // its answers, which every production VTA does.
+        let store: Arc<dyn crate::keys::seed_store::SeedStore> =
+            Arc::new(TestSeedStore(vec![0xABu8; 32]));
+        let (did, _vm) = test_vta_did();
+        (did, store, Some(test_vta_signer()))
+    };
 
     let mut config: AppConfig = toml::from_str(&format!(
         r#"
@@ -1167,7 +1279,24 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
     // gives the *listener* its own, and the mediator permits one socket per DID
     // — a second would be terminated as `w.websocket.duplicate-channel`. Same
     // split, and the same reason, as `MockVtcDidcomm`.
-    let transport = build_transport_state(opts.vta_transport.as_ref(), did_resolver.as_ref()).await;
+    let mut transport =
+        build_transport_state(opts.vta_transport.as_ref(), did_resolver.as_ref()).await;
+
+    // A REST-only VTA signs with its own `#key-0`, exactly as production does.
+    // `build_transport_state` only ever fills these from a `did:peer:2`
+    // transport identity, so without this a `MockVta` answers unsigned — which
+    // the real thing does not, and which every round-trip test now fails on.
+    // The transport key wins where there is one: that is the production
+    // ordering and this must not change it.
+    if transport.signing_vm_id.is_none()
+        && let Some(signer) = own_signer
+    {
+        use affinidi_secrets_resolver::SecretsResolver as _;
+        let (resolver, _task) = affinidi_secrets_resolver::ThreadedSecretsResolver::new(None).await;
+        resolver.insert(signer.secret).await;
+        transport.secrets_resolver = Some(Arc::new(resolver));
+        transport.signing_vm_id = Some(signer.vm_id);
+    }
 
     let policy_ks = store.keyspace(crate::keyspaces::POLICY).unwrap();
     let state = crate::server::AppState {

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -506,9 +506,26 @@ async fn validate_payload(
 /// RECOMMENDED rather than REQUIRED and whose variant §7.3 makes undeclarable
 /// by a task.
 ///
-/// An agent with no signing identity yet (before setup) answers unsigned rather
-/// than failing — it has nothing to sign with, and refusing would make an
-/// unprovisioned VTA unusable rather than merely unattributable.
+/// # Two failures that look alike and mean opposite things
+///
+/// **No signing identity configured at all** — an agent before setup. It
+/// answers unsigned, because it has nothing to sign with and refusing would
+/// make an unprovisioned VTA unusable rather than merely unattributable. That
+/// is unchanged and deliberate.
+///
+/// **Configured to sign, and cannot** — a resident secret that is missing, or a
+/// signature that fails to attach. This used to answer unsigned too, on the
+/// reasoning that "the work is done and the caller is entitled to the result,
+/// attributable or not". That reasoning had a premise: that nobody checked. It
+/// stopped being true when the client began verifying replies
+/// (OpenVTC/verifiable-trust-infrastructure#1341), and the two halves compose
+/// badly — this agent logs an error and answers 200, the caller refuses the
+/// reply, and the message the operator reads blames *the reply* for something
+/// that is wrong with *this agent's key*. The caller is not entitled to a
+/// result they will discard; they are entitled to know why.
+///
+/// So a misconfiguration is now an error naming itself. It is a 500 because it
+/// is this agent's fault and retrying the same call will not fix it.
 async fn sign_success_response(state: &AppState, outcome: TrustTaskOutcome) -> TrustTaskOutcome {
     if !outcome.status.is_success() {
         return outcome;
@@ -521,8 +538,8 @@ async fn sign_success_response(state: &AppState, outcome: TrustTaskOutcome) -> T
     };
     use affinidi_tdk::secrets_resolver::SecretsResolver as _;
     let Some(secret) = resolver.get_secret(vm_id).await else {
-        tracing::error!(%vm_id, "no resident secret for the signing key; answering unsigned");
-        return outcome;
+        tracing::error!(%vm_id, "no resident secret for the signing key");
+        return cannot_sign(vm_id, "its signing key is not resident");
     };
 
     match attach_proof(&secret, &outcome.body).await {
@@ -530,10 +547,32 @@ async fn sign_success_response(state: &AppState, outcome: TrustTaskOutcome) -> T
             status: outcome.status,
             body,
         },
-        // Every failure inside answers unsigned rather than turning a successful
-        // operation into a failure over its envelope: the work is done and the
-        // caller is entitled to the result, attributable or not.
-        None => outcome,
+        None => {
+            tracing::error!(%vm_id, "the signature would not attach");
+            cannot_sign(vm_id, "its signature would not attach")
+        }
+    }
+}
+
+/// The answer when this agent is configured to sign and cannot.
+///
+/// Names the verification method, because that is the thing an operator can go
+/// and look at, and says the work was done — a caller that retries a mutating
+/// call on this error would repeat it.
+fn cannot_sign(vm_id: &str, why: &str) -> TrustTaskOutcome {
+    let body = serde_json::json!({
+        "type": "https://trusttasks.org/spec/trust-task-error/0.5",
+        "payload": {
+            "code": "internalError",
+            "message": format!(
+                "this agent completed the request and could not sign its answer, because {why}                  ({vm_id}). The work is done — do not retry a change on this error. An unsigned                  answer is bytes rather than evidence, so it is withheld rather than sent."
+            ),
+            "retryable": false,
+        },
+    });
+    TrustTaskOutcome {
+        status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        body: serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec()),
     }
 }
 
@@ -2137,9 +2176,10 @@ mod tests {
         assert!(
             body[..end].contains("sign_success_response("),
             "the dispatch spine no longer signs its responses. 265 published \
-             specifications require a proof on the response (SPEC §7.3 item 7), \
-             and no consumer verifies one — so nothing else in this workspace \
-             would notice."
+             specifications require a proof on the response (SPEC §7.3 item 7). \
+             `VtaClient` verifies one since #1341, so dropping this would break \
+             every round-trip test — but it would break them by blaming the \
+             reply, which is a long way from the cause."
         );
     }
 

--- a/vta-service/tests/api_integration.rs
+++ b/vta-service/tests/api_integration.rs
@@ -613,7 +613,10 @@ async fn admin_can_read_config() {
         .iter()
         .find(|f| f["key"] == "vta_did")
         .expect("vta_did is registered and readable");
-    assert_eq!(did["value"], "did:key:z6MkTestVTA");
+    assert_eq!(
+        did["value"],
+        "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD"
+    );
     assert_eq!(did["source"], "setup");
 }
 
@@ -679,7 +682,10 @@ async fn super_admin_cannot_rewrite_the_vta_identity() {
         .iter()
         .find(|f| f["key"] == "vta_did")
         .expect("vta_did registered");
-    assert_eq!(did["value"], "did:key:z6MkTestVTA", "{body}");
+    assert_eq!(
+        did["value"], "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
+        "{body}"
+    );
 }
 
 #[tokio::test]

--- a/vta-service/tests/approvals_breakglass_cli.rs
+++ b/vta-service/tests/approvals_breakglass_cli.rs
@@ -31,7 +31,7 @@ fn write_config(dir: &Path) -> std::path::PathBuf {
     std::fs::write(
         &config_path,
         format!(
-            r#"vta_did = "did:key:z6MkTestVTA"
+            r#"vta_did = "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD"
 
 [server]
 port = 8080

--- a/vta-service/tests/authenticate_trust_task.rs
+++ b/vta-service/tests/authenticate_trust_task.rs
@@ -79,7 +79,7 @@ fn signed_authenticate_doc(
         "type": "https://trusttasks.org/spec/auth/authenticate/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": { "challenge": challenge, "sessionId": session_id },
     });
     let mut doc: TrustTask<Value> = serde_json::from_value(doc_json).unwrap();
@@ -288,7 +288,7 @@ async fn tt_challenge_returns_tt_response_doc() {
         "type": "https://trusttasks.org/spec/auth/challenge/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": { "subject": did },
     });
     let (status, body) = send(

--- a/vta-service/tests/idempotency_trust_task.rs
+++ b/vta-service/tests/idempotency_trust_task.rs
@@ -92,7 +92,7 @@ fn create_doc_as(seed: u8, envelope_id: &str, label: &str, idempotency_key: Opti
         "type": KEYS_CREATE,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": vta_service::test_support::did_for_seed(seed).0,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {
             "keyType": "ed25519",
             "derivationPath": "",
@@ -136,7 +136,7 @@ async fn key_count(router: &axum::Router, token: &str) -> usize {
         "type": KEYS_LIST,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": caller(),
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": { "contextId": CONTEXT },
     });
     let (status, body) = post(router, token, &doc).await;
@@ -297,7 +297,7 @@ async fn the_same_key_on_a_different_task_is_refused() {
         "type": "https://trusttasks.org/spec/vta/webvh/dids/create/1.0",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": caller(),
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "idempotencyKey": "urn:uuid:idem-cross",
         "payload": { "contextId": CONTEXT, "portable": true },
     });
@@ -334,7 +334,7 @@ async fn a_key_on_a_retry_safe_task_is_ignored_not_rejected() {
         "type": KEYS_LIST,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": caller(),
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "idempotencyKey": "urn:uuid:idem-on-a-read",
         "payload": { "contextId": CONTEXT },
     });

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -85,7 +85,7 @@ async fn mock_vta_gates_authenticated_routes() {
 // ── Provisionable MockVta: the OpenVTC bootstrap→join e2e seams (issue #406) ──
 
 /// `start_provisionable` must serve a real, self-resolving `did:key` VTA DID —
-/// not the non-resolvable `z6MkTestVTA` sentinel the cheap app uses. This is the
+/// not merely the signing `did:key` the cheap app now derives. This is the
 /// VTA-identity half of Gap 1: only a real `did:key` lets the VTA sign the
 /// authorization VC and seal the provision bundle. A harness drives provisioning
 /// URL-direct with [`MockVta::base_url`] + [`MockVta::vta_did`] (no DID→URL
@@ -101,7 +101,7 @@ async fn provisionable_mock_exposes_a_real_vta_did() {
         "expected a real ed25519 did:key, got {did}"
     );
     assert_ne!(
-        did, "did:key:z6MkTestVTA",
+        did, "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "provisionable mock must not use the non-resolvable sentinel DID"
     );
     mock.shutdown().await;

--- a/vta-service/tests/pending_presentation_trust_task.rs
+++ b/vta-service/tests/pending_presentation_trust_task.rs
@@ -116,7 +116,7 @@ fn tt(id: &str, type_uri: &str, issuer: &str, payload: Value) -> Value {
         "type": type_uri,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": issuer,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": payload,
     }))
     .expect("envelope deserialises");

--- a/vta-service/tests/persona_trust_task.rs
+++ b/vta-service/tests/persona_trust_task.rs
@@ -111,7 +111,14 @@ async fn post(
     uri: &str,
     payload: Value,
 ) -> (StatusCode, Value) {
-    post_to(router, token, "did:key:z6MkTestVTA", uri, payload).await
+    post_to(
+        router,
+        token,
+        "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
+        uri,
+        payload,
+    )
+    .await
 }
 
 /// As [`post`], addressed to `recipient`.
@@ -178,7 +185,14 @@ async fn put_attribute(
     claim_type: &str,
     value: &str,
 ) -> String {
-    put_attribute_at(router, token, "did:key:z6MkTestVTA", claim_type, value).await
+    put_attribute_at(
+        router,
+        token,
+        "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
+        claim_type,
+        value,
+    )
+    .await
 }
 
 /// As [`put_attribute`], against the VTA named by `recipient`.

--- a/vta-service/tests/refresh_trust_task.rs
+++ b/vta-service/tests/refresh_trust_task.rs
@@ -64,7 +64,7 @@ fn refresh_doc(refresh_token: &str) -> Vec<u8> {
         "type": "https://trusttasks.org/spec/auth/refresh/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": "did:key:z6MkRefresher",
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": { "refreshToken": refresh_token },
     })
     .to_string()

--- a/vta-service/tests/revoke_session_trust_task.rs
+++ b/vta-service/tests/revoke_session_trust_task.rs
@@ -77,7 +77,7 @@ async fn revoke(
         "type": "https://trusttasks.org/spec/auth/revoke-session/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": &caller(),
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": { "sessionId": target },
     }))
     .expect("envelope deserialises");

--- a/vta-service/tests/session_jti_pin.rs
+++ b/vta-service/tests/session_jti_pin.rs
@@ -80,7 +80,7 @@ async fn whoami_status(
             "type": "https://trusttasks.org/spec/auth/whoami/0.1",
             "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
             "issuer": did,
-            "recipient": "did:key:z6MkTestVTA",
+            "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
             "payload": {},
         }))
         .expect("envelope deserialises");

--- a/vta-service/tests/sessions_list_trust_task.rs
+++ b/vta-service/tests/sessions_list_trust_task.rs
@@ -110,7 +110,7 @@ async fn sessions_list_returns_only_callers_active_sessions() {
         "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {},
     }))
     .expect("envelope deserialises");
@@ -172,7 +172,7 @@ async fn sessions_list_without_bearer_is_unauthorized() {
         "type": "https://trusttasks.org/spec/auth/sessions/list/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": "did:key:z6MkAnon",
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {},
     });
     let req = Request::builder()

--- a/vta-service/tests/step_up_approve_response.rs
+++ b/vta-service/tests/step_up_approve_response.rs
@@ -128,7 +128,7 @@ async fn did_signed_approve_response_elevates_session_to_aal2() {
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {
             "subject": did,
             "sessionId": session_id,
@@ -289,7 +289,7 @@ async fn did_signed_approve_response_0_2_elevates_session_to_aal2() {
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.2",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {
             "subject": did,
             "sessionId": session_id,
@@ -717,7 +717,7 @@ async fn delegated_approve_response_elevates_the_subjects_session() {
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": approver_did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {
             "subject": subject,
             "sessionId": session_id,
@@ -860,7 +860,7 @@ async fn unauthorized_approver_cannot_elevate() {
         "type": "https://trusttasks.org/spec/auth/step-up/approve-response/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": rogue_did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {
             "subject": subject,
             "sessionId": session_id,

--- a/vta-service/tests/vault_trust_task.rs
+++ b/vta-service/tests/vault_trust_task.rs
@@ -131,7 +131,7 @@ async fn post_vault(
         "type": uri,
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": holder_did(),
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": payload,
     }))
     .expect("envelope deserialises");

--- a/vta-service/tests/whoami_trust_task.rs
+++ b/vta-service/tests/whoami_trust_task.rs
@@ -73,7 +73,7 @@ async fn whoami_reports_live_session_acr_not_stale_token() {
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {},
     }))
     .expect("envelope deserialises");
@@ -190,7 +190,7 @@ async fn whoami_reports_effective_capabilities_including_an_additive_grant() {
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {},
     }))
     .expect("envelope deserialises");
@@ -281,7 +281,7 @@ async fn whoami_does_not_invent_a_capability_nobody_granted() {
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": did,
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {},
     }))
     .expect("envelope deserialises");
@@ -315,7 +315,7 @@ async fn whoami_without_bearer_is_unauthorized() {
         "type": "https://trusttasks.org/spec/auth/whoami/0.1",
         "issuedAt": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "issuer": "did:key:z6MkAnon",
-        "recipient": "did:key:z6MkTestVTA",
+        "recipient": "did:key:z6MkfMo6gxqdBhaHMNnmfhgZFBjpCDTkmJMJLoypsBZS9PwD",
         "payload": {},
     });
     let req = Request::builder()


### PR DESCRIPTION
Third wave of the #1341 regression, and the first fixed at the cause rather than per-test. `vta-service`'s round-trip suite goes **0/10 → 10/10 without touching a single test**.

## The harness never did what production does

`server.rs` sets `signing_vm_id` to `{vta_did}#key-0` for every DID method that is not `did:peer` — so a REST-only VTA signs its answers with its own key and needs no transport identity to do it.

`build_test_app` populated that slot **only** from `build_transport_state`, which requires a `did:peer:2`. So a `MockVta` answered unsigned where the real thing signs, and every round-trip test failed with the client blaming the reply for something the harness had never provided.

**This corrects something I said earlier in review**: I claimed REST-only VTAs were broken in production. They are not — I had read the harness and not `server.rs`. No deployment change and no re-commissioning is needed.

## The sentinel had to go, for the reason `TEST_ADMIN_SEED` already records

The mock's `did:key:z6MkTestVTA` was not a `did:key` at all — the same mistake that constant's doc-comment describes fixing for the *admin* identity, and for the same reason: nothing resolves it, so nothing it signs can carry a verifiable proof. It is now derived from `TEST_VTA_SEED`, and the 28 references that named the literal name the real one.

Deliberately **not** a full provisioning: the default mock gets a real identity and the key behind it, and still no seed records or keystore, so a test asserting an *unprovisioned* VTA still gets one. Only enough to sign.

## One sharp edge, now in a helper

`Secret::from_multibase` requires the multicodec prefix (`0x80 0x26`, ed25519-priv) and refuses raw bytes with `Unsupported key type`; `decode_private_key_multibase` accepts either. The two encodings look interchangeable and are not — `secret_from_ed25519` is the one place that knows.

## Also in the spine

A VTA **configured to sign and unable to** now answers with a 500 naming the verification method, instead of silently answering unsigned into a client that will refuse it and report *the reply* as the problem. A VTA with no signing identity at all still answers unsigned — unchanged, and correct for a pre-setup agent.

## Two known failures remain

Not fixed here, and both are the same regression in further stand-ins:

**`mock_vta::services_write_paths_against_a_hosted_vta_did`** — and this one may be a real finding rather than a fixture. #1341's *second* check fires: the reply claims to come from a `did:webvh` identity but is signed by the underlying `did:key`. *"The proof verifies, which means somebody really signed it — just not the agent this client is talking to."* Whether a hosted VTA publishes `#key-0` in its webvh document, so the signature is attributable to the webvh DID, wants checking against `server.rs` before anyone assumes it is only the harness. **I am explicitly not asserting either way** — I made that mistake once already today.

**`vti-e2e-tests::client_didcomm`** — 33 failures, a separate DIDComm responder that stands in for a VTA the same way.

CI will still be red on those two. This is a strict improvement on main, not a green light.