### PR TITLE
docs(rooms): record the three decisions, and what each one obliges

### DIFF
--- a/docs/05-design-notes/data-rooms-epoch-anchoring.md
+++ b/docs/05-design-notes/data-rooms-epoch-anchoring.md
@@ -1,13 +1,20 @@
 # Anchoring a room's renewals in its witnessed log
 
-Status: **open question, not a plan.** One decision has to be made before any of
-this can be built, and it is written down here because it was blocking in a
-conversation rather than in the repository.
+Status: **decided, and now buildable.** This was an open question; it was
+answered on 2026-09-09 and the note is kept as the reasoning behind the answer
+rather than as a request for one.
 
 [`data-rooms.md`](data-rooms.md) §9 says a renewal writes the room's current
 **MLS epoch authenticator** and **version watermark** to the room's witnessed
-`did:webvh` log. It does not say *where in the log entry they go*, and there is
-no obvious slot. That is the question.
+`did:webvh` log. It did not say *where in the log entry they go*, and there was
+no obvious slot. **They go in a typed service entry — §3a.** The alternatives in
+§3b and §3c are kept because a shape chosen with its rejected siblings deleted is
+one nobody can argue with later.
+
+The other question §5 raised — *what a client does with a mismatch* — is
+answered too, and by the same decision that answers it for
+[`data-rooms-read-through.md`](data-rooms-read-through.md): **serve reads, refuse
+writes.** The two notes were asking one question in two vocabularies.
 
 ---
 
@@ -67,7 +74,7 @@ So the answer is "somewhere in `state`", and the real question is **what shape**
 
 ## 3. Three shapes, and what each costs
 
