### PR TITLE
fix(admin-ui): pin js-yaml past the merge-key advisory

### DIFF
--- a/vtc-service/admin-ui/package-lock.json
+++ b/vtc-service/admin-ui/package-lock.json
@@ -880,9 +880,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/vtc-service/admin-ui/package.json
+++ b/vtc-service/admin-ui/package.json
@@ -32,5 +32,8 @@
     "openapi-typescript": "^7.13.0",
     "typescript": "^5.7.2",
     "vite": "^8.0.0"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.2"
   }
 }


### PR DESCRIPTION
Dependabot has been reporting one **high** on this repository's default branch for a while (`security/dependabot/38`). It is `js-yaml` 4.3.1 in `vtc-service/admin-ui` — *`maxTotalMergeKeys` does not limit CPU use for empty merge sources* — fixed in 4.3.2.

## What the exposure actually is

Worth stating rather than repeating the label. It is a **dev** dependency, reached only through `@redocly/openapi-core`, and it is **not in the shipped bundle**:

```
node_modules/@redocly/openapi-core  1.34.19  dev
node_modules/js-yaml                4.3.1    dev
```

The vulnerability is CPU exhaustion parsing hostile YAML, and the only YAML that parser sees is this repository's own OpenAPI description. **The real risk here is low.**

The reason to fix it anyway is not the vulnerability. A standing "1 high" on the default branch is a banner on every push, and a banner that is always there is one nobody reads — including on the day it means something. Clearing it costs three lines.

## Done with `overrides`, not `--save-dev`

The obvious command — `npm install js-yaml@^4.3.2 --save-dev` — is wrong, and I did it first and backed it out. It adds `js-yaml` to `devDependencies`, which says this package uses it directly. It does not; it is pulled in by Redocly.

`overrides` is npm's mechanism for constraining what a dependency brings with it, and is what the plugin repo already uses to hold `@swc/core` below the version that breaks its bundler.

```json
"overrides": { "js-yaml": "^4.3.2" }
```

Lockfile moves 4.3.1 → 4.3.2 and nothing else does.

## Checks

- `npm ci` — clean
- `npm run build` — clean, `✓ built in 1.08s`