### PR TITLE
fix(room-host)!: a TSP reply is the document, matching the VTC

### DIFF
--- a/room-host/src/didcomm.rs
+++ b/room-host/src/didcomm.rs
@@ -288,17 +288,7 @@ pub async fn serve(
         let reply = answer.document;
 
         let sent = match frame.message.protocol {
-            Protocol::TSP => {
-                send_tsp(
-                    &atm,
-                    &profile,
-                    &mediator_did,
-                    &sender,
-                    &reply,
-                    &reply_thread,
-                )
-                .await
-            }
+            Protocol::TSP => send_tsp(&atm, &profile, &mediator_did, &sender, &reply).await,
             _ => {
                 send_didcomm(
                     &atm,
@@ -381,15 +371,6 @@ fn unwrap_request(protocol: Protocol, payload: &[u8]) -> Option<Request> {
     }
 }
 
-/// Frame an answer for TSP: `{ thid, document }`.
-///
-/// The document is unchanged inside it. TSP has no headers, so correlation has to ride in the
-/// payload — and it is the *reply* that needs it, not the request: a request's type is the
-/// document's own `type` field, but nothing in a document says which request it answers.
-fn tsp_reply(document: &serde_json::Value, thread: &str) -> serde_json::Value {
-    serde_json::json!({ "thid": thread, "document": document })
-}
-
 /// Return an answer over DIDComm: authcrypt to the caller, then forward through the mediator.
 ///
 /// Two hops, because a mediator refuses direct delivery of inner messages. It unwraps the
@@ -434,25 +415,24 @@ async fn send_didcomm(
 
 /// Return an answer over TSP: sealed end-to-end to the caller, routed through the mediator.
 ///
-/// # Why the reply is wrapped and the request was not
+/// # No wrapper, because the document already threads itself
 ///
-/// TSP has no headers — no `type`, no `thid` — so a caller with two requests outstanding has
-/// nothing to tell the answers apart by. A *request* needs none, because its type is the
-/// Trust-Task document's own `type` field; a *reply* does, because correlation is the one
-/// thing the document cannot carry about itself.
+/// TSP has no headers, so it is tempting to conclude correlation must be added around the
+/// document. It must not: a routed Trust-Task response carries its own `threadId`, set to the
+/// request's `id`, and that is what a caller matches on. Wrapping it says the same thing
+/// twice — and disagrees with the other host of this protocol.
 ///
-/// So the reply is `{ thid, document }` and the document is unchanged inside it. A caller
-/// that ignored the wrapper and read the document would still be reading the same bytes the
-/// HTTP and DIDComm carriers deliver.
+/// This did wrap it, as `{ thid, document }`, which made a `room-host` reply unreadable to a
+/// client written against `vtc-service` and the reverse. Both now send the document and
+/// nothing else, byte-identical to the HTTP body in either direction.
 async fn send_tsp(
     atm: &Arc<ATM>,
     profile: &Arc<ATMProfile>,
     mediator_did: &str,
     sender: &str,
     reply: &serde_json::Value,
-    thread: &str,
 ) -> anyhow::Result<()> {
-    let bytes = serde_json::to_vec(&tsp_reply(reply, thread))?;
+    let bytes = serde_json::to_vec(reply)?;
     atm.tsp()
         .send_routed(
             profile,
@@ -559,22 +539,5 @@ mod tests {
         // caller never sent, which is the same failure as threading on the wrong one.
         let no_id = serde_json::to_vec(&json!({ "type": "x", "payload": {} })).unwrap();
         assert_eq!(unwrap_request(Protocol::TSP, &no_id), None);
-    }
-
-    /// The TSP reply puts the thread where a caller looks, and leaves the document alone.
-    #[test]
-    fn a_tsp_reply_carries_the_thread_beside_an_untouched_document() {
-        let answer = json!({ "type": "…#response", "payload": { "records": [] } });
-        let framed = tsp_reply(&answer, "urn:uuid:33333333-3333-3333-3333-333333333333");
-
-        assert_eq!(
-            framed["thid"],
-            "urn:uuid:33333333-3333-3333-3333-333333333333"
-        );
-        assert_eq!(
-            framed["document"], answer,
-            "a caller that ignored the wrapper would read the same bytes the other two \
-             carriers deliver"
-        );
     }
 }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -1444,6 +1444,48 @@ mod tests {
         }
     }
 
+    /// **A TSP reply is the document, with nothing around it.**
+    ///
+    /// This host used to wrap it as `{ thid, document }`, on the reasoning that TSP has no
+    /// headers so correlation had to be added. It does not: a routed response carries its own
+    /// `threadId`, set to the request's `id`. The wrapper said the same thing twice and made
+    /// this host's replies unreadable to a client written against `vtc-service`, which sends
+    /// the document bare — two hosts of one protocol disagreeing about the wire.
+    ///
+    /// Asserted as a property of `dispatch` rather than of a framing function, because there
+    /// is no longer a framing function and that is the point.
+    #[tokio::test]
+    async fn a_tsp_answer_is_the_document_and_threads_on_the_request() {
+        let (_dir, st) = state();
+        let app = router(st.clone());
+        let f = RoomFixture::new(Visibility::Open).await;
+        register(&app, &f).await;
+
+        let document = vta_sdk::trust_task_sign::build_signed(
+            ROOMS_RECORDS_LIST_TYPE,
+            serde_json::json!({ "roomId": f.room.room_id, "presentation": f.as_owner() }),
+            &f.owner.did,
+            &f.owner.secret_multibase,
+            "did:key:zHost",
+        )
+        .await
+        .unwrap();
+        let request_id: Value = serde_json::from_str(&document).unwrap();
+        let request_id = request_id["id"].as_str().unwrap().to_string();
+
+        // What the TSP arm sends is exactly this — `send_tsp` serialises it unchanged.
+        let answer = dispatch(&st, document.as_bytes()).await.document;
+
+        assert_eq!(
+            answer["threadId"], request_id,
+            "the document threads itself, which is why nothing needs to wrap it"
+        );
+        assert!(
+            answer.get("thid").is_none(),
+            "and it carries no second, disagreeing copy of that: {answer}"
+        );
+    }
+
     /// Registration is the one verb no chain can authorize, so the proof on the request
     /// is the whole of its defence — and `ownerDid` is a payload field until something
     /// checks it against the signer.


### PR DESCRIPTION
Two hosts of one protocol disagreed about the wire, so a client could not be written against both.

`vtc-service` sends a TSP reply as the Trust-Task document and nothing else:

```rust
// No re-wrapping: TSP carries the Trust-Task document bytes directly, which is
// exactly what the spine returns.
```

`room-host` (mine, #1369) wrapped it as `{ thid, document }`, reasoning that TSP has no headers so correlation had to be added around the payload.

**That reasoning was wrong, and the evidence was inside the document all along.** A routed Trust-Task response carries its own `threadId`, set to the request's `id`. The wrapper said the same thing a second time in a different spelling — and the effect was that a client written against `vtc-service` read nothing from `room-host`, and the reverse. Silently: as a reply no waiter ever matched, which presents as a timeout.

Found while making the data-room demo site able to front a real VTC. Everything else lined up — the VTC serves the whole `rooms/*` family over DIDComm *and* TSP through the same `dispatch_trust_task_core` spine, over the same `DidCommTransport` — and then the reply came back in a shape the client did not recognise.

Both now send the document bare, byte-identical to the HTTP body in either direction.

## Breaking

For anything written against the wrapper, which is this workspace's own demo client, fixed alongside. `vtc-service` already accepts *both* shapes on receive (`tsp_reply_document` falls back to the bare document), so nothing there has to move.

## Testing

The test that pinned the wrapper is replaced by one pinning the agreement: the answer threads itself, and carries no second disagreeing copy of that. Asserted on `dispatch` rather than on a framing function — because there is no longer a framing function, which is the point. 29 + 2 tests pass, clippy clean.