### PR TITLE
feat(rooms)!: traces, and a response type for the single-record read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9636,9 +9636,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cac8a2d80fece4f26156b4064de2a3319bad0e5ce25159df2ed4a5bf9deb282"
+checksum = "5e9eb7c7122aef0a6e192de33bc38e25c8a5a4931d67a5d0e6ec1428efbc091b"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.19.0", default-features = false, features = [
+trust-tasks-rs = { version = "0.19.1", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -63,9 +63,9 @@ use vti_common::store::{KeyspaceHandle, Store};
 use vti_rooms::audit::{self as rooms_audit, RoomOperation};
 use vti_rooms::wire::{
     ChainBody, ChainResponse, ClaimOwnerBody, CreateRoomBody, CreateRoomResponse, CurateRecordBody,
-    CurateRecordResponse, GetRecordBody, ListRecordsBody, ListRecordsResponse, MintEpochBody,
-    MintEpochResponse, OwnerResponse, PutRecordBody, PutRecordResponse, ROOMS_CREATE_TYPE,
-    ROOMS_EPOCH_CHAIN_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_OWNER_CLAIM_TYPE,
+    CurateRecordResponse, GetRecordBody, GetRecordResponse, ListRecordsBody, ListRecordsResponse,
+    MintEpochBody, MintEpochResponse, OwnerResponse, PutRecordBody, PutRecordResponse,
+    ROOMS_CREATE_TYPE, ROOMS_EPOCH_CHAIN_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_OWNER_CLAIM_TYPE,
     ROOMS_OWNER_TRANSFER_TYPE, ROOMS_RECORDS_CURATE_TYPE, ROOMS_RECORDS_GET_TYPE,
     ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE, TransferOwnerBody,
 };
@@ -479,7 +479,10 @@ async fn get(
     match storage::get_record(&state.records, &req.room_id, &req.key).await {
         Ok(record) => {
             audit_room(&room, &authorized, RoomOperation::GetRecord, Some(&req.key));
-            respond(doc, record)
+            // Answered through the response type for the same reason the VTC is:
+            // `respond(doc, record)` put the *storage* record on the wire.
+            let (commitment, trace) = record_verification(state, &req.room_id, &req.key).await;
+            respond(doc, GetRecordResponse::of(&record, commitment, trace))
         }
         Err(e) => from_app_error(doc, &e),
     }
@@ -543,26 +546,68 @@ async fn list(
                     // The reference host commits too. A host that served
                     // listings without one would be a working example of the
                     // thing the commitment exists to make detectable.
-                    data_commitment: match storage::data_commitment(&state.records, &req.room_id)
-                        .await
-                    {
-                        Ok(root) => Some(vti_rooms::merkle::to_multibase(&root)),
-                        Err(e) => {
-                            // Advisory, so it must not fail the read — a member
-                            // who asked for records and got an error because the
-                            // tree was unhappy has lost a working operation.
-                            tracing::error!(
-                                room = %req.room_id,
-                                error = %e,
-                                "could not compute the data commitment; answering without one"
-                            );
-                            None
-                        }
-                    },
+                    data_commitment: room_commitment(state, &req.room_id).await,
                 },
             )
         }
         Err(e) => from_app_error(doc, &e),
+    }
+}
+
+/// The room's commitment and this record's trace, from one snapshot.
+///
+/// Both or neither. A trace with no commitment is a path to a root the reader
+/// was not given — the specification forbids it with `dependentRequired`, and
+/// serving one would be a host offering evidence it withheld the subject of.
+///
+/// A failure is answered with neither rather than with an error: these are
+/// additional guarantees the specification makes OPTIONAL precisely so a host
+/// that cannot assert one says nothing instead of something false. A member who
+/// asked for a record and got an error because the *tree* was unhappy has lost
+/// a working operation to an advisory one.
+async fn record_verification(
+    state: &HostState,
+    room_id: &str,
+    key: &str,
+) -> (Option<String>, Option<vti_rooms::merkle::InclusionProof>) {
+    match storage::data_commitment_with_trace(&state.records, room_id, key).await {
+        Ok((root, trace)) => (Some(vti_rooms::merkle::to_multibase(&root)), trace),
+        Err(e) => {
+            tracing::error!(
+                room = %room_id,
+                error = %e,
+                "could not commit the room; answering the read without a commitment or a trace"
+            );
+            (None, None)
+        }
+    }
+}
+
+/// The room's data commitment, or `None` if it could not be computed.
+///
+/// **A failure here must not fail the read.** The commitment is an additional
+/// guarantee and the specification makes it OPTIONAL precisely so a host that
+/// cannot assert one says nothing rather than something false — a member who
+/// asked for records and got an error because the *tree* was unhappy has lost a
+/// working operation to an advisory one.
+///
+/// Logged rather than swallowed: a host that has quietly stopped committing
+/// looks, to a member, exactly like one that never did.
+///
+/// One function for both reads, mirroring the VTC's, because a listing and a
+/// read that disagreed about the room's root would be this host equivocating
+/// with itself.
+async fn room_commitment(state: &HostState, room_id: &str) -> Option<String> {
+    match storage::data_commitment(&state.records, room_id).await {
+        Ok(root) => Some(vti_rooms::merkle::to_multibase(&root)),
+        Err(e) => {
+            tracing::error!(
+                room = %room_id,
+                error = %e,
+                "could not compute the room's data commitment; answering without one"
+            );
+            None
+        }
     }
 }
 

--- a/room-host/src/mirror.rs
+++ b/room-host/src/mirror.rs
@@ -189,7 +189,14 @@ pub async fn pull_once(state: &HostState, mirror: &MirroredRoom) -> anyhow::Resu
                 &mirror.signer_key_multibase,
             )
             .await?;
