### PR TITLE
chore(ci): release-plz action 0.5.131 -> 0.5.136

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,7 +148,7 @@ jobs:
         # moving major tag, so `@v0` resolves to nothing and the job fails at
         # "Set up job" before running a step. (actions/checkout@v6 works
         # because that repo does publish v6 — the convention is not universal.)
-        uses: release-plz/action@v0.5.131
+        uses: release-plz/action@v0.5.136
         with:
           command: release
         env:
@@ -231,7 +231,7 @@ jobs:
         # moving major tag, so `@v0` resolves to nothing and the job fails at
         # "Set up job" before running a step. (actions/checkout@v6 works
         # because that repo does publish v6 — the convention is not universal.)
-        uses: release-plz/action@v0.5.131
+        uses: release-plz/action@v0.5.136
         with:
           command: release-pr
         env:


### PR DESCRIPTION
`Release-plz PR` has failed on every run since #1336 and has produced no Release
PR. 0.5.136 is "Update to 0.3.165", and 0.3.165 carries the fix this needs:

  release-plz 0.3.165 — Other: list packaged crate files without invoking cargo
  (release-plz/release-plz#3044), released 2026-09-10 17:37

That is the exact bottom of our failure chain:

    1: failed to retrieve difference of package vti-common
    2: failed to check package equality for `vti-common` at commit f43d26eb
    5: cannot get packaged files from cargo package list
    6: error while running `cargo package`: failed to select a version for the
       requirement `vta-sdk = "^0.34"`

release-plz baselines each crate on the commit where its published version was
set, clones the repo there and runs `cargo package` to list the files. For 19
crates that commit is `f43d26eb` (`chore: release (#1336)`), whose tree does not
resolve — it left `room-host` requiring `vta-sdk = "0.34"` after bumping vta-sdk
to 0.35.0. If the file list no longer goes through cargo, that tree stops
mattering.

## Why this rather than the alternative

The alternative works and is proven: publishing a crate from a good commit moves
its baseline past f43d26eb. #1406 did that for `vta-sdk`, and the next run got
further — it failed on `vti-common` instead, which is the mechanism confirming
itself.

But that is per-crate, and 18 remain. Doing it deliberately means choosing 18
version bumps by hand, without the semver checks release-plz would have applied,
and publishing all of them to crates.io — where a version cannot be withdrawn,
only yanked. A one-line action bump that might make the whole problem moot is
worth trying first, and costs a CI run to find out.

If the next `Release-plz PR` run still fails, the hand-bump is still available
and nothing here blocks it.

#1409 guards the manifest inconsistency itself, so a future release cannot
create this state again. This is about recovering from the one already in
history, which no change to `main` can reach.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>