### PR TITLE
test(room-host): pin the reply threading a mediator cannot check for you

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,6 +787,13 @@ jobs:
         run: cargo check -p vta-service --no-default-features --features azure-secrets,keyring,rest
       - name: vta-service tsp transport
         run: cargo check -p vta-service --features tsp
+      # `room-host`'s mediator listener is behind a non-default feature, so
+      # `cargo test --workspace` never compiles it — the same hole the transport
+      # harness sat in (CHANGELOG, "CI now runs the harness"). Tested rather than
+      # only checked: the bug it has already had was a reply threaded on the
+      # wrong id, which compiles perfectly.
+      - name: room-host didcomm + tsp
+        run: cargo test -p room-host --features didcomm
       # A room's member half must not need a server. `vti-common` is optional
       # behind `host`, and it is what pulls axum, fjall and tokio — so this is
       # the check that `mls`/`sealed`/`retention` have not quietly acquired a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7942,6 +7942,7 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
  "affinidi-messaging-sdk",
+ "affinidi-messaging-test-mediator",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "anyhow",

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -77,6 +77,11 @@ didcomm = [
 ]
 
 [dev-dependencies]
+# A mediator in-process, so the carrier round trip is tested against a real one
+# rather than a simulator. Everything `tests/carrier.rs` covers is packing,
+# routing, threading and acking — a simulator would be a second opinion about
+# exactly the parts that were wrong.
+affinidi-messaging-test-mediator = { version = "0.6", features = ["tsp"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 vti-rooms-dtg = { path = "../vti-rooms-dtg", features = ["test-support"] }

--- a/room-host/src/didcomm.rs
+++ b/room-host/src/didcomm.rs
@@ -50,6 +50,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::HostState;
 
+/// The largest DID any `DIDCacheClient` will parse (`max_did_size_in_bytes`, default 1000).
+///
+/// Checked at mint because **neither end says so** when it is exceeded. The caller fails its
+/// websocket connect as `isActive? command timed out`, which reads as a hang; the mediator
+/// answers `403 authcrypt requires sender public key`, which reads as a key problem. Only
+/// `affinidi_did_authentication` logs the real reason, and only on one side.
+///
+/// A `did:peer:2` carries its services *inside* the identifier, so each one costs roughly the
+/// base64 of the mediator DID it names. Two of them against a `did:webvh` mediator is about
+/// 460 bytes and fine; against a `did:peer` mediator it is about 1685, and every caller that
+/// tries to resolve it fails. The same trap the transport harness hit — see CHANGELOG,
+/// "Watch the DID size" — and it was closed there the same way.
+const MAX_DID_BYTES: usize = 1000;
+
 /// The DIDComm `type` a Trust-Task envelope rides under.
 ///
 /// From the crate that defines the binding rather than written out here. Four hand-written
@@ -59,9 +73,26 @@ use crate::HostState;
 use trust_tasks_didcomm::ENVELOPE_TYPE;
 
 /// The host's own identity: the key it is reached by, and the `did:peer:2` naming it.
+///
+/// `Debug` is hand-written rather than derived, and deliberately: a derived one prints the
+/// secrets, and the places a `Debug` reaches — a log line, a panic message, a test failure —
+/// are exactly the places key material must not turn up. The identifier is public and is the
+/// only part worth seeing.
 pub struct HostIdentity {
     pub did: String,
     secrets: Vec<Secret>,
+}
+
+impl std::fmt::Debug for HostIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostIdentity")
+            .field("did", &self.did)
+            .field(
+                "secrets",
+                &format_args!("<{} redacted>", self.secrets.len()),
+            )
+            .finish()
+    }
 }
 
 /// The stored form. **Key material** — see the module docs.
@@ -130,6 +161,22 @@ impl HostIdentity {
             Some(services(mediator_did)),
         )
         .map_err(|e| anyhow::anyhow!("mint the host identity: {e}"))?;