-        let record: Record = serde_json::from_value(full)?;
+        // The wire is not this host's storage format. It used to be — a get
+        // response deserialised straight into `Record`, which worked only
+        // because the response *was* the storage record — and that coupling is
+        // what put a storage type on the wire. `Record::from_wire` is the stated
+        // inverse of `Record::committed`, so the mirror now reads a response and
+        // rebuilds a record, rather than assuming they are one thing.
+        let wire: vti_rooms::wire::GetRecordResponse = serde_json::from_value(full)?;
+        let record = Record::from_wire(&wire.record)?;
         let version = record.version;
 
         match storage::store_mirrored_record(

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -33,8 +33,9 @@ use vti_rooms::authz::{self, Action};
 use vti_rooms::storage;
 use vti_rooms::wire::{
     ChainBody, ChainResponse, ClaimOwnerBody, CreateRoomBody, CreateRoomResponse, CurateRecordBody,
-    CurateRecordResponse, GetRecordBody, ListRecordsBody, ListRecordsResponse, MintEpochBody,
-    MintEpochResponse, OwnerResponse, PutRecordBody, PutRecordResponse, TransferOwnerBody,
+    CurateRecordResponse, GetRecordBody, GetRecordResponse, ListRecordsBody, ListRecordsResponse,
+    MintEpochBody, MintEpochResponse, OwnerResponse, PutRecordBody, PutRecordResponse,
+    TransferOwnerBody,
 };
 use vti_rooms::{Record, RecordStatus, Room};
 use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier, nomination};
@@ -393,28 +394,11 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
                 Some(&req.key),
             )
             .await;
-            // Serialised then extended rather than wrapped in a new type: the
-            // shape this has always returned is what consumers parse, and the
-            // commitment is one more member on it.
-            let mut payload = match serde_json::to_value(&record) {
-                Ok(v) => v,
-                Err(e) => {
-                    return app_error_to_reject(
-                        &doc,
-                        &vti_common::error::AppError::Internal(format!(
-                            "serialise record `{}`: {e}",
-                            req.key
-                        )),
-                    );
-                }
-            };
-            if let (Some(obj), Some(root)) = (
-                payload.as_object_mut(),
-                room_commitment(state, &req.room_id).await,
-            ) {
-                obj.insert("dataCommitment".into(), Value::String(root));
-            }
-            success_response(&doc, payload)
+            // The response is a type, not the stored record with a member bolted
+            // on. Serialising `Record` was what put a bare `sealed` string and
+            // six undeclared members on the wire — see `GetRecordResponse`.
+            let (commitment, trace) = record_verification(state, &req.room_id, &req.key).await;
+            success_response(&doc, GetRecordResponse::of(&record, commitment, trace))
         }
         Err(e) => app_error_to_reject(&doc, &e),
     }
@@ -478,6 +462,35 @@ pub(crate) async fn handle_list_records(
             data_commitment: room_commitment(state, &req.room_id).await,
         },
     )
+}
+
+/// The room's commitment and this record's trace, from one snapshot.
+///
+/// Both or neither. A trace with no commitment is a path to a root the reader
+/// was not given — the specification forbids it with `dependentRequired`, and
+/// serving one would be a host offering evidence it withheld the subject of.
+///
+/// A failure is answered with neither rather than with an error: these are
+/// additional guarantees the specification makes OPTIONAL precisely so a host
+/// that cannot assert one says nothing instead of something false. A member who
+/// asked for a record and got an error because the *tree* was unhappy has lost
+/// a working operation to an advisory one.
+async fn record_verification(
+    state: &AppState,
+    room_id: &str,
+    key: &str,
+) -> (Option<String>, Option<vti_rooms::merkle::InclusionProof>) {
+    match storage::data_commitment_with_trace(&state.room_records_ks, room_id, key).await {
+        Ok((root, trace)) => (Some(vti_rooms::merkle::to_multibase(&root)), trace),
+        Err(e) => {
+            tracing::error!(
+                room = %room_id,
+                error = %e,
+                "could not commit the room; answering the read without a commitment or a trace"
+            );
+            (None, None)
+        }
+    }
 }
 
 /// The room's data commitment, or `None` if it could not be computed.

--- a/vti-rooms/src/lib.rs
+++ b/vti-rooms/src/lib.rs
@@ -443,6 +443,108 @@ impl Record {
         }
         serde_json::Value::Object(map)
     }
