### PR TITLE
feat(deps)!: dtg-credentials 0.6 -> 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,9 +3495,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.6.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f292eb5ba50d7f69dd9671e87b4d6ceddbeb973cbf0c05715220bee8446ff90"
+checksum = "fa51b03528a22ad07cd0f812a99fae834b7867c205943a40ad90bb8eb62edb08"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -3506,7 +3506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tracing",
 ]
@@ -9591,9 +9591,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.18.0"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b3ff12a929ebae90844cbf38232092a60acbc59591999ad57453d6d19bb183"
+checksum = "df30d9c2a63dc5147b9fee773cc8ccce201b45ffd6a3a4724dd4a8e02dfdbbd2"
 dependencies = [
  "chrono",
  "serde",
@@ -9605,9 +9605,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.18.0"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b338e33658f9e40246f014cd7695331214e529afee8a465f55ac868bf606b978"
+checksum = "16c64a454241025f8a83d7f0ecc39e3b745a25ddf5abcc1cbe2267df5ede7ed5"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9621,9 +9621,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.18.0"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c33d0c0a90e12dc67b07786124f849ccbd5b7e2eb14f5675e1c8b0671443023"
+checksum = "1401db12f853877d33100b6e2345ec41c699d12b11a4c92f5ad39f14317512a2"
 dependencies = [
  "axum",
  "chrono",
@@ -9640,9 +9640,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.18.0"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62814df673aaaae19d948cf7d6cc662236257566df5bd790779bc156edc86ebf"
+checksum = "6cb7ad2f8a084f794485bb4467aef387fb9592609c7a2faaeb82e0c547a50deb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ affinidi-messaging-core = "0.1"
 futures-util = "0.3"
 
 # Decentralized Trust Graph Credentials
-dtg-credentials = "0.6"
+dtg-credentials = "=0.9.1"
 
 # JSON Schema validation (issue-time credentialSchema checks)
 jsonschema = "0.49"

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -338,8 +338,11 @@ pub(crate) enum RoomCommands {
         /// Base URL of the host storing the room.
         #[arg(long)]
         host: String,
-        /// The host's DID. Omit and the minted presentation is not bound to a
-        /// host — usable by anyone who observes it until it expires.
+        /// The host's DID — the recipient the request document names.
+        ///
+        /// It does not affect how the presentation is bound. That is always to
+        /// the DID you authenticate as, so a captured one is worthless to
+        /// whoever captured it whether this is given or not.
         #[arg(long)]
         host_did: Option<String>,
         /// Only records whose key starts with this.

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -592,7 +592,7 @@ async fn act_four(
     )
     .await?;
 
-    let nomination = g.nominate(&g.successor.did, Some(24 * 365)).await;
+    let nomination = g.nominate(&g.successor.did, 24 * 365).await;
     note("the room issued this nomination to its successor long ago, granting `succeed` —");
     note("a word no room task accepts, so it confers nothing at all while Alice is present");
 
@@ -668,7 +668,7 @@ async fn act_four(
         .claim_owner(
             &successor_session(&h),
             // A nomination the room really did issue — naming somebody else.
-            &h.nominate(&h.agent.did, Some(24)).await,
+            &h.nominate(&h.agent.did, 24).await,
             None,
             &h.successor.did,
             &h.successor.secret_multibase,
@@ -687,7 +687,7 @@ async fn act_four(
     let claimed = client
         .claim_owner(
             &successor_session(&h),
-            &h.nominate(&h.successor.did, Some(24 * 365)).await,
+            &h.nominate(&h.successor.did, 24 * 365).await,
             Some("the owner has been unreachable since March"),
             &h.successor.did,
             &h.successor.secret_multibase,

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -1684,7 +1684,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
                 "reason": "the owner has been unreachable since March",
             }),
@@ -1717,7 +1717,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,
@@ -1740,7 +1740,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,
@@ -1766,7 +1766,7 @@ mod tests {
             ROOMS_OWNER_CLAIM_TYPE,
             serde_json::json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
             &f.successor,

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -35,11 +35,12 @@ use vtc_client::rooms::{CleartextContent, RoomSession, Visibility};
 
 /// Everything a room command needs to reach both parties.
 ///
-/// The host DID is optional because an operator may not know it, and the cost
-/// of not knowing is stated rather than hidden: without it the minted
-/// presentation carries no audience, so it is bearer-shaped against that room
-/// for its four-hour life. With it, a captured presentation is worthless to
-/// anyone else.
+/// The host DID is optional because an operator may not know it, and it names the
+/// **recipient** of the document — nothing more. It used to be passed as the presentation's
+/// `audience` as well, on the reading that this bound the presentation to one host; it does
+/// not, and could not, because the verifier compares `audience` to the presenter. See
+/// [`present`]. A presentation is bound to whoever will sign the request, always, so there
+/// is no longer an unbound case for an operator to be warned about.
 pub struct RoomTarget<'a> {
     pub host_url: &'a str,
     pub host_did: Option<&'a str>,
@@ -56,21 +57,37 @@ impl RoomTarget<'_> {
     }
 }
 
-/// Mint a presentation for one action, and warn when it will be unbound.
+/// Mint a presentation for one action, bound to the party that will present it.
+///
+/// # `audience` is the presenter, not the host
+///
+/// This passed `target.host_did` until it was found never to work. `audience` is not who
+/// the presentation is addressed to: `dtg_credentials::authority::verify_chain` compares it
+/// to the **presenter** — "the leaf must be presentable by whoever is presenting it" — so
+/// it is holder binding, and its job is to make a captured presentation worthless to
+/// whoever captured it.
+///
+/// Filled with the host's DID, it named a party no presenter can ever match, and the host
+/// refused every request as `WrongAudience`. Omitting `--host-did` "worked" only because an
+/// absent audience skips the check, leaving the presentation bearer-shaped for its whole
+/// four-hour life — so the flag's two states were *broken* and *unprotected*.
+///
+/// `presenter` is [`RoomSigner::did`], which already documents the rule this restores: a
+/// room request is signed by the party the presentation was minted for.
+///
+/// The **published spec disagrees** — `rooms/keys/present/0.1` calls `audience` "the party
+/// the presentation is for … a host's identifier, normally" — and that conflict is real and
+/// filed upstream. This binds to the presenter because that is what the verifier does
+/// today, and a presentation that cannot verify protects nobody while it is being wrong in
+/// the other direction.
 async fn present(
     client: &VtaClient,
     target: &RoomTarget<'_>,
     action: &str,
+    presenter: &str,
 ) -> Result<RoomSession, Box<dyn std::error::Error>> {
-    if target.host_did.is_none() {
-        eprintln!(
-            "note: no --host-did given, so this presentation is not bound to a host. \
-             Anyone who observes it can use it against this room until it expires."
-        );
-    }
-
     let minted = client
-        .room_present(target.room_id, action, target.host_did, None)
+        .room_present(target.room_id, action, Some(presenter), None)
         .await?;
     session_from_minted(target.room_id, &minted)
 }
@@ -153,7 +170,7 @@ pub async fn cmd_rooms_list(
     since_version: Option<u64>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read").await?;
+    let session = present(client, &target, "read", signer.did).await?;
     let listing = target
         .client()
         .list_records(
@@ -201,7 +218,7 @@ pub async fn cmd_rooms_get(
     signer: RoomSigner<'_>,
     key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read").await?;
+    let session = present(client, &target, "read", signer.did).await?;
     let record = target
         .client()
         .get_record(&session, key, signer.did, signer.key_multibase)
@@ -274,7 +291,7 @@ pub async fn cmd_rooms_put(
     body: String,
     expected_version: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "write").await?;
+    let session = present(client, &target, "write", signer.did).await?;
     let put = target
         .client()
         .put_record(
@@ -319,7 +336,7 @@ pub async fn cmd_rooms_curate(
     // what a room's shared knowledge is worth is a different act from adding to
     // it. So the presentation is minted for `curate`, and a member who only
     // writes is refused here rather than at the host.
-    let session = present(client, &target, "curate").await?;
+    let session = present(client, &target, "curate", signer.did).await?;
 
     let out = target
         .client()
@@ -358,7 +375,7 @@ pub async fn cmd_rooms_renew(
     epoch: u32,
     reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "admin").await?;
+    let session = present(client, &target, "admin", signer.did).await?;
     let minted = target
         .client()
         .mint_epoch(

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -37,10 +37,9 @@ use vtc_client::rooms::{CleartextContent, RoomSession, Visibility};
 ///
 /// The host DID is optional because an operator may not know it, and it names the
 /// **recipient** of the document — nothing more. It used to be passed as the presentation's
-/// `audience` as well, on the reading that this bound the presentation to one host; it does
-/// not, and could not, because the verifier compares `audience` to the presenter. See
-/// [`present`]. A presentation is bound to whoever will sign the request, always, so there
-/// is no longer an unbound case for an operator to be warned about.
+/// `audience` as well, on the reading that this bound the presentation to one host. It never
+/// could: see [`present`]. A presentation is bound to whoever will sign the request, always,
+/// so there is no unbound case for an operator to be warned about.
 pub struct RoomTarget<'a> {
     pub host_url: &'a str,
     pub host_did: Option<&'a str>,
@@ -57,38 +56,31 @@ impl RoomTarget<'_> {
     }
 }
 
-/// Mint a presentation for one action, bound to the party that will present it.
+/// Mint a presentation for one action.
 ///
-/// # `audience` is the presenter, not the host
+/// # There is no party to name here, and there used to be two
 ///
-/// This passed `target.host_did` until it was found never to work. `audience` is not who
-/// the presentation is addressed to: `dtg_credentials::authority::verify_chain` compares it
-/// to the **presenter** — "the leaf must be presentable by whoever is presenting it" — so
-/// it is holder binding, and its job is to make a captured presentation worthless to
-/// whoever captured it.
+/// This passed `target.host_did` as the presentation's `audience` until that was found
+/// never to work: `audience` named the party that had to *present* the credential, not the
+/// one it was addressed to, so filling it with a host's DID named somebody no presenter can
+/// ever be, and every request was refused. Omitting `--host-did` "worked" only because an
+/// absent audience skipped the check — so the flag's two states were *broken* and
+/// *unprotected*, with nothing in between.
 ///
-/// Filled with the host's DID, it named a party no presenter can ever match, and the host
-/// refused every request as `WrongAudience`. Omitting `--host-did` "worked" only because an
-/// absent audience skips the check, leaving the presentation bearer-shaped for its whole
-/// four-hour life — so the flag's two states were *broken* and *unprotected*.
+/// Neither the field nor this parameter survives. A presentation is granted to the caller
+/// the VTA authenticated and a host refuses a chain granting to anyone else, so who may
+/// present is established rather than declared; and it is bound to a *room* rather than a
+/// host, so there is no destination to name either. `--host-did` keeps its real job:
+/// naming the document's `recipient`.
 ///
-/// `presenter` is [`RoomSigner::did`], which already documents the rule this restores: a
-/// room request is signed by the party the presentation was minted for.
-///
-/// The **published spec disagrees** — `rooms/keys/present/0.1` calls `audience` "the party
-/// the presentation is for … a host's identifier, normally" — and that conflict is real and
-/// filed upstream. This binds to the presenter because that is what the verifier does
-/// today, and a presentation that cannot verify protects nobody while it is being wrong in
-/// the other direction.
+/// See `rooms/keys/present/0.2`, which removed both members, and
+/// trustoverip/dtgwg-trust-tasks-tf#414.
 async fn present(
     client: &VtaClient,
     target: &RoomTarget<'_>,
     action: &str,
-    presenter: &str,
 ) -> Result<RoomSession, Box<dyn std::error::Error>> {
-    let minted = client
-        .room_present(target.room_id, action, Some(presenter), None)
-        .await?;
+    let minted = client.room_present(target.room_id, action).await?;
     session_from_minted(target.room_id, &minted)
 }
 
@@ -170,7 +162,7 @@ pub async fn cmd_rooms_list(
     since_version: Option<u64>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read", signer.did).await?;
+    let session = present(client, &target, "read").await?;
     let listing = target
         .client()
         .list_records(
@@ -218,7 +210,7 @@ pub async fn cmd_rooms_get(
     signer: RoomSigner<'_>,
     key: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "read", signer.did).await?;
+    let session = present(client, &target, "read").await?;
     let record = target
         .client()
         .get_record(&session, key, signer.did, signer.key_multibase)
@@ -291,7 +283,7 @@ pub async fn cmd_rooms_put(
     body: String,
     expected_version: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "write", signer.did).await?;
+    let session = present(client, &target, "write").await?;
     let put = target
         .client()
         .put_record(
@@ -336,7 +328,7 @@ pub async fn cmd_rooms_curate(
     // what a room's shared knowledge is worth is a different act from adding to
     // it. So the presentation is minted for `curate`, and a member who only
     // writes is refused here rather than at the host.
-    let session = present(client, &target, "curate", signer.did).await?;
+    let session = present(client, &target, "curate").await?;
 
     let out = target
         .client()
@@ -375,7 +367,7 @@ pub async fn cmd_rooms_renew(
     epoch: u32,
     reason: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let session = present(client, &target, "admin", signer.did).await?;
+    let session = present(client, &target, "admin").await?;
     let minted = target
         .client()
         .mint_epoch(

--- a/vta-sdk/src/client/rooms.rs
+++ b/vta-sdk/src/client/rooms.rs
@@ -37,37 +37,30 @@ use crate::trust_tasks;
 const ROOM_TT_TIMEOUT: u64 = 30;
 
 impl VtaClient {
-    /// `rooms/keys/present/0.1` — mint a presentation for **one** operation.
+    /// `rooms/keys/present` — mint a presentation for **one** operation.
     ///
     /// `action` is a single room verb (`read`, `write`, `curate`, `admin`);
-    /// there is no "everything" value, deliberately. `audience`, when given,
-    /// binds the minted leaf to that party so a captured presentation is
-    /// worthless elsewhere — pass the host's DID whenever you know it.
+    /// there is no "everything" value, deliberately.
+    ///
+    /// **There is nothing to say about who may present it.** The VTA grants the
+    /// minted leaf to the caller it authenticated, and a host refuses a chain
+    /// whose leaf grants to anyone else — so a presentation minted for this
+    /// client is worthless to anybody who captures it, and a parameter naming a
+    /// different party would only be a way to get that wrong. There is likewise
+    /// nothing to say about the host: the chain is bound to a *room*, which is
+    /// what lets a room have more than one host, and binding the *request* to
+    /// its destination is the `recipient` member of the document that carries
+    /// this, per SPEC.md §4.8.2.
     ///
     /// The reply carries `presentation` (send this to the host) and
     /// `expiresAt`. A request for more than the principal holds fails at the
     /// VTA, in the credential library, rather than producing a presentation the
     /// host will later refuse.
-    pub async fn room_present(
-        &self,
-        room_id: &str,
-        action: &str,
-        audience: Option<&str>,
-        nonce: Option<&str>,
-    ) -> Result<Value, VtaError> {
-        let mut payload = json!({
+    pub async fn room_present(&self, room_id: &str, action: &str) -> Result<Value, VtaError> {
+        let payload = json!({
             "roomId": room_id,
             "action": action,
         });
-        // Omitted rather than sent as null: the published payload types the
-        // members as strings, and a `null` would fail schema validation at the
-        // spine — the defect class #919 and #921 both landed in.
-        if let Some(audience) = audience {
-            payload["audience"] = Value::String(audience.to_string());
-        }
-        if let Some(nonce) = nonce {
-            payload["nonce"] = Value::String(nonce.to_string());
-        }
         self.dispatch_trust_task(
             trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1,
             payload,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -799,7 +799,8 @@ pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memo
 /// `spec/rooms/keys/present/0.1` — an agent asks the VTA holding its
 /// principal's room credentials to mint a presentation for **one** room
 /// operation. The credentials never cross to the agent; only the presentation
-/// does, and it is scoped to the action and audience it was asked for.
+/// does, it is scoped to the action it was asked for, and it is granted to the
+/// caller — so it is worthless to anybody who captures it.
 /// Auth: `roomPresent` capability, plus context access for the principal's key.
 pub const TASK_ROOMS_KEYS_PRESENT_0_1: &str = "https://trusttasks.org/spec/rooms/keys/present/0.1";
 

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -27,10 +27,18 @@
 //! have handed the caller its principal's whole standing in the room, which is precisely the
 //! outcome attenuation exists to prevent.
 //!
-//! **A presentation reusable elsewhere.** Where the caller names an `audience`, the leaf is
-//! bound to it, and `verify_chain` refuses a chain link presented by anyone else. Without an
-//! audience the presentation is bearer-shaped against that room, which is why callers that
-//! know their host should always name it.
+//! **A presentation somebody else can use.** The leaf grants to the DID this VTA
+//! authenticated for the request, and a host refuses a chain whose leaf grants to anyone but
+//! the party that signed what it received. So a presentation minted here is usable by the
+//! caller and by nobody else — and the caller cannot ask for one made out to a third party,
+//! because it never gets to name the subject.
+//!
+//! **A presentation bound to a host.** Deliberately not offered, because it would not mean
+//! anything. The chain is scoped to the *room*; a chain rooted in one room confers nothing
+//! anywhere else, and any host serving that room would honour it — a room may have more than
+//! one host, and moving between them without reissuing credentials is the point. Binding a
+//! *request* to its destination is the job of the `recipient` member on the document that
+//! carries the presentation, which its `proof` covers (SPEC.md §4.8.2).
 //!
 //! **The keys.** Nothing in the response carries key material in either direction. An oracle
 //! that returned the principal's VAC itself would be a credential-release call wearing a
@@ -88,8 +96,6 @@ pub async fn present(
     agent_did: &str,
     room_id: &str,
     action: &str,
-    audience: Option<&str>,
-    nonce: Option<&str>,
 ) -> Result<MintedPresentation, AppError> {
     let scope = auth.act_scope();
 
@@ -114,7 +120,11 @@ pub async fn present(
             vec![action.to_string()],
             now,
             Some(expires),
-            audience.map(str::to_string),
+            // No audience. The leaf is bound to its subject — `agent_did`, the caller this
+            // VTA authenticated — and a verifier requires the presenter to be that subject.
+            // A second field naming who may present could only repeat the subject or
+            // contradict it, which is why dtg-credentials removed it.
+            None,
         )
         .map_err(|e| {
             // The common case is asking for an action the principal does not hold, and
@@ -143,15 +153,16 @@ pub async fn present(
 
     // Leaf first, then the credential the room issued. Every link the host will rely on is
     // present, because the host will not fetch one.
-    let mut presentation = serde_json::json!({
+    // No nonce. A presentation is a bundle of credentials signed by their *issuers*, never
+    // by the party presenting it, so a challenge placed inside it is unauthenticated — an
+    // attacker replaying a captured presentation copies the challenge with everything else.
+    // Freshness belongs to the request: the room task document carrying this is signed by
+    // the presenter and carries `id` and `issuedAt`, which is what SPEC.md §7.2 item 11
+    // keys duplicate-execution protection on.
+    let presentation = serde_json::json!({
         "membership": vmc,
         "authority": [leaf_json, vac],
     });
-    // Echoed rather than interpreted: the verifier chose it, and its value to them is that
-    // it came back unchanged.
-    if let Some(nonce) = nonce {
-        presentation["nonce"] = Value::String(nonce.to_string());
-    }
 
     Ok(MintedPresentation {
         presentation,

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -115,16 +115,15 @@ pub async fn present(
     let now = Utc::now();
     let expires = now + PRESENTATION_LIFETIME;
     let mut leaf = root
+        // No audience parameter: the leaf is bound to its subject — `agent_did`, the caller
+        // this VTA authenticated — and `verify_chain` requires the presenter to BE that
+        // subject. A second field naming who may present could only repeat the subject or
+        // contradict it, which is why dtg-credentials 0.8.0 removed it.
         .attenuate(
             agent_did.to_string(),
             vec![action.to_string()],
             now,
-            Some(expires),
-            // No audience. The leaf is bound to its subject — `agent_did`, the caller this
-            // VTA authenticated — and a verifier requires the presenter to be that subject.
-            // A second field naming who may present could only repeat the subject or
-            // contradict it, which is why dtg-credentials removed it.
-            None,
+            expires,
         )
         .map_err(|e| {
             // The common case is asking for an action the principal does not hold, and

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -472,20 +472,23 @@ pub(super) async fn handle_backfill(
     // `read`, and only `read`. Reading the room and reading the parts of it
     // written earlier are the same act, so they take the same grant; asking for
     // more would hand the host authority the operation never needed.
-    let minted = match crate::operations::room_oracle::present(
-        state,
-        auth,
-        &vta_did,
-        &req.room_id,
-        "read",
-        Some(req.host.as_str()),
-        None,
-    )
-    .await
-    {
-        Ok(m) => m,
-        Err(e) => return app_error_to_reject(&doc, e),
-    };
+    //
+    // The caller-named `host` is NOT bound into the presentation, and used to be
+    // — passed as the leaf's `audience`, which named the party that had to
+    // present the credential rather than the one it was sent to, so every
+    // backfill this VTA attempted was refused. What makes a caller-named host
+    // safe is that the leaf grants to `vta_did`: a host of the caller's
+    // choosing receives something only this agent can act with, so naming one
+    // transfers no standing. What it does gain is sight of the principal's
+    // credentials, which is a disclosure rather than an escalation — see
+    // `rooms/keys/backfill/0.1`.
+    let minted =
+        match crate::operations::room_oracle::present(state, auth, &vta_did, &req.room_id, "read")
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
 
     let mut payload = serde_json::json!({
         "roomId": req.room_id,

--- a/vta-service/src/trust_tasks/room_keys.rs
+++ b/vta-service/src/trust_tasks/room_keys.rs
@@ -6,8 +6,8 @@
 //! Three gates, in order, and the order matters:
 //!
 //! 1. **Capability.** [`Capability::RoomPresent`], registered upstream as `roomPresent`.
-//!    Deliberately not [`Capability::Sign`]: an agent that may ask for a scoped,
-//!    audience-bound presentation is not thereby an agent that may sign *anything at all*
+//!    Deliberately not [`Capability::Sign`]: an agent that may ask for a scoped
+//!    presentation granted to itself is not thereby an agent that may sign *anything at all*
 //!    with its principal's key. Gating an oracle on the generic signing oracle would grant
 //!    strictly more than the task needs, which is the opposite of what an oracle is for.
 //! 2. **Context**, inside `resolve_holder_keys` — the caller must be permitted to act in the
@@ -71,17 +71,7 @@ pub(super) async fn handle_present(
         .and_then(|v| v.as_str().map(str::to_string))
         .unwrap_or_default();
 
-    let minted = match room_oracle::present(
-        state,
-        auth,
-        &auth.did,
-        &req.room_id,
-        &action,
-        req.audience.as_deref(),
-        req.nonce.as_ref().map(|n| n.as_ref()),
-    )
-    .await
-    {
+    let minted = match room_oracle::present(state, auth, &auth.did, &req.room_id, &action).await {
         Ok(m) => m,
         Err(e) => return app_error_to_reject(&doc, e),
     };

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -207,13 +207,35 @@ pub(super) async fn handle_issue_authority(
     // action list rather than reading it as "everything", and the schema refuses it before
     // that — two layers, because "confers nothing" and "confers everything" are exactly the
     // two readings a careless consumer might choose between.
+    // `validUntil` is REQUIRED on an authority credential, and this task mints a chain
+    // ROOT — the grant nothing else can withdraw. Nothing about the subject's standing is
+    // consulted at verification, so a root that never expires is authority the room cannot
+    // take back at all; a verifier refuses a chain link carrying none, so one minted without
+    // it could not have been used anyway.
+    //
+    // `rooms/owner/issue-authority/0.2` makes the member REQUIRED and the generated payload
+    // non-optional, which retires this check. Until this task moves to 0.2 the 0.1 payload
+    // still admits an absent value, so it is refused here rather than defaulted: how long a
+    // room's authority lasts is the owner's judgement about their own room, and picking a
+    // lifetime for them would make that judgement silently.
+    let Some(valid_until) = req.valid_until else {
+        return app_error_to_reject(
+            &doc,
+            vti_common::error::AppError::Validation(
+                "validUntil is required: a chain root that never expires is authority the \
+                 room cannot withdraw, and a verifier refuses a grant carrying no expiry"
+                    .into(),
+            ),
+        );
+    };
+
     let vac = match dtg_credentials::DTGCredential::new_vac(
         req.room_id.clone(),
         req.subject.clone(),
         req.room_id.clone(),
         actions,
         chrono::Utc::now(),
-        req.valid_until,
+        valid_until,
     ) {
         Ok(v) => v,
         Err(e) => {

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -1821,7 +1821,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.successor.did, Some(24)).await,
+                "nomination": f.nominate(&f.successor.did, 24).await,
                 "presentation": f.as_successor(),
                 "reason": "unreachable since March",
             }),
@@ -1847,7 +1847,7 @@ mod tests {
         let f = RoomFixture::new(Visibility::Open).await;
         create_expiring(state, &f, days_ago(60)).await;
 
-        let nomination = f.nominate(&f.successor.did, Some(24)).await;
+        let nomination = f.nominate(&f.successor.did, 24).await;
 
         // The owner returns and mints an epoch — ordinary use, nothing succession-specific.
         let out = handle_mint_epoch(
@@ -1900,7 +1900,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
         )
@@ -1926,7 +1926,7 @@ mod tests {
             &f,
             json!({
                 "roomId": f.room.room_id,
-                "nomination": f.nominate(&f.agent.did, Some(24)).await,
+                "nomination": f.nominate(&f.agent.did, 24).await,
                 "presentation": f.as_successor(),
             }),
         )

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -29,7 +29,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 
 # `authority::verify_chain` and the VAC/VDC types. Was a pinned git rev while
 # 0.6.0 sat merged and unreleased; released 2026-09-03.
-dtg-credentials = "0.6"
+dtg-credentials = "=0.9.1"
 
 async-trait = "0.1"
 # Both hosts already carry a `VerificationMethodResolver`, so the key adapter wraps

--- a/vti-rooms-dtg/src/lib.rs
+++ b/vti-rooms-dtg/src/lib.rs
@@ -287,22 +287,14 @@ impl ChainVerifier for DtgChainVerifier {
         )
         .map_err(|e| chain_refusal(&room.room_id, e))?;
 
-        // `verify_chain` takes `presenter` but uses it for **one** thing: the `audience`
-        // check, where a link that names an audience must be presented by that audience. It
-        // does not require the leaf to grant to the presenter, and that is deliberate on
-        // its side — the leaf's subject is "who may act", and binding that to the party the
-        // *transport* authenticated is a question about this request, not about the chain.
-        //
-        // Which makes it ours, and it is not optional: without it a presentation is a
-        // bearer token, and anyone who observes one inherits everything it confers. A test
-        // above presents an agent's chain as the agent's human and expects a refusal.
-        if verified.subject != presenter {
-            return Err(AppError::Forbidden(format!(
-                "the chain's leaf grants to `{}`, not to the party that signed this \
-                 request; a presentation is bound to its presenter, not bearer",
-                verified.subject
-            )));
-        }
+        // The presenter check that used to live here is now `verify_chain`'s own: since
+        // dtg-credentials 0.8.0 it requires the leaf to grant to `presenter` and refuses
+        // with `NotThePresenter` otherwise. It was written here first, and independently in
+        // `nomination.rs`, because the library took a `presenter` and used it only for the
+        // `audience` comparison — so a leaf carrying no audience was accepted from anybody.
+        // Two copies of a rule is one place for it to be forgotten; it moved to the one
+        // place every verifier reaches. A test below presents an agent's chain as the
+        // agent's human and still expects a refusal, which is what pins it.
 
         // The pooling defence: membership and authority must describe one subject.
         match room.visibility {
@@ -422,7 +414,7 @@ mod tests {
             scope.into(),
             actions.iter().map(|s| s.to_string()).collect(),
             chrono::Utc::now() - chrono::Duration::hours(1),
-            Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+            chrono::Utc::now() + chrono::Duration::hours(1),
         )
         .expect("build a VAC");
 
@@ -608,7 +600,7 @@ mod signed {
             room_did.clone(),
             vec!["read".into(), "write".into()],
             now - Duration::minutes(1),
-            Some(now + Duration::days(30)),
+            now + Duration::days(30),
         )
         .expect("owner VAC")
         .with_id("urn:uuid:vac-owner");
@@ -621,8 +613,7 @@ mod signed {
                 agent_did.clone(),
                 vec!["read".into()],
                 now - Duration::minutes(1),
-                Some(now + Duration::hours(4)),
-                None,
+                now + Duration::hours(4),
             )
             .expect("attenuate")
             .with_id("urn:uuid:vac-agent");
@@ -946,7 +937,7 @@ pub mod test_support {
                     "admin".into(),
                 ],
                 now - Duration::minutes(1),
-                Some(now + Duration::days(30)),
+                now + Duration::days(30),
             )
             .expect("owner VAC")
             .with_id("urn:uuid:vac-owner");
@@ -962,8 +953,7 @@ pub mod test_support {
                     agent.did.clone(),
                     vec!["read".into()],
                     now - Duration::minutes(1),
-                    Some(now + Duration::hours(4)),
-                    None,
+                    now + Duration::hours(4),
                 )
                 .expect("attenuate to the agent")
                 .with_id("urn:uuid:vac-agent");
@@ -989,7 +979,7 @@ pub mod test_support {
                 room_key.did.clone(),
                 vec!["read".into()],
                 now - Duration::minutes(1),
-                Some(now + Duration::days(30)),
+                now + Duration::days(30),
             )
             .expect("successor VAC")
             .with_id("urn:uuid:vac-successor");
@@ -1070,7 +1060,7 @@ pub mod test_support {
         /// Signed by the **room**, because that is the only issuer a nomination can have —
         /// an owner nominating in their own name would be a chain rooted at a person, and
         /// the whole point is that it is rooted at the room they are stepping away from.
-        pub async fn nominate(&self, successor: &str, valid_until: Option<i64>) -> String {
+        pub async fn nominate(&self, successor: &str, valid_until: i64) -> String {
             let now = Utc::now();
             let mut vac = DTGCredential::new_vac(
                 self.room_key.did.clone(),
@@ -1078,7 +1068,7 @@ pub mod test_support {
                 self.room_key.did.clone(),
                 vec![crate::ACTION_SUCCEED.into()],
                 now - Duration::minutes(1),
-                valid_until.map(|h| now + Duration::hours(h)),
+                now + Duration::hours(valid_until),
             )
             .expect("nomination VAC")
             .with_id("urn:uuid:vac-nomination");

--- a/vti-rooms-dtg/src/nomination.rs
+++ b/vti-rooms-dtg/src/nomination.rs
@@ -73,16 +73,12 @@ pub async fn verify(
     )
     .map_err(|e| chain_refusal(room_id, e))?;
 
-    // `verify_chain` uses `claimant` only for the audience check; it does not require the
-    // grant to name them. Without this a nomination would be a bearer token, and anyone who
-    // ever observed one could take the room the moment it went dormant.
-    if verified.subject != claimant {
-        return Err(AppError::Forbidden(format!(
-            "the nomination names `{}`, not the party claiming; a nomination is not \
-             transferable",
-            verified.subject
-        )));
-    }
+    // That a nomination is not transferable is `verify_chain`'s rule now, not this
+    // function's: since dtg-credentials 0.8.0 it requires the leaf to grant to `claimant`.
+    // Before that it used the argument only for the `audience` comparison, so a nomination
+    // carrying none was a bearer token and anyone who had ever seen one could take the room
+    // the moment it went dormant. The test below still claims with the wrong party and
+    // expects a refusal.
 
     Ok(VerifiedNomination {
         successor: verified.subject,
@@ -121,7 +117,7 @@ mod tests {
         subject: &str,
         scope: &str,
         actions: Vec<String>,
-        valid_until: Option<chrono::DateTime<Utc>>,
+        valid_until: chrono::DateTime<Utc>,
     ) -> String {
         let now = Utc::now();
         let mut vac = DTGCredential::new_vac(
@@ -145,7 +141,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await
     }
@@ -182,7 +178,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 
@@ -220,7 +216,7 @@ mod tests {
             &f.successor_did,
             &other_room,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 
@@ -240,7 +236,7 @@ mod tests {
             &f.successor_did,
             &f.room_did,
             vec![ACTION_SUCCEED.into()],
-            Some(Utc::now() - Duration::days(1)),
+            Utc::now() - Duration::days(1),
         )
         .await;
 
@@ -266,7 +262,7 @@ mod tests {
                 "curate".into(),
                 "admin".into(),
             ],
-            Some(Utc::now() + Duration::days(365)),
+            Utc::now() + Duration::days(365),
         )
         .await;
 


### PR DESCRIPTION
> **Stacked on #1356.** Base is `fix/presentation-audience-binds-presenter`; merge that first
> and this retargets to `main` on its own.

This workspace was three releases behind, and the one that matters is **0.8.0: a VAC is not
a bearer credential.** `verify_chain` now requires the leaf to grant to the presenter.

We were safe without it only because `vti-rooms-dtg` wrote that check by hand — **twice**,
in `lib.rs` and `nomination.rs`, having hit the gap independently each time. Both copies had
the same comment explaining why they had to exist:

> `verify_chain` takes `presenter` but uses it for **one** thing: the `audience` check… It
> does not require the leaf to grant to the presenter… Which makes it ours, and it is not
> optional: without it a presentation is a bearer token.

That is no longer true, and a stale rationale on a security check is worse than no comment.
Both are removed; the rule lives in `verify_chain`, which refuses with `NotThePresenter`, and
0.9.1 extends it to the VDC via `delegation::verify_chain`.

**The tests that pinned the behaviour are unchanged** — an agent's chain presented by the
agent's human, a nomination claimed by the wrong party — and still expect a refusal. That is
what shows the rule survived the move rather than being quietly dropped.

## Pinned `=0.9.1`, deliberately

0.9.1 is **API-breaking under a patch version** — its own changelog says so, and the version
was chosen knowingly because 0.9.0 had published hours earlier with no consumers. A caret
`"0.9"` would let a routine `cargo update` take that break without anyone deciding to. The
exact pin makes upgrading an act rather than an accident.

## `validUntil`, and why the handler refuses instead of defaulting

`new_vac`'s `valid_until` stopped being an `Option` in 0.7.0, when WD02 made `validUntil`
REQUIRED on a VAC. `rooms/owner/issue-authority` passes `req.valid_until` straight through
and the `0.1` payload types it optional — so this workspace could ask for a **chain root
that never expires**, which no verifier would have accepted.

trustoverip/dtgwg-trust-tasks-tf#418 makes the member REQUIRED in `0.2`, and its generated
payload non-optional, which retires the question entirely. Until this task moves to `0.2`
the check lives in the handler — and it **refuses** rather than substituting a default. How
long a room's authority lasts is the owner's judgement about their own room; a recipient
that picked a lifetime would be making that judgement silently, in the one place the owner
cannot see it.

## Blocked upstream: the 0.2 cut-over is not in this PR

Moving to `rooms/keys/present/0.2` and `rooms/owner/issue-authority/0.2` needs
`trust-tasks-rs 0.19`, and that is blocked by a dependency of ours, not by us:

```
affinidi-messaging-sdk 0.22.0  ->  trust-tasks-rs 0.18.9
```

Pinning this workspace at 0.19 therefore puts **two** versions of `trust-tasks-rs` in the
graph, and `MediatorAcl` — which crosses the `vta-sdk` / `affinidi-messaging-sdk` boundary —
becomes two distinct types. The compiler names it directly: *"there are multiple different
versions of crate `trust_tasks_rs` in the dependency graph"*. Bumping the four sibling
`trust-tasks-*` pins together does not help; the duplicate arrives through messaging-sdk.

This is the public-dependency hazard in its usual shape: nothing in our own manifests is
wrong, and no semver check would have flagged it. The cut-over follows once messaging-sdk
re-pins to 0.19 — worth raising there.

## Verified

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all` — clean
- `cargo test -p vti-rooms-dtg -p vti-rooms -p vta-sdk -p vta-cli-common` — 840 passed, 0 failed

Lockfile moves only `dtg-credentials` (and `sha2` beneath it); nothing else resolves
differently.