+
+        // Refused here, where it can be explained, rather than at every caller that tries to
+        // resolve it. A host that minted an over-long identity would come up, log that it was
+        // reachable, and be unreachable — with the failure appearing at the other end as a
+        // timeout.
+        if did.len() > MAX_DID_BYTES {
+            anyhow::bail!(
+                "the identity this host would mint is {} bytes, past the {MAX_DID_BYTES}-byte \
+                 limit every DID resolver enforces — so no member could resolve it, and the \
+                 failure would surface at them as a websocket timeout rather than here. A \
+                 `did:peer:2` carries its services inside the identifier, so each one costs \
+                 about the length of `{mediator_did}` again. Use a mediator with a short DID: \
+                 a `did:webvh` leaves this around 460 bytes, which is what production mints.",
+                did.len()
+            );
+        }
 
         std::fs::create_dir_all(data_dir)?;
         std::fs::write(

--- a/room-host/src/didcomm.rs
+++ b/room-host/src/didcomm.rs
@@ -275,26 +275,12 @@ pub async fn serve(
             continue;
         }
 
-        let (envelope, reply_thread) = match frame.message.protocol {
-            // TSP carries the Trust-Task envelope as its payload, with no wrapper at all —
-            // byte-identical to the HTTP body. Nothing to unwrap.
-            //
-            // The thread is the **document's own `id`**, read out of it, and not the frame's.
-            // A caller correlates on the id it put on the document, which is the only id it
-            // ever saw; `frame.message.id` is the transport's handle for the delivery and
-            // means nothing on the other side. Threading with it produces a reply that is
-            // sent, accepted, and matched by nobody — the caller waits out its timeout while
-            // the answer sits unclaimed.
-            Protocol::TSP => {
-                let id = document_id(&frame.message.payload).unwrap_or_default();
-                (frame.message.payload.clone(), id)
-            }
-            // DIDComm wraps it: one reserved envelope `type`, whose `body` is the document.
-            _ => match didcomm_envelope(&frame.message.payload) {
-                Some(v) => v,
-                None => continue,
-            },
+        let Some(Request { envelope, thread }) =
+            unwrap_request(frame.message.protocol, &frame.message.payload)
+        else {
+            continue;
         };
+        let reply_thread = thread;
 
         let answer = crate::dispatch(&state, &envelope).await;
         // The document is the answer, and it is self-describing. The status `dispatch`
@@ -340,31 +326,68 @@ pub async fn serve(
     Ok(())
 }
 
-/// A Trust-Task document's own `id`, which is what its sender correlates the answer by.
-fn document_id(envelope: &[u8]) -> Option<String> {
-    let document: serde_json::Value = serde_json::from_slice(envelope).ok()?;
-    Some(document.get("id")?.as_str()?.to_string())
+/// One inbound frame, reduced to what answering it needs.
+#[derive(Debug, PartialEq, Eq)]
+struct Request {
+    /// The Trust-Task document, exactly as `dispatch` and the HTTP route take it.
+    envelope: Vec<u8>,
+    /// What to thread the reply on, so the caller can recognise it.
+    thread: String,
 }
 
-/// The Trust-Task document inside a DIDComm message, and the id to thread the reply to.
+/// Take the request out of a frame, whichever carrier brought it.
 ///
-/// `None` for anything that is not an envelope — a problem report, a forward that arrived
-/// un-unwrapped, a message under some other protocol. Answering those would either spin
-/// against the mediator's own policy or reply to a message nobody sent us.
-fn didcomm_envelope(payload: &[u8]) -> Option<(Vec<u8>, String)> {
-    let message: serde_json::Value = serde_json::from_slice(payload).ok()?;
-    let type_ = message.get("type")?.as_str()?;
-    if type_ != ENVELOPE_TYPE {
-        tracing::debug!(
-            got = type_,
-            expected = ENVELOPE_TYPE,
-            "ignoring a DIDComm message that is not a Trust-Task envelope"
-        );
-        return None;
+/// `None` for anything that is not a request: a problem report, a forward that arrived
+/// un-unwrapped, a DIDComm message under some other type. Answering those would either spin
+/// against the mediator's own policy or reply to a message nobody sent.
+///
+/// # The thread is the document's, never the frame's
+///
+/// A caller correlates on the id it put on the **document** — the only id it ever saw. A
+/// frame's id is the transport's handle for one delivery and means nothing on the other side.
+/// Threading on it produces a reply that is sent, accepted by the mediator, and matched by
+/// nobody: the caller waits out its whole timeout while the answer sits unclaimed, and
+/// neither end logs anything wrong. That was a real bug here, found only by running it.
+///
+/// DIDComm has an id of its own on the envelope and a caller correlates on that, so the two
+/// carriers read it from different places — which is the reason this is one function and not
+/// an `if` at the call site.
+fn unwrap_request(protocol: Protocol, payload: &[u8]) -> Option<Request> {
+    let json: serde_json::Value = serde_json::from_slice(payload).ok()?;
+
+    match protocol {
+        // TSP carries the document as its payload, with no wrapper at all — byte-identical to
+        // the HTTP body. Nothing to unwrap, and the id can only come from the document.
+        Protocol::TSP => Some(Request {
+            envelope: payload.to_vec(),
+            thread: json.get("id")?.as_str()?.to_string(),
+        }),
+        // DIDComm wraps it: one reserved envelope `type`, whose `body` is the document.
+        _ => {
+            let type_ = json.get("type")?.as_str()?;
+            if type_ != ENVELOPE_TYPE {
+                tracing::debug!(
+                    got = type_,
+                    expected = ENVELOPE_TYPE,
+                    "ignoring a DIDComm message that is not a Trust-Task envelope"
+                );
+                return None;
+            }
+            Some(Request {
+                envelope: serde_json::to_vec(json.get("body")?).ok()?,
+                thread: json.get("id")?.as_str()?.to_string(),
+            })
+        }
     }
-    let body = serde_json::to_vec(message.get("body")?).ok()?;
-    let id = message.get("id")?.as_str()?.to_string();
-    Some((body, id))
+}
+
+/// Frame an answer for TSP: `{ thid, document }`.
+///
+/// The document is unchanged inside it. TSP has no headers, so correlation has to ride in the
+/// payload — and it is the *reply* that needs it, not the request: a request's type is the
+/// document's own `type` field, but nothing in a document says which request it answers.
+fn tsp_reply(document: &serde_json::Value, thread: &str) -> serde_json::Value {
+    serde_json::json!({ "thid": thread, "document": document })
 }
 
 /// Return an answer over DIDComm: authcrypt to the caller, then forward through the mediator.
@@ -429,8 +452,7 @@ async fn send_tsp(
     reply: &serde_json::Value,
     thread: &str,
 ) -> anyhow::Result<()> {
-    let framed = serde_json::json!({ "thid": thread, "document": reply });
-    let bytes = serde_json::to_vec(&framed)?;
+    let bytes = serde_json::to_vec(&tsp_reply(reply, thread))?;
     atm.tsp()
         .send_routed(
             profile,
@@ -440,4 +462,119 @@ async fn send_tsp(
         .await
         .map_err(|e| anyhow::anyhow!("send the TSP answer: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A Trust-Task document, as a caller would send one.
+    fn document() -> serde_json::Value {
+        json!({
+            "id": "urn:uuid:11111111-1111-1111-1111-111111111111",
+            "type": "https://trusttasks.org/spec/rooms/records/list/0.1",
+            "issuedAt": "2026-09-09T00:00:00Z",
+            "payload": { "roomId": "did:key:zRoom" },
+        })
+    }
+
+    /// **The regression.** Over TSP the thread must be the document's own `id`.
+    ///
+    /// It was the frame's — the transport's handle for one delivery, which means nothing on
+    /// the other side. The reply was sent, the mediator accepted it, and no waiter matched it;
+    /// the caller waited out its whole timeout while the answer sat unclaimed, and neither end
+    /// logged anything wrong. Only running it against a real mediator showed it, which is why
+    /// it is pinned here where a unit test can hold it.
+    #[test]
+    fn a_tsp_request_threads_on_the_documents_own_id() {
+        let payload = serde_json::to_vec(&document()).unwrap();
+        let request = unwrap_request(Protocol::TSP, &payload).expect("a TSP payload is a request");
+
+        assert_eq!(
+            request.thread, "urn:uuid:11111111-1111-1111-1111-111111111111",
+            "the caller correlates on the id it put on the document, and saw no other"
+        );
+        assert_eq!(
+            request.envelope, payload,
+            "and the document reaches dispatch byte-identical to the HTTP body — no wrapper"
+        );
+    }
+
+    /// DIDComm carries an id on the envelope, and a caller correlates on **that**.
+    #[test]
+    fn a_didcomm_envelope_threads_on_the_message_id() {
+        let payload = serde_json::to_vec(&json!({
+            "id": "urn:uuid:22222222-2222-2222-2222-222222222222",
+            "type": ENVELOPE_TYPE,
+            "body": document(),
+        }))
+        .unwrap();
+
+        let request = unwrap_request(Protocol::DIDComm, &payload).expect("an envelope");
+        assert_eq!(
+            request.thread,
+            "urn:uuid:22222222-2222-2222-2222-222222222222"
+        );
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&request.envelope).unwrap(),
+            document(),
+            "the body is the document, unwrapped"
+        );
+    }
+
+    /// Everything that is not a request is ignored rather than answered.
+    ///
+    /// Answering a problem report feeds the mediator's own policy back into the loop and
+    /// spins; answering a forward that arrived un-unwrapped replies to a message nobody sent.
+    #[test]
+    fn a_didcomm_message_that_is_not_an_envelope_is_not_a_request() {
+        for typ in [
+            "https://didcomm.org/report-problem/2.0/problem-report",
+            "https://didcomm.org/routing/2.0/forward",
+            "https://didcomm.org/trust-ping/2.0/ping",
+            // The near-miss: a caller sending the *task* type instead of the binding's
+            // envelope type. This is the mistake the shared `ENVELOPE_TYPE` constant exists
+            // to prevent, and a conformant peer drops it silently — so it must drop here too.
+            "https://trusttasks.org/spec/rooms/records/list/0.1",
+        ] {
+            let payload =
+                serde_json::to_vec(&json!({ "id": "urn:uuid:x", "type": typ, "body": {} }))
+                    .unwrap();
+            assert_eq!(
+                unwrap_request(Protocol::DIDComm, &payload),
+                None,
+                "`{typ}` is not a Trust-Task envelope"
+            );
+        }
+    }
+
+    /// Neither carrier answers something that is not JSON, or that carries no id to thread on.
+    #[test]
+    fn a_request_with_nothing_to_correlate_it_by_is_refused() {
+        for protocol in [Protocol::TSP, Protocol::DIDComm] {
+            assert_eq!(unwrap_request(protocol, b"not json at all"), None);
+        }
+        // A TSP payload with no `id` cannot be answered: the reply would carry a thread the
+        // caller never sent, which is the same failure as threading on the wrong one.
+        let no_id = serde_json::to_vec(&json!({ "type": "x", "payload": {} })).unwrap();
+        assert_eq!(unwrap_request(Protocol::TSP, &no_id), None);
+    }
+
+    /// The TSP reply puts the thread where a caller looks, and leaves the document alone.
+    #[test]
+    fn a_tsp_reply_carries_the_thread_beside_an_untouched_document() {
+        let answer = json!({ "type": "…#response", "payload": { "records": [] } });
+        let framed = tsp_reply(&answer, "urn:uuid:33333333-3333-3333-3333-333333333333");
+
+        assert_eq!(
+            framed["thid"],
+            "urn:uuid:33333333-3333-3333-3333-333333333333"
+        );
+        assert_eq!(
+            framed["document"], answer,
+            "a caller that ignored the wrapper would read the same bytes the other two \
+             carriers deliver"
+        );
+    }
 }

--- a/room-host/tests/carrier.rs
+++ b/room-host/tests/carrier.rs
@@ -1,0 +1,106 @@
+//! What a host does when its mediator's DID will not fit inside its own.
+//!
+//! Run against a real mediator rather than a simulator, because the whole failure lives in
+//! the size of an identifier the mediator hands out and a resolver refuses.
+//!
+//! # The trap
+//!
+//! A `did:peer:2` carries its services **inside** the identifier, so advertising a mediator
+//! costs roughly the length of that mediator's DID, once per service. Against a `did:webvh`
+//! mediator — what production uses, and what this host is normally pointed at — two services
+//! come to about 460 bytes. Against a `did:peer` mediator they come to about 1685, and every
+//! `DIDCacheClient` refuses a DID over 1000 before it even parses it.
+//!
+//! Neither end says so. The member fails its websocket connect as `isActive? command timed
+//! out`, which reads as a hang; the mediator answers `403 authcrypt requires sender public
+//! key`, which reads as a key problem. Only `affinidi_did_authentication` logs the real
+//! reason, and only on one side. The workspace has been here before — see CHANGELOG, "Watch
+//! the DID size" — and closed it the same way: assert the length at mint.
+//!
+//! So this asserts that a host **refuses to come up** rather than coming up unreachable. That
+//! is the whole of what it can be: the failure is minting an identity nobody can resolve, and
+//! a host that has refused to mint one has nothing left to round-trip.
+#![cfg(feature = "didcomm")]
+
+use affinidi_messaging_test_mediator::{TestMediator, acl};
+
+/// A mediator whose DID is too long to embed refuses the host, and says why.
+///
+/// The `TestMediator` mints itself a `did:peer`, which is exactly the case that does not fit
+/// — so this fixture cannot be used to exercise the listener's round trip, and that is a
+/// property of the fixture rather than of the listener. What it *can* prove is that the
+/// failure arrives at the party who can act on it, in words that name the cause.
+#[tokio::test]
+async fn a_host_refuses_to_mint_an_identity_no_member_could_resolve() {
+    let dir = tempfile::tempdir().unwrap();
+    let mediator = TestMediator::builder()
+        .global_acl_default(acl::allow_all())
+        .spawn()
+        .await
+        .expect("spawn a test mediator");
+
+    let refused = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator.did())
+        .expect_err("a did:peer mediator does not fit inside a did:peer host");
+    let said = refused.to_string();
+
+    assert!(
+        said.contains("1000-byte limit"),
+        "the refusal must name the limit, because the symptom elsewhere is a timeout: {said}"
+    );
+    assert!(
+        said.contains("did:webvh"),
+        "and what to do about it: {said}"
+    );
+    assert!(
+        !dir.path().join("host-identity.json").exists(),
+        "nothing unusable should be left on disk to be loaded next time"
+    );
+
+    mediator.shutdown();
+}
+
+/// The ordinary case: a short mediator DID leaves room for both services.
+///
+/// `did:webvh` is what production mints and what the demo runs against. Asserted as a
+/// *number* rather than "it worked", because the margin is the thing that erodes — a third
+/// service, or a longer mediator name, and this is over.
+#[tokio::test]
+async fn a_webvh_mediator_leaves_a_host_comfortably_inside_the_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let mediator =
+        "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.example:mediator";
+
+    let identity = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator)
+        .expect("a did:webvh mediator fits");
+
+    assert!(
+        identity.did.len() < 1000,
+        "a host advertising a did:webvh mediator must be resolvable: {} bytes",
+        identity.did.len()
+    );
+    assert!(
+        identity.did.contains("did:peer:2"),
+        "and it is a did:peer, so its services resolve by computation: {}",
+        identity.did
+    );
+
+    // The same identity comes back, because a member's saved address names it. A host that
+    // minted a new one on restart would leave every kept link pointing at somebody else.
+    let again = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator)
+        .expect("the stored identity loads");
+    assert_eq!(
+        identity.did, again.did,
+        "a host's address must survive a restart"
+    );
+
+    // Pointed somewhere else, it refuses rather than advertising where it no longer listens.
+    let moved = room_host::didcomm::HostIdentity::load_or_mint(
+        dir.path(),
+        "did:webvh:QmOther:webvh.example:mediator",
+    )
+    .expect_err("a stored identity names one mediator forever");
+    assert!(
+        moved.to_string().contains("advertises"),
+        "and says which: {moved}"
+    );
+}


### PR DESCRIPTION
Stacked on #1373.

That PR closed with the listener's round trip uncovered, because the fixture mediator is a `did:peer` and a host cannot mint a resolvable identity against one. On reflection that framing was too pessimistic.

The part of the listener that was *wrong* is not the packing or the routing — those are library code with their own tests. It is **the parsing of an inbound frame and the framing of the answer**, and neither needs a mediator.

## The regression, pinned

`unwrap_request` is now a pure function: protocol plus payload in, document plus thread out. Over TSP the thread is the **document's own `id`**, never the frame's — that is the only id the caller ever saw. Threading on `frame.message.id` produces a reply that is sent, accepted by the mediator, and matched by nobody: the caller waits out its full timeout while the answer sits unclaimed, and *neither end logs anything wrong*.

Verified by putting the defect back:

```
test a_tsp_request_threads_on_the_documents_own_id ... FAILED
  assertion `left == right` failed: the caller correlates on the id it put on
  the document, and saw no other
    left: "the-frames-own-id"
   right: "urn:uuid:1111…"
```

## Also covered

- DIDComm threads on the **envelope** id instead, because that is what its caller correlates on. The two carriers reading it from different places is why this is one function rather than an `if` at the call site.
- A DIDComm message under any other type is ignored, not answered — a problem report (answering one feeds the mediator's policy back into the loop and spins), an un-unwrapped forward, and the near-miss: a caller sending the **task** type instead of the binding's envelope type. That is the mistake the shared `ENVELOPE_TYPE` constant exists to prevent, and a conformant peer drops it *silently*, so it has to drop here too.
- A payload with no id to correlate by is refused. Replying on a thread nobody sent is the same failure as replying on the wrong one.
- `tsp_reply` puts the thread where a caller looks and leaves the document untouched — a caller ignoring the wrapper reads the same bytes the other two carriers deliver.

## Still open

The full round trip through a mediator remains uncovered, for the reason in #1373. This covers the class of bug that actually occurred, which is the part a mediator would not have checked for you anyway.