-### 3a. A typed service entry (recommended)
+### 3a. A typed service entry — **decided**
 
 ```jsonc
 "service": [
@@ -173,10 +180,18 @@ anyway by having entries.
   (§7.1's first row) cannot anchor honestly, since the party being checked
   would be writing the check. Worth stating as a constraint on that
   configuration rather than discovering it later.
-- **What a client does with a mismatch.** An anchored authenticator that does
-  not match the member's own is evidence of a fork, and evidence is not an
-  action. Refuse to read? Warn? Both, depending on tier? §9 does not say, and a
-  detection nobody acts on is a log line.
+- ~~**What a client does with a mismatch.**~~ **Answered: serve reads, refuse
+  writes.** An anchored authenticator that does not match the member's own is
+  evidence of a fork, and evidence is not an action — so the action is stated.
+  Reading is how a member gathers what they need to show what happened, and the
+  records that would prove it are inside the room a refusal would lock them out
+  of; writing to a host you have caught is what compounds the damage. The same
+  rule governs a root that fails to reconcile
+  ([`data-rooms-read-through.md`](data-rooms-read-through.md) §5), because it is
+  the same question. **The refusal is the mechanism and a flag is not**: a rule
+  nobody would guess needs the refused write to explain itself in the room's own
+  words, or the member reads it as their agent malfunctioning and blames the
+  wrong party.
 - **Cadence as a room parameter.** §9 says a high-assurance room anchors per
   commit. `rooms/create/0.1` has no member for it — the same gap the hosting
   axes hit in the creation-policy work — so either it is a client-side setting
@@ -186,7 +201,7 @@ anyway by having entries.
 
 ## 6. What this unblocks
 
-With the shape settled, the work is bounded and sits entirely on the owner's
+The shape is settled, so the work is bounded and sits entirely on the owner's
 side:
 
 1. `RoomGroup::epoch_authenticator()` already returns the value (implemented).
@@ -197,6 +212,16 @@ side:
 None of it needs a host change, which is consistent with §9: the host's
 contribution to lifecycle is *never deciding*, and the anchor is what makes that
 checkable rather than trusted.
+
+It also unblocks something outside §9. The **data commitment** now shipped on
+both read paths offers three comparisons, and the anchor is the only one that
+needs neither a gossip channel rooms deliberately do not have nor durable state
+in a member's agent — so until this is built, a root is comparable only by an
+agent that has read the same room before. `dataCommitment` rides the same slot
+this note settles, as
+[`data-rooms-verified-reads.md`](data-rooms-verified-reads.md) §3.2 anticipated;
+it is one more member of the `serviceEndpoint` map above, not a second
+mechanism.
 
 ---
 

--- a/docs/05-design-notes/data-rooms-read-through.md
+++ b/docs/05-design-notes/data-rooms-read-through.md
@@ -1,6 +1,7 @@
 # Read-through: the agent as the room's memory
 
-Status: **proposal for review, not a plan.** It works out the last unbuilt piece
+Status: **accepted.** The question in §5 was answered on 2026-09-09; the
+sequencing in §6 stands, amended by that answer. It works out the last unbuilt piece
 of the rooms UI far enough to be argued with, and names one thing that has to be
 decided before any of it is built.
 
@@ -138,31 +139,60 @@ sealed.
 
 ---
 
-## 5. What has to be decided
+## 5. Decided: serve reads, refuse writes
 
-**One question, and it is not a small one: what does the agent do when it catches
-a host?**
+**What does the agent do when it catches a host?** Answered 2026-09-09:
+**it keeps serving reads and refuses to write.**
 
-Three answers, and the note deliberately does not pick:
+Reading is how a member gathers the evidence, and the records they may need in
+order to prove what happened are inside the room they would otherwise be locked
+out of — by their own agent, on account of somebody else's misbehaviour. Writing
+to a host you have caught is the act that compounds the damage: it hands more
+material to a party you now have reason to believe will misrepresent what it
+holds.
 
-- **Refuse the read.** Honest, and it makes the detection load-bearing. It also
-  means a member whose host has misbehaved once loses access to their own room
-  through their own agent — including, plausibly, the records they need to prove
-  what happened.
-- **Return the record, flagged.** The member keeps working. A flag that appears
-  in a pane and blocks nothing is a flag that gets dismissed, and the room's
-  vocabulary has no word for *this host has been caught* that is stronger than a
-  pill.
-- **Refuse to write, serve reads.** The asymmetry has some logic — writing to a
-  host you have caught equivocating is the act that compounds the damage, while
-  reading is how you gather evidence — but it is a rule nobody would guess, so it
-  would need to be said very loudly on screen.
+The two answers not taken, and why they are worth remembering rather than
+deleting:
 
-A second, smaller question rides along: **how much history does the agent keep?**
-Retaining every `(headVersion, root)` grows without bound. Retaining only the
-latest catches a host that answers two reads inconsistently and misses one that
-alternates. The obvious middle — the last N, plus the highest `headVersion` ever
-seen — is probably right, and "probably" is why it is written here.
+- **Refuse the read.** Honest, and it makes the detection unmissable. It also
+  punishes the member for the host's act, at the exact moment they most need
+  what the room holds.
+- **Return it flagged, block nothing.** A flag that appears in a pane and stops
+  no action is a flag that gets dismissed. The room's on-screen vocabulary has
+  no word for *this host has been caught* stronger than a pill, and inventing
+  one is not a substitute for a mechanism.
+
+### The refusal is the mechanism; the flag is not
+
+This is the part that decides whether the rule works. "Serve reads, refuse
+writes" is a rule **nobody would guess**, so a member who hits it and is only
+shown a failure will read it as a bug in their agent — and the one thing worse
+than no detection is a detection the member blames on the wrong party.
+
+So the refusal owes an explanation in the room's own words, at the point of the
+refused write, saying what was observed and what it means: *two different record
+sets, both claimed as this room at version N.* A pill will not carry that. This
+is a copy problem before it is a code problem, and it belongs in
+`design-docs/persona-vocabulary.md`'s sibling for rooms rather than in a
+component.
+
+### And it makes the memory a prerequisite, not a second increment
+
+§6 originally sequenced the root memory after the tasks, as an additive extra.
+The decision changes that: **a refusal that lasts only as long as the process
+that noticed is not a refusal.** An agent that catches a host, then restarts and
+happily writes, has a detection and no consequence. So the durable
+`(headVersion, root)` record is load-bearing from the first increment that
+refuses anything — the tasks may ship verifying-and-reporting before it, but
+they may not ship *refusing* before it.
+
+### How much history to keep
+
+Still open, and genuinely smaller. Retaining every `(headVersion, root)` grows
+without bound; retaining only the latest catches a host that answers two reads
+inconsistently and misses one that alternates. The obvious middle — the last N,
+plus the highest `headVersion` ever seen — is probably right, and "probably" is
+why it stays written down. Nothing is blocked on it: the first N can be one.
 
 ---
 
@@ -173,9 +203,11 @@ without the memory.** They unblock the console immediately, and trace
 verification against the root in the same response is worth having on its own —
 it is what makes a served trace mean anything at all.
 
-Then add the memory as a second increment, once the question in §5 has an answer.
-It is a strictly additive change to a task that already exists by then, and it is
-the one piece here that turns a commitment from a number into a check.
+Then the memory — which §5's answer promotes from *additive extra* to
+*prerequisite of any refusal*. It is still a strictly additive change to tasks
+that exist by then, and it is the one piece here that turns a commitment from a
+number into a check. A read task may ship verifying-and-reporting without it; a
+write task may not ship refusing without it.
 
 `rooms/keys/write` last. It composes two things that already work and unblocks
 nothing that reading does not.

--- a/docs/05-design-notes/data-rooms.md
+++ b/docs/05-design-notes/data-rooms.md
@@ -1065,10 +1065,16 @@ read an `open` room the same way an agent's recall marks one.
    roots "cannot claim a transient" — false while a room moves, and corrected in
    tt#422 by carrying `headVersion` and `recordCount` beside the root.
 
-   What remains is the **witnessed anchor**, which is what turns a root from the
-   host's own assertion into evidence, and which is still blocked on
-   [`data-rooms-epoch-anchoring.md`](data-rooms-epoch-anchoring.md)'s open
-   question — and a party that *compares* roots, which is item 9.
+   The tree head followed in tt#422: a root names no state, so two of them
+   differing is a room that moved as readily as a host that equivocated — which
+   the shipped prose had got wrong. `headVersion` and `recordCount` fix it.
+
+   What remains is not implementation. The **witnessed anchor** is what turns a
+   root from the host's own assertion into evidence, and it is **no longer
+   blocked**: [`data-rooms-epoch-anchoring.md`](data-rooms-epoch-anchoring.md)'s
+   question was answered on 2026-09-09 (shape 3a, a typed service entry), and the
+   commitment rides the same slot. The other half is a party that *compares*
+   roots, which is item 9.
 8. **Rooms created before the chain** (§5.5) — a room that has already advanced
    past epoch 1 has lost the keys to everything below its current epoch, and
    nothing can recover them: no member retained the old exporters and the host
@@ -1089,9 +1095,16 @@ read an `open` room the same way an agent's recall marks one.
    Worked out in
    [`data-rooms-read-through.md`](data-rooms-read-through.md), which recommends
    `rooms/keys/{read,browse}` with verification first and the root memory second,
-   and leaves one question open on purpose: **what an agent does when it catches
-   a host** — refusing the read locks a member out of their own room with their
-   own agent, and a flag that blocks nothing is a flag that gets dismissed.
+   Its open question — **what an agent does when it catches a host** — was
+   answered on 2026-09-09: **serve reads, refuse writes.** Reading is how a
+   member gathers the evidence, and the records that would prove what happened
+   are inside the room a refusal would lock them out of; writing to a host you
+   have caught compounds the damage. Two consequences worth carrying: the
+   **refusal is the mechanism and a flag is not**, so a refused write owes an
+   explanation in the room's own words or the member blames their own agent; and
+   the agent's durable root memory becomes a **prerequisite** of any refusal
+   rather than a second increment, because a refusal that lasts only as long as
+   the process that noticed is not one.
 
 ---
 


### PR DESCRIPTION
Both open questions in the rooms design notes are answered. Recorded where the reasoning lives rather than only in a conversation — which is exactly what left the anchoring note marked "open question, not a plan" for two days, by its own admission ("it was blocking in a conversation rather than in the repository").

## One: a client that catches a host serves reads and refuses writes

It was asked **twice, in two vocabularies** — `data-rooms-read-through.md` §5 (two roots at one `headVersion`) and `data-rooms-epoch-anchoring.md` §5 (an anchored authenticator that does not match the member's own) — and it is one question. Answered once, in both notes.

Reading is how a member gathers the evidence, and the records that would prove what happened are inside the room a refusal would lock them out of — by their own agent, over somebody else's act. Writing to a host you have caught is what compounds the damage.

Two consequences the notes now carry, because neither falls out of the rule by itself:

**The refusal is the mechanism; the flag is not.** "Serve reads, refuse writes" is a rule nobody would guess, so a member who hits it and is shown only a failure reads it as their agent malfunctioning — and a detection the member blames on the wrong party is worse than no detection. The refused write owes an explanation in the room's own words, at the point of refusal: *two different record sets, both claimed as this room at version N*. A pill will not carry that. It is a copy problem before it is a code problem.

**The agent's root memory is a prerequisite, not a second increment.** §6 originally sequenced it after the tasks as an additive extra. It cannot be: a refusal that lasts only as long as the process that noticed is not a refusal — an agent that catches a host, restarts, and happily writes has a detection and no consequence. A read task may ship verifying-and-reporting without durable `(headVersion, root)` state; a write task may not ship *refusing* without it. §6's sequencing is amended.

Both rejected answers are kept rather than deleted, with why.

## Two: anchoring takes shape 3a

A typed service entry. §3b and §3c stay, because a shape chosen with its rejected siblings deleted is one nobody can argue with later.

This unblocks something outside §9 as well. The data commitment now shipped on both read paths offers three comparisons, and **the anchor is the only one needing neither a gossip channel rooms deliberately lack nor durable state in a member's agent** — so until it exists, a root is comparable only by an agent that has read the same room before. The commitment rides the same `serviceEndpoint` slot this note settles, as `data-rooms-verified-reads.md` §3.2 anticipated; it is one more member of that map, not a second mechanism.

## Three: `vti-rooms` has no external consumers

Not a note change. Recorded because it is the standing answer to whether its API breaks need batching — they do not, while it is alpha, and three consecutive PRs have relied on that being true without ever having asked.

## Also

§14 items 7 and 9 follow. Item 7 additionally gains tt#422: a root names no state, so two of them differing is a room that moved as readily as a host that equivocated — which the shipped prose had got wrong, and which is fixed by `headVersion` and `recordCount`.

Documentation only. Stacks alongside #1375, which implements the tree head.