### PR TITLE
docs: link the VTI specification and require conformance to it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,26 @@ Workspace-wide design principles, crate map, and integration-flow reference.
 Each crate also has its own CLAUDE.md for crate-specific guidance; consult
 those in addition to this file.
 
+## The specification comes first
+
+This workspace implements the VTI specification: <https://trustoverip.github.io/dtgwg-vti-spec/>
+
+Before changing the authority model (contexts, ACL entries, roles,
+capabilities, approvals), the client lifecycle, the operation surface,
+transports, sessions, credentials or the audit trail, **read what the
+specification requires**. It is normative; this code is an implementation of
+it. Where they disagree, the specification is correct and the code changes.
+
+- Cite requirement identifiers (`VTI-ACL-021`, `VTI-CLT-023`) in commit
+  messages, in comments explaining a constraint that would otherwise look
+  arbitrary, and in test names where a test holds a requirement.
+- Never diverge silently. A divergence goes in the specification's divergence
+  register (Appendix F) with the requirement, the behaviour and the intended
+  resolution; recording it is not an exemption from it.
+- "The existing code does it this way" is not an argument against a
+  requirement. Several requirements exist precisely because the obvious
+  implementation is wrong in a way that only appears adversarially.
+
 ## Workspace layout
 
 Rust workspace (edition 2024, resolver 3, MSRV 1.95.0). Dependencies flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,40 @@ Thank you for contributing! Before you contribute, we ask some things of you:
 - Please follow our Code of Conduct, the Contributor Covenant. You can find a copy [in this repository](CODE_OF_CONDUCT.md) or under https://www.contributor-covenant.org/
 - All Contributors must agree to [a CLA](.github/CLA/INDIVIDUAL.md). When opening a PR, the system will guide you through the process. However, if you contribute on behalf of a legal entity, we ask of you to agree to [a different CLA](.github/CLA/ENTITY.md). In that case, please contact us.
 
+## The specification
+
+This workspace implements the **Verifiable Trust Infrastructure (VTI)
+specification**: <https://trustoverip.github.io/dtgwg-vti-spec/>
+
+**Read it before you change anything it governs** — the authority model (trust
+contexts, access control entries, roles, capabilities, approvals), the client
+lifecycle, the operation surface, transports and delivery, sessions,
+credentials, or the audit trail.
+
+The specification is normative and this code is an implementation of it. Where
+the two disagree, the specification is what is correct and the code is what
+changes. That direction is deliberate: several of its requirements prohibit an
+encoding or a default that is easy to implement, widely used, and wrong in a
+way that only shows up under adversarial conditions.
+
+**Cite requirements by identifier.** Requirements carry stable identifiers such
+as `VTI-ACL-021` or `VTI-CLT-023`. Use them in PR descriptions, in comments
+explaining a constraint that would otherwise look arbitrary, and in the names of
+tests that exist to hold a requirement. A reviewer who can follow the identifier
+to the requirement can check the change against something other than your
+description of it.
+
+**Do not diverge silently.** If behaviour here cannot conform — or you believe
+it should not — record it in the specification's divergence register
+(Appendix F) with the requirement, the observed behaviour and the intended
+resolution. Recording a divergence is not an exemption from the requirement
+(VTI-CNF-015), and if you think the requirement itself is wrong, that is a
+change proposal against the specification, argued on its merits. The two are
+different and should not arrive as the same pull request.
+
+A divergence that is written down is one that can be planned against. One that
+is only known gets rediscovered by whoever composes the system next.
+
 ## Development Setup
 
 ### Prerequisites
@@ -61,6 +95,8 @@ Before submitting a pull request:
 - [ ] `cargo fmt --check` shows no formatting issues
 - [ ] New public functions have `///` doc comments
 - [ ] Security-sensitive changes include tests (auth, ACL, crypto)
