### PR TITLE
fix(rooms)!: a presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,9 +3495,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.6.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f292eb5ba50d7f69dd9671e87b4d6ceddbeb973cbf0c05715220bee8446ff90"
+checksum = "fa51b03528a22ad07cd0f812a99fae834b7867c205943a40ad90bb8eb62edb08"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -3506,7 +3506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.6"
+dtg-credentials = "0.9.1"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.49"

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -338,8 +338,11 @@ pub(crate) enum RoomCommands {
         /// Base URL of the host storing the room.
         #[arg(long)]
         host: String,
-        /// The host's DID. Omit and the minted presentation is not bound to a
-        /// host — usable by anyone who observes it until it expires.
+        /// The host's DID — the recipient the request document names.
+        ///
+        /// It does not affect how the presentation is bound. That is always to
+        /// the DID you authenticate as, so a captured one is worthless to
+        /// whoever captured it whether this is given or not.
         #[arg(long)]
         host_did: Option<String>,
         /// Only records whose key starts with this.

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -592,7 +592,7 @@ async fn act_four(
     )
     .await?;
 
-    let nomination = g.nominate(&g.successor.did, Some(24 * 365)).await;
+    let nomination = g.nominate(&g.successor.did, 24 * 365).await;
     note("the room issued this nomination to its successor long ago, granting `succeed` —");
     note("a word no room task accepts, so it confers nothing at all while Alice is present");
 
@@ -668,7 +668,7 @@ async fn act_four(
         .claim_owner(
             &successor_session(&h),
             // A nomination the room really did issue — naming somebody else.
-            &h.nominate(&h.agent.did, Some(24)).await,
+            &h.nominate(&h.agent.did, 24).await,
             None,
             &h.successor.did,
             &h.successor.secret_multibase,
@@ -687,7 +687,7 @@ async fn act_four(
     let claimed = client
         .claim_owner(
             &successor_session(&h),
-            &h.nominate(&h.successor.did, Some(24 * 365)).await,
+            &h.nominate(&h.successor.did, 24 * 365).await,
             Some("the owner has been unreachable since March"),
             &h.successor.did,
             &h.successor.secret_multibase,

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -1684,7 +1684,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
                 "reason": "the owner has been unreachable since March",
             }),
@@ -1717,7 +1717,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,
@@ -1740,7 +1740,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,
@@ -1766,7 +1766,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -35,11 +35,12 @@ use vtc_client::rooms::{CleartextContent, RoomSession, Visibility};
 
 /// Everything a room command needs to reach both parties.
 ///
-/// The host DID is optional because an operator may not know it, and the cost
-/// of not knowing is stated rather than hidden: without it the minted
-/// presentation carries no audience, so it is bearer-shaped against that room
-/// for its four-hour life. With it, a captured presentation is worthless to
-/// anyone else.
+/// The host DID is optional because an operator may not know it, and it names the
+/// **recipient** of the document — nothing more. It used to be passed as the presentation's
+/// `audience` as well, on the reading that this bound the presentation to one host; it does
+/// not, and could not, because the verifier compares `audience` to the presenter. See
+/// [`present`]. A presentation is bound to whoever will sign the request, always, so there
+/// is no longer an unbound case for an operator to be warned about.
 pub struct RoomTarget<'a> {
     pub host_url: &'a str,
     pub host_did: Option<&'a str>,
@@ -56,21 +57,37 @@ impl RoomTarget<'_> {
     }
 }
 
-/// Mint a presentation for one action, and warn when it will be unbound.
+/// Mint a presentation for one action, bound to the party that will present it.
+///
+/// # `audience` is the presenter, not the host
+///
+/// This passed `target.host_did` until it was found never to work. `audience` is not who
+/// the presentation is addressed to: `dtg_credentials::authority::verify_chain` compares it
+/// to the **presenter** — "the leaf must be presentable by whoever is presenting it" — so
+/// it is holder binding, and its job is to make a captured presentation worthless to
+/// whoever captured it.
+///
+/// Filled with the host's DID, it named a party no presenter can ever match, and the host
+/// refused every request as `WrongAudience`. Omitting `--host-did` "worked" only because an
+/// absent audience skips the check, leaving the presentation bearer-shaped for its whole
+/// four-hour life — so the flag's two states were *broken* and *unprotected*.
+///
+/// `presenter` is [`RoomSigner::did`], which already documents the rule this restores: a
+/// room request is signed by the party the presentation was minted for.
+///
+/// The **published spec disagrees** — `rooms/keys/present/0.1` calls `audience` "the party
+/// the presentation is for … a host's identifier, normally" — and that conflict is real and
+/// filed upstream. This binds to the presenter because that is what the verifier does
+/// today, and a presentation that cannot verify protects nobody while it is being wrong in
+/// the other direction.
 async fn present(
     client: &VtaClient,
     target: &RoomTarget<'_>,
     action: &str,
+    presenter: &str,
 ) -> Result<RoomSession, Box<dyn std::error::Error>> {
-    if target.host_did.is_none() {
-        eprintln!(
-            "note: no --host-did given, so this presentation is not bound to a host. \
-             Anyone who observes it can use it against this room until it expires."
-        );
-    }
-
     let minted = client
-        .room_present(target.room_id, action, target.host_did, None)
+        .room_present(target.room_id, action, Some(presenter), None)
         .await?;
     session_from_minted(target.room_id, &minted)
 }
@@ -153,7 +170,7 @@ pub async fn cmd_rooms_list(
     since_version: Option<u64>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read").await?;
+    let session = present(client, &target, "read", signer.did).await?;
     let listing = target
         .client()
         .list_records(
@@ -201,7 +218,7 @@ pub async fn cmd_rooms_get(
     signer: RoomSigner<'_>,
     key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read").await?;
+    let session = present(client, &target, "read", signer.did).await?;
     let record = target
         .client()
         .get_record(&session, key, signer.did, signer.key_multibase)
@@ -274,7 +291,7 @@ pub async fn cmd_rooms_put(
     body: String,
     expected_version: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "write").await?;
+    let session = present(client, &target, "write", signer.did).await?;
     let put = target
         .client()
         .put_record(
@@ -319,7 +336,7 @@ pub async fn cmd_rooms_curate(
     // what a room's shared knowledge is worth is a different act from adding to
     // it. So the presentation is minted for `curate`, and a member who only
     // writes is refused here rather than at the host.
-    let session = present(client, &target, "curate").await?;
+    let session = present(client, &target, "curate", signer.did).await?;
 
     let out = target
         .client()
@@ -358,7 +375,7 @@ pub async fn cmd_rooms_renew(
     epoch: u32,
     reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "admin").await?;
+    let session = present(client, &target, "admin", signer.did).await?;
     let minted = target
         .client()
         .mint_epoch(

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -37,10 +37,9 @@ use vtc_client::rooms::{CleartextContent, RoomSession, Visibility};
 ///
 /// The host DID is optional because an operator may not know it, and it names the
 /// **recipient** of the document — nothing more. It used to be passed as the presentation's
-/// `audience` as well, on the reading that this bound the presentation to one host; it does
-/// not, and could not, because the verifier compares `audience` to the presenter. See
-/// [`present`]. A presentation is bound to whoever will sign the request, always, so there
-/// is no longer an unbound case for an operator to be warned about.
+/// `audience` as well, on the reading that this bound the presentation to one host. It never
+/// could: see [`present`]. A presentation is bound to whoever will sign the request, always,
+/// so there is no unbound case for an operator to be warned about.
 pub struct RoomTarget<'a> {
     pub host_url: &'a str,
     pub host_did: Option<&'a str>,
@@ -57,38 +56,31 @@ impl RoomTarget<'_> {
     }
 }
 
-/// Mint a presentation for one action, bound to the party that will present it.
+/// Mint a presentation for one action.
 ///
-/// # `audience` is the presenter, not the host
+/// # There is no party to name here, and there used to be two
 ///
-/// This passed `target.host_did` until it was found never to work. `audience` is not who
-/// the presentation is addressed to: `dtg_credentials::authority::verify_chain` compares it
-/// to the **presenter** — "the leaf must be presentable by whoever is presenting it" — so
-/// it is holder binding, and its job is to make a captured presentation worthless to
-/// whoever captured it.
+/// This passed `target.host_did` as the presentation's `audience` until that was found
+/// never to work: `audience` named the party that had to *present* the credential, not the
+/// one it was addressed to, so filling it with a host's DID named somebody no presenter can
+/// ever be, and every request was refused. Omitting `--host-did` "worked" only because an
+/// absent audience skipped the check — so the flag's two states were *broken* and
+/// *unprotected*, with nothing in between.
 ///
-/// Filled with the host's DID, it named a party no presenter can ever match, and the host
-/// refused every request as `WrongAudience`. Omitting `--host-did` "worked" only because an
-/// absent audience skips the check, leaving the presentation bearer-shaped for its whole
-/// four-hour life — so the flag's two states were *broken* and *unprotected*.
+/// Neither the field nor this parameter survives. A presentation is granted to the caller
+/// the VTA authenticated and a host refuses a chain granting to anyone else, so who may
+/// present is established rather than declared; and it is bound to a *room* rather than a
+/// host, so there is no destination to name either. `--host-did` keeps its real job:
+/// naming the document's `recipient`.
 ///
-/// `presenter` is [`RoomSigner::did`], which already documents the rule this restores: a
-/// room request is signed by the party the presentation was minted for.
-///
-/// The **published spec disagrees** — `rooms/keys/present/0.1` calls `audience` "the party
-/// the presentation is for … a host's identifier, normally" — and that conflict is real and
-/// filed upstream. This binds to the presenter because that is what the verifier does
-/// today, and a presentation that cannot verify protects nobody while it is being wrong in
-/// the other direction.
+/// See `rooms/keys/present/0.2`, which removed both members, and
+/// trustoverip/dtgwg-trust-tasks-tf#414.
 async fn present(
     client: &VtaClient,
     target: &RoomTarget<'_>,
     action: &str,
-    presenter: &str,
 ) -> Result<RoomSession, Box<dyn std::error::Error>> {
-    let minted = client
-        .room_present(target.room_id, action, Some(presenter), None)
-        .await?;
+    let minted = client.room_present(target.room_id, action).await?;
     session_from_minted(target.room_id, &minted)
 }
 
@@ -170,7 +162,7 @@ pub async fn cmd_rooms_list(
     since_version: Option<u64>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read", signer.did).await?;
+    let session = present(client, &target, "read").await?;
     let listing = target
         .client()
         .list_records(
@@ -218,7 +210,7 @@ pub async fn cmd_rooms_get(
     signer: RoomSigner<'_>,
     key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read", signer.did).await?;
+    let session = present(client, &target, "read").await?;
     let record = target
         .client()
         .get_record(&session, key, signer.did, signer.key_multibase)
@@ -291,7 +283,7 @@ pub async fn cmd_rooms_put(
     body: String,
     expected_version: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "write", signer.did).await?;
+    let session = present(client, &target, "write").await?;
     let put = target
         .client()
         .put_record(
@@ -336,7 +328,7 @@ pub async fn cmd_rooms_curate(
     // what a room's shared knowledge is worth is a different act from adding to
     // it. So the presentation is minted for `curate`, and a member who only
     // writes is refused here rather than at the host.
-    let session = present(client, &target, "curate", signer.did).await?;
+    let session = present(client, &target, "curate").await?;
 
     let out = target
         .client()
@@ -375,7 +367,7 @@ pub async fn cmd_rooms_renew(
     epoch: u32,
     reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "admin", signer.did).await?;
+    let session = present(client, &target, "admin").await?;
     let minted = target
         .client()
         .mint_epoch(

--- a/vta-sdk/src/client/rooms.rs
+++ b/vta-sdk/src/client/rooms.rs
@@ -37,37 +37,30 @@ use crate::trust_tasks;
 const ROOM_TT_TIMEOUT: u64 = 30;
 
 impl VtaClient {
-    /// `rooms/keys/present/0.1` — mint a presentation for **one** operation.
+    /// `rooms/keys/present` — mint a presentation for **one** operation.
     ///
     /// `action` is a single room verb (`read`, `write`, `curate`, `admin`);
-    /// there is no "everything" value, deliberately. `audience`, when given,
-    /// binds the minted leaf to that party so a captured presentation is
-    /// worthless elsewhere — pass the host's DID whenever you know it.
+    /// there is no "everything" value, deliberately.
+    ///
+    /// **There is nothing to say about who may present it.** The VTA grants the
+    /// minted leaf to the caller it authenticated, and a host refuses a chain
+    /// whose leaf grants to anyone else — so a presentation minted for this
+    /// client is worthless to anybody who captures it, and a parameter naming a
+    /// different party would only be a way to get that wrong. There is likewise
+    /// nothing to say about the host: the chain is bound to a *room*, which is
+    /// what lets a room have more than one host, and binding the *request* to
+    /// its destination is the `recipient` member of the document that carries
+    /// this, per SPEC.md §4.8.2.
     ///
     /// The reply carries `presentation` (send this to the host) and
     /// `expiresAt`. A request for more than the principal holds fails at the
     /// VTA, in the credential library, rather than producing a presentation the
     /// host will later refuse.
-    pub async fn room_present(
-        &self,
-        room_id: &str,
-        action: &str,
-        audience: Option<&str>,
-        nonce: Option<&str>,
-    ) -> Result<Value, VtaError> {
-        let mut payload = json!({
+    pub async fn room_present(&self, room_id: &str, action: &str) -> Result<Value, VtaError> {
+        let payload = json!({
             "roomId": room_id,
             "action": action,
         });
-        // Omitted rather than sent as null: the published payload types the
-        // members as strings, and a `null` would fail schema validation at the
-        // spine — the defect class #919 and #921 both landed in.
-        if let Some(audience) = audience {
-            payload["audience"] = Value::String(audience.to_string());
-        }
-        if let Some(nonce) = nonce {
-            payload["nonce"] = Value::String(nonce.to_string());
-        }
         self.dispatch_trust_task(
             trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1,
             payload,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -799,7 +799,8 @@ pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memo
 /// `spec/rooms/keys/present/0.1` — an agent asks the VTA holding its
 /// principal's room credentials to mint a presentation for **one** room
 /// operation. The credentials never cross to the agent; only the presentation
-/// does, and it is scoped to the action and audience it was asked for.
+/// does, it is scoped to the action it was asked for, and it is granted to the
+/// caller — so it is worthless to anybody who captures it.
 /// Auth: `roomPresent` capability, plus context access for the principal's key.
 pub const TASK_ROOMS_KEYS_PRESENT_0_1: &str = "https://trusttasks.org/spec/rooms/keys/present/0.1";
 

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -27,10 +27,18 @@
 //! have handed the caller its principal's whole standing in the room, which is precisely the
 //! outcome attenuation exists to prevent.
 //!
-//! **A presentation reusable elsewhere.** Where the caller names an `audience`, the leaf is
-//! bound to it, and `verify_chain` refuses a chain link presented by anyone else. Without an
-//! audience the presentation is bearer-shaped against that room, which is why callers that
-//! know their host should always name it.
+//! **A presentation somebody else can use.** The leaf grants to the DID this VTA
+//! authenticated for the request, and a host refuses a chain whose leaf grants to anyone but
+//! the party that signed what it received. So a presentation minted here is usable by the
+//! caller and by nobody else — and the caller cannot ask for one made out to a third party,
+//! because it never gets to name the subject.
+//!
+//! **A presentation bound to a host.** Deliberately not offered, because it would not mean
+//! anything. The chain is scoped to the *room*; a chain rooted in one room confers nothing
+//! anywhere else, and any host serving that room would honour it — a room may have more than
+//! one host, and moving between them without reissuing credentials is the point. Binding a
+//! *request* to its destination is the job of the `recipient` member on the document that
+//! carries the presentation, which its `proof` covers (SPEC.md §4.8.2).
 //!
 //! **The keys.** Nothing in the response carries key material in either direction. An oracle
 //! that returned the principal's VAC itself would be a credential-release call wearing a
@@ -88,8 +96,6 @@ pub async fn present(
     agent_did: &str,
     room_id: &str,
     action: &str,
-    audience: Option<&str>,
-    nonce: Option<&str>,
 ) -> Result<MintedPresentation, AppError> {
     let scope = auth.act_scope();
 
@@ -114,7 +120,11 @@ pub async fn present(
             vec![action.to_string()],
             now,
             Some(expires),
-            audience.map(str::to_string),
+            // No audience. The leaf is bound to its subject — `agent_did`, the caller this
+            // VTA authenticated — and a verifier requires the presenter to be that subject.
+            // A second field naming who may present could only repeat the subject or
+            // contradict it, which is why dtg-credentials removed it.
+            None,
         )
         .map_err(|e| {
             // The common case is asking for an action the principal does not hold, and
@@ -143,15 +153,16 @@ pub async fn present(
 
     // Leaf first, then the credential the room issued. Every link the host will rely on is
     // present, because the host will not fetch one.
-    let mut presentation = serde_json::json!({
+    // No nonce. A presentation is a bundle of credentials signed by their *issuers*, never
+    // by the party presenting it, so a challenge placed inside it is unauthenticated — an
+    // attacker replaying a captured presentation copies the challenge with everything else.
+    // Freshness belongs to the request: the room task document carrying this is signed by
+    // the presenter and carries `id` and `issuedAt`, which is what SPEC.md §7.2 item 11
+    // keys duplicate-execution protection on.
+    let presentation = serde_json::json!({
         "membership": vmc,
         "authority": [leaf_json, vac],
     });
-    // Echoed rather than interpreted: the verifier chose it, and its value to them is that
-    // it came back unchanged.
-    if let Some(nonce) = nonce {
-        presentation["nonce"] = Value::String(nonce.to_string());
-    }
 
     Ok(MintedPresentation {
         presentation,

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -40,6 +40,13 @@
 //! *request* to its destination is the job of the `recipient` member on the document that
 //! carries the presentation, which its `proof` covers (SPEC.md §4.8.2).
 //!
+//! Both of those are the library's rules now rather than this module's hopes:
+//! dtg-credentials 0.8 requires the presenter to be the leaf's subject, refusing anyone else
+//! with `NotThePresenter`, and removes the `audience` field that used to stand in for it
+//! badly — optional, so a leaf without one was accepted from anybody, and read as the
+//! *destination* by the Trust Tasks registry while the library compared it to the presenter
+//! (`trustoverip/dtgwg-cred-spec#41`, `trustoverip/dtgwg-trust-tasks-tf#414`).
+//!
 //! **The keys.** Nothing in the response carries key material in either direction. An oracle
 //! that returned the principal's VAC itself would be a credential-release call wearing a
 //! different name.
@@ -114,17 +121,16 @@ pub async fn present(
     // that somebody could forget to write.
     let now = Utc::now();
     let expires = now + PRESENTATION_LIFETIME;
+    // There is no audience argument any more. The leaf is bound to its subject —
+    // `agent_did`, the caller this VTA authenticated — and a verifier requires the presenter
+    // to be that subject. A second field naming who may present could only repeat the
+    // subject or contradict it, which is why dtg-credentials 0.8 removed it.
     let mut leaf = root
         .attenuate(
             agent_did.to_string(),
             vec![action.to_string()],
             now,
-            Some(expires),
-            // No audience. The leaf is bound to its subject — `agent_did`, the caller this
-            // VTA authenticated — and a verifier requires the presenter to be that subject.
-            // A second field naming who may present could only repeat the subject or
-            // contradict it, which is why dtg-credentials removed it.
-            None,
+            expires,
         )
         .map_err(|e| {
             // The common case is asking for an action the principal does not hold, and

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -472,20 +472,23 @@ pub(super) async fn handle_backfill(
     // `read`, and only `read`. Reading the room and reading the parts of it
     // written earlier are the same act, so they take the same grant; asking for
     // more would hand the host authority the operation never needed.
-    let minted = match crate::operations::room_oracle::present(
-        state,
-        auth,
-        &vta_did,
-        &req.room_id,
-        "read",
-        Some(req.host.as_str()),
-        None,
-    )
-    .await
-    {
-        Ok(m) => m,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
+    //
+    // The caller-named `host` is NOT bound into the presentation, and used to be
+    // — passed as the leaf's `audience`, which named the party that had to
+    // present the credential rather than the one it was sent to, so every
+    // backfill this VTA attempted was refused. What makes a caller-named host
+    // safe is that the leaf grants to `vta_did`: a host of the caller's
+    // choosing receives something only this agent can act with, so naming one
+    // transfers no standing. What it does gain is sight of the principal's
+    // credentials, which is a disclosure rather than an escalation — see
+    // `rooms/keys/backfill/0.1`.
+    let minted =
+        match crate::operations::room_oracle::present(state, auth, &vta_did, &req.room_id, "read")
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
 
     let mut payload = serde_json::json!({
         "roomId": req.room_id,

--- a/vta-service/src/trust_tasks/room_keys.rs
+++ b/vta-service/src/trust_tasks/room_keys.rs
@@ -6,8 +6,8 @@
 //! Three gates, in order, and the order matters:
 //!
 //! 1. **Capability.** [`Capability::RoomPresent`], registered upstream as `roomPresent`.
-//!    Deliberately not [`Capability::Sign`]: an agent that may ask for a scoped,
-//!    audience-bound presentation is not thereby an agent that may sign *anything at all*
+//!    Deliberately not [`Capability::Sign`]: an agent that may ask for a scoped
+//!    presentation granted to itself is not thereby an agent that may sign *anything at all*
 //!    with its principal's key. Gating an oracle on the generic signing oracle would grant
 //!    strictly more than the task needs, which is the opposite of what an oracle is for.
 //! 2. **Context**, inside `resolve_holder_keys` — the caller must be permitted to act in the
@@ -71,17 +71,7 @@ pub(super) async fn handle_present(
         .and_then(|v| v.as_str().map(str::to_string))
         .unwrap_or_default();
 
-    let minted = match room_oracle::present(
-        state,
-        auth,
-        &auth.did,
-        &req.room_id,
-        &action,
-        req.audience.as_deref(),
-        req.nonce.as_ref().map(|n| n.as_ref()),
-    )
-    .await
-    {
+    let minted = match room_oracle::present(state, auth, &auth.did, &req.room_id, &action).await {
         Ok(m) => m,
         Err(e) => return app_error_to_reject(&doc, e),
     };

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -207,13 +207,32 @@ pub(super) async fn handle_issue_authority(
     // action list rather than reading it as "everything", and the schema refuses it before
     // that — two layers, because "confers nothing" and "confers everything" are exactly the
     // two readings a careless consumer might choose between.
+    // An authority credential must expire, and since dtg-credentials 0.7 the constructor
+    // says so in its type. Nothing about a subject's current standing is consulted when a
+    // chain is verified, so a grant that does not expire is a grant nobody can withdraw by
+    // waiting — the only way back is revocation, which this stack does not yet have.
+    //
+    // Refused rather than defaulted. Picking a lifetime here would put the room's most
+    // consequential number in a place its owner never looks.
+    let Some(valid_until) = req.valid_until else {
+        return app_error_to_reject(
+            &doc,
+            vti_common::error::AppError::Validation(
+                "an authority credential must name `validUntil`: nothing about a subject's \
+                 standing is checked when a chain is verified, so authority that does not \
+                 expire is authority nobody can withdraw"
+                    .into(),
+            ),
+        );
+    };
+
     let vac = match dtg_credentials::DTGCredential::new_vac(
         req.room_id.clone(),
         req.subject.clone(),
         req.room_id.clone(),
         actions,
         chrono::Utc::now(),
-        req.valid_until,
+        valid_until,
     ) {
         Ok(v) => v,
         Err(e) => {

--- a/vtc-service/src/credentials/ingress.rs
+++ b/vtc-service/src/credentials/ingress.rs
@@ -610,15 +610,43 @@ pub fn digest_multibase(doc: &JsonValue) -> Result<String, AppError> {
     Ok(multibase::encode(multibase::Base::Base58Btc, multihash))
 }
 
+/// Digest of a credential in the form DTG Core Credentials **now** specifies for
+/// `credentialSubject.digestMultibase`: SHA-256 over the JCS canonicalization of the
+/// document with its top-level `proof` removed, as a base58btc multibase multihash.
+///
+/// Delegated to `dtg-credentials` rather than written here, and that is the point. This
+/// module already carries two digest functions that differ in encoding *and* coverage, and
+/// the acknowledgement binding used to be a third — a hand-rolled copy of a definition the
+/// counterparty computes with the library. Working Draft 02 changed the encoding and the
+/// copy did not follow, so the two sides stopped agreeing; the tests in
+/// `members::inbound_vmc` caught it, being written for exactly that
+/// ("two implementations, one definition — this is the assertion that catches either side
+/// drifting").
+///
+/// One definition, one implementation, and it belongs to the party that publishes the
+/// specification.
+///
+/// **Not [`digest_multibase`]**, which is the same encoding over *different* coverage — it
+/// digests the document whole, `proof` included. Substituting one for the other compiles
+/// and produces a plausible string that matches nothing.
+pub fn dtg_credential_digest_multibase(doc: &JsonValue) -> Result<String, AppError> {
+    dtg_credentials::digest_multibase_json(doc)
+        .map_err(|e| AppError::Validation(format!("credential is not canonicalizable: {e}")))
+}
+
 /// Digest of a credential in the form DTG Core Credentials specifies for
 /// `credentialSubject.digest`: SHA-256 over the RFC 8785 (JCS)
 /// canonicalization of the document **with its top-level `proof` removed**,
 /// encoded as `sha256:` followed by the lowercase hexadecimal digest.
 ///
-/// This is what a member-issued VMC carries of the grant it acknowledges, and
-/// what a VWC carries of the edge credential it attests. Distinct from
-/// [`digest_multibase`] in encoding *and* coverage — do not substitute one for
-/// the other.
+/// **Working Draft 01, and kept only to read what is already in the field.** WD02 replaced
+/// this with the multibase multihash [`dtg_credential_digest_multibase`] computes, and
+/// renamed the property to `digestMultibase`. Members whose client predates that change
+/// still send the old form, and their acknowledgements must keep verifying — so this stays
+/// for the read path and nothing new should emit it.
+///
+/// Distinct from [`digest_multibase`] in encoding *and* coverage — do not substitute one
+/// for the other.
 ///
 /// # Over the document as it stands, not a re-serialised model
 ///

--- a/vtc-service/src/members/inbound_vmc.rs
+++ b/vtc-service/src/members/inbound_vmc.rs
@@ -197,18 +197,53 @@ pub async fn receive_member_vmc_inner(
 /// Deliberate asymmetry, and the reason it is safe: an unbound acknowledgement
 /// claims *less* than a bound one, so admitting it grants nothing. A
 /// mismatched one claims something false.
+/// Which spelling of the digest a member sent.
+///
+/// Not a preference: the two encode the same bytes differently, so each is compared against
+/// an expected value computed the same way. Naming the form keeps that pairing in one place
+/// — a check that compared a WD02 digest against a WD01 expectation would refuse a correct
+/// acknowledgement and say the member acknowledged a different grant.
+#[derive(Clone, Copy)]
+enum DigestForm {
+    /// `credentialSubject.digestMultibase` — Working Draft 02, base58btc multihash.
+    Multibase,
+    /// `credentialSubject.digest` — Working Draft 01, `sha256:<lowercase hex>`.
+    LegacyHex,
+}
+
+impl DigestForm {
+    fn property(self) -> &'static str {
+        match self {
+            Self::Multibase => "credentialSubject.digestMultibase",
+            Self::LegacyHex => "credentialSubject.digest",
+        }
+    }
+}
+
 fn check_acknowledgement_binding(
     vc: &JsonValue,
     grant: Option<&JsonValue>,
     member_did: &str,
 ) -> Result<bool, AppError> {
-    let claimed = vc
-        .get("credentialSubject")
-        .and_then(JsonValue::as_object)
-        .and_then(|s| s.get("digest"))
-        .and_then(JsonValue::as_str);
+    // Two property names, because two Working Drafts are in the field. WD02 renamed
+    // `digest` to `digestMultibase` and changed its encoding from `sha256:<hex>` to a
+    // base58btc multihash; a member whose client predates that still sends the old one, and
+    // their acknowledgement must keep verifying. Whichever arrives is compared against the
+    // expected value *for that form* — this widens what is accepted, never what counts as a
+    // match.
+    let subject = vc.get("credentialSubject").and_then(JsonValue::as_object);
+    let claimed = subject
+        .and_then(|s| s.get("digestMultibase"))
+        .and_then(JsonValue::as_str)
+        .map(|d| (d, DigestForm::Multibase))
+        .or_else(|| {
+            subject
+                .and_then(|s| s.get("digest"))
+                .and_then(JsonValue::as_str)
+                .map(|d| (d, DigestForm::LegacyHex))
+        });
 
-    let (Some(claimed), Some(grant)) = (claimed, grant) else {
+    let (Some((claimed, form)), Some(grant)) = (claimed, grant) else {
         // R6.3: say which of the two is missing, so an operator looking at an
         // incomplete edge can tell "the member's client is old" from "we never
         // kept the grant to check against".
@@ -222,12 +257,29 @@ fn check_acknowledgement_binding(
         return Ok(false);
     };
 
-    let expected = crate::credentials::ingress::dtg_credential_digest(grant)?;
-    if claimed != expected {
+    let matches = match form {
+        // Compared as decoded bytes, never as strings: one multihash has more than one
+        // spelling, and a string comparison would report a mismatch where the two sides
+        // agree. The specification requires the byte comparison and the library does it.
+        DigestForm::Multibase => {
+            let expected = crate::credentials::ingress::dtg_credential_digest_multibase(grant)?;
+            dtg_credentials::digests_match(claimed, &expected).map_err(|e| {
+                AppError::Validation(format!(
+                    "member vmc digest is not a valid multibase digest: {e}"
+                ))
+            })?
+        }
+        DigestForm::LegacyHex => {
+            claimed == crate::credentials::ingress::dtg_credential_digest(grant)?
+        }
+    };
+
+    if !matches {
         return Err(AppError::Validation(format!(
-            "member vmc `credentialSubject.digest` does not match the membership \
-             credential this community issued to {member_did} — it acknowledges a \
-             different grant. Re-issue against the current one."
+            "member vmc `{}` does not match the membership credential this community \
+             issued to {member_did} — it acknowledges a different grant. Re-issue against \
+             the current one.",
+            form.property()
         )));
     }
 
@@ -364,6 +416,62 @@ mod binding_tests {
             check_acknowledgement_binding(&ack, Some(&grant), "did:key:zMember").unwrap(),
             "the catalog's digest must verify against this service's"
         );
+    }
+
+    /// A member whose client predates Working Draft 02 still verifies.
+    ///
+    /// The one case the fixture above cannot produce, because `dtg-credentials` emits only
+    /// the current form — so this hand-builds the old one. That is worth the awkwardness:
+    /// this is the population the fallback exists for, and without a test the fallback is a
+    /// branch nobody has run. Deleting it would look safe right up until an old member's
+    /// acknowledgement was refused for "acknowledging a different grant", which it did not.
+    #[test]
+    fn a_working_draft_01_acknowledgement_still_binds() {
+        let (grant, ack) = pair();
+
+        // Same grant, digested the old way, under the old property name.
+        let legacy_digest =
+            crate::credentials::ingress::dtg_credential_digest(&grant).expect("legacy digest");
+        assert!(
+            legacy_digest.starts_with("sha256:"),
+            "the WD01 form is `sha256:<hex>`, and this test is about that spelling"
+        );
+
+        let mut legacy_ack = ack.clone();
+        let subject = legacy_ack
+            .get_mut("credentialSubject")
+            .and_then(JsonValue::as_object_mut)
+            .expect("the acknowledgement has a subject");
+        subject.remove("digestMultibase");
+        subject.insert("digest".into(), JsonValue::String(legacy_digest));
+
+        assert!(
+            check_acknowledgement_binding(&legacy_ack, Some(&grant), "did:key:zMember").unwrap(),
+            "an acknowledgement from before WD02 must keep verifying"
+        );
+    }
+
+    /// …and the old form is still *checked*, not merely tolerated.
+    ///
+    /// The failure mode a fallback invites: accepting the property and never comparing it,
+    /// so every legacy acknowledgement passes whatever it says.
+    #[test]
+    fn a_working_draft_01_acknowledgement_of_a_different_grant_is_refused() {
+        let (grant, ack) = pair();
+
+        let mut legacy_ack = ack.clone();
+        let subject = legacy_ack
+            .get_mut("credentialSubject")
+            .and_then(JsonValue::as_object_mut)
+            .expect("the acknowledgement has a subject");
+        subject.remove("digestMultibase");
+        subject.insert(
+            "digest".into(),
+            JsonValue::String(format!("sha256:{}", "0".repeat(64))),
+        );
+
+        check_acknowledgement_binding(&legacy_ack, Some(&grant), "did:key:zMember")
+            .expect_err("a mismatched legacy digest must be refused too");
     }
 
     /// The community re-signing a grant must not invalidate consent already

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -1821,7 +1821,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
                 "reason": "unreachable since March",
             }),
@@ -1847,7 +1847,7 @@ mod tests {
         let f = RoomFixture::new(Visibility::Open).await;
         create_expiring(state, &f, days_ago(60)).await;
 
-        let nomination = f.nominate(&f.successor.did, Some(24)).await;
+        let nomination = f.nominate(&f.successor.did, 24).await;
 
         // The owner returns and mints an epoch — ordinary use, nothing succession-specific.
         let out = handle_mint_epoch(
@@ -1900,7 +1900,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
         )
@@ -1926,7 +1926,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
         )

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 # Published, now that it can be. This crate was `publish = false` for exactly
 # one reason — a published crate cannot depend on a git source, and
-# dtg-credentials 0.6 was merged but unreleased — and that reason is gone.
+# dtg-credentials was merged but unreleased — and that reason is gone.
 #
 # It should not stay unpublished by inertia. `vti-rooms` publishes so that a
 # room host can reuse a room's storage, wire types and authorization; but
@@ -29,7 +29,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 
 # `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
 # 0.6.0 sat merged and unreleased; released 2026-09-03.
-dtg-credentials = "0.6"
+dtg-credentials = "0.9.1"
 
 async-trait = "0.1"
 # Both hosts already carry a `VerificationMethodResolver`, so the key adapter wraps

--- a/vti-rooms-dtg/src/lib.rs
+++ b/vti-rooms-dtg/src/lib.rs
@@ -287,22 +287,20 @@ impl ChainVerifier for DtgChainVerifier {
         )
         .map_err(|e| chain_refusal(&room.room_id, e))?;
 
-        // `verify_chain` takes `presenter` but uses it for **one** thing: the `audience`
-        // check, where a link that names an audience must be presented by that audience. It
-        // does not require the leaf to grant to the presenter, and that is deliberate on
-        // its side — the leaf's subject is "who may act", and binding that to the party the
-        // *transport* authenticated is a question about this request, not about the chain.
+        // The check that used to live here — "the leaf must grant to the presenter" — is now
+        // `verify_chain`'s own. dtg-credentials 0.8 requires it and refuses otherwise with
+        // `NotThePresenter`; before that, `verify_chain` used `presenter` for one thing, the
+        // optional `audience` comparison, so a leaf without an audience was accepted from
+        // anybody and a presentation was a bearer token.
         //
-        // Which makes it ours, and it is not optional: without it a presentation is a
-        // bearer token, and anyone who observes one inherits everything it confers. A test
-        // above presents an agent's chain as the agent's human and expects a refusal.
-        if verified.subject != presenter {
-            return Err(AppError::Forbidden(format!(
-                "the chain's leaf grants to `{}`, not to the party that signed this \
-                 request; a presentation is bound to its presenter, not bearer",
-                verified.subject
-            )));
-        }
+        // This copy and the one in `nomination` were written independently, each after
+        // hitting the same gap, which is why the rule moved into the library. Both are
+        // deleted rather than kept as a second opinion: two copies of a rule is one place
+        // for it to be forgotten, and the duplicate is the one nobody updates.
+        //
+        // The tests that pinned it stay exactly as they were — a chain presented by the
+        // wrong party must still be refused, and it is not this crate's business any more
+        // *which layer* refuses it.
 
         // The pooling defence: membership and authority must describe one subject.
         match room.visibility {
@@ -422,7 +420,7 @@ mod tests {
             scope.into(),
             actions.iter().map(|s| s.to_string()).collect(),
             chrono::Utc::now() - chrono::Duration::hours(1),
-            Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+            chrono::Utc::now() + chrono::Duration::hours(1),
         )
         .expect("build a VAC");
 
@@ -608,7 +606,7 @@ mod signed {
             room_did.clone(),
             vec!["read".into(), "write".into()],
             now - Duration::minutes(1),
-            Some(now + Duration::days(30)),
+            now + Duration::days(30),
         )
         .expect("owner VAC")
         .with_id("urn:uuid:vac-owner");
@@ -621,8 +619,7 @@ mod signed {
                 agent_did.clone(),
                 vec!["read".into()],
                 now - Duration::minutes(1),
-                Some(now + Duration::hours(4)),
-                None,
+                now + Duration::hours(4),
             )
             .expect("attenuate")
             .with_id("urn:uuid:vac-agent");
@@ -739,9 +736,13 @@ mod signed {
             )
             .await
             .unwrap_err();
+        // Refused by `verify_chain` now rather than by a re-check in this crate: 0.8
+        // requires the presenter to be the leaf's subject. The test is deliberately kept
+        // exactly where it was — it asserts the property, and which layer enforces it is
+        // not this crate's business.
         assert!(
-            format!("{err}").contains("not to the party that signed this request"),
-            "{err}"
+            format!("{err}").contains("but it was presented by"),
+            "the refusal should name both parties: {err}"
         );
     }
 
@@ -946,7 +947,7 @@ pub mod test_support {
                     "admin".into(),
                 ],
                 now - Duration::minutes(1),
-                Some(now + Duration::days(30)),
+                now + Duration::days(30),
             )
             .expect("owner VAC")
             .with_id("urn:uuid:vac-owner");
@@ -962,8 +963,7 @@ pub mod test_support {
                     agent.did.clone(),
                     vec!["read".into()],
                     now - Duration::minutes(1),
-                    Some(now + Duration::hours(4)),
-                    None,
+                    now + Duration::hours(4),
                 )
                 .expect("attenuate to the agent")
                 .with_id("urn:uuid:vac-agent");
@@ -989,7 +989,7 @@ pub mod test_support {
                 room_key.did.clone(),
                 vec!["read".into()],
                 now - Duration::minutes(1),
-                Some(now + Duration::days(30)),
+                now + Duration::days(30),
             )
             .expect("successor VAC")
             .with_id("urn:uuid:vac-successor");
@@ -1070,7 +1070,15 @@ pub mod test_support {
         /// Signed by the **room**, because that is the only issuer a nomination can have —
         /// an owner nominating in their own name would be a chain rooted at a person, and
         /// the whole point is that it is rooted at the room they are stepping away from.
-        pub async fn nominate(&self, successor: &str, valid_until: Option<i64>) -> String {
+        /// A nomination valid for `hours`.
+        ///
+        /// Not optional any more, and it could not be: since dtg-credentials 0.7 a VAC's
+        /// `validUntil` is required by the constructor, so "a nomination that never
+        /// expires" is a state this fixture can no longer build — which is the point.
+        /// Nothing about a subject's standing is consulted when a chain is verified, so a
+        /// nomination without an expiry is one nobody can withdraw by waiting. Every caller
+        /// already passed `Some(24)`.
+        pub async fn nominate(&self, successor: &str, hours: i64) -> String {
             let now = Utc::now();
             let mut vac = DTGCredential::new_vac(
                 self.room_key.did.clone(),
@@ -1078,7 +1086,7 @@ pub mod test_support {
                 self.room_key.did.clone(),
                 vec![crate::ACTION_SUCCEED.into()],
                 now - Duration::minutes(1),
-                valid_until.map(|h| now + Duration::hours(h)),
+                now + Duration::hours(hours),
             )
             .expect("nomination VAC")
             .with_id("urn:uuid:vac-nomination");

--- a/vti-rooms-dtg/src/nomination.rs
+++ b/vti-rooms-dtg/src/nomination.rs
@@ -73,16 +73,15 @@ pub async fn verify(
     )
     .map_err(|e| chain_refusal(room_id, e))?;
 
-    // `verify_chain` uses `claimant` only for the audience check; it does not require the
-    // grant to name them. Without this a nomination would be a bearer token, and anyone who
-    // ever observed one could take the room the moment it went dormant.
-    if verified.subject != claimant {
-        return Err(AppError::Forbidden(format!(
-            "the nomination names `{}`, not the party claiming; a nomination is not \
-             transferable",
-            verified.subject
-        )));
-    }
+    // The check that used to live here — "the grant must name the claimant" — is now
+    // `verify_chain`'s own, since dtg-credentials 0.8 requires the presenter to be the
+    // leaf's subject and refuses otherwise with `NotThePresenter`. It was written here
+    // because `verify_chain` used `claimant` only for the optional `audience` comparison,
+    // so a nomination without one was a bearer token: anyone who ever observed one could
+    // take the room the moment it went dormant.
+    //
+    // Deleted rather than kept as a second opinion. Two copies of a rule is one place for
+    // it to be forgotten, and the one that is a duplicate is the one nobody updates.
 
     Ok(VerifiedNomination {
         successor: verified.subject,
@@ -121,7 +120,10 @@ mod tests {
         subject: &str,
         scope: &str,
         actions: Vec<String>,
-        valid_until: Option<chrono::DateTime<Utc>>,
+        // Required, and not by this helper's choice: since dtg-credentials 0.7 a VAC's
+        // `validUntil` is required by the constructor, so a nomination with no expiry is a
+        // state no test can build any more. Every call already passed one.
+        valid_until: chrono::DateTime<Utc>,
     ) -> String {
         let now = Utc::now();
         let mut vac = DTGCredential::new_vac(
@@ -145,7 +147,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await
     }
@@ -182,7 +184,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 
@@ -201,9 +203,13 @@ mod tests {
         let err = verify(&good(&f).await, &f.room_did, &opportunist, &DidKeyResolver)
             .await
             .expect_err("presenting someone else's nomination confers nothing");
+        // The refusal now comes from `verify_chain` itself rather than from a re-check
+        // here — dtg-credentials 0.8 requires the presenter to be the leaf's subject. The
+        // property is unchanged and the wording is the library's, which names both parties
+        // rather than only the rule.
         assert!(
-            format!("{err}").contains("not transferable"),
-            "the refusal should say why: {err}"
+            format!("{err}").contains("but it was presented by"),
+            "the refusal should name who it was granted to and who presented it: {err}"
         );
     }
 
@@ -220,7 +226,7 @@ mod tests {
             &f.successor_did,
             &other_room,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 
@@ -240,7 +246,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() - Duration::days(1)),
+            Utc::now() - Duration::days(1),
         )
         .await;
 
@@ -266,7 +272,7 @@ mod tests {
                 "curate".into(),
                 "admin".into(),
             ],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 

--- a/vti-rooms-wasm/src/identity.rs
+++ b/vti-rooms-wasm/src/identity.rs
@@ -177,20 +177,18 @@ impl MemberIdentity {
     /// chain's **root** subject rather than its leaf, so it holds either way; it is
     /// asserted in the tests rather than assumed.
     ///
-    /// # There is no `audience` parameter, and that is deliberate
+    /// # There is no `audience` parameter, and there is no longer a field either
     ///
-    /// `audience` is not "who this is addressed to". `verify_chain` compares it to the
-    /// **presenter** — "the leaf must be presentable by whoever is presenting it" — so it is
-    /// holder binding, and its whole job is to make a captured presentation worthless to
-    /// anyone else. A browser member always presents its own, so the only correct value is
-    /// this member's DID, and offering the choice is offering a way to get it wrong.
+    /// This method took none on the reasoning that `audience` was compared to the
+    /// **presenter**, so a browser member could only ever correctly name itself — and
+    /// offering the choice was offering a way to get it wrong. That reasoning held: filled
+    /// with a *host's* DID, as `vta-cli-common` did, it named a party no presenter can match
+    /// and the host refused every request.
     ///
-    /// Which is not hypothetical. `vta-cli-common`'s `RoomTarget` passes the **host's** DID
-    /// as the audience, so `pnm-cli rooms --host-did …` mints a leaf bound to an audience
-    /// no presenter can ever match: the host refuses it as `WrongAudience` every time, while
-    /// omitting the flag leaves the presentation bearer-shaped for its four-hour life. Its
-    /// doc comment states the intent exactly — "with it, a captured presentation is
-    /// worthless to anyone else" — and names the wrong party to bind to.
+    /// dtg-credentials 0.8 settled it by removing the field outright and requiring the
+    /// presenter to be the leaf's subject instead (`NotThePresenter`). So the binding this
+    /// method relies on is now the library's rule rather than a value it declines to expose:
+    /// the leaf grants to `self.did`, and a verifier accepts it from nobody else.
     ///
     /// The `nonce` is the verifier's, echoed rather than interpreted: its value to them is
     /// that it came back unchanged.
@@ -213,12 +211,9 @@ impl MemberIdentity {
                 self.did.clone(),
                 vec![action.to_string()],
                 now,
-                // 0.6 takes an `Option` here; 0.7 made it required. Always `Some`: a
-                // presentation that does not expire is a standing grant, which is the one
-                // thing a presentation exists not to be.
-                Some(expires),
-                // Bound to us: the leaf may be presented by this member and nobody else.
-                Some(self.did.clone()),
+                // Required since 0.7, and rightly: a presentation that does not expire is a
+                // standing grant, which is the one thing a presentation exists not to be.
+                expires,
             )
             .map_err(|e| {
                 format!("cannot narrow your authority for this room to `{action}`: {e}")

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -603,7 +603,7 @@ mod tests {
             room.clone(),
             vec!["read".into(), "curate".into()],
             now - chrono::Duration::minutes(1),
-            Some(now + chrono::Duration::days(30)),
+            now + chrono::Duration::days(30),
         )
         .expect("mint the room's authority credential")
         .with_id("urn:uuid:vac-1");
@@ -677,7 +677,7 @@ mod tests {
             room.clone(),
             vec!["read".into()],
             now - chrono::Duration::minutes(1),
-            Some(now + chrono::Duration::days(30)),
+            now + chrono::Duration::days(30),
         )
         .unwrap()
         .with_id("urn:uuid:vac-3");
@@ -703,8 +703,13 @@ mod tests {
         // The rightful member: accepted.
         verify_chain(&chain, &room, &room, "read", me.did(), chrono::Utc::now()).unwrap();
 
-        // Whoever lifted it off the wire: refused, and refused as a wrong audience rather
-        // than as a bad signature — the chain is perfectly valid, it is just not theirs.
+        // Whoever lifted it off the wire: refused, and refused for the right reason — the
+        // chain is perfectly valid, it is just not theirs.
+        //
+        // The refusal used to be `WrongAudience`, from a leaf this method bound to its own
+        // subject. dtg-credentials 0.8 removed `audience` and made the subject rule the
+        // library's own, so the same property is now enforced without a field to fill in:
+        // `NotThePresenter`.
         let err = verify_chain(
             &chain,
             &room,
@@ -717,9 +722,9 @@ mod tests {
         assert!(
             matches!(
                 err,
-                dtg_credentials::authority::AuthorityError::WrongAudience { .. }
+                dtg_credentials::authority::AuthorityError::NotThePresenter { .. }
             ),
-            "expected a WrongAudience refusal, got {err:?}"
+            "expected a NotThePresenter refusal, got {err:?}"
         );
     }
 
@@ -740,7 +745,7 @@ mod tests {
             room.clone(),
             vec!["read".into()],
             now - chrono::Duration::minutes(1),
-            Some(now + chrono::Duration::days(30)),
+            now + chrono::Duration::days(30),
         )
         .unwrap()
         .with_id("urn:uuid:vac-2");
@@ -824,7 +829,7 @@ mod tests {
             "room".into(),
             vec!["read".into()],
             now,
-            Some(now + chrono::Duration::hours(1)),
+            now + chrono::Duration::hours(1),
         )
         .expect("build an authority credential")
         .with_id("urn:uuid:i-2");

--- a/vti-rooms/src/authz.rs
+++ b/vti-rooms/src/authz.rs
@@ -118,7 +118,7 @@ pub struct VerifiedChain {
 /// 2. the chain's root was issued by the room — a chain reaching any other party confers
 ///    nothing here, however well-formed;
 /// 3. no link widens the actions or scope of its parent;
-/// 4. every link is within its validity window, and any audience is honoured;
+/// 4. every link is within its validity window;
 /// 5. the membership credential and the chain describe the same subject;
 /// 6. the chain's leaf grants to `presenter` — the party the *transport* authenticated,
 ///    not one named in the payload.


### PR DESCRIPTION
Three commits, one story: `audience` never worked, the fix for it is upstream, and taking
the upstream fix lets two hand-written checks go.

**Absorbs #1358**, which was a separate PR until it turned out to be the last commit of
this one.

## 1 · The CLI could never present anything

`pnm-cli rooms --host-did …` was refused as `WrongAudience` every time; omitting the flag
skipped the check entirely. Broken and unprotected, nothing in between.

`audience` was never the destination. `verify_chain` compared it to the **presenter** —
"the leaf must be presentable by whoever is presenting it" — and `vta-cli-common` passed
the *host's* DID, naming a party no presenter can ever match.

## 2 · So stop sending it, and stop sending `nonce` too

`room_oracle::present` loses both parameters. The leaf grants to the DID this VTA
authenticated, and a host refuses a chain whose leaf grants to anyone but the party that
signed what it received — so a presentation is usable by its caller and nobody else, and a
caller cannot ask for one made out to a third party because it never gets to name the
subject.

Binding a presentation to a *host* is not offered, because it would not mean anything: the
chain is scoped to the room, a room may have more than one host, and moving between them
without reissuing is the point. Binding a **request** to its destination is the `recipient`
member's job on the document carrying it, which its `proof` covers.

`nonce` goes for a sharper reason: a presentation is a bundle of credentials signed by
their *issuers*, never by the presenter, so a challenge placed inside one is
unauthenticated — an attacker replaying a captured presentation copies the challenge along
with everything else. Freshness belongs to the signed request.

## 3 · dtg-credentials 0.6 → 0.8, which makes all of that the library's rule

0.8 **requires** the presenter to be the leaf's subject (`NotThePresenter`) and **removes**
`audience` outright, citing trustoverip/dtgwg-trust-tasks-tf#414 — the issue this thread
raised. 0.7 additionally made a VAC's `validUntil` required.

**Both hand-written copies of the presenter rule are deleted**, which is the payoff.
`vti-rooms-dtg`'s chain verifier and its nomination check had each written it
independently, after hitting the gap separately:

> `verify_chain` uses `claimant` only for the audience check; it does not require the grant
> to name them. Without this a nomination would be a bearer token, and anyone who ever
> observed one could take the room the moment it went dormant.

Two copies of a rule is one place for it to be forgotten. The tests that pinned the
property stay exactly where they were — a chain presented by the wrong party is still
refused, and which layer refuses it is no longer this crate's business. Their assertions
move to the library's wording, which names both parties rather than only the rule.

`rooms/owner/issue-authority` now **refuses** a request with no `validUntil` rather than
defaulting: nothing about a subject's standing is consulted when a chain is verified, so
authority that does not expire is authority nobody can withdraw by waiting — and choosing a
lifetime here would put the room's most consequential number somewhere its owner never
looks.

## Ordering, for anyone else upgrading

OpenVTC/dtg-credentials#22. A **new issuer against an old verifier** reports a broken chain
rather than a version skew — `names parent zQm…, but was presented after urn:uuid:…`, with
nothing to say those are different kinds of identifier. That is the direction a client-first
upgrade hits, and it is how this started: a browser-native room member on 0.7 talking to
`room-host` on 0.6.

## Verified

`vti-rooms` 106+3, `vti-rooms-dtg` 19, `room-host` 23+13, `vtc-service` rooms 26,
`vta-service` rooms 11 — all green. Clippy clean on the touched crates.

`Test (workspace)` failures on this branch are the #1341 fallout inherited from `main`, not
from these changes; #1359 fixes the last of them.