### PR TITLE
feat(keys): export one key by name, and retire seeds/export-mnemonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9645,9 +9645,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ecea203d52cf77d7798248c444ff0ae1e1fed11aa0063a4024471c099f9c16"
+checksum = "f2dbddbfa65cacec94a8c6423fdde6bfd3236c1e2ac51fd6276c5f801682566f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.20.2", default-features = false, features = [
+trust-tasks-rs = { version = "0.20.3", default-features = false, features = [
   "validate",
   "all-specs",
 ] }

--- a/tests/e2e/tests/client_didcomm.rs
+++ b/tests/e2e/tests/client_didcomm.rs
@@ -479,12 +479,12 @@ async fn multibase_import_key_via_didcomm_uses_the_canonical_task() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_key_secret_via_didcomm() {
-    // The trust-task twin lives in the seeds slice
-    // (`spec/vta/seeds/export-mnemonic/1.0`) — same `{ key_id }` request.
+    // `keys/export-secret/0.1` — the honest name, in the keys family. This
+    // used to name a URI in the seeds slice that exported no seed.
     let (mediator, responder, client) = build_didcomm(|msg_type, body| {
-        if is_tt(msg_type, body, trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0) {
+        if is_tt(msg_type, body, trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1) {
             tt_ok(
-                trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
+                trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1,
                 json!({
                     "key_id": "k1",
                     "key_type": "ed25519",

--- a/vta-mcp/src/guard.rs
+++ b/vta-mcp/src/guard.rs
@@ -104,7 +104,7 @@ const SLUG_OVERRIDES: &[(&str, Risk)] = &[
     // Secret material, emitted.
     ("vault/release", Risk::Sensitive),
     ("vault/proxy-login", Risk::Sensitive),
-    ("vta/seeds/export-mnemonic", Risk::Sensitive),
+    ("keys/export-secret", Risk::Sensitive),
     // Returns the private keys of a context's DID. The verb rule would read
     // `secrets` as an ordinary mutation, and the task's own `sideEffects` are
     // `none` — it reads and changes nothing — so neither the verb nor the side

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -150,13 +150,20 @@ impl VtaClient {
             .ok_or_else(|| VtaError::NotFound(format!("no key record for `{key_id}`")))
     }
 
-    /// Export a key's secret material. The trust-task twin lives in the
-    /// seeds slice (`spec/vta/seeds/export-mnemonic/1.0`) — same
-    /// `{ key_id }` request and the same
-    /// `operations::keys::get_key_secret` spine as the legacy message.
+    /// Export one key's private half.
+    ///
+    /// `keys/export-secret/0.1`. This used to dispatch
+    /// `vta/seeds/export-mnemonic/1.0`, which exported no mnemonic and no seed
+    /// — a per-key secret export wearing the name of the thing it was migrated
+    /// from, in the wrong family, with no published spec, and gated on **global
+    /// Admin** so that wanting one key meant holding authority over every other
+    /// context in the VTA. The replacement is admin of the key's own scope.
+    ///
+    /// The response is private key material in the clear: never log it, never
+    /// cache it in a shared store, never put it in a diagnostic bundle.
     pub async fn get_key_secret(&self, key_id: &str) -> Result<GetKeySecretResponse, VtaError> {
         self.rpc_tt(
-            trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
+            trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1,
             serde_json::to_value(crate::protocols::key_management::secret::GetKeySecretBody {
                 key_id: key_id.to_string(),
             })?,

--- a/vta-sdk/src/client/secrets.rs
+++ b/vta-sdk/src/client/secrets.rs
@@ -1,7 +1,6 @@
 //! Convenience methods for paginating + bundling key secrets via [`VtaClient`].
 
 use super::VtaClient;
-use crate::did_secrets::select_secret_kid;
 use crate::error::VtaError;
 
 impl VtaClient {
@@ -61,96 +60,20 @@ impl VtaClient {
     ///   which secrets belong to the DID. It now lives on one side.
     /// - A bundle assembled from N independent answers has no single point at
     ///   which the VTA decided to release it — nothing to audit, and nothing a
-    ///   future "this key may not leave" rule could hook.
-    ///
-    /// # Falling back
-    ///
-    /// A VTA older than the task answers `unsupportedType`, and this falls back
-    /// to the old walk so a service can be upgraded before the VTA it talks to
-    /// is. The fallback is temporary: it is the last caller of
-    /// `seeds/export-mnemonic`, which goes when it does.
+    ///   future "this key may not leave" rule could hook — which
+    ///   `keys/set-exportability` now is.
     pub async fn fetch_did_secrets_bundle(
         &self,
         context_id: &str,
     ) -> Result<crate::did_secrets::DidSecretsBundle, VtaError> {
-        match self
-            .rpc_tt::<crate::protocols::context_management::secrets::ContextSecretsResultBody>(
+        let body: crate::protocols::context_management::secrets::ContextSecretsResultBody = self
+            .rpc_tt(
                 crate::trust_tasks::TASK_CONTEXTS_SECRETS_1_0,
                 serde_json::json!({ "id": context_id }),
                 30,
             )
-            .await
-        {
-            Ok(body) => return Ok(body.into()),
-            Err(VtaError::UnsupportedTaskType { .. }) => {
-                tracing::warn!(
-                    context = %context_id,
-                    "this VTA does not serve vta/contexts/secrets/1.0; falling back to the                      per-key export, which requires global Admin. Upgrade the VTA to drop                      that requirement — the fallback is removed when seeds/export-mnemonic is."
-                );
-            }
-            Err(e) => return Err(e),
-        }
-        self.fetch_did_secrets_bundle_per_key(context_id).await
-    }
-
-    /// The pre-`vta/contexts/secrets/1.0` walk. See the fallback note on
-    /// [`Self::fetch_did_secrets_bundle`]; removed with
-    /// `seeds/export-mnemonic`.
-    async fn fetch_did_secrets_bundle_per_key(
-        &self,
-        context_id: &str,
-    ) -> Result<crate::did_secrets::DidSecretsBundle, VtaError> {
-        let ctx = self.get_context(context_id).await?;
-        let did = ctx.did.ok_or_else(|| {
-            VtaError::Validation(format!("context '{context_id}' has no DID assigned"))
-        })?;
-
-        let page_size = 100u64;
-        let mut offset = 0u64;
-        let mut secrets = Vec::new();
-
-        loop {
-            let resp = self
-                .list_keys(offset, page_size, Some("active"), Some(context_id))
-                .await?;
-            if resp.keys.is_empty() {
-                break;
-            }
-            for key in &resp.keys {
-                let secret_resp = self.get_key_secret(&key.key_id).await?;
-                let entry = crate::did_secrets::SecretEntry::from(secret_resp);
-                // The kid a mediator matches inbound JWE recipients against MUST be
-                // a verification-method id of *this* context's DID. Resolve it from
-                // the authoritative store key_id (falling back to the label only
-                // when the label is itself a VM id), and drop anything that isn't a
-                // VM id of `did` — see [`select_secret_kid`].
-                match select_secret_kid(&did, &entry.key_id, key.label.as_deref()) {
-                    Some(kid) => secrets.push(crate::did_secrets::SecretEntry {
-                        key_id: kid,
-                        ..entry
-                    }),
-                    None => {
-                        tracing::warn!(
-                            context = %context_id,
-                            did = %did,
-                            key_id = %entry.key_id,
-                            label = key.label.as_deref().unwrap_or(""),
-                            "excluding secret from did-secrets bundle: not a verification \
-                             method of the context DID (e.g. an admin did:key minted into \
-                             this context, or a free-text-labelled key). Including it would \
-                             corrupt the DIDComm operating-secret set and break the \
-                             mediator's exact-match recipient lookup."
-                        );
-                    }
-                }
-            }
-            offset += resp.keys.len() as u64;
-            if offset >= resp.total {
-                break;
-            }
-        }
-
-        Ok(crate::did_secrets::DidSecretsBundle { did, secrets })
+            .await?;
+        Ok(body.into())
     }
 }
 
@@ -225,77 +148,39 @@ mod tests {
         );
     }
 
-    /// A VTA older than the task must not become a hard failure: a service has
-    /// to be upgradable before the VTA it talks to is.
+    /// One route, and no second one to drift. The fallback that used to sit
+    /// here existed so a service could be upgraded before the VTA it talked to
+    /// was; that gap has been closed by deployment, and keeping a second path
+    /// to the same bundle would keep `seeds/export-mnemonic` alive to serve it.
     #[tokio::test]
-    async fn an_old_vta_falls_back_to_the_per_key_walk() {
+    async fn an_old_vta_is_a_clear_failure_not_a_silent_downgrade() {
         let (client, sink) = client_of(|uri| {
-            if uri == crate::trust_tasks::TASK_CONTEXTS_SECRETS_1_0 {
-                return Err(VtaError::UnsupportedTaskType {
-                    type_uri: uri.to_string(),
-                    served_versions: Vec::new(),
-                });
-            }
-            if uri == crate::trust_tasks::TASK_CONTEXTS_GET_1_0 {
-                return Ok(json!({ "id": "rooms/host-1", "name": "Host", "did": DID,
-                                  "basePath": "m/0", "createdAt": "2026-01-01T00:00:00Z",
-                                  "updatedAt": "2026-01-01T00:00:00Z" }));
-            }
-            if uri == crate::trust_tasks::TASK_KEYS_LIST_0_1 {
-                return Ok(json!({
-                    "keys": [ { "keyId": format!("{DID}#key-0"), "keyType": "ed25519",
-                                "status": "active", "publicKey": "zPub",
-                                "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-01T00:00:00Z",
-                                "origin": "derived", "derivationPath": "m/0" } ],
-                    "total": 1
-                }));
-            }
-            if uri == crate::trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0 {
-                // Serialised from the real response type rather than written by
-                // hand: a hand-written fixture drifts silently when a member is
-                // added, and passes for the wrong reason.
-                return Ok(serde_json::to_value(
-                    crate::protocols::key_management::secret::GetKeySecretResultBody {
-                        key_id: format!("{DID}#key-0"),
-                        key_type: crate::keys::KeyType::Ed25519,
-                        public_key_multibase: "zPub".into(),
-                        private_key_multibase: "zSigning".into(),
-                    },
-                )
-                .expect("the secret response serialises"));
-            }
-            panic!("unexpected task: {uri}")
+            Err(VtaError::UnsupportedTaskType {
+                type_uri: uri.to_string(),
+                served_versions: Vec::new(),
+            })
         });
 
-        let bundle = client
+        let err = client
             .fetch_did_secrets_bundle("rooms/host-1")
             .await
-            .expect("the old walk still assembles a bundle");
-
-        assert_eq!(bundle.did, DID);
-        assert_eq!(bundle.secrets.len(), 1);
-        assert_eq!(bundle.secrets[0].key_id, format!("{DID}#key-0"));
-
-        let seen = sink.seen.lock().expect("not poisoned").clone();
-        assert_eq!(
-            seen.first().map(String::as_str),
-            Some(crate::trust_tasks::TASK_CONTEXTS_SECRETS_1_0),
-            "the new task must be tried first, so an upgraded VTA never takes the old path"
-        );
+            .expect_err("a VTA that does not serve the task cannot answer");
         assert!(
-            seen.iter()
-                .any(|u| u == crate::trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0),
-            "the fallback is the last caller of seeds/export-mnemonic — when this \
-             assertion has nothing to find, the fallback and that task can both go"
+            matches!(err, VtaError::UnsupportedTaskType { .. }),
+            "the refusal must say which task is missing, so the fix is 'upgrade the VTA' \
+             rather than a puzzle; got {err:?}"
+        );
+        assert_eq!(
+            sink.seen.lock().expect("not poisoned").len(),
+            1,
+            "one attempt: no per-key walk to fall back to"
         );
     }
 
-    /// Any other error is the caller's to see. Falling back on, say, a
-    /// permission refusal would turn one clear error into a second, more
-    /// confusing one from a path the caller is even less entitled to.
+    /// A refusal surfaces as itself. There is nothing to retry it against, and
+    /// nothing that could turn a permission error into a different one.
     #[tokio::test]
-    async fn a_non_version_error_does_not_fall_back() {
+    async fn a_refusal_surfaces_as_itself() {
         let (client, sink) = client_of(|_| Err(VtaError::Forbidden("no access".into())));
 
         let err = client
@@ -306,7 +191,7 @@ mod tests {
         assert_eq!(
             sink.seen.lock().expect("not poisoned").len(),
             1,
-            "one attempt, no fallback"
+            "one attempt"
         );
     }
 }

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -199,6 +199,13 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // what makes a blind retry safe — a producer that retried a lost `false`
     // must land on `false`, never toggle back to `true`.
     (trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1, RetrySafe),
+    // `ReadOnly`, for the same reason as `vta/contexts/secrets` above: it reads
+    // one key and changes nothing, so it needs no dedup record and therefore
+    // parks no secret in one. The URI it replaces was classified `KeyedSecret`
+    // on the stated grounds that "the export guard is one-shot" — there was no
+    // guard, and there never had been. The name said mnemonic, the comment said
+    // guard, and the code did neither.
+    (trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1, ReadOnly),
     // Signing is a pure function of key + payload; the same request signs the
     // same bytes. No durable effect beyond the audit row.
     (trust_tasks::TASK_KEYS_SIGN_0_1, ReadOnly),
@@ -212,18 +219,14 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     // Rotation re-parents the key hierarchy. A second rotation on a lost reply
     // rotates again, past the seed the caller thinks it landed on.
     (trust_tasks::TASK_SEEDS_ROTATE_1_0, Keyed),
-    // Response is the mnemonic itself, and the export guard is one-shot.
-    (trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0, KeyedSecret),
     // `ReadOnly` even though the response carries private keys, and the
-    // distinction is worth stating because `export-mnemonic` above looks like
-    // the same task and is not. That one is `KeyedSecret` because its export
-    // guard is **one-shot** — a second call is not a second read, it is a
-    // second consumption of a guard — so it needs dedup, and `KeyedSecret` is
-    // how a task that needs dedup avoids parking a secret in the dedup store.
-    // This task has no guard: it is `sideEffects: none`, and a second call
+    // reasoning is worth keeping because it is not the obvious answer.
+    // `KeyedSecret` exists for a task that needs dedup *and* returns a secret,
+    // so that the dedup store never becomes a second place secrets live. This
+    // task needs no dedup at all: `sideEffects: none`, and a second call
     // returns the same bundle. `ReadOnly` therefore takes the dedup path out
     // altogether (`idempotency.rs` early-returns unless `needs_key()`), so no
-    // response body is stored at all — the same protection, reached by the
+    // response body is stored — the same protection, reached by the
     // classification actually being true rather than by a stronger one.
     (trust_tasks::TASK_CONTEXTS_SECRETS_1_0, ReadOnly),
     // ── Audit ───────────────────────────────────────────────────────────

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -434,6 +434,28 @@ pub const TASK_KEYS_REVOKE_0_1: &str = "https://trusttasks.org/spec/keys/revoke/
 pub const TASK_KEYS_SET_EXPORTABILITY_0_1: &str =
     "https://trusttasks.org/spec/keys/set-exportability/0.1";
 
+/// `spec/keys/export-secret/0.1` — release the private half of one named key.
+///
+/// The honest name for what `vta/seeds/export-mnemonic/1.0` actually did, in
+/// the family it belongs to. That URI exports no mnemonic and no seed: it is a
+/// per-key secret export that kept the name of the thing it was migrated from,
+/// and it had no published spec at all.
+///
+/// Auth: admin of the key's own scope — not the global Admin the old URI
+/// demanded, which gave a caller wanting one key authority over every other
+/// context in the VTA.
+///
+/// Two refusals hold regardless of authority, and are the reason this belongs
+/// in the `keys` family: an internal key is never released to anyone, and a key
+/// marked non-exportable ([`TASK_KEYS_SET_EXPORTABILITY_0_1`]) is refused about
+/// the *key* rather than the asker.
+///
+/// Payload: [`crate::protocols::key_management::secret::GetKeySecretBody`].
+/// Returns
+/// [`crate::protocols::key_management::secret::GetKeySecretResultBody`] —
+/// private key material in the clear, so never log or cache the response.
+pub const TASK_KEYS_EXPORT_SECRET_0_1: &str = "https://trusttasks.org/spec/keys/export-secret/0.1";
+
 /// `spec/vta/keys/sign/1.0` — sign a base64url-encoded payload with a
 /// stored key (raw-bytes signing oracle).
 /// Payload: [`crate::protocols::key_management::sign::SignRequestBody`].
@@ -470,15 +492,6 @@ pub const TASK_SEEDS_LIST_1_0: &str = "https://trusttasks.org/spec/vta/seeds/lis
 /// Payload: [`crate::protocols::seed_management::rotate::RotateSeedBody`].
 /// Auth: Admin.
 pub const TASK_SEEDS_ROTATE_1_0: &str = "https://trusttasks.org/spec/vta/seeds/rotate/1.0";
-
-/// `spec/vta/seeds/export-mnemonic/1.0` — one-shot BIP-39 mnemonic
-/// export under `MnemonicExportGuard`. Was `/keys/{id}/secret` in
-/// the legacy REST surface — relocated to the seeds slice because it
-/// operates on the seed identifier, not an individual key.
-/// Payload: [`crate::protocols::key_management::secret::GetKeySecretBody`].
-/// Auth: Admin only. Zeroized on drop.
-pub const TASK_SEEDS_EXPORT_MNEMONIC_1_0: &str =
-    "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0";
 
 // ─── Services slice (spec/vta/services/*) ────────────────────────────────
 //
@@ -1887,13 +1900,13 @@ pub const ALL_URIS: &[&str] = &[
     TASK_KEYS_RENAME_0_1,
     TASK_KEYS_REVOKE_0_1,
     TASK_KEYS_SET_EXPORTABILITY_0_1,
+    TASK_KEYS_EXPORT_SECRET_0_1,
     TASK_KEYS_SIGN_0_1,
     TASK_KEYS_DERIVE_AND_SIGN_0_1,
     TASK_KEYS_DERIVE_AND_SIGN_DOCUMENT_0_1,
     // Seeds slice
     TASK_SEEDS_LIST_1_0,
     TASK_SEEDS_ROTATE_1_0,
-    TASK_SEEDS_EXPORT_MNEMONIC_1_0,
     // Services slice
     TASK_SERVICES_LIST_1_0,
     TASK_SERVICES_GET_1_0,

--- a/vta-sdk/tests/client_rest.rs
+++ b/vta-sdk/tests/client_rest.rs
@@ -36,8 +36,7 @@ const TASK_KEYS_LIST: &str = "https://trusttasks.org/spec/keys/list/0.1";
 const TASK_AUDIT_LIST: &str = "https://trusttasks.org/spec/audit/list/0.1";
 /// `get_key_secret` dispatches this: the operation moved to the seeds slice
 /// because it acts on the seed behind the key, not the key itself.
-const TASK_SEEDS_EXPORT_MNEMONIC: &str =
-    "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0";
+const TASK_KEYS_EXPORT_SECRET: &str = "https://trusttasks.org/spec/keys/export-secret/0.1";
 const TASK_WEBVH_DIDS_LIST: &str = "https://trusttasks.org/spec/vta/webvh/dids/list/1.0";
 
 /// A success response document carrying `payload`.
@@ -1996,9 +1995,7 @@ async fn fetch_context_secrets_walks_all_pages() {
     Mock::given(method("POST"))
         .and(path("/trust-tasks"))
         .and(auth_match())
-        .and(body_partial_json(
-            json!({"type": TASK_SEEDS_EXPORT_MNEMONIC}),
-        ))
+        .and(body_partial_json(json!({"type": TASK_KEYS_EXPORT_SECRET})))
         .respond_with(
             tt_ok(json!({
                 "key_id": "k",

--- a/vta-service/src/deprecation.rs
+++ b/vta-service/src/deprecation.rs
@@ -307,7 +307,7 @@ const SUPERSEDED: &[(&str, &str, &str, &str)] = &[
         "GET",
         "/keys/{key_id}/secret",
         "GET /keys/{key_id}/secret",
-        trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0,
+        trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1,
     ),
     (
         "POST",

--- a/vta-service/src/trust_tasks/conformance.rs
+++ b/vta-service/src/trust_tasks/conformance.rs
@@ -157,6 +157,7 @@ use vta_sdk::protocols::key_management::import::ImportKeyBody;
 use vta_sdk::protocols::key_management::list::{ListKeysBody, ListKeysResultBody};
 use vta_sdk::protocols::key_management::rename::{RenameKeyBody, RenameKeyResultBody};
 use vta_sdk::protocols::key_management::revoke::{RevokeKeyBody, RevokeKeyResultBody};
+use vta_sdk::protocols::key_management::secret::{GetKeySecretBody, GetKeySecretResultBody};
 use vta_sdk::protocols::key_management::set_exportability::{
     SetKeyExportabilityBody, SetKeyExportabilityResultBody,
 };
@@ -1054,6 +1055,27 @@ fn table() -> Vec<(&'static str, Conformance)> {
                     key_id: "app-signing-key".into(),
                     status: KeyStatus::Revoked,
                     updated_at: dt(),
+                })
+            ),
+        ),
+        (
+            uris::TASK_KEYS_EXPORT_SECRET_0_1,
+            checked!(
+                specs::keys::export_secret::v0_1::Payload,
+                specs::keys::export_secret::v0_1::Response,
+                to_v(GetKeySecretBody {
+                    key_id: "app-signing-key".into(),
+                }),
+                // Serialised from the type the service answers with. The
+                // response is a private key, so what this pins is that the
+                // shape carrying one matches the published schema exactly —
+                // there is no second chance to notice a drift here, because
+                // nothing downstream inspects a key it failed to parse.
+                to_v(GetKeySecretResultBody {
+                    key_id: "app-signing-key".into(),
+                    key_type: vta_sdk::keys::KeyType::Ed25519,
+                    public_key_multibase: "zPub".into(),
+                    private_key_multibase: "zPriv".into(),
                 })
             ),
         ),

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -17,6 +17,7 @@ use vta_sdk::protocols::key_management::import::{ImportKeyBody, ImportKeyRespons
 use vta_sdk::protocols::key_management::list::ListKeysBody;
 use vta_sdk::protocols::key_management::rename::RenameKeyBody;
 use vta_sdk::protocols::key_management::revoke::RevokeKeyBody;
+use vta_sdk::protocols::key_management::secret::GetKeySecretBody;
 use vta_sdk::protocols::key_management::sign::SignRequestBody;
 
 use crate::auth::AuthClaims;
@@ -218,6 +219,47 @@ pub(super) async fn handle_set_exportability(
                 key,
             },
         ),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
+/// Handler for `keys/export-secret/0.1`.
+///
+/// Admin **of the key's own scope**: `require_admin` is the role floor and
+/// `get_key_secret`'s own `require_context` is the scope, so an admin of one
+/// context reaches no other context's keys. The URI this replaces
+/// (`vta/seeds/export-mnemonic/1.0`) demanded global Admin for the same act,
+/// which handed a caller wanting one key authority over everything else.
+///
+/// The two refusals the spec makes consumer requirements — an internal key is
+/// never released, and a non-exportable key is refused about the key rather
+/// than the asker — are both enforced inside `get_key_secret`, which is the one
+/// place a private key leaves. Re-checking them here would be a second set of
+/// rules to keep in step.
+pub(super) async fn handle_export_secret(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    let req: GetKeySecretBody = match parse_payload(&doc) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    match operations::keys::get_key_secret(
+        &state.keys_ks,
+        &state.imported_ks,
+        &state.seed_store,
+        &state.audit_sink,
+        auth,
+        &req.key_id,
+        TRANSPORT_TRUST_TASK,
+    )
+    .await
+    {
+        Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, e),
     }
 }

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -246,7 +246,6 @@ const UNSPECCED_DISPATCHED_URIS: &[&str] = &[
     // ─ vta/seeds/* — keep-and-spec under `vta/` (reduction plan §E).
     "https://trusttasks.org/spec/vta/seeds/list/1.0",
     "https://trusttasks.org/spec/vta/seeds/rotate/1.0",
-    "https://trusttasks.org/spec/vta/seeds/export-mnemonic/1.0",
     // ─ vta/audit retention pair — candidate `audit/retention/{show,update}`.
     "https://trusttasks.org/spec/vta/audit/get-retention/1.0",
     "https://trusttasks.org/spec/vta/audit/update-retention/1.0",
@@ -1709,6 +1708,11 @@ dispatch_table! {
     // one.
     vta_sdk::trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1 => keys::handle_set_exportability
         [ Mutating Metadata false ],
+    // `None Secret false`: it reads existing material and changes nothing, and
+    // what it discloses is a private key. Same classification as
+    // `vta/contexts/secrets`, for the same reason — the act is disclosure.
+    vta_sdk::trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1 => keys::handle_export_secret
+        [ None Secret false ],
     vta_sdk::trust_tasks::TASK_KEYS_SIGN_0_1 => keys::handle_sign
         [ None None true ],
     vta_sdk::trust_tasks::TASK_KEYS_DERIVE_AND_SIGN_0_1 => keys::handle_derive_and_sign
@@ -1720,8 +1724,6 @@ dispatch_table! {
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_SEEDS_ROTATE_1_0 => seeds::handle_rotate
         [ Destructive None false ],
-    vta_sdk::trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0 => seeds::handle_export_mnemonic
-        [ None Secret false ],
     // ─── Audit slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_AUDIT_LIST_0_1 => audit::handle_list_logs
         [ None Metadata false ],
@@ -2323,12 +2325,17 @@ mod tests {
             "proxy-login acts as the subject"
         );
 
-        let seed = class_for(vta_sdk::trust_tasks::TASK_SEEDS_EXPORT_MNEMONIC_1_0)
-            .expect("seed export is classified");
+        let export = class_for(vta_sdk::trust_tasks::TASK_KEYS_EXPORT_SECRET_0_1)
+            .expect("key export is classified");
         assert_eq!(
-            seed.exposure.discloses,
+            export.exposure.discloses,
             Discloses::Secret,
-            "exporting the mnemonic discloses a secret"
+            "releasing a key's private half discloses a secret"
+        );
+        assert_eq!(
+            export.side_effects,
+            SideEffectLevel::None,
+            "it reads one key and changes nothing — the act is disclosure, not mutation"
         );
 
         assert!(

--- a/vta-service/src/trust_tasks/seeds.rs
+++ b/vta-service/src/trust_tasks/seeds.rs
@@ -1,12 +1,15 @@
 //! Seeds slice trust-task handlers.
 //!
-//! Auth: Admin for list/rotate; Admin for export-mnemonic (one-shot
-//! mnemonic dump under `MnemonicExportGuard`).
+//! Auth: Admin for list/rotate.
+//!
+//! The per-key secret export that used to live here has moved to
+//! `keys/export-secret/0.1`, in the family it belongs to. It was never a
+//! mnemonic or a seed export — no task in this slice releases either, and seed
+//! material leaves only through `vta/backup/*`.
 
 use super::helpers::TrustTaskOutcome;
 use serde_json::Value;
 use trust_tasks_rs::TrustTask;
-use vta_sdk::protocols::key_management::secret::GetKeySecretBody;
 use vta_sdk::protocols::seed_management::list::ListSeedsBody;
 use vta_sdk::protocols::seed_management::rotate::RotateSeedBody;
 
@@ -55,37 +58,6 @@ pub(super) async fn handle_rotate(
         &state.audit_sink,
         &auth.did,
         req.mnemonic.as_deref(),
-        TRANSPORT_TRUST_TASK,
-    )
-    .await
-    {
-        Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, e),
-    }
-}
-
-/// Handler for `spec/vta/seeds/export-mnemonic/1.0`. Admin only.
-/// One-shot mnemonic export under `MnemonicExportGuard`; the returned
-/// payload zeroizes on drop.
-pub(super) async fn handle_export_mnemonic(
-    state: &AppState,
-    auth: &AuthClaims,
-    doc: TrustTask<Value>,
-) -> TrustTaskOutcome {
-    if let Err(e) = auth.require_admin() {
-        return app_error_to_reject(&doc, e);
-    }
-    let req: GetKeySecretBody = match parse_payload(&doc) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-    match operations::keys::get_key_secret(
-        &state.keys_ks,
-        &state.imported_ks,
-        &state.seed_store,
-        &state.audit_sink,
-        auth,
-        &req.key_id,
         TRANSPORT_TRUST_TASK,
     )
     .await

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -463,7 +463,7 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     // 77.
     (
         "https://trusttasks.org/spec/vta/",
-        7,
+        6,
         "VTA Trust Task surface at 1.0 — predates the registry and was never reconciled with it. \
          Down from 55 via #840 phase A: config/{get,update} onto config/{show,patch}, \
          provision-integration/request onto provision/integration/0.2, acl/* onto the \
@@ -501,10 +501,17 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
          dtgwg-trust-tasks-tf#347 and served here by the move to trust-tasks-rs 0.17.7 — the \
          same mechanism as the 22 above it, and the same move retired all six from \
          UNSPECCED_DISPATCHED_URIS into real conformance witnesses. What is left is the seeds \
-         and attestation families and the vault secrets lifecycle. `vta/seeds/*` is the one \
-         entry here that should never leave by the first route: it returns key material, the \
-         browser extension bans its URIs from every bundle it ships, and a spec would not \
-         change either fact",
+         and attestation families and the vault secrets lifecycle. 7 -> 6 is a third \
+         mechanism, and worth telling apart from the two above it. \
+         `vta/seeds/export-mnemonic/1.0` neither gained a spec at this authority nor was \
+         simply deleted: the operation MOVED to `keys/export-secret/0.1` on the canonical \
+         authority, specified upstream as dtgwg-trust-tasks-tf#446, and the `vta/` URI was \
+         retired behind it. That is the right route for this one precisely because the note \
+         below is right — a `vta/seeds/*` URI returning key material should never gain a spec \
+         under that name. It exported no seed and no mnemonic; it was a per-key secret export \
+         wearing the name of what it was migrated from, and moving it to the keys family is \
+         what let it be specified honestly. The `vta/seeds/*` entries that remain are \
+         list and rotate, and the note still holds for them",
     ),
 ];
 


### PR DESCRIPTION
`keys/export-secret/0.1` (trustoverip/dtgwg-trust-tasks-tf#446, in
trust-tasks-rs 0.20.3) replaces `vta/seeds/export-mnemonic/1.0`.

## What the old URI was

It exported no mnemonic and no seed. It was a per-key secret export that kept
the name of the thing it was migrated from (`GET /keys/{key_id}/secret`), in the
seeds family rather than the keys one, with **no published spec at all**, gated
on **global Admin** — so a caller wanting one key needed authority over every
other context in the VTA.

Three operator commands sit on it and keep working, because they go through
`VtaClient::get_key_secret`, which is the seam: `keys get --secret`,
`keys secrets`, and the contexts DID-export flow. `keys bundle` already moved to
`vta/contexts/secrets` in #1400.

## Two things that were never true

Retiring it meant reading what it actually did, and two long-standing
descriptions turned out to describe nothing:

- Its retry-safety entry was `KeyedSecret` "because the export guard is
  one-shot". There is no guard in `get_key_secret` and there never was. The
  replacement is `ReadOnly` — true, and it keeps the response out of the dedup
  store by taking that path out entirely rather than by carrying a stronger
  label.
- The handler's doc claimed "one-shot mnemonic export under
  `MnemonicExportGuard`; the returned payload zeroizes on drop", none of which
  was in the function it sat on.

The name said mnemonic, the comment said guard, the code did neither.

## Authority

`require_admin` for the role floor and `get_key_secret`'s own `require_context`
for the scope: admin **of the key's own context**, not of everything. The two
refusals the spec makes consumer requirements — an internal key is never
released, a non-exportable key is refused about the key rather than the asker —
are already enforced inside `get_key_secret`, which is the single place a
private key leaves. Re-checking them in the handler would be a second set of
rules to keep in step.

## The SDK fallback goes too

`fetch_did_secrets_bundle` no longer falls back to the per-key walk. That
fallback existed so a service could be upgraded before the VTA it talks to; a
VTA carrying #1400 is deployed, so the gap it bridged is closed. It was also the
last caller keeping the old URI alive. An older VTA is now a clear
`UnsupportedTaskType` naming the missing task — "upgrade the VTA" rather than a
puzzle — and there is one route to a bundle instead of two that could drift.

Retired here: the handler, the dispatch entry, the const, its
`UNSPECCED_DISPATCHED_URIS` row (the allowlist shrinks, which is the direction it
is supposed to move), and the deprecation-registry row for
`GET /keys/{key_id}/secret`, which now points at the new URI so the legacy REST
route still names its replacement.

Ledgers: published spec, retry safety, the MCP risk census (`Sensitive`, renamed
in place), and a conformance witness serialised from the response type.
The plugin's task-surface snapshot moved in OpenVTC/vta-browser-plugin#227.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>