### PR TITLE
feat(rooms)!: cut over to present/0.2 and issue-authority/0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1185f26910648388327dea8997e3e62531b50c9a0dd9cd750a32c46d0f7c0f"
+checksum = "8396d9206908dc1d0fd6449c7cb5b5e4db455ca0a304f75444c9aa0c621b21bf"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -382,7 +382,7 @@ dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-mediator-config",
- "affinidi-messaging-sdk 0.22.0",
+ "affinidi-messaging-sdk",
  "affinidi-rate-limit",
  "affinidi-secrets-resolver",
  "affinidi-task-utils",
@@ -428,7 +428,7 @@ dependencies = [
  "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "url",
  "uuid",
 ]
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b9e798e2e40bc949067add965f7539e0dc6a48fc3550fc7c7e8d8cba444359"
+checksum = "57125239a953a49c06b88746fd2aede838aa611274bf91f7952656c6c747d804"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -516,58 +516,21 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tracing",
- "trust-tasks-rs 0.17.10",
- "uuid",
-]
-
-[[package]]
-name = "affinidi-messaging-sdk"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b579af2fee18048f092391f3c73e1b6a7be44fed38ed2bf79e03b58b9cafc84b"
-dependencies = [
- "affinidi-crypto",
- "affinidi-did-authentication",
- "affinidi-did-common",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-encoding",
- "affinidi-messaging-core",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-mediator-common",
- "affinidi-secrets-resolver",
- "affinidi-task-utils",
- "affinidi-tdk-common",
- "affinidi-tsp",
- "ahash",
- "async-trait",
- "base64 0.23.1",
- "futures-util",
- "rand 0.10.2",
- "regex",
- "reqwest",
- "rustls",
- "serde",
- "serde_json",
- "sha256",
- "thiserror 2.0.20",
- "tokio",
- "tokio-tungstenite 0.30.0",
- "tracing",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c5f50dfcde03a3b9ee6d7d4282e6fcf18700fc67e6324fca551d7583bb20dd"
+checksum = "5f3a3e0f6b7c734f9e769344296cd5aba8f7cbd815b9012ee349261df9d6778a"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-mediator",
  "affinidi-messaging-mediator-common",
- "affinidi-messaging-sdk 0.22.0",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "async-trait",
@@ -736,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796229a5640d2c8e1ae81242ff86a1147994210542e3d1cdd59ec1df12bce3ea"
+checksum = "14a2c38268859db8bdf250a3587a4a38e6ea5b9e6cc9f6a1cad2a8f25b30dbaf"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -747,7 +710,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-meeting-place",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.22.0",
+ "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
  "affinidi-tsp",
@@ -7995,7 +7958,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "uuid",
  "vta-sdk",
  "vtc-client",
@@ -9607,23 +9570,23 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b3ff12a929ebae90844cbf38232092a60acbc59591999ad57453d6d19bb183"
+checksum = "cb8aee6485cda7f0dddb2a296fd55e54d624feac258d8c70374547866e10794d"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b338e33658f9e40246f014cd7695331214e529afee8a465f55ac868bf606b978"
+checksum = "dddfed74e984b3b56b8e1044dff4ffd18434f2b8c0f3190b8b1665f019902a78"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9631,15 +9594,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c33d0c0a90e12dc67b07786124f849ccbd5b7e2eb14f5675e1c8b0671443023"
+checksum = "f204b41468c547a91f4a25557079a240826b7a2a32c4ac7353eeb25d500d735b"
 dependencies = [
  "axum",
  "chrono",
@@ -9650,15 +9613,15 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62814df673aaaae19d948cf7d6cc662236257566df5bd790779bc156edc86ebf"
+checksum = "58fb8652b4644ed53795569ea619dcb92e24150a789a1b5b86de91643af84fe7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9668,29 +9631,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
 ]
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.10"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc5ec5115dcde391d27997c940949f29061bcf38cdf8050a155264c08f1817"
-dependencies = [
- "async-trait",
- "chrono",
- "regress",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "trust-tasks-rs"
-version = "0.18.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b18725200227aa173e4c7b6b89450bf6d42ab4add65caf510464378f196356"
+checksum = "6cac8a2d80fece4f26156b4064de2a3319bad0e5ce25159df2ed4a5bf9deb282"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10446,7 +10394,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tracing-subscriber",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "uniffi",
  "vta-sdk",
 ]
@@ -10464,7 +10412,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "ulid",
  "vta-keyspaces",
  "vti-common",
@@ -10502,7 +10450,7 @@ dependencies = [
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.22.0",
+ "affinidi-messaging-sdk",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
@@ -10544,7 +10492,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "uuid",
@@ -10568,7 +10516,7 @@ dependencies = [
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.21.1",
+ "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
@@ -10629,7 +10577,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "url",
  "urlencoding",
  "utoipa",
@@ -10798,7 +10746,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "vta-sdk",
  "vti-rooms",
 ]
@@ -10870,7 +10818,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-https",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "unicode-normalization",
  "url",
  "utoipa",
@@ -10928,7 +10876,7 @@ dependencies = [
  "tower",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -10944,7 +10892,7 @@ version = "0.6.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk 0.21.1",
+ "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
@@ -10988,7 +10936,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tls_codec",
  "tokio",
- "trust-tasks-rs 0.18.11",
+ "trust-tasks-rs",
  "vti-common",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ uniffi = "0.32"
 # the floor is now structural rather than a specific patch: do not move this
 # back below 0.9, and do not drop to a bare major.
 # 0.11 re-exports `affinidi-mdoc` 0.3 — see the coupling note on `coset` below.
-affinidi-tdk = "0.12"
+affinidi-tdk = "0.13"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -284,12 +284,12 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.18.11", default-features = false, features = [
+trust-tasks-rs = { version = "0.19.0", default-features = false, features = [
   "validate",
   "all-specs",
 ] }
-trust-tasks-capability-client = "0.18"
-trust-tasks-https = { version = "0.18", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-capability-client = "0.19"
+trust-tasks-https = { version = "0.19", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -300,8 +300,8 @@ trust-tasks-https = { version = "0.18", default-features = false, features = ["s
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.18", default-features = false }
-trust-tasks-proof = { version = "0.18", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.19", default-features = false }
+trust-tasks-proof = { version = "0.19", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -19,7 +19,7 @@ autobins = false
 
 [dev-dependencies]
 # Embedded mediator fixture from affinidi-tdk-rs.
-affinidi-messaging-test-mediator = { version = "0.5", features = ["tsp"] }
+affinidi-messaging-test-mediator = { version = "0.6", features = ["tsp"] }
 
 # VTA: enable the `test-support` feature so we can stand up complete VTA
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
@@ -31,7 +31,7 @@ vti-common = { path = "../../vti-common" }
 affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
-affinidi-messaging-sdk = "0.21"
+affinidi-messaging-sdk = "0.23"
 affinidi-messaging-didcomm = "0.15"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -265,7 +265,7 @@ futures-util = { workspace = true, optional = true }
 # `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to
 # one instance, the one `affinidi_tdk::messaging` re-exports) so the `tsp`
 # feature can turn its `tsp` on — mirrors what `vta-service` does.
-affinidi-messaging-sdk = { version = "0.22", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.23", optional = true, default-features = false }
 reqwest = { workspace = true, optional = true }
 # Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
 rustls = { workspace = true, optional = true }

--- a/vta-sdk/src/client/rooms.rs
+++ b/vta-sdk/src/client/rooms.rs
@@ -62,7 +62,7 @@ impl VtaClient {
             "action": action,
         });
         self.dispatch_trust_task(
-            trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1,
+            trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_2,
             payload,
             ROOM_TT_TIMEOUT,
         )

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -407,7 +407,7 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // and a caller that lost the reply has no way to use the one it never saw.
     // Keying it would buy a dedup record against a duplicate that costs
     // nothing, at the price of failing a retry the caller legitimately needs.
-    (trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1, RetrySafe),
+    (trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_2, RetrySafe),
     // Reads group state and returns plaintext. Nothing is written, and a second
     // execution is indistinguishable from one.
     (trust_tasks::TASK_ROOMS_KEYS_OPEN_0_1, ReadOnly),
@@ -459,7 +459,7 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // this axis is about.
     (trust_tasks::TASK_ROOMS_OWNER_REGISTER_0_1, RetrySafe),
     (trust_tasks::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1, Keyed),
-    (trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1, Keyed),
+    (trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_2, Keyed),
     (trust_tasks::TASK_VTA_MEMORY_DELETE_0_1, RetrySafe),
     // ── Application state ───────────────────────────────────────────────
     //

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -796,13 +796,13 @@ pub const TASK_VTA_MEMORY_PUT_0_1: &str = "https://trusttasks.org/spec/vta/memor
 /// access. Payload: [`crate::protocols::memory::MemoryListBody`].
 pub const TASK_VTA_MEMORY_LIST_0_1: &str = "https://trusttasks.org/spec/vta/memory/list/0.1";
 
-/// `spec/rooms/keys/present/0.1` — an agent asks the VTA holding its
+/// `spec/rooms/keys/present/0.2` — an agent asks the VTA holding its
 /// principal's room credentials to mint a presentation for **one** room
 /// operation. The credentials never cross to the agent; only the presentation
 /// does, it is scoped to the action it was asked for, and it is granted to the
 /// caller — so it is worthless to anybody who captures it.
 /// Auth: `roomPresent` capability, plus context access for the principal's key.
-pub const TASK_ROOMS_KEYS_PRESENT_0_1: &str = "https://trusttasks.org/spec/rooms/keys/present/0.1";
+pub const TASK_ROOMS_KEYS_PRESENT_0_2: &str = "https://trusttasks.org/spec/rooms/keys/present/0.2";
 
 /// `spec/rooms/keys/open/0.1` — an agent sends a sealed record and gets its
 /// plaintext. The key never crosses. Auth: `roomOpen` capability.
@@ -868,12 +868,14 @@ pub const TASK_ROOMS_OWNER_REGISTER_0_1: &str =
 pub const TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1: &str =
     "https://trusttasks.org/spec/rooms/owner/issue-membership/0.1";
 
-/// `spec/rooms/owner/issue-authority/0.1` — mint a Verifiable Authority Credential — a
-/// chain root at the room's scope, conferring read/write/curate/admin.
+/// `spec/rooms/owner/issue-authority/0.2` — mint a Verifiable Authority Credential — a
+/// chain root at the room's scope, conferring read/write/curate/admin. `validUntil` is
+/// REQUIRED: a root is the grant nothing else can withdraw, so expiry is the only way it
+/// ends short of revocation.
 /// Auth: `credentialWrite` capability, plus whatever the key oracle says about
 /// naming the room's signing key.
-pub const TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1: &str =
-    "https://trusttasks.org/spec/rooms/owner/issue-authority/0.1";
+pub const TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_2: &str =
+    "https://trusttasks.org/spec/rooms/owner/issue-authority/0.2";
 
 /// `spec/vta/memory/delete/0.1` — remove one entry by key (`not_found` if
 /// absent). Auth: context access. Payload:
@@ -1941,7 +1943,7 @@ pub const ALL_URIS: &[&str] = &[
     // Agent-memory slice (spec/vta/memory/*)
     TASK_VTA_MEMORY_PUT_0_1,
     TASK_VTA_MEMORY_LIST_0_1,
-    TASK_ROOMS_KEYS_PRESENT_0_1,
+    TASK_ROOMS_KEYS_PRESENT_0_2,
     TASK_ROOMS_KEYS_OPEN_0_1,
     TASK_ROOMS_KEYS_KEY_PACKAGE_0_1,
     TASK_ROOMS_KEYS_WELCOME_0_1,
@@ -1953,7 +1955,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ROOMS_OWNER_INVITE_0_1,
     TASK_ROOMS_OWNER_REGISTER_0_1,
     TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1,
-    TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1,
+    TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_2,
     TASK_VTA_MEMORY_DELETE_0_1,
     // Application-state slice (spec/vta/app-state/*)
     TASK_VTA_APP_STATE_GET_1_0,

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -264,7 +264,7 @@ futures-util = "0.3"
 # crate's `tsp` feature and are NOT reachable via `affinidi-tdk/tsp`. The crate
 # is already present transitively via `affinidi-tdk` at the same 0.18.x; this
 # entry adds no new code when `tsp` is off (optional + default-features off).
-affinidi-messaging-sdk = { version = "0.21", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.23", optional = true, default-features = false }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"
 affinidi-did-resolver-cache-sdk = { workspace = true }
@@ -337,7 +337,7 @@ tempfile = { version = "3", optional = true }
 # A real dependency rather than a dev-dependency: `test-support` exists to serve
 # *external* consumers, and a dev-dependency would not be available to them.
 # `tsp` so the mediator routes raw-TSP frames, not just DIDComm.
-affinidi-messaging-test-mediator = { version = "0.5", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.6", optional = true, features = [
     "tsp",
 ] }
 libc = { workspace = true, optional = true }

--- a/vta-service/src/operations/room_oracle.rs
+++ b/vta-service/src/operations/room_oracle.rs
@@ -165,9 +165,23 @@ pub async fn present(
     // Freshness belongs to the request: the room task document carrying this is signed by
     // the presenter and carries `id` and `issuedAt`, which is what SPEC.md §7.2 item 11
     // keys duplicate-execution protection on.
+    // Credentials cross as JSON **strings**, not as objects. `AuthorityPresentation` types
+    // both members as strings — the host's opener accepts base64url or bare JSON text and
+    // selects on a leading `{` — so an object here is not a presentation a host can even
+    // deserialize, let alone verify. It emitted objects until this task moved to `0.2`,
+    // whose response schema names the shared component and made the disagreement a type
+    // error instead of a runtime refusal nothing in this workspace exercised.
+    let as_text = |v: &Value, what: &str| -> Result<Value, AppError> {
+        serde_json::to_string(v)
+            .map(Value::String)
+            .map_err(|e| AppError::Internal(format!("serialise the {what}: {e}")))
+    };
     let presentation = serde_json::json!({
-        "membership": vmc,
-        "authority": [leaf_json, vac],
+        "membership": as_text(&vmc, "membership credential")?,
+        "authority": [
+            as_text(&leaf_json, "attenuated credential")?,
+            as_text(&vac, "room-issued credential")?,
+        ],
     });
 
     Ok(MintedPresentation {

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2165,15 +2165,20 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
-            uris::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1,
+            uris::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_2,
             checked!(
-                specs::rooms::owner::issue_authority::v0_1::Payload,
-                specs::rooms::owner::issue_authority::v0_1::Response,
+                specs::rooms::owner::issue_authority::v0_2::Payload,
+                specs::rooms::owner::issue_authority::v0_2::Response,
                 json!({
                     "roomId": "did:webvh:example.com:rooms:northwind",
                     "signingKeyId": "room-northwind-signing",
                     "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-                    "actions": ["read", "write"]
+                    "actions": ["read", "write"],
+                    // REQUIRED since 0.2. The 0.1 witness omitted it, which is what this
+                    // harness caught on the move: a chain root with no expiry is authority
+                    // nobody can withdraw by waiting, and this service could have emitted
+                    // exactly this request.
+                    "validUntil": "2026-02-01T00:00:00Z"
                 }),
                 json!({ "credential": "eyJhbGciOiJFZERTQSJ9.room-credential",
                     "credentialId": "urn:uuid:11111111-1111-4111-8111-111111111111" })
@@ -2206,22 +2211,27 @@ fn table() -> Vec<(&'static str, Conformance)> {
         // ordering is the contract with every verifier — a witness that showed
         // it either way round would check nothing about the half that matters.
         (
-            uris::TASK_ROOMS_KEYS_PRESENT_0_1,
+            uris::TASK_ROOMS_KEYS_PRESENT_0_2,
             checked!(
-                specs::rooms::keys::present::v0_1::Payload,
-                specs::rooms::keys::present::v0_1::Response,
+                specs::rooms::keys::present::v0_2::Payload,
+                specs::rooms::keys::present::v0_2::Response,
+                // `audience` and `nonce` are gone in 0.2. This witness carried a HOST DID
+                // as the audience — the exact shape dtgwg-trust-tasks-tf#414 reported, which
+                // no host could ever accept, since the field named the party that had to
+                // PRESENT the credential.
                 json!({
                     "roomId": "did:webvh:example.com:rooms:northwind",
-                    "action": "read",
-                    "audience": "did:key:z6MkHost",
-                    "nonce": "n-1"
+                    "action": "read"
                 }),
+                // Credentials are STRINGS. The witness carried objects, matching what the
+                // oracle emitted and what no host could deserialize; 0.2's response names
+                // the shared `AuthorityPresentation`, which types both members as strings.
                 json!({
                     "presentation": {
-                        "membership": { "id": "urn:uuid:vmc-1" },
+                        "membership": "{\"id\":\"urn:uuid:vmc-1\"}",
                         "authority": [
-                            { "id": "urn:uuid:vac-agent" },
-                            { "id": "urn:uuid:vac-member" }
+                            "{\"id\":\"urn:uuid:vac-agent\"}",
+                            "{\"id\":\"urn:uuid:vac-member\"}"
                         ]
                     },
                     "expiresAt": TS

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1804,7 +1804,7 @@ dispatch_table! {
     // An agent asks for a scoped presentation over its principal's room
     // credentials. Gated on the `roomPresent` capability plus context access
     // for the principal's key — NOT on `Sign`, which would grant far more.
-    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_1 => room_keys::handle_present
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_PRESENT_0_2 => room_keys::handle_present
         [ None Metadata false ],
     // Group custody: how a group reaches this VTA, and what it does with one.
     // Three inbound (a room's owner reaching us) and one outbound-facing; only
@@ -1837,7 +1837,7 @@ dispatch_table! {
         [ Mutating Metadata true ],
     vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1 => room_owner::handle_issue_membership
         [ Mutating Metadata false ],
-    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_1 => room_owner::handle_issue_authority
+    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_2 => room_owner::handle_issue_authority
         [ Mutating Metadata false ],
     // ─── Application-state slice (spec/vta/app-state/*) ──────────
     // Versioned, namespaced per-context JSON the VTA stores but never

--- a/vta-service/src/trust_tasks/room_keys.rs
+++ b/vta-service/src/trust_tasks/room_keys.rs
@@ -1,4 +1,4 @@
-//! The room-oracle slice — `spec/rooms/keys/present/0.1`.
+//! The room-oracle slice — `spec/rooms/keys/present/0.2`.
 //!
 //! An agent asks its principal's VTA to mint a presentation for one room operation. The
 //! orchestration is [`crate::operations::room_oracle`]; this is the dispatch surface.
@@ -48,7 +48,7 @@ async fn require_cap(
     super::helpers::require_capability(state, auth, doc, cap, "minting a room presentation").await
 }
 
-/// `rooms/keys/present/0.1`.
+/// `rooms/keys/present/0.2`.
 pub(super) async fn handle_present(
     state: &AppState,
     auth: &AuthClaims,
@@ -58,7 +58,7 @@ pub(super) async fn handle_present(
         return r;
     }
 
-    let req: trust_tasks_rs::specs::rooms::keys::present::v0_1::Payload = match parse_payload(&doc)
+    let req: trust_tasks_rs::specs::rooms::keys::present::v0_2::Payload = match parse_payload(&doc)
     {
         Ok(r) => r,
         Err(resp) => return resp,

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -195,7 +195,7 @@ pub(super) async fn handle_issue_authority(
         return r;
     }
 
-    let req: trust_tasks_rs::specs::rooms::owner::issue_authority::v0_1::Payload =
+    let req: trust_tasks_rs::specs::rooms::owner::issue_authority::v0_2::Payload =
         match parse_payload(&doc) {
             Ok(r) => r,
             Err(resp) => return resp,
@@ -207,32 +207,20 @@ pub(super) async fn handle_issue_authority(
     // action list rather than reading it as "everything", and the schema refuses it before
     // that — two layers, because "confers nothing" and "confers everything" are exactly the
     // two readings a careless consumer might choose between.
-    // An authority credential must expire, and since dtg-credentials 0.7 the constructor
-    // says so in its type. Nothing about a subject's current standing is consulted when a
-    // chain is verified, so a grant that does not expire is a grant nobody can withdraw by
-    // waiting — the only way back is revocation, which this stack does not yet have.
-    //
-    // Refused rather than defaulted. Picking a lifetime here would put the room's most
-    // consequential number in a place its owner never looks.
-    let Some(valid_until) = req.valid_until else {
-        return app_error_to_reject(
-            &doc,
-            vti_common::error::AppError::Validation(
-                "an authority credential must name `validUntil`: nothing about a subject's \
-                 standing is checked when a chain is verified, so authority that does not \
-                 expire is authority nobody can withdraw"
-                    .into(),
-            ),
-        );
-    };
-
+    // `validUntil` is not checked here any more, and its absence is not a case this
+    // function can reach: `issue-authority/0.2` makes the member REQUIRED, so the generated
+    // payload types it as a `DateTime` and the envelope schema rejects a request without one
+    // before dispatch. The rule is unchanged — nothing about a subject's standing is
+    // consulted when a chain is verified, so a root that does not expire is authority nobody
+    // can withdraw by waiting — it is simply enforced a layer up now, which is where a
+    // shape constraint belongs.
     let vac = match dtg_credentials::DTGCredential::new_vac(
         req.room_id.clone(),
         req.subject.clone(),
         req.room_id.clone(),
         actions,
         chrono::Utc::now(),
-        valid_until,
+        req.valid_until,
     ) {
         Ok(v) => v,
         Err(e) => {

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -221,7 +221,7 @@ affinidi-messaging-didcomm = "0.15"
 # mediator-side twin of the client-side failure this crate's TSP work is about.
 # Always on (not conditioned on this crate's `tsp`): the harness is test-only,
 # and a mediator that can route TSP is harmless to the DIDComm suite.
-affinidi-messaging-test-mediator = { version = "0.5", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.6", optional = true, features = [
     "tsp",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }


### PR DESCRIPTION
The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked by
affinidi/affinidi-tdk-rs#784. Closes out the `audience` thread that started at
trustoverip/dtgwg-trust-tasks-tf#414.

## Untying the dependency knot consolidated more than expected

`trust-tasks-rs 0.19` carries both new spec versions, and this workspace could not take it:
`affinidi-messaging-sdk 0.22.0` required `0.18`, so pinning `0.19` put two `trust-tasks-rs`
nodes in the graph and broke `vta-sdk` on `expected MediatorAcl, found a different
MediatorAcl`. TDK #784 moved the messaging family to `0.19` / `0.23.0`.

Taking it exposed pins that had quietly drifted apart underneath — `vta-sdk` on
messaging-sdk `0.22` while `vta-service` and the e2e tests sat on `0.21`:

| in the lockfile | before | after |
|---|---|---|
| `trust-tasks-rs` | **3** versions (0.17.10, 0.18.9, 0.19.0) | **1** |
| `affinidi-messaging-sdk` | **3** versions (0.21.1, 0.22.0, 0.23.0) | **1** |

## The cut-over

`rooms/keys/present` and `rooms/owner/issue-authority` both move `0.1` → `0.2`. Both `0.1`s
are retired upstream, and **neither is dual-accepted, deliberately**: for `present`, `0.1`'s
extra members are exactly the two nothing could honour; for `issue-authority`, accepting
`0.1` means accepting a request with no `validUntil`, which is the thing `0.2` exists to
refuse.

The hand-rolled `validUntil` guard in `room_owner.rs` is **deleted**. `0.2` makes the member
REQUIRED, so the generated payload types it as a `DateTime` and the envelope schema rejects a
request without one before dispatch. Same rule, one layer up — where a shape constraint
belongs.

## Two defects the conformance harness caught on the move

`every_witnessed_task_round_trips_through_its_generated_types` refused two witnesses that had
been green for as long as they existed:

1. **`issue-authority` carried no `validUntil`** — a chain root with no expiry, the exact
   request `0.2` forbids, and one this service could have emitted.
2. **`present` carried `"audience": "did:key:z6MkHost"`** — a *host* DID, the precise shape
   #414 reported as impossible to satisfy, since the field named the party that had to
   **present** the credential. The bug was sitting in our own conformance fixture.

That harness did exactly what it exists for: the specs moved, and it named the two requests
that no longer conform rather than letting them rot.

## And one it could only catch once the response was typed

`room_oracle` emitted `membership` and `authority[]` as JSON **objects**.
`AuthorityPresentation` types both as **strings** — the host's opener reads base64url or bare
JSON text, selecting on a leading `{`. So the oracle's output **could not deserialize at a
host at all**: `rooms/keys/present` had never worked end to end.

It went unseen because `0.1`'s response typed `presentation` as an opaque
`additionalProperties: true` object. `0.2` names the shared component instead, turning a
runtime refusal nothing exercised into a compile-time type error. The oracle now serialises
each credential before it goes in.

That is the first half of #1357. The round-trip test it asks for — mint through
`room_oracle::present`, feed the result to `DtgChainVerifier`, assert the chain verifies — is
still worth writing, and is the single test that would have caught **all three** of these.

## Verified

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all` — clean
- `cargo check -p vti-rooms-wasm --target wasm32-unknown-unknown` — clean. This crate is
  **not** built by a default workspace check, which is how it was missed once already.
- `cargo test --workspace --exclude vtc-service --exclude vtc-client` — all passed

Branched from `05504b11` rather than the tip, so it may want a rebase before merge; no
conflicts expected.