### PR TITLE
fix(ci): the Nitro image copies every workspace member

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,6 +601,12 @@ jobs:
       - uses: actions/checkout@v7
       - name: Lockfile self-pin guard
         run: bash scripts/check-lockfile-self-pins.sh
+      # Same shape of invariant, same reason to check it early: a whole-tree property
+      # whose only other alarm is at the end of a multi-minute image build, worded as a
+      # version-resolution error about a placeholder version that exists nowhere in the
+      # tree. See the script header.
+      - name: Nitro image copies every workspace member
+        run: python3 scripts/check-nitro-copies-every-member.py
 
   authz-context-types:
     # An approver's device chooses which approval card to render by

--- a/Dockerfile.nitro
+++ b/Dockerfile.nitro
@@ -152,6 +152,7 @@ COPY vtc-service/ vtc-service/
 COPY vti-common/ vti-common/
 COPY vti-rooms/ vti-rooms/
 COPY vti-rooms-dtg/ vti-rooms-dtg/
+COPY vti-rooms-wasm/ vti-rooms-wasm/
 COPY vti-secrets/ vti-secrets/
 COPY vti-webauthn/ vti-webauthn/
 

--- a/scripts/check-nitro-copies-every-member.py
+++ b/scripts/check-nitro-copies-every-member.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Every workspace member must be COPYed into the Nitro enclave image.
+
+`Dockerfile.nitro` lists members one by one rather than using `COPY . .`, so that a
+`deploy/nitro/config.toml` edit does not invalidate the Rust build cache. The cost of that
+choice is a list that has to be maintained, and the Dockerfile says what happens when it is
+not:
+
+    A member missing from this list keeps cargo-chef's skeleton stub instead of its real
+    source, which fails the build below rather than silently producing a broken binary.
+
+That failure is the right one, but it arrives at the end of a multi-minute image build and
+reads as a version-resolution error about a crate nobody touched:
+
+    error: failed to select a version for the requirement `vti-rooms = "^0.0.1"`
+    required by package `vti-rooms-wasm v0.0.1`
+
+`0.0.1` is cargo-chef's placeholder, not anything in the tree — which is why the message
+sends you looking at the wrong file. This says the same thing in a second, naming the member
+and the line to add.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent
+workspace = (root / "Cargo.toml").read_text()
+dockerfile = (root / "Dockerfile.nitro").read_text()
+
+block = re.search(r"(?s)members\s*=\s*\[(.*?)\]", workspace)
+if not block:
+    sys.exit("could not find `members` in the workspace Cargo.toml")
+
+members = re.findall(r'"([^"]+)"', block.group(1))
+
+missing = []
+for member in members:
+    # `deploy/` is deliberately excluded — its config is baked in a later stage. A nested
+    # member is covered by a COPY of any ancestor directory, which is how `tests/e2e` rides
+    # in on `COPY tests/ tests/`.
+    if member == "deploy":
+        continue
+    parts = member.split("/")
+    covered = any(
+        f"COPY {'/'.join(parts[: i + 1])}/ {'/'.join(parts[: i + 1])}/" in dockerfile
+        for i in range(len(parts))
+    )
+    if not covered:
+        missing.append(member)
+
+if missing:
+    print("Dockerfile.nitro does not copy every workspace member.\n")
+    for member in missing:
+        print(f"  missing: {member}")
+    print("\nAdd, in the COPY block:\n")
+    for member in missing:
+        print(f"  COPY {member}/ {member}/")
+    print(
+        "\nWithout it cargo-chef's skeleton stub is used instead of the real source, and the\n"
+        "image build fails with a version-resolution error naming a placeholder `0.0.1`."
+    )
+    sys.exit(1)
+
+print(f"Dockerfile.nitro copies all {len(members)} workspace members")


### PR DESCRIPTION
**`main` cannot build the enclave image.** #1347 added `vti-rooms-wasm` to the workspace
without adding it to `Dockerfile.nitro`'s COPY block. Mine, and it slipped through because
the Docker job does not run on every PR.

## The Dockerfile predicted this exactly

> A member missing from this list keeps cargo-chef's skeleton stub instead of its real
> source, which fails the build below rather than silently producing a broken binary.

Failing is right — that block lists members one by one so a `deploy/nitro/config.toml` edit
does not invalidate the Rust build cache, and the cost of that choice is a list somebody has
to maintain.

**Where and how it fails is the problem:**

```
error: failed to select a version for the requirement `vti-rooms = "^0.0.1"`
candidate versions found which didn't match: 0.1.3
required by package `vti-rooms-wasm v0.0.1 (/build/vti-rooms-wasm)`
```

`0.0.1` is cargo-chef's placeholder. It exists nowhere in the tree — `vti-rooms-wasm` is
`0.1.0` and depends on `vti-rooms = "0.1"`, both correct. So the message sends you to a
manifest that is already right, at the end of a multi-minute image build.

## Two changes

1. The missing `COPY vti-rooms-wasm/ vti-rooms-wasm/`.
2. A guard that says the same thing in a second and names the line to add.

The guard hangs off the `lockfile self-pins` job, which is the same shape of check — a
whole-tree invariant rather than a diff against a base ref, cheap, and deliberately **not**
PR-only. That last part matters here: a merge is exactly how this got in.

It also handles nested members properly, so `tests/e2e` is correctly seen as covered by
`COPY tests/ tests/` rather than reported missing.

## Verified

- `python3 scripts/check-nitro-copies-every-member.py` — passes, all 31 members.
- Removing the new COPY line reproduces the failure, naming `vti-rooms-wasm` and printing
  the line to add. A guard that has not been seen to fire is a guard nobody knows works.