### PR TITLE
feat(keys): give an operator a way to set exportability

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -2792,6 +2792,30 @@ pub(crate) enum KeyCommands {
         /// Key ID
         key_id: String,
     },
+    /// Set whether a key's private half may ever be released.
+    ///
+    /// `--exportable false` tells the VTA to refuse every future export of the
+    /// key. It can still be *used* — signing, key agreement — so anything that
+    /// asks the VTA to act with the key keeps working; only handing the
+    /// material out stops.
+    ///
+    /// The two directions do not cost the same. Restricting a key needs admin
+    /// of its context; releasing one that is restricted needs strictly more:
+    /// super-admin, or a fresh step-up on your session. That asymmetry is the
+    /// point — a restriction the party who imposed it can lift unilaterally
+    /// protects against accident but not against someone holding that party's
+    /// credentials.
+    ///
+    /// The value is required and there is no toggle: the state is absolute, so
+    /// re-running a command whose output you did not see lands where you asked
+    /// rather than undoing it.
+    SetExportability {
+        /// Key ID
+        key_id: String,
+        /// Whether the private half may be released.
+        #[arg(long)]
+        exportable: bool,
+    },
     /// Rename a key
     Rename {
         /// Current key ID

--- a/pnm-cli/src/commands/keys.rs
+++ b/pnm-cli/src/commands/keys.rs
@@ -51,6 +51,9 @@ pub(crate) async fn run(
         }
         KeyCommands::Get { key_id, secret } => keys::cmd_key_get(client, &key_id, secret).await,
         KeyCommands::Revoke { key_id } => keys::cmd_key_revoke(client, &key_id).await,
+        KeyCommands::SetExportability { key_id, exportable } => {
+            keys::cmd_key_set_exportability(client, &key_id, exportable).await
+        }
         KeyCommands::Rename { key_id, new_key_id } => {
             keys::cmd_key_rename(client, &key_id, &new_key_id).await
         }

--- a/vta-cli-common/src/commands/keys.rs
+++ b/vta-cli-common/src/commands/keys.rs
@@ -256,6 +256,13 @@ pub async fn cmd_key_get(
         println!("Derivation Path: {}", resp.derivation_path);
         println!("Public Key:      {}", resp.public_key);
         println!("Status:          {}", resp.status);
+        // Printed only when it has been decided. A line reading "Exportable:
+        // yes" on every key would turn "nobody has considered this" into
+        // "somebody allowed it" — the same conflation the record avoids by
+        // storing `None` rather than `Some(true)`.
+        if resp.exportable == Some(false) {
+            println!("Exportable:      no — the private half is never released");
+        }
         if let Some(label) = &resp.label {
             println!("Label:           {label}");
         }
@@ -267,6 +274,38 @@ pub async fn cmd_key_get(
             "Updated At:      {}",
             crate::duration::format_local_datetime(resp.updated_at)
         );
+    }
+    Ok(())
+}
+
+/// Mark a key as releasable, or refuse every future export of it.
+///
+/// `exportable` is required rather than defaulted and there is no toggle: the
+/// state is absolute, so re-running a command whose output you did not see
+/// lands where you asked rather than undoing it.
+pub async fn cmd_key_set_exportability(
+    client: &VtaClient,
+    key_id: &str,
+    exportable: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let resp = client.set_key_exportability(key_id, exportable).await?;
+    if crate::render::is_json_output() {
+        crate::render::print_json(&resp)?;
+        return Ok(());
+    }
+    if resp.key.exportable == Some(false) {
+        println!("{} is no longer exportable.", resp.key.key_id);
+        println!(
+            "Its private half will not be released to any caller. It can still be used for \
+             signing and key agreement, so anything that asks the VTA to *use* it keeps working."
+        );
+        println!(
+            "Undoing this needs more authority than setting it did — super-admin, or a fresh \
+             step-up on your session."
+        );
+    } else {
+        println!("{} is exportable.", resp.key.key_id);
+        println!("Ordinary release rules apply: a caller entitled to the key can be given it.");
     }
     Ok(())
 }

--- a/vta-sdk/src/client/keys.rs
+++ b/vta-sdk/src/client/keys.rs
@@ -275,6 +275,33 @@ impl VtaClient {
         .await
     }
 
