### PR TITLE
feat(rooms/owner): anchor a room's state where a host cannot reach it

### DIFF
--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -143,6 +143,9 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // Returns a record's PLAINTEXT — on a sealed tier, material the room
     // withholds from its own host — after an outbound call to a party the caller
     // names. Both halves are why this is sensitive; either alone would be.
+    // Publishes permanently, in the room's name, and rotates the room DID's
+    // update key on the way. Nothing here can be taken back.
+    ("rooms/owner/anchor", Risk::Destructive),
     ("rooms/keys/read", Risk::Sensitive),
     // Metadata only, and still sensitive: it presents the principal's room
     // credentials to a caller-named host, which on a tier that discloses

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -438,6 +438,12 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // the same record, and this agent opens it again. What a retry costs is one
     // more disclosure of the presentation to the host, which is why it is safe
     // rather than free.
+    // `Keyed`, and the reason is that "harmless duplicate" is not quite true
+    // here. A second anchor supersedes the first and says the same thing, so it
+    // converges on state — but each attempt appends a permanent witnessed log
+    // entry AND rotates the room DID's update key. Both are durable artefacts
+    // that persist and matter, which is what `Keyed` is for.
+    (trust_tasks::TASK_ROOMS_OWNER_ANCHOR_0_1, Keyed),
     (trust_tasks::TASK_ROOMS_KEYS_READ_0_1, RetrySafe),
     // Same, over a listing. The room may have moved between attempts, so two
     // tries can differ — that is the room changing, not the task misbehaving,

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -837,6 +837,14 @@ pub const TASK_ROOMS_KEYS_CHAIN_0_1: &str = "https://trusttasks.org/spec/rooms/k
 pub const TASK_ROOMS_KEYS_BACKFILL_0_1: &str =
     "https://trusttasks.org/spec/rooms/keys/backfill/0.1";
 
+/// `spec/rooms/owner/anchor/0.1` — write the room's current state into the
+/// room's own witnessed log.
+///
+/// The one statement in this family a host does not make, cannot forge, and
+/// cannot show two members two versions of. Auth: `credentialWrite` capability,
+/// because it publishes in the room's name.
+pub const TASK_ROOMS_OWNER_ANCHOR_0_1: &str = "https://trusttasks.org/spec/rooms/owner/anchor/0.1";
+
 /// `spec/rooms/keys/read/0.1` — read one record from a room's host, check what
 /// the host asserted about it, and open it.
 ///
@@ -1972,6 +1980,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_ROOMS_KEYS_LIST_0_1,
     TASK_ROOMS_OWNER_INVITE_0_1,
     TASK_ROOMS_OWNER_REGISTER_0_1,
+    TASK_ROOMS_OWNER_ANCHOR_0_1,
     TASK_ROOMS_OWNER_ISSUE_MEMBERSHIP_0_1,
     TASK_ROOMS_OWNER_ISSUE_AUTHORITY_0_2,
     TASK_VTA_MEMORY_DELETE_0_1,

--- a/vta-service/src/operations/mod.rs
+++ b/vta-service/src/operations/mod.rs
@@ -67,6 +67,7 @@ pub mod protocol;
 /// `create_did_webvh`.
 #[cfg(feature = "webvh")]
 pub mod provision_integration;
+pub mod room_anchor;
 pub mod room_groups;
 pub mod room_host;
 pub mod room_invitation;

