### PR TITLE
feat(rooms/keys): the agent remembers what a host said, and refuses to write to one it caught

### DIFF
--- a/vta-service/src/operations/room_groups.rs
+++ b/vta-service/src/operations/room_groups.rs
@@ -500,6 +500,150 @@ async fn store(
         .map_err(|e| AppError::Internal(format!("store group state for `{room_id}`: {e}")))
 }
 
+/// Prefix for what a host has told this agent about a room's tree.
+const ROOTS_PREFIX: &str = "room-roots:";
+
+/// Storage key for a room's observed roots.
+fn roots_key(room_id: &str) -> String {
+    format!("{ROOTS_PREFIX}{room_id}")
+}
+
+/// How many `(headVersion, root)` observations to keep per room.
+///
+/// One is weaker than it looks in a specific way, and stronger than it looks in
+/// another. It *does* catch a host that alternates at one version — `(V, A)`
+/// then `(V, B)` differ, and differ again on the way back. What it misses is a
+/// head that **advances and then goes backwards**: `(V, A)`, `(V+1, X)`,
+/// `(V, B)` leaves the agent holding `V+1` with nothing to compare `V` against.
+/// That is the mirror case and the rollback case, which are the two this is for.
+///
+/// Sixteen versions is more history than a member reads across in a session, and
+/// a few hundred bytes.
+const KEEP_ROOTS: usize = 16;
+
+/// What a host has said about a room's tree, over time.
+///
+/// **Keyed by room, not by host**, and that is the decision worth not undoing. A
+/// room's tree at version `V` is a fact about the *room*; who served it is not
+/// part of that fact. Keying by `(room, host)` would file two hosts of one room
+/// in two drawers and never compare them — and a room may deliberately have
+/// several, a mirror serving reads while its primary takes writes.
+///
+/// Keyed this way, a member who reads the same room from two of its hosts gets
+/// the comparison for free: two hosts reporting **different roots at one
+/// `headVersion`** is exactly as damning as one host disagreeing with itself.
+/// That is a comparison the specification's own list does not include, and it
+/// needs no gossip channel, no anchor and no second member.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RootHistory {
+    /// Observations, most recent `headVersion` last. At most [`KEEP_ROOTS`].
+    pub seen: Vec<RootObservation>,
+    /// The highest `headVersion` ever seen for this room.
+    ///
+    /// Separate from `seen` because it answers a question no single pair can:
+    /// **has this room gone backwards?** A pruned observation still leaves this
+    /// behind.
+    pub highest: u64,
+    /// The version at which this room was caught, if it ever was.
+    ///
+    /// **Remembered rather than recomputed.** A conflict is a fact about the
+    /// past, and the pair that revealed it is prunable — an agent that inferred
+    /// "caught" from what it still holds would exonerate a host by doing enough
+    /// reading. Once set it is never cleared here: it is cleared by
+    /// [`forget`], with the membership.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caught_at: Option<u64>,
+}
+
+/// One thing a host said about a room's tree.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RootObservation {
+    pub head_version: u64,
+    /// The root, as the wire spells it — a `DigestMultibase`.
+    pub root: String,
+}
+
+/// What comparing a root against what is held came to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RootVerdict {
+    /// Seen at this head before, same root.
+    Agree,
+    /// Seen at this head before, **different root**. A host caught: there is no
+    /// write to attribute the difference to, because a write would have moved
+    /// the head.
+    Conflict,
+    /// First observation at this head. Not evidence of anything — a memory of
+    /// one is not a comparison.
+    NoneHeld,
+}
+
+/// Record what a host asserted, and say what it came to.
+///
+/// The write happens either way, including on a conflict: an agent that stopped
+/// recording once it caught a host would forget the evidence at the moment it
+/// acquired it.
+pub async fn observe_head(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+    head_version: u64,
+    root: &str,
+) -> Result<RootVerdict, AppError> {
+    let key = roots_key(room_id);
+    let mut history: RootHistory = groups
+        .get(key.clone())
+        .await
+        .map_err(|e| AppError::Internal(format!("read the root history of `{room_id}`: {e}")))?
+        .unwrap_or_default();
+
+    let verdict = match history.seen.iter().find(|o| o.head_version == head_version) {
+        Some(prior) if prior.root == root => RootVerdict::Agree,
+        Some(_) => RootVerdict::Conflict,
+        None => RootVerdict::NoneHeld,
+    };
+
+    if matches!(verdict, RootVerdict::Conflict) {
+        // Earliest wins: the first version at which this host was caught is the
+        // one worth naming, and later conflicts do not make the first less true.
+        history.caught_at = Some(
+            history
+                .caught_at
+                .map_or(head_version, |v| v.min(head_version)),
+        );
+    }
+    if matches!(verdict, RootVerdict::NoneHeld) {
+        history.seen.push(RootObservation {
+            head_version,
+            root: root.to_string(),
+        });
+        history.seen.sort_by_key(|o| o.head_version);
+        // Drop the OLDEST versions, not the oldest writes: what a member is
+        // likely to read again is what the room is at now.
+        if history.seen.len() > KEEP_ROOTS {
+            let excess = history.seen.len() - KEEP_ROOTS;
+            history.seen.drain(0..excess);
+        }
+    }
+    history.highest = history.highest.max(head_version);
+
+    groups
+        .insert(key, &history)
+        .await
+        .map_err(|e| AppError::Internal(format!("record the root history of `{room_id}`: {e}")))?;
+    Ok(verdict)
+}
+
+/// Everything this agent has been told about a room's tree, for a caller that
+/// wants to compare out of band.
+pub async fn root_history(groups: &KeyspaceHandle, room_id: &str) -> Result<RootHistory, AppError> {
+    groups
+        .get(roots_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("read the root history of `{room_id}`: {e}")))
+        .map(Option::unwrap_or_default)
+}
+
 /// Discard everything this VTA holds for a room.
 ///
 /// Called on removal from the group. A key-holder that kept its state would retain the
