### PR TITLE
feat(room-host): keep the host identity where every other service does

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7959,6 +7959,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tower",
  "tower-http 0.7.1",
  "tracing",
@@ -7972,6 +7973,7 @@ dependencies = [
  "vti-common",
  "vti-rooms",
  "vti-rooms-dtg",
+ "vti-secrets",
 ]
 
 [[package]]

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -56,6 +56,13 @@ affinidi-tdk = { workspace = true, optional = true }
 # `DidCommTransport` and `affinidi-messaging-core`'s shapes.
 affinidi-messaging-sdk = { version = "0.23", optional = true, default-features = false, features = ["tsp"] }
 affinidi-messaging-core = { workspace = true, optional = true }
+# **The same secret storage every other service in this workspace uses.** The
+# host's identity is a private key; it belongs behind the same `[secrets]`
+# config and the same backends the VTA and VTC take, not in a file this crate
+# invented. See `didcomm::HostIdentity`.
+vti-secrets = { path = "../vti-secrets", version = "0.3", optional = true }
+# Reading the `[secrets]` table out of a config file.
+toml = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }
 # `ENVELOPE_TYPE`, from the crate that defines the binding rather than a fourth
 # hand-written copy of the URI.
@@ -65,8 +72,21 @@ futures-util = { workspace = true, optional = true }
 
 [features]
 default = []
+keyring = ["vti-secrets/keyring"]
+config-secret = ["vti-secrets/config-seed"]
+aws-secrets = ["vti-secrets/aws-secrets"]
+gcp-secrets = ["vti-secrets/gcp-secrets"]
+azure-secrets = ["vti-secrets/azure-secrets"]
+vault-secrets = ["vti-secrets/vault-secrets"]
+k8s-secrets = ["vti-secrets/k8s-secrets"]
 ## Serve Trust Tasks over DIDComm and TSP at a mediator, as well as over HTTP.
