### PR TITLE
perf(rooms): measure what the commitment costs, and decide from the number

### DIFF
--- a/docs/05-design-notes/data-rooms-verified-reads.md
+++ b/docs/05-design-notes/data-rooms-verified-reads.md
@@ -179,6 +179,39 @@ receipt would be checked. The receipt is evidence with nothing yet to contradict
 No zkVM, no new cryptographic assumption, no change to the credential model, and
 nothing that touches how a record is sealed.
 
+### 5.1 What it actually costs, measured
+
+The store is deliberately **uncached**, and the standing rule was "correct first,
+and cache when there is a measurement saying where". Here is the measurement —
+`vti-rooms/tests/commitment_cost.rs`, release build, 2 KiB sealed bodies:
+
+| Records | `tree_head` |
+|---|---|
+| 100 | 0.46 ms |
+| 1,000 | 3.5 ms |
+| 10,000 | 34 ms |
+
+Linear, at roughly **3.4 µs per record**, dominated by hashing each 2 KiB body
+rather than by the tree. It excludes the store scan `storage::tree_head` also
+does, so a real read costs more than this.
+
+**The answer is still not to cache**, and now that is a decision from evidence
+rather than a deferral. A room under a thousand records pays about 3.5 ms per
+read, which is not the thing to fix first. And the obvious cache — a root kept
+beside the room row and recomputed on write — **moves** the cost to writes rather
+than removing it, which is a win for a read-heavy room and a loss for a
+write-heavy one. Removing it needs an *incremental* Merkle update, which is a
+different and much larger change.
+
+Two things to know before anyone does cache it:
+
+- **A stale root is worse than a slow one.** It is a *wrong* commitment, and the
+  failure it produces is an honest host appearing to equivocate — the exact
+  accusation this machinery exists to make credible.
+- **`storage::purge_record` does not touch the room row**, so a cache keyed to
+  the room's version counter would go stale there and nowhere else. It has no
+  caller outside its own tests today, which is why nothing has noticed.
+
 ---
 
 ## 6. What has to be decided first

--- a/vti-rooms/tests/commitment_cost.rs
+++ b/vti-rooms/tests/commitment_cost.rs
@@ -1,0 +1,63 @@
+//! What the record commitment actually costs, measured rather than assumed.
+//!
+//! `storage::tree_head` is deliberately uncached: a cache would have to be
+//! invalidated by every put, curate and prune, and **a stale root is worse than
+//! a slow one** — it is a *wrong* commitment, and the failure it produces is an
+//! honest host appearing to equivocate, which is the exact accusation the
+//! machinery exists to make credible.
+//!
+//! The standing decision is therefore "correct first, and cache when there is a
+//! measurement saying where". This is that measurement. It is a test rather than
+//! a benchmark because its job is to be *run* and read, not to gate anything: it
+//! asserts only an order of magnitude, so it fails if the cost changes by 10x
+//! and not if a laptop is busy.
+
+use std::time::Instant;
+
+use vti_rooms::{Record, RecordStatus};
+
+fn room(n: usize) -> Vec<Record> {
+    (0..n)
+        .map(|i| Record {
+            // Opaque keys, as a sealed tier requires — and the realistic case
+            // for sorting, since they share no prefix.
+            key: format!("{:032x}", i * 2_654_435_761usize),
+            version: i as u64 + 1,
+            epoch: Some(3),
+            status: RecordStatus::Active,
+            pinned: false,
+            // A realistic sealed body. The leaf commits to the ciphertext, so
+            // the hash input scales with what a room actually stores.
+            sealed: Some("A".repeat(2048)),
+            nonce: Some("bm9uY2UtMTI".into()),
+            cleartext: None,
+            author: None,
+            updated_at: 1_756_000_000,
+        })
+        .collect()
+}
+
+#[test]
+fn the_commitment_costs_what_it_looks_like_it_costs() {
+    let mut sizes: Vec<(usize, u128)> = Vec::new();
+    for n in [100usize, 1_000, 10_000] {
+        let mut records = room(n);
+        let started = Instant::now();
+        let head = vti_rooms::merkle::tree_head(&mut records).expect("commits");
+        let micros = started.elapsed().as_micros();
+        assert_eq!(head.record_count, n as u64);
+        sizes.push((n, micros));
+        println!("tree_head over {n:>6} records × 2 KiB: {micros:>8} µs");
+    }
+
+    // The shape, not the number. Hashing is linear in total bytes and the sort
+    // is n log n, so ten times the records should cost roughly ten times as
+    // much — and conspicuously not a hundred times, which is what an accidental
+    // quadratic would look like and is the thing worth catching.
+    let (_, small) = sizes[0];
+    let (_, large) = sizes[2];
+    assert!(
+        large < small.max(1) * 1_000,
+        "100x the records cost more than 1000x the time — that is not linear: {sizes:?}"
+    );
+}


### PR DESCRIPTION
`storage::tree_head` is deliberately uncached, and the standing rule was *"correct first, and cache when there is a measurement saying where"*. This is that measurement, kept as a **runnable test** rather than a number in a commit message.

Release build, 2 KiB sealed bodies:

| Records | `tree_head` |
|---|---|
| 100 | 0.46 ms |
| 1,000 | 3.5 ms |
| 10,000 | 34 ms |

Linear, at roughly **3.4 µs per record** — dominated by hashing each 2 KiB body rather than by the tree, and *excluding* the store scan `storage::tree_head` also does, so a real read costs more than this.

## The answer is still not to cache — and now that is a decision

A room under a thousand records pays about 3.5 ms per read. That is not the thing to fix first.

And the obvious cache — a root kept beside the room row and recomputed on write — **moves** the cost to writes rather than removing it. A win for a read-heavy room, a loss for a write-heavy one. Actually *removing* it needs an incremental Merkle update, which is a different and much larger change.

## Two things recorded for whoever does cache it

- **A stale root is worse than a slow one.** It is a *wrong* commitment, and the failure it produces is an honest host appearing to equivocate — the exact accusation this machinery exists to make credible.
- **`storage::purge_record` does not touch the room row**, so a cache keyed to the room's version counter would go stale exactly there and nowhere else. It has no caller outside its own tests today, which is why nothing has noticed.

## Why a test and not a benchmark

Its job is to be run and read, not to gate anything. It asserts only an **order of magnitude**, so it fails if the cost changes by 10× and not if a laptop is busy.

What it is really guarding is the *shape*: ten times the records costing a hundred times the work is what an accidental quadratic looks like, and that is worth catching. The fixture uses opaque keys sharing no prefix, which is both what a sealed tier requires and the realistic case for the sort.

Closes X4.6 on the data-rooms todo — as *measured and deliberately not cached*, which is what the item asked for.