### PR TITLE
docs(rooms): the owner's half is a VTA task now

### DIFF
--- a/docs/02-vta/data-rooms-guide.html
+++ b/docs/02-vta/data-rooms-guide.html
@@ -190,8 +190,9 @@
             shared code so a VTC and a room host cannot disagree about what is safe</td></tr>
         <tr><td class="hd">MLS group layer, record sealing</td>
             <td>Work — create, add, remove, commit, exporter-derived storage keys</td></tr>
-        <tr><td class="hd">Member-side custody<br><span class="mono">rooms/keys/{key-package,welcome,commit,open}</span></td>
-            <td>Work. A member's VTA holds the group and opens records for their agents</td></tr>
+        <tr><td class="hd">Member-side custody<br><span class="mono">rooms/keys/{key-package,welcome,commit,open,seal,chain,backfill,list}</span></td>
+            <td>Work. A member's VTA holds the group, seals and opens records for their agents, and
+            can fetch a room's epoch chain from the host itself</td></tr>
         <tr><td class="hd">Presentation oracle<br><span class="mono">rooms/keys/present</span></td>
             <td>Works. Attenuates the member's own authority for an agent — one action, bound
             audience, four hours</td></tr>
@@ -200,12 +201,25 @@
         <tr><td class="hd">A CLI</td>
             <td><span class="yes">The member's half.</span>
             <code>pnm rooms {create,list,get,put,curate,renew}</code>, driven through the oracle
-            so the CLI never holds a room credential or a group key. Issuing a room's
-            credentials is the owner's job and needs the room's own signing key — not there
-            yet</td></tr>
+            so the CLI never holds a room credential or a group key. It carries no owner verbs,
+            and <code>put</code> still refuses a sealed room even though
+            <span class="mono">rooms/keys/seal</span> now seals one</td></tr>
         <tr><td class="hd">Credential issuance</td>
-            <td><span class="no">Library only.</span> Nothing serves “issue this member a VMC and a
-            VAC” — the owner mints them with <code>dtg-credentials</code> and delivers them out of band</td></tr>
+            <td><span class="yes">On the owner's own VTA.</span>
+            <span class="mono">rooms/owner/{invite,issue-membership,issue-authority}</span> mint the
+            invitation, membership and authority credentials in the <em>room's</em> name, signing
+            through the same gated oracle <span class="mono">keys/sign</span> uses — so the room's
+            key never materialises. No <code>pnm</code> verbs yet: a wallet drives them</td></tr>
+        <tr><td class="hd">The owner's MLS half</td>
+            <td><span class="no">Library only.</span> Forming the group and turning a joiner's
+            KeyPackage into a Welcome and a Commit has no trust task and no CLI, so admitting
+            someone to a <span class="mono">sealed</span> room is still Rust — every member-side
+            step is a task</td></tr>
+        <tr><td class="hd">A browser as a member</td>
+            <td><span class="yes">Built.</span> <code>vti-rooms-wasm</code> compiles the member
+            half — group custody, sealing, opening, the epoch chain — to WebAssembly, and
+            <code>room-host --allow-origin</code> is what lets a page reach a host at all. No key
+            crosses into JavaScript</td></tr>
         <tr><td class="hd">Governance (<code>rooms.rego</code>)</td>
             <td><span class="yes">On a VTC.</span> A community decides in Rego who may create a
             room on it; the shipped default hosts <span class="mono">open</span> /
@@ -392,9 +406,13 @@
         room's controller must be able to change — transferring ownership is a controller change,
         and <code>did:peer</code> encodes its keys in the identifier. Witness the log for any room
         whose host you do not fully trust.</p>
