### PR TITLE
feat(vta): a service can fetch the keys of the DID it operates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396d9206908dc1d0fd6449c7cb5b5e4db455ca0a304f75444c9aa0c621b21bf"
+checksum = "28f6e935295f1c9eec0fa7ee609f3f6e88f855b788712dbfac334c50279dbdf0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57125239a953a49c06b88746fd2aede838aa611274bf91f7952656c6c747d804"
+checksum = "d7e9685f131f40eacf50b705c282abf64d3226194787d90352563791dfb8a2be"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3a3e0f6b7c734f9e769344296cd5aba8f7cbd815b9012ee349261df9d6778a"
+checksum = "aed65109e4d4908f57201c680f9ac793123cd7a6dce53e2eed198b8a6724045d"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a2c38268859db8bdf250a3587a4a38e6ea5b9e6cc9f6a1cad2a8f25b30dbaf"
+checksum = "80929b92978b33a7a5f73c68430eaf962741eaad1477bbabbe1be4bf44b804d5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9579,9 +9579,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8aee6485cda7f0dddb2a296fd55e54d624feac258d8c70374547866e10794d"
+checksum = "91dcbc364465388522a8a8f9185ef676fa17f5ac4e58c61645e5820198a7efd6"
 dependencies = [
  "chrono",
  "serde",
@@ -9593,9 +9593,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dddfed74e984b3b56b8e1044dff4ffd18434f2b8c0f3190b8b1665f019902a78"
+checksum = "27e704570542ff40c852e8fcb07e3e2ff27b8e2616c6a692a617240beb0154cf"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9609,9 +9609,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f204b41468c547a91f4a25557079a240826b7a2a32c4ac7353eeb25d500d735b"
+checksum = "43b957e9d2f574bb44ab02bd47c4b4835a1077d187fa533ee7e2c0a050bbaba6"
 dependencies = [
  "axum",
  "chrono",
@@ -9628,9 +9628,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fb8652b4644ed53795569ea619dcb92e24150a789a1b5b86de91643af84fe7"
+checksum = "e71ccec02538ade2ff475d40152a869c11878ef0d6195719a682c989733262bd"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9645,9 +9645,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.19.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b445f62f4142dcce7d71d74526f815bed79bfb1d1f3b0161b86e4bb5497459"
+checksum = "f3598074d90446fba00f378c7dfb349f97601a3ce7aec36a98552d5ab8606acf"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ uniffi = "0.32"
 # the floor is now structural rather than a specific patch: do not move this
 # back below 0.9, and do not drop to a bare major.
 # 0.11 re-exports `affinidi-mdoc` 0.3 — see the coupling note on `coset` below.
-affinidi-tdk = "0.13"
+affinidi-tdk = "0.14"
 # Raw crypto primitives (ed25519↔x25519 conversion, did:key helpers). Pulled
 # directly so sealed-transfer can use `affinidi_crypto::did_key::*` without
 # going through the higher-level Secret wrapper in secrets-resolver.
@@ -284,12 +284,12 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.19.4", default-features = false, features = [
+trust-tasks-rs = { version = "0.20.1", default-features = false, features = [
   "validate",
   "all-specs",
 ] }
-trust-tasks-capability-client = "0.19"
-trust-tasks-https = { version = "0.19", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-capability-client = "0.20"
+trust-tasks-https = { version = "0.20", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -300,8 +300,8 @@ trust-tasks-https = { version = "0.19", default-features = false, features = ["s
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.19", default-features = false }
-trust-tasks-proof = { version = "0.19", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.20", default-features = false }
+trust-tasks-proof = { version = "0.20", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }
@@ -519,5 +519,3 @@ type_complexity = "allow"
 # ever reports one, the fix is the same choice we faced here: patch it (fast,
 # and it will break again on the next minor bump) or cut the dependency edge
 # upstream (slower, permanent).
-
-

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -54,7 +54,7 @@ affinidi-tdk = { workspace = true, optional = true }
 # facade forwards it on `main` since affinidi-tdk-rs#785 but in no published
 # release yet, so this asks for it directly — and would anyway, because it needs
 # `DidCommTransport` and `affinidi-messaging-core`'s shapes.
-affinidi-messaging-sdk = { version = "0.23", optional = true, default-features = false, features = ["tsp"] }
+affinidi-messaging-sdk = { version = "0.24", optional = true, default-features = false, features = ["tsp"] }
 affinidi-messaging-core = { workspace = true, optional = true }
 # **The same secret storage every other service in this workspace uses.** The
 # host's identity is a private key; it belongs behind the same `[secrets]`
@@ -112,7 +112,7 @@ didcomm = [
 # rather than a simulator. Everything `tests/carrier.rs` covers is packing,
 # routing, threading and acking — a simulator would be a second opinion about
 # exactly the parts that were wrong.
-affinidi-messaging-test-mediator = { version = "0.6", features = ["tsp"] }
+affinidi-messaging-test-mediator = { version = "0.7", features = ["tsp"] }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 vti-rooms-dtg = { path = "../vti-rooms-dtg", features = ["test-support"] }

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -19,7 +19,7 @@ autobins = false
 
 [dev-dependencies]
 # Embedded mediator fixture from affinidi-tdk-rs.
-affinidi-messaging-test-mediator = { version = "0.6", features = ["tsp"] }
+affinidi-messaging-test-mediator = { version = "0.7", features = ["tsp"] }
 
 # VTA: enable the `test-support` feature so we can stand up complete VTA
 # state (in-memory keyspaces, default `AppConfig`, bootstrap helpers)
@@ -31,7 +31,7 @@ vti-common = { path = "../../vti-common" }
 affinidi-tdk = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
-affinidi-messaging-sdk = "0.23"
+affinidi-messaging-sdk = "0.24"
 affinidi-messaging-didcomm = "0.15"
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net"] }

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -105,6 +105,21 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     ("vault/release", Risk::Sensitive),
     ("vault/proxy-login", Risk::Sensitive),
     ("vta/seeds/export-mnemonic", Risk::Sensitive),
+    // Returns the private keys of a context's DID. The verb rule would read
+    // `secrets` as an ordinary mutation, and the task's own `sideEffects` are
+    // `none` — it reads and changes nothing — so neither the verb nor the side
+    // effect is what makes it risky. What comes back is the whole authority of
+    // that DID, which is `Sensitive` by the definition above: secret material,
+    // emitted. It belongs beside `export-mnemonic`, whose replacement it is.
+    //
+    // Deliberately NOT `ReadOnly` despite being a read. `ReadOnly` is the class
+    // `--read-only` permits and means "safe to call on a whim"; handing an MCP
+    // host a signing key on a blanket `vta_call` approval is the threat model
+    // this module exists for. Note this is the opposite call from the one in
+    // `vta-sdk`'s `retry_safety`, and correctly so: that asks what a SECOND
+    // execution costs (nothing — it is idempotent), this asks what ONE
+    // execution discloses.
+    ("vta/contexts/secrets", Risk::Sensitive),
     // Authority, moved.
     ("acl/grant", Risk::Sensitive),
     ("acl/update", Risk::Sensitive),

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -275,7 +275,7 @@ futures-util = { workspace = true, optional = true }
 # `TspPingSession` needs. Depend on the same crate directly (Cargo unifies to
 # one instance, the one `affinidi_tdk::messaging` re-exports) so the `tsp`
 # feature can turn its `tsp` on — mirrors what `vta-service` does.
-affinidi-messaging-sdk = { version = "0.23", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.24", optional = true, default-features = false }
 reqwest = { workspace = true, optional = true }
 # Only for `crypto_init` (the aws-lc-rs CryptoProvider installer).
 rustls = { workspace = true, optional = true }

--- a/vta-sdk/src/protocols/context_management/mod.rs
+++ b/vta-sdk/src/protocols/context_management/mod.rs
@@ -2,6 +2,7 @@ pub mod create;
 pub mod delete;
 pub mod get;
 pub mod list;
+pub mod secrets;
 pub mod update;
 pub mod update_did;
 

--- a/vta-sdk/src/protocols/context_management/secrets.rs
+++ b/vta-sdk/src/protocols/context_management/secrets.rs
@@ -1,0 +1,172 @@
+//! `vta/contexts/secrets/1.0` — the private keys of a context's own DID.
+
+use serde::{Deserialize, Serialize};
+
+use crate::did_secrets::{DidSecretsBundle, SecretEntry};
+use crate::keys::KeyType;
+
+/// Ask for the secrets of a context's DID.
+///
+/// One request for the whole bundle rather than one per key, which is what a
+/// caller assembling a [`DidSecretsBundle`] actually wants — and it makes the
+/// authorization one decision about one context instead of N decisions about
+/// keys that happen to belong to it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetContextSecretsBody {
+    /// The context whose DID's keys are wanted. The caller must be able to act
+    /// in it; being able to act in a *different* one confers nothing here.
+    ///
+    /// Named `id` rather than `context_id` to match the rest of the
+    /// `vta/contexts/*` family, where `id` always names the context being
+    /// acted on. The spec settles it.
+    pub id: String,
+}
+
+/// What the VTA answers with: the context's DID and the keys behind it.
+///
+/// A wire type of its own rather than [`DidSecretsBundle`] directly, because
+/// the two are not the same thing. `DidSecretsBundle` is the *internal and
+/// on-disk* form — snake_case, shared with `sealed_transfer` and with operator
+/// exports that already exist on disk — and `vta/contexts/secrets/1.0`
+/// specifies lowerCamelCase members, as SPEC §4.10 requires of every Trust
+/// Task. Renaming the existing type would rewrite a format that has already
+/// been written to disk to fix a format that has never been on the wire.
+///
+/// [`From`] in both directions keeps them from drifting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextSecretsResultBody {
+    /// The DID the secrets belong to — the one recorded on the context, not
+    /// one the caller asked for.
+    pub did: String,
+    /// One entry per verification method of `did` whose secret is releasable.
+    ///
+    /// May be empty, and that is not an error: a context whose DID has no
+    /// releasable key material is a context that is not provisioned yet.
+    pub secrets: Vec<ContextSecretEntry>,
+}
+
+/// One private key, named by the verification method it backs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextSecretEntry {
+    /// The verification method this key backs, as an absolute DID URL under
+    /// the bundle's `did`. It is the DID document that decides this name, so a
+    /// consumer installs the key under a kid an inbound message will match.
+    pub key_id: String,
+    /// What the key is for. Also encoded in `private_key_multibase`'s
+    /// multicodec prefix; stated separately so a caller can select by purpose
+    /// without decoding every entry.
+    pub key_type: KeyType,
+    /// The private key, multibase (Base58BTC) over multicodec-prefixed bytes.
+    pub private_key_multibase: String,
+}
+
+impl From<SecretEntry> for ContextSecretEntry {
+    fn from(e: SecretEntry) -> Self {
+        Self {
+            key_id: e.key_id,
+            key_type: e.key_type,
+            private_key_multibase: e.private_key_multibase,
+        }
+    }
+}
+
+impl From<ContextSecretEntry> for SecretEntry {
+    fn from(e: ContextSecretEntry) -> Self {
+        Self {
+            key_id: e.key_id,
+            key_type: e.key_type,
+            private_key_multibase: e.private_key_multibase,
+        }
+    }
+}
+
+impl From<DidSecretsBundle> for ContextSecretsResultBody {
+    fn from(b: DidSecretsBundle) -> Self {
+        Self {
+            did: b.did,
+            secrets: b.secrets.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<ContextSecretsResultBody> for DidSecretsBundle {
+    fn from(b: ContextSecretsResultBody) -> Self {
+        Self {
+            did: b.did,
+            secrets: b.secrets.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reason this type exists at all: the wire form is lowerCamelCase
+    /// where the on-disk form is snake_case. If someone "simplifies" this
+    /// module away by serialising `DidSecretsBundle` directly, this fails.
+    #[test]
+    fn the_wire_form_is_lower_camel_case() {
+        let body = ContextSecretsResultBody {
+            did: "did:webvh:QmExample:example.com:rooms:host-1".into(),
+            secrets: vec![ContextSecretEntry {
+                key_id: "did:webvh:QmExample:example.com:rooms:host-1#key-0".into(),
+                key_type: KeyType::Ed25519,
+                private_key_multibase: "z3u2en7t5LR2WtQH5PfFqMqtVcSdd7ELrcFtnP63HKq4KLg".into(),
+            }],
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        let entry = &json["secrets"][0];
+        assert!(entry.get("keyId").is_some(), "expected keyId, got {entry}");
+        assert!(entry.get("keyType").is_some());
+        assert!(entry.get("privateKeyMultibase").is_some());
+        assert!(
+            entry.get("key_id").is_none(),
+            "snake_case members must not appear on the wire"
+        );
+        assert_eq!(entry["keyType"], "ed25519");
+    }
+
+    /// The two forms carry the same information, so a round trip through the
+    /// wire type must not lose or alter any of it.
+    #[test]
+    fn a_bundle_round_trips_through_the_wire_form() {
+        let bundle = DidSecretsBundle {
+            did: "did:webvh:QmExample:example.com:rooms:host-1".into(),
+            secrets: vec![
+                SecretEntry {
+                    key_id: "did:webvh:QmExample:example.com:rooms:host-1#key-0".into(),
+                    key_type: KeyType::Ed25519,
+                    private_key_multibase: "zSigning".into(),
+                },
+                SecretEntry {
+                    key_id: "did:webvh:QmExample:example.com:rooms:host-1#key-1".into(),
+                    key_type: KeyType::X25519,
+                    private_key_multibase: "zAgreement".into(),
+                },
+            ],
+        };
+        let back: DidSecretsBundle = ContextSecretsResultBody::from(bundle.clone()).into();
+        assert_eq!(back.did, bundle.did);
+        assert_eq!(back.secrets.len(), 2);
+        for (a, b) in back.secrets.iter().zip(&bundle.secrets) {
+            assert_eq!(a.key_id, b.key_id);
+            assert_eq!(a.key_type, b.key_type);
+            assert_eq!(a.private_key_multibase, b.private_key_multibase);
+        }
+    }
+
+    /// An empty bundle is a provisioning state, not a failure, and must
+    /// survive the conversion as an empty array rather than becoming absent.
+    #[test]
+    fn an_empty_bundle_stays_an_empty_array() {
+        let body = ContextSecretsResultBody::from(DidSecretsBundle {
+            did: "did:example:123".into(),
+            secrets: vec![],
+        });
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["secrets"], serde_json::json!([]));
+    }
+}

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -208,6 +208,18 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_SEEDS_ROTATE_1_0, Keyed),
     // Response is the mnemonic itself, and the export guard is one-shot.
     (trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0, KeyedSecret),
+    // `ReadOnly` even though the response carries private keys, and the
+    // distinction is worth stating because `export-mnemonic` above looks like
+    // the same task and is not. That one is `KeyedSecret` because its export
+    // guard is **one-shot** — a second call is not a second read, it is a
+    // second consumption of a guard — so it needs dedup, and `KeyedSecret` is
+    // how a task that needs dedup avoids parking a secret in the dedup store.
+    // This task has no guard: it is `sideEffects: none`, and a second call
+    // returns the same bundle. `ReadOnly` therefore takes the dedup path out
+    // altogether (`idempotency.rs` early-returns unless `needs_key()`), so no
+    // response body is stored at all — the same protection, reached by the
+    // classification actually being true rather than by a stronger one.
+    (trust_tasks::TASK_CONTEXTS_SECRETS_1_0, ReadOnly),
     // ── Audit ───────────────────────────────────────────────────────────
     (trust_tasks::TASK_AUDIT_LIST_0_1, ReadOnly),
     (trust_tasks::TASK_AUDIT_GET_RETENTION_1_0, ReadOnly),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -316,8 +316,7 @@ pub const TASK_CONTEXTS_GET_1_0: &str = "https://trusttasks.org/spec/vta/context
 /// Replaces the use of `seeds/export-mnemonic/1.0` for this, which was never a
 /// mnemonic export: it took a `key_id` and returned one key, and a caller
 /// assembling a bundle made one Admin-gated call per key.
-pub const TASK_CONTEXTS_SECRETS_1_0: &str =
-    "https://trusttasks.org/spec/vta/contexts/secrets/1.0";
+pub const TASK_CONTEXTS_SECRETS_1_0: &str = "https://trusttasks.org/spec/vta/contexts/secrets/1.0";
 
 /// `spec/vta/contexts/update/1.0` — update name/did/description.
 /// Payload: [`crate::protocols::context_management::update::UpdateContextBody`].

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -285,6 +285,40 @@ pub const TASK_CONTEXTS_CREATE_1_0: &str = "https://trusttasks.org/spec/vta/cont
 /// [`crate::protocols::context_management::get::GetContextBody`].
 pub const TASK_CONTEXTS_GET_1_0: &str = "https://trusttasks.org/spec/vta/contexts/get/1.0";
 
+/// `spec/vta/contexts/secrets/1.0` — the private keys of a context's own DID,
+/// for the service that operates it.
+///
+/// **What a service needs to be itself.** An integration whose identity the VTA
+/// manages — a mediator, a room-host, a did-hosting service — has to hold that
+/// DID's private keys to decrypt what is addressed to it. It cannot delegate
+/// that per-frame, so it fetches them once at startup and caches them.
+///
+/// Auth: **Application or higher**, and only for a context the caller may act
+/// in. That is deliberately not Admin: reading the keys of the DID you already
+/// operate is not an administrative act, and requiring Admin meant every
+/// integration was granted authority over everything else in the VTA in order
+/// to be itself.
+///
+/// The scoping is what makes the lower role safe, so it is asserted rather than
+/// described — see `contexts::handle_secrets`.
+///
+/// Payload:
+/// [`crate::protocols::context_management::secrets::GetContextSecretsBody`].
+/// Returns a
+/// [`crate::protocols::context_management::secrets::ContextSecretsResultBody`]
+/// — the spec's lowerCamelCase wire form of a
+/// [`crate::did_secrets::DidSecretsBundle`].
+///
+/// The response carries private keys in the clear, which is why the dispatch
+/// entry classifies it `Discloses::Secret` and why it must not be logged,
+/// cached in a shared store, or put in a diagnostic bundle.
+///
+/// Replaces the use of `seeds/export-mnemonic/1.0` for this, which was never a
+/// mnemonic export: it took a `key_id` and returned one key, and a caller
+/// assembling a bundle made one Admin-gated call per key.
+pub const TASK_CONTEXTS_SECRETS_1_0: &str =
+    "https://trusttasks.org/spec/vta/contexts/secrets/1.0";
+
 /// `spec/vta/contexts/update/1.0` — update name/did/description.
 /// Payload: [`crate::protocols::context_management::update::UpdateContextBody`].
 /// Auth: Super Admin only.
@@ -1816,6 +1850,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_CONTEXTS_GET_1_0,
     TASK_CONTEXTS_UPDATE_1_0,
     TASK_CONTEXTS_UPDATE_DID_1_0,
+    TASK_CONTEXTS_SECRETS_1_0,
     TASK_CONTEXTS_PREVIEW_DELETE_1_0,
     TASK_CONTEXTS_DELETE_1_0,
     // Keys slice

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -264,7 +264,7 @@ futures-util = "0.3"
 # crate's `tsp` feature and are NOT reachable via `affinidi-tdk/tsp`. The crate
 # is already present transitively via `affinidi-tdk` at the same 0.18.x; this
 # entry adds no new code when `tsp` is off (optional + default-features off).
-affinidi-messaging-sdk = { version = "0.23", optional = true, default-features = false }
+affinidi-messaging-sdk = { version = "0.24", optional = true, default-features = false }
 async-trait = "0.1"
 affinidi-tdk-common = "0.6"
 affinidi-did-resolver-cache-sdk = { workspace = true }
@@ -337,7 +337,7 @@ tempfile = { version = "3", optional = true }
 # A real dependency rather than a dev-dependency: `test-support` exists to serve
 # *external* consumers, and a dev-dependency would not be available to them.
 # `tsp` so the mediator routes raw-TSP frames, not just DIDComm.
-affinidi-messaging-test-mediator = { version = "0.6", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.7", optional = true, features = [
     "tsp",
 ] }
 libc = { workspace = true, optional = true }

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -48,6 +48,65 @@ pub struct ExportDeps<'a> {
     pub seed_store: &'a Arc<dyn SeedStore>,
 }
 
+
+/// Every private key of `context_id`'s own DID, for the service that operates it.
+///
+/// # Why this exists as one operation
+///
+/// A service that the VTA holds an identity for has to hold that DID's private keys to
+/// decrypt what is addressed to it — it cannot ask the VTA per frame. So it fetches them at
+/// startup. Assembling that bundle used to mean listing the context's keys and then calling
+/// the per-key export once each, and *that* export was gated on the global Admin role — so
+/// being a service required authority over the whole VTA.
+///
+/// One call, one authorization decision, about the one thing being decided: may this caller
+/// act in this context.
+///
+/// # Application, not Admin, and what makes that safe
+///
+/// Reading the keys of the DID you already operate is not an administrative act. What keeps
+/// the lower role sound is that it is scoped twice, and neither check is this function being
+/// careful — both are checks the keys surface already makes:
+///
+/// - [`AuthClaims::require_context`], inside [`build_did_secrets_bundle`], on the context
+///   asked for — so naming somebody else's context is refused before a single key is read,
+///   and before the context is even looked up. A caller not entitled to an id is therefore
+///   refused for that reason whether or not the id exists, and "not found" is only ever said
+///   to a caller already entitled to hear it;
+/// - [`super::keys::get_key_secret`]'s own per-key context gate, which would refuse a key
+///   that somehow did not belong to the context it was listed under.
+///
+/// A caller with `Application` in context A therefore gets A's keys and no others, and a
+/// caller with no context at all gets nothing. Asserted in the tests rather than trusted.
+///
+/// # Why it delegates
+///
+/// [`build_did_secrets_bundle`] is the whole of the traversal, and the only thing that
+/// differs between its two callers is the role floor: the offline export path runs as a
+/// local super-admin, while `vta/contexts/secrets/1.0` is reachable by an `Application`. A
+/// second traversal here would be a second set of rules to keep in step — which key ids are
+/// verification methods of the DID, which secrets are excluded, how the pages are walked —
+/// and those rules are exactly the part that must not drift.
+pub async fn get_context_secrets(
+    deps: &ExportDeps<'_>,
+    auth: &AuthClaims,
+    context_id: &str,
+    channel: &str,
+) -> Result<DidSecretsBundle, AppError> {
+    // The role floor. Application or higher — a Reader may see that keys exist and a Monitor
+    // may not even do that, and neither may hold one. The scope check is the delegate's.
+    auth.require_write()?;
+    let bundle = build_did_secrets_bundle(deps, auth, context_id, channel).await?;
+    tracing::info!(
+        channel,
+        context = %context_id,
+        did = %bundle.did,
+        keys = bundle.secrets.len(),
+        "context secrets released to the service that operates them"
+    );
+    Ok(bundle)
+}
+
 /// Build a [`DidSecretsBundle`] for `context_id` by enumerating active
 /// keys in the local store and loading each secret.
 ///
@@ -346,6 +405,24 @@ mod tests {
         }
     }
 
+    /// A caller with a role and a set of contexts it may act in.
+    ///
+    /// The pair is the whole of the authorization model this task turns on:
+    /// `role` is the floor and `allowed_contexts` is the scope, and a non-empty
+    /// scope narrows even [`Role::Admin`] (only an *empty* list means "all").
+    fn scoped(role: crate::acl::Role, contexts: &[&str]) -> AuthClaims {
+        AuthClaims {
+            did: "did:key:zTestCaller".into(),
+            role,
+            allowed_contexts: contexts.iter().map(|c| (*c).to_string()).collect(),
+            session_id: "test-session".into(),
+            access_expires_at: 0,
+            issued_at: 0,
+            amr: Vec::new(),
+            acr: String::new(),
+        }
+    }
+
     #[tokio::test]
     async fn build_did_secrets_rejects_missing_context() {
         let env = open_env().await;
@@ -403,26 +480,22 @@ mod tests {
         &env.data_dir
     }
 
-    /// Happy-path coverage for the kid-selection contract: the offline
-    /// bundle must carry exactly the keys whose ids are verification
-    /// methods of the context DID, and must drop an admin `did:key`
-    /// minted into the same context (a different DID, free-text label).
+    /// The DID a seeded context is given. Every operating key below is a
+    /// verification method of it.
+    const SEEDED_DID: &str = "did:webvh:QmScid:mediator.example.com:med";
+
+    /// Stand up one context holding the three key records the bundle logic has
+    /// to tell apart: two operating keys whose ids ARE verification methods of
+    /// [`SEEDED_DID`], and an admin `did:key` minted into the same context whose
+    /// VM id belongs to a *different* DID and whose label is free text.
     ///
-    /// Locks the wiring of [`select_secret_kid`] into the offline path —
-    /// the per-decision rules are unit-tested in
-    /// `vta_sdk::did_secrets`, but this proves `build_did_secrets_bundle`
-    /// feeds it the authoritative store `key_id` (and the label) so a
-    /// refactor can't silently re-include non-VM secrets and re-brick the
-    /// mediator's exact-match recipient lookup (the storm.ws outage).
-    #[tokio::test]
-    async fn build_did_secrets_excludes_non_vm_admin_did_key() {
+    /// Shared by the kid-selection test and the authorization tests so the two
+    /// cannot disagree about what a correctly-populated context looks like.
+    async fn seed_context_with_keys(env: &TestEnv, context_id: &str) -> String {
         use crate::keys::paths::allocate_path;
         use crate::keys::{KeyRecord, store_key};
         use chrono::Utc;
         use vta_sdk::keys::{KeyOrigin, KeyStatus, KeyType};
-
-        let env = open_env().await;
-        let auth = super_admin();
 
         // Seed the external store so derived keys can be minted + read back.
         env.seed_store
@@ -430,29 +503,27 @@ mod tests {
             .await
             .expect("seed the store");
 
-        // A context with a DID assigned — the bundle is keyed on it and VM
-        // ids are matched against it.
-        let did = "did:webvh:QmScid:mediator.example.com:med";
-        crate::contexts::create_context(&env.contexts_ks, "med-ctx", "Mediator Ctx")
+        crate::contexts::create_context(&env.contexts_ks, context_id, "Mediator Ctx")
             .await
             .expect("create context");
-        let mut rec = crate::contexts::get_context(&env.contexts_ks, "med-ctx")
+        let mut rec = crate::contexts::get_context(&env.contexts_ks, context_id)
             .await
             .expect("get context")
             .expect("context exists");
-        rec.did = Some(did.to_string());
+        rec.did = Some(SEEDED_DID.to_string());
         crate::contexts::store_context(&env.contexts_ks, &rec)
             .await
             .expect("store did on context");
 
         // Mint a key record the way internal DID provisioning does: an
-        // allocated path + a directly-written KeyRecord. VM-shaped
-        // key_ids are exclusive to this internal path — the public
-        // create_key/import_key ops reject them at validation. The
-        // stored public_key is not consulted by the bundle (secrets are
-        // re-derived from the path), so a placeholder is fine here.
+        // allocated path + a directly-written KeyRecord. VM-shaped key_ids are
+        // exclusive to this internal path — the public create_key/import_key ops
+        // reject them at validation. The stored public_key is not consulted by
+        // the bundle (secrets are re-derived from the path), so a placeholder is
+        // fine here.
         async fn mint_internal(
             env: &TestEnv,
+            context_id: &str,
             base_path: &str,
             kid: &str,
             kt: KeyType,
@@ -469,7 +540,7 @@ mod tests {
                 status: KeyStatus::Active,
                 public_key: "zPlaceholderNotUnderTest".into(),
                 label: label.map(String::from),
-                context_id: Some("med-ctx".into()),
+                context_id: Some(context_id.to_string()),
                 seed_id: None,
                 origin: KeyOrigin::Derived,
                 created_at: now,
@@ -481,37 +552,51 @@ mod tests {
                 .expect("store key record");
         }
 
-        // Two operating keys whose key_ids ARE verification methods of `did`.
+        for (suffix, kt) in [("#key-0", KeyType::Ed25519), ("#key-1", KeyType::X25519)] {
+            mint_internal(
+                env,
+                context_id,
+                &rec.base_path,
+                &format!("{SEEDED_DID}{suffix}"),
+                kt,
+                None,
+            )
+            .await;
+        }
         mint_internal(
-            &env,
+            env,
+            context_id,
             &rec.base_path,
-            &format!("{did}#key-0"),
-            KeyType::Ed25519,
-            None,
-        )
-        .await;
-        mint_internal(
-            &env,
-            &rec.base_path,
-            &format!("{did}#key-1"),
-            KeyType::X25519,
-            None,
-        )
-        .await;
-
-        // An admin did:key minted into the same context: its VM id belongs
-        // to a *different* DID and its label is free text. Must be excluded.
-        let admin = "did:key:z6Mkt6eNM38RhFfjSdmXBtT1SRL7sPgPZD1MkXZbwjYBhTLf";
-        mint_internal(
-            &env,
-            &rec.base_path,
-            &format!("{admin}#z6Mkt6eNM38RhFfjSdmXBtT1SRL7sPgPZD1MkXZbwjYBhTLf"),
+            &format!("{ADMIN_DID_KEY}#z6Mkt6eNM38RhFfjSdmXBtT1SRL7sPgPZD1MkXZbwjYBhTLf"),
             KeyType::Ed25519,
             Some("admin DID for context med-ctx"),
         )
         .await;
 
-        let bundle = build_did_secrets_bundle(&deps_of(&env), &auth, "med-ctx", "test")
+        SEEDED_DID.to_string()
+    }
+
+    /// An admin `did:key` that gets minted into a service context in practice.
+    /// Not a verification method of [`SEEDED_DID`], so it belongs in no bundle.
+    const ADMIN_DID_KEY: &str = "did:key:z6Mkt6eNM38RhFfjSdmXBtT1SRL7sPgPZD1MkXZbwjYBhTLf";
+
+    /// Happy-path coverage for the kid-selection contract: the offline
+    /// bundle must carry exactly the keys whose ids are verification
+    /// methods of the context DID, and must drop an admin `did:key`
+    /// minted into the same context (a different DID, free-text label).
+    ///
+    /// Locks the wiring of [`select_secret_kid`] into the offline path —
+    /// the per-decision rules are unit-tested in
+    /// `vta_sdk::did_secrets`, but this proves `build_did_secrets_bundle`
+    /// feeds it the authoritative store `key_id` (and the label) so a
+    /// refactor can't silently re-include non-VM secrets and re-brick the
+    /// mediator's exact-match recipient lookup (the storm.ws outage).
+    #[tokio::test]
+    async fn build_did_secrets_excludes_non_vm_admin_did_key() {
+        let env = open_env().await;
+        let did = seed_context_with_keys(&env, "med-ctx").await;
+
+        let bundle = build_did_secrets_bundle(&deps_of(&env), &super_admin(), "med-ctx", "test")
             .await
             .expect("bundle builds");
 
@@ -527,8 +612,113 @@ mod tests {
              did:key minted into the context must be excluded"
         );
         assert!(
-            !bundle.secrets.iter().any(|s| s.key_id.contains(admin)),
+            !bundle.secrets.iter().any(|s| s.key_id.contains(ADMIN_DID_KEY)),
             "admin did:key must not appear in the operating-secret bundle"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // `get_context_secrets` — the Trust Task path, and the loosening it makes.
+    //
+    // This is the only operation that hands private keys to an `Application`.
+    // What makes that sound is that the entitlement is a *scope* and not a
+    // *rank*, so the tests below are written to fail if anyone ever implements
+    // it the other way round.
+    // ---------------------------------------------------------------------
+
+    /// The point of the task: a service holding a context gets that context's
+    /// DID and its operating keys, at `Application` — not `Admin`.
+    #[tokio::test]
+    async fn an_application_fetches_its_own_contexts_secrets() {
+        let env = open_env().await;
+        let did = seed_context_with_keys(&env, "med-ctx").await;
+        let auth = scoped(crate::acl::Role::Application, &["med-ctx"]);
+
+        let bundle = get_context_secrets(&deps_of(&env), &auth, "med-ctx", "test")
+            .await
+            .expect("an application may read the keys of the context it operates");
+
+        assert_eq!(bundle.did, did);
+        let mut kids: Vec<&str> = bundle.secrets.iter().map(|s| s.key_id.as_str()).collect();
+        kids.sort_unstable();
+        assert_eq!(kids, vec![format!("{did}#key-0"), format!("{did}#key-1")]);
+    }
+
+    /// The check the loosening rests on. An `Application` entitled to one
+    /// context reaches nothing in another, and the refusal is about access
+    /// rather than existence.
+    #[tokio::test]
+    async fn an_application_cannot_reach_another_contexts_secrets() {
+        let env = open_env().await;
+        seed_context_with_keys(&env, "med-ctx").await;
+        let auth = scoped(crate::acl::Role::Application, &["some-other-ctx"]);
+
+        let err = get_context_secrets(&deps_of(&env), &auth, "med-ctx", "test")
+            .await
+            .expect_err("a context you do not hold is not yours to read keys from");
+        assert!(matches!(err, AppError::Forbidden(_)), "got: {err:?}");
+    }
+
+    /// Scope, not rank. `Admin` is the highest role there is, and it still
+    /// reaches nothing outside its `allowed_contexts` — because only an *empty*
+    /// list means "all contexts". A reimplementation that treated the
+    /// entitlement as a privilege level would hand this caller every context's
+    /// key material, so this test is the guard against that specific mistake.
+    #[tokio::test]
+    async fn an_admin_of_another_context_cannot_either() {
+        let env = open_env().await;
+        seed_context_with_keys(&env, "med-ctx").await;
+        let auth = scoped(crate::acl::Role::Admin, &["some-other-ctx"]);
+
+        let err = get_context_secrets(&deps_of(&env), &auth, "med-ctx", "test")
+            .await
+            .expect_err("admin of another context is still not this context's service");
+        assert!(matches!(err, AppError::Forbidden(_)), "got: {err:?}");
+    }
+
+    /// The role floor is real and sits below the scope check. A `Reader`
+    /// entitled to exactly this context is still refused: seeing that keys
+    /// exist is not holding them.
+    #[tokio::test]
+    async fn a_reader_of_this_very_context_is_below_the_role_floor() {
+        let env = open_env().await;
+        seed_context_with_keys(&env, "med-ctx").await;
+        let auth = scoped(crate::acl::Role::Reader, &["med-ctx"]);
+
+        let err = get_context_secrets(&deps_of(&env), &auth, "med-ctx", "test")
+            .await
+            .expect_err("a reader may see that keys exist, never hold one");
+        assert!(matches!(err, AppError::Forbidden(_)), "got: {err:?}");
+    }
+
+    /// The non-leak claim the spec makes about `notFound`: entitlement is
+    /// checked before existence, so a caller who is not entitled to an id gets
+    /// the *same* refusal whether or not that id exists. Comparing the two
+    /// against each other is what makes this an assertion about
+    /// indistinguishability rather than about either case alone.
+    #[tokio::test]
+    async fn entitlement_is_checked_before_existence() {
+        let env = open_env().await;
+        seed_context_with_keys(&env, "med-ctx").await;
+        let auth = scoped(crate::acl::Role::Application, &["some-other-ctx"]);
+
+        let real = get_context_secrets(&deps_of(&env), &auth, "med-ctx", "test")
+            .await
+            .expect_err("exists, not yours");
+        let imaginary = get_context_secrets(&deps_of(&env), &auth, "no-such-ctx", "test")
+            .await
+            .expect_err("does not exist, and not yours either");
+
+        assert!(matches!(real, AppError::Forbidden(_)), "got: {real:?}");
+        assert!(
+            matches!(imaginary, AppError::Forbidden(_)),
+            "an id that does not exist must not be distinguishable from one that \
+             does but is not the caller's — got: {imaginary:?}"
+        );
+        assert_eq!(
+            real.to_string().replace("med-ctx", "<id>"),
+            imaginary.to_string().replace("no-such-ctx", "<id>"),
+            "the two refusals must differ only in the id echoed back"
         );
     }
 }

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -48,7 +48,6 @@ pub struct ExportDeps<'a> {
     pub seed_store: &'a Arc<dyn SeedStore>,
 }
 
-
 /// Every private key of `context_id`'s own DID, for the service that operates it.
 ///
 /// # Why this exists as one operation
@@ -612,7 +611,10 @@ mod tests {
              did:key minted into the context must be excluded"
         );
         assert!(
-            !bundle.secrets.iter().any(|s| s.key_id.contains(ADMIN_DID_KEY)),
+            !bundle
+                .secrets
+                .iter()
+                .any(|s| s.key_id.contains(ADMIN_DID_KEY)),
             "admin did:key must not appear in the operating-secret bundle"
         );
     }

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -3550,6 +3550,38 @@ fn webvh_and_context_witnesses() -> Vec<(&'static str, ReqParts, RespParts)> {
             (context_record(), parses::<ctx::update_did::v1_0::Response>),
         ),
         (
+            uris::TASK_CONTEXTS_SECRETS_1_0,
+            (
+                json!({ "id": "rooms/host-1" }),
+                parses::<ctx::secrets::v1_0::Payload>,
+                validates::<ctx::secrets::v1_0::Payload>,
+            ),
+            (
+                // Built by SERIALISING the type the service actually answers with,
+                // not hand-written to match. The whole risk this witness covers is
+                // that `ContextSecretsResultBody` and the published schema disagree
+                // about member casing — the service sends lowerCamelCase because the
+                // spec says so, while the internal `DidSecretsBundle` it converts
+                // from is snake_case. A literal here would be written to match the
+                // spec and would still pass if the service drifted; this cannot.
+                serde_json::to_value(
+                    vta_sdk::protocols::context_management::secrets::ContextSecretsResultBody {
+                        did: "did:webvh:QmExample:example.com:rooms:host-1".into(),
+                        secrets: vec![
+                            vta_sdk::protocols::context_management::secrets::ContextSecretEntry {
+                                key_id: "did:webvh:QmExample:example.com:rooms:host-1#key-0".into(),
+                                key_type: vta_sdk::keys::KeyType::Ed25519,
+                                private_key_multibase:
+                                    "z3u2en7t5LR2WtQH5PfFqMqtVcSdd7ELrcFtnP63HKq4KLg".into(),
+                            },
+                        ],
+                    },
+                )
+                .expect("the response body serialises"),
+                parses::<ctx::secrets::v1_0::Response>,
+            ),
+        ),
+        (
             uris::TASK_CONTEXTS_PREVIEW_DELETE_1_0,
             (
                 json!({ "id": "personal" }),

--- a/vta-service/src/trust_tasks/contexts.rs
+++ b/vta-service/src/trust_tasks/contexts.rs
@@ -112,6 +112,48 @@ pub(super) async fn handle_get(
     }
 }
 
+/// Handler for `spec/vta/contexts/secrets/1.0` — the private keys of a context's own DID.
+///
+/// **Application or higher, and only for a context the caller may act in.** Deliberately not
+/// Admin: reading the keys of the DID you already operate is not an administrative act, and
+/// requiring Admin meant a service had to be granted authority over everything else in the
+/// VTA in order to be itself.
+///
+/// Both checks live in [`operations::keys::get_context_secrets`] rather than here, so a
+/// second entry point cannot acquire a different set of them.
+pub(super) async fn handle_secrets(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: vta_sdk::protocols::context_management::secrets::GetContextSecretsBody =
+        match parse_payload(&doc) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
+    let deps = operations::export::ExportDeps {
+        keys_ks: &state.keys_ks,
+        contexts_ks: &state.contexts_ks,
+        imported_ks: &state.imported_ks,
+        audit: &state.audit_sink,
+        acl_ks: &state.acl_ks,
+        #[cfg(feature = "webvh")]
+        webvh_ks: &state.webvh_ks,
+        seed_store: &state.seed_store,
+    };
+    match operations::export::get_context_secrets(&deps, auth, &req.id, TRANSPORT_TRUST_TASK).await
+    {
+        // The spec's response is lowerCamelCase (SPEC §4.10); `DidSecretsBundle` is the
+        // internal snake_case form, shared with the on-disk export. The conversion is the
+        // boundary between them.
+        Ok(bundle) => success_response(
+            &doc,
+            vta_sdk::protocols::context_management::secrets::ContextSecretsResultBody::from(bundle),
+        ),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
 /// Handler for `spec/vta/contexts/update/1.0`. Super-admin only.
 pub(super) async fn handle_update(
     state: &AppState,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1677,6 +1677,13 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_CONTEXTS_UPDATE_1_0 => contexts::handle_update
         [ Mutating None false ],
+    // `Secret`, not `Metadata`: the response carries private keys in the clear, and
+    // this classification — not the published registry — is what the PDP feeds into
+    // `PolicyInput`. Declaring it as a metadata read would lower the consent bar on the
+    // single most disclosing task in the surface. `None` side effects is right: it reads
+    // existing keys and mints, rotates and revokes nothing.
+    vta_sdk::trust_tasks::TASK_CONTEXTS_SECRETS_1_0 => contexts::handle_secrets
+        [ None Secret false ],
     vta_sdk::trust_tasks::TASK_CONTEXTS_UPDATE_DID_1_0 => contexts::handle_update_did
         [ Mutating None false ],
     vta_sdk::trust_tasks::TASK_CONTEXTS_PREVIEW_DELETE_1_0 => contexts::handle_preview_delete

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -221,7 +221,7 @@ affinidi-messaging-didcomm = "0.15"
 # mediator-side twin of the client-side failure this crate's TSP work is about.
 # Always on (not conditioned on this crate's `tsp`): the harness is test-only,
 # and a mediator that can route TSP is harmless to the DIDComm suite.
-affinidi-messaging-test-mediator = { version = "0.6", optional = true, features = [
+affinidi-messaging-test-mediator = { version = "0.7", optional = true, features = [
     "tsp",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }


### PR DESCRIPTION
`vta/contexts/secrets/1.0`. An integration whose identity the VTA manages — a
mediator, a room-host, a did-hosting service — has to hold that DID's private
keys to decrypt what is addressed to it. It cannot ask the VTA per frame, so it
fetches them at startup.

The only path that did that was `seeds/export-mnemonic/1.0`, and it is wrong in
three ways at once: it exports no mnemonic (it is a per-key secret export that
kept the name of the thing it was migrated from), it takes one `key_id` so a
caller assembling a bundle makes one call per key, and each of those calls is
gated on **global Admin**. Being a service therefore required authority over the
whole VTA — over every other context's keys included — in order to be itself.

One request naming one context, one response carrying that context's DID and its
key material, one authorization decision about the one thing being decided.

## Application, not Admin, and what makes that safe

Reading the keys of the DID you already operate is not an administrative act.
The loosening is real and worth being explicit about: the role floor drops from
Admin to Application. What makes it sound is that the entitlement is a **scope**
and not a **rank** —

- `require_write()` is the floor: a Reader may see that keys exist and a Monitor
  may not even do that, and neither may hold one;
- `require_context()` is the scope, and it narrows Admin too. Only an *empty*
  `allowed_contexts` means "all contexts", so an Admin of some other context
  reaches nothing here.

Five tests assert that rather than describing it, including the two mistakes a
reimplementation would actually make: treating the entitlement as a privilege
level (`an_admin_of_another_context_cannot_either`), and checking existence
before entitlement (`entitlement_is_checked_before_existence`, which compares the
two refusals against each other so "no such context" cannot become an oracle for
contexts the caller may not reach).

## Delegating rather than re-walking

The operation is a thin wrapper over `build_did_secrets_bundle`, which already
existed for the offline export path. Its first draft re-walked the context
itself, and re-walking it got two things wrong that the existing traversal has
right: it passed `None` where the label belongs, silently dropping every key
whose store id is a derivation path and whose label carries the VM id (rule 2 of
`select_secret_kid`, which exists for exactly those records), and it did not page,
so a context with more keys than one page would have been truncated without
saying so. The only thing that legitimately differs between the two callers is
the role floor — the offline path runs as a local super-admin — so that is the
only thing the wrapper adds.

## The dispatch class is `Secret`

`[ None Secret false ]`. This classification, not the published registry, is what
the PDP feeds into `PolicyInput`, so it is what sets the consent bar. The first
draft said `Metadata`, which would have treated a private-key release as a
metadata read on the most disclosing task in the surface.

## Wire form

`ContextSecretsResultBody` is a wire type of its own rather than serialising
`DidSecretsBundle` directly. They are not the same thing: `DidSecretsBundle` is
the internal and on-disk form, snake_case, shared with `sealed_transfer` and with
operator exports already written to disk, while the spec is lowerCamelCase as
SPEC §4.10 requires. Renaming the existing type would rewrite a format that has
been written to disk to fix a format that has never been on the wire. `From` in
both directions, and a test that fails if anyone collapses the two.

Spec: trustoverip/dtgwg-trust-tasks-tf#440. `every_served_uri_has_a_published_
spec_or_is_tracked_debt` fails until that merges and trust-tasks-rs releases —
deliberately not allowlisted in `UNSPECCED_DISPATCHED_URIS`, since the point of
that ledger is that it shrinks.

The spec for `vta/contexts/secrets/1.0` published in trust-tasks-rs 0.20.1
(trustoverip/dtgwg-trust-tasks-tf#440), so the URI is no longer unspecced and
`every_served_uri_has_a_published_spec_or_is_tracked_debt` goes green with
nothing added to `UNSPECCED_DISPATCHED_URIS`.

Publishing it made two further ledgers speak up, which is them working — both
key off the registry, so neither could see the task while its spec was absent:

- **Retry safety.** `ReadOnly`. The task returns private keys, so `KeyedSecret`
  looks like the careful answer and is the wrong one: `export-mnemonic` is
  `KeyedSecret` because its export guard is one-shot, not because it returns a
  secret. This task has no guard and no side effect, so `ReadOnly` is simply
  true — and it takes the dedup path out entirely, which means no response body
  is stored at all. Same protection, reached by the honest classification.

- **A conformance witness**, built by serialising the type the service actually
  answers with rather than by hand. The risk it covers is precisely that
  `ContextSecretsResultBody` (lowerCamelCase, per SPEC §4.10) and the published
  schema drift apart while the internal `DidSecretsBundle` it converts from
  stays snake_case. A hand-written literal would be written to match the spec
  and would keep passing if the service drifted; this cannot.

## The dependency move is all of them or none

trust-tasks-rs 0.20.1 and its four sibling crates, plus `affinidi-tdk` 0.14,
`affinidi-messaging-sdk` 0.24, `affinidi-messaging-mediator` 0.24 and
`affinidi-messaging-test-mediator` 0.7 — six manifests across the workspace.

None of those is optional or separable. `trust-tasks-rs` is a **public**
dependency of `affinidi-messaging-sdk`, so pinning this workspace at 0.20 while
anything still reached 0.19 puts two `trust-tasks-rs` nodes in one graph and
fails to compile on `expected MediatorAcl, found a different MediatorAcl`.

Bumping only the two obvious ones was not enough, and the way it failed is the
point: `affinidi-messaging-test-mediator` 0.6 is a **dev**-dependency of
`vtc-service`, `room-host` and the e2e tests, and it dragged
`affinidi-messaging-mediator` 0.23 and `affinidi-messaging-sdk` 0.23 back in
behind it — a stale 0.19.4 node arriving through the test harness rather than
through anything the workspace declares directly. Verified after the fact:
`cargo tree -i trust-tasks-rs` now resolves exactly one node, 0.20.1, and the
long-standing 0.17.10 cycle (published `vta-sdk` -> `affinidi-tdk` 0.11 ->
`affinidi-messaging-sdk` 0.21.1) is gone with it.

The upstream half of this is affinidi/affinidi-tdk-rs#786.