### PR TITLE
test(vta): the replay guard's duplicate check compared a proof that is re-signed

### DIFF
--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -3367,10 +3367,38 @@ mod replay_guard {
         // where it is unavoidable, and it is harmless — every proof in this
         // framework is computed over JCS, which is itself key-ordered, so a
         // re-ordered document verifies identically.
-        let (a, b): (Value, Value) = (
+        //
+        // And compared **without the proof**, which is the part that made this
+        // test flaky: `record_response` is called inside
+        // `dispatch_trust_task_inner`, while `sign_success_response` runs in the
+        // outer `dispatch_trust_task` — so the guard caches the *unsigned*
+        // response and every delivery, first or duplicate, is signed afresh on
+        // the way out. `proof.created` has one-second resolution, so two
+        // signings that straddle a second produce two different proofs over the
+        // same document and this assertion failed for a reason that had nothing
+        // to do with the guard.
+        //
+        // Re-signing per delivery is the right behaviour, not a defect to work
+        // around here: a replayed proof would carry a `created` drifting further
+        // into the past on every retry, and §7.2 item 11 asks for the prior
+        // *response*, which is the payload. So the payload is what is compared,
+        // and that both answers are signed at all is asserted separately —
+        // dropping the proof from the comparison must not quietly become
+        // "nobody checks there is one".
+        let (mut a, mut b): (Value, Value) = (
             serde_json::from_slice(&first.body).expect("first body"),
             serde_json::from_slice(&second.body).expect("second body"),
         );
+        for doc in [&mut a, &mut b] {
+            let proof = doc
+                .as_object_mut()
+                .expect("a response is an object")
+                .remove("proof");
+            assert!(
+                proof.is_some(),
+                "every response this spine returns carries a proof, duplicate or not"
+            );
+        }
         assert_eq!(
             a, b,
             "the duplicate must be answered with the prior response"


### PR DESCRIPTION
`trust_tasks::replay_guard::a_redelivered_document_is_absorbed_not_executed_again` fails intermittently. It failed on #1391, whose changes are rooms-only and touch neither the guard nor signing.

## The cause is the spine's own ordering

`record_response` is called inside `dispatch_trust_task_inner`. `sign_success_response` runs in the **outer** `dispatch_trust_task`. So the guard caches the **unsigned** response, and every delivery — first or duplicate — is signed afresh on the way out.

`proof.created` has one-second resolution. Two signings that straddle a second produce two different proofs over the same document:

```
proof.created:  "2026-09-10T08:57:29Z"   vs   "2026-09-10T08:57:30Z"
```

Everything else in the two documents was identical — **`issuedAt` included, at nanosecond precision** (`...29.999185522Z` on both). That is what says the cached document really was replayed, and only its proof is new. The failure had nothing to do with what the test was testing.

## Re-signing per delivery is right, and is not what I changed

A replayed proof would carry a `created` drifting further into the past on every retry. And §7.2 item 11 asks for the prior **response**, which is the payload — that is what is preserved, and it is preserved exactly.

So the test compares the payload, with the proof removed from both documents first.

## The half that is easy to lose

Dropping `proof` from a comparison is one edit away from *"nobody checks there is one"* — which is how a test protecting two properties quietly ends up protecting one. So each document's proof is asserted present as it is removed:

```rust
assert!(proof.is_some(),
    "every response this spine returns carries a proof, duplicate or not");
```

## Checks

- `cargo test -p vta-service --lib trust_tasks::replay_guard` — 2 passed
- The test failed once in CI on #1391 and passed three consecutive local runs before this change, which is the signature of a second-boundary race rather than a defect.