### PR TITLE
chore(rooms)!: dtg-credentials 0.6 → 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,9 +3495,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f292eb5ba50d7f69dd9671e87b4d6ceddbeb973cbf0c05715220bee8446ff90"
+checksum = "4c4a250f81c3939a226b6496dcaf38a5fa90e3591ab901a9421495247adaba10"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -3506,7 +3506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.6"
+dtg-credentials = "0.8"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.49"

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -592,7 +592,7 @@ async fn act_four(
     )
     .await?;
 
-    let nomination = g.nominate(&g.successor.did, Some(24 * 365)).await;
+    let nomination = g.nominate(&g.successor.did, 24 * 365).await;
     note("the room issued this nomination to its successor long ago, granting `succeed` —");
     note("a word no room task accepts, so it confers nothing at all while Alice is present");
 
@@ -668,7 +668,7 @@ async fn act_four(
         .claim_owner(
             &successor_session(&h),
             // A nomination the room really did issue — naming somebody else.
-            &h.nominate(&h.agent.did, Some(24)).await,
+            &h.nominate(&h.agent.did, 24).await,
             None,
             &h.successor.did,
             &h.successor.secret_multibase,
@@ -687,7 +687,7 @@ async fn act_four(
     let claimed = client
         .claim_owner(
             &successor_session(&h),
-            &h.nominate(&h.successor.did, Some(24 * 365)).await,
+            &h.nominate(&h.successor.did, 24 * 365).await,
             Some("the owner has been unreachable since March"),
             &h.successor.did,
             &h.successor.secret_multibase,

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -1684,7 +1684,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
                 "reason": "the owner has been unreachable since March",
             }),
@@ -1717,7 +1717,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,
@@ -1740,7 +1740,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,
@@ -1766,7 +1766,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -27,10 +27,19 @@
 //! have handed the caller its principal's whole standing in the room, which is precisely the
 //! outcome attenuation exists to prevent.
 //!
-//! **A presentation reusable elsewhere.** Where the caller names an `audience`, the leaf is
-//! bound to it, and `verify_chain` refuses a chain link presented by anyone else. Without an
-//! audience the presentation is bearer-shaped against that room, which is why callers that
-//! know their host should always name it.
+//! **A presentation usable by whoever captured it.** The leaf grants to `agent_did` — the
+//! party the transport authenticated — and since dtg-credentials 0.8 `verify_chain` REQUIRES
+//! the presenter to be the leaf's subject, refusing anyone else with `NotThePresenter`. So a
+//! presentation lifted off the wire authorises nothing for the party that lifted it.
+//!
+//! That used to be `audience`'s job and it did it badly: the field was optional, so a leaf
+//! without one was accepted from anybody, and the Trust Tasks registry described it as the
+//! party a presentation is *for* while the library compared it to the presenter — so an
+//! implementation following the registry minted leaves the verifier refused every time.
+//! 0.8 removes it and makes the subject rule normative
+//! (`trustoverip/dtgwg-cred-spec#41`, `trustoverip/dtgwg-trust-tasks-tf#414`). The
+//! destination question it was reaching for is answered a layer up, by the Trust Task
+//! document's `recipient`, which its `proof` covers.
 //!
 //! **The keys.** Nothing in the response carries key material in either direction. An oracle
 //! that returned the principal's VAC itself would be a credential-release call wearing a
@@ -88,7 +97,13 @@ pub async fn present(
     agent_did: &str,
     room_id: &str,
     action: &str,
-    audience: Option<&str>,
+    // Accepted and ignored. `rooms/keys/present/0.1` still carries an `audience` member and
+    // dtg-credentials 0.8 removed the field it fed. Taking it and doing nothing keeps every
+    // existing caller working — the CLI names its host here — while the binding comes from
+    // the subject rule instead. Removing it from the schema is proposed in
+    // `trustoverip/dtgwg-trust-tasks-tf#414`; until that lands, accepting it is better than
+    // refusing a request that is not wrong, and far better than pretending it still binds.
+    _audience: Option<&str>,
     nonce: Option<&str>,
 ) -> Result<MintedPresentation, AppError> {
     let scope = auth.act_scope();
@@ -113,8 +128,7 @@ pub async fn present(
             agent_did.to_string(),
             vec![action.to_string()],
             now,
-            Some(expires),
-            audience.map(str::to_string),
+            expires,
         )
         .map_err(|e| {
             // The common case is asking for an action the principal does not hold, and

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -207,13 +207,32 @@ pub(super) async fn handle_issue_authority(
     // action list rather than reading it as "everything", and the schema refuses it before
     // that — two layers, because "confers nothing" and "confers everything" are exactly the
     // two readings a careless consumer might choose between.
+    // An authority credential must expire, and since dtg-credentials 0.7 the constructor
+    // says so in its type. Nothing about a subject's current standing is consulted when a
+    // chain is verified, so a grant that does not expire is a grant nobody can withdraw by
+    // waiting — the only way back is revocation, which this stack does not yet have.
+    //
+    // Refused rather than defaulted. Picking a lifetime here would put the room's most
+    // consequential number in a place its owner never looks.
+    let Some(valid_until) = req.valid_until else {
+        return app_error_to_reject(
+            &doc,
+            vti_common::error::AppError::Validation(
+                "an authority credential must name `validUntil`: nothing about a subject's \
+                 standing is checked when a chain is verified, so authority that does not \
+                 expire is authority nobody can withdraw"
+                    .into(),
+            ),
+        );
+    };
+
     let vac = match dtg_credentials::DTGCredential::new_vac(
         req.room_id.clone(),
         req.subject.clone(),
         req.room_id.clone(),
         actions,
         chrono::Utc::now(),
-        req.valid_until,
+        valid_until,
     ) {
         Ok(v) => v,
         Err(e) => {

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -1821,7 +1821,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
                 "reason": "unreachable since March",
             }),
@@ -1847,7 +1847,7 @@ mod tests {
         let f = RoomFixture::new(Visibility::Open).await;
         create_expiring(state, &f, days_ago(60)).await;
 
-        let nomination = f.nominate(&f.successor.did, Some(24)).await;
+        let nomination = f.nominate(&f.successor.did, 24).await;
 
         // The owner returns and mints an epoch — ordinary use, nothing succession-specific.
         let out = handle_mint_epoch(
@@ -1900,7 +1900,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
         )
@@ -1926,7 +1926,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
         )

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 # Published, now that it can be. This crate was `publish = false` for exactly
 # one reason — a published crate cannot depend on a git source, and
-# dtg-credentials 0.6 was merged but unreleased — and that reason is gone.
+# dtg-credentials was merged but unreleased — and that reason is gone.
 #
 # It should not stay unpublished by inertia. `vti-rooms` publishes so that a
 # room host can reuse a room's storage, wire types and authorization; but
@@ -29,7 +29,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 
 # `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
 # 0.6.0 sat merged and unreleased; released 2026-09-03.
-dtg-credentials = "0.6"
+dtg-credentials = "0.8"
 
 async-trait = "0.1"
 # Both hosts already carry a `VerificationMethodResolver`, so the key adapter wraps

--- a/vti-rooms-dtg/src/lib.rs
+++ b/vti-rooms-dtg/src/lib.rs
@@ -287,22 +287,20 @@ impl ChainVerifier for DtgChainVerifier {
         )
         .map_err(|e| chain_refusal(&room.room_id, e))?;
 
-        // `verify_chain` takes `presenter` but uses it for **one** thing: the `audience`
-        // check, where a link that names an audience must be presented by that audience. It
-        // does not require the leaf to grant to the presenter, and that is deliberate on
-        // its side — the leaf's subject is "who may act", and binding that to the party the
-        // *transport* authenticated is a question about this request, not about the chain.
+        // The check that used to live here — "the leaf must grant to the presenter" — is now
+        // `verify_chain`'s own. dtg-credentials 0.8 requires it and refuses otherwise with
+        // `NotThePresenter`; before that, `verify_chain` used `presenter` for one thing, the
+        // optional `audience` comparison, so a leaf without an audience was accepted from
+        // anybody and a presentation was a bearer token.
         //
-        // Which makes it ours, and it is not optional: without it a presentation is a
-        // bearer token, and anyone who observes one inherits everything it confers. A test
-        // above presents an agent's chain as the agent's human and expects a refusal.
-        if verified.subject != presenter {
-            return Err(AppError::Forbidden(format!(
-                "the chain's leaf grants to `{}`, not to the party that signed this \
-                 request; a presentation is bound to its presenter, not bearer",
-                verified.subject
-            )));
-        }
+        // This copy and the one in `nomination` were written independently, each after
+        // hitting the same gap, which is why the rule moved into the library. Both are
+        // deleted rather than kept as a second opinion: two copies of a rule is one place
+        // for it to be forgotten, and the duplicate is the one nobody updates.
+        //
+        // The tests that pinned it stay exactly as they were — a chain presented by the
+        // wrong party must still be refused, and it is not this crate's business any more
+        // *which layer* refuses it.
 
         // The pooling defence: membership and authority must describe one subject.
         match room.visibility {
@@ -422,7 +420,7 @@ mod tests {
             scope.into(),
             actions.iter().map(|s| s.to_string()).collect(),
             chrono::Utc::now() - chrono::Duration::hours(1),
-            Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+            chrono::Utc::now() + chrono::Duration::hours(1),
         )
         .expect("build a VAC");
 
@@ -608,7 +606,7 @@ mod signed {
             room_did.clone(),
             vec!["read".into(), "write".into()],
             now - Duration::minutes(1),
-            Some(now + Duration::days(30)),
+            now + Duration::days(30),
         )
         .expect("owner VAC")
         .with_id("urn:uuid:vac-owner");
@@ -621,8 +619,7 @@ mod signed {
                 agent_did.clone(),
                 vec!["read".into()],
                 now - Duration::minutes(1),
-                Some(now + Duration::hours(4)),
-                None,
+                now + Duration::hours(4),
             )
             .expect("attenuate")
             .with_id("urn:uuid:vac-agent");
@@ -739,9 +736,13 @@ mod signed {
             )
             .await
             .unwrap_err();
+        // Refused by `verify_chain` now rather than by a re-check in this crate: 0.8
+        // requires the presenter to be the leaf's subject. The test is deliberately kept
+        // exactly where it was — it asserts the property, and which layer enforces it is
+        // not this crate's business.
         assert!(
-            format!("{err}").contains("not to the party that signed this request"),
-            "{err}"
+            format!("{err}").contains("but it was presented by"),
+            "the refusal should name both parties: {err}"
         );
     }
 
@@ -946,7 +947,7 @@ pub mod test_support {
                     "admin".into(),
                 ],
                 now - Duration::minutes(1),
-                Some(now + Duration::days(30)),
+                now + Duration::days(30),
             )
             .expect("owner VAC")
             .with_id("urn:uuid:vac-owner");
@@ -962,8 +963,7 @@ pub mod test_support {
                     agent.did.clone(),
                     vec!["read".into()],
                     now - Duration::minutes(1),
-                    Some(now + Duration::hours(4)),
-                    None,
+                    now + Duration::hours(4),
                 )
                 .expect("attenuate to the agent")
                 .with_id("urn:uuid:vac-agent");
@@ -989,7 +989,7 @@ pub mod test_support {
                 room_key.did.clone(),
                 vec!["read".into()],
                 now - Duration::minutes(1),
-                Some(now + Duration::days(30)),
+                now + Duration::days(30),
             )
             .expect("successor VAC")
             .with_id("urn:uuid:vac-successor");
@@ -1070,7 +1070,15 @@ pub mod test_support {
         /// Signed by the **room**, because that is the only issuer a nomination can have —
         /// an owner nominating in their own name would be a chain rooted at a person, and
         /// the whole point is that it is rooted at the room they are stepping away from.
-        pub async fn nominate(&self, successor: &str, valid_until: Option<i64>) -> String {
+        /// A nomination valid for `hours`.
+        ///
+        /// Not optional any more, and it could not be: since dtg-credentials 0.7 a VAC's
+        /// `validUntil` is required by the constructor, so "a nomination that never
+        /// expires" is a state this fixture can no longer build — which is the point.
+        /// Nothing about a subject's standing is consulted when a chain is verified, so a
+        /// nomination without an expiry is one nobody can withdraw by waiting. Every caller
+        /// already passed `Some(24)`.
+        pub async fn nominate(&self, successor: &str, hours: i64) -> String {
             let now = Utc::now();
             let mut vac = DTGCredential::new_vac(
                 self.room_key.did.clone(),
@@ -1078,7 +1086,7 @@ pub mod test_support {
                 self.room_key.did.clone(),
                 vec![crate::ACTION_SUCCEED.into()],
                 now - Duration::minutes(1),
-                valid_until.map(|h| now + Duration::hours(h)),
+                now + Duration::hours(hours),
             )
             .expect("nomination VAC")
             .with_id("urn:uuid:vac-nomination");

--- a/vti-rooms-dtg/src/nomination.rs
+++ b/vti-rooms-dtg/src/nomination.rs
@@ -73,16 +73,15 @@ pub async fn verify(
     )
     .map_err(|e| chain_refusal(room_id, e))?;
 
-    // `verify_chain` uses `claimant` only for the audience check; it does not require the
-    // grant to name them. Without this a nomination would be a bearer token, and anyone who
-    // ever observed one could take the room the moment it went dormant.
-    if verified.subject != claimant {
-        return Err(AppError::Forbidden(format!(
-            "the nomination names `{}`, not the party claiming; a nomination is not \
-             transferable",
-            verified.subject
-        )));
-    }
+    // The check that used to live here — "the grant must name the claimant" — is now
+    // `verify_chain`'s own, since dtg-credentials 0.8 requires the presenter to be the
+    // leaf's subject and refuses otherwise with `NotThePresenter`. It was written here
+    // because `verify_chain` used `claimant` only for the optional `audience` comparison,
+    // so a nomination without one was a bearer token: anyone who ever observed one could
+    // take the room the moment it went dormant.
+    //
+    // Deleted rather than kept as a second opinion. Two copies of a rule is one place for
+    // it to be forgotten, and the one that is a duplicate is the one nobody updates.
 
     Ok(VerifiedNomination {
         successor: verified.subject,
@@ -121,7 +120,10 @@ mod tests {
         subject: &str,
         scope: &str,
         actions: Vec<String>,
-        valid_until: Option<chrono::DateTime<Utc>>,
+        // Required, and not by this helper's choice: since dtg-credentials 0.7 a VAC's
+        // `validUntil` is required by the constructor, so a nomination with no expiry is a
+        // state no test can build any more. Every call already passed one.
+        valid_until: chrono::DateTime<Utc>,
     ) -> String {
         let now = Utc::now();
         let mut vac = DTGCredential::new_vac(
@@ -145,7 +147,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await
     }
@@ -182,7 +184,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 
@@ -201,9 +203,13 @@ mod tests {
         let err = verify(&good(&f).await, &f.room_did, &opportunist, &DidKeyResolver)
             .await
             .expect_err("presenting someone else's nomination confers nothing");
+        // The refusal now comes from `verify_chain` itself rather than from a re-check
+        // here — dtg-credentials 0.8 requires the presenter to be the leaf's subject. The
+        // property is unchanged and the wording is the library's, which names both parties
+        // rather than only the rule.
         assert!(
-            format!("{err}").contains("not transferable"),
-            "the refusal should say why: {err}"
+            format!("{err}").contains("but it was presented by"),
+            "the refusal should name who it was granted to and who presented it: {err}"
         );
     }
 
@@ -220,7 +226,7 @@ mod tests {
             &f.successor_did,
             &other_room,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 
@@ -240,7 +246,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() - Duration::days(1)),
+            Utc::now() - Duration::days(1),
         )
         .await;
 
@@ -266,7 +272,7 @@ mod tests {
                 "curate".into(),
                 "admin".into(),
             ],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 

--- a/vti-rooms/src/authz.rs
+++ b/vti-rooms/src/authz.rs
@@ -118,7 +118,7 @@ pub struct VerifiedChain {
 /// 2. the chain's root was issued by the room — a chain reaching any other party confers
 ///    nothing here, however well-formed;
 /// 3. no link widens the actions or scope of its parent;
-/// 4. every link is within its validity window, and any audience is honoured;
+/// 4. every link is within its validity window;
 /// 5. the membership credential and the chain describe the same subject;
 /// 6. the chain's leaf grants to `presenter` — the party the *transport* authenticated,
 ///    not one named in the payload.


### PR DESCRIPTION
Two breaking releases at once, and the second is why this is worth doing now rather than
eventually.

## 0.8 — a VAC is not a bearer credential

`verify_chain` now **requires the presenter to be the leaf's subject**, refusing otherwise
with `NotThePresenter`. Before, it used `presenter` for one thing — comparing it against
the leaf's *optional* `audience` — so a leaf without one was accepted from **anybody**, and
a captured presentation was a bearer token.

**Both hand-written copies of that rule are deleted.** That is the payoff.
`vti-rooms-dtg`'s chain verifier and its nomination check had each written it
independently, after hitting the gap separately, each with a comment explaining why they
had to:

> `verify_chain` uses `claimant` only for the audience check; it does not require the grant
> to name them. Without this a nomination would be a bearer token, and anyone who ever
> observed one could take the room the moment it went dormant.

Two copies of a rule is one place for it to be forgotten, and the duplicate is the one
nobody updates.

**The tests that pinned the property stay exactly where they were.** A chain presented by
the wrong party is still refused; which layer refuses it is no longer this crate's
business. Their assertions move to the library's wording, which is better — it names both
parties rather than only the rule:

> the chain's leaf grants to `did:key:z6Mkfr2…`, but it was presented by `did:key:z6Mkn5Z…`

`audience` is gone from the credential. `room_oracle::present` still accepts the
`rooms/keys/present/0.1` payload member and ignores it, so every existing caller keeps
working — the CLI names its host there. Removing it from the schema is proposed in
trustoverip/dtgwg-trust-tasks-tf#414. Accepting a request that is not wrong beats refusing
it, and both beat pretending the value still binds something.

## 0.7 — digests, and a required expiry

`validUntil` became required on `new_vac`. `rooms/owner/issue-authority` now **refuses** a
request without one rather than defaulting: nothing about a subject's standing is consulted
when a chain is verified, so authority that does not expire is authority nobody can
withdraw by waiting — and picking a lifetime here would put the room's most consequential
number somewhere its owner never looks.

The same rule made `Option` dead in two test fixtures. Every caller already passed a value,
and "a nomination that never expires" is now a state no test can construct, so both
signatures lose the `Option`.

## Ordering, for anyone else upgrading

Filed as OpenVTC/dtg-credentials#22. A **new issuer against an old verifier** reports a
broken chain rather than a version skew — `names parent zQm…, but was presented after
urn:uuid:…`, with nothing to say those are different kinds of identifier. That is the
direction a client-first upgrade hits, and it is how this whole thread started: a
browser-native room member on 0.7 talking to `room-host` on 0.6.

## Verified

| | |
|---|---|
| `vti-rooms` | 78 + 13 passed |
| `vti-rooms-dtg` | 19 passed |
| `room-host` | 23 passed |
| `vtc-service` rooms | 26 passed |
| `vta-service` rooms | 11 passed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |

Marked `!`: `rooms/owner/issue-authority` now refuses a request it previously accepted, and
`AuthorityPresentation`'s `audience` no longer binds anything.