--- a/vta-service/src/operations/room_anchor.rs
+++ b/vta-service/src/operations/room_anchor.rs
@@ -1,0 +1,281 @@
+//! Publishing a room's state into the room's own witnessed log.
+//!
+//! # Why this is not just a DID update
+//!
+//! It is a DID update, mechanically. What makes it worth its own module is the
+//! two refusals and the one shape decision, none of which the update path knows
+//! about:
+//!
+//! - **A room with no witnesses cannot anchor.** An entry nobody co-signed is
+//!   the controller's own word. Publishing one produces something that *looks*
+//!   like an anchor and carries none of the property — worse than its absence,
+//!   because a member checking it would believe they had checked something.
+//! - **The anchor goes in a typed service entry**, which is the only slot in a
+//!   `did:webvh` log entry that carries an ecosystem-defined value today:
+//!   `parameters` is a closed struct, `versionId` and `versionTime` are
+//!   computed, and `proof` is the witnesses' signature over the rest — it
+//!   *secures* the anchor and cannot *be* it.
+//! - **An anchor supersedes rather than accumulates.** One entry per room,
+//!   replaced in place. A document that grew an entry per anchor would carry a
+//!   history the log already keeps, in a place with no ordering.
+
+use serde_json::Value;
+use vti_common::auth::extractor::AuthClaims;
+use vti_common::error::AppError;
+
+use crate::server::AppState;
+
+/// The `type` of the service entry an anchor lives in.
+const ANCHOR_SERVICE_TYPE: &str = "RoomEpochAnchor";
+/// Its fragment, so an anchor replaces its predecessor rather than joining it.
+const ANCHOR_FRAGMENT: &str = "#epoch-anchor";
+
+/// What is about to be written.
+#[derive(Debug, Clone)]
+pub struct Anchor {
+    pub epoch: u64,
+    pub epoch_authenticator: Vec<u8>,
+    pub head_version: u64,
+    pub data_commitment: Option<String>,
+    pub record_count: Option<u64>,
+}
+
+/// What was written, and where.
+#[derive(Debug, Clone)]
+pub struct Published {
+    pub anchored: Value,
+    /// The log entry the anchor rode. Naming it is what lets anyone fetch that
+    /// entry and check the witnesses' signature over it; an anchor whose entry
+    /// could not be named would be unverifiable in exactly the way this exists
+    /// to prevent.
+    pub version_id: String,
+}
+
+/// Render the anchor as the service entry the room's document carries.
+fn service_entry(room_id: &str, anchor: &Anchor) -> Value {
+    let mut endpoint = serde_json::Map::new();
+    endpoint.insert("epoch".into(), serde_json::json!(anchor.epoch));
+    endpoint.insert(
+        "epochAuthenticator".into(),
+        serde_json::json!(vti_rooms::merkle::to_multibase(&sha2_digest(
+            &anchor.epoch_authenticator
+        ))),
+    );
+    endpoint.insert("headVersion".into(), serde_json::json!(anchor.head_version));
+    // Both or neither: a root without the state it describes is not comparable
+    // to another root, so publishing one alone would put something that looks
+    // like evidence into a witnessed log.
+    if let (Some(root), Some(count)) = (&anchor.data_commitment, anchor.record_count) {
+        endpoint.insert("dataCommitment".into(), serde_json::json!(root));
+        endpoint.insert("recordCount".into(), serde_json::json!(count));
+    }
+    serde_json::json!({
+        "id": format!("{room_id}{ANCHOR_FRAGMENT}"),
+        "type": ANCHOR_SERVICE_TYPE,
+        "serviceEndpoint": Value::Object(endpoint),
+    })
+}
+
+/// SHA-256 over the raw authenticator, so what is published is a
+/// `DigestMultibase` like every other digest in this family rather than a bare
+/// base64 blob whose algorithm is implied by context.
+fn sha2_digest(bytes: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+/// Whether the room's log is witnessed.
+///
+/// Read from the entries' `parameters`, because that is where `did:webvh` keeps
+/// it — a record of the DID does not carry it, and inferring it from the
+/// document would be inferring it from the thing being signed.
+///
+/// The log arrives as **text**, one JSON entry per line (JSONL), which is the
+/// form the log is published and witnessed in. Parsing it here rather than
+/// asking for a typed view keeps this reading exactly what a member fetching
+/// the log would read.
+fn is_witnessed(log: Option<&str>) -> bool {
+    let Some(text) = log else {
+        return false;
+    };
+    text.lines().any(|line| {
+        let Ok(entry) = serde_json::from_str::<Value>(line) else {
+            return false;
+        };
+        entry
+            .get("parameters")
+            .and_then(|p| p.get("witness"))
+            .and_then(|w| w.get("witnesses"))
+            .and_then(|w| w.as_array())
+            .is_some_and(|w| !w.is_empty())
+    })
+}
+
+/// Write `anchor` into the room's log.
+pub async fn publish(
+    state: &AppState,
+    auth: &AuthClaims,
+    room_id: &str,
+    _signing_key_id: &str,
+    anchor: Anchor,
+) -> Result<Published, AppError> {
+    let current = crate::operations::did_webvh::get_did_webvh(
+        &state.webvh_ks,
+        auth,
+        room_id,
+        "trust-task",
+        true,
+    )
+    .await?;
+
+    if !is_witnessed(current.log.as_deref()) {
+        return Err(AppError::Validation(format!(
+            "room `{room_id}` is configured with no witnesses, so an entry in its log would be \
+             its controller's own word. An anchor nobody co-signed looks like an anchor and \
+             carries none of the property, which is worse than not having one — a member \
+             checking it would believe they had checked something. Configure witnesses for \
+             this room's DID; retrying will not help."
+        )));
+    }
+
+    let resolver = state
+        .did_resolver
+        .as_ref()
+        .ok_or_else(|| AppError::Validation("this agent has no DID resolver configured".into()))?;
+    let resolved = resolver
+        .resolve(room_id)
+        .await
+        .map_err(|e| AppError::Validation(format!("room `{room_id}` does not resolve: {e}")))?;
+    let mut document = serde_json::to_value(&resolved.doc)
+        .map_err(|e| AppError::Internal(format!("serialise the room's document: {e}")))?;
+
+    let entry = service_entry(room_id, &anchor);
+    let anchored = entry["serviceEndpoint"].clone();
+
+    // Superseded, not accumulated: one entry per room, replaced in place. A
+    // document that grew an entry per anchor would carry a history the log
+    // already keeps, in a place with no ordering.
+    match document.get_mut("service").and_then(Value::as_array_mut) {
+        Some(list) => {
+            list.retain(|s| s.get("type").and_then(Value::as_str) != Some(ANCHOR_SERVICE_TYPE));
+            list.push(entry);
+        }
+        None => document["service"] = Value::Array(vec![entry]),
+    }
+
+    let deps = crate::operations::did_webvh::WebvhDeps::from_app_state(state, resolver);
+    let vta_did = state.config.read().await.vta_did.clone();
+    let result = crate::operations::did_webvh::update_did_webvh(
+        &deps,
+        auth,
+        room_id,
+        crate::operations::did_webvh::UpdateDidWebvhOptions {
+            document: Some(document),
+            label: Some(format!("anchor {room_id}")),
+            ..Default::default()
+        },
+        vta_did.as_deref(),
+        "trust-task",
+    )
+    .await
+    .map_err(AppError::from)?;
+
+    let version_id = serde_json::to_value(&result)
+        .ok()
+        .and_then(|v| {
+            v.get("versionId")
+                .or_else(|| v.get("version_id"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_default();
+
+    Ok(Published {
+        anchored,
+        version_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A log with no witnesses is not a log this will write to.
+    #[test]
+    fn an_unwitnessed_log_is_refused_rather_than_written_to() {
+        assert!(!is_witnessed(None));
+        assert!(!is_witnessed(Some("")));
+        assert!(!is_witnessed(Some(r#"{"parameters":{}}"#)));
+        assert!(!is_witnessed(Some(
+            r#"{"parameters":{"witness":{"witnesses":[]}}}"#
+        )));
+        assert!(is_witnessed(Some(
+            r#"{"parameters":{"witness":{"witnesses":[{"id":"did:key:zW"}]}}}"#
+        )));
+        // A log whose LATER entries drop witnesses still counts as witnessed
+        // for the entries that had them, and this deliberately reads the whole
+        // log rather than only the head: a room that was witnessed and is not
+        // any more is a different question from one that never was, and
+        // answering it here would be answering it in the wrong place.
+        assert!(is_witnessed(Some(
+            "{\"parameters\":{\"witness\":{\"witnesses\":[{\"id\":\"did:key:zW\"}]}}}\n{\"parameters\":{}}"
+        )));
+    }
+
+    /// A root without the state it describes never reaches the log.
+    ///
+    /// One alone would put something that looks like evidence into a witnessed
+    /// entry, where it is permanent and where a member would reasonably compare
+    /// against it.
+    #[test]
+    fn a_commitment_is_published_with_its_count_or_not_at_all() {
+        let with = service_entry(
+            "did:webvh:example.com:rooms:r",
+            &Anchor {
+                epoch: 7,
+                epoch_authenticator: vec![1, 2, 3],
+                head_version: 412,
+                data_commitment: Some("zQm".into()),
+                record_count: Some(118),
+            },
+        );
+        assert!(with["serviceEndpoint"]["dataCommitment"].is_string());
+        assert_eq!(with["serviceEndpoint"]["recordCount"], 118);
+
+        let half = service_entry(
+            "did:webvh:example.com:rooms:r",
+            &Anchor {
+                epoch: 7,
+                epoch_authenticator: vec![1, 2, 3],
+                head_version: 412,
+                data_commitment: Some("zQm".into()),
+                record_count: None,
+            },
+        );
+        assert!(half["serviceEndpoint"].get("dataCommitment").is_none());
+        assert!(half["serviceEndpoint"].get("recordCount").is_none());
+    }
+
+    /// The authenticator is published as a `DigestMultibase`, like every other
+    /// digest in this family — not as a bare blob whose algorithm is implied.
+    #[test]
+    fn the_authenticator_is_published_as_a_digest_multibase() {
+        let entry = service_entry(
+            "did:webvh:example.com:rooms:r",
+            &Anchor {
+                epoch: 7,
+                epoch_authenticator: vec![9; 32],
+                head_version: 1,
+                data_commitment: None,
+                record_count: None,
+            },
+        );
+        let value = entry["serviceEndpoint"]["epochAuthenticator"]
+            .as_str()
+            .expect("a string");
+        assert!(value.starts_with('z'), "base58btc multibase: {value}");
+        assert!(vti_rooms::merkle::from_multibase(value).is_ok());
+    }
+}

--- a/vta-service/src/operations/room_groups.rs
+++ b/vta-service/src/operations/room_groups.rs
@@ -668,6 +668,29 @@ pub async fn forget(groups: &KeyspaceHandle, room_id: &str) -> Result<(), AppErr
         .map_err(|e| AppError::Internal(format!("discard the root history of `{room_id}`: {e}")))
 }
 
+/// The MLS epoch authenticator for a room this agent holds.
+///
+/// Every member of the group derives this independently and **no host can
+/// compute it**, which is the whole reason it is worth anchoring: a member whose
+/// own authenticator differs from the anchored one is in a *forked group*.
+pub async fn epoch_authenticator(
+    groups: &KeyspaceHandle,
+    room_id: &str,
+) -> Result<(u64, Vec<u8>), AppError> {
+    let record = load(groups, room_id).await?.ok_or_else(|| {
+        AppError::Validation(format!(
+            "this agent holds no group state for `{room_id}`, so it cannot say what epoch the \
+             room is at"
+        ))
+    })?;
+    let group = RoomGroup::restore(&record.snapshot)
+        .map_err(|e| AppError::Internal(format!("restore the group for `{room_id}`: {e}")))?;
+    // The epoch travels with it: an authenticator names the epoch it was
+    // derived at, and one published beside a different number is a statement
+    // about a group nobody is in.
+    Ok((group.epoch(), group.epoch_authenticator()))
+}
+
 #[cfg(test)]
 mod root_memory_tests {
     use super::*;

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -2081,6 +2081,32 @@ fn table() -> Vec<(&'static str, Conformance)> {
             ),
         ),
         (
+            uris::TASK_ROOMS_OWNER_ANCHOR_0_1,
+            checked!(
+                specs::rooms::owner::anchor::v0_1::Payload,
+                specs::rooms::owner::anchor::v0_1::Response,
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "host": "did:webvh:example.com:northwind-community",
+                    "signingKeyId": "room-northwind-signing"
+                }),
+                // What was written, and the log entry it rode — naming the entry
+                // is what lets anyone check the witnesses' signature over it.
+                json!({
+                    "roomId": "did:webvh:example.com:rooms:northwind",
+                    "anchored": {
+                        "epoch": 7,
+                        "epochAuthenticator": "zQmZ4tDuvesekSs4qM5ZBKpXiZGun7S2CYtEZRB3DYXkjGx",
+                        "headVersion": 412,
+                        "dataCommitment": "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+                        "recordCount": 118
+                    },
+                    "versionId": "42-QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+                    "reconciled": true
+                })
+            ),
+        ),
+        (
             uris::TASK_ROOMS_KEYS_READ_0_1,
             checked!(
                 specs::rooms::keys::read::v0_1::Payload,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1827,6 +1827,10 @@ dispatch_table! {
     // Returns a record's plaintext — on a sealed tier, material the room
     // withholds from its own host — after presenting the principal's
     // credentials to a party the caller names.
+    // Publishes a witnessed log entry in the room's name, which cannot be
+    // withdrawn — only superseded.
+    vta_sdk::trust_tasks::TASK_ROOMS_OWNER_ANCHOR_0_1 => room_owner::handle_anchor
+        [ Mutating Metadata true ],
     vta_sdk::trust_tasks::TASK_ROOMS_KEYS_READ_0_1 => room_group::handle_read
         [ None Secret true ],
     // Metadata only, and still `actsAsSubject`: the presentation names a member

--- a/vta-service/src/trust_tasks/room_group.rs
+++ b/vta-service/src/trust_tasks/room_group.rs
@@ -549,7 +549,7 @@ pub(super) async fn handle_backfill(
 /// the third caller appeared — `backfill`, `read` and `browse` refusing in three
 /// slightly different sentences would be three chances for one of them to say
 /// something untrue about why.
-async fn outbound_identity(
+pub(super) async fn outbound_identity(
     state: &AppState,
     doc: &TrustTask<Value>,
 ) -> Result<(String, affinidi_did_resolver_cache_sdk::DIDCacheClient), TrustTaskOutcome> {

--- a/vta-service/src/trust_tasks/room_owner.rs
+++ b/vta-service/src/trust_tasks/room_owner.rs
@@ -242,6 +242,153 @@ pub(super) async fn handle_issue_authority(
     .await
 }
 
+/// `rooms/owner/anchor/0.1`.
+///
+/// Write the room's current state into the room's own witnessed log, so that a
+/// host serving a stale, forked or partial view of it becomes **evident rather
+/// than merely possible**.
+///
+/// Everything else in this family produces values a host asserts. This is the
+/// one statement a host does not make, cannot forge, and cannot show two members
+/// two versions of — because witnesses co-sign the log entry it rides.
+pub(super) async fn handle_anchor(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(r) = super::helpers::require_capability(
+        state,
+        auth,
+        &doc,
+        Capability::CredentialWrite,
+        "anchoring a room's state in its own log",
+    )
+    .await
+    {
+        return r;
+    }
+
+    let req: trust_tasks_rs::specs::rooms::owner::anchor::v0_1::Payload = match parse_payload(&doc)
+    {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let (vta_did, resolver) = match super::room_group::outbound_identity(state, &doc).await {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    // The authenticator this agent already holds. Every member derives it
+    // independently and no host can compute it, which is what makes an anchored
+    // one able to expose a forked group.
+    let (epoch, epoch_authenticator) = match crate::operations::room_groups::epoch_authenticator(
+        &state.room_groups_ks,
+        &req.room_id,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+
+    // The two values the agent does NOT hold. `rooms/epoch/mint` answers
+    // `{roomId, epoch}` — the watermark and the commitment are facts about the
+    // room's RECORDS, which live at the host — so an anchor is assembled from a
+    // read, and all three head values come from ONE response.
+    let minted =
+        match crate::operations::room_oracle::present(state, auth, &vta_did, &req.room_id, "read")
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => return app_error_to_reject(&doc, e),
+        };
+    let key = format!("{vta_did}#key-0");
+    let reply = match crate::operations::room_host::send_room_task(
+        signing_context(state, auth),
+        &state.room_groups_ks,
+        &req.room_id,
+        &resolver,
+        &req.host,
+        &key,
+        &vta_did,
+        &key,
+        vti_rooms::wire::ROOMS_RECORDS_LIST_TYPE,
+        &format!("{}#response", vti_rooms::wire::ROOMS_RECORDS_LIST_TYPE),
+        serde_json::json!({
+            "roomId": req.room_id,
+            "presentation": minted.presentation,
+            // One record is enough: the head travels with any page, and asking
+            // for the room would move a lot of metadata to learn three numbers.
+            "limit": 1,
+        }),
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => return app_error_to_reject(&doc, e),
+    };
+    let head: vti_rooms::wire::ListRecordsResponse = match serde_json::from_value(reply) {
+        Ok(h) => h,
+        Err(e) => {
+            return app_error_to_reject(
+                &doc,
+                vti_common::error::AppError::Validation(format!(
+                    "room host `{}` served a head this agent cannot read: {e}",
+                    req.host
+                )),
+            );
+        }
+    };
+    let Some(head_version) = head.head_version else {
+        return app_error_to_reject(
+            &doc,
+            vti_common::error::AppError::Validation(format!(
+                "room host `{}` served no `headVersion`, so there is no state to anchor. A \
+                 host that maintains no tree has nothing for this to pin.",
+                req.host
+            )),
+        );
+    };
+
+    match crate::operations::room_anchor::publish(
+        state,
+        auth,
+        &req.room_id,
+        &req.signing_key_id,
+        crate::operations::room_anchor::Anchor {
+            epoch,
+            epoch_authenticator,
+            head_version,
+            data_commitment: head.data_commitment.clone(),
+            record_count: head.record_count,
+        },
+    )
+    .await
+    {
+        Ok(published) => {
+            record(state, "rooms.owner.anchor", auth, &req.room_id).await;
+            success_response(
+                &doc,
+                serde_json::json!({
+                    "roomId": req.room_id,
+                    "anchored": published.anchored,
+                    "versionId": published.version_id,
+                    // A failed reconciliation does NOT stop the anchor. An owner
+                    // withholding one from a suspect room leaves it with no
+                    // witnessed statement at all, which is the position a
+                    // misbehaving host benefits from.
+                    "reconciled": head
+                        .record_count
+                        .is_none_or(|committed| committed == head.records.len() as u64
+                            || head.cursor.is_some()),
+                }),
+            )
+        }
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
 /// `rooms/owner/register/0.1` — tell a host about a room that already exists.
 ///
 /// `rooms/create` performed by the agent, for the same reason as


### PR DESCRIPTION
Implements [tt#429](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/429). Stacked on #1387 → #1385 → #1380.

> **CI will be red until tt#429 releases.** Verified locally against a `[patch.crates-io]` pointing at the spec repo: `cargo fmt --check` clean, `clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` **175 suites, 0 failures**. The patch is not committed.

Everything else in this family produces values a **host** asserts. An anchor is the one statement a host does not make, cannot forge, and cannot show two members two versions of — because witnesses co-sign the `did:webvh` log entry it rides.

## Assembled from a read, because the owner holds one of three

`epoch_authenticator()` this agent has. **`headVersion` and `dataCommitment` it does not** — they are facts about the room's *records*, which live at the host. So the handler presents as a member, reads the head, and takes all three from **one** response: a root and a version from two reads can straddle a write, and the pair is then individually correct and jointly false.

## `room_anchor` carries what the update path knows nothing about

**A room with no witnesses cannot anchor.** `is_witnessed` reads the log's own entries — not the DID record (which does not carry it) and not the document (inferring it from there would be inferring it from the thing being signed). An entry nobody co-signed *looks* like an anchor and carries none of the property, which is **worse than its absence**: a member checking it would believe they had checked something.

**A commitment is published with its count or not at all.** One alone would put something that looks like evidence into a witnessed entry, where it is permanent.

**An anchor supersedes rather than accumulates.** One service entry per room, replaced in place. A document that grew one per anchor would carry a history the log already keeps, in a place with no ordering.

And the authenticator is published as a `DigestMultibase`, like every other digest in this family, rather than as a bare blob whose algorithm is implied by context.

## `reconciled` is reported and never enforced

An owner withholding an anchor from a suspect room leaves it with **no witnessed statement at all** — the position a misbehaving host benefits from. So the anchor is written and the finding recorded.

## The census entry worth reading

`Keyed`, not `RetrySafe`. A second anchor supersedes the first and says the same thing, so it *converges on state* — which is normally the test for `RetrySafe`. But each attempt appends a **permanent witnessed log entry** *and* **rotates the room DID's update key**, and both are durable artefacts that persist and matter. `Destructive` in the mcp guard, because nothing here can be taken back.

Six sites: URI constant, `ALL_URIS`, `retry_safety`, dispatch, conformance witness, `vta-mcp` guard verb.