### PR TITLE
feat(rooms)!: a tree head, so two roots can be compared at all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9642,9 +9642,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9eb7c7122aef0a6e192de33bc38e25c8a5a4931d67a5d0e6ec1428efbc091b"
+checksum = "e8f82ca5de9096c13635dedb2d347a8aef761b21b3bf48ff43db535f5bf3e1d7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.19.1", default-features = false, features = [
+trust-tasks-rs = { version = "0.19.2", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -517,7 +517,10 @@ async fn get(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answe
             // Answered through the response type for the same reason the VTC is:
             // `respond(doc, record)` put the *storage* record on the wire.
             let (commitment, trace) = record_verification(state, &req.room_id, &req.key).await;
-            respond(doc, GetRecordResponse::of(&record, commitment, trace))
+            respond(
+                doc,
+                GetRecordResponse::of(&record, commitment.as_ref(), trace),
+            )
         }
         Err(e) => from_app_error(doc, &e),
     }
@@ -570,6 +573,7 @@ async fn list(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
             // property of the task rather than of any one host.
             // A listing names no single record; the event is that the room was surveyed.
             audit_room(&room, &authorized, RoomOperation::ListRecords, None);
+            let head = room_head(state, &req.room_id).await;
             respond(
                 doc,
                 ListRecordsResponse {
@@ -577,7 +581,13 @@ async fn list(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
                     // The reference host commits too. A host that served
                     // listings without one would be a working example of the
                     // thing the commitment exists to make detectable.
-                    data_commitment: room_commitment(state, &req.room_id).await,
+                    // One head, so the three values a reader compares cannot come
+                    // from three moments.
+                    data_commitment: head
+                        .as_ref()
+                        .map(|h| vti_rooms::merkle::to_multibase(&h.root)),
+                    record_count: head.as_ref().map(|h| h.record_count),
+                    head_version: head.as_ref().map(|h| h.head_version),
                 },
             )
         }
@@ -600,9 +610,12 @@ async fn record_verification(
     state: &HostState,
     room_id: &str,
     key: &str,
-) -> (Option<String>, Option<vti_rooms::merkle::InclusionProof>) {
-    match storage::data_commitment_with_trace(&state.records, room_id, key).await {
-        Ok((root, trace)) => (Some(vti_rooms::merkle::to_multibase(&root)), trace),
+) -> (
+    Option<vti_rooms::merkle::TreeHead>,
+    Option<vti_rooms::merkle::InclusionProof>,
+) {
+    match storage::tree_head_with_trace(&state.records, room_id, key).await {
+        Ok((head, trace)) => (Some(head), trace),
         Err(e) => {
             tracing::error!(
                 room = %room_id,
@@ -628,9 +641,9 @@ async fn record_verification(
 /// One function for both reads, mirroring the VTC's, because a listing and a
 /// read that disagreed about the room's root would be this host equivocating
 /// with itself.
-async fn room_commitment(state: &HostState, room_id: &str) -> Option<String> {
-    match storage::data_commitment(&state.records, room_id).await {
-        Ok(root) => Some(vti_rooms::merkle::to_multibase(&root)),
+async fn room_head(state: &HostState, room_id: &str) -> Option<vti_rooms::merkle::TreeHead> {
+    match storage::tree_head(&state.records, room_id).await {
+        Ok(head) => Some(head),
         Err(e) => {
             tracing::error!(
                 room = %room_id,

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -398,7 +398,10 @@ pub(crate) async fn handle_get_record(state: &AppState, doc: TrustTask<Value>) -
             // on. Serialising `Record` was what put a bare `sealed` string and
             // six undeclared members on the wire — see `GetRecordResponse`.
             let (commitment, trace) = record_verification(state, &req.room_id, &req.key).await;
-            success_response(&doc, GetRecordResponse::of(&record, commitment, trace))
+            success_response(
+                &doc,
+                GetRecordResponse::of(&record, commitment.as_ref(), trace),
+            )
         }
         Err(e) => app_error_to_reject(&doc, &e),
     }
@@ -455,11 +458,18 @@ pub(crate) async fn handle_list_records(
     // A listing names no single record, so the entry records the room and the fact of a
     // listing — which is the event: who has seen what this room holds.
     audit_room(state, &room, &authorized, RoomOperation::ListRecords, None).await;
+    let head = room_head(state, &req.room_id).await;
     success_response(
         &doc,
         ListRecordsResponse {
             records: records.iter().take(limit).map(|r| r.metadata()).collect(),
-            data_commitment: room_commitment(state, &req.room_id).await,
+            // One head, so the three values a reader compares cannot come
+            // from three moments.
+            data_commitment: head
+                .as_ref()
+                .map(|h| vti_rooms::merkle::to_multibase(&h.root)),
+            record_count: head.as_ref().map(|h| h.record_count),
+            head_version: head.as_ref().map(|h| h.head_version),
         },
     )
 }
@@ -479,9 +489,12 @@ async fn record_verification(
     state: &AppState,
     room_id: &str,
     key: &str,
-) -> (Option<String>, Option<vti_rooms::merkle::InclusionProof>) {
-    match storage::data_commitment_with_trace(&state.room_records_ks, room_id, key).await {
-        Ok((root, trace)) => (Some(vti_rooms::merkle::to_multibase(&root)), trace),
+) -> (
+    Option<vti_rooms::merkle::TreeHead>,
+    Option<vti_rooms::merkle::InclusionProof>,
+) {
+    match storage::tree_head_with_trace(&state.room_records_ks, room_id, key).await {
+        Ok((head, trace)) => (Some(head), trace),
         Err(e) => {
             tracing::error!(
                 room = %room_id,
@@ -503,9 +516,9 @@ async fn record_verification(
 ///
 /// Logged rather than swallowed silently: a host that has quietly stopped
 /// committing looks, to a member, exactly like a host that never did.
-async fn room_commitment(state: &AppState, room_id: &str) -> Option<String> {
-    match storage::data_commitment(&state.room_records_ks, room_id).await {
-        Ok(root) => Some(vti_rooms::merkle::to_multibase(&root)),
+async fn room_head(state: &AppState, room_id: &str) -> Option<vti_rooms::merkle::TreeHead> {
+    match storage::tree_head(&state.room_records_ks, room_id).await {
+        Ok(head) => Some(head),
         Err(e) => {
             tracing::error!(
                 room = %room_id,

--- a/vti-rooms/src/merkle.rs
+++ b/vti-rooms/src/merkle.rs
@@ -155,18 +155,74 @@ pub fn root_of(leaves: &[Hash]) -> Hash {
     level[0]
 }
 
+/// A room's **tree head**: the root, and the two values that say which state it
+/// covers.
+///
+/// # Why these travel together and are computed together
+///
+/// A root on its own is not comparable to another root. A room moves — every
+/// put, curate and retraction changes the tree — so two roots differing is the
+/// most ordinary observation there is, and a host shown to have served two
+/// different ones answers *there was a write between your reads*. Certificate
+/// Transparency does not have this problem because a signed tree head is a root
+/// **and a size**; this family shipped the root alone until
+/// `trust-tasks-tf#422`.
+///
+/// All three come out of **one** pass over one set, and that is a correctness
+/// requirement rather than a tidiness one. `head_version` read from the room's
+/// own `next_version` counter would be a *second* read, and two reads are not a
+/// snapshot: a write landing between them labels a root with a version from
+/// another moment, so two honest members end up holding roots over different
+/// trees under one version. That reads as equivocation and is not, and **a
+/// false accusation discredits the mechanism rather than the host** — the worst
+/// outcome available here. Ordering the two reads does not help in either
+/// direction; only taking both from one set closes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TreeHead {
+    /// The root of the record tree.
+    pub root: Hash,
+    /// How many records the tree covers — leaves, tombstones included.
+    pub record_count: u64,
+    /// The highest version among those records, `0` if there are none.
+    ///
+    /// Taken from the committed set, never from the room row. It equals the
+    /// room's last assigned version for any host that has not **erased** a
+    /// record: versions are assigned strictly increasing, and a retraction keeps
+    /// its tombstone. [`crate::storage::purge_record`] is the erasure path and
+    /// has no caller outside its own tests; a family that exposes one owes this
+    /// definition another look, because an erasure moves the root without
+    /// necessarily moving this.
+    pub head_version: u64,
+}
+
+/// Sort `records` by key, hash them, and return the whole [`TreeHead`].
+///
+/// The sort is here rather than assumed of the caller because the ordering *is*
+/// the completeness property — see [`commit_records`], which is this with the
+/// head discarded.
+pub fn tree_head(records: &mut [Record]) -> Result<TreeHead, MerkleError> {
+    records.sort_by(|a, b| a.key.cmp(&b.key));
+    let leaves = records
+        .iter()
+        .map(|r| leaf_hash(&r.committed()))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(TreeHead {
+        root: root_of(&leaves),
+        record_count: leaves.len() as u64,
+        // `max` over the same slice the leaves came from. An empty room has no
+        // version to report and answers 0, which is the state it is in rather
+        // than a missing value.
+        head_version: records.iter().map(|r| r.version).max().unwrap_or(0),
+    })
+}
+
 /// Sort `records` by key, hash them, and return the data commitment.
 ///
 /// The sort is here rather than assumed of the caller because the ordering *is*
 /// the completeness property: a root computed over records in storage order
 /// proves membership and nothing about absence.
 pub fn commit_records(records: &mut [Record]) -> Result<Hash, MerkleError> {
-    records.sort_by(|a, b| a.key.cmp(&b.key));
-    let leaves = records
-        .iter()
-        .map(|r| leaf_hash(&r.committed()))
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(root_of(&leaves))
+    tree_head(records).map(|head| head.root)
 }
 
 /// One step of an inclusion proof: a sibling and which side it sits on.

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -505,12 +505,12 @@ pub async fn list_records(
 /// So: correct first, and cache when there is a measurement saying where. The
 /// natural shape is a root kept beside the room row and updated on write, which
 /// is a different change with its own invariant to hold.
-pub async fn data_commitment(
+pub async fn tree_head(
     records: &KeyspaceHandle,
     room_id: &str,
-) -> Result<crate::merkle::Hash, AppError> {
+) -> Result<crate::merkle::TreeHead, AppError> {
     let mut all = list_records(records, room_id, None, None).await?;
-    crate::merkle::commit_records(&mut all)
+    crate::merkle::tree_head(&mut all)
         .map_err(|e| AppError::Internal(format!("commit the records of `{room_id}`: {e}")))
 }
 
@@ -532,27 +532,37 @@ pub async fn data_commitment(
 /// has just read the record can only see as a race with a retraction — the root
 /// is still honest and is still returned, so the read answers with a
 /// commitment and no path rather than failing.
-pub async fn data_commitment_with_trace(
+pub async fn tree_head_with_trace(
     records: &KeyspaceHandle,
     room_id: &str,
     key: &str,
-) -> Result<(crate::merkle::Hash, Option<crate::merkle::InclusionProof>), AppError> {
+) -> Result<
+    (
+        crate::merkle::TreeHead,
+        Option<crate::merkle::InclusionProof>,
+    ),
+    AppError,
+> {
     let mut all = list_records(records, room_id, None, None).await?;
     // Ordering is the commitment's, so the index has to come from the sorted
-    // set — `commit_records` sorts in place, which is why this reads the
-    // position afterwards rather than before.
+    // set — `tree_head` sorts in place, which is why this reads the position
+    // afterwards rather than before.
     all.sort_by(|a, b| a.key.cmp(&b.key));
     let leaves = all
         .iter()
         .map(|r| crate::merkle::leaf_hash(&r.committed()))
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| AppError::Internal(format!("commit the records of `{room_id}`: {e}")))?;
-    let root = crate::merkle::root_of(&leaves);
+    let head = crate::merkle::TreeHead {
+        root: crate::merkle::root_of(&leaves),
+        record_count: leaves.len() as u64,
+        head_version: all.iter().map(|r| r.version).max().unwrap_or(0),
+    };
     let trace = all
         .iter()
         .position(|r| r.key == key)
         .and_then(|index| crate::merkle::inclusion_proof(&leaves, index));
-    Ok((root, trace))
+    Ok((head, trace))
 }
 
 /// What one curation changes.
@@ -785,7 +795,7 @@ mod tests {
                 .unwrap();
         }
 
-        let whole_room = data_commitment(&rec, "r1").await.unwrap();
+        let whole_room = tree_head(&rec, "r1").await.unwrap().root;
 
         // What a host serving two of the three records would be committing to.
         let mut short = list_records(&rec, "r1", None, None).await.unwrap();
@@ -813,12 +823,64 @@ mod tests {
                 .unwrap();
         }
 
-        let root = data_commitment(&rec, "r1").await.unwrap();
+        let root = tree_head(&rec, "r1").await.unwrap().root;
         // A filtered listing returns fewer records; the room is unchanged, so
         // the commitment must be too.
         let filtered = list_records(&rec, "r1", Some("a"), None).await.unwrap();
         assert!(filtered.len() < 3, "the fixture must actually filter");
-        assert_eq!(data_commitment(&rec, "r1").await.unwrap(), root);
+        assert_eq!(tree_head(&rec, "r1").await.unwrap().root, root);
+    }
+
+    /// The head's three values describe one set, and they are read from it.
+    ///
+    /// `head_version` is deliberately **not** the room's `next_version - 1`,
+    /// even though the two agree here. A counter is a second read, and a write
+    /// landing between the two labels a root with a version from another
+    /// moment — two honest members then hold roots over different trees under
+    /// one version, which reads as equivocation and is not. This test pins the
+    /// values; the doc on `merkle::TreeHead` pins the reason.
+    #[tokio::test]
+    async fn the_head_reports_the_set_it_committed_to() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for (i, key) in ["a", "b", "c"].iter().enumerate() {
+            put_record(&rooms, &rec, "r1", open_record(key), None, i as u64 + 1)
+                .await
+                .unwrap();
+        }
+
+        let head = tree_head(&rec, "r1").await.unwrap();
+        assert_eq!(head.record_count, 3);
+        assert_eq!(
+            head.head_version,
+            get_room(&rooms, "r1").await.unwrap().next_version - 1,
+            "with no erasure the committed maximum is the room's last assigned version"
+        );
+
+        // A retraction is a mutation: it takes a version, keeps its tombstone,
+        // and so moves the head without changing the count.
+        curate_record(
+            &rooms,
+            &rec,
+            "r1",
+            "b",
+            Curation {
+                status: Some(RecordStatus::Retracted),
+                ..Curation::default()
+            },
+            4,
+        )
+        .await
+        .unwrap();
+        let after = tree_head(&rec, "r1").await.unwrap();
+        assert_eq!(after.record_count, 3, "a tombstone is still a record");
+        assert!(
+            after.head_version > head.head_version,
+            "a retraction advances the head"
+        );
+        assert_ne!(after.root, head.root, "and it moves the root");
     }
 
     /// An empty room has an honest commitment rather than no commitment.
@@ -829,7 +891,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            data_commitment(&rec, "r1").await.unwrap(),
+            tree_head(&rec, "r1").await.unwrap().root,
             crate::merkle::empty_root()
         );
     }

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -310,6 +310,23 @@ pub struct GetRecordResponse {
     /// no tree must not invent a root.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data_commitment: Option<String>,
+    /// How many records the room holds, as of `data_commitment`.
+    ///
+    /// A reader cannot recompute the root from a listing — a leaf commits to a
+    /// whole record and a listing returns a projection — but it can **count**.
+    /// Only against a complete listing, read to the end with no prefix and no
+    /// watermark; against a page it is a discrepancy the reader manufactured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub record_count: Option<u64>,
+    /// The highest record version the commitment covers, as of
+    /// `data_commitment`.
+    ///
+    /// What makes two roots comparable at all: same head and different roots is
+    /// a host caught, with no write to attribute the difference to. Without it,
+    /// two roots differing is a room that moved as readily as a host that
+    /// equivocated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_version: Option<u64>,
     /// The path from this record's leaf to `data_commitment`.
     ///
     /// Served only with the commitment it reaches, and computed from the same
@@ -329,12 +346,14 @@ impl GetRecordResponse {
     #[must_use]
     pub fn of(
         record: &Record,
-        data_commitment: Option<String>,
+        head: Option<&crate::merkle::TreeHead>,
         trace: Option<crate::merkle::InclusionProof>,
     ) -> Self {
         Self {
             record: record.committed(),
-            data_commitment,
+            data_commitment: head.map(|h| crate::merkle::to_multibase(&h.root)),
+            record_count: head.map(|h| h.record_count),
+            head_version: head.map(|h| h.head_version),
             trace,
         }
     }
@@ -353,6 +372,23 @@ pub struct ListRecordsResponse {
     /// here", and a fabricated one would say the opposite while meaning less.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_commitment: Option<String>,
+    /// How many records the room holds, as of `data_commitment`.
+    ///
+    /// A reader cannot recompute the root from a listing — a leaf commits to a
+    /// whole record and a listing returns a projection — but it can **count**.
+    /// Only against a complete listing, read to the end with no prefix and no
+    /// watermark; against a page it is a discrepancy the reader manufactured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub record_count: Option<u64>,
+    /// The highest record version the commitment covers, as of
+    /// `data_commitment`.
+    ///
+    /// What makes two roots comparable at all: same head and different roots is
+    /// a host caught, with no write to attribute the difference to. Without it,
+    /// two roots differing is a room that moved as readily as a host that
+    /// equivocated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_version: Option<u64>,
 }
 
 /// `rooms/records/curate/0.1` request.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -396,7 +396,7 @@ fn get_record_response_conforms() {
             ..sealed.clone()
         },
     ];
-    let root = merkle::commit_records(&mut records).expect("commits");
+    let head = merkle::tree_head(&mut records).expect("commits");
     let leaves: Vec<merkle::Hash> = records
         .iter()
         .map(|r| merkle::leaf_hash(&r.committed()).expect("hashes"))
@@ -407,11 +407,7 @@ fn get_record_response_conforms() {
         .expect("the record is in its own room");
     let trace = merkle::inclusion_proof(&leaves, index).expect("a trace for a record that exists");
 
-    let response = GetRecordResponse::of(
-        &sealed,
-        Some(merkle::to_multibase(&root)),
-        Some(trace.clone()),
-    );
+    let response = GetRecordResponse::of(&sealed, Some(&head), Some(trace.clone()));
     let value = serde_json::to_value(&response).expect("serialise");
     assert_eq!(
         value["sealed"]["ciphertext"], "c2VhbGVkLWJvZHk",
@@ -426,6 +422,14 @@ fn get_record_response_conforms() {
         "the committed form renders RFC 3339, not the unix seconds it stores: {value}"
     );
     assert_eq!(value["pinned"], true, "pinned is committed: {value}");
+    assert_eq!(
+        value["recordCount"], 2,
+        "the count is the room's, not the page's: {value}"
+    );
+    assert_eq!(
+        value["headVersion"], 3,
+        "the head is the highest version the commitment covers: {value}"
+    );
     assert!(
         value["trace"][0]["sibling"]
             .as_str()
@@ -452,9 +456,12 @@ fn get_record_response_conforms() {
     let value = serde_json::to_value(GetRecordResponse::of(&open, None, None)).expect("serialise");
     assert!(
         value.get("dataCommitment").is_none()
+            && value.get("recordCount").is_none()
+            && value.get("headVersion").is_none()
             && value.get("sealed").is_none()
             && value.get("pinned").is_none(),
-        "an absent optional must be absent, and `pinned: false` is spelled by absence: {value}"
+        "an absent optional must be absent, `pinned: false` is spelled by absence, and a host \
+         with no tree asserts none of the head: {value}"
     );
     check::<GetResponse>("GetRecordResponse (open)", &value);
 
@@ -502,7 +509,7 @@ fn a_reader_verifies_a_trace_from_the_response_alone() {
         .collect();
 
     let mut ordered = room.clone();
-    let root = merkle::commit_records(&mut ordered).expect("commits");
+    let head = merkle::tree_head(&mut ordered).expect("commits");
     let leaves: Vec<merkle::Hash> = ordered
         .iter()
         .map(|r| merkle::leaf_hash(&r.committed()).expect("hashes"))
@@ -511,7 +518,7 @@ fn a_reader_verifies_a_trace_from_the_response_alone() {
     for (index, record) in ordered.iter().enumerate() {
         let response = GetRecordResponse::of(
             record,
-            Some(merkle::to_multibase(&root)),
+            Some(&head),
             Some(merkle::inclusion_proof(&leaves, index).expect("a trace")),
         );
         // Everything past this line is what a *reader* does: it has bytes.


### PR DESCRIPTION
Implements [trust-tasks-tf#422](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/422), released as `trust-tasks-rs` 0.19.2. It is the last implementation piece of verified reads: a reader now gets a root, **the state that root describes**, and a path from their record to it.

## Why a root alone was not enough

The commitment shipped as a bare root, and the prose claimed a host showing two members two different roots "cannot claim a transient". It can: a room moves on every put, curate and retraction, so the host answers *there was a write between your reads* and nothing contradicts it. The comparison the whole member exists for could not be performed by anybody.

Certificate Transparency does not have that problem because **a signed tree head is a root _and a size_**. This family shipped the root and dropped the rest.

## `merkle::TreeHead`

```rust
pub struct TreeHead {
    pub root: Hash,
    pub record_count: u64,
    pub head_version: u64,
}
```

One type, produced by one function from one pass over one set — and that is a **correctness requirement rather than tidiness**. `head_version` read from the room's own `next_version` counter would be a *second* read, and two reads are not a snapshot:

```
member A:  scan records → S1                    … counter → V+1
member B:              [write lands]  scan → S2 … counter → V+1
```

Both report `headVersion: V+1` over different trees. Two honest members, two different roots, one version — which reads as **equivocation and is not**. Ordering the reads the other way admits the mirror case; only taking both from one set closes it. A false accusation discredits the mechanism rather than the host, which is the worst outcome this machinery has.

The type makes it structural rather than remembered:

```rust
pub fn of(record: &Record, head: Option<&TreeHead>, trace: Option<InclusionProof>) -> Self
```

A caller cannot serve a root without its head, or a head from a different moment, because there is no way to spell it.

## What moved

| before | after |
|---|---|
| `storage::data_commitment` | `storage::tree_head` |
| `storage::data_commitment_with_trace` | `storage::tree_head_with_trace` |
| host helper `room_commitment` | `room_head` |
| `merkle::commit_records` | now `tree_head(...).map(\|h\| h.root)` — one implementation of the walk |

Both hosts serve `dataCommitment`, `recordCount` and `headVersion` on **both** read paths, from the head they already computed.

## Tests

`the_head_reports_the_set_it_committed_to` pins the part that would otherwise rot:

```rust
assert_eq!(head.head_version, get_room(&rooms, "r1").await.unwrap().next_version - 1,
    "with no erasure the committed maximum is the room's last assigned version");
```

The two agree — and the test exists to say *why we do not read the counter*, so that nobody later simplifies it into one. It then retracts a record and checks the count stays at 3 (a tombstone is still a record) while the head advances and the root moves.

Conformance gains assertions that a served head carries all three, and that a host with no tree asserts **none** of them — `dataCommitment`, `recordCount` and `headVersion` all absent, alongside `pinned: false` being spelled by absence.

## The erasure corollary

A host that *erases* a record — as distinct from retracting it, which leaves a tombstone in the tree — moves the root without necessarily moving `head_version`. I checked rather than assumed: `vti_rooms::storage::purge_record` exists and has **no caller outside its own tests**, so nothing exposes it. Documented on `TreeHead` as something a family that exposes one would owe another look.

## Checks

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green
- Verified twice: against a local `[patch.crates-io]` while 0.19.2 was in the release queue, then again against the published crate with the patch removed.

`!` for `vti-rooms`' own API, which is alpha and has no external consumers.

## Next

With this in, verified reads is complete as a mechanism. What remains is what turns a root into evidence rather than the host's own assertion:

- the **witnessed anchor** — now unblocked, shape 3a decided (`data-rooms-epoch-anchoring.md`);
- the **agent's root memory**, and the rule that a client which catches a host **serves reads and refuses writes** — decided, and it makes the memory a prerequisite of the refusal rather than an optional second increment, since a refusal that lasts only as long as the process that noticed is not a refusal.