@@ -513,5 +657,122 @@ pub async fn forget(groups: &KeyspaceHandle, room_id: &str) -> Result<(), AppErr
     groups
         .remove(pending_key(room_id))
         .await
-        .map_err(|e| AppError::Internal(format!("discard a pending key package: {e}")))
+        .map_err(|e| AppError::Internal(format!("discard a pending key package: {e}")))?;
+    // The root history goes with the membership. It carries no record content,
+    // but it is a record of when this member read this room, and an agent that
+    // kept it afterwards would be keeping a diary of a room its principal can no
+    // longer open.
+    groups
+        .remove(roots_key(room_id))
+        .await
+        .map_err(|e| AppError::Internal(format!("discard the root history of `{room_id}`: {e}")))
+}
+
+#[cfg(test)]
+mod root_memory_tests {
+    use super::*;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    const ROOM: &str = "did:webvh:example.com:rooms:northwind";
+    const A: &str = "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+    const B: &str = "zQmXo1sV5aJ7bT2kQdF9wRnPzYcH4uMgLtEjV6NrBqWsDpK";
+
+    async fn open() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(crate::keyspaces::ROOM_GROUPS).unwrap();
+        (dir, ks)
+    }
+
+    /// A memory of one is not a comparison, and the first read must say so.
+    #[tokio::test]
+    async fn a_first_reading_holds_nothing_to_compare() {
+        let (_d, ks) = open().await;
+        assert_eq!(
+            observe_head(&ks, ROOM, 412, A).await.unwrap(),
+            RootVerdict::NoneHeld
+        );
+    }
+
+    /// The whole mechanism: same state, two roots, no write to blame.
+    #[tokio::test]
+    async fn two_roots_at_one_version_is_a_host_caught() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 412, A).await.unwrap();
+        assert_eq!(
+            observe_head(&ks, ROOM, 412, A).await.unwrap(),
+            RootVerdict::Agree
+        );
+        assert_eq!(
+            observe_head(&ks, ROOM, 412, B).await.unwrap(),
+            RootVerdict::Conflict
+        );
+    }
+
+    /// A room that moved is not a host that lied, and the version is what tells
+    /// them apart. Without it every second read would look like equivocation.
+    #[tokio::test]
+    async fn a_different_version_is_a_different_moment() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 412, A).await.unwrap();
+        assert_eq!(
+            observe_head(&ks, ROOM, 413, B).await.unwrap(),
+            RootVerdict::NoneHeld,
+            "a write moved the head, so a different root explains itself"
+        );
+    }
+
+    /// One slot would miss this, which is why the memory is a map.
+    ///
+    /// The head advances and then a host serves the older version again — the
+    /// mirror case and the rollback case. An agent keeping only the latest pair
+    /// is holding `V+1` and has nothing to compare `V` against.
+    #[tokio::test]
+    async fn a_head_that_goes_backwards_is_still_compared() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 412, A).await.unwrap();
+        observe_head(&ks, ROOM, 500, B).await.unwrap();
+        assert_eq!(
+            observe_head(&ks, ROOM, 412, B).await.unwrap(),
+            RootVerdict::Conflict,
+            "the older version is still held, and its root still disagrees"
+        );
+    }
+
+    /// The bound drops the OLDEST versions and keeps the highest-ever anyway,
+    /// because "has this room gone backwards" is a question no single pair can
+    /// answer.
+    #[tokio::test]
+    async fn the_history_is_bounded_and_the_high_water_mark_survives_it() {
+        let (_d, ks) = open().await;
+        for v in 1..=(KEEP_ROOTS as u64 + 5) {
+            observe_head(&ks, ROOM, v, A).await.unwrap();
+        }
+        let history = root_history(&ks, ROOM).await.unwrap();
+        assert_eq!(history.seen.len(), KEEP_ROOTS);
+        assert_eq!(history.highest, KEEP_ROOTS as u64 + 5);
+        assert_eq!(
+            history.seen.first().unwrap().head_version,
+            6,
+            "the oldest versions are what gets dropped"
+        );
+    }
+
+    /// Bounded by membership. An agent that kept this after a removal would keep
+    /// a record of when its principal read a room it can no longer open.
+    #[tokio::test]
+    async fn forgetting_a_room_forgets_what_its_host_said() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 412, A).await.unwrap();
+        forget(&ks, ROOM).await.unwrap();
+        assert_eq!(
+            observe_head(&ks, ROOM, 412, B).await.unwrap(),
+            RootVerdict::NoneHeld,
+            "nothing survived the removal to compare against"
+        );
+    }
 }

