### PR TITLE
fix(room-host): follow vta-sdk to 0.35, which is what blocks the release

### DIFF
--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -63,7 +63,7 @@ affinidi-messaging-core = { workspace = true, optional = true }
 vti-secrets = { path = "../vti-secrets", version = "0.3", optional = true }
 # The session store behind `onboarding` — which backend is an operator's choice,
 # exactly as `[secrets]` is.
-vta-sdk = { path = "../vta-sdk", version = "0.34", optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.35", optional = true }
 # Reading the `[secrets]` table out of a config file.
 toml = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }


### PR DESCRIPTION
The release of #1336 failed at the first crate it tried to publish:

```
failed to publish vta-sdk: failed to select a version for the requirement `vta-sdk = "^0.34"`
candidate versions found which didn't match: 0.35.0
required by package `room-host v0.1.0`
```

release-plz bumped `vta-sdk` to 0.35.0 and updated the requirement in **every** crate that depends on it — twenty-four of them — **except this one**. `room-host` still asked for `^0.34`, and a path dependency whose `version` no longer matches the crate it points at makes the whole workspace unresolvable. `cargo publish` refuses before uploading anything.

## Nothing else is stale

I checked all of them rather than fixing the one the error named:

- every other `vta-sdk` requirement is already `0.35`
- every `vti-rooms` requirement is already `0.2`

So this is one line, and the next crate in the publish order will not fail the same way.

## Why release-plz missed it, I do not know

Worth not guessing at. The neighbouring `vti-rooms-dtg` is also `publish = false`, also declares `vta-sdk` with `optional = true`, and **was** updated. So neither of the obvious explanations holds.

What is worth noting is the failure's shape: it is invisible at build time — `cargo build` and `cargo test` are perfectly happy, because the path dependency resolves locally regardless of the `version` field — and only appears at **publish** time, when the version bumps are already merged and the tags already cut. That is the worst moment to find it.

## Checks

- `cargo check -p room-host` — clean
- `cargo package -p vta-sdk` — resolves and packages (241 files, 3.1 MiB), which is the exact step that was failing