### PR TITLE
feat(rooms/epoch): a host relays commits and forgets a chain on request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9643,9 +9643,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b1b65db50a01f5615765b3d902a37f541325be156669aef06d4fc23f24874"
+checksum = "44b445f62f4142dcce7d71d74526f815bed79bfb1d1f3b0161b86e4bb5497459"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.19.3", default-features = false, features = [
+trust-tasks-rs = { version = "0.19.4", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/room-host/src/lib.rs
+++ b/room-host/src/lib.rs
@@ -66,12 +66,14 @@ use vti_common::error::AppError;
 use vti_common::store::{KeyspaceHandle, Store};
 use vti_rooms::audit::{self as rooms_audit, RoomOperation};
 use vti_rooms::wire::{
-    ChainBody, ChainResponse, ClaimOwnerBody, CreateRoomBody, CreateRoomResponse, CurateRecordBody,
-    CurateRecordResponse, GetRecordBody, GetRecordResponse, ListRecordsBody, ListRecordsResponse,
-    MintEpochBody, MintEpochResponse, OwnerResponse, PutRecordBody, PutRecordResponse,
-    ROOMS_CREATE_TYPE, ROOMS_EPOCH_CHAIN_TYPE, ROOMS_EPOCH_MINT_TYPE, ROOMS_OWNER_CLAIM_TYPE,
-    ROOMS_OWNER_TRANSFER_TYPE, ROOMS_RECORDS_CURATE_TYPE, ROOMS_RECORDS_GET_TYPE,
-    ROOMS_RECORDS_LIST_TYPE, ROOMS_RECORDS_PUT_TYPE, TransferOwnerBody,
+    ChainBody, ChainResponse, ClaimOwnerBody, CommitsBody, CommitsResponse, CreateRoomBody,
+    CreateRoomResponse, CurateRecordBody, CurateRecordResponse, GetRecordBody, GetRecordResponse,
+    ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse, OwnerResponse,
+    PruneBody, PruneResponse, PutRecordBody, PutRecordResponse, ROOMS_CREATE_TYPE,
+    ROOMS_EPOCH_CHAIN_TYPE, ROOMS_EPOCH_COMMITS_TYPE, ROOMS_EPOCH_MINT_TYPE,
+    ROOMS_EPOCH_PRUNE_TYPE, ROOMS_OWNER_CLAIM_TYPE, ROOMS_OWNER_TRANSFER_TYPE,
+    ROOMS_RECORDS_CURATE_TYPE, ROOMS_RECORDS_GET_TYPE, ROOMS_RECORDS_LIST_TYPE,
+    ROOMS_RECORDS_PUT_TYPE, TransferOwnerBody,
 };
 use vti_rooms::{
     ROOM_RECORDS_KEYSPACE, ROOMS_KEYSPACE, Record, RecordStatus, Room,
@@ -317,6 +319,8 @@ pub async fn dispatch(state: &Arc<HostState>, body: &[u8]) -> Answer {
         ROOMS_RECORDS_CURATE_TYPE => curate(state, &doc, payload).await,
         ROOMS_EPOCH_MINT_TYPE => mint(state, &doc, payload).await,
         ROOMS_EPOCH_CHAIN_TYPE => epoch_chain(state, &doc, payload).await,
+        ROOMS_EPOCH_PRUNE_TYPE => epoch_prune(state, &doc, payload).await,
+        ROOMS_EPOCH_COMMITS_TYPE => epoch_commits(state, &doc, payload).await,
         ROOMS_OWNER_TRANSFER_TYPE => transfer_owner(state, &doc, payload).await,
         ROOMS_OWNER_CLAIM_TYPE => claim_owner(state, &doc, payload).await,
         other => reject(
@@ -798,12 +802,149 @@ async fn mint(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answ
             {
                 return from_app_error(doc, &e);
             }
+            // And the commit, on the same terms: this is the moment the
+            // committer holds it, and a room that advances without leaving it
+            // somewhere fetchable forks every member who was not online.
+            if let Some(commit) = &req.commit
+                && let Err(e) =
+                    storage::put_commit(&state.epoch_links, &req.room_id, req.epoch, commit).await
+            {
+                return from_app_error(doc, &e);
+            }
             audit_room(&room, &authorized, RoomOperation::MintEpoch, None);
             respond(
                 doc,
                 MintEpochResponse {
                     room_id: updated.room_id,
                     epoch: updated.epoch,
+                },
+            )
+        }
+        Err(e) => from_app_error(doc, &e),
+    }
+}
+
+/// `rooms/epoch/prune/0.1` — drop the chain below an epoch.
+///
+/// The **rungs** go, not the records. A pruned room still holds every record and
+/// this host still serves them; what is gone is the ability to derive the keys
+/// they were sealed under, for anyone who has not already derived them.
+async fn epoch_prune(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answer {
+    let req: PruneBody = match serde_json::from_value(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            return reject(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: e.to_string(),
+                },
+            );
+        }
+    };
+    let room = match storage::get_room(&state.rooms, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let (presenter, verifier) = match state.presenter_and_verifier(doc).await {
+        Ok(p) => p,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    // `admin`, not `curate`: pruning makes no statement about any record, and
+    // every member who can write can curate.
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        Action::Admin,
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    if req.before_epoch >= room.epoch {
+        return from_app_error(
+            doc,
+            &AppError::Validation(format!(
+                "`beforeEpoch` {} is at or above the current epoch {} of `{}`; pruning there \
+                 would drop the whole chain, not shorten it",
+                req.before_epoch, room.epoch, req.room_id
+            )),
+        );
+    }
+    match storage::prune_chain(&state.epoch_links, &req.room_id, req.before_epoch).await {
+        Ok((pruned, earliest_rung)) => {
+            audit_room(&room, &authorized, RoomOperation::MintEpoch, None);
+            respond(
+                doc,
+                PruneResponse {
+                    room_id: req.room_id,
+                    pruned: pruned as u32,
+                    earliest_rung,
+                },
+            )
+        }
+        Err(e) => from_app_error(doc, &e),
+    }
+}
+
+/// `rooms/epoch/commits/0.1` — serve the commits a member missed.
+///
+/// Safe on every tier: a commit is ciphertext plus a leaf index and **names
+/// nobody**, which is the difference from a Welcome and why the host is
+/// deliberately off that path and on this one.
+async fn epoch_commits(state: &HostState, doc: &TrustTask<Value>, payload: Value) -> Answer {
+    let req: CommitsBody = match serde_json::from_value(payload) {
+        Ok(r) => r,
+        Err(e) => {
+            return reject(
+                doc,
+                RejectReason::MalformedRequest {
+                    reason: e.to_string(),
+                },
+            );
+        }
+    };
+    let room = match storage::get_room(&state.rooms, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let (presenter, verifier) = match state.presenter_and_verifier(doc).await {
+        Ok(p) => p,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        Action::Read,
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return from_app_error(doc, &e),
+    };
+    match storage::commits_since(
+        &state.epoch_links,
+        &req.room_id,
+        req.since_epoch,
+        req.limit.unwrap_or(100).clamp(1, 100) as usize,
+    )
+    .await
+    {
+        Ok(commits) => {
+            audit_room(&room, &authorized, RoomOperation::ListRecords, None);
+            respond(
+                doc,
+                CommitsResponse {
+                    room_id: req.room_id,
+                    commits,
+                    // Read from the room, never computed from the answer.
+                    room_epoch: room.epoch,
                 },
             )
         }

--- a/vtc-service/src/rooms/handlers.rs
+++ b/vtc-service/src/rooms/handlers.rs
@@ -32,10 +32,10 @@ use vti_rooms::audit::{self as rooms_audit, RoomOperation};
 use vti_rooms::authz::{self, Action};
 use vti_rooms::storage;
 use vti_rooms::wire::{
-    ChainBody, ChainResponse, ClaimOwnerBody, CreateRoomBody, CreateRoomResponse, CurateRecordBody,
-    CurateRecordResponse, GetRecordBody, GetRecordResponse, ListRecordsBody, ListRecordsResponse,
-    MintEpochBody, MintEpochResponse, OwnerResponse, PutRecordBody, PutRecordResponse,
-    TransferOwnerBody,
+    ChainBody, ChainResponse, ClaimOwnerBody, CommitsBody, CommitsResponse, CreateRoomBody,
+    CreateRoomResponse, CurateRecordBody, CurateRecordResponse, GetRecordBody, GetRecordResponse,
+    ListRecordsBody, ListRecordsResponse, MintEpochBody, MintEpochResponse, OwnerResponse,
+    PruneBody, PruneResponse, PutRecordBody, PutRecordResponse, TransferOwnerBody,
 };
 use vti_rooms::{Record, RecordStatus, Room};
 use vti_rooms_dtg::{DataIntegrityKeys, DtgChainVerifier, nomination};
@@ -611,6 +611,18 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
             {
                 return app_error_to_reject(&doc, &e);
             }
+            // The commit, on the same terms and for the same reason: this is the
+            // moment the committer holds it, and a room that advances without
+            // leaving it somewhere fetchable forks every member who was not
+            // online. `put_commit` refuses to replace one, because the first
+            // published is the one members may already have applied.
+            if let Some(commit) = &req.commit
+                && let Err(e) =
+                    storage::put_commit(&state.room_epoch_links_ks, &req.room_id, req.epoch, commit)
+                        .await
+            {
+                return app_error_to_reject(&doc, &e);
+            }
             audit_room(state, &room, &authorized, RoomOperation::MintEpoch, None).await;
             success_response(
                 &doc,
@@ -622,6 +634,147 @@ pub(crate) async fn handle_mint_epoch(state: &AppState, doc: TrustTask<Value>) -
         }
         Err(e) => app_error_to_reject(&doc, &e),
     }
+}
+
+/// `rooms/epoch/prune/0.1`.
+///
+/// Drop the epoch key chain below an epoch. The **rungs** go, not the records: a
+/// pruned room still holds every record and this host still serves them, and
+/// what is gone is the ability to derive the keys they were sealed under. Closer
+/// to losing a key than to shredding a document, and irreversible either way.
+pub(crate) async fn handle_epoch_prune(
+    state: &AppState,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: PruneBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let room = match storage::get_room(&state.rooms_ks, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let (presenter, verifier) = match presenter_and_verifier(state, &doc).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    // `admin`, not `curate`: pruning makes no statement about any record, and
+    // every member who can write can curate — which would put "end the room's
+    // readable history" within reach of every writer.
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        Action::Admin,
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    // Refused rather than performed. `beforeEpoch: currentEpoch` reads like
+    // "keep from here" and would drop every rung, leaving a member who restarts
+    // unable to derive anything below the epoch they are handed next — a
+    // plausible typo with a consequence nobody would choose.
+    if req.before_epoch >= room.epoch {
+        return app_error_to_reject(
+            &doc,
+            &vti_common::error::AppError::Validation(format!(
+                "`beforeEpoch` {} is at or above the current epoch {} of `{}`; pruning there \
+                 would drop the whole chain, not shorten it",
+                req.before_epoch, room.epoch, req.room_id
+            )),
+        );
+    }
+
+    let (pruned, earliest_rung) = match storage::prune_chain(
+        &state.room_epoch_links_ks,
+        &req.room_id,
+        req.before_epoch,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    audit_room(state, &room, &authorized, RoomOperation::MintEpoch, None).await;
+    success_response(
+        &doc,
+        PruneResponse {
+            room_id: req.room_id,
+            pruned: pruned as u32,
+            earliest_rung,
+        },
+    )
+}
+
+/// `rooms/epoch/commits/0.1`.
+///
+/// Serve the commits a member missed. Relaying these is safe on every tier — a
+/// commit is ciphertext plus a leaf index and **names nobody**, which is the
+/// difference from a Welcome, and why the host is deliberately off that path and
+/// on this one.
+pub(crate) async fn handle_epoch_commits(
+    state: &AppState,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: CommitsBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let room = match storage::get_room(&state.rooms_ks, &req.room_id).await {
+        Ok(r) => r,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let (presenter, verifier) = match presenter_and_verifier(state, &doc).await {
+        Ok(p) => p,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+    let authorized = match authz::authorize(
+        &room,
+        &req.presentation,
+        Action::Read,
+        &presenter,
+        now(),
+        &verifier,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    let commits = match storage::commits_since(
+        &state.room_epoch_links_ks,
+        &req.room_id,
+        req.since_epoch,
+        req.limit.unwrap_or(100).clamp(1, 100) as usize,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => return app_error_to_reject(&doc, &e),
+    };
+
+    audit_room(state, &room, &authorized, RoomOperation::ListRecords, None).await;
+    success_response(
+        &doc,
+        CommitsResponse {
+            room_id: req.room_id,
+            commits,
+            // Read from the room, never computed from the answer. They differ
+            // exactly when a commit is missing, and that difference is what
+            // tells a member a delivery is missing rather than their own state
+            // being broken.
+            room_epoch: room.epoch,
+        },
+    )
 }
 
 /// `rooms/epoch/chain/0.1`.

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -246,6 +246,12 @@ async fn dispatch_typed(
         rooms_wire::ROOMS_EPOCH_CHAIN_TYPE => {
             crate::rooms::handlers::handle_epoch_chain(state, doc).await
         }
+        rooms_wire::ROOMS_EPOCH_PRUNE_TYPE => {
+            crate::rooms::handlers::handle_epoch_prune(state, doc).await
+        }
+        rooms_wire::ROOMS_EPOCH_COMMITS_TYPE => {
+            crate::rooms::handlers::handle_epoch_commits(state, doc).await
+        }
         rooms_wire::ROOMS_OWNER_TRANSFER_TYPE => {
             crate::rooms::handlers::handle_transfer_owner(state, doc).await
         }
@@ -365,6 +371,8 @@ pub(crate) const DISPATCHED_URIS: &[&str] = &[
     rooms_wire::ROOMS_RECORDS_LIST_TYPE,
     rooms_wire::ROOMS_EPOCH_MINT_TYPE,
     rooms_wire::ROOMS_EPOCH_CHAIN_TYPE,
+    rooms_wire::ROOMS_EPOCH_PRUNE_TYPE,
+    rooms_wire::ROOMS_EPOCH_COMMITS_TYPE,
     rooms_wire::ROOMS_RECORDS_CURATE_TYPE,
     rooms_wire::ROOMS_OWNER_TRANSFER_TYPE,
     rooms_wire::ROOMS_OWNER_CLAIM_TYPE,

--- a/vti-rooms/src/storage.rs
+++ b/vti-rooms/src/storage.rs
@@ -145,6 +145,118 @@ pub async fn prune_epoch_links_before(
     Ok(dropped)
 }
 
+/// Drop the chain below `before_epoch`, and report how far back it still reaches.
+///
+/// # Two numbers, because they are not the same question
+///
+/// `pruned` is what this call removed. `earliest_rung` is how far back a member
+/// can now actually walk — and those come apart, because **a chain can already
+/// have a gap**: rungs are delivered per commit and a delivery that never
+/// happened leaves one. A prune below an existing gap removes rungs and changes
+/// nothing about reach, and reporting `before_epoch` back would tell an operator
+/// they had achieved something they had not.
+///
+/// `earliest_rung` is read from what survives rather than computed from the
+/// request, which is the only way it can be true.
+pub async fn prune_chain(
+    links: &KeyspaceHandle,
+    room_id: &str,
+    before_epoch: u32,
+) -> Result<(usize, u32), AppError> {
+    // `prune_epoch_links_before` drops `epoch <= n`, and this drops *below*
+    // `before_epoch` — so the boundary is one lower. Off by one here would
+    // silently take the epoch the caller meant to keep.
+    let dropped = prune_epoch_links_before(links, room_id, before_epoch.saturating_sub(1)).await?;
+    let remaining = list_epoch_links(links, room_id).await?;
+    let earliest = remaining
+        .iter()
+        .map(|l| l.epoch)
+        .min()
+        .unwrap_or(before_epoch);
+    Ok((dropped, earliest))
+}
+
+/// Prefix for the commits a host relays.
+const COMMITS_PREFIX: &str = "room-commit:";
+
+/// Storage key for one relayed commit. Zero-padded so a prefix scan is ordered.
+fn commit_key(room_id: &str, epoch: u32) -> String {
+    format!("{COMMITS_PREFIX}{room_id}:{epoch:010}")
+}
+
+/// Store the commit that produced an epoch, for members who were not online.
+///
+/// **Refuses to replace an existing one**, for the same reason `put_epoch_link`
+/// does and with a sharper consequence: the first commit published is the one
+/// members may already have applied, and a second would fork the very group the
+/// relay exists to keep together.
+pub async fn put_commit(
+    commits: &KeyspaceHandle,
+    room_id: &str,
+    epoch: u32,
+    commit: &str,
+) -> Result<(), AppError> {
+    let key = commit_key(room_id, epoch);
+    if commits.get_raw(key.clone()).await?.is_some() {
+        return Err(AppError::Conflict(format!(
+            "a commit for epoch {epoch} of `{room_id}` is already held; replacing it would \
+             fork the members who have applied it"
+        )));
+    }
+    commits
+        .insert(key, &commit.to_string())
+        .await
+        .map_err(|e| AppError::Internal(format!("store the commit for `{room_id}`: {e}")))
+}
+
+/// The commits above `since_epoch`, in order and **stopping at the first gap**.
+///
+/// MLS commits apply in sequence: one applied out of order, or over a gap, is
+/// rejected by the group. So a host that is missing one returns the run it holds
+/// *up to* the gap rather than skipping past it — a short answer is recoverable,
+/// while a set with a hole in it is a member stuck at an epoch who cannot say
+/// why.
+pub async fn commits_since(
+    commits: &KeyspaceHandle,
+    room_id: &str,
+    since_epoch: u32,
+    limit: usize,
+) -> Result<Vec<crate::wire::RelayedCommit>, AppError> {
+    let pairs = commits
+        .prefix_iter_raw(format!("{COMMITS_PREFIX}{room_id}:"))
+        .await?;
+    let mut held: Vec<(u32, String)> = Vec::with_capacity(pairs.len());
+    for (k, v) in pairs {
+        let key = String::from_utf8(k)
+            .map_err(|e| AppError::Internal(format!("commit key is not utf-8: {e}")))?;
+        let Some(epoch) = key.rsplit(':').next().and_then(|e| e.parse::<u32>().ok()) else {
+            continue;
+        };
+        let commit: String = serde_json::from_slice(&v)
+            .map_err(|e| AppError::Internal(format!("decode a commit in `{room_id}`: {e}")))?;
+        held.push((epoch, commit));
+    }
+    held.sort_by_key(|(epoch, _)| *epoch);
+
+    let mut out = Vec::new();
+    let mut expected = since_epoch + 1;
+    for (epoch, commit) in held {
+        if epoch < expected {
+            continue;
+        }
+        // The gap. Stop rather than skip.
+        if epoch != expected {
+            break;
+        }
+        out.push(crate::wire::RelayedCommit { epoch, commit });
+        expected += 1;
+        if out.len() >= limit {
+            break;
+        }
+    }
+    Ok(out)
+}
+
 /// Register a room.
 ///
 /// Refuses to replace an existing one: re-registering would silently reset the epoch and
@@ -1778,5 +1890,125 @@ mod tests {
     async fn listing_rooms_is_empty_on_a_host_that_holds_none() {
         let (_d, rooms, _r) = open().await;
         assert!(list_rooms(&rooms).await.expect("list").is_empty());
+    }
+}
+
+#[cfg(test)]
+mod relay_and_prune_tests {
+    use super::*;
+    use crate::wire::EpochLink;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    const ROOM: &str = "r1";
+
+    async fn open2() -> (tempfile::TempDir, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("rooms").unwrap();
+        (dir, ks)
+    }
+
+    fn link(epoch: u32) -> EpochLink {
+        EpochLink {
+            epoch,
+            wrapped: "d3JhcHBlZA".into(),
+            nonce: "bm9uY2U".into(),
+        }
+    }
+
+    /// The boundary. `before_epoch` means *below*, so the epoch named survives —
+    /// off by one here silently takes the rung the caller meant to keep.
+    #[tokio::test]
+    async fn pruning_below_an_epoch_keeps_that_epoch() {
+        let (_d, ks) = open2().await;
+        // From 2: a rung wraps the PREVIOUS epoch's key, so epoch 1 has no
+        // predecessor to link to and `put_epoch_link` refuses one. The chain
+        // ending at 2 is what a room that has always been chained looks like.
+        for e in 2..=5 {
+            put_epoch_link(&ks, ROOM, &link(e)).await.unwrap();
+        }
+        let (pruned, earliest) = prune_chain(&ks, ROOM, 4).await.unwrap();
+        assert_eq!(pruned, 2, "epochs 2 and 3 go");
+        assert_eq!(earliest, 4, "and 4 is what the caller asked to keep");
+    }
+
+    /// `earliest_rung` is read from what survives, not from the request — a
+    /// chain with a gap already stopped somewhere, and echoing the request would
+    /// tell an operator they had achieved something they had not.
+    #[tokio::test]
+    async fn a_prune_below_an_existing_gap_reports_the_gap() {
+        let (_d, ks) = open2().await;
+        // 2, 3, then nothing until 7: a delivery that never happened.
+        for e in [2u32, 3, 7, 8] {
+            put_epoch_link(&ks, ROOM, &link(e)).await.unwrap();
+        }
+        let (pruned, earliest) = prune_chain(&ks, ROOM, 4).await.unwrap();
+        assert_eq!(pruned, 2);
+        assert_eq!(
+            earliest, 7,
+            "reach is 7 whatever the request said, because the chain already stopped there"
+        );
+    }
+
+    /// Nothing to do is a success, not a failure to retry.
+    #[tokio::test]
+    async fn pruning_a_chain_that_is_already_short_is_a_success() {
+        let (_d, ks) = open2().await;
+        put_epoch_link(&ks, ROOM, &link(9)).await.unwrap();
+        let (pruned, earliest) = prune_chain(&ks, ROOM, 5).await.unwrap();
+        assert_eq!(pruned, 0);
+        assert_eq!(earliest, 9);
+    }
+
+    /// A commit is published once. The first is the one members may already have
+    /// applied, and a second would fork the group the relay exists to hold
+    /// together.
+    #[tokio::test]
+    async fn a_commit_is_never_replaced() {
+        let (_d, ks) = open2().await;
+        put_commit(&ks, ROOM, 3, "AAEC").await.unwrap();
+        assert!(
+            put_commit(&ks, ROOM, 3, "ZZZZ").await.is_err(),
+            "replacing a published commit must be refused"
+        );
+    }
+
+    /// The rule that keeps a catching-up member from being handed something the
+    /// group will reject: stop at the gap rather than skipping it.
+    #[tokio::test]
+    async fn the_relay_stops_at_a_gap_rather_than_skipping_it() {
+        let (_d, ks) = open2().await;
+        for e in [4u32, 5, 7] {
+            put_commit(&ks, ROOM, e, "AAEC").await.unwrap();
+        }
+        let served = commits_since(&ks, ROOM, 3, 100).await.unwrap();
+        assert_eq!(
+            served.iter().map(|c| c.epoch).collect::<Vec<_>>(),
+            vec![4, 5],
+            "7 is past a gap at 6, and serving it would produce a commit the group rejects"
+        );
+    }
+
+    /// Ordered and bounded, and a member asks again from where they reached.
+    #[tokio::test]
+    async fn the_relay_serves_in_order_and_honours_the_page() {
+        let (_d, ks) = open2().await;
+        for e in 1..=6u32 {
+            put_commit(&ks, ROOM, e, "AAEC").await.unwrap();
+        }
+        let first = commits_since(&ks, ROOM, 0, 3).await.unwrap();
+        assert_eq!(
+            first.iter().map(|c| c.epoch).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        let next = commits_since(&ks, ROOM, 3, 3).await.unwrap();
+        assert_eq!(
+            next.iter().map(|c| c.epoch).collect::<Vec<_>>(),
+            vec![4, 5, 6]
+        );
     }
 }

--- a/vti-rooms/src/wire.rs
+++ b/vti-rooms/src/wire.rs
@@ -56,6 +56,10 @@ pub const ROOMS_OWNER_TRANSFER_TYPE: &str = "https://trusttasks.org/spec/rooms/o
 pub const ROOMS_OWNER_CLAIM_TYPE: &str = "https://trusttasks.org/spec/rooms/owner/claim/0.1";
 /// `rooms/records/curate/0.1`.
 pub const ROOMS_RECORDS_CURATE_TYPE: &str = "https://trusttasks.org/spec/rooms/records/curate/0.1";
+/// `rooms/epoch/prune/0.1`.
+pub const ROOMS_EPOCH_PRUNE_TYPE: &str = "https://trusttasks.org/spec/rooms/epoch/prune/0.1";
+/// `rooms/epoch/commits/0.1`.
+pub const ROOMS_EPOCH_COMMITS_TYPE: &str = "https://trusttasks.org/spec/rooms/epoch/commits/0.1";
 
 /// Every `rooms/*` URI this service dispatches.
 pub const ROOMS_DISPATCHED_URIS: &[&str] = &[
@@ -68,6 +72,8 @@ pub const ROOMS_DISPATCHED_URIS: &[&str] = &[
     ROOMS_RECORDS_CURATE_TYPE,
     ROOMS_OWNER_TRANSFER_TYPE,
     ROOMS_OWNER_CLAIM_TYPE,
+    ROOMS_EPOCH_PRUNE_TYPE,
+    ROOMS_EPOCH_COMMITS_TYPE,
 ];
 
 /// What a party presents to act on a room.
@@ -515,6 +521,19 @@ pub struct MintEpochBody {
     /// matches, and MUST NOT replace a rung it already holds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub link: Option<EpochLink>,
+    /// The MLS commit that produced this epoch, base64url, for the host to relay
+    /// to members who were not online to receive it.
+    ///
+    /// Carried here for the same reason `link` is: minting is the moment the
+    /// committer holds it, and a separate publish task would be a second chance
+    /// to forget. A room that advances without leaving the commit somewhere
+    /// fetchable **forks**.
+    ///
+    /// A host MUST NOT replace a commit it already holds for an epoch: the first
+    /// one published is the one members may already have applied, and a second
+    /// would fork the very group it was meant to keep together.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
@@ -543,6 +562,83 @@ pub struct ChainResponse {
     pub room_id: String,
     /// The rungs, highest epoch first and contiguous within the range returned.
     pub links: Vec<EpochLink>,
+}
+
+/// `rooms/epoch/prune/0.1` request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PruneBody {
+    pub room_id: String,
+    /// Drop every rung **below** this epoch. The chain walks backwards, so this
+    /// is a floor rather than a ceiling.
+    pub before_epoch: u32,
+    pub presentation: AuthorityPresentation,
+    /// Why, for the room's audit trail. A prune is irreversible and
+    /// unattributable after the fact — the rungs are simply gone — so the only
+    /// record of intent is the one made at the time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// `rooms/epoch/prune/0.1#response`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PruneResponse {
+    pub room_id: String,
+    /// How many rungs were dropped. `0` is a **success**: the chain already went
+    /// back no further, and a caller reading it as a failure would retry an
+    /// operation with nothing left to do.
+    pub pruned: u32,
+    /// How far back the chain still reaches.
+    ///
+    /// **Not a restatement of `before_epoch`.** A chain can already have a gap —
+    /// rungs are delivered per commit, and a delivery that never happened leaves
+    /// one — and a prune below that gap changes nothing about how far back a
+    /// member can actually walk. Echoing the request would tell an operator they
+    /// had achieved something they had not.
+    pub earliest_rung: u32,
+}
+
+/// One commit a room made, as the relay serves it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RelayedCommit {
+    pub epoch: u32,
+    /// The MLS commit, base64url, **exactly as it was published**. A host that
+    /// re-encoded it would produce something the group rejects.
+    pub commit: String,
+}
+
+/// `rooms/epoch/commits/0.1` request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommitsBody {
+    pub room_id: String,
+    /// The epoch this member is at; the host returns what is **above** it.
+    pub since_epoch: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    pub presentation: AuthorityPresentation,
+}
+
+/// `rooms/epoch/commits/0.1#response`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitsResponse {
+    pub room_id: String,
+    /// The commits above `since_epoch`, **in ascending epoch order and with no
+    /// gaps**. MLS commits apply in sequence, so one served out of order or over
+    /// a gap is rejected by the group — a host missing one returns the run it
+    /// holds *up to* the gap and stops.
+    pub commits: Vec<RelayedCommit>,
+    /// Where the room is now.
+    ///
+    /// **Not `since_epoch` plus the number returned.** They differ exactly when a
+    /// commit is missing or the page ended early, and that difference is the
+    /// useful part: a member who applies everything served and is still behind
+    /// knows a delivery is missing rather than concluding their own state is
+    /// broken.
+    pub room_epoch: u32,
 }
 
 /// `rooms/epoch/mint/0.1#response`.

--- a/vti-rooms/tests/schema_conformance.rs
+++ b/vti-rooms/tests/schema_conformance.rs
@@ -182,6 +182,7 @@ fn mint_epoch_conforms() {
         epoch: 2,
         presentation: presentation(),
         link: None,
+        commit: Some("AAECAwQFBgcICQoLDA0ODw".into()),
         reason: Some("membership change".into()),
     };
     check::<Payload>(
@@ -643,6 +644,73 @@ fn a_trace_without_a_commitment_is_refused() {
     );
 }
 
+/// The two host verbs that relay and forget.
+///
+/// `prune` reports **reach**, not the request — a chain can already have a gap,
+/// and echoing `beforeEpoch` would tell an operator they had achieved something
+/// they had not. `commits` reports the room's epoch read from the room, never
+/// `sinceEpoch` plus the count, because they differ exactly when a delivery is
+/// missing and that difference is what tells a member so.
+#[test]
+fn prune_and_commits_conform() {
+    use trust_tasks_rs::specs::rooms::epoch::commits::v0_1::{
+        Payload as CommitsPayload, Response as CommitsResp,
+    };
+    use trust_tasks_rs::specs::rooms::epoch::prune::v0_1::{
+        Payload as PrunePayload, Response as PruneResp,
+    };
+
+    check::<PrunePayload>(
+        "PruneBody",
+        &serde_json::to_value(PruneBody {
+            room_id: "did:webvh:example.com:rooms:northwind".into(),
+            before_epoch: 5,
+            presentation: presentation(),
+            reason: Some("retention: past the agreed window".into()),
+        })
+        .expect("serialise"),
+    );
+    check::<PruneResp>(
+        "PruneResponse",
+        &serde_json::to_value(PruneResponse {
+            room_id: "did:webvh:example.com:rooms:northwind".into(),
+            pruned: 4,
+            earliest_rung: 5,
+        })
+        .expect("serialise"),
+    );
+
+    check::<CommitsPayload>(
+        "CommitsBody",
+        &serde_json::to_value(CommitsBody {
+            room_id: "did:webvh:example.com:rooms:northwind".into(),
+            since_epoch: 5,
+            limit: Some(50),
+            presentation: presentation(),
+        })
+        .expect("serialise"),
+    );
+    let served = serde_json::to_value(CommitsResponse {
+        room_id: "did:webvh:example.com:rooms:northwind".into(),
+        commits: vec![
+            RelayedCommit {
+                epoch: 6,
+                commit: "AAECAwQFBgcICQoLDA0ODw".into(),
+            },
+            RelayedCommit {
+                epoch: 7,
+                commit: "EBESExQVFhcYGRobHB0eHw".into(),
+            },
+        ],
+        // Further ahead than the commits reach: a delivery is missing, and the
+        // member is told rather than left to infer it.
+        room_epoch: 9,
+    })
+    .expect("serialise");
+    assert_eq!(served["roomEpoch"], 9);
+    check::<CommitsResp>("CommitsResponse", &served);
+}
+
 /// A ciphertext with no nonce is a corrupt store, and loses its body rather
 /// than gaining a fabricated half of one.
 ///
@@ -845,6 +913,14 @@ fn every_dispatched_uri_is_the_published_one() {
         (
             ROOMS_OWNER_CLAIM_TYPE,
             <rooms::owner::claim::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_EPOCH_PRUNE_TYPE,
+            <rooms::epoch::prune::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
+        ),
+        (
+            ROOMS_EPOCH_COMMITS_TYPE,
+            <rooms::epoch::commits::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI,
         ),
     ];
 


### PR DESCRIPTION
Implements [tt#431](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/431) and [tt#432](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/432), released in `trust-tasks-rs` 0.19.4. The last two verbs the rooms family owed — X4.2 and X4.4 on the todo.

## The relay

Every epoch change is a commit, and every member must apply it or fall out of the group. Without somewhere to fetch one, the only way it reaches a member is the owner sending it: **O(n) deliveries per renewal**, to parties the owner must have addresses for, all of which must be online. A room whose members are people with browsers does not have that.

`rooms/epoch/mint` gains an optional `commit` — published where it is *produced*, because that is the moment the committer holds it and a separate task would be a second chance to forget. `rooms/epoch/commits` serves them.

**`commits_since` stops at the first gap rather than skipping it.** MLS commits apply in sequence, so serving 4, 5, 7 hands a member something the group rejects with nothing to point at. A short answer is recoverable; a set with a hole in it is a member stuck at an epoch who cannot say why.

**`room_epoch` is read from the room, never computed from the answer.** The difference is exactly what tells a member a delivery is missing rather than their own state being broken.

**`put_commit` refuses to replace one**, on the same terms as `put_epoch_link` and with a sharper consequence: the first published is the one members may already have applied, and a second forks the group the relay exists to hold together.

## The prune

`rooms/epoch/prune` drops the chain below an epoch. **The rungs go, not the records** — a pruned room still holds every record and still serves them; what is gone is the ability to *derive* the keys they were sealed under. Closer to losing a key than to shredding a document.

`admin`, not `curate`: pruning makes no statement about any record, and every member who can write can curate.

**`prune_chain` reports reach, not the request.** A chain can already have a gap, and a prune below one changes nothing about how far back a member can walk — `a_prune_below_an_existing_gap_reports_the_gap` pins it at 7 where the request said 4. And `beforeEpoch` at or above the room's current epoch is **refused**: it reads like *keep from here* and would drop the whole chain.

Commits live in the epoch-links keyspace rather than a new one — same lifetime, same owner, same deletion semantics, and a new keyspace would owe a DID-deletion-effect census entry for no benefit.

## Two defects this found in its own making

Worth carrying, because both are the same shape — *a second list nobody updated*:

**An unimported constant in a `match` arm does not fail to compile. It becomes a binding that matches everything.** `ROOMS_EPOCH_PRUNE_TYPE` was missing from room-host's imports, so every arm after it was dead and owner transfer, owner claim and the unknown-task refusal were all parsed as prune requests. Three tests said so precisely:

```
unknown field `newOwnerDid`, expected one of `roomId`, `beforeEpoch`, `presentation`, `reason`
```

**`vtc-service` declares its supported URIs in a list separate from its dispatch match**, and the census caught the omission with the right words: *"this VTC does not declare it — a client would be told it is unsupported at every version."*

Also corrected: my `put_epoch_link` fixtures started at epoch 1, which it rightly refuses — a rung wraps the **previous** epoch's key, so epoch 1 has no predecessor to link to.

## Checks

Against the **released** 0.19.4, no local patch:

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **176 suites, 0 failures**
- Both CI feature combinations (`rest,didcomm` and `rest`, `--no-default-features`) — 0 errors