### PR TITLE
fix: the last two #1341 fallout failures

### DIFF
--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -34,14 +34,12 @@ use vta_sdk::protocols::key_management::sign::SignAlgorithm;
 use vta_sdk::trust_tasks;
 
 mod common;
-use common::test_vta_responder::{ResponderReply, TestVtaResponder};
+// `TT_ENVELOPE` lives with the responder because that is what decides which
+// replies it signs: one definition, so a test cannot dispatch under one
+// envelope type and be answered unsigned under another.
+use common::test_vta_responder::{ResponderReply, TT_ENVELOPE, TestVtaResponder};
 
 // ── Trust-task envelope helpers ─────────────────────────────────────
-
-/// The DIDComm binding envelope every Trust Task rides in. `rpc_tt` sends
-/// this as the message type and puts the trust-task document in the body;
-/// the reply must come back under the same type (`send_and_wait` checks it).
-const TT_ENVELOPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
 
 /// True when this inbound message is a Trust Task dispatch for `tt_uri`.
 ///

--- a/tests/e2e/tests/common/test_vta_responder.rs
+++ b/tests/e2e/tests/common/test_vta_responder.rs
@@ -56,6 +56,17 @@ use affinidi_tdk::messaging::profiles::ATMProfile;
 use serde_json::Value;
 use tokio::sync::oneshot;
 
