### PR TITLE
feat(rooms/keys): read and browse — the agent fetches, checks, and opens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9643,9 +9643,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f82ca5de9096c13635dedb2d347a8aef761b21b3bf48ff43db535f5bf3e1d7"
+checksum = "bd5b1b65db50a01f5615765b3d902a37f541325be156669aef06d4fc23f24874"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.19.2", default-features = false, features = [
+trust-tasks-rs = { version = "0.19.3", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/room-host/examples/data_room.rs
+++ b/room-host/examples/data_room.rs
@@ -168,6 +168,7 @@ async fn act_one(client: &VtcClient) -> anyhow::Result<()> {
             &agent,
             Some("decision/"),
             None,
+            None,
             &f.agent.did,
             &f.agent.secret_multibase,
         )

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -559,16 +559,20 @@ async fn list(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
         Ok(a) => a,
         Err(e) => return from_app_error(doc, &e),
     };
-    match storage::list_records(
+    // Paginated honestly: the page the caller asked for, and a cursor when more
+    // remain. This used to `take(limit)` and drop the rest without a word, so a
+    // short page and a complete room were indistinguishable.
+    match storage::list_records_page(
         &state.records,
         &req.room_id,
         req.prefix.as_deref(),
         req.since_version,
+        req.cursor.as_deref(),
+        req.limit,
     )
     .await
     {
-        Ok(records) => {
-            let limit = req.limit.unwrap_or(usize::MAX);
+        Ok(page) => {
             // Metadata, never bodies — the same rule the VTC serves under, because it is a
             // property of the task rather than of any one host.
             // A listing names no single record; the event is that the room was surveyed.
@@ -577,7 +581,8 @@ async fn list(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
             respond(
                 doc,
                 ListRecordsResponse {
-                    records: records.iter().take(limit).map(|r| r.metadata()).collect(),
+                    records: page.records.iter().map(|r| r.metadata()).collect(),
+                    cursor: page.cursor,
                     // The reference host commits too. A host that served
                     // listings without one would be a working example of the
                     // thing the commitment exists to make detectable.

--- a/room-host/src/mirror.rs
+++ b/room-host/src/mirror.rs
@@ -149,15 +149,42 @@ pub async fn pull_once(state: &HostState, mirror: &MirroredRoom) -> anyhow::Resu
     )?;
 
     let since = room.watermark();
-    let listing = client
-        .list_records(
-            &session,
-            None,
-            Some(since),
-            &mirror.signer_did,
-            &mirror.signer_key_multibase,
-        )
-        .await?;
+
+    // Read the listing to its END. A host pages now, and **absence of the
+    // cursor is the only end-of-listing signal** — a mirror that took the first
+    // page would silently stop replicating at the page size and look perfectly
+    // healthy doing it. A short page says nothing.
+    let mut pending: Vec<serde_json::Value> = Vec::new();
+    let mut cursor: Option<String> = None;
+    // A far side that will not end is a fault rather than a large room: at the
+    // host's maximum page this is a quarter of a million records, and returning
+    // what had been collected would reintroduce the silent-truncation defect
+    // one layer up and with a longer array.
+    const MAX_PAGES: usize = 500;
+    for page in 0..=MAX_PAGES {
+        if page == MAX_PAGES {
+            anyhow::bail!(
+                "room `{}` did not finish listing after {MAX_PAGES} pages; refusing to \
+                 replicate a prefix as though it were the room",
+                mirror.room_id
+            );
+        }
+        let listing = client
+            .list_records(
+                &session,
+                None,
+                Some(since),
+                cursor.as_deref(),
+                &mirror.signer_did,
+                &mirror.signer_key_multibase,
+            )
+            .await?;
+        pending.extend(listing.records);
+        match listing.cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
 
     let mut outcome = PullOutcome {
         copied: 0,
@@ -167,7 +194,6 @@ pub async fn pull_once(state: &HostState, mirror: &MirroredRoom) -> anyhow::Resu
     // Ordered by version so an interrupted pull leaves a prefix rather than a
     // hole: the watermark then resumes from the last record actually stored,
     // and nothing between it and the primary's head is silently skipped.
-    let mut pending: Vec<serde_json::Value> = listing.records;
     pending.sort_by_key(|r| {
         r.get("version")
             .and_then(serde_json::Value::as_u64)

--- a/vta-cli-common/src/commands/rooms.rs
+++ b/vta-cli-common/src/commands/rooms.rs
@@ -163,16 +163,38 @@ pub async fn cmd_rooms_list(
     limit: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let session = present(client, &target, "read").await?;
-    let listing = target
+
+    // Read the listing to its END, then let `limit` decide how much to PRINT.
+    // A host pages, and absence of the cursor is the only end-of-listing signal
+    // — taking the first page would print "3 record(s)" over a room holding
+    // three hundred, which is the failure this whole member exists to prevent.
+    let mut listing = target
         .client()
         .list_records(
             &session,
             prefix,
             since_version,
+            None,
             signer.did,
             signer.key_multibase,
         )
         .await?;
+    let mut cursor = listing.cursor.clone();
+    while let Some(c) = cursor {
+        let next = target
+            .client()
+            .list_records(
+                &session,
+                prefix,
+                since_version,
+                Some(&c),
+                signer.did,
+                signer.key_multibase,
+            )
+            .await?;
+        cursor = next.cursor.clone();
+        listing.records.extend(next.records);
+    }
 
     if crate::render::is_json_output() {
         crate::render::print_json(&listing.records)?;
@@ -186,8 +208,16 @@ pub async fn cmd_rooms_list(
         return Ok(());
     }
 
-    println!("{} record(s):", listing.records.len());
-    for r in listing.records.iter().take(limit.unwrap_or(usize::MAX)) {
+    let shown = limit.unwrap_or(usize::MAX).min(listing.records.len());
+    if shown < listing.records.len() {
+        println!(
+            "{} record(s), showing {shown} — pass a larger --limit for the rest:",
+            listing.records.len()
+        );
+    } else {
+        println!("{} record(s):", listing.records.len());
+    }
+    for r in listing.records.iter().take(shown) {
         let key = r.get("key").and_then(Value::as_str).unwrap_or("?");
         let version = r.get("version").and_then(Value::as_u64).unwrap_or(0);
         let status = r.get("status").and_then(Value::as_str).unwrap_or("active");

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -140,6 +140,14 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // same reason `chain` is — it extends what this agent can decrypt — with the
     // addition that it makes an outbound call to a party the caller names.
     ("rooms/keys/backfill", Risk::Sensitive),
+    // Returns a record's PLAINTEXT — on a sealed tier, material the room
+    // withholds from its own host — after an outbound call to a party the caller
+    // names. Both halves are why this is sensitive; either alone would be.
+    ("rooms/keys/read", Risk::Sensitive),
+    // Metadata only, and still sensitive: it presents the principal's room
+    // credentials to a caller-named host, which on a tier that discloses
+    // subjects names them to it.
+    ("rooms/keys/browse", Risk::Sensitive),
     // Secret material, accepted AND emitted. `seal` takes a record's plaintext and
     // returns it encrypted under the room's key — the one direction in this family
     // where cleartext room material travels INTO the oracle. It belongs beside

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -434,6 +434,15 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // and re-fetching from the host yields the same rungs. A retry that arrives
     // after the first succeeded stores nothing and reports the same reach.
     (trust_tasks::TASK_ROOMS_KEYS_BACKFILL_0_1, RetrySafe),
+    // A read stores nothing and changes nothing at either end: the host serves
+    // the same record, and this agent opens it again. What a retry costs is one
+    // more disclosure of the presentation to the host, which is why it is safe
+    // rather than free.
+    (trust_tasks::TASK_ROOMS_KEYS_READ_0_1, RetrySafe),
+    // Same, over a listing. The room may have moved between attempts, so two
+    // tries can differ — that is the room changing, not the task misbehaving,
+    // and `headVersion` is what tells them apart.
+    (trust_tasks::TASK_ROOMS_KEYS_BROWSE_0_1, RetrySafe),
     // Sealing is a pure function of the key and the bytes, and it stores nothing:
     // a lost reply costs the caller a round trip, never any state. Re-sealing the
     // same body yields a different nonce, which is correct and changes nothing.

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -837,6 +837,22 @@ pub const TASK_ROOMS_KEYS_CHAIN_0_1: &str = "https://trusttasks.org/spec/rooms/k
 pub const TASK_ROOMS_KEYS_BACKFILL_0_1: &str =
     "https://trusttasks.org/spec/rooms/keys/backfill/0.1";
 
+/// `spec/rooms/keys/read/0.1` — read one record from a room's host, check what
+/// the host asserted about it, and open it.
+///
+/// Four acts by the only party that can do the fourth: the epoch key never
+/// leaves the key holder, so a surface that fetched the record itself would
+/// still come back here to open it, holding a half-verified record in between.
+/// Auth: `roomOpen` capability.
+pub const TASK_ROOMS_KEYS_READ_0_1: &str = "https://trusttasks.org/spec/rooms/keys/read/0.1";
+
+/// `spec/rooms/keys/browse/0.1` — list a room's records at its host, and check
+/// the listing against what the host committed to.
+///
+/// Never returns bodies; that is a property of the task rather than of the tier,
+/// and is why browsing and reading are two. Auth: `roomOpen` capability.
+pub const TASK_ROOMS_KEYS_BROWSE_0_1: &str = "https://trusttasks.org/spec/rooms/keys/browse/0.1";
+
 /// `spec/rooms/keys/seal/0.1` — seal one record body with the room's current
 /// epoch key. The mirror of `open`: plaintext in, ciphertext out, key stays put.
 /// Auth: `roomOpen` capability. It does not write — the caller takes the result
@@ -1950,6 +1966,8 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ROOMS_KEYS_COMMIT_0_1,
     TASK_ROOMS_KEYS_CHAIN_0_1,
     TASK_ROOMS_KEYS_BACKFILL_0_1,
+    TASK_ROOMS_KEYS_READ_0_1,
+    TASK_ROOMS_KEYS_BROWSE_0_1,
     TASK_ROOMS_KEYS_SEAL_0_1,
     TASK_ROOMS_KEYS_LIST_0_1,
     TASK_ROOMS_OWNER_INVITE_0_1,

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2081,6 +2081,71 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
+            uris::TASK_ROOMS_KEYS_READ_0_1,
+            checked!(
+                specs::rooms::keys::read::v0_1::Payload,
+                specs::rooms::keys::read::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "host": "did:webvh:example.com:northwind-community",
+                    "key": "giXFLTGBdnnQJRoIsktuIg"
+                }),
+                // A verified trace beside a root, which is what a healthy read
+                // looks like — and `priorRoots` is present because an agent that
+                // keeps no history must say so rather than omit the question.
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "key": "giXFLTGBdnnQJRoIsktuIg",
+                    "version": 412,
+                    "status": "active",
+                    "updatedAt": "2026-01-01T00:00:00Z",
+                    "plaintext": "eyJ0aXRsZSI6IlByaWNpbmcgaG9sZHMifQ",
+                    "verification": {
+                        "trace": "verified",
+                        "priorRoots": "notChecked",
+                        "head": {
+                            "dataCommitment": "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+                            "recordCount": 118,
+                            "headVersion": 412
+                        }
+                    }
+                })
+            ),
+        ),
+        (
+            uris::TASK_ROOMS_KEYS_BROWSE_0_1,
+            checked!(
+                specs::rooms::keys::browse::v0_1::Payload,
+                specs::rooms::keys::browse::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "host": "did:webvh:example.com:northwind-community"
+                }),
+                // Complete, unfiltered, and the count reconciles — the only
+                // shape in which `count` means anything at all.
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "records": [{
+                        "key": "giXFLTGBdnnQJRoIsktuIg",
+                        "version": 412,
+                        "epoch": 7,
+                        "status": "active",
+                        "updatedAt": "2026-01-01T00:00:00Z"
+                    }],
+                    "complete": true,
+                    "verification": {
+                        "priorRoots": "notChecked",
+                        "count": "agrees",
+                        "head": {
+                            "dataCommitment": "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+                            "recordCount": 1,
+                            "headVersion": 412
+                        }
+                    }
+                })
+            ),
+        ),
+        (
             uris::TASK_ROOMS_KEYS_SEAL_0_1,
             checked!(
                 specs::rooms::keys::seal::v0_1::Payload,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1824,6 +1824,15 @@ dispatch_table! {
     // only how far back the agent can now read.
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_BACKFILL_0_1 => room_group::handle_backfill
         [ Mutating Metadata true ],
+    // Returns a record's plaintext — on a sealed tier, material the room
+    // withholds from its own host — after presenting the principal's
+    // credentials to a party the caller names.
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_READ_0_1 => room_group::handle_read
+        [ None Secret true ],
+    // Metadata only, and still `actsAsSubject`: the presentation names a member
+    // of the room to the host it is shown to.
+    vta_sdk::trust_tasks::TASK_ROOMS_KEYS_BROWSE_0_1 => room_group::handle_browse
+        [ None Metadata true ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_SEAL_0_1 => room_group::handle_seal
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_LIST_0_1 => room_group::handle_list

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -448,25 +448,9 @@ pub(super) async fn handle_backfill(
         Err(resp) => return resp,
     };
 
-    let vta_did = match state.config.read().await.vta_did.clone() {
-        Some(d) => d,
-        None => {
-            return app_error_to_reject(
-                &doc,
-                vti_common::error::AppError::Validation(
-                    "this agent has no DID of its own, so it cannot present to a host as itself"
-                        .into(),
-                ),
-            );
-        }
-    };
-    let Some(resolver) = state.did_resolver.clone() else {
-        return app_error_to_reject(
-            &doc,
-            vti_common::error::AppError::Validation(
-                "this agent has no DID resolver configured, so it cannot find the host".into(),
-            ),
-        );
+    let (vta_did, resolver) = match outbound_identity(state, &doc).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
     };
 
     // `read`, and only `read`. Reading the room and reading the parts of it
@@ -552,6 +536,380 @@ pub(super) async fn handle_backfill(
             "earliestReadableEpoch": earliest,
             "fetched": fetched,
             "stored": stored,
+        }),
+    )
+}
+
+/// This agent's own DID and a resolver, or the refusal that says which is missing.
+///
+/// Every task in this family that acts **outward** needs both: it presents as
+/// itself, and it has to find the host it was told to speak to. Extracted when
+/// the third caller appeared — `backfill`, `read` and `browse` refusing in three
+/// slightly different sentences would be three chances for one of them to say
+/// something untrue about why.
+async fn outbound_identity(
+    state: &AppState,
+    doc: &TrustTask<Value>,
+) -> Result<(String, affinidi_did_resolver_cache_sdk::DIDCacheClient), TrustTaskOutcome> {
+    let Some(vta_did) = state.config.read().await.vta_did.clone() else {
+        return Err(app_error_to_reject(
+            doc,
+            vti_common::error::AppError::Validation(
+                "this agent has no DID of its own, so it cannot present to a host as itself".into(),
+            ),
+        ));
+    };
+    let Some(resolver) = state.did_resolver.clone() else {
+        return Err(app_error_to_reject(
+            doc,
+            vti_common::error::AppError::Validation(
+                "this agent has no DID resolver configured, so it cannot find the host".into(),
+            ),
+        ));
+    };
+    Ok((vta_did, resolver))
+}
+
+/// The three values a host asserts about a room, as this agent passes them on.
+///
+/// All three or none: a root without the state it describes is not comparable
+/// to another root, which is the whole of `headVersion` — see
+/// `trust-tasks-tf#422`.
+fn head_of(
+    commitment: Option<&String>,
+    record_count: Option<u64>,
+    head_version: Option<u64>,
+) -> Option<Value> {
+    match (commitment, record_count, head_version) {
+        (Some(c), Some(n), Some(v)) => Some(serde_json::json!({
+            "dataCommitment": c,
+            "recordCount": n,
+            "headVersion": v,
+        })),
+        _ => None,
+    }
+}
+
+/// Replay a record's trace against the commitment served **beside it**.
+///
+/// The leaf preimage is the response payload with its verification members
+/// removed, which is exactly `CommittedRecord` — so this hashes what it was
+/// given rather than reconstructing anything, and a reader that cannot reach the
+/// leaf has been served a record that does not match what the host committed to.
+///
+/// Never a root from an earlier read. A trace is a statement about the tree it
+/// was cut from, and a room moves.
+fn verify_trace(reply: &vti_rooms::wire::GetRecordResponse) -> &'static str {
+    let (Some(commitment), Some(trace)) = (&reply.data_commitment, &reply.trace) else {
+        // A host that maintains no tree must not invent a root, so its silence
+        // is legal and informative rather than a failure.
+        return "notOffered";
+    };
+    let Ok(root) = vti_rooms::merkle::from_multibase(commitment) else {
+        return "failed";
+    };
+    let Ok(leaf) = vti_rooms::merkle::leaf_hash(&reply.record) else {
+        return "failed";
+    };
+    if vti_rooms::merkle::verify_inclusion(&root, &leaf, trace) {
+        "verified"
+    } else {
+        "failed"
+    }
+}
+
+/// `rooms/keys/read/0.1`.
+///
+/// Mint the presentation, ask the host, check what came back, open it. The
+/// fourth act is why the other three are here: the epoch key never leaves this
+/// agent, so a surface that fetched the record itself would come back to open
+/// it anyway, holding a half-verified record in between.
+pub(super) async fn handle_read(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::RoomOpen,
+        "reading a room record",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::keys::read::v0_1::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let (vta_did, resolver) = match outbound_identity(state, &doc).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // `read`, and only `read`. The caller-named host is not bound into the
+    // presentation: what makes naming one safe is that the leaf grants to
+    // `vta_did`, so a host of the caller's choosing receives something only this
+    // agent can act with. What it gains is sight of the credentials, which is a
+    // disclosure rather than an escalation.
+    let minted =
+        match crate::operations::room_oracle::present(state, auth, &vta_did, &req.room_id, "read")
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+
+    let key = format!("{vta_did}#key-0");
+    let reply = match crate::operations::room_host::send_room_task(
+        signing_context(state, auth),
+        &resolver,
+        &req.host,
+        &key,
+        &vta_did,
+        &key,
+        vti_rooms::wire::ROOMS_RECORDS_GET_TYPE,
+        &format!("{}#response", vti_rooms::wire::ROOMS_RECORDS_GET_TYPE),
+        serde_json::json!({
+            "roomId": req.room_id,
+            "key": req.key,
+            "presentation": minted.presentation,
+        }),
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // `send_room_task` has already verified the reply's proof AND bound the
+    // proven signer to the host that was addressed — a proof that verifies
+    // against some other party is a reply from somebody else.
+    let served: vti_rooms::wire::GetRecordResponse = match serde_json::from_value(reply) {
+        Ok(r) => r,
+        Err(e) => {
+            return app_error_to_reject(
+                &doc,
+                vti_common::error::AppError::Internal(format!(
+                    "room host `{}` served a record this agent cannot read: {e}",
+                    req.host
+                )),
+            );
+        }
+    };
+
+    let trace = verify_trace(&served);
+
+    // Opened here or nowhere. A tombstone has no body and that is an answer
+    // rather than a failure: the record's standing is what the caller asked for.
+    let mut payload = serde_json::json!({
+        "roomId": req.room_id,
+        "key": served.record.key,
+        "version": served.record.version,
+        "status": served.record.status,
+        "updatedAt": served.record.updated_at,
+        "verification": {
+            "trace": trace,
+            // Until this agent keeps a root history there is nothing to compare
+            // against, and saying so is not the same as saying nothing was
+            // found. `notChecked` is the honest answer.
+            "priorRoots": "notChecked",
+        },
+    });
+    if let Some(author) = &served.record.author {
+        payload["author"] = serde_json::json!(author);
+    }
+    if let Some(head) = head_of(
+        served.data_commitment.as_ref(),
+        served.record_count,
+        served.head_version,
+    ) {
+        payload["verification"]["head"] = head;
+    }
+
+    if let Some(sealed) = &served.record.sealed {
+        let plaintext = match room_groups::open_record(
+            &state.room_groups_ks,
+            &req.room_id,
+            &served.record.key,
+            served.record.version,
+            &sealed.ciphertext,
+            &sealed.nonce,
+            sealed.epoch,
+        )
+        .await
+        {
+            Ok(p) => p,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+        payload["plaintext"] = serde_json::json!(plaintext);
+    } else if let Some(cleartext) = &served.record.cleartext {
+        payload["cleartext"] = cleartext.clone();
+    }
+
+    record(state, "rooms.keys.read", auth, &req.room_id).await;
+    success_response(&doc, payload)
+}
+
+/// `rooms/keys/browse/0.1`.
+///
+/// Metadata, never bodies — a property of the task rather than of the tier, and
+/// why browsing and reading are two: looking at a room's shelf should not
+/// decrypt the room.
+pub(super) async fn handle_browse(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::RoomOpen,
+        "listing a room's records",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::keys::browse::v0_1::Payload = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let (vta_did, resolver) = match outbound_identity(state, &doc).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    let minted =
+        match crate::operations::room_oracle::present(state, auth, &vta_did, &req.room_id, "read")
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+
+    let key = format!("{vta_did}#key-0");
+    let mut records: Vec<Value> = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut head: Option<Value> = None;
+    let mut complete = false;
+    // A listing is read to its END, and absence of the cursor is the only thing
+    // that says so. A short page says nothing — which is exactly why the count
+    // check below is conditioned on having reached the end.
+    const MAX_PAGES: usize = 64;
+    for page in 0..MAX_PAGES {
+        let mut payload = serde_json::json!({
+            "roomId": req.room_id,
+            "presentation": minted.presentation,
+        });
+        if let Some(p) = &req.prefix {
+            payload["prefix"] = serde_json::json!(p);
+        }
+        if let Some(v) = req.since_version {
+            payload["sinceVersion"] = serde_json::json!(v);
+        }
+        if let Some(l) = req.limit {
+            payload["limit"] = serde_json::json!(u64::from(l));
+        }
+        if let Some(c) = &cursor {
+            payload["cursor"] = serde_json::json!(c);
+        }
+
+        let reply = match crate::operations::room_host::send_room_task(
+            signing_context(state, auth),
+            &resolver,
+            &req.host,
+            &key,
+            &vta_did,
+            &key,
+            vti_rooms::wire::ROOMS_RECORDS_LIST_TYPE,
+            &format!("{}#response", vti_rooms::wire::ROOMS_RECORDS_LIST_TYPE),
+            payload,
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+
+        let listing: vti_rooms::wire::ListRecordsResponse = match serde_json::from_value(reply) {
+            Ok(l) => l,
+            Err(e) => {
+                return app_error_to_reject(
+                    &doc,
+                    vti_common::error::AppError::Internal(format!(
+                        "room host `{}` served a listing this agent cannot read: {e}",
+                        req.host
+                    )),
+                );
+            }
+        };
+
+        // The head is the LAST page's, because that is the snapshot the caller's
+        // view ends at. Taking the first page's would label a set the agent went
+        // on to extend.
+        head = head_of(
+            listing.data_commitment.as_ref(),
+            listing.record_count,
+            listing.head_version,
+        );
+        records.extend(listing.records);
+
+        match listing.cursor {
+            Some(next) => cursor = Some(next),
+            None => {
+                complete = true;
+                break;
+            }
+        }
+        // Stopping of this agent's own accord is not the end of the listing, and
+        // saying otherwise would turn a page bound into a withheld record.
+        if page + 1 == MAX_PAGES {
+            break;
+        }
+    }
+
+    // The one check a listing can make with no anchor and no second party — and
+    // it is only meaningful against a complete, unfiltered listing. Anything
+    // else legitimately holds fewer, and comparing it is a discrepancy the
+    // reader manufactured.
+    let filtered = req.prefix.is_some() || req.since_version.is_some();
+    let count = match (&head, complete, filtered) {
+        (None, _, _) => "notOffered",
+        (Some(_), false, _) | (Some(_), _, true) => "notComparable",
+        (Some(h), true, false) => {
+            let committed = h["recordCount"].as_u64().unwrap_or_default();
+            if records.len() as u64 == committed {
+                "agrees"
+            } else {
+                "short"
+            }
+        }
+    };
+
+    let mut verification = serde_json::json!({
+        "priorRoots": "notChecked",
+        "count": count,
+    });
+    if let Some(h) = head {
+        verification["head"] = h;
+    }
+
+    record(state, "rooms.keys.browse", auth, &req.room_id).await;
+    success_response(
+        &doc,
+        serde_json::json!({
+            "roomId": req.room_id,
+            "records": records,
+            "complete": complete,
+            "verification": verification,
         }),
     )
 }
@@ -672,5 +1030,88 @@ pub(super) async fn record(state: &AppState, action: &str, auth: &AuthClaims, ro
     .await
     {
         tracing::error!(error = %e, action, "failed to record a room-group audit entry");
+    }
+}
+
+#[cfg(test)]
+mod verification_tests {
+    use super::*;
+    use vti_rooms::{Record, RecordStatus};
+
+    fn room() -> Vec<Record> {
+        ["a", "b", "c"]
+            .iter()
+            .enumerate()
+            .map(|(i, key)| Record {
+                key: (*key).into(),
+                version: i as u64 + 1,
+                epoch: Some(2),
+                status: RecordStatus::Active,
+                pinned: false,
+                sealed: Some("c2VhbGVkLWJvZHk".into()),
+                nonce: Some("bm9uY2UtMTI".into()),
+                cleartext: None,
+                author: None,
+                updated_at: 1_756_000_000,
+            })
+            .collect()
+    }
+
+    /// A host that serves a real trace is believed, and one that serves a bad
+    /// one is not — checked from the response alone, which is all the agent has.
+    #[test]
+    fn a_trace_is_replayed_against_the_root_served_beside_it() {
+        let mut records = room();
+        let head = vti_rooms::merkle::tree_head(&mut records).expect("commits");
+        let leaves: Vec<_> = records
+            .iter()
+            .map(|r| vti_rooms::merkle::leaf_hash(&r.committed()).expect("hashes"))
+            .collect();
+        let trace = vti_rooms::merkle::inclusion_proof(&leaves, 1).expect("a trace");
+
+        let good = vti_rooms::wire::GetRecordResponse::of(&records[1], Some(&head), Some(trace));
+        assert_eq!(verify_trace(&good), "verified");
+
+        // The same trace against a different record. The arithmetic does not
+        // close, and this is the case a host that substitutes a record produces.
+        let wrong = vti_rooms::wire::GetRecordResponse {
+            record: records[0].committed(),
+            ..good.clone()
+        };
+        assert_eq!(verify_trace(&wrong), "failed");
+    }
+
+    /// A host that maintains no tree is legal, and its silence is not a failure.
+    ///
+    /// The distinction matters because the two would otherwise be rendered the
+    /// same: a member told "unverified" for a host that never claimed anything
+    /// learns nothing, while one told "notOffered" has learned that this host
+    /// offers no completeness guarantee — which is true, and theirs to act on.
+    #[test]
+    fn a_host_that_offers_no_tree_is_not_a_host_that_failed() {
+        let records = room();
+        let bare = vti_rooms::wire::GetRecordResponse::of(&records[0], None, None);
+        assert_eq!(verify_trace(&bare), "notOffered");
+
+        // A commitment with no trace is the same answer: there is nothing to
+        // replay, and calling that a failure would accuse a host of arithmetic
+        // it never did.
+        let mut records = room();
+        let head = vti_rooms::merkle::tree_head(&mut records).expect("commits");
+        let rootless = vti_rooms::wire::GetRecordResponse::of(&records[0], Some(&head), None);
+        assert_eq!(verify_trace(&rootless), "notOffered");
+    }
+
+    /// The head travels whole or not at all.
+    ///
+    /// A root without the state it describes is not comparable to another root,
+    /// so passing one on alone would hand a member a value that looks like
+    /// evidence and cannot be used as any.
+    #[test]
+    fn a_partial_head_is_no_head() {
+        assert!(head_of(Some(&"zQm…".to_string()), Some(118), Some(412)).is_some());
+        assert!(head_of(Some(&"zQm…".to_string()), None, Some(412)).is_none());
+        assert!(head_of(Some(&"zQm…".to_string()), Some(118), None).is_none());
+        assert!(head_of(None, Some(118), Some(412)).is_none());
     }
 }

--- a/vtc-client/src/rooms/mod.rs
+++ b/vtc-client/src/rooms/mod.rs
@@ -230,11 +230,16 @@ impl VtcClient {
     /// `since_version` is the incremental-sync watermark, and the response **includes
     /// tombstones**: a caller that never saw a retraction would resurrect the record on its
     /// next full rebuild.
+    ///
+    /// `cursor` continues a previous page. **A listing is not complete until the response's
+    /// `cursor` is absent** — a page shorter than the one asked for says nothing, which is
+    /// why this takes the token rather than leaving callers to guess from a length.
     pub async fn list_records(
         &self,
         session: &RoomSession,
         prefix: Option<&str>,
         since_version: Option<u64>,
+        cursor: Option<&str>,
         signer_did: &str,
         private_key_multibase: &str,
     ) -> Result<ListRecordsResponse, VtcError> {
@@ -247,6 +252,9 @@ impl VtcClient {
         }
         if let Some(v) = since_version {
             payload["sinceVersion"] = serde_json::json!(v);
+        }
+        if let Some(c) = cursor {
+            payload["cursor"] = serde_json::json!(c);
         }
         let value = self
             .room_task(

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -442,19 +442,23 @@ pub(crate) async fn handle_list_records(
         Err(e) => return app_error_to_reject(&doc, &e),
     };
 
-    let records = match storage::list_records(
+    // Paginated honestly: the page the caller asked for, and a cursor when more
+    // remain. This used to `take(limit)` and drop the rest without a word, so a
+    // short page and a complete room were indistinguishable.
+    let page = match storage::list_records_page(
         &state.room_records_ks,
         &req.room_id,
         req.prefix.as_deref(),
         req.since_version,
+        req.cursor.as_deref(),
+        req.limit,
     )
     .await
     {
-        Ok(r) => r,
+        Ok(p) => p,
         Err(e) => return app_error_to_reject(&doc, &e),
     };
 
-    let limit = req.limit.unwrap_or(usize::MAX);
     // A listing names no single record, so the entry records the room and the fact of a
     // listing — which is the event: who has seen what this room holds.
     audit_room(state, &room, &authorized, RoomOperation::ListRecords, None).await;
@@ -462,7 +466,8 @@ pub(crate) async fn handle_list_records(
     success_response(
         &doc,
         ListRecordsResponse {
-            records: records.iter().take(limit).map(|r| r.metadata()).collect(),
+            records: page.records.iter().map(|r| r.metadata()).collect(),
+            cursor: page.cursor,
             // One head, so the three values a reader compares cannot come
             // from three moments.
             data_commitment: head

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -505,6 +505,92 @@ pub async fn list_records(
 /// So: correct first, and cache when there is a measurement saying where. The
 /// natural shape is a root kept beside the room row and updated on write, which
 /// is a different change with its own invariant to hold.
+/// The largest page a host will serve, however much a caller asks for.
+///
+/// A listing used to be unbounded: `limit` was applied with `take` and anything
+/// beyond it was dropped **silently**, so a short page and a complete room were
+/// the same bytes. That is worse than not paginating at all, because a caller
+/// cannot tell the two apart and every client that "worked" was one that had
+/// not yet met a big enough room.
+///
+/// The ceiling is the host's own, not the caller's: a response carrying an
+/// entire room is a denial-of-service surface a host hands out for free.
+pub const MAX_PAGE: usize = 500;
+
+/// One page of a listing, and where the next one starts.
+#[derive(Debug, Clone)]
+pub struct Page {
+    pub records: Vec<Record>,
+    /// `Some` when more records remain. **Absence is the only end-of-listing
+    /// signal** — a consumer MUST NOT infer exhaustion from a short page.
+    pub cursor: Option<String>,
+}
+
+/// The cursor's shape: the version of the last record on the page.
+///
+/// # Why it is not authenticated, and does not need to be
+///
+/// `rooms/records/list/0.1` calls this an opaque token and says a host MUST NOT
+/// accept one it did not issue, which reads as though it wants a signature. It
+/// does not, and pretending otherwise would be security theatre with a key
+/// nobody has: a cursor here expresses *start above version N*, which is
+/// precisely what `sinceVersion` already lets any caller ask for directly. A
+/// forged cursor can skip a caller's own records and nothing else.
+///
+/// What the host does enforce is the **shape**, so a value from somewhere else
+/// is refused rather than silently reinterpreted.
+fn encode_cursor(version: u64) -> String {
+    format!("v{version}")
+}
+
+fn decode_cursor(cursor: &str) -> Result<u64, AppError> {
+    cursor
+        .strip_prefix('v')
+        .and_then(|rest| rest.parse::<u64>().ok())
+        .ok_or_else(|| {
+            AppError::Validation(format!(
+                "`{cursor}` is not a cursor this host issued; continue a listing with the \
+                 `cursor` from its previous page, or start again without one"
+            ))
+        })
+}
+
+/// One page of a room's records, ordered by version, with an honest cursor.
+///
+/// # The filters are the caller's to repeat
+///
+/// A cursor carries **position and nothing else**. A caller that continues with
+/// a different `prefix` or `since_version` gets that different query resumed
+/// from this position, which is a coherent thing to ask for and almost never
+/// what anyone means. Repeat the filters.
+pub async fn list_records_page(
+    records: &KeyspaceHandle,
+    room_id: &str,
+    key_prefix: Option<&str>,
+    since_version: Option<u64>,
+    cursor: Option<&str>,
+    limit: Option<usize>,
+) -> Result<Page, AppError> {
+    // A cursor and a watermark say the same kind of thing, so the later of the
+    // two wins rather than one silently overriding the other.
+    let floor = match cursor {
+        Some(c) => Some(decode_cursor(c)?.max(since_version.unwrap_or(0))),
+        None => since_version,
+    };
+    let mut all = list_records(records, room_id, key_prefix, floor).await?;
+
+    let page = limit.unwrap_or(MAX_PAGE).clamp(1, MAX_PAGE);
+    let more = all.len() > page;
+    all.truncate(page);
+    let cursor = more
+        .then(|| all.last().map(|r| encode_cursor(r.version)))
+        .flatten();
+    Ok(Page {
+        records: all,
+        cursor,
+    })
+}
+
 pub async fn tree_head(
     records: &KeyspaceHandle,
     room_id: &str,
@@ -829,6 +915,141 @@ mod tests {
         let filtered = list_records(&rec, "r1", Some("a"), None).await.unwrap();
         assert!(filtered.len() < 3, "the fixture must actually filter");
         assert_eq!(tree_head(&rec, "r1").await.unwrap().root, root);
+    }
+
+    /// A listing pages to its end, and the cursor is the only thing that says so.
+    ///
+    /// The defect this replaces was silent: `take(limit)` dropped the remainder
+    /// without a word, so a short page and a complete room were the same bytes
+    /// and every client that "worked" was one that had not met a big enough
+    /// room yet.
+    #[tokio::test]
+    async fn a_listing_pages_to_its_end() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for i in 0..7u64 {
+            put_record(
+                &rooms,
+                &rec,
+                "r1",
+                open_record(&format!("k{i}")),
+                None,
+                i + 1,
+            )
+            .await
+            .unwrap();
+        }
+
+        let mut seen = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut pages = 0;
+        loop {
+            let page = list_records_page(&rec, "r1", None, None, cursor.as_deref(), Some(3))
+                .await
+                .unwrap();
+            pages += 1;
+            seen.extend(page.records.iter().map(|r| r.key.clone()));
+            match page.cursor {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+            assert!(pages < 10, "the listing never ended");
+        }
+        assert_eq!(pages, 3, "7 records at 3 a page is three pages");
+        assert_eq!(seen.len(), 7, "every record was returned exactly once");
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), 7, "a record was served on two pages");
+    }
+
+    /// The boundary that decides whether "short page means the end" is safe.
+    ///
+    /// With exactly a page's worth left there is no cursor — so a caller that
+    /// inferred the end from a *full* page would ask for one more and a caller
+    /// that inferred it from a *short* page would be right by luck. Only the
+    /// cursor's absence is load-bearing.
+    #[tokio::test]
+    async fn an_exactly_full_last_page_carries_no_cursor() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for i in 0..4u64 {
+            put_record(
+                &rooms,
+                &rec,
+                "r1",
+                open_record(&format!("k{i}")),
+                None,
+                i + 1,
+            )
+            .await
+            .unwrap();
+        }
+
+        let first = list_records_page(&rec, "r1", None, None, None, Some(2))
+            .await
+            .unwrap();
+        assert_eq!(first.records.len(), 2);
+        let cursor = first.cursor.expect("two of four remain");
+
+        let second = list_records_page(&rec, "r1", None, None, Some(&cursor), Some(2))
+            .await
+            .unwrap();
+        assert_eq!(second.records.len(), 2, "the last page is full");
+        assert!(
+            second.cursor.is_none(),
+            "a full page with nothing after it must still say it is the end"
+        );
+    }
+
+    /// A cursor from somewhere else is refused rather than reinterpreted.
+    #[tokio::test]
+    async fn a_cursor_this_host_did_not_issue_is_refused() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        assert!(
+            list_records_page(&rec, "r1", None, None, Some("412"), None)
+                .await
+                .is_err(),
+            "a bare number is not this host's cursor shape"
+        );
+        assert!(
+            list_records_page(&rec, "r1", None, None, Some("vNaN"), None)
+                .await
+                .is_err()
+        );
+    }
+
+    /// A host bounds its own response even when the caller asks for everything.
+    #[tokio::test]
+    async fn a_host_caps_the_page_it_will_serve() {
+        let (_d, rooms, rec) = open().await;
+        create_room(&rooms, &room("r1", Visibility::Open))
+            .await
+            .unwrap();
+        for i in 0..3u64 {
+            put_record(
+                &rooms,
+                &rec,
+                "r1",
+                open_record(&format!("k{i}")),
+                None,
+                i + 1,
+            )
+            .await
+            .unwrap();
+        }
+        // Asking for more than the ceiling gets the ceiling, not the ask.
+        let page = list_records_page(&rec, "r1", None, None, None, Some(MAX_PAGE * 10))
+            .await
+            .unwrap();
+        assert_eq!(page.records.len(), 3);
+        assert!(page.cursor.is_none());
     }
 
     /// The head's three values describe one set, and they are read from it.

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -225,6 +225,17 @@ pub struct ListRecordsBody {
     pub prefix: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub since_version: Option<u64>,
+    /// Opaque continuation token from a previous response.
+    ///
+    /// This member is in the published request schema and was **missing here**,
+    /// and `deny_unknown_fields` turns a missing member into a refusal: a
+    /// conforming client that paged got its second page rejected as malformed.
+    /// The two halves of the defect were symmetrical — a host that never issued
+    /// a cursor and could not have accepted one back.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Page size to ask for. **Never a cap on the result**: a caller that wants
+    /// the whole room follows [`ListRecordsResponse::cursor`] to its absence.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
 }
@@ -370,6 +381,14 @@ pub struct ListRecordsResponse {
     /// Optional on the wire because a host that maintains no tree must not
     /// invent a root: its absence honestly says "no completeness guarantee
     /// here", and a fabricated one would say the opposite while meaning less.
+    /// Present when more records remain, absent at the end.
+    ///
+    /// **Absence is the only end-of-listing signal**, which is why a host that
+    /// truncated silently was worse than one that did not paginate at all: a
+    /// short page and a complete room were the same bytes. A consumer MUST NOT
+    /// infer exhaustion from a page shorter than the limit it asked for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_commitment: Option<String>,
     /// How many records the room holds, as of `data_commitment`.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -150,6 +150,7 @@ fn get_and_list_requests_conform() {
         presentation: presentation(),
         prefix: Some("decision/".into()),
         since_version: Some(4),
+        cursor: Some("v412".into()),
         limit: Some(50),
     };
     check::<ListPayload>(
@@ -163,6 +164,7 @@ fn get_and_list_requests_conform() {
         presentation: presentation(),
         prefix: None,
         since_version: None,
+        cursor: None,
         limit: None,
     };
     check::<ListPayload>(
@@ -357,6 +359,21 @@ fn responses_conform() {
     );
 
     check::<ListResponse>("ListRecordsResponse", &json!({ "records": records }));
+
+    // And with a cursor, which is what a host serves when more remain. The
+    // member was in the published schema and this implementation never emitted
+    // it, so a caller could not tell a page from a room.
+    check::<ListResponse>(
+        "ListRecordsResponse mid-listing",
+        &serde_json::to_value(ListRecordsResponse {
+            records: records.clone(),
+            cursor: Some("v412".into()),
+            data_commitment: None,
+            record_count: None,
+            head_version: None,
+        })
+        .expect("serialise"),
+    );
 }
 
 /// The single-record read, on every tier and on a tombstone.


### PR DESCRIPTION
Implements [tt#426](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/426). Stacked on #1380 (honest pagination), which `browse` needs.

The console cannot address a host — its carrier passes `{type, payload}` and the offscreen document supplies its own agent as the recipient — so `rooms/records/*` is unreachable from the surfaces a person actually uses. And a `dataCommitment` is inert without a party that checks it. **Both are the member's own agent.**

## `rooms/keys/read` — four acts by the only party that can do the fourth

Mint the presentation, ask the host, check what came back, open it. The epoch key never leaves here, so a surface that fetched the record itself would come back to open it anyway, holding a half-verified record in between.

Three checks, each stated because each has a way of being skipped:

1. **The reply is signed by the host that was _addressed_.** `send_room_task` already verifies the proof *and* binds the proven signer to the host named — a proof that verifies against some other party is a reply from somebody else.
2. **`verify_trace` replays the path against the commitment served _beside it_.** The leaf preimage is the response payload with its verification members removed, which is exactly `CommittedRecord` — so it hashes what it was **given** rather than reconstructing anything, and never a root kept from an earlier read.
3. **`priorRoots` answers `notChecked`** until the root memory exists. Deliberately not `noneHeld`: *one says nothing was found, the other says nothing was looked for*, and an agent that omitted the question would read as a clean bill of health.

## A verdict is never an error

Nothing in `verification` fails the task, including the values that report a host caught out. An agent refusing a member their own record because the **host** misbehaved punishes them for somebody else's act, and locks them out of the room holding the records that would show what happened. The consequence belongs on the write path.

## `rooms/keys/browse` — the check only a listing can make

A reader cannot recompute a root from a listing (a leaf commits to a whole record; a listing returns a projection) — but it can **count**. A host that omits a record while committing to a tree that holds it contradicts itself **inside one exchange**, with no anchor and no second member.

It follows the host's cursor to the end and reports `complete`, because a page bound and a withheld record produce the same shorter array. `count` is `notComparable` unless the listing is complete *and* unfiltered, which will be the common answer and is not a fault.

## Two small things worth a look

- **`head_of` passes the three head values on whole or not at all.** A root without the state it describes is not comparable to another root, so forwarding one alone would hand a member something that looks like evidence and is not.
- **`outbound_identity` is extracted from `backfill`** on its third caller. Three handlers refusing in three slightly different sentences is three chances for one of them to say something untrue about why.

## Census and tests

Six sites each: URI constant, `ALL_URIS`, `retry_safety`, dispatch, conformance witness, `vta-mcp` guard verb.

`verification_tests` pins the trace replay **from the response alone**, the difference between a host that *failed* and one that never claimed anything, and that a partial head is no head.

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **175 suites, 0 failures**

## One thing I did not fix

The four extended error codes `rooms/keys/read` declares are **not emitted** here — and nor are `backfill`'s. Every handler in this family maps to the standard reject reasons instead. That is pre-existing rather than something this adds, and it is worth fixing across the family rather than in one task, so I have left it and said so.