--- a/vta-service/src/operations/room_host.rs
+++ b/vta-service/src/operations/room_host.rs
@@ -215,6 +215,74 @@ pub fn read_reply(doc: &Value, expected: &str, host: &str) -> Result<Value, AppE
     )))
 }
 
+/// Room tasks that CHANGE a room, as opposed to reading one.
+///
+/// The list is by URI rather than by a flag on the task, because the decision it
+/// feeds is this agent's and not the specification's: a host is entitled to
+/// serve all of these, and what changes is whether *this* agent is willing to
+/// hand it more material.
+const MUTATING_ROOM_TASKS: &[&str] = &[
+    vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE,
+    vti_rooms::wire::ROOMS_RECORDS_CURATE_TYPE,
+    vti_rooms::wire::ROOMS_EPOCH_MINT_TYPE,
+    vti_rooms::wire::ROOMS_OWNER_TRANSFER_TYPE,
+];
+
+/// Refuse to write to a host this agent has caught contradicting itself.
+///
+/// # The rule, and why it is asymmetric
+///
+/// **Serve reads, refuse writes.** Reading is how a member gathers the evidence,
+/// and the records that would prove what happened are inside the room a refusal
+/// would lock them out of — by their own agent, over somebody else's act.
+/// Writing to a host you have caught is what compounds the damage: it hands more
+/// material to a party you now have reason to believe will misrepresent what it
+/// holds.
+///
+/// # Why here rather than in one task
+///
+/// This is a property of the agent's outbound path, not of any single verb. Put
+/// it in a write task and the next write task has to remember it; put it here
+/// and every one of them inherits it. The refusal names the room and says what
+/// was observed, because a member who is told only "refused" concludes their own
+/// agent is broken — and a detection attributed to the wrong party is worse than
+/// no detection.
+///
+/// A conflict this agent cannot read is not a host that behaved: a storage
+/// failure answers `Ok`, because refusing every write on an unreadable history
+/// would turn a local fault into an accusation.
+pub async fn refuse_if_caught(
+    groups: &vti_common::store::KeyspaceHandle,
+    room_id: &str,
+    task: &str,
+) -> Result<(), AppError> {
+    if !MUTATING_ROOM_TASKS.contains(&task) {
+        return Ok(());
+    }
+    let history = match crate::operations::room_groups::root_history(groups, room_id).await {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(
+                room = %room_id,
+                error = %e,
+                "could not read this agent's root history; allowing the write rather than \
+                 turning a local fault into an accusation"
+            );
+            return Ok(());
+        }
+    };
+    if let Some(caught) = history.caught_at {
+        return Err(AppError::Forbidden(format!(
+            "this agent has been given two different record sets for `{room_id}`, both \
+             claimed at version {caught}. One of them is wrong, and a write cannot explain \
+             the difference — a write moves the version. Reading this room still works, and \
+             is how the evidence is gathered; writing to a host that has contradicted itself \
+             is refused."
+        )));
+    }
+    Ok(())
+}
+
 /// Send one room task to `host` and return the response document's `payload`.
 ///
 /// `signing_key_id` and `issuer` name the identity this VTA signs as. For a