-        <p class="code">pnm bootstrap provision-request --template room \
-  --var WEBVH_SERVER=https://dids.example.org \
-  --var MEDIATOR_DID=did:web:mediator.example.org --out room-request.json</p>
+        <p class="code">pnm did-mgmt dids create --context personal --template room \
+  --server &lt;webvh-server-id&gt; --var WEBVH_SERVER=https://dids.example.org \
+  --var MEDIATOR_DID=did:web:mediator.example.org</p>
+        <p>Keep both halves of what that prints — the DID <em>and</em> the signing key id. Every
+        owner verb names the key rather than looking it up, because nothing maps a room's DID to
+        the key it was minted with, so a DID without its key id is a room that cannot invite
+        anyone.</p>
       </li>
       <li>
         <h3>Register it with a host</h3>
@@ -409,8 +427,13 @@
         <h3>Issue yourself membership and authority</h3>
         <p>A membership credential (you are in this room) and an authority credential (what you may
         do: <code>read</code>, <code>write</code>, <code>curate</code>, <code>admin</code>), both
-        signed by the room's key. Store them in your VTA's credential vault — the oracle finds them
-        by issuer, so a credential filed anywhere else is one it cannot use.</p>
+        signed by the room's key — two calls to the VTA that holds it,
+        <span class="mono">rooms/owner/issue-membership</span> and
+        <span class="mono">rooms/owner/issue-authority</span>. An authority credential must name
+        its expiry: nothing about a subject's standing is checked when a chain is verified, so a
+        grant that never expires is a grant nobody can withdraw by waiting. Store both in your
+        VTA's credential vault — the oracle finds them by issuer, so a credential filed anywhere
+        else is one it cannot use.</p>
       </li>
       <li>
         <h3>On a sealed tier, form the MLS group</h3>

--- a/docs/02-vta/data-rooms.md
+++ b/docs/02-vta/data-rooms.md
@@ -80,11 +80,13 @@ knowing which half you are standing on saves an afternoon.
 | `open` and `attributed` rooms | **Serve.** Create, records, curate, epoch mint, transfer, claim |
 | `private` rooms | **Store but refuse to serve.** The same-subject binding needs a ZK profile the DTG working group has not settled; `vti-rooms-dtg` refuses rather than guessing, so a VTC and a room host cannot disagree about it |
 | MLS group layer, record sealing | **Work** (`vti-rooms` `mls` feature) — create, add/remove, commit, exporter-derived storage keys |
-| VTA custody: `rooms/keys/{key-package,welcome,commit,open}` | **Work.** A member's VTA holds the group and opens records for their agents |
+| VTA custody: `rooms/keys/{key-package,welcome,commit,open,seal,chain,backfill,list}` | **Work.** A member's VTA holds the group, seals and opens records for their agents, and can fetch a room's epoch chain from the host itself |
 | The presentation oracle: `rooms/keys/present` | **Works.** Attenuates the member's own VAC for an agent |
 | Succession: nomination, transfer, claim | **Work**, including the "renewing defeats a pending claim" property |