+
+    /// The **leaf preimage**: this record in the form the room's commitment
+    /// covers.
+    ///
+    /// Not [`Record`] itself, and the difference is the whole point. Hashing
+    /// the storage record made the commitment reproducible only by another copy
+    /// of this crate: `updatedAt` is unix seconds here and RFC 3339 on the wire,
+    /// `epoch` and `nonce` are flat here and inside `sealed` on the wire, and
+    /// `epoch` serialises as `null` on an open room where the wire has it
+    /// absent. Three ways for two honest implementations to disagree about a
+    /// root, and nothing said which one counted.
+    ///
+    /// `sealed` is assembled only when all three of its parts are present. A
+    /// ciphertext with no nonce or no epoch is a **corrupt store** —
+    /// [`storage::put_record`] writes the three together or writes nothing — and
+    /// it degrades to a body-less record rather than to a fabricated half of
+    /// one, because a substituted epoch hands a reader a body whose AEAD open
+    /// fails for a reason pointing at the wrong thing.
+    #[must_use]
+    pub fn committed(&self) -> wire::CommittedRecord {
+        let sealed = match (&self.sealed, &self.nonce, self.epoch) {
+            (Some(ciphertext), Some(nonce), Some(epoch)) => Some(wire::SealedContent {
+                ciphertext: ciphertext.clone(),
+                nonce: nonce.clone(),
+                epoch,
+            }),
+            _ => None,
+        };
+        wire::CommittedRecord {
+            key: self.key.clone(),
+            version: self.version,
+            status: self.status,
+            updated_at: rfc3339(self.updated_at),
+            pinned: self.pinned,
+            author: self.author.clone(),
+            sealed,
+            cleartext: self.cleartext.clone(),
+        }
+    }
+
+    /// Read a wire record back into a storage record — the inverse of
+    /// [`Record::committed`].
+    ///
+    /// # Why this has to exist
+    ///
+    /// A mirror pulls records from its primary and stores them, and it used to
+    /// do that with `serde_json::from_value::<Record>(response)` — which worked
+    /// only because the response *was* the storage record. That coupling is
+    /// what put a storage type on the wire in the first place, so removing one
+    /// without the other breaks replication. The two functions are inverses and
+    /// `a_record_round_trips_through_its_committed_form` says so, which is a
+    /// property rather than the coincidence of their being one type.
+    ///
+    /// # One thing does not survive, deliberately
+    ///
+    /// A **retracted** record keeps its epoch in storage and has nowhere to put
+    /// it on the wire: the epoch travels inside `sealed`, where the AEAD binds
+    /// it, and a tombstone has no `sealed`. So a mirrored tombstone comes back
+    /// with `epoch: None`.
+    ///
+    /// That is the right trade rather than a gap to plug. A top-level `epoch`
+    /// beside `sealed` is a second place for the same value to live, which is
+    /// the disagreement this whole type exists to end — and a tombstone's epoch
+    /// is read nowhere: the only check against it (`storage::put_record`) runs
+    /// on a write that a retracted record can never take again.
+    pub fn from_wire(record: &wire::CommittedRecord) -> Result<Self, FromWireError> {
+        let parsed = chrono::DateTime::parse_from_rfc3339(&record.updated_at).map_err(|_| {
+            FromWireError::UpdatedAt {
+                key: record.key.clone(),
+                value: record.updated_at.clone(),
+            }
+        })?;
+        let updated_at =
+            u64::try_from(parsed.timestamp()).map_err(|_| FromWireError::UpdatedAt {
+                key: record.key.clone(),
+                value: record.updated_at.clone(),
+            })?;
+        Ok(Self {
+            key: record.key.clone(),
+            version: record.version,
+            epoch: record.sealed.as_ref().map(|s| s.epoch),
+            status: record.status,
+            pinned: record.pinned,
+            sealed: record.sealed.as_ref().map(|s| s.ciphertext.clone()),
+            nonce: record.sealed.as_ref().map(|s| s.nonce.clone()),
+            cleartext: record.cleartext.clone(),
+            author: record.author.clone(),
+            updated_at,
+        })
+    }
+}
+
+/// A wire record that could not be read back into a storage record.
+#[derive(Debug, thiserror::Error)]
+pub enum FromWireError {
+    /// `updatedAt` was not an RFC 3339 timestamp, or named an instant before
+    /// the epoch. Either way the record cannot be stored: a mirror that guessed
+    /// a time would write a record whose age is fiction.
+    #[error(
+        "record `{key}` carries `updatedAt` = `{value}`, which is not a storable RFC 3339 timestamp"
+    )]
+    UpdatedAt { key: String, value: String },
 }
 
 #[cfg(test)]

--- a/vti-rooms/src/merkle.rs
+++ b/vti-rooms/src/merkle.rs
@@ -20,7 +20,7 @@
 //! unsorted leaves can prove everything it contains and nothing about what it
 //! omits — which is the property being bought.
 //!
-//! # A leaf commits to the whole record
+//! # A leaf commits to the whole record, in its WIRE form
 //!
 //! Not to the body, and not to a chosen subset. A host that could flip `status`
 //! from active to retracted, or move `pinned`, or rewrite `author` on an
@@ -28,6 +28,17 @@
 //! touching a byte of ciphertext. Picking fields invites picking wrongly, so the
 //! leaf commits to the record's canonical JSON (RFC 8785) — every member,
 //! present or absent, in an order no refactor can change.
+//!
+//! **The record it hashes is [`CommittedRecord`], not [`Record`].** This is the
+//! difference between a commitment two implementations can compare and one only
+//! another copy of this crate can reproduce, and it is not a detail: `updatedAt`
+//! is unix seconds in storage and RFC 3339 on the wire, `epoch` and `nonce` are
+//! flat in storage and inside `sealed` on the wire, and `epoch` serialises as
+//! `null` on an open room where the wire has it absent. An earlier version of
+//! this module hashed the storage record, so every root it produced was
+//! unreachable by any reader — survivable while the only use was comparing two
+//! roots from the same build, and not survivable once a trace has to be
+//! *computable by someone else*.
 //!
 //! **The plaintext is never involved.** On the sealed tiers the host holds
 //! ciphertext and could not commit to a body if it wanted to; the leaf commits
@@ -44,6 +55,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::Record;
+use crate::wire::CommittedRecord;
 
 /// Prefix for a leaf hash (RFC 6962 §2.1).
 const LEAF_PREFIX: u8 = 0x00;