@@ -223,6 +291,8 @@ pub fn read_reply(doc: &Value, expected: &str, host: &str) -> Result<Value, AppE
 /// minted for this same DID or the host will (correctly) refuse it.
 pub async fn send_room_task(
     ctx: SigningContext<'_>,
+    groups: &vti_common::store::KeyspaceHandle,
+    room_id: &str,
     resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
     host: &str,
     signing_key_id: &str,
@@ -232,6 +302,11 @@ pub async fn send_room_task(
     response_task: &str,
     payload: Value,
 ) -> Result<Value, AppError> {
+    // Before anything leaves. Threaded through the seam rather than left to each
+    // caller: a write task added later inherits the refusal instead of having to
+    // remember it, which is the difference between a rule and a convention.
+    refuse_if_caught(groups, room_id, task).await?;
+
     let resolved = resolver.resolve(host).await.map_err(|e| {
         AppError::Validation(format!(
             "the room host `{host}` does not resolve, so there is nothing to send to: {e}"
@@ -461,5 +536,96 @@ mod tests {
         )
         .expect_err("wrong task");
         assert!(err.to_string().contains("contract break"));
+    }
+}
+
+#[cfg(test)]
+mod write_gate_tests {
+    use super::*;
+    use crate::operations::room_groups::observe_head;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    const ROOM: &str = "did:webvh:example.com:rooms:northwind";
+    const A: &str = "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+    const B: &str = "zQmXo1sV5aJ7bT2kQdF9wRnPzYcH4uMgLtEjV6NrBqWsDpK";
+
+    async fn open() -> (tempfile::TempDir, vti_common::store::KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace(crate::keyspaces::ROOM_GROUPS).unwrap();
+        (dir, ks)
+    }
+
+    /// The asymmetry, which is the whole rule: a caught host still serves reads.
+    ///
+    /// Refusing the read would punish the member for the host's act and lock
+    /// them out of the room holding the records that would show what happened.
+    #[tokio::test]
+    async fn a_caught_host_is_refused_writes_and_still_serves_reads() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 412, A).await.unwrap();
+        observe_head(&ks, ROOM, 412, B).await.unwrap();
+
+        let refused = refuse_if_caught(&ks, ROOM, vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE)
+            .await
+            .expect_err("a write to a caught host must be refused");
+        let said = refused.to_string();
+        assert!(
+            said.contains("412") && said.contains("Reading this room still works"),
+            "the refusal must name what was observed and what still works: {said}"
+        );
+
+        refuse_if_caught(&ks, ROOM, vti_rooms::wire::ROOMS_RECORDS_GET_TYPE)
+            .await
+            .expect("reads are served");
+        refuse_if_caught(&ks, ROOM, vti_rooms::wire::ROOMS_RECORDS_LIST_TYPE)
+            .await
+            .expect("listings are served");
+    }
+
+    /// A room that has only ever agreed is written to without ceremony.
+    #[tokio::test]
+    async fn a_host_that_has_not_been_caught_is_not_refused() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 412, A).await.unwrap();
+        observe_head(&ks, ROOM, 413, B).await.unwrap();
+        refuse_if_caught(&ks, ROOM, vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE)
+            .await
+            .expect("two moments are not a contradiction");
+    }
+
+    /// The refusal outlives the observation that produced it.
+    ///
+    /// A conflict is a fact about the past, and the pair that revealed it is
+    /// prunable — an agent that recomputed "caught" from what it still holds
+    /// would exonerate a host by doing enough reading.
+    #[tokio::test]
+    async fn being_caught_survives_the_history_being_pruned() {
+        let (_d, ks) = open().await;
+        observe_head(&ks, ROOM, 1, A).await.unwrap();
+        observe_head(&ks, ROOM, 1, B).await.unwrap();
+        // Push the conflicting pair off the end of the bounded map.
+        for v in 2..=64u64 {
+            observe_head(&ks, ROOM, v, A).await.unwrap();
+        }
+        assert!(
+            refuse_if_caught(&ks, ROOM, vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE)
+                .await
+                .is_err(),
+            "reading past a conflict must not clear it"
+        );
+    }
+
+    /// A local storage fault is not a host that misbehaved.
+    #[tokio::test]
+    async fn a_room_with_no_history_at_all_is_written_to() {
+        let (_d, ks) = open().await;
+        refuse_if_caught(&ks, ROOM, vti_rooms::wire::ROOMS_RECORDS_PUT_TYPE)
+            .await
+            .expect("nothing observed is not something caught");
     }
 }

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -488,6 +488,8 @@ pub(super) async fn handle_backfill(
     let key = format!("{vta_did}#key-0");
     let reply = match crate::operations::room_host::send_room_task(
         signing_context(state, auth),
+        &state.room_groups_ks,
+        &req.room_id,
         &resolver,
         &req.host,
         &key,
@@ -590,6 +592,48 @@ fn head_of(
     }
 }
 
+/// Record what a host asserted about a room, and say what comparing it came to.
+///
+/// **This is the comparison no other party on the member's side can make.** A
+/// tab does not outlive itself and a CLI keeps nothing; the agent is the only
+/// one that saw both reads.
+///
+/// It is keyed by **room, not host**, which buys a comparison the specification
+/// does not list: two hosts of one room reporting different roots at one
+/// `headVersion` is exactly as damning as one host disagreeing with itself, and
+/// a room may deliberately have several — a mirror serving reads while its
+/// primary takes writes. A mirror that merely *lags* reports a lower
+/// `headVersion` and is correctly not compared at all.
+///
+/// A host that asserted nothing is `notChecked` rather than `noneHeld`: one says
+/// nothing was found, the other says nothing was looked for.
+async fn compare_head(state: &AppState, room_id: &str, head: Option<&Value>) -> &'static str {
+    let Some(head) = head else {
+        return "notChecked";
+    };
+    let (Some(version), Some(root)) = (
+        head["headVersion"].as_u64(),
+        head["dataCommitment"].as_str(),
+    ) else {
+        return "notChecked";
+    };
+    match room_groups::observe_head(&state.room_groups_ks, room_id, version, root).await {
+        Ok(room_groups::RootVerdict::Agree) => "agree",
+        Ok(room_groups::RootVerdict::Conflict) => "conflict",
+        Ok(room_groups::RootVerdict::NoneHeld) => "noneHeld",
+        Err(e) => {
+            // A memory this agent could not read is not a host that behaved. It
+            // says so rather than reporting a comparison it did not make.
+            tracing::error!(
+                room = %room_id,
+                error = %e,
+                "could not read this agent's root history; answering without a comparison"
+            );
+            "notChecked"
+        }
+    }
+}
+
 /// Replay a record's trace against the commitment served **beside it**.
 ///
 /// The leaf preimage is the response payload with its verification members