-| **A CLI** | **`pnm rooms {create,list,get,put,curate,renew}`** — the member's surface, driven through the oracle so the CLI holds no room credentials and no group key. The **owner's** surface (issuing VIC/VMC/VAC) is not there: it needs the room's own signing key |
-| **Credential issuance** | **Library only.** Nothing serves "issue this member a VMC and a VAC"; the room's owner mints them with `dtg-credentials` and delivers them out of band |
+| **A CLI** | **`pnm rooms {create,list,get,put,curate,renew}`** — the member's surface, driven through the oracle so the CLI holds no room credentials and no group key. It carries **no owner verbs**, and `put` still refuses a sealed room even though `rooms/keys/seal/0.1` now seals one |
+| **Credential issuance** | **Works, on the owner's own VTA.** `rooms/owner/{invite,issue-membership,issue-authority}` mint the VIC, VMC and VAC in the *room's* name, signing through the gated key oracle so the room's key never materialises (§5.3). No `pnm` verbs and no `VtaClient` helpers yet: the operator surface is a wallet, or a Trust Task document you build yourself |
+| **The owner's MLS half** | **Library only.** `RoomGroup::{create,add_member}` — forming the group, and turning a joiner's KeyPackage into a Welcome + Commit — has no trust task and no CLI. Every *member*-side step is a task, so admitting someone to a **sealed** room is the one part of §6 that is still Rust |
+| **A browser as a member** | **Works.** `vti-rooms-wasm` compiles the member half — group custody, sealing, opening, the epoch chain — to WebAssembly; `room-host --allow-origin` is what lets a page reach a host at all. No key ever crosses into JavaScript |
 | **Governance (`rooms.rego`)** | **On a VTC.** A community decides who may create a room on it, in Rego, with the shipped default hosting `open`/`attributed` for its own members. A standalone `room-host` has no policy engine — T1's governance is its owner (§8.4) |
 | **Read mirrors** (T3) | **`room-host --mirror-config`** — a host serves a read-only copy fed by `sinceVersion` pulls and refuses every write, naming the primary. A mirror pulls **as a member**, presenting a room-issued `read` chain |
 | **Reading across a membership change** | **Works, including for a member who has just joined.** Records are sealed per epoch, and the *epoch key chain* carries a member back across every advance. The owner hands each rung to the host on `rooms/epoch/mint`; a joiner fetches the chain with `rooms/epoch/chain` and reads everything the room retains. Rungs are ciphertext — the key that opens one is a storage key no host holds |
@@ -155,23 +157,29 @@ Four steps. Steps 1 and 3 are the owner's own work; only step 2 touches a host.
 The room's DID is its identifier and its credential issuer, so it must be
 minted before anything else exists.
 
-**Production shape — `did:webvh` via the `room` DID template:**
+**Production shape — `did:webvh` via the `room` DID template, minted in a VTA:**
 
 ```bash
-pnm bootstrap provision-request \
+pnm did-mgmt dids create \
+  --context personal \
   --template room \
+  --server <webvh-server-id> \
   --var WEBVH_SERVER=https://dids.example.org \
   --var MEDIATOR_DID=did:web:mediator.example.org \
-  --var 'LABEL=Northwind deal room' \
-  --out room-request.json
-
-pnm bootstrap provision-integration \
-  --request room-request.json \
-  --context personal \
-  --out room-bundle.asc
-
-pnm bootstrap open --bundle room-bundle.asc --expect-digest <sha256-from-producer>
+  --var 'LABEL=Northwind deal room'
 ```
+
+**Keep both halves of what that prints — `DID:` and `Signing key:`.** Every
+`rooms/owner/*` call names the key rather than looking it up, because nothing
+maps a room's DID to the key it was minted with and a mapping invented for
+convenience is one that goes stale at the first rotation. A DID without its key
+id is a room that cannot invite anyone; `pnm keys list --context <id>` is the way
+back if you lose it.
+
+The template puts the signing key at `{DID}#key-1` and names it in
+`assertionMethod`, which is what the VTA's room signer assumes. A room whose
+document says otherwise still mints credentials — they simply verify nowhere, at
+first use, loudly.
 
 `did:webvh` rather than `did:peer` on purpose: a `did:peer` encodes its keys in
 the identifier, so its controller can never change — and transferring a room is
@@ -179,12 +187,11 @@ a controller change. Set `WITNESSES` for any room whose host you do not fully
 trust; witnessing is what makes a host serving a stale log *evident* rather than
 merely possible.
 
-> **Gap to know about:** no installer consumes a `room` bundle yet. `pnm
-> bootstrap open` prints the payload summary; extracting the room's signing key
-> to issue credentials with means opening the sealed payload yourself via
-> `vta_sdk::sealed_transfer`. Until that lands, most non-production rooms use a
-> locally-minted `did:key` (below), which also means the host needs no network
-> DID resolution at all.
+`pnm bootstrap provision-request --template room` renders the same template and
+is the shape to reach for when the room's keys must reach *another* party — it
+seals them to a holder DID. It is not the shape for a room you run yourself: no
+installer consumes a `room` bundle, and you do not need one, because the VTA that
+minted the key can sign as the room without the key ever materialising (§5.3).
 
 **Evaluation shape — a local `did:key`:** mint an Ed25519 key, form
 `did:key:z6Mk…`, and use that as both the room's identifier and its issuing key.
