### PR TITLE
fix(release): move the release baseline off an unresolvable commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10449,7 +10449,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.35.0"
+version = "0.35.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true


### PR DESCRIPTION
release-plz has failed on every run since 13:17 today and has produced no
Release PR. The cause is not the workflow and not the tag.

## What is actually happening

release-plz baselines each crate on **the commit where its version was last
set**, clones the repo there, and runs `cargo package` to diff the contents. For
`vta-sdk` that commit is `f43d26eb` — `chore: release (#1336)` — which bumped
`vta-sdk` to 0.35.0 and left `room-host` requiring `vta-sdk = "0.34"`. That tree
does not resolve:

    error: failed to select a version for the requirement `vta-sdk = "^0.34"`
    candidate versions found which didn't match: 0.35.0
    required by package `room-host v0.1.0 (…/room-host)`

Reproduced deterministically in a worktree at that commit.

#1397 already fixed `main`, and the tag `vta-sdk-v0.35.0` already points at
#1397 rather than at the release commit — both locally and on the remote. Neither
helps, because neither is what release-plz baselines on. `main` packages
cleanly today; only the historical baseline is broken, and nothing that edits
`main` can move it.

## Why a hand-edited version, when release-plz owns versions

It normally does, and a feature PR must never touch a `version` field. This is
not that: the baseline only moves when `vta-sdk`'s version changes, and
release-plz cannot produce that commit because it fails before it gets there. The
one edit it cannot make for itself is the one that unsticks it.

After this merges, the last version-change commit for `vta-sdk` is this one,
whose tree resolves — verified with `cargo package --list -p vta-sdk`, 243 files,
no error. release-plz then diffs successfully and opens the Release PR it has
been unable to open, which will publish 0.35.1.

No changelog entry here: `vta-sdk/CHANGELOG.md` is git-cliff output and says not
to edit it by hand. The Release PR writes it.

Nothing else has to move. Every dependent pins `vta-sdk = "0.35"`, and 0.35.1
satisfies that.

## The thing worth fixing properly

`release-plz.toml` says it "still updates an unpublished crate's version and
dependency requirements (so the workspace stays coherent when a published
dependency bumps)". At #1336 it did not: `room-host` is `publish = false` and its
requirement was left behind, which is what made that tree unresolvable. Until
that is understood, the next release that bumps a crate a `publish = false`
member depends on can strand the baseline the same way.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>