### PR TITLE
fix(room-host): refuse to mint an identity no member could resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,6 +787,13 @@ jobs:
         run: cargo check -p vta-service --no-default-features --features azure-secrets,keyring,rest
       - name: vta-service tsp transport
         run: cargo check -p vta-service --features tsp
+      # `room-host`'s mediator listener is behind a non-default feature, so
+      # `cargo test --workspace` never compiles it — the same hole the transport
+      # harness sat in (CHANGELOG, "CI now runs the harness"). Tested rather than
+      # only checked: the bug it has already had was a reply threaded on the
+      # wrong id, which compiles perfectly.
+      - name: room-host didcomm + tsp
+        run: cargo test -p room-host --features didcomm
       # A room's member half must not need a server. `vti-common` is optional
       # behind `host`, and it is what pulls axum, fjall and tokio — so this is
       # the check that `mls`/`sealed`/`retention` have not quietly acquired a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7942,6 +7942,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
  "affinidi-messaging-sdk",
+ "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "anyhow",

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -77,6 +77,11 @@ didcomm = [
 ]
 
 [dev-dependencies]
+# A mediator in-process, so the carrier round trip is tested against a real one
+# rather than a simulator. Everything `tests/carrier.rs` covers is packing,
+# routing, threading and acking — a simulator would be a second opinion about
+# exactly the parts that were wrong.
+affinidi-messaging-test-mediator = { version = "0.6", features = ["tsp"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 vti-rooms-dtg = { path = "../vti-rooms-dtg", features = ["test-support"] }

--- a/room-host/src/didcomm.rs
+++ b/room-host/src/didcomm.rs
@@ -50,6 +50,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::HostState;
 
+/// The largest DID any `DIDCacheClient` will parse (`max_did_size_in_bytes`, default 1000).
+///
+/// Checked at mint because **neither end says so** when it is exceeded. The caller fails its
+/// websocket connect as `isActive? command timed out`, which reads as a hang; the mediator
+/// answers `403 authcrypt requires sender public key`, which reads as a key problem. Only
+/// `affinidi_did_authentication` logs the real reason, and only on one side.
+///
+/// A `did:peer:2` carries its services *inside* the identifier, so each one costs roughly the
+/// base64 of the mediator DID it names. Two of them against a `did:webvh` mediator is about
+/// 460 bytes and fine; against a `did:peer` mediator it is about 1685, and every caller that
+/// tries to resolve it fails. The same trap the transport harness hit — see CHANGELOG,
+/// "Watch the DID size" — and it was closed there the same way.
+const MAX_DID_BYTES: usize = 1000;
+
 /// The DIDComm `type` a Trust-Task envelope rides under.
 ///
 /// From the crate that defines the binding rather than written out here. Four hand-written
@@ -59,9 +73,26 @@ use crate::HostState;
 use trust_tasks_didcomm::ENVELOPE_TYPE;
 
 /// The host's own identity: the key it is reached by, and the `did:peer:2` naming it.
+///
+/// `Debug` is hand-written rather than derived, and deliberately: a derived one prints the
+/// secrets, and the places a `Debug` reaches — a log line, a panic message, a test failure —
+/// are exactly the places key material must not turn up. The identifier is public and is the
+/// only part worth seeing.
 pub struct HostIdentity {
     pub did: String,
     secrets: Vec<Secret>,
+}
+
+impl std::fmt::Debug for HostIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostIdentity")
+            .field("did", &self.did)
+            .field(
+                "secrets",
+                &format_args!("<{} redacted>", self.secrets.len()),
+            )
+            .finish()
+    }
 }
 
 /// The stored form. **Key material** — see the module docs.
@@ -130,6 +161,22 @@ impl HostIdentity {
             Some(services(mediator_did)),
         )
         .map_err(|e| anyhow::anyhow!("mint the host identity: {e}"))?;