+    /// Set whether a key's private half may be released.
+    ///
+    /// `exportable` is the state the key should be in afterwards, **not a
+    /// delta**, so a retry of a lost `false` lands on `false` rather than
+    /// toggling back. There is deliberately no toggle form.
+    ///
+    /// The two directions do not cost the same. Imposing the restriction needs
+    /// admin of the key's context; lifting it needs strictly more — super-admin
+    /// or a live step-up. A restriction the party who imposed it can lift
+    /// unilaterally protects against accident but not against a compromised
+    /// caller holding that party's credentials, which is the case it exists for.
+    pub async fn set_key_exportability(
+        &self,
+        key_id: &str,
+        exportable: bool,
+    ) -> Result<
+        crate::protocols::key_management::set_exportability::SetKeyExportabilityResultBody,
+        VtaError,
+    > {
+        self.rpc_tt(
+            trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1,
+            serde_json::json!({ "keyId": key_id, "exportable": exportable }),
+            30,
+        )
+        .await
+    }
+
     // ── Import key methods ──────────────────────────────────────────
 
     /// Fetch an ephemeral wrapping key for REST key import.
@@ -322,5 +349,55 @@ impl VtaClient {
             30,
         )
         .await
+    }
+}
+
+#[cfg(all(test, feature = "test-loopback", feature = "client"))]
+mod exportability_tests {
+    use crate::client::loopback::RecordingSink;
+    use std::sync::Arc;
+
+    /// The producer side of `keys/set-exportability`: the URI it dispatches and
+    /// the body it builds.
+    ///
+    /// Worth pinning because this method is the only way an operator can reach
+    /// the task — the VTA served it for a release with no client and no CLI, so
+    /// nothing would have noticed a wrong URI here.
+    #[tokio::test]
+    async fn it_sends_the_state_absolutely_under_the_right_uri() {
+        let sink = Arc::new(RecordingSink::new());
+        let client = crate::client::VtaClient::loopback(sink.clone());
+
+        // The response will not deserialize from `null`; the request was
+        // captured before that, which is what this test is asking about.
+        let _ = client.set_key_exportability("app-signing-key", false).await;
+
+        let (uri, payload) = sink.recorded().pop().expect("one task was dispatched");
+        assert_eq!(uri, crate::trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1);
+        assert_eq!(payload["keyId"], "app-signing-key");
+        assert_eq!(
+            payload["exportable"], false,
+            "a boolean, not a string: `\"false\"` is truthy in several languages \
+             and would invert the request"
+        );
+        assert!(
+            payload.get("toggle").is_none(),
+            "the state is absolute — a toggle would make a retried request undo itself"
+        );
+    }
+
+    /// The other direction reaches the same task. It is the one the VTA gates
+    /// harder, and a client that spelled it differently would fail at the far
+    /// end rather than here.
+    #[tokio::test]
+    async fn releasing_uses_the_same_task() {
+        let sink = Arc::new(RecordingSink::new());
+        let client = crate::client::VtaClient::loopback(sink.clone());
+
+        let _ = client.set_key_exportability("app-signing-key", true).await;
+
+        let (uri, payload) = sink.recorded().pop().expect("one task was dispatched");
+        assert_eq!(uri, crate::trust_tasks::TASK_KEYS_SET_EXPORTABILITY_0_1);
+        assert_eq!(payload["exportable"], true);
     }
 }


### PR DESCRIPTION
#1401 taught the VTA to serve `keys/set-exportability/0.1` and shipped no way to
call it — no client method, no CLI. The feature was unreachable for a release.

    pnm keys set-exportability <KEY_ID> --exportable false

`--exportable` is required rather than defaulted, and there is no toggle form.
The state is absolute, so re-running a command whose output you did not see
lands where you asked rather than undoing it — which is the same property the
spec insists on, surfaced where an operator meets it.

## Saying what actually happened

Restricting a key prints what still works, not just what stopped: the private
half will not be released, and the key can still sign and perform key agreement,
so anything asking the VTA to *use* it keeps working. That distinction is the
whole shape of the feature and it is exactly what an operator will be unsure
about after running the command.

It also says undoing it needs more authority than setting it did — super-admin
or a fresh step-up — so the asymmetry is discovered before somebody needs it
rather than at the moment they are trying to recover a key.

## Making the state visible

`keys get` now prints exportability, **but only when it is `false`**. A line
reading "Exportable: yes" on every key would turn "nobody has considered this"
into "somebody allowed it" — the same conflation the record itself avoids by
storing `None` rather than `Some(true)`. Setting a flag you cannot then observe
is half a feature; printing it as a decision nobody made is worse than not
printing it.

## Tests

Two producer-side tests through the loopback sink, pinning the URI and the body.
Worth having precisely because this method is the only path to the task: the VTA
served it for a release with nothing calling it, so a wrong URI here would have
gone unnoticed the same way the missing surface did.

One asserts `exportable` goes on the wire as a boolean — `"false"` is truthy in
several languages, and that is the one mistake that would silently invert the
request.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>