@@ -231,25 +238,54 @@ is not the `ownerDid` they name is refused (§8.4).
 ### 5.3 Issue the owner's own credentials
 
 The room is now registered and **nobody can do anything in it**, including you.
-Authority comes from credentials the room issued, so mint two with the room's
-key:
+Authority comes from credentials the room issued, so mint two in the room's name:
 
 - a **VMC** — the room's statement that this DID is a member;
 - a **VAC** granting `read`, `write`, `curate`, `admin`.
 
-```rust
-use dtg_credentials::DTGCredential;
+**The VTA holding the room's key mints both**, over two Trust Tasks — the same
+two an owner uses for every later member (§6):
 
-let mut vac = DTGCredential::new_vac(
-    room_did.to_string(),      // issuer: the room
-    owner_did.to_string(),     // subject: the member
-    room_did.to_string(),      // scope: the room governs itself
-    vec!["read".into(), "write".into(), "curate".into(), "admin".into()],
-    now - Duration::minutes(1),
-    Some(now + Duration::days(30)),
-)?;
-vac.sign(&room_secret, None).await?;
+```jsonc
+// rooms/owner/issue-membership/0.1
+{ "roomId": "did:webvh:…", "signingKeyId": "<from §5.1>",
+  "subject": "did:key:zOwner", "validUntil": "2027-01-01T00:00:00Z" }
+
+// rooms/owner/issue-authority/0.1
+{ "roomId": "did:webvh:…", "signingKeyId": "<from §5.1>",
+  "subject": "did:key:zOwner",
+  "actions": ["read", "write", "curate", "admin"],
+  "validUntil": "2026-10-09T00:00:00Z" }
 ```
+
+Each returns `{ credential, credentialId }` — the signed credential, and the id
+bound into its proof, which is what tells a re-send from a renewal.
+
+Three things about that pair are load-bearing:
+
+- **The key never materialises.** `operations::room_issuance` signs through
+  `operations::keys::sign_payload`, the same gated oracle `keys/sign` uses, so
+  the room's secret is loaded, used and zeroized without any caller seeing it.
+- **`validUntil` is required on a VAC, and refused rather than defaulted.** A
+  chain root is authority that nothing withdraws by waiting — nothing about a
+  subject's standing is consulted when a chain is verified, and this stack has no
+  revocation — so expiry is the whole of how a grant ends. Defaulting it would
+  put a room's most consequential number somewhere its owner never looks.
+- **What authorizes the call is the `credentialWrite` capability plus control of
+  the key**, never a check that you are the owner. "Owner" is a fact about the
+  room's DID controller and a VTA is not a DID resolver; where key and controller
+  have come apart, the credential simply fails to verify. Grant it the way §7
+  grants the room capabilities — `pnm acl create --did <did> … --capabilities
+  credential-write` — and note what it opens: a DID holding it can admit and
+  promote in any room whose signing key it can name. What narrows that is the
+  key oracle's own gates — the key's context, the entry's key scope, and the
+  context policy's signing limit — not the capability.
+
+No `pnm` verb reaches these yet and `VtaClient` has no helper — a wallet drives
+them, or you build the Trust Task document yourself with
+`vta_sdk::trust_task_sign::build_signed`. The library path
+(`DTGCredential::new_vmc` / `new_vac`, signed with a key you hold) still works
+and is what `RoomFixture` and the `data_room` example do.
 
 Then store both in the member's VTA credential vault:
 
@@ -319,15 +355,20 @@ sequenceDiagram
 
 Step by step:
 
-1. **The owner issues a VIC** naming the joiner, from the room's key, and
-   delivers it — DIDComm on a sealed room, because a server-side invitation
-   store would hand the host the membership at invite time.
+1. **The owner issues a VIC** naming the joiner, from the room's key
+   (`rooms/owner/invite/0.1` — `roomId`, `signingKeyId`, `subject`,
+   `validUntil`), and delivers it — DIDComm on a sealed room, because a
+   server-side invitation store would hand the host the membership at invite
+   time.
 2. **The joiner's VTA mints a KeyPackage** (`rooms/keys/key-package/0.1`,
    invitation required). Minting retains a private key against a Welcome that
    may never come, which is why it is not offered unconditionally; unused
    packages expire after 7 days.
 3. **The owner adds the leaf** — `RoomGroup::add_member(key_package)` produces a
-   Welcome and a Commit — and sends the Welcome to the joiner.
+   Welcome and a Commit — and sends the Welcome to the joiner. **This step is
+   library-only**: no trust task, no CLI. On a sealed room the owner's half of a
+   join is Rust against `vti-rooms`, even though every step the joiner performs
+   is a task.
 4. **The joiner's VTA processes it** (`rooms/keys/welcome/0.1`, same invitation).
    The invitation is consumed **after** the join succeeds, so a Welcome that
    failed to process does not strand the member with a spent invitation and no
@@ -591,10 +632,13 @@ ciphertext back to the VTA to open. A member who holds less than the action
 needs is refused by their own VTA rather than by the host, which is the earlier
 and clearer of the two.
 
-Two things it deliberately cannot do. **Write to a sealed room**: sealing needs
-the room's group key, which lives in the VTA, and no task seals on a caller's
-behalf. **Issue credentials**: minting a VIC, VMC or VAC needs the *room's*
-signing key, which is the owner's — a different party with different custody.
+Two things it cannot do. **Write to a sealed room** — sealing needs the room's
+group key, which lives in the VTA. That is now a gap in the CLI rather than in
+the model: `rooms/keys/seal/0.1` seals a body under the current epoch for a
+caller holding `roomOpen`, so a client that calls it can write to a sealed room.
+`pnm rooms put` does not yet, and its refusal still says no such task exists.
+**Issue credentials** — the owner's verbs (§5.3) are served by a VTA but reached
+from a wallet; the CLI has no `rooms owner …` surface.
 
 ### From Rust
 
@@ -785,6 +829,7 @@ recover but a fresh invitation from every owner.
 | `this VTA holds no AuthorityCredential issued by room …` | The member's VMC/VAC are not in the credential vault (§5.3) |
 | `this VTA holds N AuthorityCredentials issued by room …` | Two credentials of one kind for one room; the oracle will not guess which to attenuate |
 | record "does not open", VTA reports an older epoch | A missed commit (§6). Deliver it |
+| `an authority credential must name \`validUntil\`` | `rooms/owner/issue-authority` with no expiry. There is no default and no revocation — pick a window (§5.3) |
 | `no invitation presented for room …` | `key-package`/`welcome` without the VIC, or the VIC names someone else |
 | `invitation … has already been used` | Single use. Issue a fresh one |
 | a room "is live" / "not claimable" | The owner renewed. The claim is correctly dead |