@@ -71,9 +83,16 @@ pub enum MerkleError {
 /// Hash one record into a leaf.
 ///
 /// Canonical JSON per RFC 8785, so the leaf commits to what the record *means*
-/// rather than to one serialiser's field order. A field added to [`Record`]
-/// later is committed automatically, which is the point of not enumerating.
-pub fn leaf_hash(record: &Record) -> Result<Hash, MerkleError> {
+/// rather than to one serialiser's field order. A member added to
+/// [`CommittedRecord`] later is committed automatically, which is the point of
+/// not enumerating.
+///
+/// It takes the **committed** form rather than the stored one because that is
+/// what a reader has: a consumer verifying a trace holds a
+/// `rooms/records/get` response, strips `dataCommitment`, `trace` and `ext`,
+/// and hashes what is left. Anything this function could not be handed by a
+/// reader is a root the reader cannot check.
+pub fn leaf_hash(record: &CommittedRecord) -> Result<Hash, MerkleError> {
     let canonical =
         serde_json_canonicalizer::to_vec(record).map_err(|source| MerkleError::Canonicalise {
             key: record.key.clone(),
@@ -145,7 +164,7 @@ pub fn commit_records(records: &mut [Record]) -> Result<Hash, MerkleError> {
     records.sort_by(|a, b| a.key.cmp(&b.key));
     let leaves = records
         .iter()
-        .map(leaf_hash)
+        .map(|r| leaf_hash(&r.committed()))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(root_of(&leaves))
 }
@@ -154,8 +173,13 @@ pub fn commit_records(records: &mut [Record]) -> Result<Hash, MerkleError> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProofStep {
-    /// The sibling hash, hex-encoded on the wire.
-    #[serde(with = "hex_hash")]
+    /// The sibling hash, a `DigestMultibase` on the wire.
+    ///
+    /// The same encoding `dataCommitment` uses, and for the same reason: a bare
+    /// hex string hard-codes SHA-256 into the wire contract, where a multihash
+    /// names the algorithm in-band. A trace and the root it reaches would
+    /// otherwise be spelled two ways in one document.
+    #[serde(with = "multibase_hash")]
     pub sibling: Hash,
     /// Whether the sibling is the **left** child; the proven node is the other.
     pub sibling_is_left: bool,
@@ -222,34 +246,19 @@ pub fn verify_inclusion(root: &Hash, leaf: &Hash, proof: &InclusionProof) -> boo
     &current == root
 }
 
-/// Hex for the wire, because a commitment travels in JSON and bytes do not.
-mod hex_hash {
-    use super::Hash;
+/// `DigestMultibase` for the wire, because a digest travels in JSON and bytes
+/// do not — and because the root beside it is spelled the same way.
+mod multibase_hash {
+    use super::{Hash, from_multibase, to_multibase};
     use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
 
     pub fn serialize<S: Serializer>(value: &Hash, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str(&hex(value))
+        s.serialize_str(&to_multibase(value))
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Hash, D::Error> {
         let text = String::deserialize(d)?;
-        let bytes = unhex(&text).ok_or_else(|| D::Error::custom("not a 32-byte hex digest"))?;
-        Ok(bytes)
-    }
-
-    fn hex(bytes: &Hash) -> String {
-        bytes.iter().map(|b| format!("{b:02x}")).collect()
-    }
-
-    fn unhex(text: &str) -> Option<Hash> {
-        if text.len() != 64 {
-            return None;
-        }
-        let mut out = [0u8; 32];
-        for (i, byte) in out.iter_mut().enumerate() {
-            *byte = u8::from_str_radix(text.get(i * 2..i * 2 + 2)?, 16).ok()?;
-        }
-        Some(out)
+        from_multibase(&text).map_err(D::Error::custom)
     }
 }
 
@@ -393,10 +402,10 @@ mod tests {
                 },
             ),
         ];
-        let original = leaf_hash(&base).expect("hashes");
+        let original = leaf_hash(&base.committed()).expect("hashes");
         for (what, altered) in &mut cases {
             assert_ne!(
-                leaf_hash(altered).expect("hashes"),
+                leaf_hash(&altered.committed()).expect("hashes"),
                 original,
                 "a host could change `{what}` without moving the leaf"
             );
@@ -419,8 +428,8 @@ mod tests {
     /// node's preimage can be offered as a leaf.
     #[test]
     fn a_leaf_and_a_node_over_the_same_bytes_differ() {
-        let a = leaf_hash(&record("a", 1)).expect("hashes");
-        let b = leaf_hash(&record("b", 2)).expect("hashes");
+        let a = leaf_hash(&record("a", 1).committed()).expect("hashes");
+        let b = leaf_hash(&record("b", 2).committed()).expect("hashes");
         let parent = node_hash(&a, &b);
 
         let mut undomained = Sha256::new();
@@ -439,7 +448,7 @@ mod tests {
             let root = commit_records(&mut records).expect("commits");
             let leaves: Vec<Hash> = records
                 .iter()
-                .map(|r| leaf_hash(r).expect("hashes"))
+                .map(|r| leaf_hash(&r.committed()).expect("hashes"))
                 .collect();
 
             for (i, leaf) in leaves.iter().enumerate() {
@@ -462,11 +471,11 @@ mod tests {
         let root = commit_records(&mut records).expect("commits");
         let leaves: Vec<Hash> = records
             .iter()
-            .map(|r| leaf_hash(r).expect("hashes"))
+            .map(|r| leaf_hash(&r.committed()).expect("hashes"))
             .collect();
         let proof = inclusion_proof(&leaves, 0).expect("proof");
 
-        let outsider = leaf_hash(&record("zzz", 99)).expect("hashes");
+        let outsider = leaf_hash(&record("zzz", 99).committed()).expect("hashes");
         assert!(
             !verify_inclusion(&root, &outsider, &proof),
             "a record the room does not hold proved against its root"
@@ -484,7 +493,7 @@ mod tests {
         let root = commit_records(&mut records).expect("commits");
         let leaves: Vec<Hash> = records
             .iter()
-            .map(|r| leaf_hash(r).expect("hashes"))
+            .map(|r| leaf_hash(&r.committed()).expect("hashes"))
             .collect();
         let mut proof = inclusion_proof(&leaves, 1).expect("proof");
 
@@ -501,7 +510,7 @@ mod tests {
 
     #[test]
     fn an_index_outside_the_tree_has_no_proof() {
-        let leaves = [leaf_hash(&record("a", 1)).expect("hashes")];
+        let leaves = [leaf_hash(&record("a", 1).committed()).expect("hashes")];
         assert!(inclusion_proof(&leaves, 1).is_none());
         assert!(inclusion_proof(&[], 0).is_none());
     }
@@ -552,7 +561,7 @@ mod tests {
     fn a_step_round_trips_through_json() {
         let leaves: Vec<Hash> = ["a", "b", "c"]
             .iter()
-            .map(|k| leaf_hash(&record(k, 1)).expect("hashes"))
+            .map(|k| leaf_hash(&record(k, 1).committed()).expect("hashes"))
             .collect();
         let proof = inclusion_proof(&leaves, 0).expect("proof");
         let json = serde_json::to_string(&proof).expect("serialises");

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -514,6 +514,47 @@ pub async fn data_commitment(
         .map_err(|e| AppError::Internal(format!("commit the records of `{room_id}`: {e}")))
 }
 
+/// The room's data commitment **and** the trace for one record, from one scan.
+///
+/// # Why they are computed together and not separately
+///
+/// A trace is a statement about the tree it was cut from, and a room moves. Two
+/// calls — one for the root, one for the path — can straddle a write, and the
+/// pair a host then serves is *individually* correct and *jointly* false: the
+/// trace does not reach the root, the reader concludes the host is equivocating,
+/// and the host has done nothing wrong. That is the worst available failure,
+/// because it discredits the mechanism rather than the host.
+///
+/// The specification requires the same snapshot for both. One function is how
+/// that requirement is held rather than remembered.
+///
+/// `None` for the trace means the key is not in the room, which a caller that
+/// has just read the record can only see as a race with a retraction — the root
+/// is still honest and is still returned, so the read answers with a
+/// commitment and no path rather than failing.
+pub async fn data_commitment_with_trace(
+    records: &KeyspaceHandle,
+    room_id: &str,
+    key: &str,
+) -> Result<(crate::merkle::Hash, Option<crate::merkle::InclusionProof>), AppError> {
+    let mut all = list_records(records, room_id, None, None).await?;
+    // Ordering is the commitment's, so the index has to come from the sorted
+    // set — `commit_records` sorts in place, which is why this reads the
+    // position afterwards rather than before.
+    all.sort_by(|a, b| a.key.cmp(&b.key));
+    let leaves = all
+        .iter()
+        .map(|r| crate::merkle::leaf_hash(&r.committed()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| AppError::Internal(format!("commit the records of `{room_id}`: {e}")))?;
+    let root = crate::merkle::root_of(&leaves);
+    let trace = all
+        .iter()
+        .position(|r| r.key == key)
+        .and_then(|index| crate::merkle::inclusion_proof(&leaves, index));
+    Ok((root, trace))
+}
+
 /// What one curation changes.
 ///
 /// A struct rather than three parameters because they are one *decision* — a curator

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{RecordStatus, Visibility};
+use crate::{Record, RecordStatus, Visibility};
 
 /// `rooms/create/0.1`.
 pub const ROOMS_CREATE_TYPE: &str = "https://trusttasks.org/spec/rooms/create/0.1";
@@ -227,6 +227,117 @@ pub struct ListRecordsBody {
     pub since_version: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
+}
+
+/// **The leaf preimage of the record tree** — the object a host hashes into a
+/// leaf and a reader reassembles to check a [`crate::merkle::InclusionProof`].
+///
+/// This is the wire's `CommittedRecord` (`rooms/_shared/0.1`), and it is
+/// deliberately not [`Record`]. A commitment nobody but its author can
+/// recompute is not a commitment, and hashing the *storage* record made it one:
+/// `updatedAt` is unix seconds in the store and RFC 3339 on the wire, `epoch`
+/// and `nonce` sit flat in the store and inside `sealed` on the wire, and
+/// `epoch` serialises as `null` on an open room where the wire has it absent.
+/// A second implementation reading only the specification could not reproduce
+/// a single root.
+///
+/// **Absence carries meaning**, so every presence rule here is exact:
+///
+/// - `pinned` is serialised **only** when true. `false` is not a spelling of
+///   this member; absent is. Two spellings would give one record two roots.
+/// - `epoch` is not a member. It lives inside `sealed`, where the AEAD binds
+///   it, and a top-level copy would be a second place for it to disagree with
+///   itself.
+/// - `sealed` on the sealed tiers, `cleartext` on `open`, and **neither** on a
+///   `retracted` tombstone.
+/// - `title`/`description` are not members: a listing lifts them out of an open
+///   room's body, and committing to both would commit to the same bytes twice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommittedRecord {
+    pub key: String,
+    pub version: u64,
+    pub status: RecordStatus,
+    /// RFC 3339. The digest is over the **wire** form, never over the unix
+    /// seconds the store keeps.
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pinned: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sealed: Option<SealedContent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleartext: Option<serde_json::Value>,
+}
+
+/// `rooms/records/get/0.1#response`.
+///
+/// # Why this type exists, having not existed
+///
+/// Both hosts answered a read by serialising [`Record`] — the *storage* record
+/// — and adding `dataCommitment` to whatever came out. That is not this task's
+/// response and never was. `sealed` is stored as a bare base64url string where
+/// the schema types it as a `SealedRecord` object, and `epoch`, `nonce`,
+/// `status`, `pinned`, `author` and `updatedAt` were emitted flat — so under the
+/// response's `additionalProperties: false` a single read produced a type error
+/// and six violations.
+///
+/// It survived because this module's rule — every wire type appears in
+/// `tests/schema_conformance.rs` — can only be applied to types that *exist*.
+/// A response with no type had no line to be missing from, and a storage record
+/// reached the wire because nothing stood between them.
+///
+/// The consumer is not hypothetical: `@openvtc/pnm-core`'s `roomsRecordsGet` is
+/// typed on the **generated** payload, so a caller reading `sealed.ciphertext`
+/// got `undefined` from a live host — with a green type-check on both sides.
+///
+/// # The response *is* the leaf preimage, plus three members
+///
+/// Strip `dataCommitment`, `trace` and `ext` and what remains is exactly a
+/// [`CommittedRecord`], which is why the flattened field is that type rather
+/// than a repetition of it. A reader reassembles the preimage by **deletion**,
+/// not reconstruction, and the ciphertext is never carried twice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetRecordResponse {
+    /// Everything the room's commitment covers.
+    #[serde(flatten)]
+    pub record: CommittedRecord,
+    /// The room's data commitment, as a `DigestMultibase`.
+    ///
+    /// Optional for the same reason it is on a listing: a host that maintains
+    /// no tree must not invent a root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_commitment: Option<String>,
+    /// The path from this record's leaf to `data_commitment`.
+    ///
+    /// Served only with the commitment it reaches, and computed from the same
+    /// snapshot: a trace is a statement about the tree it was cut from, and a
+    /// room moves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace: Option<crate::merkle::InclusionProof>,
+}
+
+impl GetRecordResponse {
+    /// The response for `record`, with whatever verification the host can
+    /// offer.
+    ///
+    /// Built here rather than in each host so the two cannot answer a read
+    /// differently — which is exactly how the shape above went wrong, in two
+    /// files, for as long as the response had no type.
+    #[must_use]
+    pub fn of(
+        record: &Record,
+        data_commitment: Option<String>,
+        trace: Option<crate::merkle::InclusionProof>,
+    ) -> Self {
+        Self {
+            record: record.committed(),
+            data_commitment,
+            trace,
+        }
+    }
 }
 
 /// `rooms/records/list/0.1#response`.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -33,7 +33,7 @@
 use serde_json::{Value, json};
 use trust_tasks_rs::validate::ValidatedPayload;
 use vti_rooms::wire::*;
-use vti_rooms::{Record, RecordStatus, Visibility};
+use vti_rooms::{Record, RecordStatus, Visibility, merkle};
 
 /// Validate `value` against the schema published for `T`.
 fn check<T: ValidatedPayload>(what: &str, value: &Value) {
@@ -357,6 +357,295 @@ fn responses_conform() {
     );
 
     check::<ListResponse>("ListRecordsResponse", &json!({ "records": records }));
+}
+
+/// The single-record read, on every tier and on a tombstone.
+///
+/// This is the test that was missing, and its absence is why the read shipped
+/// non-conforming: the rule in `wire`'s header — every wire type appears here —
+/// could not reach a response that was never a type. Both hosts serialised
+/// `Record` itself, which puts a bare `sealed` string where the schema types an
+/// object and adds six members `additionalProperties: false` forbids.
+///
+/// It builds through `GetRecordResponse::of` rather than a literal for the same
+/// reason the listing runs `Record::metadata()`: the conversion is the thing
+/// that has to conform, and a literal written beside it would only ever agree
+/// with itself.
+#[test]
+fn get_record_response_conforms() {
+    use trust_tasks_rs::specs::rooms::records::get::v0_1::Response as GetResponse;
+
+    // A sealed record, as `attributed` and `private` store one, answered with
+    // both verification members.
+    let sealed = Record {
+        key: "giXFLTGBdnnQJRoIsktuIg".into(),
+        version: 3,
+        epoch: Some(2),
+        status: RecordStatus::Active,
+        pinned: true,
+        sealed: Some("c2VhbGVkLWJvZHk".into()),
+        nonce: Some("bm9uY2UtMTI".into()),
+        cleartext: None,
+        author: None,
+        updated_at: 1_756_000_000,
+    };
+    let mut records = vec![
+        sealed.clone(),
+        Record {
+            key: "aaa".into(),
+            ..sealed.clone()
+        },
+    ];
+    let root = merkle::commit_records(&mut records).expect("commits");
+    let leaves: Vec<merkle::Hash> = records
+        .iter()
+        .map(|r| merkle::leaf_hash(&r.committed()).expect("hashes"))
+        .collect();
+    let index = records
+        .iter()
+        .position(|r| r.key == sealed.key)
+        .expect("the record is in its own room");
+    let trace = merkle::inclusion_proof(&leaves, index).expect("a trace for a record that exists");
+
+    let response = GetRecordResponse::of(
+        &sealed,
+        Some(merkle::to_multibase(&root)),
+        Some(trace.clone()),
+    );
+    let value = serde_json::to_value(&response).expect("serialise");
+    assert_eq!(
+        value["sealed"]["ciphertext"], "c2VhbGVkLWJvZHk",
+        "the wire carries one SealedRecord object, not three flat members: {value}"
+    );
+    assert_eq!(
+        value["sealed"]["epoch"], 2,
+        "the epoch travels inside the sealed body, where the AEAD binds it: {value}"
+    );
+    assert_eq!(
+        value["updatedAt"], "2025-08-24T01:46:40Z",
+        "the committed form renders RFC 3339, not the unix seconds it stores: {value}"
+    );
+    assert_eq!(value["pinned"], true, "pinned is committed: {value}");
+    assert!(
+        value["trace"][0]["sibling"]
+            .as_str()
+            .expect("a sibling is a string")
+            .starts_with('z'),
+        "a sibling is a DigestMultibase, spelled as the root beside it is: {value}"
+    );
+    check::<GetResponse>("GetRecordResponse (sealed, with a trace)", &value);
+
+    // An open record: a cleartext body, no epoch, and no commitment because
+    // this host does not maintain a tree.
+    let open = Record {
+        key: "decision/pricing-2026".into(),
+        version: 1,
+        epoch: None,
+        status: RecordStatus::Active,
+        pinned: false,
+        sealed: None,
+        nonce: None,
+        cleartext: Some(json!({ "body": "Agreed not to reprice before the renewal closes." })),
+        author: Some("did:key:z6MkAlice".into()),
+        updated_at: 1_756_000_100,
+    };
+    let value = serde_json::to_value(GetRecordResponse::of(&open, None, None)).expect("serialise");
+    assert!(
+        value.get("dataCommitment").is_none()
+            && value.get("sealed").is_none()
+            && value.get("pinned").is_none(),
+        "an absent optional must be absent, and `pinned: false` is spelled by absence: {value}"
+    );
+    check::<GetResponse>("GetRecordResponse (open)", &value);
+
+    // A tombstone: no body at all, and it still has to conform.
+    let tombstone = Record {
+        key: "giXFLTGBdnnQJRoIsktuIg".into(),
+        version: 5,
+        epoch: Some(2),
+        status: RecordStatus::Retracted,
+        pinned: false,
+        sealed: None,
+        nonce: None,
+        cleartext: None,
+        author: None,
+        updated_at: 1_756_000_200,
+    };
+    let value =
+        serde_json::to_value(GetRecordResponse::of(&tombstone, None, None)).expect("serialise");
+    check::<GetResponse>("GetRecordResponse (tombstone)", &value);
+}
+
+/// A reader reassembles the leaf preimage by DELETING three members, and the
+/// trace it was handed reaches the root it was handed.
+///
+/// This is the whole property, run the way a consumer runs it: from the bytes
+/// of a response, with no access to the host's tree. Every earlier test in this
+/// family checks a host against itself.
+#[test]
+fn a_reader_verifies_a_trace_from_the_response_alone() {
+    let room: Vec<Record> = ["a", "b", "c", "d", "e"]
+        .iter()
+        .enumerate()
+        .map(|(i, key)| Record {
+            key: (*key).into(),
+            version: i as u64 + 1,
+            epoch: Some(2),
+            status: RecordStatus::Active,
+            pinned: false,
+            sealed: Some("c2VhbGVkLWJvZHk".into()),
+            nonce: Some("bm9uY2UtMTI".into()),
+            cleartext: None,
+            author: None,
+            updated_at: 1_756_000_000,
+        })
+        .collect();
+
+    let mut ordered = room.clone();
+    let root = merkle::commit_records(&mut ordered).expect("commits");
+    let leaves: Vec<merkle::Hash> = ordered
+        .iter()
+        .map(|r| merkle::leaf_hash(&r.committed()).expect("hashes"))
+        .collect();
+
+    for (index, record) in ordered.iter().enumerate() {
+        let response = GetRecordResponse::of(
+            record,
+            Some(merkle::to_multibase(&root)),
+            Some(merkle::inclusion_proof(&leaves, index).expect("a trace")),
+        );
+        // Everything past this line is what a *reader* does: it has bytes.
+        let bytes = serde_json::to_value(&response).expect("serialise");
+        let mut preimage = bytes.as_object().expect("an object").clone();
+        for member in ["dataCommitment", "trace", "ext"] {
+            preimage.remove(member);
+        }
+        let committed: vti_rooms::wire::CommittedRecord =
+            serde_json::from_value(Value::Object(preimage)).expect("the preimage is a record");
+
+        let leaf = merkle::leaf_hash(&committed).expect("hashes");
+        let served_root =
+            merkle::from_multibase(bytes["dataCommitment"].as_str().expect("a commitment"))
+                .expect("the root decodes");
+        let served_trace: merkle::InclusionProof =
+            serde_json::from_value(bytes["trace"].clone()).expect("the trace decodes");
+
+        assert!(
+            merkle::verify_inclusion(&served_root, &leaf, &served_trace),
+            "record `{}` does not verify against the root served beside it",
+            record.key
+        );
+    }
+}
+
+/// The two conversions are inverses, which is what lets a mirror stop treating
+/// the wire as its storage format.
+#[test]
+fn a_record_round_trips_through_its_committed_form() {
+    let sealed = Record {
+        key: "giXFLTGBdnnQJRoIsktuIg".into(),
+        version: 7,
+        epoch: Some(4),
+        status: RecordStatus::Deprecated,
+        pinned: true,
+        sealed: Some("c2VhbGVkLWJvZHk".into()),
+        nonce: Some("bm9uY2UtMTI".into()),
+        cleartext: None,
+        author: Some("did:key:z6MkAlice".into()),
+        updated_at: 1_756_000_000,
+    };
+    let back = Record::from_wire(&sealed.committed()).expect("reads back");
+    assert_eq!(
+        serde_json::to_value(&back).expect("serialise"),
+        serde_json::to_value(&sealed).expect("serialise"),
+        "a sealed record must survive the wire form unchanged"
+    );
+
+    // The one documented loss: a tombstone's epoch has nowhere to live on the
+    // wire, because the epoch travels inside `sealed` and a tombstone has none.
+    let tombstone = Record {
+        status: RecordStatus::Retracted,
+        sealed: None,
+        nonce: None,
+        ..sealed.clone()
+    };
+    let back = Record::from_wire(&tombstone.committed()).expect("reads back");
+    assert_eq!(
+        back.epoch, None,
+        "a tombstone's epoch is not carried, and that is stated rather than discovered"
+    );
+    assert_eq!(back.status, RecordStatus::Retracted);
+    assert_eq!(back.version, tombstone.version);
+}
+
+/// A trace without the root it reaches is refused by the schema, which is what
+/// makes the test above mean something.
+///
+/// `GetRecordResponse::of` cannot produce this state — it takes both or
+/// neither — so this is deliberately a hand-built document. What it pins is not
+/// our code but the *validator*: `dependentRequired` is the only thing standing
+/// between a host serving a path to a root it withheld and a reader with no way
+/// to say so, and a constraint no test exercises is one that can be dropped from
+/// a schema without anything going red.
+#[test]
+fn a_trace_without_a_commitment_is_refused() {
+    use trust_tasks_rs::specs::rooms::records::get::v0_1::Response as GetResponse;
+
+    let orphan = json!({
+        "key": "giXFLTGBdnnQJRoIsktuIg",
+        "version": 3,
+        "status": "active",
+        "updatedAt": "2025-08-24T01:46:40Z",
+        "trace": [{
+            "sibling": "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            "siblingIsLeft": true
+        }]
+    });
+    assert!(
+        GetResponse::validate_value(&orphan).is_err(),
+        "a trace served without its dataCommitment must not validate"
+    );
+
+    // And the same document with the root put back does validate — otherwise
+    // the assertion above would pass for any reason at all.
+    let mut whole = orphan.as_object().expect("an object").clone();
+    whole.insert(
+        "dataCommitment".into(),
+        json!("zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR"),
+    );
+    check::<GetResponse>(
+        "GetRecordResponse (trace with its commitment)",
+        &Value::Object(whole),
+    );
+}
+
+/// A ciphertext with no nonce is a corrupt store, and loses its body rather
+/// than gaining a fabricated half of one.
+///
+/// `rooms/records/put` writes the three parts together or writes nothing, so
+/// this is unreachable by construction. It is pinned anyway because the
+/// alternative — defaulting the epoch to zero to make the object well-formed —
+/// hands a reader a body whose AEAD open fails for a reason that points at the
+/// wrong thing, and that is the kind of convenience someone adds later while
+/// tidying a `match`.
+#[test]
+fn a_half_sealed_record_loses_its_body() {
+    let half = Record {
+        key: "giXFLTGBdnnQJRoIsktuIg".into(),
+        version: 3,
+        epoch: None,
+        status: RecordStatus::Active,
+        pinned: false,
+        sealed: Some("c2VhbGVkLWJvZHk".into()),
+        nonce: Some("bm9uY2UtMTI".into()),
+        cleartext: None,
+        author: None,
+        updated_at: 1_756_000_000,
+    };
+    assert!(
+        half.committed().sealed.is_none(),
+        "a sealed body with no epoch must not be assembled with a substitute one"
+    );
 }
 
 /// Curate shipped without an entry here — the same omission as its missing dispatch-census


### PR DESCRIPTION
Verified reads, finished. A commitment lets a reader catch a host that equivocates; a **trace** proves a particular record sits under the root that host just asserted. This serves them — and fixes the conformance defect that adding them uncovered.

Implements [trust-tasks-tf#419](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/419), released as `trust-tasks-rs` 0.19.1.

## `rooms/records/get` has never conformed to its published schema

Both hosts answered a read by serialising `vti_rooms::Record` — the *storage* record — and adding `dataCommitment` to whatever came out:

```
"c2VhbGVk" is not of type "object";
Additional properties are not allowed
('author', 'epoch', 'nonce', 'pinned', 'status', 'updatedAt' were unexpected)
```

`sealed` is stored as a bare base64url string where the schema types it as a `SealedRecord` object, and six members were emitted flat under an `additionalProperties: false` response.

It survived because `vti_rooms::wire`'s rule — *every wire type appears in `tests/schema_conformance.rs`* — can only be applied to types that **exist**. A response that was never a type had no line to be missing from, and a storage record reached the wire because nothing stood between them.

The consumer is not hypothetical: `@openvtc/pnm-core`'s `roomsRecordsGet` is typed on the **generated** payload, so a caller reading `sealed.ciphertext` got `undefined` from a live host — with a green type-check on both sides. The record-read UI would have been the first thing to hit it.

## The leaf preimage was not reproducible either

`leaf_hash` canonicalised the storage record, so every root it produced was unreachable by any reader: `updatedAt` is unix seconds in storage and RFC 3339 on the wire, `epoch`/`nonce` are flat in storage and inside `sealed` on the wire, and `epoch` serialises as `null` on an open room where the wire has it absent.

Survivable while the only use was comparing two roots from the same build. Not survivable once a trace has to be **computable by someone else** — which is exactly what #419 settled, as `CommittedRecord`.

## What this adds

| | |
|---|---|
| `wire::CommittedRecord` | the leaf preimage, with every presence rule exact (`pinned` only when true, `epoch` only inside `sealed`) |
| `wire::GetRecordResponse` | that, plus `dataCommitment` and `trace`. `#[serde(flatten)]` on the committed half, so the response literally **is** the preimage plus three members |
| `Record::committed()` / `Record::from_wire()` | inverses, pinned as a round-trip property |
| `merkle::leaf_hash(&CommittedRecord)` | takes what a reader has, not what a host stores |
| `ProofStep.sibling` | a `DigestMultibase`, not hex — a trace and the root it reaches were spelled two ways in one document |
| `storage::data_commitment_with_trace` | root and path from **one scan** |
| both hosts | serve them, both-or-neither |
| `room-host` `room_commitment` | extracted from the listing so a listing and a read cannot disagree about the room's root |

**One scan, not two, is a correctness requirement rather than an optimisation.** Two calls can straddle a write, and the pair a host then serves is *individually* correct and *jointly* false: the trace does not reach the root, the reader concludes the host is equivocating, and the host has done nothing wrong. That is the worst available failure, because it discredits the mechanism rather than the host. The specification requires the same snapshot; one function is how that gets held rather than remembered.

## The mirror was the same defect wearing another hat

`room-host/src/mirror.rs` deserialised the get response straight back into a `Record`. That worked only because the response *was* the storage record — so conforming the response without touching the mirror breaks replication, which is what the test suite said when I tried it:

```
the mirror pulls from its primary: missing field `status`
```

It now reads a `GetRecordResponse` and rebuilds through `Record::from_wire`. The two conversions being inverses is a **property with a test**, rather than the coincidence of their being one type.

**One documented loss:** a retracted record's epoch does not survive. The epoch travels inside `sealed`, where the AEAD binds it, and a tombstone has none. A top-level copy beside `sealed` would be a second place for the same value to disagree with itself — the thing this type exists to end. Checked before accepting it: nothing reads a tombstone's epoch (the only check runs on a write a retracted record can never take again) and `store_mirrored_record` does not validate it. Stated in `from_wire`, pinned by a test.

## Tests

The one that matters does what a **consumer** does — takes the response bytes, deletes `dataCommitment`/`trace`/`ext`, hashes what is left, and verifies the trace against the root served beside it, for every record in a five-record room, with no access to the host's tree. Every earlier test in this family only ever checked a host against itself.

Also added: `get_record_response_conforms` (both tiers, a tombstone, and a trace), the round-trip, the half-sealed corrupt-store case, and `a_trace_without_a_commitment_is_refused` — a hand-built document, because `GetRecordResponse::of` cannot produce that state and what needs pinning is that `dependentRequired` is *enforced by the validator*. A constraint no test exercises can be dropped from a schema without anything going red.

## Checks

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green
- Pin moved to `trust-tasks-rs` 0.19.1 (from 0.19.0), which carries #419.

The `!` is for `vti-rooms`' own API: `leaf_hash` now takes `&CommittedRecord`, and every root this crate computes changes. No published root is invalidated in practice — nothing has anchored one yet.

## Next

The consumer half: `@openvtc/pnm-core/rooms` can verify a trace on `@openvtc/trust-tasks` 0.18.1, which lands with the record-read UI rather than ahead of it. And the witnessed anchor, which is what turns a root from the host's own assertion into evidence — still riding `data-rooms-epoch-anchoring.md`'s open question.