+- [ ] Changes to the authority model, client lifecycle, operation surface, transports, sessions, credentials or audit conform to the [VTI specification](https://trustoverip.github.io/dtgwg-vti-spec/), and cite the requirement identifiers they implement
+- [ ] Any divergence from the specification is recorded in its divergence register (Appendix F), not left implicit
 - [ ] PR title is a conventional commit — it becomes the changelog entry (see [Changelog](#changelog))
 - [ ] No `version = ` edits in any `Cargo.toml` — the Release PR assigns versions (see [RELEASING.md](RELEASING.md))
 - [ ] Commits are signed off (DCO: `git commit -s`) — required for all outside contributions

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ A Rust workspace implementing the two service backends of the
 
 Plus the CLIs, SDKs, and shared crates that compose them.
 
+## Specification
+
+This workspace implements the **Verifiable Trust Infrastructure (VTI)
+specification**: <https://trustoverip.github.io/dtgwg-vti-spec/>
+(source: [trustoverip/dtgwg-vti-spec](https://github.com/trustoverip/dtgwg-vti-spec)).
+
+The specification is normative and this workspace is an implementation of it.
+Where the two disagree, the specification is what is correct and the code is
+what changes. Known differences are recorded in the specification's divergence
+register (Appendix F), with the requirement, the observed behaviour and the
+intended resolution.
+
+Read it before changing the authority model, the client lifecycle, the
+operation surface, transports, sessions, credentials or the audit trail — see
+[CONTRIBUTING.md](CONTRIBUTING.md#the-specification).
+
 ## Which service do you need?
 
 ```mermaid

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,11 @@ A guided tour of the workspace: what the VTA and VTC are, how to
 operate each one, how to integrate with them, and where the design
 decisions live.
 
+These documents describe **what this workspace does**. What a conforming
+implementation **must** do is the VTI specification: <https://trustoverip.github.io/dtgwg-vti-spec/>. Where the two
+disagree, the specification is correct — see
+[CONTRIBUTING.md](../CONTRIBUTING.md#the-specification).
+
 ## How this tree is organised
 
 ```mermaid
@@ -41,6 +46,7 @@ VTA via the `vtc-host` DID template.
 
 | Task | Start here |
 |---|---|
+| Find out what is **required** rather than what is built | [The VTI specification](https://trustoverip.github.io/dtgwg-vti-spec/) — normative |
 | Understand VTI as a whole | [Overview](01-concepts/overview.md) |
 | Decide between VTA and VTC | [Root README — Which service do you need?](../README.md#which-service-do-you-need) |
 | Stand up a VTA from scratch | [VTA cold-start](02-vta/cold-start.md) |


### PR DESCRIPTION
This workspace implements the VTI specification and nothing in the repository said so. A contributor changing the authority model, the client lifecycle, the operation surface, transports, sessions, credentials or the audit trail had no way to discover that a normative document governs it.

**Specification:** <https://trustoverip.github.io/dtgwg-vti-spec/> (source: [trustoverip/dtgwg-vti-spec](https://github.com/trustoverip/dtgwg-vti-spec)) — 411 numbered requirements across 21 chapters.

## What this changes

- **README** — a `## Specification` section directly under the intro.
- **docs/README.md** — a line distinguishing what these docs are (*what this workspace does*) from what the specification is (*what a conforming implementation must do*), and a first row in the "If you're trying to…" table.
- **CLAUDE.md** — the same rule for agent contributors, who otherwise read the crate map and infer the design from the code.
- **CONTRIBUTING.md** — a `## The specification` section, plus two PR checklist items.

Each states the direction of authority explicitly: **the specification is normative and this code is an implementation of it. Where the two disagree, the specification is correct and the code changes.**

## What CONTRIBUTING now asks for

**Cite requirement identifiers** (`VTI-ACL-021`, `VTI-CLT-023`) in PR descriptions, in comments explaining a constraint that would otherwise look arbitrary, and in the names of tests that exist to hold a requirement. A reviewer who can follow the identifier to the requirement can check a change against something other than the author's description of it.

**Do not diverge silently.** A divergence goes in the specification's divergence register (Appendix F) with the requirement, the observed behaviour and the intended resolution. Recording it is not an exemption (VTI-CNF-015) — and if the requirement itself is wrong, that is a change proposal against the specification, argued on its merits, and a different pull request.

CLAUDE.md carries one extra line aimed at how this failure actually happens: *"the existing code does it this way" is not an argument against a requirement* — several requirements exist precisely because the obvious implementation is wrong in a way that only appears adversarially.

## Context

The register already holds a first gap analysis of this workspace against the spec — eight findings observed from the source and five requirements recorded as open. The highest-value ones, in order: the general `sign_payload` path signs opaque octets; the auth challenge distinguishes a known subject from an unknown one; `session_pubkey_b58btc` is accepted and discarded; the VTA's default audit sink is unchained while the VTC's chains; and audit rows embed subject identifiers, which is the one that cannot be fixed retroactively.