+/// The DIDComm binding envelope a Trust Task rides in, and the only reply this
+/// responder signs.
+///
+/// The body under this type is a Trust-Task document, and `VtaClient` verifies
+/// its proof (OpenVTC/verifiable-trust-infrastructure#1341). A reply under any
+/// other type — the legacy protocol messages, a problem report, the
+/// deliberately-wrong types `didcomm_session.rs` sends — is not a Trust-Task
+/// document, nothing verifies it, and a `proof` member on it is a member its
+/// consumer never asked for.
+pub const TT_ENVELOPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+
 /// Reply the responder builds for an inbound message.
 pub enum ResponderReply {
     /// Successful result. `result_type` is the DIDComm `typ` field of
@@ -99,6 +110,23 @@ pub enum ResponderError {
     Profile(String),
     #[error("websocket enable failed: {0}")]
     Websocket(String),
+    #[error("the responder identity carries no Ed25519 verification key to sign with")]
+    NoSigningKey,
+}
+
+/// The responder's own Ed25519 verification key — the one its replies are
+/// signed with, and the one a client resolves out of its `did:peer:2` document.
+///
+/// Chosen by key *type* rather than by the `#key-1` fragment `generate_did_peer`
+/// happens to mint: the fragment is a numbering convention, the key type is the
+/// property that makes a key able to sign. The X25519 half (`#key-2`) is for
+/// encryption and cannot.
+fn signing_secret(secrets: &[Secret]) -> Result<Secret, ResponderError> {
+    secrets
+        .iter()
+        .find(|s| s.get_key_type() == affinidi_secrets_resolver::secrets::KeyType::Ed25519)
+        .cloned()
+        .ok_or(ResponderError::NoSigningKey)
 }
 
 /// A `did:peer:2`-identified DIDComm responder, listening on a
@@ -128,6 +156,9 @@ impl TestVtaResponder {
             None,
         )
         .map_err(|e| ResponderError::DidGeneration(e.to_string()))?;
+        // Resolved before anything is stood up: an identity that cannot sign is
+        // a fixture bug, and failing here leaks no socket.
+        let signer = signing_secret(&secrets)?;
 
         // 2. Stand up TDK + ATM + profile.
         let tdk = TDKSharedState::new(
@@ -179,6 +210,7 @@ impl TestVtaResponder {
                 atm_loop,
                 profile_loop,
                 responder_did,
+                signer,
                 handler,
                 &mut shutdown_rx,
             )
@@ -241,6 +273,7 @@ impl TestVtaResponder {
     where
         F: Fn(&str, &Value) -> ResponderReply + Send + Sync + 'static,
     {
+        let signer = signing_secret(&secrets)?;
         let tdk = TDKSharedState::new(
             TDKConfig::builder()
                 .build()
@@ -288,6 +321,7 @@ impl TestVtaResponder {
                 atm_loop,
                 profile_loop,
                 responder_did,
+                signer,
                 handler,
                 &mut shutdown_rx,
             )
@@ -334,6 +368,7 @@ async fn run_dispatch_loop<F>(
     atm: Arc<ATM>,
     profile: Arc<ATMProfile>,
     responder_did: String,
+    signer: Secret,
     handler: Arc<F>,
     shutdown_rx: &mut oneshot::Receiver<()>,
 ) where
@@ -380,7 +415,7 @@ async fn run_dispatch_loop<F>(
         };
 
         let reply = handler(&msg.typ, &msg.body);
-        let (result_type, body) = match reply {
+        let (result_type, mut body) = match reply {
             ResponderReply::Ok { result_type, body } => (result_type, body),
             ResponderReply::Problem { code, comment } => (
                 "https://didcomm.org/report-problem/2.0/problem-report".to_string(),
@@ -388,6 +423,20 @@ async fn run_dispatch_loop<F>(
             ),
             ResponderReply::Drop => continue,
         };
+
+        // A VTA signs every Trust-Task success response, and `VtaClient` now
+        // checks it — so a stand-in that answers unsigned is not a cheap mock,
+        // it is an agent that behaves in a way no real one does. This calls the
+        // agent's own signing code (`test_support::sign_response_document`)
+        // rather than a lookalike, and signs with this responder's own
+        // verification key, so the proven signer is the DID the client
+        // addressed.
+        if result_type == TT_ENVELOPE
+            && !vta_service::test_support::sign_response_document(&signer, &mut body).await
+        {
+            tracing::error!("the responder could not sign its reply; sending nothing");
+            continue;
+        }
 
         let reply_id = uuid::Uuid::new_v4().to_string();
         let reply_msg = Message::build(reply_id.clone(), result_type, body)

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -234,6 +234,36 @@ pub(crate) fn test_vta_signer() -> VtaOwnSigner {
     }
 }
 
+/// Sign a Trust-Task response document the way this agent signs its own.
+///
+/// The agent's own [`attach_proof_in_place`](crate::trust_tasks::attach_proof_in_place),
+/// exposed so a harness standing in for a VTA signs identically rather than
+/// approximately. `secret.id` names the verification method the proof carries,
+/// so it has to be a key in the stand-in's own DID document — `{did}#key-1` for
+/// a `did:peer:2` minted with an Ed25519 verification key first.
+///
+/// # Why a harness needs this at all
+///
+/// `VtaClient` verifies a reply's proof and binds the proven signer to the
+/// agent it is addressing (OpenVTC/verifiable-trust-infrastructure#1341). A
+/// responder that answers unsigned is therefore not a cheap stand-in any more —
+/// it is a VTA that behaves in a way no real one does, and every round trip
+/// through it fails with the client blaming the reply. Same reasoning as
+/// [`TEST_VTA_SEED`], one layer further out: that one covers a mock this crate
+/// builds, this one a DIDComm responder in a downstream test crate.
+///
+/// Sign only what the binding says is a Trust-Task document. A reply body under
+/// some other DIDComm type is not one, nothing verifies it, and a `proof`
+/// member added to it is a member its consumer never asked for.
+///
+/// `false` when the signature will not attach.
+pub async fn sign_response_document(
+    secret: &affinidi_secrets_resolver::secrets::Secret,
+    doc: &mut serde_json::Value,
+) -> bool {
+    crate::trust_tasks::attach_proof_in_place(secret, doc).await
+}
+
 /// An ed25519 signing key as a `Secret`.
 ///
 /// **Multicodec-prefixed** (`0x80 0x26`, ed25519-priv). `Secret::from_multibase`

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -594,11 +594,37 @@ async fn attach_proof(
             return None;
         }
     };
+    if !attach_proof_in_place(secret, &mut doc).await {
+        return None;
+    }
+    serde_json::to_vec(&doc)
+        .inspect_err(|e| tracing::error!(error = %e, "could not serialise the signed response"))
+        .ok()
+}
+
+/// [`attach_proof`] over a document already parsed, signing it in place.
+///
+/// Split out so a harness that *stands in* for this agent can sign a document
+/// it holds as JSON, without a serialise-and-reparse round trip on both sides —
+/// `test_support::sign_response_document` is the one caller, and it exists
+/// because a stand-in that signs differently from the thing it stands in for
+/// tests the difference rather than the contract.
+///
+/// `false` when the signature will not attach; the caller decides what an
+/// unsigned answer means, because the two callers disagree — this agent
+/// refuses to send one, a harness has nothing to refuse with.
+pub(crate) async fn attach_proof_in_place(
+    secret: &affinidi_secrets_resolver::secrets::Secret,
+    doc: &mut serde_json::Value,
+) -> bool {
     // A proof never covers itself.
-    doc.as_object_mut()?.remove("proof");
+    let Some(obj) = doc.as_object_mut() else {
+        return false;
+    };
+    obj.remove("proof");
 
     let proof = match affinidi_data_integrity::DataIntegrityProof::sign(
-        &doc,
+        &*doc,
         secret,
         affinidi_data_integrity::SignOptions::new(),
     )
@@ -607,16 +633,21 @@ async fn attach_proof(
         Ok(p) => p,
         Err(e) => {
             tracing::error!(error = %e, "could not sign the success response; answering unsigned");
-            return None;
+            return false;
         }
     };
-    let proof_value = serde_json::to_value(&proof)
+    let Ok(proof_value) = serde_json::to_value(&proof)
         .inspect_err(|e| tracing::error!(error = %e, "could not serialise the response proof"))
-        .ok()?;
-    doc.as_object_mut()?.insert("proof".into(), proof_value);
-    serde_json::to_vec(&doc)
-        .inspect_err(|e| tracing::error!(error = %e, "could not serialise the signed response"))
-        .ok()
+    else {
+        return false;
+    };
+    match doc.as_object_mut() {
+        Some(obj) => {
+            obj.insert("proof".into(), proof_value);
+            true
+        }
+        None => false,
+    }
 }
 
 pub(crate) async fn dispatch_trust_task_core(

--- a/vta-service/tests/mock_vta.rs
+++ b/vta-service/tests/mock_vta.rs
@@ -1059,6 +1059,70 @@ async fn consent_family_response_shapes() {
     mock.shutdown().await;
 }
 
+/// Dispatch one Trust Task over the REST binding, without `VtaClient`.
+///
+/// Used only by [`services_write_paths_against_a_hosted_vta_did`], and only
+/// after it repoints `vta_did`. That test hands the agent a `did:webvh` at
+/// runtime, and the agent's *response-signing* identity does not follow:
+/// `signing_vm_id` is fixed at boot (`server.rs` computes `{vta_did}#key-0`
+/// there, and `config_registry_round_trips_and_identity_stays_read_only`
+/// records that identity is read-only through config, so no live VTA reaches
+/// this state). The mock therefore answers signed as its `did:key` while
+/// claiming to be the hosted DID, and `VtaClient` — which verifies a reply's
+/// proof and binds the proven signer to the agent it is addressing
+/// (OpenVTC/verifiable-trust-infrastructure#1341) — refuses every answer.
+/// Correctly: that is the check working.
+///
+/// Booting the mock with the hosted identity would fix the signer and not the
+/// verification. `did:webvh:…:webvh-host.test` is minted against
+/// [`StubWebvhHost`], which publishes nothing and answers on loopback under a
+/// domain that resolves nowhere — so a reply signed as that DID is
+/// unverifiable by *any* client, in this process or another. There is no
+/// arrangement of this fixture in which a verifying client accepts an answer
+/// from a stub-hosted DID.
+///
+/// The subject here is the agent's `services/*` write paths, so the request
+/// goes direct: the same signed document `VtaClient` builds
+/// (`trust_task_sign::build_signed` is the code path behind
+/// `signed_task_document`), to the same `/trust-tasks` route, with the same
+/// bearer token. Everything server-side is unchanged — §7.2 admission, the
+/// dispatch spine, the handlers, the response proof. Only the client-side
+/// verification of the reply is out of the picture, and it is not what this
+/// test is about.
+async fn post_trust_task(
+    mock: &MockVta,
+    identity: &vta_sdk::client::ClientIdentity,
+    token: &str,
+    type_uri: &str,
+    payload: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let body = vta_sdk::trust_task_sign::build_signed(
+        type_uri,
+        payload,
+        &identity.client_did,
+        &identity.private_key_multibase,
+        &identity.vta_did,
+    )
+    .await
+    .map_err(|e| format!("build a signed {type_uri}: {e}"))?;
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/trust-tasks", mock.base_url()))
+        .bearer_auth(token)
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {type_uri}: {e}"))?;
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(format!("{type_uri} answered {status}: {text}"));
+    }
+    serde_json::from_str(&text).map_err(|e| format!("{type_uri} reply is not JSON: {e} ({text})"))
+}
+
 /// The `services/*` write paths, against a VTA whose own DID is hosted.
 ///
 /// These were the last uncovered block with a shared cause. `services/enable`
@@ -1138,16 +1202,17 @@ async fn services_write_paths_against_a_hosted_vta_did_inner() {
         cfg.vta_did = Some(did.clone());
     }
 
-    // And re-address the client. The VTA's identity just changed, and a
+    // And re-address the caller. The VTA's identity just changed, and a
     // document's `recipient` has to name the consumer it is sent to — SPEC §7.2
     // item 5 rejects one that does not. Reusing the old client would fail on
     // `wrongRecipient` before reaching anything this test is about.
+    //
+    // From here the dispatches go over the REST binding directly rather than
+    // through `VtaClient`; `post_trust_task` records why.
     let (identity, token) = mock
         .ctx
         .mint_signing_identity(0x40, "admin", vec![], &did)
         .await;
-    let client = VtaClient::new(mock.base_url()).with_identity(identity);
-    client.set_token_async(token).await;
 
     // REST throughout: it is the transport with no live handshake, so these
     // exercise the publish path rather than a service-liveness probe.
@@ -1156,41 +1221,45 @@ async fn services_write_paths_against_a_hosted_vta_did_inner() {
     // document advertises no REST service, while the fixture's config says REST
     // is on. Reconciling that disagreement is what enable is for — and until
     // this change it refused to, leaving the state unmanageable.
-    client
-        .dispatch_trust_task(
-            vta_sdk::trust_tasks::TASK_SERVICES_ENABLE_1_0,
-            serde_json::json!({ "service": "rest", "config": { "url": "https://vta.test" } }),
-            30,
-        )
-        .await
-        .expect("services/enable");
+    post_trust_task(
+        &mock,
+        &identity,
+        &token,
+        vta_sdk::trust_tasks::TASK_SERVICES_ENABLE_1_0,
+        serde_json::json!({ "service": "rest", "config": { "url": "https://vta.test" } }),
+    )
+    .await
+    .expect("services/enable");
 
-    client
-        .dispatch_trust_task(
-            vta_sdk::trust_tasks::TASK_SERVICES_UPDATE_1_0,
-            serde_json::json!({ "service": "rest", "config": { "url": "https://vta.test/moved" } }),
-            30,
-        )
-        .await
-        .expect("services/update");
+    post_trust_task(
+        &mock,
+        &identity,
+        &token,
+        vta_sdk::trust_tasks::TASK_SERVICES_UPDATE_1_0,
+        serde_json::json!({ "service": "rest", "config": { "url": "https://vta.test/moved" } }),
+    )
+    .await
+    .expect("services/update");
 
-    client
-        .dispatch_trust_task(
-            vta_sdk::trust_tasks::TASK_SERVICES_DISABLE_1_0,
-            serde_json::json!({ "service": "rest" }),
-            30,
-        )
-        .await
-        .expect("services/disable");
+    post_trust_task(
+        &mock,
+        &identity,
+        &token,
+        vta_sdk::trust_tasks::TASK_SERVICES_DISABLE_1_0,
+        serde_json::json!({ "service": "rest" }),
+    )
+    .await
+    .expect("services/disable");
 
-    client
-        .dispatch_trust_task(
-            vta_sdk::trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
-            serde_json::json!({ "service": "rest" }),
-            30,
-        )
-        .await
-        .expect("services/rollback");
+    post_trust_task(
+        &mock,
+        &identity,
+        &token,
+        vta_sdk::trust_tasks::TASK_SERVICES_ROLLBACK_1_0,
+        serde_json::json!({ "service": "rest" }),
+    )
+    .await
+    .expect("services/rollback");
 
     // `passkey-vms/revoke` is *not* here, and the reason is worth recording:
     // it refuses a fragment that is not on the document


### PR DESCRIPTION
The end of the #1341 arc. `VtaClient` began verifying reply proofs and binding
the proven signer to the agent it is addressing; that broke roughly a hundred
tests across the workspace, revealed one target at a time because `cargo test`
stops at the first failing one. #1348, #1350 and #1355 took the first three
waves. These are the last two, and they have nothing in common but the cause.

Both are in one PR because CI runs the workspace suite: split across two, each
would be red on the other's failure until both merged.

## `tests/e2e/tests/client_didcomm.rs` — 33 failures

`TestVtaResponder` stands in for a VTA and answered unsigned. That was a cheap
approximation until a client started checking; now it is an agent that behaves
in a way no real one does, and every round trip through it failed with the
client blaming the reply.

It signs with the agent's own code rather than a lookalike:
`trust_tasks::attach_proof` is split into an in-place half over a parsed
document and `test_support::sign_response_document` exposes it. A harness that
signs *approximately* like the thing it stands in for tests the difference
rather than the contract. The key is the responder's own Ed25519 verification
method, found by key type rather than by the `#key-1` fragment
`generate_did_peer` happens to mint, so the proven signer is the `did:peer:2`
the client addressed.

Only replies under the Trust-Task DIDComm envelope are signed. A legacy
protocol message, a problem report and the deliberately-wrong types
`didcomm_session.rs` sends are not Trust-Task documents, nothing verifies them,
and a `proof` member on one is a member its consumer never asked for.
`TT_ENVELOPE` moves to the responder and `client_didcomm.rs` imports it — one
definition, so a test cannot dispatch under one envelope type and be answered
unsigned under another.

## `mock_vta::services_write_paths_against_a_hosted_vta_did`

That test repoints `cfg.vta_did` at a `did:webvh` the mock mints at runtime.
The response-signing identity does not follow — `signing_vm_id` is computed
once at boot — so the mock answers signed as its `did:key` while claiming to be
the hosted DID, and the client refuses. The refusal is right; the fixture is
what is inconsistent.

Booting the mock with the hosted identity is the obvious repair and fixes the
signer without fixing the verification. The DID is minted against
`StubWebvhHost`, which publishes nothing and answers on loopback under a domain
that resolves nowhere, so a reply signed as it is unverifiable by any client in
any process. There is no arrangement of this fixture in which a verifying
client accepts an answer from a stub-hosted DID.

The subject of the test is the agent's `services/*` write paths, so the four
dispatches go over the REST binding directly: the same signed document
`VtaClient` builds, to the same `/trust-tasks` route, with the same bearer
token. Everything server-side is unchanged — §7.2 admission, the dispatch
spine, the handlers, the response proof. Only the client's verification of the
reply is out of the picture, and it is not what this test covers.

Making `signing_vm_id` runtime-mutable was the other candidate and is worse: it
would reshape `AppState` to permit something production forbids, which
`config_registry_round_trips_and_identity_stays_read_only` exists to record.

## Verified

- `cargo test --workspace --exclude vtc-service --exclude vtc-client
  --no-fail-fast` — no failures. This is CI's exact command; a per-crate run is
  not the same suite (three `vta-sdk` integration binaries have no tests at all
  under default features).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, as are the
  two feature-restricted `vta-service` runs CI adds.
- `cargo fmt --all -- --check` — clean.