@@ -807,6 +852,7 @@ and `vtc-service`:
 | `rooms/records/list/0.1` | `read` |
 | `rooms/records/curate/0.1` | `curate` |
 | `rooms/epoch/mint/0.1` | `admin` |
+| `rooms/epoch/chain/0.1` | `read` — reading the room and reading what was written before you joined are the same act |
 | `rooms/owner/transfer/0.1` | `admin` |
 | `rooms/owner/claim/0.1` | nomination + membership + dormancy |
 
@@ -819,7 +865,24 @@ and `vtc-service`:
 | `rooms/keys/welcome/0.1` | that invitation, consumed |
 | `rooms/keys/commit/0.1` | the MLS group itself |
 | `rooms/keys/open/0.1` | `roomOpen` capability |
+| `rooms/keys/seal/0.1` | `roomOpen` capability |
+| `rooms/keys/list/0.1` | `roomOpen` capability |
+| `rooms/keys/chain/0.1` | `roomOpen` capability |
+| `rooms/keys/backfill/0.1` | `roomOpen` capability |
 | `rooms/keys/present/0.1` | `roomPresent` capability + context access |
+
+**Owner tasks** (`https://trusttasks.org/spec/rooms/owner/…`), served by
+`vta-service` — the room's own key, used without it leaving the VTA. The family
+name is shared with `rooms/owner/{transfer,claim}` above and the server is not:
+those two change a row on a **host**, these four mint credentials on the VTA that
+holds the room's key:
+
+| URI | What it mints | Authorized by |
+|---|---|---|
+| `rooms/owner/invite/0.1` | a VIC — single-use consent to join | `credentialWrite` + control of the room's key |
+| `rooms/owner/issue-membership/0.1` | a VMC — the room's statement that a DID is a member | same |
+| `rooms/owner/issue-authority/0.1` | a VAC chain root; `validUntil` required | same |
+| `rooms/owner/register/0.1` | nothing — asks this VTA to call `rooms/create` on a host, signing **as the agent**, not as the room | same, plus a VTA DID and a resolver |
 
 **Constants**
 