+
+        // Refused here, where it can be explained, rather than at every caller that tries to
+        // resolve it. A host that minted an over-long identity would come up, log that it was
+        // reachable, and be unreachable — with the failure appearing at the other end as a
+        // timeout.
+        if did.len() > MAX_DID_BYTES {
+            anyhow::bail!(
+                "the identity this host would mint is {} bytes, past the {MAX_DID_BYTES}-byte \
+                 limit every DID resolver enforces — so no member could resolve it, and the \
+                 failure would surface at them as a websocket timeout rather than here. A \
+                 `did:peer:2` carries its services inside the identifier, so each one costs \
+                 about the length of `{mediator_did}` again. Use a mediator with a short DID: \
+                 a `did:webvh` leaves this around 460 bytes, which is what production mints.",
+                did.len()
+            );
+        }
 
         std::fs::create_dir_all(data_dir)?;
         std::fs::write(

--- a/room-host/tests/carrier.rs
+++ b/room-host/tests/carrier.rs
@@ -1,0 +1,106 @@
+//! What a host does when its mediator's DID will not fit inside its own.
+//!
+//! Run against a real mediator rather than a simulator, because the whole failure lives in
+//! the size of an identifier the mediator hands out and a resolver refuses.
+//!
+//! # The trap
+//!
+//! A `did:peer:2` carries its services **inside** the identifier, so advertising a mediator
+//! costs roughly the length of that mediator's DID, once per service. Against a `did:webvh`
+//! mediator — what production uses, and what this host is normally pointed at — two services
+//! come to about 460 bytes. Against a `did:peer` mediator they come to about 1685, and every
+//! `DIDCacheClient` refuses a DID over 1000 before it even parses it.
+//!
+//! Neither end says so. The member fails its websocket connect as `isActive? command timed
+//! out`, which reads as a hang; the mediator answers `403 authcrypt requires sender public
+//! key`, which reads as a key problem. Only `affinidi_did_authentication` logs the real
+//! reason, and only on one side. The workspace has been here before — see CHANGELOG, "Watch
+//! the DID size" — and closed it the same way: assert the length at mint.
+//!
+//! So this asserts that a host **refuses to come up** rather than coming up unreachable. That
+//! is the whole of what it can be: the failure is minting an identity nobody can resolve, and
+//! a host that has refused to mint one has nothing left to round-trip.
+#![cfg(feature = "didcomm")]
+
+use affinidi_messaging_test_mediator::{TestMediator, acl};
+
+/// A mediator whose DID is too long to embed refuses the host, and says why.
+///
+/// The `TestMediator` mints itself a `did:peer`, which is exactly the case that does not fit
+/// — so this fixture cannot be used to exercise the listener's round trip, and that is a
+/// property of the fixture rather than of the listener. What it *can* prove is that the
+/// failure arrives at the party who can act on it, in words that name the cause.
+#[tokio::test]
+async fn a_host_refuses_to_mint_an_identity_no_member_could_resolve() {
+    let dir = tempfile::tempdir().unwrap();
+    let mediator = TestMediator::builder()
+        .global_acl_default(acl::allow_all())
+        .spawn()
+        .await
+        .expect("spawn a test mediator");
+
+    let refused = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator.did())
+        .expect_err("a did:peer mediator does not fit inside a did:peer host");
+    let said = refused.to_string();
+
+    assert!(
+        said.contains("1000-byte limit"),
+        "the refusal must name the limit, because the symptom elsewhere is a timeout: {said}"
+    );
+    assert!(
+        said.contains("did:webvh"),
+        "and what to do about it: {said}"
+    );
+    assert!(
+        !dir.path().join("host-identity.json").exists(),
+        "nothing unusable should be left on disk to be loaded next time"
+    );
+
+    mediator.shutdown();
+}
+
+/// The ordinary case: a short mediator DID leaves room for both services.
+///
+/// `did:webvh` is what production mints and what the demo runs against. Asserted as a
+/// *number* rather than "it worked", because the margin is the thing that erodes — a third
+/// service, or a longer mediator name, and this is over.
+#[tokio::test]
+async fn a_webvh_mediator_leaves_a_host_comfortably_inside_the_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let mediator =
+        "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.example:mediator";
+
+    let identity = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator)
+        .expect("a did:webvh mediator fits");
+
+    assert!(
+        identity.did.len() < 1000,
+        "a host advertising a did:webvh mediator must be resolvable: {} bytes",
+        identity.did.len()
+    );
+    assert!(
+        identity.did.contains("did:peer:2"),
+        "and it is a did:peer, so its services resolve by computation: {}",
+        identity.did
+    );
+
+    // The same identity comes back, because a member's saved address names it. A host that
+    // minted a new one on restart would leave every kept link pointing at somebody else.
+    let again = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator)
+        .expect("the stored identity loads");
+    assert_eq!(
+        identity.did, again.did,
+        "a host's address must survive a restart"
+    );
+
+    // Pointed somewhere else, it refuses rather than advertising where it no longer listens.
+    let moved = room_host::didcomm::HostIdentity::load_or_mint(
+        dir.path(),
+        "did:webvh:QmOther:webvh.example:mediator",
+    )
+    .expect_err("a stored identity names one mediator forever");
+    assert!(
+        moved.to_string().contains("advertises"),
+        "and says which: {moved}"
+    );
+}


### PR DESCRIPTION
I set out to add the integration test #1369 was missing, and found a defect in the thing I was trying to test.

## A host could come up unreachable and say it was fine

A `did:peer:2` carries its services **inside** the identifier, so advertising a mediator costs roughly that mediator's DID again, once per service. Two services:

| mediator | host DID | resolvable? |
|---|---|---|
| `did:webvh` (production, and the demo) | ~460 bytes | yes |
| `did:peer` | ~1685 bytes | **no** — every `DIDCacheClient` refuses over 1000 |

The host minted it, logged that it was reachable, and was not. And neither end says why: the member fails its websocket connect as `isActive? command timed out` (reads as a hang), the mediator answers `403 authcrypt requires sender public key` (reads as a key problem). Only `affinidi_did_authentication` logs the real reason, on one side.

This workspace has been here before — CHANGELOG, *"Watch the DID size"*, where the transport harness hit the identical trap — and closed it by asserting the length at mint. Same fix: the host now refuses to start, names the limit and what to do about it, and leaves nothing half-written on disk to be loaded next time.

## CI was building none of it

The listener is behind a non-default feature, so `cargo test --workspace` skipped it: **not tested, not even compiled.** A workspace change could have broken it silently. That is precisely the hole the transport harness sat in ("CI now **runs** the harness — `transport-harness` is not a default feature").

A Feature-combos step now runs `cargo test -p room-host --features didcomm`. Tested rather than only checked, deliberately: the one bug this module has had was a reply threaded on the wrong id, which compiles perfectly.

## What is covered, and what still is not

`tests/carrier.rs` runs against a real `TestMediator` and asserts the failure lands where somebody can act on it, plus the ordinary case: a `did:webvh` mediator leaves a host inside the limit, the identity survives a restart (a member's saved address names it), and pointing it at a different mediator refuses rather than advertising where it no longer listens.

**The round trip through the listener still has no automated cover**, and the reason is in the file: the fixture mediator is itself a `did:peer`, so a host pointed at it cannot mint a resolvable identity — the very thing this PR asserts. Covering it needs a fixture with a short DID. The path has been exercised by hand against a live `did:webvh` mediator over both carriers.

`HostIdentity` also gains a hand-written `Debug`: `expect_err` wants one, and a derived one prints the secrets — a log line, a panic message and a test failure being exactly where key material must not appear.