@@ -667,6 +711,8 @@ pub(super) async fn handle_read(
     let key = format!("{vta_did}#key-0");
     let reply = match crate::operations::room_host::send_room_task(
         signing_context(state, auth),
+        &state.room_groups_ks,
+        &req.room_id,
         &resolver,
         &req.host,
         &key,
@@ -712,22 +758,19 @@ pub(super) async fn handle_read(
         "version": served.record.version,
         "status": served.record.status,
         "updatedAt": served.record.updated_at,
-        "verification": {
-            "trace": trace,
-            // Until this agent keeps a root history there is nothing to compare
-            // against, and saying so is not the same as saying nothing was
-            // found. `notChecked` is the honest answer.
-            "priorRoots": "notChecked",
-        },
+        "verification": { "trace": trace },
     });
     if let Some(author) = &served.record.author {
         payload["author"] = serde_json::json!(author);
     }
-    if let Some(head) = head_of(
+    let head = head_of(
         served.data_commitment.as_ref(),
         served.record_count,
         served.head_version,
-    ) {
+    );
+    payload["verification"]["priorRoots"] =
+        serde_json::json!(compare_head(state, &req.room_id, head.as_ref()).await);
+    if let Some(head) = head {
         payload["verification"]["head"] = head;
     }
 
@@ -824,6 +867,8 @@ pub(super) async fn handle_browse(
 
         let reply = match crate::operations::room_host::send_room_task(
             signing_context(state, auth),
+            &state.room_groups_ks,
+            &req.room_id,
             &resolver,
             &req.host,
             &key,
@@ -895,7 +940,7 @@ pub(super) async fn handle_browse(
     };
 
     let mut verification = serde_json::json!({
-        "priorRoots": "notChecked",
+        "priorRoots": compare_head(state, &req.room_id, head.as_ref()).await,
         "count": count,
     });
     if let Some(h) = head {

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -321,6 +321,8 @@ pub(super) async fn handle_register(
     let key = format!("{vta_did}#key-0");
     let reply = match crate::operations::room_host::send_room_task(
         signing_context(state, auth),
+        &state.room_groups_ks,
+        &req.room_id,
         &resolver,
         &req.host,
         &key,


### PR DESCRIPTION
Completes what #1385 left as `notChecked`, and adds the consequence. Stacked on #1385 → #1380.

A commitment read once proves nothing. It becomes evidence compared against a copy the host did not choose — and the only such copy available today is **the one this host gave the same member earlier**. A tab does not outlive itself and a CLI keeps nothing, so the agent is the only party on the member's side that saw both reads.

## Keyed by room, not by host

The line worth not undoing. **A room's tree at version `V` is a fact about the room**; who served it is not part of that fact. Keying by `(room, host)` files two hosts of one room in two drawers and never compares them — and a room may deliberately have several, a mirror serving reads while its primary takes writes.

Keyed this way, a member who reads one room from two of its hosts gets the comparison **for free**, which is a comparison the specification's own list does not include. A mirror that merely *lags* reports a lower `headVersion` and is correctly not compared at all.

## How much, and why not one

A bounded map of `headVersion → root`, sixteen versions, plus the highest ever seen.

One slot **would** catch a host that alternates at one version — `(V, A)` then `(V, B)` differ, and differ again on the way back. What it misses is a head that advances and then goes backwards:

```
(V, A)  →  (V+1, X)  →  (V, B)
```

That is the mirror case and the rollback case — the two this exists for. `a_head_that_goes_backwards_is_still_compared` is the test.

`highest` is separate because it answers a question no single pair can: *has this room gone backwards?*

## `caught_at` is remembered, not recomputed

A conflict is a fact about the past, and the pair that revealed it is prunable. An agent that inferred "caught" from what it still holds would **exonerate a host by doing enough reading**. `being_caught_survives_the_history_being_pruned` pins it.

Dropped by `forget`, with the membership. It carries no record content, but it *is* a record of when this member read this room, and an agent keeping it afterwards would keep a diary of a room its principal can no longer open.

## The refusal lives at the outbound seam, not in a task

`send_room_task` now takes the group keyspace and the room, and refuses a mutating verb for a room this agent has caught. **Put it in a write task and the next write task has to remember it; put it here and every one of them inherits it** — the difference between a rule and a convention.

`rooms/owner/register` is deliberately *not* on the mutating list: refusing it would block a member registering the room with a **different** host, which is the repair.

The refusal names the room, the version, and says **reading still works** — because a member told only "refused" concludes their own agent is broken.

An unreadable history answers `Ok` rather than refusing. Turning a local storage fault into an accusation is the one failure mode worse than missing one.

## Checks

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **175 suites, 0 failures**

Ten new tests, including the two that would pass against a weaker design and should not.