### PR TITLE
security(auth): stop the challenge endpoint disclosing enrolment

### DIFF
--- a/vtc-service/tests/auth_acl_roles.rs
+++ b/vtc-service/tests/auth_acl_roles.rs
@@ -1,13 +1,26 @@
 //! P0.16 — a non-admin `VtcRole` ACL row must not 500 the unauthenticated
 //! `POST /v1/auth/challenge` or leak serde internals.
 //!
-//! Before the fix, `check_acl` routed through `vti_common::acl::check_acl_full`,
-//! which deserializes the `acl:<did>` row into the VTA `Role` taxonomy and
-//! hard-errors on a VTC-only role string (`moderator`/`issuer`/`member`/
-//! `custom:*`) → `AppError::Serialization` → HTTP 500 whose body carried the
-//! serde text to an unauthenticated caller. The fix decodes the row with the
-//! VTC decoder and maps `VtcRole → Role`, returning a clean 403 for
-//! non-admin roles while the admin row still authenticates.
+//! Before the original fix, `check_acl` routed through
+//! `vti_common::acl::check_acl_full`, which deserializes the `acl:<did>` row
+//! into the VTA `Role` taxonomy and hard-errors on a VTC-only role string
+//! (`moderator`/`issuer`/`member`/`custom:*`) → `AppError::Serialization` →
+//! HTTP 500 whose body carried the serde text to an unauthenticated caller.
+//! The fix decodes the row with the VTC decoder and maps `VtcRole → Role`.
+//!
+//! # Why these tests no longer assert 403
+//!
+//! They asserted the *mechanism* the fix happened to use, not the property it
+//! protects. The property is that an unauthenticated caller learns nothing
+//! from this endpoint — no serde internals, no role name, and (since
+//! VTI-SES-007) nothing about the subject at all.
+//!
+//! A 403 for a moderator and a 200 for an admin discloses which subjects hold
+//! an admissible role here, to anyone who can name a DID. So the challenge
+//! endpoint now answers every caller identically and the refusal moves to
+//! authenticate, which requires the subject's private key. These tests assert
+//! that: the answer is the same for a non-admin row and for a DID this VTC has
+//! never seen, and it still carries none of what the original bug leaked.
 
 use reqwest::StatusCode;
 use serde_json::{Value, json};
@@ -48,7 +61,7 @@ async fn challenge(base_url: &str, did: &str) -> (StatusCode, String) {
 }
 
 #[tokio::test]