+##
+## Secret backends are opt-in on top, exactly as they are for the VTA and VTC —
+## a host with none configured keeps its identity in a plaintext file under
+## `--data-dir`, which is right for a laptop and not for anything else.
 didcomm = [
+    "dep:vti-secrets",
+    "dep:toml",
     "dep:affinidi-tdk",
     "dep:affinidi-messaging-sdk",
     "dep:affinidi-messaging-core",

--- a/room-host/src/didcomm.rs
+++ b/room-host/src/didcomm.rs
@@ -29,9 +29,20 @@
 //! A host's DID is what a member's saved address names. If it changed on restart, every link
 //! anybody had kept would point at a host that no longer exists — and the failure would be a
 //! timeout, which reads as "the host is down" rather than "the host is now somebody else".
-//! So it is minted once into the data directory and read back thereafter.
+//! So it is minted once and read back thereafter.
+//!
+//! # Where it is kept, and why not here
+//!
+//! Through [`vti_secrets::create_seed_store`] — the same `[secrets]` config and the same
+//! backends the VTA and the VTC take: keyring, AWS, GCP, Azure, Vault, Kubernetes, or a
+//! plaintext file. This crate used to write its own JSON beside the records and harden the
+//! file mode, which is defensible on a laptop and wrong the moment a host is deployed: a
+//! private key on a container volume, with no path to the secret manager the rest of the
+//! deployment already uses.
+//!
+//! Nothing here knows which backend it got. That is the point of the trait, and it is why
+//! adding a backend is a feature flag rather than a change to this file.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use affinidi_messaging_core::{MessageTransport, Protocol};
@@ -112,25 +123,23 @@ struct IdentityFile {
 }
 
 impl HostIdentity {
-    /// Load this host's identity, minting one on first use.
+    /// Load this host's identity from `secrets`, minting one on first use.
     ///
     /// `did:peer:2`, so the identifier carries both its keys **and** the mediator it is
     /// reached at. That is what makes `?at=<did>` a complete address: a member resolves it
     /// by computation — no network, no registry — and learns where to dial and what to seal
     /// to. A `did:key` could not say the second thing, and a `did:webvh` would make every
     /// member fetch a log to talk to a host that is already telling them everything.
-    pub fn load_or_mint(data_dir: &Path, mediator_did: &str) -> anyhow::Result<Self> {
-        let path = data_dir.join("host-identity.json");
-
-        if path.exists() {
-            if let Err(e) = vti_common::secure_file::restrict_file_to_owner(&path) {
-                tracing::warn!(
-                    path = %path.display(),
-                    error = %e,
-                    "could not restrict the host identity to its owner; it holds a private key"
-                );
-            }
-            let file: IdentityFile = serde_json::from_slice(&std::fs::read(&path)?)?;
+    pub async fn load_or_mint(
+        store: &dyn vti_common::seed_store::SeedStore,
+        mediator_did: &str,
+    ) -> anyhow::Result<Self> {
+        if let Some(stored) = store
+            .get()
+            .await
+            .map_err(|e| anyhow::anyhow!("read the host identity: {e}"))?
+        {
+            let file: IdentityFile = serde_json::from_slice(&stored)?;
             // A `did:peer` encodes its keys *and its services* in the identifier, so an
             // identity minted against one mediator names that mediator forever. Pointed at a
             // different one, the stored DID would advertise somewhere this host no longer
@@ -138,11 +147,10 @@ impl HostIdentity {
             // Refuse rather than serve a lie about where we are.
             if file.mediator != mediator_did {
                 anyhow::bail!(
-                    "the stored host identity at {} advertises {}, not {}. A did:peer names \
-                     its services in its identifier, so changing mediator means a new \
-                     identity and a new address — delete it to mint one, and expect saved \
-                     links to stop resolving.",
-                    path.display(),
+                    "the stored host identity advertises {}, not {}. A did:peer names its \
+                     services in its identifier, so changing mediator means a new identity \
+                     and a new address — clear the stored secret to mint one, and expect \
+                     saved links to stop resolving.",
                     file.mediator,
                     mediator_did
                 );
@@ -178,20 +186,25 @@ impl HostIdentity {
             );
         }
 
-        std::fs::create_dir_all(data_dir)?;
-        std::fs::write(
-            &path,
-            serde_json::to_vec_pretty(&IdentityFile {
-                did: did.clone(),
-                mediator: mediator_did.to_string(),
-                secrets: secrets.clone(),
-            })?,
-        )?;
-        if let Err(e) = vti_common::secure_file::restrict_file_to_owner(&path) {
+        let file = serde_json::to_vec(&IdentityFile {
+            did: did.clone(),
+            mediator: mediator_did.to_string(),
+            secrets: secrets.clone(),
+        })?;
+        store
+            .set(&file)
+            .await
+            .map_err(|e| anyhow::anyhow!("store the host identity: {e}"))?;
+
+        // A backend that does not survive a restart cannot hold this. The DID is a member's
+        // saved address, so an identity that evaporates makes every kept link point at a host
+        // that no longer exists — and it would present as a timeout, long after the choice
+        // that caused it.
+        if !store.set_persists_across_restart() {
             tracing::warn!(
-                path = %path.display(),
-                error = %e,
-                "could not restrict the host identity to its owner; it holds a private key"
+                did = %did,
+                "this host's identity is in a store that does not survive a restart — every \
+                 saved address for it will stop resolving when this process ends"
             );
         }
 

--- a/room-host/src/main.rs
+++ b/room-host/src/main.rs
@@ -4,6 +4,15 @@
 //! test or the `data_room` example without a socket.
 
 use clap::Parser;
+
+/// The wrapper a `[secrets]` table arrives in, so the file reads the same as every other
+/// service's config rather than being a bare table this binary alone would accept.
+#[cfg(feature = "didcomm")]
+#[derive(serde::Deserialize)]
+struct SecretsFile {
+    #[serde(default)]
+    secrets: vti_secrets::SecretsConfig,
+}
 use room_host::{open_state_with_resolver, router_with_origins};
 
 #[derive(Parser, Debug)]
@@ -53,6 +62,15 @@ struct Args {
     #[cfg(feature = "didcomm")]
     #[arg(long)]
     mediator_did: Option<String>,
+
+    /// A TOML file carrying a `[secrets]` table, in the shape the VTA and VTC take.
+    ///
+    /// Omitted, the host keeps its identity in a plaintext file under `--data-dir`. That is
+    /// the right default for running this on a laptop and the wrong one for a deployment: it
+    /// is a private key on whatever volume the container was given.
+    #[cfg(feature = "didcomm")]
+    #[arg(long)]
+    secrets: Option<std::path::PathBuf>,
 
     /// Seconds between mirror pulls.
     ///
@@ -106,8 +124,36 @@ async fn main() -> anyhow::Result<()> {
     // by the first member who cannot reach it.
     #[cfg(feature = "didcomm")]
     if let Some(mediator_did) = args.mediator_did.clone() {
+        // The same `[secrets]` shape the VTA and VTC take. With none configured this is a
+        // plaintext file under `--data-dir`, which is right for a laptop; a deployment points
+        // it at the secret manager it already runs.
+        let secrets = match &args.secrets {
+            Some(path) => {
+                let text = std::fs::read_to_string(path)?;
+                toml::from_str::<SecretsFile>(&text)?.secrets
+            }
+            // No `[secrets]` given: keep the identity in a cleartext file under `--data-dir`,
+            // and say so rather than doing it quietly. `vti-secrets` gates plaintext behind
+            // an explicit opt-in because for a VTA the secret is a BIP-32 master seed; for a
+            // host it is one service identity that holds no room keys and can read no record.
+            // That makes the default defensible, not invisible — an operator who is going to
+            // deploy this should be told once, here, rather than find out from the volume.
+            None => {
+                let mut config = vti_secrets::SecretsConfig::default();
+                config.backend = Some(vti_secrets::SecretBackend::Plaintext);
+                config.allow_plaintext = true;
+                tracing::warn!(
+                    data_dir = %args.data_dir.display(),
+                    "no --secrets given, so this host's identity is kept in a cleartext file \
+                     under --data-dir. Pass --secrets with a `[secrets]` table to use the \
+                     keyring or a secret manager, in the same shape the VTA and VTC take."
+                );
+                config
+            }
+        };
+        let store = vti_secrets::create_seed_store(&secrets, &args.data_dir)?;
         let identity =
-            room_host::didcomm::HostIdentity::load_or_mint(&args.data_dir, &mediator_did)?;
+            room_host::didcomm::HostIdentity::load_or_mint(store.as_ref(), &mediator_did).await?;
         // Printed, not only logged. It is this host's *address* — the thing a member puts
         // after `?at=` — and an operator has to be able to copy it out of a terminal.
         println!("host DID: {}", identity.did);

--- a/room-host/tests/carrier.rs
+++ b/room-host/tests/carrier.rs
@@ -24,6 +24,59 @@
 
 use affinidi_messaging_test_mediator::{TestMediator, acl};
 
+/// A seed store over a temporary directory — the plaintext backend, which is what a host with
+/// no `[secrets]` configuration gets.
+fn a_store(dir: &std::path::Path) -> Box<dyn vti_common::seed_store::SeedStore> {
+    // `SecretsConfig` is `#[non_exhaustive]`, so it is built by mutation rather than by a
+    // struct literal — which is the crate telling consumers not to depend on its shape.
+    let mut config = vti_secrets::SecretsConfig::default();
+    config.backend = Some(vti_secrets::SecretBackend::Plaintext);
+    config.allow_plaintext = true;
+    vti_secrets::create_seed_store(&config, dir).expect("a plaintext seed store")
+}
+
+/// **The identity survives a restart through whatever backend it was given.**
+///
+/// This is the property a member's saved address depends on, and it used to be a file this
+/// crate wrote and hardened itself. It now goes through `vti-secrets`, the same `[secrets]`
+/// config and the same backends the VTA and VTC take — so the durability question is the
+/// backend's, and this asserts the host asks it correctly rather than asserting a file
+/// exists.
+#[tokio::test]
+async fn the_identity_round_trips_through_the_configured_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let mediator = "did:webvh:QmScid:webvh.example:mediator";
+
+    let first =
+        room_host::didcomm::HostIdentity::load_or_mint(a_store(dir.path()).as_ref(), mediator)
+            .await
+            .expect("mint");
+
+    // A *different* store instance over the same directory, which is what a restart is.
+    let again =
+        room_host::didcomm::HostIdentity::load_or_mint(a_store(dir.path()).as_ref(), mediator)
+            .await
+            .expect("load");
+    assert_eq!(
+        first.did, again.did,
+        "a host's address must survive a restart"
+    );
+
+    // And a store with nothing in it mints a different one — so the test above is reading
+    // what was stored rather than deriving the same DID twice from the same inputs.
+    let elsewhere = tempfile::tempdir().unwrap();
+    let fresh = room_host::didcomm::HostIdentity::load_or_mint(
+        a_store(elsewhere.path()).as_ref(),
+        mediator,
+    )
+    .await
+    .expect("mint");
+    assert_ne!(
+        first.did, fresh.did,
+        "an empty store means a new identity, not a rediscovered one"
+    );
+}
+
 /// A mediator whose DID is too long to embed refuses the host, and says why.
 ///
 /// The `TestMediator` mints itself a `did:peer`, which is exactly the case that does not fit
@@ -39,8 +92,12 @@ async fn a_host_refuses_to_mint_an_identity_no_member_could_resolve() {
         .await
         .expect("spawn a test mediator");
 
-    let refused = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator.did())
-        .expect_err("a did:peer mediator does not fit inside a did:peer host");
+    let refused = room_host::didcomm::HostIdentity::load_or_mint(
+        a_store(dir.path()).as_ref(),
+        mediator.did(),
+    )
+    .await
+    .expect_err("a did:peer mediator does not fit inside a did:peer host");
     let said = refused.to_string();
 
     assert!(
@@ -70,8 +127,10 @@ async fn a_webvh_mediator_leaves_a_host_comfortably_inside_the_limit() {
     let mediator =
         "did:webvh:QmTS3a3H9Dk4ZMPAZ8jNWGeyPbuKrPbrPZcSbg8CJ6yynD:webvh.example:mediator";
 
-    let identity = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator)
-        .expect("a did:webvh mediator fits");
+    let identity =
+        room_host::didcomm::HostIdentity::load_or_mint(a_store(dir.path()).as_ref(), mediator)
+            .await
+            .expect("a did:webvh mediator fits");
 
     assert!(
         identity.did.len() < 1000,
@@ -86,8 +145,10 @@ async fn a_webvh_mediator_leaves_a_host_comfortably_inside_the_limit() {
 
     // The same identity comes back, because a member's saved address names it. A host that
     // minted a new one on restart would leave every kept link pointing at somebody else.
-    let again = room_host::didcomm::HostIdentity::load_or_mint(dir.path(), mediator)
-        .expect("the stored identity loads");
+    let again =
+        room_host::didcomm::HostIdentity::load_or_mint(a_store(dir.path()).as_ref(), mediator)
+            .await
+            .expect("the stored identity loads");
     assert_eq!(
         identity.did, again.did,
         "a host's address must survive a restart"
@@ -95,9 +156,10 @@ async fn a_webvh_mediator_leaves_a_host_comfortably_inside_the_limit() {
 
     // Pointed somewhere else, it refuses rather than advertising where it no longer listens.
     let moved = room_host::didcomm::HostIdentity::load_or_mint(
-        dir.path(),
+        a_store(dir.path()).as_ref(),
         "did:webvh:QmOther:webvh.example:mediator",
     )
+    .await
     .expect_err("a stored identity names one mediator forever");
     assert!(
         moved.to_string().contains("advertises"),


### PR DESCRIPTION
The host's identity is a private key, and `room-host` was storing it in a JSON file of its own invention, guarded by a file mode — which I added in #1369 and which is the odd one out in this workspace.

`vta-service` and `vtc-service` both take their secrets through `vti-secrets`. `room-host` did not.

Defensible on a laptop. Wrong the moment a host is deployed: a private key on whatever volume the container was handed, with no path to the secret manager the rest of the deployment already runs.

## Now the same as everything else

Through `vti-secrets::create_seed_store` — the same `[secrets]` table and the same backends behind the same feature flags: `keyring`, `aws-secrets`, `gcp-secrets`, `azure-secrets`, `vault-secrets`, `k8s-secrets`. `--secrets` names a TOML file carrying the table.

Nothing in `didcomm.rs` knows which backend it got. That is the point of the trait, and it is why adding a backend here is a feature flag rather than an edit to that file.

## The plaintext default, made explicit rather than removed

With no `--secrets`, the identity stays in a cleartext file under `--data-dir` — and the host **warns at startup**, naming the directory and what to pass instead.

`vti-secrets` gates plaintext behind `allow_plaintext` because for a VTA the secret is a BIP-32 master seed and one wrong TOML key puts it on disk in clear. For a room-host it is one service identity that holds no room keys and can read no record, so the default is defensible — but it should not be *invisible*. An operator about to deploy is told once, here, rather than finding out from the volume.

`set_persists_across_restart()` is checked and warned on too: a member's saved address names this DID, so an identity in a store that evaporates makes every kept link resolve to a host that no longer exists — presenting as a timeout, long after the choice that caused it.

## Testing

The added test asserts the round trip goes through the **store**, not a file: the same directory yields the same DID, and an empty directory yields a *different* one — so it is reading what was stored rather than re-deriving the same value from the same inputs twice. 29 + 3 tests pass with the feature on, the default build is unaffected, clippy clean.

## Next

This is the storage half. The onboarding half — `vti-secrets`'s own `IntegrationOnboarding`, the ephemeral `did:key` → ACL grant → auto-rotate flow the mediator, PNM and did-hosting already use — is the follow-up, and is what lets a host be handed a VTA-provisioned `did:webvh` instead of minting its own `did:peer`.