### PR TITLE
test(rooms): an invitation's window, which neither gate was checking

### DIFF
--- a/vta-service/src/operations/room_invitation.rs
+++ b/vta-service/src/operations/room_invitation.rs
@@ -264,15 +264,91 @@ mod tests {
         id: &str,
     ) -> String {
         let now = Utc::now();
-        let mut vic = DTGCredential::new_vic(
-            issuer.to_string(),
-            subject.to_string(),
+        an_invitation_valid(
+            issuer,
+            signer,
+            subject,
+            id,
             now - chrono::Duration::minutes(1),
             Some(now + chrono::Duration::hours(1)),
         )
-        .with_id(id);
+        .await
+    }
+
+    /// The same, with the window said explicitly.
+    ///
+    /// Split out because a window cannot be tested by a helper that hardcodes a good one —
+    /// which is why it was not tested.
+    async fn an_invitation_valid(
+        issuer: &str,
+        signer: &affinidi_secrets_resolver::secrets::Secret,
+        subject: &str,
+        id: &str,
+        from: chrono::DateTime<Utc>,
+        until: Option<chrono::DateTime<Utc>>,
+    ) -> String {
+        let mut vic = DTGCredential::new_vic(issuer.to_string(), subject.to_string(), from, until)
+            .with_id(id);
         vic.sign(signer, None).await.expect("sign the invitation");
         serde_json::to_string(vic.credential()).expect("serialise")
+    }
+
+    /// **An invitation's window, which nothing was checking.**
+    ///
+    /// Both clauses were here and both were unexercised — on this side and in the browser
+    /// member's copy of the same gate (`vti-rooms-wasm`). That is the failure mode worth
+    /// naming: a regression here breaks nothing visibly. Expired invitations simply keep
+    /// working, and the party who would care — whoever issued one and expected it to lapse —
+    /// has no way to find out.
+    #[tokio::test]
+    async fn an_invitation_outside_its_window_is_refused() {
+        let (room, room_secret) = a_party(0x47);
+        let me = "did:key:zMember";
+        let now = Utc::now();
+
+        let expired = an_invitation_valid(
+            &room,
+            &room_secret,
+            me,
+            "urn:uuid:w-1",
+            now - chrono::Duration::hours(2),
+            Some(now - chrono::Duration::hours(1)),
+        )
+        .await;
+        let err = verify(&expired, &room, me, &DidKeyOnly)
+            .await
+            .expect_err("an invitation that has run out must not still admit");
+        assert!(format!("{err}").contains("expired"), "{err}");
+
+        let premature = an_invitation_valid(
+            &room,
+            &room_secret,
+            me,
+            "urn:uuid:w-2",
+            now + chrono::Duration::hours(1),
+            Some(now + chrono::Duration::hours(2)),
+        )
+        .await;
+        let err = verify(&premature, &room, me, &DidKeyOnly)
+            .await
+            .expect_err("nor one that has not started");
+        assert!(format!("{err}").contains("not valid yet"), "{err}");
+
+        // No `validUntil` at all: the credential type permits it, so a room *can* issue one
+        // that never lapses. Asserted as accepted, because that is the issuer's decision and
+        // not something a verifier should overrule on their behalf.
+        let forever = an_invitation_valid(
+            &room,
+            &room_secret,
+            me,
+            "urn:uuid:w-3",
+            now - chrono::Duration::minutes(1),
+            None,
+        )
+        .await;
+        verify(&forever, &room, me, &DidKeyOnly)
+            .await
+            .expect("an open-ended invitation is the issuer's call, not this gate's");
     }
 
     #[tokio::test]

--- a/vti-rooms-wasm/src/lib.rs
+++ b/vti-rooms-wasm/src/lib.rs
@@ -493,7 +493,7 @@ mod tests {
         (did, secret)
     }
 
-    /// An invitation from `room` to `subject`, signed.
+    /// An invitation from `room` to `subject`, signed, open from a minute ago for an hour.
     fn an_invitation(
         room: &str,
         secret: &affinidi_secrets_resolver::secrets::Secret,
@@ -501,11 +501,33 @@ mod tests {
         id: &str,
     ) -> String {
         let now = chrono::Utc::now();
+        an_invitation_valid(
+            room,
+            secret,
+            subject,
+            id,
+            now - chrono::Duration::minutes(1),
+            Some(now + chrono::Duration::hours(1)),
+        )
+    }
+
+    /// The same, with the window said explicitly.
+    ///
+    /// Split out because a window cannot be tested by a helper that hardcodes a good one —
+    /// which is why it was not tested.
+    fn an_invitation_valid(
+        room: &str,
+        secret: &affinidi_secrets_resolver::secrets::Secret,
+        subject: &str,
+        id: &str,
+        from: chrono::DateTime<chrono::Utc>,
+        until: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> String {
         let mut vic = dtg_credentials::DTGCredential::new_vic(
             room.to_string(),
             subject.to_string(),
-            now - chrono::Duration::minutes(1),
-            Some(now + chrono::Duration::hours(1)),
+            from,
+            until,
         )
         .with_id(id);
         futures_lite::future::block_on(vic.sign(secret, None)).expect("sign the invitation");
@@ -923,6 +945,71 @@ mod tests {
             verify(&good, &room, me, &spent)
                 .unwrap_err()
                 .contains("already been used")
+        );
+    }
+
+    /// **An invitation's window is the other half of single-use, and nothing was testing it.**
+    ///
+    /// Both clauses were here and both were unexercised — on this side and in
+    /// `vta-service`'s copy of the same gate. Which is the failure mode worth naming: a
+    /// regression would not break anything visibly. Expired invitations would simply keep
+    /// working, and a room's owner would have no way to tell, because the artefact that
+    /// stopped meaning anything is the one they issued and forgot.
+    ///
+    /// An hour is chosen for a real invitation because it is an act somebody is about to
+    /// perform, not a standing entitlement. That reasoning is only true if the window is
+    /// enforced.
+    #[test]
+    fn an_invitation_outside_its_window_is_refused() {
+        let (room, secret) = a_room(0x24);
+        let me = "did:key:zMe";
+        let now = chrono::Utc::now();
+
+        let expired = an_invitation_valid(
+            &room,
+            &secret,
+            me,
+            "urn:uuid:w-1",
+            now - chrono::Duration::hours(2),
+            Some(now - chrono::Duration::hours(1)),
+        );
+        assert!(
+            verify(&expired, &room, me, &[])
+                .unwrap_err()
+                .contains("expired"),
+            "an invitation that has run out must not still admit"
+        );
+
+        let premature = an_invitation_valid(
+            &room,
+            &secret,
+            me,
+            "urn:uuid:w-2",
+            now + chrono::Duration::hours(1),
+            Some(now + chrono::Duration::hours(2)),
+        );
+        assert!(
+            verify(&premature, &room, me, &[])
+                .unwrap_err()
+                .contains("not valid yet"),
+            "nor one that has not started"
+        );
+
+        // No `validUntil` at all. The credential type permits it, so a room *can* issue one
+        // that never expires — and this asserts the gate treats that as the room's decision
+        // rather than quietly refusing it. An invitation with no end is a policy question for
+        // whoever issues it, not something a member's key holder overrules.
+        let forever = an_invitation_valid(
+            &room,
+            &secret,
+            me,
+            "urn:uuid:w-3",
+            now - chrono::Duration::minutes(1),
+            None,
+        );
+        assert!(
+            verify(&forever, &room, me, &[]).is_ok(),
+            "an open-ended invitation is the issuer's call, not this gate's"
         );
     }
 


### PR DESCRIPTION
There are two copies of the room-invitation gate — `vta-service`'s and the browser member's in `vti-rooms-wasm` — and they were both a test short, on the same clause.

Five clauses covered on both sides. The **validity window** exercised on neither.

## Why this one is worth catching

It is the quiet failure. A regression here breaks nothing visibly: expired invitations simply keep working, and the party who would care — whoever issued one and expected it to lapse — has no way to find out. Contrast the forgery clause, whose absence at least lets an attacker in loudly.

A room invitation is given an hour on the grounds that it is *an act somebody is about to perform rather than a standing entitlement*. That reasoning is only true while the window is enforced.

## Covered now, on both sides

- **expired** — `validUntil` in the past.
- **not yet valid** — `validFrom` in the future.
- **no `validUntil` at all**, asserted as *accepted*. The credential type permits it, so a room can issue one that never lapses; a verifier refusing it would be overruling the issuer's decision rather than checking it.

Verified by deleting the expiry clause from each gate in turn — the new test is the only one that fails, on both sides:

```
test tests::an_invitation_outside_its_window_is_refused ... FAILED
test operations::room_invitation::tests::an_invitation_outside_its_window_is_refused ... FAILED
```

## Why it went untested

The fixture could not express it. Both `an_invitation` helpers hardcoded a good window, so no test could have written the case even if someone had thought of it. Each now has an `an_invitation_valid` taking the window explicitly — which is the whole reason a reachable clause was never reached.

## The duplication itself

Still there, and still worth closing, but not here. Sharing the gate needs `vti-rooms-dtg` to build for `wasm32`, and it cannot: it takes `AppError` from `vti-common`, `AppError` implements `IntoResponse`, and so it is axum-bound by design (`vti-rooms-dtg` currently fails to compile for wasm on tokio's net stack). Splitting that is a workspace-wide change to the central error type, not something to fold into a test PR.

## Testing

`vti-rooms-wasm` 10 passed; `vta-service --lib` 1070 passed, 0 failed. Clippy clean.