-async fn moderator_row_yields_clean_403_not_500_serde_leak() {
+async fn moderator_row_does_not_leak_at_challenge() {
     let mock = MockVtc::start().await;
     let did = "did:key:z6MkModerator";
     store_acl_entry(&mock.vtc.state.acl_ks, &entry(did, VtcRole::Moderator))
@@ -59,21 +72,57 @@ async fn moderator_row_yields_clean_403_not_500_serde_leak() {
 
     assert_eq!(
         status,
-        StatusCode::FORBIDDEN,
-        "moderator must get a clean 403, not a 500: {body}"
+        StatusCode::OK,
+        "the challenge endpoint answers every caller identically (VTI-SES-007): {body}"
     );
-    // The pre-fix bug leaked the serde error text. Make sure none of it
-    // (nor the role name) appears in the response to an unauth caller.
+    // The pre-fix bug leaked the serde error text. Neither it nor the role
+    // name may reach an unauthenticated caller by any route.
     assert!(
         !body.contains("unknown variant") && !body.contains("moderator"),
-        "challenge 403 body must not leak serde internals or the role: {body}"
+        "challenge body must not leak serde internals or the role: {body}"
+    );
+
+    mock.shutdown().await;
+}
+
+/// The property, stated directly: a subject this VTC holds a non-admin row for
+/// is indistinguishable, at this endpoint, from one it has never heard of.
+#[tokio::test]
+async fn a_non_admin_row_is_indistinguishable_from_an_unknown_subject() {
+    let mock = MockVtc::start().await;
+    let known = "did:key:z6MkModeratorTwo";
+    store_acl_entry(&mock.vtc.state.acl_ks, &entry(known, VtcRole::Moderator))
+        .await
+        .expect("seed moderator acl row");
+
+    let (known_status, known_body) = challenge(mock.base_url(), known).await;
+    let (stranger_status, stranger_body) =
+        challenge(mock.base_url(), "did:key:z6MkNeverSeenBefore").await;
+
+    assert_eq!(known_status, stranger_status);
+
+    let field_names = |body: &str| -> Vec<String> {
+        let v: Value = serde_json::from_str(body).expect("challenge body is JSON");
+        let mut keys: Vec<String> = v
+            .as_object()
+            .expect("challenge body is an object")
+            .keys()
+            .cloned()
+            .collect();
+        keys.sort();
+        keys
+    };
+    assert_eq!(
+        field_names(&known_body),
+        field_names(&stranger_body),
+        "the two answers must have the same shape: {known_body} vs {stranger_body}"
     );
 
     mock.shutdown().await;
 }
 
 #[tokio::test]
-async fn every_non_admin_vtc_role_is_cleanly_forbidden() {
+async fn no_vtc_role_leaks_at_challenge() {
     let mock = MockVtc::start().await;
     let cases = [
         ("did:key:z6MkIssuer", VtcRole::Issuer),
@@ -87,37 +136,13 @@ async fn every_non_admin_vtc_role_is_cleanly_forbidden() {
         let (status, body) = challenge(mock.base_url(), did).await;
         assert_eq!(
             status,
-            StatusCode::FORBIDDEN,
-            "{role} must yield 403, got {status}: {body}"
+            StatusCode::OK,
+            "{role} must be answered like every other caller, got {status}: {body}"
         );
         assert!(
             !body.contains("unknown variant"),
-            "{role} 403 body must not leak serde internals: {body}"
+            "{role} challenge body must not leak serde internals: {body}"
         );
     }
-    mock.shutdown().await;
-}
-
-#[tokio::test]
-async fn admin_row_still_authenticates() {
-    let mock = MockVtc::start().await;
-    let did = "did:key:z6MkAdminRow";
-    store_acl_entry(&mock.vtc.state.acl_ks, &entry(did, VtcRole::Admin))
-        .await
-        .expect("seed admin acl row");
-
-    let (status, body) = challenge(mock.base_url(), did).await;
-
-    assert_eq!(status, StatusCode::OK, "admin must authenticate: {body}");
-    let parsed: Value = serde_json::from_str(&body).expect("challenge json");
-    assert!(
-        parsed["challenge"].as_str().is_some_and(|c| !c.is_empty()),
-        "expected a challenge in the response: {body}"
-    );
-    assert!(
-        parsed["sessionId"].as_str().is_some(),
-        "expected a sessionId in the response: {body}"
-    );
-
     mock.shutdown().await;
 }

--- a/vti-common/src/auth/backend.rs
+++ b/vti-common/src/auth/backend.rs
@@ -278,6 +278,22 @@ pub trait AuthBackend: Send + Sync + 'static {
     /// before any other gate fires.
     async fn check_acl(&self, did: &str) -> Result<RoleResolution<Self::Role>, Self::Error>;
 
+    /// Whether `did` currently has an effective ACL entry.
+    ///
+    /// Used by [`crate::auth::handlers::handle_challenge`], which needs to
+    /// know whether to persist a session but **must not disclose the answer
+    /// to the caller**. Returning `bool` rather than `Result` is deliberate:
+    /// the caller cannot act on the difference between "no entry" and "the
+    /// ACL store failed", and both have to produce the same response, so a
+    /// failure reads as absent and the request gets an unusable challenge.
+    /// The real error surfaces at `/auth/authenticate`, where the caller has
+    /// already proven control of the DID.
+    ///
+    /// Default: `check_acl(did).await.is_ok()`.
+    async fn has_effective_entry(&self, did: &str) -> bool {
+        self.check_acl(did).await.is_ok()
+    }
+
     /// Optional DID-method validation gate. Default: accept any
     /// method (backends with no allowlist). VTA overrides in TEE
     /// mode to enforce `allowed_did_methods`.

--- a/vti-common/src/auth/handlers/challenge.rs
+++ b/vti-common/src/auth/handlers/challenge.rs
@@ -2,18 +2,49 @@
 //!
 //! Flow:
 //! 1. Validate DID method (backend hook, default no-op).
-//! 2. ACL gate — DID must be present + unexpired.
-//! 3. Per-DID rate limit — bounds concurrent `ChallengeSent`
-//!    sessions per DID at the backend's configured cap.
+//! 2. Resolve whether the subject has an effective ACL entry —
+//!    which decides what this handler *does*, never what it
+//!    *says*.
+//! 3. Per-DID rate limit for an enrolled subject — bounds
+//!    concurrent `ChallengeSent` sessions at the backend's cap.
 //! 4. Mint 32-byte challenge (OS RNG, hex-encoded).
 //! 5. Optional TEE attestation (backend hook, default
 //!    not-attested).
-//! 6. Persist `ChallengeSent` session with `tee_attested` set
-//!    from the attestation outcome and `amr`/`acr` empty —
-//!    populated when the session transitions to `Authenticated`
-//!    by [`super::handle_authenticate`].
-//! 7. Emit `ChallengeIssued` audit event and return canonical
-//!    `ChallengeResponse`.
+//! 6. For an enrolled subject, persist a `ChallengeSent` session
+//!    with `tee_attested` set from the attestation outcome and
+//!    `amr`/`acr` empty — populated when the session transitions
+//!    to `Authenticated` by [`super::handle_authenticate`]. For
+//!    any other subject, persist nothing.
+//! 7. Return the canonical `ChallengeResponse` either way.
+//!
+//! # Why an unenrolled subject is answered, not refused
+//!
+//! A challenge endpoint that refuses an unknown subject and
+//! answers a known one is an enumeration oracle: anyone who can
+//! guess or harvest identifiers learns which of them this node
+//! holds authority for, which is the first step in targeting the
+//! people behind them. The information is disclosed by the
+//! *shape* of the answer, so no amount of care in the error
+//! message removes it.
+//!
+//! So both subjects get a challenge, and only an enrolled one
+//! gets a session to redeem it against. The challenge issued to
+//! an unenrolled subject is unusable — `/auth/authenticate` finds
+//! no session and refuses, in the same terms it refuses every
+//! other pre-authentication failure ([`crate::error::AppError`]'s
+//! `From<AuthError>` impl). Redeeming it requires the DID's
+//! private key in any case, which a party probing identifiers it
+//! does not control never has.
+//!
+//! What this deliberately does not spend: an unenrolled subject
+//! costs one RNG draw and no write, so the endpoint cannot be
+//! used to fill the session store with identifiers nobody
+//! enrolled. The residual signal is timing — a persisted session
+//! is a store round-trip that a decoy is not — and closing that
+//! belongs with the store, not here.
+//!
+//! Implements VTI-SES-006 and VTI-SES-007 of the VTI
+//! specification (<https://trustoverip.github.io/dtgwg-vti-spec/>).
 
 use uuid::Uuid;
 use vta_sdk::protocols::auth::{ChallengeResponse, epoch_to_rfc3339};
@@ -30,10 +61,16 @@ pub async fn handle_challenge<B: AuthBackend>(
     // ---- Gates: DID method, ACL, rate limit ----
 
     backend.validate_did(&input.did).await?;
-    backend.check_acl(&input.did).await?;
 
+    // Decides what happens below, and nothing about the response. An
+    // unenrolled subject is answered exactly as an enrolled one is; see the
+    // module docs.
+    let enrolled = backend.has_effective_entry(&input.did).await;
+
+    // The rate limit counts persisted sessions, so it only bites where there
+    // are any. An unenrolled subject writes nothing to be limited.
     let limit = backend.max_pending_challenges_per_did();
-    if limit > 0 {
+    if enrolled && limit > 0 {
         let pending = backend
             .sessions()
             .count_pending_challenges(&input.did)
@@ -79,16 +116,28 @@ pub async fn handle_challenge<B: AuthBackend>(
         session_pubkey_b58btc: input.session_pubkey_b58btc,
     };
 
-    backend
-        .sessions()
-        .store_session(&session)
-        .await
-        .map_err(|e| AuthError::Internal(format!("store_session failed: {e:?}")))?;
+    if enrolled {
+        backend
+            .sessions()
+            .store_session(&session)
+            .await
+            .map_err(|e| AuthError::Internal(format!("store_session failed: {e:?}")))?;
 
-    backend.audit(AuthAuditEvent::ChallengeIssued {
-        did: &session.did,
-        session_id: &session_id,
-    });
+        backend.audit(AuthAuditEvent::ChallengeIssued {
+            did: &session.did,
+            session_id: &session_id,
+        });
+    } else {
+        // Not an audit event: nothing was granted, and an operator paging
+        // through `ChallengeIssued` rows should not find entries for
+        // subjects that hold no authority. It is a warning because a run of
+        // these is what identifier probing looks like.
+        tracing::warn!(
+            did = %session.did,
+            "auth challenge requested for a subject with no effective ACL entry — \
+             answered with an unusable challenge, nothing persisted"
+        );
+    }
 
     Ok(ChallengeResponse {
         challenge,
@@ -96,4 +145,202 @@ pub async fn handle_challenge<B: AuthBackend>(
         expires_at: epoch_to_rfc3339(created_at.saturating_add(backend.challenge_ttl())),
         tee_attestation: attestation.report,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::backend::{RoleResolution, SessionStore};
+    use crate::error::AppError;
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+
+    /// Records what was written so a test can assert that nothing was.
+    #[derive(Default)]
+    struct RecordingStore {
+        stored: Mutex<Vec<Session>>,
+    }
+
+    #[async_trait]
+    impl SessionStore for RecordingStore {
+        type Error = AppError;
+        async fn store_session(&self, s: &Session) -> Result<(), AppError> {
+            self.stored.lock().unwrap().push(s.clone());
+            Ok(())
+        }
+        async fn get_session(&self, _: &str) -> Result<Option<Session>, AppError> {
+            Ok(None)
+        }
+        async fn delete_session(&self, _: &str) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn store_refresh_index(&self, _: &str, _: &str) -> Result<(), AppError> {
+            unreachable!()
+        }
+        async fn take_session_id_by_refresh(&self, _: &str) -> Result<Option<String>, AppError> {
+            unreachable!()
+        }
+        async fn count_pending_challenges(&self, _: &str) -> Result<usize, AppError> {
+            Ok(0)
+        }
+    }
+
+    /// `Acl::Present` enrols the subject; `Absent` has no entry for it;
+    /// `Broken` fails the way a store outage does.
+    #[derive(Clone, Copy)]
+    enum Acl {
+        Present,
+        Absent,
+        Broken,
+    }
+
+    struct MockBackend {
+        store: RecordingStore,
+        acl: Acl,
+        audited: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl AuthBackend for MockBackend {
+        type Store = RecordingStore;
+        type Error = AppError;
+        type Role = String;
+
+        fn sessions(&self) -> &RecordingStore {
+            &self.store
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn mint_access_token(
+            &self,
+            _subject: &str,
+            _session_id: &str,
+            _role: &String,
+            _contexts: &[String],
+            _amr: &[String],
+            _acr: &str,
+            _tee_attested: bool,
+            _ttl_secs: u64,
+            _jti: &str,
+        ) -> Result<String, AppError> {
+            unreachable!("challenge never mints a token")
+        }
+
+        async fn check_acl(&self, _did: &str) -> Result<RoleResolution<String>, AppError> {
+            match self.acl {
+                Acl::Present => Ok(RoleResolution {
+                    role: "reader".to_string(),
+                    contexts: vec![],
+                }),
+                Acl::Absent => Err(AuthError::Forbidden.into()),
+                Acl::Broken => Err(AppError::Internal("acl keyspace unavailable".into())),
+            }
+        }
+
+        fn challenge_ttl(&self) -> u64 {
+            60
+        }
+        fn access_token_ttl(&self) -> u64 {
+            900
+        }
+        fn refresh_token_ttl(&self) -> u64 {
+            86_400
+        }
+
+        fn audit(&self, event: AuthAuditEvent<'_>) {
+            if let AuthAuditEvent::ChallengeIssued { did, .. } = event {
+                self.audited.lock().unwrap().push(did.to_string());
+            }
+        }
+    }
+
+    fn backend(acl: Acl) -> MockBackend {
+        MockBackend {
+            store: RecordingStore::default(),
+            acl,
+            audited: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn input(did: &str) -> ChallengeInput {
+        ChallengeInput {
+            did: did.to_string(),
+            session_pubkey_b58btc: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn an_enrolled_subject_gets_a_persisted_session() {
+        let b = backend(Acl::Present);
+        let resp = handle_challenge(&b, input("did:key:zEnrolled"))
+            .await
+            .unwrap();
+
+        assert_eq!(b.store.stored.lock().unwrap().len(), 1);
+        assert_eq!(b.audited.lock().unwrap().as_slice(), ["did:key:zEnrolled"]);
+        assert_eq!(resp.challenge.len(), 64, "32 bytes, hex-encoded");
+    }
+
+    /// VTI-SES-007. The response must not distinguish a subject this node
+    /// holds authority for from one it has never heard of.
+    #[tokio::test]
+    async fn an_unenrolled_subject_gets_a_challenge_and_nothing_is_persisted() {
+        let b = backend(Acl::Absent);
+        let resp = handle_challenge(&b, input("did:key:zStranger"))
+            .await
+            .expect("an unenrolled subject is answered, not refused");
+
+        assert!(
+            b.store.stored.lock().unwrap().is_empty(),
+            "a subject with no entry must not be able to fill the session store"
+        );
+        assert!(
+            b.audited.lock().unwrap().is_empty(),
+            "nothing was granted, so nothing belongs in the challenge-issued trail"
+        );
+        assert_eq!(resp.challenge.len(), 64);
+    }
+
+    /// The property is about the *shape* of the answer, so assert on the
+    /// shape rather than on either branch's internals.
+    #[tokio::test]
+    async fn the_two_answers_are_indistinguishable() {
+        let enrolled = handle_challenge(&backend(Acl::Present), input("did:key:zEnrolled"))
+            .await
+            .unwrap();
+        let stranger = handle_challenge(&backend(Acl::Absent), input("did:key:zStranger"))
+            .await
+            .unwrap();
+
+        assert_eq!(enrolled.challenge.len(), stranger.challenge.len());
+        assert_eq!(
+            enrolled.session_id.len(),
+            stranger.session_id.len(),
+            "both are UUIDs"
+        );
+        assert_eq!(
+            enrolled.tee_attestation.is_some(),
+            stranger.tee_attestation.is_some(),
+            "attestation is performed for both, or the answer says which is which"
+        );
+        assert!(!enrolled.expires_at.is_empty() && !stranger.expires_at.is_empty());
+        assert_ne!(
+            enrolled.challenge, stranger.challenge,
+            "each challenge is freshly minted"
+        );
+    }
+
+    /// A store outage must not become an oracle either: it reads as absent,
+    /// and the real error surfaces at authenticate, where the caller has
+    /// already proven control of the DID.
+    #[tokio::test]
+    async fn a_broken_acl_store_does_not_disclose_itself() {
+        let b = backend(Acl::Broken);
+        let resp = handle_challenge(&b, input("did:key:zEnrolled"))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.challenge.len(), 64);
+        assert!(b.store.stored.lock().unwrap().is_empty());
+    }
 }

--- a/vti-common/src/error.rs
+++ b/vti-common/src/error.rs
@@ -195,6 +195,14 @@ impl From<crate::auth::backend::AuthError> for AppError {
         match e {
             A::Forbidden | A::DidMethodRejected => AppError::Forbidden(e.to_string()),
             A::PendingChallengeLimitReached => AppError::Validation(e.to_string()),
+            // One message for every failure reachable *without* the
+            // subject's private key. These variants differ in ways a caller
+            // must not be able to observe: "session not found" versus
+            // "signer mismatch" tells a party probing identifiers whether
+            // the subject it named is enrolled here, which is precisely what
+            // `handle_challenge` stops disclosing at the other end of the
+            // flow. The variant is preserved for the log line; the caller is
+            // told that authentication failed.
             A::SessionNotFound
             | A::SessionStateMismatch
             | A::ChallengeMismatch
@@ -202,7 +210,10 @@ impl From<crate::auth::backend::AuthError> for AppError {
             | A::SignerMismatch
             | A::StaleMessage
             | A::RefreshTokenInvalid
-            | A::RefreshTokenExpired => AppError::Authentication(e.to_string()),
+            | A::RefreshTokenExpired => {
+                tracing::debug!(reason = %e, "authentication failed");
+                AppError::Authentication("authentication failed".into())
+            }
             A::AttestationFailed(msg) => AppError::Internal(format!("tee attestation: {msg}")),
             A::Internal(msg) => AppError::Internal(msg),
         }


### PR DESCRIPTION
First of the code fixes from the [VTI specification gap analysis](https://trustoverip.github.io/dtgwg-vti-spec/). Implements **VTI-SES-006** and **VTI-SES-007**.

## The defect

`/auth/challenge` resolved the caller's ACL entry and refused when there was none. A request naming an enrolled subject was answered; one naming an unknown subject was refused. So anyone able to guess or harvest identifiers could ask this node **which of them it holds authority for** — the first step in targeting the people behind them.

The disclosure is in the *shape* of the answer, which is why the existing doc comment on `AuthError::Forbidden` — "returned as 403 Forbidden to avoid revealing whether the DID exists in the ACL system at all" — does not achieve it. That comment makes *not in ACL* and *wrong DID method* indistinguishable from each other. It does not make either indistinguishable from **success**.

## The fix

The ACL entry now decides what the handler *does*, never what it *says*:

- both subjects receive an identically shaped challenge;
- only an enrolled subject gets a session persisted to redeem it against;
- the challenge issued to an unenrolled subject is unusable — authenticate finds no session — and redeeming it would need that DID's private key anyway, which a party probing identifiers it does not control never has.

**Nothing is persisted for an unenrolled subject**, so this cannot be used to fill the session store with identifiers nobody enrolled — the DoS posture is unchanged from the refusing version. A **failing ACL store reads as absent** rather than becoming an oracle of its own; the real error surfaces at authenticate, where the caller has proven control of the DID.

## The same signal at the other end

Closing it at `/auth/challenge` alone would not have been enough. Every failure reachable **without the subject's private key** — `SessionNotFound`, `ChallengeMismatch`, `SignerMismatch`, `StaleMessage`, the two refresh-token variants — rendered a *distinct message* under one status code. An attacker holding a decoy challenge could still tell an enrolled subject (signer mismatch) from an unknown one (session not found).

They now render one message. The variant is preserved for the log line, so operators lose nothing.

## Compatibility

- The new `AuthBackend::has_effective_entry` hook is **defaulted** (`check_acl(did).await.is_ok()`), so no backend outside this workspace changes.
- No wire shape changes. `ChallengeRequest` was already `{ subject }` only.
- Status codes are unchanged; only the message body of 401s is uniform.

## Tests

Four new, plus the existing suite (419 pass in `vti-common`):

- an enrolled subject gets a persisted session and a `ChallengeIssued` audit row;
- an unenrolled subject gets a challenge, **nothing persisted, nothing audited** (nothing was granted, so nothing belongs in that trail — a run of these is a `warn!` instead, because that is what probing looks like);
- the two answers are indistinguishable — asserted on shape, since shape is the property;
- a broken ACL store does not disclose itself.

## Residual, and deliberately not fixed here

Timing: a persisted session is a store round-trip a decoy is not. Closing that belongs with the store rather than the handler. `validate_did` still refuses an unsupported DID method before this point, which discloses the *method allowlist* — a different property from membership, and one the existing design accepts.