### PR TITLE
chore: release

### DIFF
--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -63,7 +63,7 @@ affinidi-messaging-core = { workspace = true, optional = true }
 vti-secrets = { path = "../vti-secrets", version = "0.3", optional = true }
 # The session store behind `onboarding` — which backend is an operator's choice,
 # exactly as `[secrets]` is.
-vta-sdk = { path = "../vta-sdk", version = "0.34", optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.35", optional = true }
 # Reading the `[secrets]` table out of a config file.
 toml = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.34.1 -> 0.35.0
* `vti-common`: 0.18.1 -> 0.18.2
* `vti-rooms`: 0.1.3 -> 0.2.0
* `vtc-client`: 0.5.5 -> 0.5.6
* `vta-cli-common`: 0.14.1 -> 0.15.0
* `cnm-cli`: 0.14.1 -> 0.14.2
* `pnm-cli`: 0.15.1 -> 0.16.0
* `vti-rooms-dtg`: 0.1.2 -> 0.2.0
* `vti-secrets`: 0.3.3 -> 0.3.4
* `vta-audit`: 0.3.4 -> 0.3.5
* `vta-config`: 0.4.4 -> 0.4.5
* `vta-keys`: 0.4.4 -> 0.4.5
* `vta-support`: 0.3.3 -> 0.3.4
* `vta-backup`: 0.3.4 -> 0.3.5
* `vta-persona`: 0.3.0 -> 0.3.1
* `vta-policy`: 0.3.4 -> 0.3.5
* `vta-vault`: 0.5.4 -> 0.5.5
* `vta-webvh`: 0.2.5 -> 0.2.6
* `vta-service`: 0.24.1 -> 0.25.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.35.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.34.1...vta-sdk-v0.35.0) — 2026-09-09

### Added

