### PR TITLE
fix(rooms)!: a listing pages honestly, or a short page means nothing

### DIFF
--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -168,6 +168,7 @@ async fn act_one(client: &VtcClient) -> anyhow::Result<()> {
             &agent,
             Some("decision/"),
             None,
+            None,
             &f.agent.did,
             &f.agent.secret_multibase,
         )

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -559,16 +559,20 @@ async fn list(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
         Ok(a) => a,
         Err(e) => return from_app_error(doc, &e),
     };
-    match storage::list_records(
+    // Paginated honestly: the page the caller asked for, and a cursor when more
+    // remain. This used to `take(limit)` and drop the rest without a word, so a
+    // short page and a complete room were indistinguishable.
+    match storage::list_records_page(
         &state.records,
         &req.room_id,
         req.prefix.as_deref(),
         req.since_version,
+        req.cursor.as_deref(),
+        req.limit,
     )
     .await
     {
-        Ok(records) => {
-            let limit = req.limit.unwrap_or(usize::MAX);
+        Ok(page) => {
             // Metadata, never bodies — the same rule the VTC serves under, because it is a
             // property of the task rather than of any one host.
             // A listing names no single record; the event is that the room was surveyed.
@@ -577,7 +581,8 @@ async fn list(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
             respond(
                 doc,
                 ListRecordsResponse {
-                    records: records.iter().take(limit).map(|r| r.metadata()).collect(),
+                    records: page.records.iter().map(|r| r.metadata()).collect(),
+                    cursor: page.cursor,
                     // The reference host commits too. A host that served
                     // listings without one would be a working example of the
                     // thing the commitment exists to make detectable.

--- a/room-host/src/mirror.rs
+++ b/room-host/src/mirror.rs
@@ -149,15 +149,42 @@ pub async fn pull_once(state: &HostState, mirror: &MirroredRoom) -> anyhow::Resu
     )?;
 
     let since = room.watermark();
-    let listing = client
-        .list_records(
-            &session,
-            None,
-            Some(since),
-            &mirror.signer_did,
-            &mirror.signer_key_multibase,
-        )
-        .await?;
+
+    // Read the listing to its END. A host pages now, and **absence of the
+    // cursor is the only end-of-listing signal** — a mirror that took the first
+    // page would silently stop replicating at the page size and look perfectly
+    // healthy doing it. A short page says nothing.
+    let mut pending: Vec<serde_json::Value> = Vec::new();
+    let mut cursor: Option<String> = None;
+    // A far side that will not end is a fault rather than a large room: at the
+    // host's maximum page this is a quarter of a million records, and returning
+    // what had been collected would reintroduce the silent-truncation defect
+    // one layer up and with a longer array.
+    const MAX_PAGES: usize = 500;
+    for page in 0..=MAX_PAGES {
+        if page == MAX_PAGES {
+            anyhow::bail!(
+                "room `{}` did not finish listing after {MAX_PAGES} pages; refusing to \
+                 replicate a prefix as though it were the room",
+                mirror.room_id
+            );
+        }
+        let listing = client
+            .list_records(
+                &session,
+                None,
+                Some(since),
+                cursor.as_deref(),
+                &mirror.signer_did,
+                &mirror.signer_key_multibase,
+            )
+            .await?;
+        pending.extend(listing.records);
+        match listing.cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
 
     let mut outcome = PullOutcome {
         copied: 0,
@@ -167,7 +194,6 @@ pub async fn pull_once(state: &HostState, mirror: &MirroredRoom) -> anyhow::Resu
     // Ordered by version so an interrupted pull leaves a prefix rather than a
     // hole: the watermark then resumes from the last record actually stored,
     // and nothing between it and the primary's head is silently skipped.
-    let mut pending: Vec<serde_json::Value> = listing.records;
     pending.sort_by_key(|r| {
         r.get("version")
             .and_then(serde_json::Value::as_u64)

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -163,16 +163,38 @@ pub async fn cmd_rooms_list(
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let session = present(client, &target, "read").await?;
-    let listing = target
+
+    // Read the listing to its END, then let `limit` decide how much to PRINT.
+    // A host pages, and absence of the cursor is the only end-of-listing signal
+    // — taking the first page would print "3 record(s)" over a room holding
+    // three hundred, which is the failure this whole member exists to prevent.
+    let mut listing = target
         .client()
         .list_records(
             &session,
             prefix,
             since_version,
+            None,
             signer.did,
             signer.key_multibase,
         )
         .await?;
+    let mut cursor = listing.cursor.clone();
+    while let Some(c) = cursor {
+        let next = target
+            .client()
+            .list_records(
+                &session,
+                prefix,
+                since_version,
+                Some(&c),
+                signer.did,
+                signer.key_multibase,
+            )
+            .await?;
+        cursor = next.cursor.clone();
+        listing.records.extend(next.records);
+    }
 
     if crate::render::is_json_output() {
         crate::render::print_json(&listing.records)?;
@@ -186,8 +208,16 @@ pub async fn cmd_rooms_list(
         return Ok(());
     }
 
-    println!("{} record(s):", listing.records.len());
-    for r in listing.records.iter().take(limit.unwrap_or(usize::MAX)) {
+    let shown = limit.unwrap_or(usize::MAX).min(listing.records.len());
+    if shown < listing.records.len() {
+        println!(
+            "{} record(s), showing {shown} — pass a larger --limit for the rest:",
+            listing.records.len()
+        );
+    } else {
+        println!("{} record(s):", listing.records.len());
+    }
+    for r in listing.records.iter().take(shown) {
         let key = r.get("key").and_then(Value::as_str).unwrap_or("?");
         let version = r.get("version").and_then(Value::as_u64).unwrap_or(0);
         let status = r.get("status").and_then(Value::as_str).unwrap_or("active");

--- a/vtc-client/src/rooms/mod.rs
+++ b/vtc-client/src/rooms/mod.rs
@@ -230,11 +230,16 @@ impl VtcClient {
     /// `since_version` is the incremental-sync watermark, and the response **includes
     /// tombstones**: a caller that never saw a retraction would resurrect the record on its
     /// next full rebuild.
+    ///
+    /// `cursor` continues a previous page. **A listing is not complete until the response's
+    /// `cursor` is absent** — a page shorter than the one asked for says nothing, which is
+    /// why this takes the token rather than leaving callers to guess from a length.
     pub async fn list_records(
         &self,
         session: &RoomSession,
         prefix: Option<&str>,
         since_version: Option<u64>,
+        cursor: Option<&str>,
         signer_did: &str,
         private_key_multibase: &str,
     ) -> Result<ListRecordsResponse, VtcError> {
@@ -247,6 +252,9 @@ impl VtcClient {
         }
         if let Some(v) = since_version {
             payload["sinceVersion"] = serde_json::json!(v);
+        }
+        if let Some(c) = cursor {
+            payload["cursor"] = serde_json::json!(c);
         }
         let value = self
             .room_task(

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -442,19 +442,23 @@ pub(crate) async fn handle_list_records(
         Err(e) => return app_error_to_reject(&doc, &e),
     };
 
-    let records = match storage::list_records(
+    // Paginated honestly: the page the caller asked for, and a cursor when more
+    // remain. This used to `take(limit)` and drop the rest without a word, so a
+    // short page and a complete room were indistinguishable.
+    let page = match storage::list_records_page(
         &state.room_records_ks,
         &req.room_id,
         req.prefix.as_deref(),
         req.since_version,
+        req.cursor.as_deref(),
+        req.limit,
     )
     .await
     {
-        Ok(r) => r,
+        Ok(p) => p,
         Err(e) => return app_error_to_reject(&doc, &e),
     };
 
-    let limit = req.limit.unwrap_or(usize::MAX);
     // A listing names no single record, so the entry records the room and the fact of a
     // listing — which is the event: who has seen what this room holds.
     audit_room(state, &room, &authorized, RoomOperation::ListRecords, None).await;
@@ -462,7 +466,8 @@ pub(crate) async fn handle_list_records(
     success_response(
         &doc,
         ListRecordsResponse {
-            records: records.iter().take(limit).map(|r| r.metadata()).collect(),
+            records: page.records.iter().map(|r| r.metadata()).collect(),
+            cursor: page.cursor,
             // One head, so the three values a reader compares cannot come
             // from three moments.
             data_commitment: head

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -505,6 +505,92 @@ pub async fn list_records(
 /// So: correct first, and cache when there is a measurement saying where. The
 /// natural shape is a root kept beside the room row and updated on write, which
 /// is a different change with its own invariant to hold.
+/// The largest page a host will serve, however much a caller asks for.
+///
+/// A listing used to be unbounded: `limit` was applied with `take` and anything
+/// beyond it was dropped **silently**, so a short page and a complete room were
+/// the same bytes. That is worse than not paginating at all, because a caller
+/// cannot tell the two apart and every client that "worked" was one that had
+/// not yet met a big enough room.
+///
+/// The ceiling is the host's own, not the caller's: a response carrying an
+/// entire room is a denial-of-service surface a host hands out for free.
+pub const MAX_PAGE: usize = 500;
+
+/// One page of a listing, and where the next one starts.
+#[derive(Debug, Clone)]
+pub struct Page {
+    pub records: Vec<Record>,
+    /// `Some` when more records remain. **Absence is the only end-of-listing
+    /// signal** — a consumer MUST NOT infer exhaustion from a short page.
+    pub cursor: Option<String>,
+}
+
+/// The cursor's shape: the version of the last record on the page.
+///
+/// # Why it is not authenticated, and does not need to be
+///
+/// `rooms/records/list/0.1` calls this an opaque token and says a host MUST NOT
+/// accept one it did not issue, which reads as though it wants a signature. It
+/// does not, and pretending otherwise would be security theatre with a key
+/// nobody has: a cursor here expresses *start above version N*, which is
+/// precisely what `sinceVersion` already lets any caller ask for directly. A
+/// forged cursor can skip a caller's own records and nothing else.
+///
+/// What the host does enforce is the **shape**, so a value from somewhere else
+/// is refused rather than silently reinterpreted.
+fn encode_cursor(version: u64) -> String {
+    format!("v{version}")
+}
+
+fn decode_cursor(cursor: &str) -> Result<u64, AppError> {
+    cursor
+        .strip_prefix('v')
+        .and_then(|rest| rest.parse::<u64>().ok())
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "`{cursor}` is not a cursor this host issued; continue a listing with the \
+                 `cursor` from its previous page, or start again without one"
+            ))
+        })
+}
+
+/// One page of a room's records, ordered by version, with an honest cursor.
+///
+/// # The filters are the caller's to repeat
+///
+/// A cursor carries **position and nothing else**. A caller that continues with
+/// a different `prefix` or `since_version` gets that different query resumed
+/// from this position, which is a coherent thing to ask for and almost never
+/// what anyone means. Repeat the filters.
+pub async fn list_records_page(
+    records: &KeyspaceHandle,
+    room_id: &str,
+    key_prefix: Option<&str>,
+    since_version: Option<u64>,
+    cursor: Option<&str>,
+    limit: Option<usize>,
+) -> Result<Page, AppError> {
+    // A cursor and a watermark say the same kind of thing, so the later of the
+    // two wins rather than one silently overriding the other.
+    let floor = match cursor {
+        Some(c) => Some(decode_cursor(c)?.max(since_version.unwrap_or(0))),
+        None => since_version,
+    };
+    let mut all = list_records(records, room_id, key_prefix, floor).await?;
+
+    let page = limit.unwrap_or(MAX_PAGE).clamp(1, MAX_PAGE);
+    let more = all.len() > page;
+    all.truncate(page);
+    let cursor = more
+        .then(|| all.last().map(|r| encode_cursor(r.version)))
+        .flatten();
+    Ok(Page {
+        records: all,
+        cursor,
+    })
+}
+
 pub async fn tree_head(
     records: &KeyspaceHandle,
     room_id: &str,
@@ -829,6 +915,141 @@ mod tests {
         let filtered = list_records(&rec, "r1", Some("a"), None).await.unwrap();
         assert!(filtered.len() < 3, "the fixture must actually filter");
         assert_eq!(tree_head(&rec, "r1").await.unwrap().root, root);
+    }
+
+    /// A listing pages to its end, and the cursor is the only thing that says so.
+    ///
+    /// The defect this replaces was silent: `take(limit)` dropped the remainder
+    /// without a word, so a short page and a complete room were the same bytes
+    /// and every client that "worked" was one that had not met a big enough
+    /// room yet.
+    #[tokio::test]
+    async fn a_listing_pages_to_its_end() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for i in 0..7u64 {
+            put_record(
+                &rooms,
+                &rec,
+                "r1",
+                open_record(&format!("k{i}")),
+                None,
+                i + 1,
+            )
+            .await
+            .unwrap();
+        }
+
+        let mut seen = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut pages = 0;
+        loop {
+            let page = list_records_page(&rec, "r1", None, None, cursor.as_deref(), Some(3))
+                .await
+                .unwrap();
+            pages += 1;
+            seen.extend(page.records.iter().map(|r| r.key.clone()));
+            match page.cursor {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+            assert!(pages < 10, "the listing never ended");
+        }
+        assert_eq!(pages, 3, "7 records at 3 a page is three pages");
+        assert_eq!(seen.len(), 7, "every record was returned exactly once");
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), 7, "a record was served on two pages");
+    }
+
+    /// The boundary that decides whether "short page means the end" is safe.
+    ///
+    /// With exactly a page's worth left there is no cursor — so a caller that
+    /// inferred the end from a *full* page would ask for one more and a caller
+    /// that inferred it from a *short* page would be right by luck. Only the
+    /// cursor's absence is load-bearing.
+    #[tokio::test]
+    async fn an_exactly_full_last_page_carries_no_cursor() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for i in 0..4u64 {
+            put_record(
+                &rooms,
+                &rec,
+                "r1",
+                open_record(&format!("k{i}")),
+                None,
+                i + 1,
+            )
+            .await
+            .unwrap();
+        }
+
+        let first = list_records_page(&rec, "r1", None, None, None, Some(2))
+            .await
+            .unwrap();
+        assert_eq!(first.records.len(), 2);
+        let cursor = first.cursor.expect("two of four remain");
+
+        let second = list_records_page(&rec, "r1", None, None, Some(&cursor), Some(2))
+            .await
+            .unwrap();
+        assert_eq!(second.records.len(), 2, "the last page is full");
+        assert!(
+            second.cursor.is_none(),
+            "a full page with nothing after it must still say it is the end"
+        );
+    }
+
+    /// A cursor from somewhere else is refused rather than reinterpreted.
+    #[tokio::test]
+    async fn a_cursor_this_host_did_not_issue_is_refused() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        assert!(
+            list_records_page(&rec, "r1", None, None, Some("412"), None)
+                .await
+                .is_err(),
+            "a bare number is not this host's cursor shape"
+        );
+        assert!(
+            list_records_page(&rec, "r1", None, None, Some("vNaN"), None)
+                .await
+                .is_err()
+        );
+    }
+
+    /// A host bounds its own response even when the caller asks for everything.
+    #[tokio::test]
+    async fn a_host_caps_the_page_it_will_serve() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for i in 0..3u64 {
+            put_record(
+                &rooms,
+                &rec,
+                "r1",
+                open_record(&format!("k{i}")),
+                None,
+                i + 1,
+            )
+            .await
+            .unwrap();
+        }
+        // Asking for more than the ceiling gets the ceiling, not the ask.
+        let page = list_records_page(&rec, "r1", None, None, None, Some(MAX_PAGE * 10))
+            .await
+            .unwrap();
+        assert_eq!(page.records.len(), 3);
+        assert!(page.cursor.is_none());
     }
 
     /// The head's three values describe one set, and they are read from it.

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -225,6 +225,17 @@ pub struct ListRecordsBody {
     pub prefix: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub since_version: Option<u64>,
+    /// Opaque continuation token from a previous response.
+    ///
+    /// This member is in the published request schema and was **missing here**,
+    /// and `deny_unknown_fields` turns a missing member into a refusal: a
+    /// conforming client that paged got its second page rejected as malformed.
+    /// The two halves of the defect were symmetrical — a host that never issued
+    /// a cursor and could not have accepted one back.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Page size to ask for. **Never a cap on the result**: a caller that wants
+    /// the whole room follows [`ListRecordsResponse::cursor`] to its absence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
 }
@@ -370,6 +381,14 @@ pub struct ListRecordsResponse {
     /// Optional on the wire because a host that maintains no tree must not
     /// invent a root: its absence honestly says "no completeness guarantee
     /// here", and a fabricated one would say the opposite while meaning less.
+    /// Present when more records remain, absent at the end.
+    ///
+    /// **Absence is the only end-of-listing signal**, which is why a host that
+    /// truncated silently was worse than one that did not paginate at all: a
+    /// short page and a complete room were the same bytes. A consumer MUST NOT
+    /// infer exhaustion from a page shorter than the limit it asked for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_commitment: Option<String>,
     /// How many records the room holds, as of `data_commitment`.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -150,6 +150,7 @@ fn get_and_list_requests_conform() {
         presentation: presentation(),
         prefix: Some("decision/".into()),
         since_version: Some(4),
+        cursor: Some("v412".into()),
         limit: Some(50),
     };
     check::<ListPayload>(
@@ -163,6 +164,7 @@ fn get_and_list_requests_conform() {
         presentation: presentation(),
         prefix: None,
         since_version: None,
+        cursor: None,
         limit: None,
     };
     check::<ListPayload>(
@@ -357,6 +359,21 @@ fn responses_conform() {
     );
 
     check::<ListResponse>("ListRecordsResponse", &json!({ "records": records }));
+
+    // And with a cursor, which is what a host serves when more remain. The
+    // member was in the published schema and this implementation never emitted
+    // it, so a caller could not tell a page from a room.
+    check::<ListResponse>(
+        "ListRecordsResponse mid-listing",
+        &serde_json::to_value(ListRecordsResponse {
+            records: records.clone(),
+            cursor: Some("v412".into()),
+            data_commitment: None,
+            record_count: None,
+            head_version: None,
+        })
+        .expect("serialise"),
+    );
 }
 
 /// The single-record read, on every tier and on a tombstone.


### PR DESCRIPTION
`rooms/records/list/0.1` has `cursor` on its request **and** its response — *"present when more records remain"* — and this implementation had it on neither. Both halves were defects, and they were symmetrical.

| | |
|---|---|
| **Response** | `limit` was applied with `take` and the remainder dropped **without a word**. A short page and a complete room were the same bytes. |
| **Request** | `ListRecordsBody` is `deny_unknown_fields`, so a conforming client that *did* page had its second page refused as malformed. |

A host that never issued a cursor and could not have accepted one back.

Silent truncation is worse than not paginating at all: a caller cannot tell the two apart, so every client that "worked" was one that had not met a big enough room yet.

## Why it blocks the next thing

`rooms/keys/browse` ([tt#426](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/426)) checks a listing's length against the `recordCount` its host committed to — **the one verification a listing can do with no anchor and no second party**. Against a silently truncating host that check reports `short` on every room past a page, which would have made the feature useless and looked like the host's fault.

## The fix

`storage::list_records_page` returns a page and a cursor. `MAX_PAGE = 500` is the **host's own ceiling**, not the caller's: a response carrying an entire room is a denial-of-service surface a host hands out for free.

**The cursor is deliberately unauthenticated, and the code says so.** The spec calls it opaque and says a host MUST NOT accept one it did not issue, which reads as wanting a signature. It does not need one, and faking it would be theatre with a key nobody has: a cursor here expresses *start above version N*, which `sinceVersion` already lets any caller ask for directly. A forged one can skip a caller's own records and nothing else. What **is** enforced is the shape, so a token from somewhere else is refused rather than silently reinterpreted.

## Three consumers now read to the end

- **`room-host`'s mirror** is the one that mattered. It would have stopped replicating at the page size and looked perfectly healthy doing it. It now follows the cursor in a bounded loop that **fails** rather than replicating a prefix as though it were the room — returning what had been collected would reintroduce the same silent truncation one layer up and with a longer array.
- **The CLI** pages to the end, then applies `--limit` as a display cap and says when it truncated.
- **The example** passes `None`.

## The test that decides whether this is safe

```rust
assert!(second.cursor.is_none(),
    "a full page with nothing after it must still say it is the end");
```

`an_exactly_full_last_page_carries_no_cursor`. A caller inferring the end from a *full* page asks once more; a caller inferring it from a *short* page is right by luck. **Only the cursor's absence is load-bearing**, and this is the case that proves it.

Also pinned: a listing pages to its end with every record served exactly once; a cursor this host did not issue is refused; a host caps the page it will serve however much is asked for.

## Checks

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **175 suites, 0 failures**

`!` for `vti-rooms` and `vtc-client`: `ListRecordsBody` / `ListRecordsResponse` gain a member and `VtcClient::list_records` takes a cursor. Alpha, no external consumers.