### PR TITLE
feat(rooms): a browser member verifies a did:peer room

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11021,7 +11021,10 @@ name = "vti-rooms-wasm"
 version = "0.1.0"
 dependencies = [
  "affinidi-data-integrity",
+ "affinidi-did-common",
+ "affinidi-did-resolver-traits",
  "affinidi-secrets-resolver",
+ "affinidi-tdk",
  "base64 0.23.1",
  "chrono",
  "dtg-credentials",

--- a/vti-rooms-wasm/Cargo.toml
+++ b/vti-rooms-wasm/Cargo.toml
@@ -56,6 +56,11 @@ futures-lite = "2"
 
 chrono = { workspace = true }
 multibase = { workspace = true }
+# Resolving a `did:peer` — pure computation, so it reaches wasm and needs no network.
+# The same resolver `vta-sdk`'s verifier uses, so a member and a host cannot disagree
+# about what a room's key is.
+affinidi-did-resolver-traits = { workspace = true }
+affinidi-did-common = { workspace = true }
 
 base64 = { workspace = true }
 serde = { workspace = true }
@@ -63,6 +68,9 @@ serde_json = { workspace = true }
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
+# Minting a real `did:peer:2` for the invitation test — a fixture, never a runtime dep:
+# a member resolves a did:peer, it never mints one.
+affinidi-tdk = { workspace = true }
 ed25519-dalek = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 futures-lite = "2"

--- a/vti-rooms-wasm/src/invitation.rs
+++ b/vti-rooms-wasm/src/invitation.rs
@@ -41,9 +41,15 @@
 //! # Why no resolver
 //!
 //! The proof is checked against raw public-key bytes, and a room identified by a `did:key`
-//! carries its own key in its identifier. So verification is lexical: no network, no cache,
-//! nothing to be offline. A `did:webvh` room — what production mints — would need real
-//! resolution, and that is the one thing this module would grow.
+//! or a `did:peer` carries its own key in its identifier. So verification needs no network,
+//! no cache, and nothing to be online for. The same guarantee `room-host` makes on the other
+//! side, and since `vta-sdk`'s verifier learned `did:peer` the two agree about which methods
+//! it covers.
+//!
+//! `did:peer` matters rather than being a bonus: only it can carry a **service block**, so
+//! only it lets a room advertise the mediator its members reach its owner through. A
+//! `did:webvh` room — what production mints — would need real resolution, and that is the
+//! one thing this module would grow.
 
 use chrono::Utc;
 use dtg_credentials::{DTGCredential, DTGCredentialType};
@@ -56,27 +62,74 @@ pub struct VerifiedInvitation {
     pub credential_id: String,
 }
 
-/// The Ed25519 public key a `did:key` verification method names.
+/// The Ed25519 public key a verification method names, with **no network**.
 ///
-/// `did:key:z6Mk…#z6Mk…` — the fragment is the identifier, so the key is *in* the name. The
-/// multibase decodes to a two-byte multicodec prefix (`0xed 0x01`, Ed25519) and 32 bytes of
-/// key.
-fn did_key_public_key(verification_method: &str) -> Result<Vec<u8>, String> {
+/// Two methods, and the same reason for both: they carry their keys in their identifiers,
+/// so resolving one is arithmetic rather than a lookup. That is what lets a browser member
+/// verify an invitation while offline, and it is the same guarantee `room-host` makes on
+/// the other side — its verifier is configured for no I/O, and since
+/// `vta-sdk`'s `TrustTaskVmResolver` learned `did:peer` the two agree about which methods
+/// that covers.
+///
+/// - `did:key:z6Mk…#z6Mk…` — the fragment *is* the identifier; decode the multibase.
+/// - `did:peer:2.Vz6Mk…` — resolved by `PeerResolver`, which the specification's own
+///   implementation describes as "pure computation (no IO)". Not hand-decoded here: the
+///   segment layout and the fragment convention are the resolver's to know, and a second
+///   opinion about them is a second thing to get wrong.
+///
+/// A `did:webvh` room — what production mints — would need real resolution, and that is the
+/// one thing this module would have to grow.
+fn verification_key(verification_method: &str) -> Result<Vec<u8>, String> {
     let did = verification_method
         .split('#')
         .next()
         .unwrap_or(verification_method);
-    let multibase = did
-        .strip_prefix("did:key:")
-        .ok_or_else(|| format!("`{did}` is not a did:key, and this build resolves nothing else"))?;
-    let (_base, bytes) =
-        multibase::decode(multibase).map_err(|e| format!("decode `{did}`: {e}"))?;
-    match bytes.split_at_checked(2) {
-        Some(([0xed, 0x01], key)) if key.len() == 32 => Ok(key.to_vec()),
-        _ => Err(format!(
-            "`{did}` does not name an Ed25519 key; a room signs with Ed25519"
-        )),
+
+    if let Some(multibase) = did.strip_prefix("did:key:") {
+        let (_base, bytes) =
+            multibase::decode(multibase).map_err(|e| format!("decode `{did}`: {e}"))?;
+        return match bytes.split_at_checked(2) {
+            Some(([0xed, 0x01], key)) if key.len() == 32 => Ok(key.to_vec()),
+            _ => Err(format!(
+                "`{did}` does not name an Ed25519 key; a room signs with Ed25519"
+            )),
+        };
     }
+
+    if did.starts_with("did:peer:") {
+        use affinidi_did_common::DID;
+        use affinidi_did_resolver_traits::{PeerResolver, Resolver};
+
+        let parsed =
+            DID::try_from(did).map_err(|e| format!("`{did}` is not a well-formed DID: {e}"))?;
+        let doc = PeerResolver
+            .resolve(&parsed)
+            .ok_or_else(|| format!("`{did}` is not a did:peer this build resolves"))?
+            .map_err(|e| format!("`{did}` did not resolve: {e}"))?;
+
+        // A proof names a method absolutely; a document may name it relatively. Accept
+        // both spellings of the same method rather than requiring the document to have
+        // chosen ours.
+        let relative = verification_method
+            .split_once('#')
+            .map(|(_, fragment)| format!("#{fragment}"))
+            .unwrap_or_default();
+        let entry = doc
+            .verification_method
+            .iter()
+            .find(|m| m.id.as_str() == verification_method || m.id.as_str() == relative)
+            .ok_or_else(|| {
+                format!("`{verification_method}` is not in the DID document for `{did}`")
+            })?;
+        return entry
+            .get_public_key_bytes()
+            .map_err(|e| format!("`{verification_method}` public key: {e}"));
+    }
+
+    Err(format!(
+        "`{did}` names a method this build cannot resolve without a network — only \
+         `did:key` and `did:peer` carry their keys in the identifier"
+    ))
 }
 
 /// Run the five checks. `spent` is the set of credential ids this key holder has already
@@ -154,7 +207,7 @@ pub fn verify(
         ));
     }
 
-    let key = did_key_public_key(&proof.verification_method)?;
+    let key = verification_key(&proof.verification_method)?;
     credential
         .verify_proof_with_public_key(&key)
         .map_err(|e| format!("the invitation's proof did not verify: {e}"))?;

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -803,6 +803,54 @@ mod tests {
         verify(&json, &room, me, &[]).expect("an invitation valid from now must verify now");
     }
 
+    /// A room identified by `did:peer:2` can issue an invitation this member verifies.
+    ///
+    /// The case that matters for admission: only a `did:peer:2` carries a service block, so
+    /// only it can advertise the mediator a member reaches the room's owner through. If the
+    /// invitation from such a room did not verify here, a room could be reachable and
+    /// un-joinable at the same time.
+    ///
+    /// Still no network — `PeerResolver` is pure computation, which is why the same check
+    /// works in a browser that is offline.
+    #[test]
+    fn an_invitation_from_a_did_peer_room_verifies() {
+        use affinidi_tdk::dids::{DID, KeyType, PeerKeyRole};
+
+        let (room, secrets) = DID::generate_did_peer(
+            vec![
+                (PeerKeyRole::Verification, KeyType::Ed25519),
+                (PeerKeyRole::Encryption, KeyType::X25519),
+            ],
+            None,
+        )
+        .expect("mint the room's did:peer");
+
+        // The room signs with its verification key, named the way a proof names one.
+        let signing = secrets
+            .iter()
+            .find(|s| s.id.ends_with("#key-1"))
+            .expect("the verification secret")
+            .clone();
+
+        let me = "did:key:zMember";
+        let now = chrono::Utc::now();
+        let mut vic = dtg_credentials::DTGCredential::new_vic(
+            room.clone(),
+            me.to_string(),
+            now - chrono::Duration::minutes(1),
+            Some(now + chrono::Duration::hours(1)),
+        )
+        .with_id("urn:uuid:peer-invite");
+        futures_lite::future::block_on(vic.sign(&signing, None)).expect("sign as the room");
+
+        let encoded = serde_json::to_string(vic.credential()).unwrap();
+        verify(&encoded, &room, me, &[])
+            .expect("a did:peer room's invitation must verify, with no network");
+
+        // And the issuer binding still bites: the same invitation, for somebody else.
+        assert!(verify(&encoded, &room, "did:key:zOther", &[]).is_err());
+    }
+
     /// Each of the five checks, made to bite.
     ///
     /// A gate is only worth having if every clause of it refuses something, and a five-check


### PR DESCRIPTION
The other half of #1364. That taught `vta-sdk`'s verifier that a `did:peer` needs no I/O;
this teaches the browser member the same thing — so a member and a host agree about which
methods they can check offline, rather than one of them refusing what the other accepts.

## Why `did:peer` rather than "another method for completeness"

Only a `did:peer:2` carries a **service block**, so only it lets a room advertise the
mediator its members reach its owner through. A `did:key` room can be joined only by
somebody the site was already told about — which is the boundary the data-room demo
currently runs into and says so on screen.

Without this change a room could be **reachable and un-joinable at the same time**:
advertising a mediator, while the invitations it issues fail to verify in the browser it
was advertising to.

## Resolved, not decoded

`PeerResolver` — the same one `vta-sdk` uses — rather than picking the `.V` segment out of
the identifier here. The segment layout and the fragment convention are the resolver's to
know, and a second opinion about them is a second thing to get wrong. That is the lesson
from the two hand-written presenter checks #1356 deleted, applied before making the mistake
rather than after.

Still **no network**: `PeerResolver` is pure computation, so it reaches `wasm32` and a
member verifies an invitation while offline. The unresolvable case now names both methods
it can do rather than only `did:key`.

## Verified

- New test mints a real `did:peer:2`, signs an invitation as the room, and asserts **both**
  that it verifies and that the subject binding still refuses somebody else. A resolver
  change that quietly widened what is accepted would pass the first assertion alone.
- 9 tests green; `cargo clippy -p vti-rooms-wasm --all-targets -- -D warnings` clean;
  `cargo check --target wasm32-unknown-unknown` clean.