- **rooms**: Cut over to present/0.2 and issue-authority/0.2 ([#1365](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1365))

The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked
  by affinidi/affinidi-tdk-rs#784.

  `trust-tasks-rs` 0.19 carries both new spec versions, but this workspace could
  not take it: `affinidi-messaging-sdk 0.22.0` required 0.18, so pinning 0.19 put
  two `trust-tasks-rs` nodes in the graph and broke `vta-sdk` on `expected
  MediatorAcl, found a different MediatorAcl`. TDK #784 moved the messaging family
  to 0.19 and 0.23.0.

  Taking it exposed pins that had drifted apart underneath: `vta-sdk` was on
  messaging-sdk 0.22 while `vta-service` and the e2e tests were on 0.21, and three
  `trust-tasks-rs` versions were resolving at once. All of it is now consolidated:
  the lockfile holds exactly ONE `trust-tasks-rs` and ONE `affinidi-messaging-sdk`,
  where before it held three of each.

  `rooms/keys/present` 0.1 -> 0.2 and `rooms/owner/issue-authority` 0.1 -> 0.2.
  Both 0.1s are retired upstream. Neither is dual-accepted, deliberately: for
  `present`, 0.1's extra members are exactly the two nothing could honour; for
  `issue-authority`, accepting 0.1 means accepting a request with no `validUntil`,
  which is the thing 0.2 exists to refuse.

  The hand-rolled `validUntil` guard in `room_owner.rs` is deleted. 0.2 makes the
  member REQUIRED, so the generated payload types it as a `DateTime` and the
  envelope schema rejects a request without one before dispatch. Same rule, one
  layer up, which is where a shape constraint belongs.

  `every_witnessed_task_round_trips_through_its_generated_types` refused two
  witnesses that had been green for as long as they existed:

  1. The `issue-authority` witness carried no `validUntil` — a chain root with no
     expiry, the exact request 0.2 forbids, and one this service could have sent.
  2. The `present` witness carried `"audience": "did:key:z6MkHost"` — a HOST DID,
     the precise shape #414 reported as impossible to satisfy, since the field
     named the party that had to PRESENT the credential.

  `room_oracle` emitted `membership` and `authority[]` as JSON **objects**;
  `AuthorityPresentation` types both as strings, and the host's opener reads
  base64url or bare JSON text. So the oracle's output could not deserialize at a
  host at all — `rooms/keys/present` had never worked end to end. It went unseen
  because 0.1's response typed `presentation` as an opaque object; 0.2 names the
  shared component, which turned a runtime refusal nothing exercised into a type
  error. The oracle now serialises each credential. That is the first half of
  have caught all three of these years earlier.

- **sdk**: A no-I/O verifier resolves did:peer too ([#1364](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1364))
- **sdk**: The client verifies the replies it receives ([#1341](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1341))

Completes the arc #1334 and #1335 began. Both services sign their responses;
  until now nothing checked one, so the signature was decorative. This is the
  surface that matters most — the CLI, cierge and the services all dispatch
  Trust Tasks through `VtaClient`.

  A reply is bytes off a socket. Nothing else in this path establishes who
  produced them: the transport proves a connection, and over REST not even
  that beyond TLS to a host name. Without the proof an intermediary can
  rewrite an ACL listing, flip a policy decision, or answer for an agent that
  never spoke, and every check downstream passes — because the checks
  downstream are about shape.

  Two checks, and the second is the one easy to omit: the proof must verify,
  **and its proven signer must be the agent this client is talking to**. A
  proof by somebody else's key verifies perfectly well, so skipping the
  binding turns "signed by somebody" into "signed by the agent". The expected
  signer is `ClientIdentity::vta_did`, which the client already holds.

  A client with no identity does not verify, because there is nothing to bind
  against — such a client cannot produce a conforming request either and is
  refused at the agent for a missing `recipient`. A loopback client likewise:
  its sink answers ahead of the transport and returns a value rather than a
  signed document.

  Error documents are exempt, from the specification rather than for
  convenience: `trust-task-error`'s own proof requirement is RECOMMENDED
  (SPEC §8.1), so demanding one would make every conforming refusal
  unreadable, including the ones carrying the reason a caller needs.

  `trusting_unsigned_replies()` is a staging control, not a preference. An
  agent that predates #1334/#1335 sends nothing to verify, so a client
  upgraded ahead of its agent would refuse every answer; this exists so that
  ordering can be chosen rather than endured. It weakens the check to almost
  nothing while set — an attacker who can rewrite a reply can also strip its
  proof — so a present proof is still verified and still bound.

  The resolver is built once per client and shared by clones. A
  `DIDCacheClient` is a cache; one per call would defeat it.

- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))

Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
  in trust-tasks-rs 0.18.9.

  A holder who uses this model for a while ends up with twenty profiles, and a
  flat list of twenty is a list nobody reads. A facet is the arrangement over
  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
  the profiles it groups.

  **An arrangement, not a container.** Nothing is stored inside a facet, and
  `delete_facet` touches no profile and no attribute. There is no cascading
  form because there is no cascading form of the idea: a grouping that could
  take its members with it is a folder, and a holder who reads it as a folder
  is right to be afraid of it. `releasedFaces` reports what now belongs
  nowhere, which is what a screen needs to say what it will look like
  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.

  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
  well-behaved consumer does not hold the values it would have to resend —
  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
  name. It would either request every sensitive value the holder owns to
  perform an arrangement that has nothing to do with values, or send a put
  without one and destroy them.



### Changed

- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))

Pure move plus re-exports; no behaviour changes. It exists so the next
  change can be small: `VtaClient` needs to verify the responses it receives,
  and the verifier it needs already exists one layer up where a client cannot
  reach it.

  `vti-common` was the right home while services verifying their *inbound*
  requests were the only consumer. A client verifying its *replies* is the
  same operation over the same document shape, and `vta-sdk` is the layer both
  can see.

  **The part worth not duplicating is the verification-method resolver.**
  Resolving one looks trivial and is not: a DID document may name its methods
  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
  proof always names them absolutely, so a resolver accepting only the
  spelling it expects refuses perfectly good documents from conforming peers.
  A second copy would drift, and drift in a verifier means refusing honest
  documents or accepting dishonest ones. Writing that copy is what this move
  avoids.

  Behind a new `proof-verify` feature rather than `client`, because
  `vti-common` takes `vta-sdk` with `default-features = false` and must not
  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
  that crate already depended on `affinidi-data-integrity` and the DID
  resolver directly. `client` enables it: a client that cannot verify its
  replies is the gap being closed.

  The resolver rides in the feature deliberately. Verification is only as good
  as the party it resolves — a `did:key` signer needs no I/O, and a
  `did:webvh` one, which is what a real agent is, cannot be verified without
  resolving its document.

  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
  use the flat re-export, so there is one canonical path rather than an alias
  to go stale. Two doc comments naming the old location updated with them.

  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
  tests that moved with the code.



### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>

## `vti-common`

<blockquote>

## [0.18.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.1...vti-common-v0.18.2) — 2026-09-09

### Changed

- **sdk**: Move the Trust-Task proof verifier down from vti-common ([#1340](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1340))

Pure move plus re-exports; no behaviour changes. It exists so the next
  change can be small: `VtaClient` needs to verify the responses it receives,
  and the verifier it needs already exists one layer up where a client cannot
  reach it.

  `vti-common` was the right home while services verifying their *inbound*
  requests were the only consumer. A client verifying its *replies* is the
  same operation over the same document shape, and `vta-sdk` is the layer both
  can see.

  **The part worth not duplicating is the verification-method resolver.**
  Resolving one looks trivial and is not: a DID document may name its methods
  absolutely (`did:webvh:…:glenn#key-0`) or relatively (`#key-0`), while a
  proof always names them absolutely, so a resolver accepting only the
  spelling it expects refuses perfectly good documents from conforming peers.
  A second copy would drift, and drift in a verifier means refusing honest
  documents or accepting dishonest ones. Writing that copy is what this move
  avoids.

  Behind a new `proof-verify` feature rather than `client`, because
  `vti-common` takes `vta-sdk` with `default-features = false` and must not
  acquire reqwest to keep verifying. It adds no dependency to `vti-common` —
  that crate already depended on `affinidi-data-integrity` and the DID
  resolver directly. `client` enables it: a client that cannot verify its
  replies is the gap being closed.

  The resolver rides in the feature deliberately. Verification is only as good
  as the party it resolves — a `did:key` signer needs no I/O, and a
  `did:webvh` one, which is what a real agent is, cannot be verified without
  resolving its document.

  Call sites that used the module path (`vti_common::auth::di_proof::…`) now
  use the flat re-export, so there is one canonical path rather than an alias
  to go stale. Two doc comments naming the old location updated with them.

  `cargo clippy --workspace --all-targets` clean; `vta-service --lib` 1063
  passed; `vta-sdk` + `vti-common` suites pass, including the four resolver
  tests that moved with the code.
</blockquote>

## `vti-rooms`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.3...vti-rooms-v0.2.0) — 2026-09-09

### Added

- **rooms**: Traces, and a response type for the single-record read ([#1368](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1368))

A commitment lets a reader catch a host that equivocates. A trace proves a
  particular record sits under the root that host just asserted. This serves
  them — and fixes the conformance defect that adding them uncovered.

  Implements trust-tasks-tf#419, released as trust-tasks-rs 0.19.1.

  `rooms/records/get` has never conformed to its published schema. Both hosts
  answered a read by serialising `vti_rooms::Record` — the *storage* record — and
  adding `dataCommitment` to whatever came out:

      "c2VhbGVk" is not of type "object";
      Additional properties are not allowed
      ('author','epoch','nonce','pinned','status','updatedAt' were unexpected)

  It survived because `vti_rooms::wire`'s rule — every wire type appears in
  tests/schema_conformance.rs — can only be applied to types that exist. A
  response that was never a type had no line to be missing from, and a storage
  record reached the wire because nothing stood between them. The consumer is not
  hypothetical: `@openvtc/pnm-core`'s `roomsRecordsGet` is typed on the generated
  payload, so a caller reading `sealed.ciphertext` got `undefined` from a live
  host, with a green type-check on both sides.

  The leaf preimage was not reproducible either. `leaf_hash` canonicalised the
  storage record, so every root it produced was unreachable by any reader:
  `updatedAt` is unix seconds in storage and RFC 3339 on the wire, `epoch` and
  `nonce` are flat in storage and inside `sealed` on the wire, and `epoch`
  serialises as `null` on an open room where the wire has it absent. Survivable
  while the only use was comparing two roots from the same build; not survivable
  once a trace has to be computable by someone else.

- **rooms**: Hosts compute and serve the data commitment ([#1351](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1351))

* fix(rooms): a commitment is a DigestMultibase, not bare hex

  Owed from #1346. The spec that landed with it
  (trustoverip/dtgwg-trust-tasks-tf#411) types `dataCommitment` as the
  framework's `DigestMultibase`, and the helper shipped emitting hex.

  Bare hex hard-codes SHA-256 into the wire contract, which is precisely what
  `DigestMultibase` exists to prevent: multihash names the algorithm in-band,
  so moving off SHA-256 later is a change of value rather than another schema
  revision. `0x12 0x20` then the digest, base58btc with the `z` prefix — the
  same shape `sealed_transfer::bundle_digest_multibase` already produces, so
  the two agree by construction rather than by memory.

  `from_multibase` refuses anything that is not a sha2-256 multihash. A
  commitment is what a comparison turns on, so silently accepting an algorithm
  this build cannot compute would turn "these two roots differ" into "these
  two roots are not comparable" without saying which.

  Two tests, both about the encoding being a contract rather than a detail: a
  commitment decodes to the 34-byte multihash and round-trips, and bare hex, a
  foreign algorithm, a truncated digest and non-multibase are each refused.

  The tree, the leaves and the proofs are untouched — this is the wire
  boundary only.

- **rooms**: A browser can be a room member ([#1347](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1347))

* feat(rooms): a `host` feature, so a room's member half reaches wasm

  `vti-rooms` already had two halves and no name for them: `vta-service`
  imports `mls`/`sealed`/`wire` and nothing else, while `vtc-service`,
  `room-host` and `vti-rooms-dtg` import `storage`/`authz`/`audit`. This
  names the second half `host`, on by default, and makes `vti-common`
  optional behind it.

  `vti-common` describes itself as server-side infrastructure and pulls
  axum, fjall and tokio, so it was the whole of what kept a room's member
  code off `wasm32-unknown-unknown`. With it optional,
  `--no-default-features --features mls` builds there — which is what lets
  a browser hold a room's keys itself rather than ask an agent to. See
  `docs/05-design-notes/data-rooms-demo-site.md`.

  The member half needed **no source changes** to get there. That is a
  property of `error.rs`, which deliberately does not use
  `vti_common::error::AppError` because key material is not a service's
  concern; a decision made for its own reasons that paid for itself here.

  `lifecycle` is deliberately left ungated: only hosts consume it today,
  but it needs nothing from `vti-common`, and a member computing a room's
  lifecycle state to explain it on screen should not need a host's
  dependencies.

  Three things about the wasm plumbing, each of which reports as a
  `compile_error!` that reads like an unsupported target:

  - OpenMLS 0.9 has a first-class `js` feature (`web-time` for the
    `SystemTime` wasm lacks, plus getrandom's JS backend). Declared
    per-target rather than as a feature of this crate, so building for
    wasm just works — verified wasm-only: `web-time` appears in the wasm
    tree and not the native one.
  - There are two getrandom majors in the graph. The 0.4 is ours; the 0.2
    arrives transitively under `openmls_rust_crypto` via RustCrypto's
    elliptic-curve stack, so no feature declared here could reach it.
    `getrandom_02` is a feature shim, not a dependency this crate calls.
  - With both declared per-target, **no `RUSTFLAGS` are needed** — the
    `wasm_js` feature alone selects the backend.

  CI gains two steps in the `features` job: clippy on the member half with
  no host, and a wasm32 `--lib` check, so neither property rots silently.

  `vta-service` now takes `default-features = false`: a VTA holds room keys
  and is never a room's host, so it no longer compiles one.

  * feat(rooms): vti-rooms-wasm — a data room's member half, in a browser

  The MLS group, record sealing and the epoch key chain, compiled to
  WebAssembly, so a tab can *be* a member rather than drive an agent that
  is one. `vti-rooms` supplies all of it; this crate is only the boundary,
  and its job is deciding what crosses.

  **Secrets do not cross.** Everything returned is public — a KeyPackage,
  ciphertext, an epoch number — with one deliberate exception: the
  snapshot, which is key material because OpenMLS persists a group through
  its provider rather than as a value. It goes in IndexedDB and nowhere
  else; the docs say so at the method, since it is the one thing here a
  caller could reasonably mishandle.
</blockquote>


## `vta-cli-common`

<blockquote>

## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.14.1...vta-cli-common-v0.15.0) — 2026-09-09

### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>


## `pnm-cli`

<blockquote>

## [0.16.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.15.1...pnm-cli-v0.16.0) — 2026-09-09

### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>

## `vti-rooms-dtg`

<blockquote>

## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.1.2...vti-rooms-dtg-v0.2.0) — 2026-09-09

### Fixed

- **rooms**: A presentation is bound to its presenter — and dtg-credentials 0.6 → 0.9.1 ([#1356](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1356))

* fix(rooms): bind a presentation to its presenter, not to the host

  `pnm-cli rooms --host-did …` could never work. Every request it made was
  refused as `WrongAudience`, and omitting the flag "worked" only by
  skipping the check it exists to perform — so the flag's two states were
  broken and unprotected.

  `audience` is not who a presentation is addressed to.
  `dtg_credentials::authority::verify_chain` compares it to the PRESENTER —
  "the leaf must be presentable by whoever is presenting it" — so it is
  holder binding, and its whole job is to make a captured presentation
  worthless to whoever captured it. Filled with the host's DID it named a
  party no presenter can ever match.

  The value to bind to was already named a few lines away: `RoomSigner`'s
  doc says "a room request is signed by the party the presentation was
  minted for". This passes exactly that. There is no unbound case left, so
  the warning about one goes, and `--host-did` keeps its real job of naming
  the document's recipient.
</blockquote>







## `vta-persona`

<blockquote>

## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.3.0...vta-persona-v0.3.1) — 2026-09-09

### Added

- **persona**: Say whether a link crosses a part of the holder's life ([#1342](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1342))

Serves the members added in dtgwg-trust-tasks-tf#408, published in
  trust-tasks-rs 0.18.10: `crossesFacets` and `facetIds` on a finding,
  `facetId` on each `sharedWith` location. This needs a floor of 0.18.10 —
  the spine validates OUTGOING responses, so under an older schema an analysis
  that fully succeeded would come back 500 `responseSchemaViolation` — and no
  longer moves one: main reached 0.18.11 while this sat open, which satisfies
  it. The bump this branch carried is dropped rather than resolved downward.

  **Severity is how linkable. Facets are whether the holder minds.** Nothing
  here touches `severity`, and that is the design rather than an omission. A
  value shared between two profiles in one facet still links them for anyone
  who sees both — the holder's filing changes nothing a counterparty can do —
  so softening severity on intent would report a false all-clear. What the
  facets add is a second axis: which of these findings the holder would
  actually want to act on.

  **Absent is unknown, not false.** `crosses_facets` is `Option<bool>` and is
  `None` when the holder keeps no facets, because `false` asserts these
  identities sit in one part of a life and an agent with no facets has made no
  such finding. `FacetIndex::any` is what carries that distinction, which is
  why the index is a struct rather than a map.

  **An unarranged profile is not a second facet.** Only distinct, named facets
  count toward a crossing. Counting "no facet" as one would make every holder
  who has arranged one part of their life and not the rest see a crossing on
  everything they own — the dismissal problem arriving from the other
  direction.

  `facet_index` is built once per analysis for the reason `disclosure_index`
  is: `analyze_correlation` with no `attributeId` walks the whole pool, and
  the per-finding shape re-lists every facet for every finding.

  The conformance witness now exercises the three new members rather than
  merely permitting them — they are the ones added last, and an outgoing
  member the embedded schema has not caught up with is a 500 on a call that
  succeeded.

  vta-persona 118/118 (6 new, one per rule above), vta-service lib 1063/1063,
  clippy --all-targets clean.

- **persona**: Serve persona/facet — the holder's arrangement of their identity ([#1338](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1338))

Implements the three tasks specified in dtgwg-trust-tasks-tf#405, published
  in trust-tasks-rs 0.18.9.

  A holder who uses this model for a while ends up with twenty profiles, and a
  flat list of twenty is a list nobody reads. A facet is the arrangement over
  them — "Work", "Home", "Play" — and it is agent-scoped, like the pool and
  the profiles it groups.

  **An arrangement, not a container.** Nothing is stored inside a facet, and
  `delete_facet` touches no profile and no attribute. There is no cascading
  form because there is no cascading form of the idea: a grouping that could
  take its members with it is a folder, and a holder who reads it as a folder
  is right to be afraid of it. `releasedFaces` reports what now belongs
  nowhere, which is what a screen needs to say what it will look like
  afterwards. `deleting_a_facet_deletes_nothing_it_named` pins it.

  **Membership lives on the facet.** A `facet_id` on `Attribute` would be the
  obvious alternative and is the wrong shape: `attribute/put` REPLACES, and a
  well-behaved consumer does not hold the values it would have to resend —
  `attribute/list` withholds `sensitivity: high` plaintext unless asked by
  name. It would either request every sensitive value the holder owns to
  perform an arrangement that has nothing to do with values, or send a put
  without one and destroy them.
</blockquote>




## `vta-service`

<blockquote>

## [0.25.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.24.1...vta-service-v0.25.0) — 2026-09-09

### Added

- **persona**: Say whether a link crosses a part of the holder's life ([#1342](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1342))

Serves the members added in dtgwg-trust-tasks-tf#408, published in
  trust-tasks-rs 0.18.10: `crossesFacets` and `facetIds` on a finding,
  `facetId` on each `sharedWith` location. This needs a floor of 0.18.10 —
  the spine validates OUTGOING responses, so under an older schema an analysis
  that fully succeeded would come back 500 `responseSchemaViolation` — and no
  longer moves one: main reached 0.18.11 while this sat open, which satisfies
  it. The bump this branch carried is dropped rather than resolved downward.

  **Severity is how linkable. Facets are whether the holder minds.** Nothing
  here touches `severity`, and that is the design rather than an omission. A
  value shared between two profiles in one facet still links them for anyone
  who sees both — the holder's filing changes nothing a counterparty can do —
  so softening severity on intent would report a false all-clear. What the
  facets add is a second axis: which of these findings the holder would
  actually want to act on.

  **Absent is unknown, not false.** `crosses_facets` is `Option<bool>` and is
  `None` when the holder keeps no facets, because `false` asserts these
  identities sit in one part of a life and an agent with no facets has made no
  such finding. `FacetIndex::any` is what carries that distinction, which is
  why the index is a struct rather than a map.

  **An unarranged profile is not a second facet.** Only distinct, named facets
  count toward a crossing. Counting "no facet" as one would make every holder
  who has arranged one part of their life and not the rest see a crossing on
  everything they own — the dismissal problem arriving from the other
  direction.

  `facet_index` is built once per analysis for the reason `disclosure_index`
  is: `analyze_correlation` with no `attributeId` walks the whole pool, and
  the per-finding shape re-lists every facet for every finding.

  The conformance witness now exercises the three new members rather than
  merely permitting them — they are the ones added last, and an outgoing
  member the embedded schema has not caught up with is a 500 on a call that
  succeeded.

  vta-persona 118/118 (6 new, one per rule above), vta-service lib 1063/1063,
  clippy --all-targets clean.

- **rooms**: Cut over to present/0.2 and issue-authority/0.2 ([#1365](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1365))

The consuming half of trustoverip/dtgwg-trust-tasks-tf#415 and #418, unblocked
  by affinidi/affinidi-tdk-rs#784.

  `trust-tasks-rs` 0.19 carries both new spec versions, but this workspace could
  not take it: `affinidi-messaging-sdk 0.22.0` required 0.18, so pinning 0.19 put
  two `trust-tasks-rs` nodes in the graph and broke `vta-sdk` on `expected
  MediatorAcl, found a different MediatorAcl`. TDK #784 moved the messaging family
  to 0.19 and 0.23.0.

  Taking it exposed pins that had drifted apart underneath: `vta-sdk` was on
  messaging-sdk 0.22 while `vta-service` and the e2e tests were on 0.21, and three
  `trust-tasks-rs` versions were resolving at once. All of it is now consolidated:
  the lockfile holds exactly ONE `trust-tasks-rs` and ONE `affinidi-messaging-sdk`,
  where before it held three of each.

  `rooms/keys/present` 0.1 -> 0.2 and `rooms/owner/issue-authority` 0.1 -> 0.2.
  Both 0.1s are retired upstream. Neither is dual-accepted, deliberately: for
  `present`, 0.1's extra members are exactly the two nothing could honour; for
  `issue-authority`, accepting 0.1 means accepting a request with no `validUntil`,
  which is the thing 0.2 exists to refuse.

  The hand-rolled `validUntil` guard in `room_owner.rs` is deleted. 0.2 makes the
  member REQUIRED, so the generated payload types it as a `DateTime` and the
  envelope schema rejects a request without one before dispatch. Same rule, one
  layer up, which is where a shape constraint belongs.

  `every_witnessed_task_round_trips_through_its_generated_types` refused two
  witnesses that had been green for as long as they existed:

  1. The `issue-authority` witness carried no `validUntil` — a chain root with no
     expiry, the exact request 0.2 forbids, and one this service could have sent.
  2. The `present` witness carried `"audience": "did:key:z6MkHost"` — a HOST DID,
     the precise shape #414 reported as impossible to satisfy, since the field
     named the party that had to PRESENT the credential.

  `room_oracle` emitted `membership` and `authority[]` as JSON **objects**;
  `AuthorityPresentation` types both as strings, and the host's opener reads
  base64url or bare JSON text. So the oracle's output could not deserialize at a
  host at all — `rooms/keys/present` had never worked end to end. It went unseen
  because 0.1's response typed `presentation` as an opaque object; 0.2 names the
  shared component, which turned a runtime refusal nothing exercised into a type
  error. The oracle now serialises each credential. That is the first half of
  have caught all three of these years earlier.

- **rooms**: A browser can be a room member ([#1347](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1347))

* feat(rooms): a `host` feature, so a room's member half reaches wasm

  `vti-rooms` already had two halves and no name for them: `vta-service`
  imports `mls`/`sealed`/`wire` and nothing else, while `vtc-service`,
  `room-host` and `vti-rooms-dtg` import `storage`/`authz`/`audit`. This
  names the second half `host`, on by default, and makes `vti-common`
  optional behind it.

  `vti-common` describes itself as server-side infrastructure and pulls
  axum, fjall and tokio, so it was the whole of what kept a room's member
  code off `wasm32-unknown-unknown`. With it optional,
  `--no-default-features --features mls` builds there — which is what lets
  a browser hold a room's keys itself rather than ask an agent to. See
  `docs/05-design-notes/data-rooms-demo-site.md`.

  The member half needed **no source changes** to get there. That is a
  property of `error.rs`, which deliberately does not use
  `vti_common::error::AppError` because key material is not a service's
  concern; a decision made for its own reasons that paid for itself here.

  `lifecycle` is deliberately left ungated: only hosts consume it today,
  but it needs nothing from `vti-common`, and a member computing a room's
  lifecycle state to explain it on screen should not need a host's
  dependencies.

  Three things about the wasm plumbing, each of which reports as a
  `compile_error!` that reads like an unsupported target:

  - OpenMLS 0.9 has a first-class `js` feature (`web-time` for the
    `SystemTime` wasm lacks, plus getrandom's JS backend). Declared
    per-target rather than as a feature of this crate, so building for
    wasm just works — verified wasm-only: `web-time` appears in the wasm
    tree and not the native one.
  - There are two getrandom majors in the graph. The 0.4 is ours; the 0.2
    arrives transitively under `openmls_rust_crypto` via RustCrypto's
    elliptic-curve stack, so no feature declared here could reach it.
    `getrandom_02` is a feature shim, not a dependency this crate calls.
  - With both declared per-target, **no `RUSTFLAGS` are needed** — the
    `wasm_js` feature alone selects the backend.

  CI gains two steps in the `features` job: clippy on the member half with
  no host, and a wasm32 `--lib` check, so neither property rots silently.

  `vta-service` now takes `default-features = false`: a VTA holds room keys
  and is never a room's host, so it no longer compiles one.

  * feat(rooms): vti-rooms-wasm — a data room's member half, in a browser

  The MLS group, record sealing and the epoch key chain, compiled to
  WebAssembly, so a tab can *be* a member rather than drive an agent that
  is one. `vti-rooms` supplies all of it; this crate is only the boundary,
  and its job is deciding what crosses.

  **Secrets do not cross.** Everything returned is public — a KeyPackage,
  ciphertext, an epoch number — with one deliberate exception: the
  snapshot, which is key material because OpenMLS persists a group through
  its provider rather than as a value. It goes in IndexedDB and nowhere
  else; the docs say so at the method, since it is the one thing here a
  caller could reasonably mishandle.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).