### PR TITLE
feat(sdk): a no-I/O verifier resolves did:peer too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10499,6 +10499,7 @@ dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-did-resolver-traits",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,10 @@ k8s-openapi = { version = "0.28", features = ["latest"] }
 # omit the `network` feature. The default here turns it on; dependents
 # that want the offline-only cache can opt out via `default-features = false`.
 affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
+# The local-only resolvers, for methods that carry their keys in the identifier. Not a
+# second resolver: the cache SDK already depends on this and uses the same types, but does
+# not re-export them, and a verifier promising "no I/O" needs to reach them directly.
+affinidi-did-resolver-traits = { version = "0.1" }
 
 # Agent names — human-memorable `example.com/@alice` shortcuts that resolve to
 # DIDs. Consumed by `vta_sdk::display_name` (feature `agent-names`) for the

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -29,12 +29,16 @@ proof-verify = [
   "dep:async-trait",
   "dep:affinidi-data-integrity",
   "dep:affinidi-did-resolver-cache-sdk",
+  "dep:affinidi-did-resolver-traits",
+  "dep:affinidi-did-common",
   "dep:affinidi-secrets-resolver",
   "dep:trust-tasks-rs",
 ]
 didcomm = [
   "dep:affinidi-tdk",
   "dep:affinidi-did-resolver-cache-sdk",
+  "dep:affinidi-did-resolver-traits",
+  "dep:affinidi-did-common",
   "dep:tracing",
   "dep:uuid",
   "dep:tokio",
@@ -64,6 +68,8 @@ tsp = [
   # `TspPingSession` builds a `trust_tasks_rs::TrustTask` envelope.
   "dep:trust-tasks-rs",
   "dep:affinidi-did-resolver-cache-sdk",
+  "dep:affinidi-did-resolver-traits",
+  "dep:affinidi-did-common",
   "dep:tracing",
   "dep:uuid",
   "dep:tokio",
@@ -83,6 +89,8 @@ agent-names = [
   "dep:agent-names",
   "dep:affinidi-did-common",
   "dep:affinidi-did-resolver-cache-sdk",
+  "dep:affinidi-did-resolver-traits",
+  "dep:affinidi-did-common",
   "affinidi-did-resolver-cache-sdk/agent-names",
 ]
 client = [
@@ -118,6 +126,8 @@ session = [
   # is `dirs::config_dir()` — not the XDG path on macOS or Windows.
   "dep:dirs",
   "dep:affinidi-did-resolver-cache-sdk",
+  "dep:affinidi-did-resolver-traits",
+  "dep:affinidi-did-common",
   "dep:tokio",
   # Rotation of a temp-provisioned did:key on first successful auth needs
   # a CSPRNG seed for the replacement Ed25519 key.
@@ -272,6 +282,7 @@ rustls = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 affinidi-did-resolver-cache-sdk = { workspace = true, optional = true }
+affinidi-did-resolver-traits = { workspace = true, optional = true }
 # `VerificationMethodResolver` is an async trait object; the resolver impl in
 # `trust_task_proof::vm_resolver` implements it.
 async-trait = { version = "0.1", optional = true }

--- a/vta-sdk/src/trust_task_proof/vm_resolver.rs
+++ b/vta-sdk/src/trust_task_proof/vm_resolver.rs
@@ -74,10 +74,13 @@ impl TrustTaskVmResolver {
         }
     }
 
-    /// A resolver that will only ever resolve `did:key`, with no I/O.
+    /// A resolver that performs **no I/O**: `did:key` and `did:peer`, both of which carry
+    /// their keys in the identifier.
     ///
-    /// The pre-existing behaviour, kept nameable so a caller that wants it says
-    /// so rather than getting it by omission.
+    /// The guarantee is about the network, not about the method — a caller choosing this is
+    /// saying no unauthenticated request may make it fetch. `did:peer` satisfies that as
+    /// fully as `did:key` does, and excluding it only refused credentials this could have
+    /// checked.
     #[must_use]
     pub fn did_key_only() -> Self {
         Self { resolver: None }
@@ -102,6 +105,23 @@ impl TrustTaskVmResolver {
         // First, and unconditionally: the key is in the identifier.
         if base_did.starts_with("did:key:") {
             return resolve_did_key(vm);
+        }
+
+        // So is a `did:peer`'s, and that matters more than it looks.
+        //
+        // A `did:peer:2` encodes its keys and its services inline, so resolving one is —
+        // in `PeerResolver`'s own words — "pure computation (no IO)". Treating it as
+        // needing a network resolver made `did_key_only()` mean "did:key only" when what
+        // it exists to promise is that **no unauthenticated request can make this verifier
+        // fetch**. Those are different guarantees, and the narrower one refuses credentials
+        // it could have checked without touching the network.
+        //
+        // Concretely: a room identified by `did:peer:2` can advertise a mediator, which is
+        // how a member reaches its owner — a `did:key` cannot, having no service block. So
+        // a host wanting to serve such a room had to enable network resolution it does not
+        // need, and accept the exposure that flag exists to gate.
+        if base_did.starts_with("did:peer:") {
+            return resolve_did_peer(vm, base_did);
         }
 
         let resolver = self.resolver.as_ref().ok_or_else(|| {
@@ -142,6 +162,50 @@ impl TrustTaskVmResolver {
     }
 }
 
+/// Resolve a `did:peer` verification method with no I/O.
+///
+/// The document is derived from the identifier and its keys expanded, then the method is
+/// looked up exactly as the network path looks one up — including accepting both the
+/// absolute and relative spellings of the same id, because a proof always names a method
+/// absolutely while a document may not.
+fn resolve_did_peer(vm: &str, base_did: &str) -> Result<ResolvedKey, DataIntegrityError> {
+    use affinidi_did_common::DID;
+    use affinidi_did_resolver_traits::{PeerResolver, Resolver};
+
+    let did = DID::try_from(base_did).map_err(|e| {
+        DataIntegrityError::Resolver(format!("`{base_did}` is not a well-formed DID: {e}"))
+    })?;
+    let doc = PeerResolver
+        .resolve(&did)
+        .ok_or_else(|| {
+            DataIntegrityError::Resolver(format!(
+                "`{base_did}` is not a did:peer this build resolves"
+            ))
+        })?
+        .map_err(|e| DataIntegrityError::Resolver(format!("`{base_did}` did not resolve: {e}")))?;
+
+    let relative = vm
+        .split_once('#')
+        .map(|(_, fragment)| format!("#{fragment}"))
+        .unwrap_or_default();
+    let entry = doc
+        .verification_method
+        .iter()
+        .find(|m| m.id.as_str() == vm || m.id.as_str() == relative)
+        .ok_or_else(|| {
+            DataIntegrityError::Resolver(format!(
+                "verificationMethod `{vm}` is not in the DID document for `{base_did}`"
+            ))
+        })?;
+
+    let bytes = entry.get_public_key_bytes().map_err(|e| {
+        DataIntegrityError::Resolver(format!(
+            "verificationMethod `{vm}` public key could not be extracted: {e}"
+        ))
+    })?;
+    Ok(ResolvedKey::new(KeyType::Ed25519, bytes))
+}
+
 #[async_trait::async_trait]
 impl VerificationMethodResolver for TrustTaskVmResolver {
     async fn resolve_vm(&self, vm: &str) -> Result<ResolvedKey, DataIntegrityError> {
@@ -171,6 +235,50 @@ mod tests {
             .await
             .expect("did:key resolves with no cache client");
         assert_eq!(key.public_key_bytes, sk.verifying_key().to_bytes().to_vec());
+    }
+
+    /// A `did:peer` resolves with **no resolver configured**, which is the point.
+    ///
+    /// Its keys are in its identifier, so this needs no network — and a verifier configured
+    /// to do no I/O should therefore accept it. Before this it did not, and a host wanting
+    /// to serve a `did:peer` room had to turn on network resolution it never used.
+    ///
+    /// A `did:peer:2` is used rather than a `did:peer:0` because that is the shape a room
+    /// needs: only numalgo 2 carries a service block, which is how a room advertises the
+    /// mediator its members reach its owner through.
+    #[tokio::test]
+    async fn did_peer_resolves_with_no_resolver_configured() {
+        use affinidi_tdk::dids::{DID, KeyType};
+
+        let (did, secrets) = DID::generate_did_peer(
+            vec![
+                (
+                    affinidi_tdk::dids::PeerKeyRole::Verification,
+                    KeyType::Ed25519,
+                ),
+                (affinidi_tdk::dids::PeerKeyRole::Encryption, KeyType::X25519),
+            ],
+            None,
+        )
+        .expect("mint a did:peer");
+
+        let vm = format!("{did}#key-1");
+        let resolved = TrustTaskVmResolver::did_key_only()
+            .resolve_vm(&vm)
+            .await
+            .expect("a did:peer carries its keys in its identifier, so this needs no network");
+
+        // The same key the minting side holds — resolution is not merely succeeding, it is
+        // returning the right bytes.
+        let expected = secrets
+            .iter()
+            .find(|s| s.id.ends_with("#key-1"))
+            .expect("the verification secret");
+        assert_eq!(
+            resolved.public_key_bytes,
+            expected.get_public_bytes(),
+            "the resolved key must be the one the DID names"
+        );
     }
 
     /// The refusal has to say *why* it refused, because "did not resolve" and


### PR DESCRIPTION
`TrustTaskVmResolver::did_key_only()` promises that **no unauthenticated request can make a
verifier fetch**. It delivered that by resolving only `did:key` — but a `did:peer` carries
its keys in its identifier just as a `did:key` does, and `PeerResolver` says so in its own
words:

> Resolution is pure computation (no IO).

So the narrow verifier was refusing credentials it could have checked without touching the
network. The guarantee it offers is about **I/O**, not about a method, and the two had been
conflated.

## Why this matters beyond tidiness

A room identified by `did:peer:2` **can advertise a mediator** — which is how a member
reaches the room's owner to be admitted. A `did:key` cannot, having no service block, which
is exactly why a real room mints `did:webvh`.

So a host wanting to serve a `did:peer` room had to enable network resolution it would never
use, and accept the exposure `--resolve-dids` exists to gate:

> Off by default. […] turning network resolution on means an unauthenticated request can
> make this host fetch, so it is a decision an operator makes rather than a default they
> inherit.

That trade was being demanded for a method that needs none of it.

## Implementation

`PeerResolver` from `affinidi-did-resolver-traits` — which the cache SDK already depends on
but does not re-export, hence the direct dependency. The verification method is then looked
up exactly as the network path looks one up, including accepting both the absolute and
relative spellings of an id, because a proof always names a method absolutely while a
document may not.

No behaviour change for `did:key`, `did:webvh`, or a network-configured resolver. The
`did:webvh` refusal still names the configuration, and its test still passes unchanged.

## Verified

- New test mints a real `did:peer:2` and asserts the **resolved bytes are the minting side's
  key**, not merely that resolution succeeded. numalgo 2 rather than 0, because only 2
  carries a service block — the shape a room needs.
- `cargo test -p vta-sdk --all-features` — green.
- `cargo clippy -p vta-sdk --all-features --all-targets -- -D warnings` — clean.

Found while trying to give the data-room demo's rooms a mediator, which is the piece that
would let somebody be let into a room the site was not told about
(`docs/05-design-notes/data-rooms-demo-site.md`).