### PR DESCRIPTION
The data-rooms guide and its HTML companion predated #1329 and #1332, so they still told an owner that issuing a room's credentials was library work — "nothing serves *issue this member a VMC and a VAC*". A VTA serves it now, and a guide pointing at `dtg-credentials` and a hand-held signing key was sending people the long way round.

Docs only. No code, no version, no changelog fragment.

### What changed

- **§2 state table.** "Credential issuance: library only" → the `rooms/owner/{invite,issue-membership,issue-authority}` tasks, keeping the qualifier that matters: no `pnm` verbs and no `VtaClient` helper, so the operator surface is a wallet or a Trust Task document you build yourself. Two rows added — **the owner's MLS half**, which really is library-only, and **a browser as a member** (`vti-rooms-wasm`, `room-host --allow-origin`). The custody row gains `seal`, `chain`, `backfill`, `list`.
- **§5.1.** Mint the room with `pnm did-mgmt dids create --template room`, which keeps the key in the VTA and prints the `Signing key:` id every owner verb has to name. `provision-request --template room` stays documented as what it is for: getting a room's keys to *another* party. The old "open the sealed payload yourself" note is gone.
- **§5.3.** Rewritten around the two tasks, with payload shapes taken from the published schemas (`roomId`, `signingKeyId`, `subject`, `validUntil`, `actions`) and the `{credential, credentialId}` response. Says why the key never materialises, why `validUntil` is refused rather than defaulted, and that `credential-write` plus control of the key — never an ownership check — is what authorizes the call.
- **§6.** Names `rooms/owner/invite/0.1`, and says plainly that turning a joiner's KeyPackage into a Welcome and a Commit has no task and no CLI: the one part of a sealed-room join still done in Rust.
- **§9.** A correction, not an addition. "No task seals on a caller's behalf" is no longer true — `rooms/keys/seal/0.1` seals for a caller holding `roomOpen`. It is `pnm rooms put` that has not caught up, and its refusal still tells operators the task does not exist.
- **§11 / §12.** The `validUntil` refusal; the four missing `rooms/keys/*` rows and `rooms/epoch/chain`; a new owner-task table, with a note that `rooms/owner/{transfer,claim}` above it are *host* tasks despite the shared family name.
- **`data-rooms-guide.html`** carries the same table rows, mint command, and issue-yourself step, so the two do not disagree.

### Two follow-ups this does not do

- `vta-cli-common/src/commands/rooms.rs:305` still refuses a sealed `put` with "no task seals on a caller's behalf". That is a code change and wants its own PR.
- The in-flight rooms 0.2 cutover moves `rooms/keys/present` and `rooms/owner/issue-authority` to `/0.2`; the two §12 tables here will need those two strings bumped in that PR.
