### PR TITLE
feat(vta): a key can be marked as never leaving the VTA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9645,9 +9645,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3598074d90446fba00f378c7dfb349f97601a3ce7aec36a98552d5ab8606acf"
+checksum = "86ecea203d52cf77d7798248c444ff0ae1e1fed11aa0063a4024471c099f9c16"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.20.1", default-features = false, features = [
+trust-tasks-rs = { version = "0.20.2", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/vta-backup/src/ops/mod.rs
+++ b/vta-backup/src/ops/mod.rs
@@ -1218,6 +1218,7 @@ mod tests {
             label: None,
             context_id: None,
             seed_id: None,
+            exportable: None,
             origin: KeyOrigin::Derived,
             created_at: now,
             updated_at: now,

--- a/vta-keys/src/lib.rs
+++ b/vta-keys/src/lib.rs
@@ -72,6 +72,10 @@ pub async fn save_key_record(
         label: Some(label.to_string()),
         context_id: context_id.map(String::from),
         seed_id,
+        // Absent, not `Some(true)`: a newly created key has never been asked
+        // about, and recording an explicit "allowed" would be a claim nobody
+        // made. See `KeyRecord::exportable`.
+        exportable: None,
         origin: KeyOrigin::Derived,
         created_at: now,
         updated_at: now,

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -120,6 +120,12 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // execution costs (nothing — it is idempotent), this asks what ONE
     // execution discloses.
     ("vta/contexts/secrets", Risk::Sensitive),
+    // Custody rules, changed. `keys/set-exportability` decides whether a key
+    // may ever leave — one direction forecloses that, the other restores it —
+    // so a blanket `vta_call` approval must not silently cover it. The verb
+    // rule would read `set-exportability` as an ordinary mutation, and in the
+    // lifting direction it is the step that lets a protected key out.
+    ("keys/set-exportability", Risk::Sensitive),
     // Authority, moved.
     ("acl/grant", Risk::Sensitive),
     ("acl/update", Risk::Sensitive),

--- a/vta-sdk/src/keys/mod.rs
+++ b/vta-sdk/src/keys/mod.rs
@@ -86,6 +86,25 @@ pub struct KeyRecord {
     /// Absent when unset, never `null`; the component types it `integer`.
     #[serde(default, alias = "seed_id", skip_serializing_if = "Option::is_none")]
     pub seed_id: Option<u32>,
+    /// Whether the private half may be released to a caller.
+    ///
+    /// `Some(false)` means every export of this key is refused and it can only
+    /// be *used* — signing, key agreement — so the material never leaves.
+    ///
+    /// **`None` means exportable.** That is the permissive reading and it is
+    /// deliberate: it is what every record written before this member existed
+    /// already meant, so adding the member cannot silently retract access that
+    /// callers already have. `Option<bool>` rather than a `#[serde(default)]`
+    /// `bool` for the same reason the spec declares no JSON Schema `default` —
+    /// a materialised default would rewrite absent as an explicit `true` on the
+    /// next save, turning "never asked" into "asked and allowed".
+    ///
+    /// Not a statement about recoverability. A whole-store backup is a
+    /// different mechanism from an export to a caller, and `vta-backup` reads
+    /// the `SeedStore` directly rather than going through `get_key_secret`, so
+    /// a non-exportable key still restores.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exportable: Option<bool>,
     #[serde(default = "default_derived")]
     pub origin: KeyOrigin,
     #[serde(alias = "created_at")]

--- a/vta-sdk/src/protocols/key_management/mod.rs
+++ b/vta-sdk/src/protocols/key_management/mod.rs
@@ -7,6 +7,7 @@ pub mod list;
 pub mod rename;
 pub mod revoke;
 pub mod secret;
+pub mod set_exportability;
 pub mod sign;
 
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/key-management/1.0";

--- a/vta-sdk/src/protocols/key_management/set_exportability.rs
+++ b/vta-sdk/src/protocols/key_management/set_exportability.rs
@@ -1,0 +1,33 @@
+//! `keys/set-exportability/0.1` — whether a key's private half may be released.
+
+use serde::{Deserialize, Serialize};
+
+use crate::keys::KeyRecord;
+
+/// Ask a custodian to change whether one key may be exported.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SetKeyExportabilityBody {
+    #[serde(rename = "keyId", alias = "key_id")]
+    pub key_id: String,
+    /// The state the key should be in afterwards — **not a delta**.
+    ///
+    /// Absolute so a producer that retries a request whose reply was lost lands
+    /// where it asked rather than the opposite. A `toggle` member would
+    /// reintroduce exactly that failure, which is why the spec has none and one
+    /// of its negative fixtures is a request carrying one.
+    pub exportable: bool,
+}
+
+/// The record as it now stands.
+///
+/// Wrapped in `key` to match `keys/show` and `keys/create`, which is what the
+/// spec's response schema says. Returning the whole record lets a producer
+/// confirm the state it asked for without a second round trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct SetKeyExportabilityResultBody {
+    pub key: KeyRecord,
+}

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -193,6 +193,12 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_KEYS_SHOW_0_1, ReadOnly),
     (trust_tasks::TASK_KEYS_RENAME_0_1, RetrySafe),
     (trust_tasks::TASK_KEYS_REVOKE_0_1, RetrySafe),
+    // `RetrySafe`, not `Keyed`: `exportable` is an absolute state, so a second
+    // execution converges on the same record rather than leaving a second
+    // artefact. That is the property the spec insists on, and it is exactly
+    // what makes a blind retry safe — a producer that retried a lost `false`
+    // must land on `false`, never toggle back to `true`.
+    (trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1, RetrySafe),
     // Signing is a pure function of key + payload; the same request signs the
     // same bytes. No durable effect beyond the audit row.
     (trust_tasks::TASK_KEYS_SIGN_0_1, ReadOnly),

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -415,6 +415,25 @@ pub const TASK_KEYS_RENAME_0_1: &str = "https://trusttasks.org/spec/keys/rename/
 /// Auth: Admin.
 pub const TASK_KEYS_REVOKE_0_1: &str = "https://trusttasks.org/spec/keys/revoke/0.1";
 
+/// `spec/keys/set-exportability/0.1` — whether a key's private half may be
+/// released to a caller.
+///
+/// **The two directions do not carry the same entitlement, and that asymmetry
+/// is the point.** Imposing the restriction forecloses something and needs
+/// admin of the key's context. Lifting it restores an ability that was
+/// deliberately taken away, and needs strictly more: super-admin, or a live
+/// step-up on the session.
+///
+/// A restriction that whoever imposed it can lift again protects against
+/// accident but not against a compromised caller holding that party's
+/// credentials — which is the case the restriction exists for.
+///
+/// Payload:
+/// [`crate::protocols::key_management::set_exportability::SetKeyExportabilityBody`].
+/// Returns the key record; never any private material.
+pub const TASK_KEYS_SET_EXPORTABILITY_0_1: &str =
+    "https://trusttasks.org/spec/keys/set-exportability/0.1";
+
 /// `spec/vta/keys/sign/1.0` — sign a base64url-encoded payload with a
 /// stored key (raw-bytes signing oracle).
 /// Payload: [`crate::protocols::key_management::sign::SignRequestBody`].
@@ -1867,6 +1886,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_KEYS_SHOW_0_1,
     TASK_KEYS_RENAME_0_1,
     TASK_KEYS_REVOKE_0_1,
+    TASK_KEYS_SET_EXPORTABILITY_0_1,
     TASK_KEYS_SIGN_0_1,
     TASK_KEYS_DERIVE_AND_SIGN_0_1,
     TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,

--- a/vta-service/src/did_key.rs
+++ b/vta-service/src/did_key.rs
@@ -193,6 +193,7 @@ async fn import_ed25519_did_key(
 
     let now = Utc::now();
     let record = KeyRecord {
+        exportable: None,
         key_id: key_id.clone(),
         derivation_path: String::new(),
         key_type: KeyType::Ed25519,

--- a/vta-service/src/operations/credential_exchange.rs
+++ b/vta-service/src/operations/credential_exchange.rs
@@ -2251,6 +2251,7 @@ mod tests {
             .insert(
                 crate::keys::store_key(&key_id),
                 &KeyRecord {
+                    exportable: None,
                     key_id: key_id.clone(),
                     derivation_path: path.into(),
                     key_type: KeyType::Ed25519,
@@ -2505,6 +2506,7 @@ mod tests {
             .insert(
                 crate::keys::store_key(&key_id),
                 &KeyRecord {
+                    exportable: None,
                     key_id: key_id.clone(),
                     derivation_path: path.into(),
                     key_type: KeyType::Ed25519,

--- a/vta-service/src/operations/did_webvh/update/mod.rs
+++ b/vta-service/src/operations/did_webvh/update/mod.rs
@@ -407,6 +407,7 @@ mod tests {
         // Legacy KeyRecord exists in `key:*` but nothing in webvh_keys.
         let key_id = format!("did:webvh:{scid}#key-0");
         let record = KeyRecord {
+            exportable: None,
             key_id: key_id.clone(),
             derivation_path: "m/26'/0'/0'/0".into(),
             key_type: KeyType::Ed25519,

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -533,6 +533,7 @@ mod tests {
                 .expect("allocate path");
             let now = Utc::now();
             let record = KeyRecord {
+                exportable: None,
                 key_id: kid.to_string(),
                 derivation_path: path,
                 key_type: kt,

--- a/vta-service/src/operations/holder_keys.rs
+++ b/vta-service/src/operations/holder_keys.rs
@@ -222,6 +222,7 @@ mod tests {
         let key_id = format!("{subject_did}#{multibase}");
 
         let record = KeyRecord {
+            exportable: None,
             key_id: key_id.clone(),
             derivation_path: path.to_string(),
             key_type: KeyType::Ed25519,

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -108,6 +108,7 @@ async fn create_internal_key(
         public_key: public_key.clone(),
         label: label.clone(),
         context_id: context_id.clone(),
+        exportable: None,
         // No seed is involved, so there is no seed generation to pin to.
         seed_id: None,
         origin: keys::KeyOrigin::Internal,
@@ -248,6 +249,7 @@ pub async fn create_key(
         public_key: public_key.clone(),
         label: params.label.clone(),
         context_id: context_id.clone(),
+        exportable: None,
         seed_id: Some(active_id),
         origin: keys::KeyOrigin::Derived,
         created_at: now,
@@ -394,6 +396,7 @@ pub async fn import_key(
         label: params.label.clone(),
         context_id: context_id.clone(),
         seed_id: None,
+        exportable: None,
         origin: KeyOrigin::Imported,
         created_at: now,
         updated_at: now,
@@ -742,6 +745,25 @@ pub async fn get_key_secret(
         )));
     }
 
+    // The exportability restriction, enforced at the one place a private key
+    // leaves the VTA. This function is the export surface — the callers are
+    // `seeds/export-mnemonic`, `build_did_secrets_bundle` (and so
+    // `vta/contexts/secrets`), and the operator's own CLI export prompt.
+    // `get_key_secret_internal` is deliberately NOT gated here: it is the *use*
+    // surface, loading a key so the VTA can sign or decrypt with it, and a key
+    // that may not leave may still be used. Gating it would break the VTA's own
+    // signing rather than protect anything, because nothing it returns reaches
+    // a caller.
+    //
+    // `None` means exportable — see `KeyRecord::exportable`. Only an explicit
+    // `Some(false)` refuses, so records written before the member existed are
+    // unaffected.
+    if record.exportable == Some(false) {
+        return Err(AppError::Forbidden(format!(
+            "key `{key_id}` is marked non-exportable and its private half is never              released; it can still be used for signing and key agreement. Changing              that needs `keys/set-exportability` with authority beyond the one that              set it"
+        )));
+    }
+
     let (public_key_multibase, private_key_multibase) = match record.origin {
         // Unreachable: the early return above refuses internal keys. Kept as a
         // second, local refusal so deleting that guard cannot quietly turn this
@@ -830,6 +852,110 @@ pub async fn get_key_secret(
         public_key_multibase,
         private_key_multibase,
     })
+}
+
+/// Set whether a key's private half may be released, and refuse to make that
+/// decision cheaply reversible.
+///
+/// # The asymmetry is the feature
+///
+/// A restriction that whoever imposed it can lift again protects against
+/// accident but not against a compromised caller holding that party's
+/// credentials — which is the case the restriction exists for. So the two
+/// directions do not carry the same entitlement:
+///
+/// - **Imposing it** (`exportable: false`) needs admin of the key's context.
+///   Foreclosing something is the safe direction.
+/// - **Lifting it** (`false` → `true`) needs that *and* one of two things
+///   beyond it: super-admin, or a live step-up on this session. Either is
+///   strictly more than the entitlement that imposed it, which is what
+///   `keys/set-exportability/0.1` requires of a conforming consumer. The spec
+///   deliberately does not name the mechanism — SPEC §7.3 item 13 forbids a
+///   specification from mandating a step-up — so choosing these two is this
+///   VTA's policy, and either satisfies the rule.
+///
+/// Offering both rather than only super-admin matters operationally: a
+/// deployment with no super-admin session to hand can still recover a key it
+/// locked down, by stepping up. One with no step-up policy configured can still
+/// do it as super-admin. Requiring only one of them would strand somebody.
+///
+/// # Idempotent, and only the transition is gated
+///
+/// `exportable` is an absolute state, not a toggle, so a producer that retries
+/// a request whose reply was lost lands where it asked. Setting `true` on a key
+/// that is already exportable takes nothing away and so takes the ordinary
+/// path — only a real `false` → `true` transition meets the stronger gate.
+pub async fn set_key_exportability(
+    keys_ks: &KeyspaceHandle,
+    sessions_ks: &KeyspaceHandle,
+    audit: &vta_audit::SharedAuditSink,
+    auth: &AuthClaims,
+    key_id: &str,
+    exportable: bool,
+    channel: &str,
+) -> Result<KeyRecord, AppError> {
+    let mut record: KeyRecord = keys_ks
+        .get(keys::store_key(key_id))
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("key {key_id} not found")))?;
+
+    // Standing over the key's scope, exactly as the export path requires it.
+    if let Some(ref ctx) = record.context_id {
+        auth.require_context(ctx)?;
+    } else if !auth.is_super_admin() {
+        return Err(AppError::Forbidden(
+            "only super admin can act on keys without a context".into(),
+        ));
+    }
+    auth.require_admin()?;
+
+    // An internal key has no export surface at all, so `exportable: true` is
+    // asking for something no authority can grant. Refused as a precondition
+    // rather than a permission failure — retrying as super-admin changes
+    // nothing, and saying "forbidden" would send the operator to look for more
+    // authority that does not exist.
+    if record.origin == KeyOrigin::Internal && exportable {
+        return Err(AppError::Validation(format!(
+            "key `{key_id}` is an internal key: its private half is never released              regardless of this setting, so it cannot be made exportable"
+        )));
+    }
+
+    let currently = record.exportable != Some(false);
+    if !currently && exportable {
+        // The one gated transition. Super-admin OR a live step-up; the error
+        // names both, because a caller told only "forbidden" cannot tell which
+        // of the two routes is open to it.
+        if auth.require_super_admin().is_err() {
+            auth.require_fresh_step_up(sessions_ks).await.map_err(|_| {
+                AppError::Forbidden(format!(
+                    "making `{key_id}` exportable again needs more authority than the                      admin that restricted it: either super-admin, or a fresh step-up                      on this session"
+                ))
+            })?;
+        }
+    }
+
+    record.exportable = Some(exportable);
+    record.updated_at = chrono::Utc::now();
+    keys_ks.insert(keys::store_key(key_id), &record).await?;
+
+    audit!(
+        "key.set_exportability",
+        actor = &auth.did,
+        resource = key_id,
+        outcome = "success"
+    );
+    let _ = audit::record(
+        audit,
+        "key.set_exportability",
+        &auth.did,
+        Some(key_id),
+        "success",
+        Some(channel),
+        record.context_id.as_deref(),
+    )
+    .await;
+
+    Ok(record)
 }
 
 /// Internal-authority variant of [`get_key_secret`] that bypasses the
@@ -1416,6 +1542,7 @@ mod tests {
         imported_ks: KeyspaceHandle,
         internal_ks: KeyspaceHandle,
         acl_ks: KeyspaceHandle,
+        sessions_ks: KeyspaceHandle,
         seed_store: Arc<dyn SeedStore>,
         _dir: tempfile::TempDir,
     }
@@ -1436,6 +1563,7 @@ mod tests {
             let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
             let internal_ks = store.keyspace(crate::keyspaces::INTERNAL_KEYS).unwrap();
             let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
+            let sessions_ks = store.keyspace(crate::keyspaces::SESSIONS).unwrap();
 
             // 32-byte seed; will be expanded to 64 bytes by BIP-32 internally
             let seed_store: Arc<dyn SeedStore> =
@@ -1453,8 +1581,24 @@ mod tests {
                 imported_ks,
                 internal_ks,
                 acl_ks,
+                sessions_ks,
                 seed_store,
                 _dir: dir,
+            }
+        }
+
+        /// Admin of `test-ctx` and nothing else — the entitlement that may
+        /// impose the export restriction but must not be able to lift it.
+        fn context_admin_auth(&self) -> AuthClaims {
+            AuthClaims {
+                did: "did:key:z6MkCtxAdmin".to_string(),
+                role: Role::Admin,
+                allowed_contexts: vec!["test-ctx".to_string()],
+                session_id: "ctx-admin-session".into(),
+                access_expires_at: 0,
+                issued_at: 0,
+                amr: Vec::new(),
+                acr: String::new(),
             }
         }
 
@@ -2685,6 +2829,37 @@ mod tests {
     }
     // ── internal (non-extractable) keys ──────────────────────────────
 
+    /// An ordinary derived key in `test-ctx` — the scope `context_admin_auth`
+    /// administers, so the exportability tests exercise a real context admin
+    /// rather than borrowing super-admin authority.
+    async fn mint_derived(h: &TestHarness, key_id: &str) -> KeyRecord {
+        create_key(
+            &h.keys_ks,
+            &h.internal_ks,
+            &h.contexts_ks,
+            &h.seed_store,
+            &h.audit,
+            &h.super_admin_auth(),
+            CreateKeyParams {
+                internal: false,
+                key_type: KeyType::Ed25519,
+                derivation_path: None,
+                key_id: Some(key_id.to_string()),
+                mnemonic: None,
+                label: None,
+                context_id: Some("test-ctx".to_string()),
+            },
+            "test",
+        )
+        .await
+        .expect("mint derived key");
+        h.keys_ks
+            .get(keys::store_key(key_id))
+            .await
+            .expect("read back")
+            .expect("the record exists")
+    }
+
     async fn mint_internal(h: &TestHarness, key_id: &str) -> CreateKeyResultBody {
         create_key(
             &h.keys_ks,
@@ -2730,6 +2905,254 @@ mod tests {
         assert!(
             matches!(&err, AppError::Forbidden(m) if m.contains("internal key")),
             "a super-admin must still be refused; got {err:?}"
+        );
+    }
+
+    // ── exportability ────────────────────────────────────────────────
+    //
+    // The member's whole value is that the two directions are not equally easy
+    // to travel. These assert the relation, not just each end of it.
+
+    /// A key created the ordinary way carries no opinion, and absence reads as
+    /// exportable — the compatibility guarantee for every record written before
+    /// the member existed.
+    #[tokio::test]
+    async fn a_key_is_exportable_until_someone_says_otherwise() {
+        let h = TestHarness::new().await;
+        let created = mint_derived(&h, "k-open").await;
+        assert_eq!(
+            created.exportable, None,
+            "a new key records no decision; `Some(true)` would be a claim nobody made"
+        );
+
+        get_key_secret(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.seed_store,
+            &h.audit,
+            &h.super_admin_auth(),
+            "k-open",
+            "test",
+        )
+        .await
+        .expect("absence must read as exportable");
+    }
+
+    /// The restriction bites at the one place a private key leaves the VTA.
+    #[tokio::test]
+    async fn a_restricted_key_is_never_exported() {
+        let h = TestHarness::new().await;
+        mint_derived(&h, "k-shut").await;
+
+        set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &h.context_admin_auth(),
+            "k-shut",
+            false,
+            "test",
+        )
+        .await
+        .expect("a context admin may impose the restriction");
+
+        let err = get_key_secret(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.seed_store,
+            &h.audit,
+            &h.super_admin_auth(),
+            "k-shut",
+            "test",
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Forbidden(m) if m.contains("non-exportable")),
+            "even a super-admin is refused the material; got {err:?}"
+        );
+    }
+
+    /// The asymmetry itself. The same claim that imposed the restriction must
+    /// not be able to lift it — otherwise the restriction protects against
+    /// accident but not against a compromised caller holding that claim, which
+    /// is the case it exists for.
+    #[tokio::test]
+    async fn the_admin_that_restricted_a_key_cannot_release_it_again() {
+        let h = TestHarness::new().await;
+        mint_derived(&h, "k-asym").await;
+        let admin = h.context_admin_auth();
+
+        set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &admin,
+            "k-asym",
+            false,
+            "test",
+        )
+        .await
+        .expect("imposing is the cheap direction");
+
+        let err = set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &admin,
+            "k-asym",
+            true,
+            "test",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(&err, AppError::Forbidden(m)
+                if m.contains("super-admin") && m.contains("step-up")),
+            "the refusal must name both routes, or a caller cannot tell which is \
+             open to it; got {err:?}"
+        );
+    }
+
+    /// Super-admin is one of the two ways past that gate.
+    #[tokio::test]
+    async fn a_super_admin_can_release_a_restricted_key() {
+        let h = TestHarness::new().await;
+        mint_derived(&h, "k-reopen").await;
+
+        set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &h.context_admin_auth(),
+            "k-reopen",
+            false,
+            "test",
+        )
+        .await
+        .expect("restrict");
+
+        let record = set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &h.super_admin_auth(),
+            "k-reopen",
+            true,
+            "test",
+        )
+        .await
+        .expect("a super-admin holds strictly more than the context admin that restricted it");
+        assert_eq!(record.exportable, Some(true));
+
+        get_key_secret(
+            &h.keys_ks,
+            &h.imported_ks,
+            &h.seed_store,
+            &h.audit,
+            &h.super_admin_auth(),
+            "k-reopen",
+            "test",
+        )
+        .await
+        .expect("and the key exports again");
+    }
+
+    /// Only a real `false` -> `true` transition meets the stronger gate.
+    /// Setting `true` on an already-exportable key takes nothing away, so
+    /// gating it would demand super-admin for a no-op — and would make a
+    /// retried request harder to complete than the original.
+    #[tokio::test]
+    async fn re_asserting_exportable_on_an_open_key_is_not_gated() {
+        let h = TestHarness::new().await;
+        mint_derived(&h, "k-noop").await;
+
+        let record = set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &h.context_admin_auth(),
+            "k-noop",
+            true,
+            "test",
+        )
+        .await
+        .expect("a context admin may confirm what is already true");
+        assert_eq!(record.exportable, Some(true));
+    }
+
+    /// Idempotent in the other direction too: `exportable` is an absolute
+    /// state, so a producer retrying a lost `false` lands on `false` rather
+    /// than toggling back.
+    #[tokio::test]
+    async fn restricting_twice_stays_restricted() {
+        let h = TestHarness::new().await;
+        mint_derived(&h, "k-twice").await;
+        let admin = h.context_admin_auth();
+
+        for _ in 0..2 {
+            let record = set_key_exportability(
+                &h.keys_ks,
+                &h.sessions_ks,
+                &h.audit,
+                &admin,
+                "k-twice",
+                false,
+                "test",
+            )
+            .await
+            .expect("a repeat is a no-op, not a toggle");
+            assert_eq!(record.exportable, Some(false));
+        }
+    }
+
+    /// Scope still applies: an admin of another context reaches nothing here,
+    /// the same rule the export path enforces.
+    #[tokio::test]
+    async fn an_admin_of_another_context_cannot_set_exportability() {
+        let h = TestHarness::new().await;
+        mint_derived(&h, "k-scope").await;
+        let mut elsewhere = h.context_admin_auth();
+        elsewhere.allowed_contexts = vec!["some-other-ctx".to_string()];
+
+        let err = set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &elsewhere,
+            "k-scope",
+            false,
+            "test",
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppError::Forbidden(_)), "got: {err:?}");
+    }
+
+    /// An internal key can never be released, so asking for that is a
+    /// precondition failure rather than a permission one — retrying with more
+    /// authority changes nothing, and `Forbidden` would send the operator
+    /// looking for authority that does not exist.
+    #[tokio::test]
+    async fn an_internal_key_cannot_be_made_exportable() {
+        let h = TestHarness::new().await;
+        mint_internal(&h, "k-internal").await;
+
+        let err = set_key_exportability(
+            &h.keys_ks,
+            &h.sessions_ks,
+            &h.audit,
+            &h.super_admin_auth(),
+            "k-internal",
+            true,
+            "test",
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("internal key")),
+            "got: {err:?}"
         );
     }
 

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -2712,6 +2712,7 @@ pub async fn seed_holder_key(
         label: None,
         context_id: context_id.map(str::to_string),
         seed_id: None,
+        exportable: None,
         origin: KeyOrigin::Derived,
         created_at: chrono::Utc::now(),
         updated_at: chrono::Utc::now(),

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -157,6 +157,9 @@ use vta_sdk::protocols::key_management::import::ImportKeyBody;
 use vta_sdk::protocols::key_management::list::{ListKeysBody, ListKeysResultBody};
 use vta_sdk::protocols::key_management::rename::{RenameKeyBody, RenameKeyResultBody};
 use vta_sdk::protocols::key_management::revoke::{RevokeKeyBody, RevokeKeyResultBody};
+use vta_sdk::protocols::key_management::set_exportability::{
+    SetKeyExportabilityBody, SetKeyExportabilityResultBody,
+};
 use vta_sdk::protocols::key_management::sign::{SignAlgorithm, SignRequestBody, SignResultBody};
 use vta_sdk::protocols::memory::{
     MemoryDeleteBody, MemoryDeleteResponse, MemoryItem, MemoryListBody, MemoryListResponse,
@@ -377,6 +380,7 @@ fn policy_module_view() -> PolicyModuleView {
 /// A fully-populated canonical `KeyRecord` (the keys family's shared component).
 fn key_record() -> KeyRecord {
     KeyRecord {
+        exportable: None,
         key_id: "app-signing-key".into(),
         derivation_path: "m/26'/2'/0'/1'".into(),
         key_type: KeyType::Ed25519,
@@ -1050,6 +1054,39 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     key_id: "app-signing-key".into(),
                     status: KeyStatus::Revoked,
                     updated_at: dt(),
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_SET_EXPORTABILITY_0_1,
+            checked!(
+                specs::keys::set_exportability::v0_1::Payload,
+                specs::keys::set_exportability::v0_1::Response,
+                to_v(SetKeyExportabilityBody {
+                    key_id: "app-signing-key".into(),
+                    exportable: false,
+                }),
+                // Serialised from the type the service actually answers with.
+                // The risk this covers is the response wrapping: the spec wraps
+                // the record in `key` to match `keys/show`, and a bare record
+                // would validate against neither. A hand-written literal would
+                // be written to match the spec and keep passing if the service
+                // drifted.
+                to_v(SetKeyExportabilityResultBody {
+                    key: vta_sdk::keys::KeyRecord {
+                        key_id: "app-signing-key".into(),
+                        derivation_path: "m/0".into(),
+                        key_type: vta_sdk::keys::KeyType::Ed25519,
+                        status: KeyStatus::Active,
+                        public_key: "zPub".into(),
+                        label: None,
+                        context_id: Some("rooms".into()),
+                        seed_id: None,
+                        exportable: Some(false),
+                        origin: vta_sdk::keys::KeyOrigin::Derived,
+                        created_at: dt(),
+                        updated_at: dt(),
+                    },
                 })
             ),
         ),

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -184,6 +184,44 @@ pub(super) async fn handle_revoke(
     }
 }
 
+/// Handler for `keys/set-exportability/0.1`.
+///
+/// Admin of the key's context to impose the restriction; strictly more than
+/// that to lift it. The asymmetry lives in the operation rather than here,
+/// because it depends on the key's *current* state — a handler-level gate would
+/// have to demand the stronger authority for both directions, which would make
+/// locking a key down as hard as unlocking it and so discourage the safe move.
+pub(super) async fn handle_set_exportability(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let req: vta_sdk::protocols::key_management::set_exportability::SetKeyExportabilityBody =
+        match parse_payload(&doc) {
+            Ok(r) => r,
+            Err(resp) => return resp,
+        };
+    match operations::keys::set_key_exportability(
+        &state.keys_ks,
+        &state.sessions_ks,
+        &state.audit_sink,
+        auth,
+        &req.key_id,
+        req.exportable,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(key) => success_response(
+            &doc,
+            vta_sdk::protocols::key_management::set_exportability::SetKeyExportabilityResultBody {
+                key,
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
 /// Handler for `keys/sign/0.1`. Application-or-higher (write).
 ///
 /// Decodes the base64url payload before invoking the signing oracle —

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1703,6 +1703,12 @@ dispatch_table! {
         [ Mutating None false ],
     vta_sdk::trust_tasks::TASK_KEYS_REVOKE_0_1 => keys::handle_revoke
         [ Destructive None false ],
+    // `Mutating` and `Metadata`: it changes one member of a key record and
+    // discloses only the record. It never reads or releases key material — the
+    // task decides whether a *future* export may happen, and does not perform
+    // one.
+    vta_sdk::trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1 => keys::handle_set_exportability
+        [ Mutating Metadata false ],
     vta_sdk::trust_tasks::TASK_KEYS_SIGN_0_1 => keys::handle_sign
         [ None None true ],
     vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1 => keys::handle_derive_and_sign


### PR DESCRIPTION
The VTA releases private keys to entitled callers — that is what
`vta/contexts/secrets` is for. For some keys that is exactly wrong: the key
signs something whose authority should never be reproducible outside the VTA,
and no future caller, however well authorised, should walk away with it.

Spec: trustoverip/dtgwg-trust-tasks-tf#443, in trust-tasks-rs 0.20.2.

## `exportable` on `KeyRecord`

`Some(false)` means every export is refused and the key can only be *used*.

**`None` means exportable**, and it is `Option<bool>` rather than a
`#[serde(default)] bool` for a specific reason: a materialised default would
rewrite absent as an explicit `true` on the next save, turning "never asked"
into "asked and allowed" for every key that predates the member. New keys are
minted `None` for the same reason — recording `Some(true)` would be a claim
nobody made.

It says nothing about recoverability. `vta-backup` reads the `SeedStore`
directly rather than going through `get_key_secret`, so a restricted key still
restores from a whole-VTA backup. If it did not, operators would avoid the flag
for fear of stranding a key, which is the opposite of the intended effect.

## Enforced at the export surface, not the use surface

The check is in `get_key_secret` — the one place a private key leaves. Its
callers are `seeds/export-mnemonic`, `build_did_secrets_bundle` (and so
`vta/contexts/secrets`), and the operator's CLI export prompt.

`get_key_secret_internal` is deliberately **not** gated. That is the *use*
surface: it loads a key so the VTA can sign or decrypt with it, and nothing it
returns reaches a caller. A key that may not leave may still be used, and gating
it there would break the VTA's own signing while protecting nothing.

I checked this rather than assumed it — the four `did_webvh.rs` call sites of
`get_key_secret` look like internal signing and are not: two sit behind an
explicit "Export DID secrets bundle?" prompt, two are tests.

## The asymmetry is the feature

- Imposing (`exportable: false`) needs admin of the key's context.
- Lifting (`false` -> `true`) needs that **and** one of: super-admin, or a live
  step-up on the session.

A restriction that whoever imposed it can lift again protects against accident
but not against a compromised caller holding that party's credentials — which is
the case the restriction exists for. The spec requires "strictly stronger" and
deliberately does not name a mechanism (SPEC §7.3 item 13 forbids a spec from
mandating a step-up), so choosing these two is this VTA's policy; either
satisfies it.

Offering both matters operationally: a deployment with no super-admin session to
hand can still recover a key by stepping up, and one with no step-up policy can
still do it as super-admin. Requiring only one would strand somebody. The
refusal names both routes, because a caller told only "forbidden" cannot tell
which is open to it.

Only a real `false` -> `true` transition meets the stronger gate. Re-asserting
`true` on an open key takes nothing away, and gating it would demand super-admin
for a no-op — making a retried request harder to complete than the original.

Eight tests, including the one that matters: the context admin that restricted a
key cannot release it again.

## Ledgers

All four that had an opinion last time: published spec (0.20.2), retry safety
(`RetrySafe` — the state is absolute, so a retry converges rather than toggling),
the MCP risk census (`Sensitive`, beside the other custody operations — the verb
rule would read `set-exportability` as an ordinary mutation), and a conformance
witness built by serialising the real response type, which is what catches the
`key` wrapper the spec requires.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>