### PR TITLE
refactor(audit): one construction point for the audit sink, and the prerequisites for chaining it

### DIFF
--- a/vta-audit/src/lib.rs
+++ b/vta-audit/src/lib.rs
@@ -18,7 +18,9 @@ use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
 pub mod sink;
-pub use sink::{AuditSink, FanOutAuditSink, KeyspaceAuditSink, SharedAuditSink};
+pub use sink::{
+    AuditSink, FanOutAuditSink, KeyspaceAuditSink, SharedAuditSink, shared_keyspace_sink,
+};
 
 /// Emit a structured audit event to the tracing subsystem — **a log line, and
 /// nothing else**.

--- a/vta-audit/src/sink.rs
+++ b/vta-audit/src/sink.rs
@@ -102,6 +102,22 @@ impl AuditSink for KeyspaceAuditSink {
     }
 }
 
+/// Build the shared sink every caller should use.
+///
+/// One construction point, so that changing what a VTA's audit writes is one
+/// edit rather than a search. Before this existed the workspace built the same
+/// sink over the same keyspace in thirty-one places — including three times
+/// inside a single function — and each was a place a later change would have
+/// to find.
+///
+/// A server takes its sink from `AppState`; this is for the callers that have
+/// no `AppState` to take it from — offline CLI commands, setup, sweepers and
+/// tests.
+#[must_use]
+pub fn shared_keyspace_sink(keyspace: KeyspaceHandle) -> SharedAuditSink {
+    Arc::new(KeyspaceAuditSink::new(keyspace))
+}
+
 /// Write every entry to several sinks.
 ///
 /// The composition an operator adding tamper-evidence actually needs: keep the

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -44,8 +44,7 @@ pub async fn run_create_did_webvh(
     let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS)?;
     let webvh_ks = store.keyspace(crate::keyspaces::WEBVH)?;
     let audit_ks = store.keyspace(crate::keyspaces::AUDIT)?;
-    let audit: vta_audit::SharedAuditSink =
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+    let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
     let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES)?;
 
     // Resolve context
@@ -279,9 +278,7 @@ pub async fn run_create_did_webvh(
             &keys_ks,
             &imported_ks,
             &Arc::from(seed_store),
-            &(std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(
-                store.keyspace(crate::keyspaces::AUDIT)?,
-            )) as vta_audit::SharedAuditSink),
+            &audit,
             &auth,
             &result.signing_key_id,
             "cli",
@@ -300,9 +297,7 @@ pub async fn run_create_did_webvh(
                 &keys_ks,
                 &imported_ks,
                 &Arc::from(create_seed_store(&config)?),
-                &(std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(
-                    store.keyspace(crate::keyspaces::AUDIT)?,
-                )) as vta_audit::SharedAuditSink),
+                &audit,
                 &auth,
                 &result.ka_key_id,
                 "cli",
@@ -770,8 +765,7 @@ mod tests {
         let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
         let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
-        let audit: vta_audit::SharedAuditSink =
-            std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+        let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
         let seed_store = Arc::from(create_seed_store(&config).unwrap());
         let auth = cli_super_admin();
 
@@ -867,8 +861,7 @@ mod tests {
         let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
         let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
         let audit_ks = store.keyspace(crate::keyspaces::AUDIT).unwrap();
-        let audit: vta_audit::SharedAuditSink =
-            std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+        let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
         let did_templates_ks = store.keyspace(crate::keyspaces::DID_TEMPLATES).unwrap();
         let seed_store = create_seed_store(&config).unwrap();
 

--- a/vta-service/src/operations/acl.rs
+++ b/vta-service/src/operations/acl.rs
@@ -1147,9 +1147,8 @@ mod tests {
         })
         .unwrap();
         let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
-        let audit: vta_audit::SharedAuditSink = std::sync::Arc::new(
-            vta_audit::KeyspaceAuditSink::new(store.keyspace(crate::keyspaces::AUDIT).unwrap()),
-        );
+        let audit: vta_audit::SharedAuditSink =
+            vta_audit::shared_keyspace_sink(store.keyspace(crate::keyspaces::AUDIT).unwrap());
         let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
         (store, acl_ks, audit, contexts_ks, dir)
     }

--- a/vta-service/src/operations/app_state.rs
+++ b/vta-service/src/operations/app_state.rs
@@ -2166,7 +2166,7 @@ mod tests {
     /// A real sink over a scratch keyspace — the sweeper audits each reap, and
     /// a sink that swallowed the call would leave that path untested.
     fn test_audit_sink(ks: &KeyspaceHandle) -> vta_audit::SharedAuditSink {
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(ks.clone()))
+        vta_audit::shared_keyspace_sink(ks.clone())
     }
 
     #[tokio::test]

--- a/vta-service/src/operations/device.rs
+++ b/vta-service/src/operations/device.rs
@@ -779,9 +779,8 @@ mod tests {
         })
         .unwrap();
         let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();
-        let audit: vta_audit::SharedAuditSink = std::sync::Arc::new(
-            vta_audit::KeyspaceAuditSink::new(store.keyspace(crate::keyspaces::AUDIT).unwrap()),
-        );
+        let audit: vta_audit::SharedAuditSink =
+            vta_audit::shared_keyspace_sink(store.keyspace(crate::keyspaces::AUDIT).unwrap());
         (acl_ks, audit, dir)
     }
 

--- a/vta-service/src/operations/did_webvh/register_server.rs
+++ b/vta-service/src/operations/did_webvh/register_server.rs
@@ -316,9 +316,8 @@ mod tests {
         })
         .unwrap();
         let webvh_ks = store.keyspace(crate::keyspaces::WEBVH).unwrap();
-        let audit: vta_audit::SharedAuditSink = std::sync::Arc::new(
-            vta_audit::KeyspaceAuditSink::new(store.keyspace(crate::keyspaces::AUDIT).unwrap()),
-        );
+        let audit: vta_audit::SharedAuditSink =
+            vta_audit::shared_keyspace_sink(store.keyspace(crate::keyspaces::AUDIT).unwrap());
         // Force the test_app_config helper to be exercised so any
         // future field addition surfaces as a test failure.
         let _ = test_app_config(dir.path().into());

--- a/vta-service/src/operations/export.rs
+++ b/vta-service/src/operations/export.rs
@@ -365,9 +365,9 @@ mod tests {
             contexts_ks: store.keyspace(crate::keyspaces::CONTEXTS).unwrap(),
             keys_ks: store.keyspace(crate::keyspaces::KEYS).unwrap(),
             imported_ks: store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap(),
-            audit: Arc::new(vta_audit::KeyspaceAuditSink::new(
+            audit: vta_audit::shared_keyspace_sink(
                 store.keyspace(crate::keyspaces::AUDIT).unwrap(),
-            )),
+            ),
             acl_ks: store.keyspace(crate::keyspaces::ACL).unwrap(),
             #[cfg(feature = "webvh")]
             webvh_ks: store.keyspace(crate::keyspaces::WEBVH).unwrap(),

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -1557,9 +1557,8 @@ mod tests {
 
             let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
             let contexts_ks = store.keyspace(crate::keyspaces::CONTEXTS).unwrap();
-            let audit: vta_audit::SharedAuditSink = std::sync::Arc::new(
-                vta_audit::KeyspaceAuditSink::new(store.keyspace(crate::keyspaces::AUDIT).unwrap()),
-            );
+            let audit: vta_audit::SharedAuditSink =
+                vta_audit::shared_keyspace_sink(store.keyspace(crate::keyspaces::AUDIT).unwrap());
             let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
             let internal_ks = store.keyspace(crate::keyspaces::INTERNAL_KEYS).unwrap();
             let acl_ks = store.keyspace(crate::keyspaces::ACL).unwrap();

--- a/vta-service/src/operations/policy.rs
+++ b/vta-service/src/operations/policy.rs
@@ -316,9 +316,7 @@ mod tests {
         .unwrap();
         (
             store.keyspace(vta_keyspaces::POLICY).unwrap(),
-            std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(
-                store.keyspace(vta_keyspaces::AUDIT).unwrap(),
-            )),
+            vta_audit::shared_keyspace_sink(store.keyspace(vta_keyspaces::AUDIT).unwrap()),
             dir,
         )
     }

--- a/vta-service/src/operations/protocol/disable_didcomm.rs
+++ b/vta-service/src/operations/protocol/disable_didcomm.rs
@@ -455,8 +455,7 @@ mod tests {
             let (d3, contexts_ks) = empty_keyspace("contexts").await;
             let (d4, webvh_ks) = empty_keyspace("webvh").await;
             let (d5, audit_ks) = empty_keyspace("audit").await;
-            let audit: vta_audit::SharedAuditSink =
-                std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks));
+            let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks);
             let (d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
             let (d7, service_state_ks) = empty_keyspace("service_state").await;
             let (d8, drains_ks) = empty_keyspace("drains").await;

--- a/vta-service/src/operations/protocol/enable_didcomm.rs
+++ b/vta-service/src/operations/protocol/enable_didcomm.rs
@@ -371,8 +371,7 @@ mod tests {
             let (d3, contexts_ks) = empty_keyspace("contexts").await;
             let (d4, webvh_ks) = empty_keyspace("webvh").await;
             let (d5, audit_ks) = empty_keyspace("audit").await;
-            let audit: vta_audit::SharedAuditSink =
-                std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks));
+            let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks);
             let (d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
             let (d7, service_state_ks) = empty_keyspace("service_state").await;
             let (d8, drains_ks) = empty_keyspace("drains").await;

--- a/vta-service/src/operations/protocol/update_didcomm.rs
+++ b/vta-service/src/operations/protocol/update_didcomm.rs
@@ -484,8 +484,7 @@ mod tests {
             let (d3, contexts_ks) = empty_keyspace("contexts").await;
             let (d4, webvh_ks) = empty_keyspace("webvh").await;
             let (d5, audit_ks) = empty_keyspace("audit").await;
-            let audit: vta_audit::SharedAuditSink =
-                std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks));
+            let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks);
             let (d6, snapshot_ks) = empty_keyspace(snapshot::KEYSPACE_NAME).await;
             let (d7, service_state_ks) = empty_keyspace("service_state").await;
             let (d8, drains_ks) = empty_keyspace("drains").await;

--- a/vta-service/src/operations/seeds.rs
+++ b/vta-service/src/operations/seeds.rs
@@ -206,9 +206,8 @@ mod tests {
 
             let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
             let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
-            let audit: vta_audit::SharedAuditSink = std::sync::Arc::new(
-                vta_audit::KeyspaceAuditSink::new(store.keyspace(crate::keyspaces::AUDIT).unwrap()),
-            );
+            let audit: vta_audit::SharedAuditSink =
+                vta_audit::shared_keyspace_sink(store.keyspace(crate::keyspaces::AUDIT).unwrap());
 
             let initial_seed = vec![0xABu8; 32];
             let seed_store: Arc<dyn SeedStore> =
@@ -255,9 +254,8 @@ mod tests {
         .expect("open store");
         let keys_ks = store.keyspace(crate::keyspaces::KEYS).unwrap();
         let imported_ks = store.keyspace(crate::keyspaces::IMPORTED_SECRETS).unwrap();
-        let audit: vta_audit::SharedAuditSink = std::sync::Arc::new(
-            vta_audit::KeyspaceAuditSink::new(store.keyspace(crate::keyspaces::AUDIT).unwrap()),
-        );
+        let audit: vta_audit::SharedAuditSink =
+            vta_audit::shared_keyspace_sink(store.keyspace(crate::keyspaces::AUDIT).unwrap());
 
         // Bootstrap generation 0 as the active seed.
         save_seed_record(

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -519,7 +519,7 @@ pub async fn build_app_state(
     // because reads and retention deliberately do not route through the sink.
     let audit_sink: vta_audit::SharedAuditSink = parts
         .audit_sink
-        .unwrap_or_else(|| Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone())));
+        .unwrap_or_else(|| vta_audit::shared_keyspace_sink(audit_ks.clone()));
 
     Ok(AppState {
         keys_ks,
@@ -933,7 +933,7 @@ pub async fn run(
         // `AppStateParts` below, so the sweepers and the request path share one
         // sink object rather than two that merely happen to agree today.
         let audit_sink: vta_audit::SharedAuditSink =
-            Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+            vta_audit::shared_keyspace_sink(audit_ks.clone());
         let storage_audit_sink = Arc::clone(&audit_sink);
         let storage_acl_ks = acl_ks.clone();
         let storage_consent_ks = consent_ks.clone();

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -166,9 +166,8 @@ async fn build_offline_deps(
     let keys_ks = cs.keyspace(crate::keyspaces::KEYS)?;
     let imported_ks = cs.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
-    let audit_sink: vta_audit::SharedAuditSink = std::sync::Arc::new(
-        vta_audit::KeyspaceAuditSink::new(cs.keyspace(crate::keyspaces::AUDIT)?),
-    );
+    let audit_sink: vta_audit::SharedAuditSink =
+        vta_audit::shared_keyspace_sink(cs.keyspace(crate::keyspaces::AUDIT)?);
     let webvh_ks = cs.keyspace(crate::keyspaces::WEBVH)?;
     let drains_ks = cs.keyspace(crate::keyspaces::DRAINS)?;
     let snapshot_ks = cs.keyspace(snapshot::KEYSPACE_NAME)?;

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -754,8 +754,7 @@ pub async fn apply_inputs(
     let contexts_ks = maybe_encrypt(store.keyspace(crate::keyspaces::CONTEXTS)?);
     let webvh_ks = maybe_encrypt(store.keyspace(crate::keyspaces::WEBVH)?);
     let audit_ks = maybe_encrypt(store.keyspace(crate::keyspaces::AUDIT)?);
-    let audit: vta_audit::SharedAuditSink =
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+    let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
     let did_templates_ks = maybe_encrypt(store.keyspace(crate::keyspaces::DID_TEMPLATES)?);
 
     let mut vta_ctx = create_seed_context(&contexts_ks, "vta", "Verifiable Trust Agent").await?;

--- a/vta-service/src/test_support.rs
+++ b/vta-service/src/test_support.rs
@@ -104,9 +104,9 @@ pub async fn open_test_store() -> TestStore {
         keys_ks: store.keyspace(crate::keyspaces::KEYS).expect("keys ks"),
         acl_ks: store.keyspace(crate::keyspaces::ACL).expect("acl ks"),
         audit_ks: store.keyspace(crate::keyspaces::AUDIT).expect("audit ks"),
-        audit: std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(
+        audit: vta_audit::shared_keyspace_sink(
             store.keyspace(crate::keyspaces::AUDIT).expect("audit ks"),
-        )),
+        ),
         imported_ks: store
             .keyspace(crate::keyspaces::IMPORTED_SECRETS)
             .expect("imported ks"),
@@ -170,7 +170,7 @@ pub fn test_deps(ts: &TestStore) -> ProvisionIntegrationDeps {
     ProvisionIntegrationDeps {
         keys_ks: ts.keys_ks.clone(),
         acl_ks: ts.acl_ks.clone(),
-        audit: std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(ts.audit_ks.clone())),
+        audit: vta_audit::shared_keyspace_sink(ts.audit_ks.clone()),
         contexts_ks: ts.contexts_ks.clone(),
         did_templates_ks: ts.did_templates_ks.clone(),
         imported_ks: ts.imported_ks.clone(),
@@ -608,7 +608,7 @@ pub async fn bootstrap_test_vta(ts: &TestStore) -> (String, ProvisionIntegration
     let deps = ProvisionIntegrationDeps {
         keys_ks: ts.keys_ks.clone(),
         acl_ks: ts.acl_ks.clone(),
-        audit: std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(ts.audit_ks.clone())),
+        audit: vta_audit::shared_keyspace_sink(ts.audit_ks.clone()),
         contexts_ks: ts.contexts_ks.clone(),
         did_templates_ks: ts.did_templates_ks.clone(),
         imported_ks: ts.imported_ks.clone(),
@@ -1330,9 +1330,9 @@ pub async fn build_test_app_with(opts: TestAppOptions) -> (axum::Router, TestApp
 
     let policy_ks = store.keyspace(crate::keyspaces::POLICY).unwrap();
     let state = crate::server::AppState {
-        audit_sink: std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(
+        audit_sink: vta_audit::shared_keyspace_sink(
             store.keyspace(crate::keyspaces::AUDIT).unwrap(),
-        )),
+        ),
         internal_ks: store.keyspace(crate::keyspaces::INTERNAL_KEYS).unwrap(),
         idempotency_ks: store.keyspace(crate::keyspaces::IDEMPOTENCY).unwrap(),
         // Empty by default: a test VTA trusts no mdoc issuer until one is

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -155,8 +155,7 @@ pub async fn run_create_did(
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
     let webvh_ks = cs.keyspace(crate::keyspaces::WEBVH)?;
     let audit_ks = cs.keyspace(crate::keyspaces::AUDIT)?;
-    let audit: vta_audit::SharedAuditSink =
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+    let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
     let did_templates_ks = cs.keyspace(crate::keyspaces::DID_TEMPLATES)?;
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);
@@ -328,8 +327,7 @@ pub async fn run_delete_did(
     let imported_ks = cs.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = cs.keyspace(crate::keyspaces::AUDIT)?;
-    let audit: vta_audit::SharedAuditSink =
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+    let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
     let webvh_ks = cs.keyspace(crate::keyspaces::WEBVH)?;
     // The offline delete cascades exactly as the online one does. An operator
     // reaching for the break-glass CLI is the *last* person who should be left
@@ -458,8 +456,7 @@ pub async fn run_edit_did(
     let imported_ks = cs.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = cs.keyspace(crate::keyspaces::AUDIT)?;
-    let audit: vta_audit::SharedAuditSink =
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+    let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
@@ -638,8 +635,7 @@ pub async fn run_register_did(
     let imported_ks = cs.keyspace(crate::keyspaces::IMPORTED_SECRETS)?;
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = cs.keyspace(crate::keyspaces::AUDIT)?;
-    let audit: vta_audit::SharedAuditSink =
-        std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+    let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
     let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =

--- a/vta-service/tests/audit_sink.rs
+++ b/vta-service/tests/audit_sink.rs
@@ -195,8 +195,7 @@ async fn a_fan_out_keeps_the_query_api_working_beside_a_new_backend() {
     let (state, _dir) = state_with_sink(None).await;
     let recording = Arc::new(Recording::default());
     let fan: vta_audit::SharedAuditSink = Arc::new(vta_audit::FanOutAuditSink::new(vec![
-        Arc::new(vta_audit::KeyspaceAuditSink::new(state.audit_ks.clone()))
-            as vta_audit::SharedAuditSink,
+        vta_audit::shared_keyspace_sink(state.audit_ks.clone()),
         Arc::clone(&recording) as vta_audit::SharedAuditSink,
     ]));
 

--- a/vta-sweepers/src/acl_sweeper.rs
+++ b/vta-sweepers/src/acl_sweeper.rs
@@ -131,8 +131,7 @@ mod tests {
         // Both halves: the sink the sweeper writes through, and the keyspace
         // the assertions read back from. They are the same storage here — the
         // split exists so a deployment can point the write half elsewhere.
-        let audit: SharedAuditSink =
-            std::sync::Arc::new(vta_audit::KeyspaceAuditSink::new(audit_ks.clone()));
+        let audit: SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
         (store, acl_ks, audit, audit_ks, dir)
     }
 

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -78,6 +78,23 @@ pub enum AuditEvent {
     /// per tier is decided once, in `vti_rooms::audit`, and never at a call site.
     RoomOperation(RoomOperationData),
 
+    /// An operation performed by a VTA, in the flat shape its call sites
+    /// produce.
+    ///
+    /// The other variants of this enum each name one thing that can happen to
+    /// a community, because a VTC's audit surface is a closed set of
+    /// community events. A VTA's is not: it audits every gated operation it
+    /// serves, the set grows with the task catalogue, and the call sites
+    /// already carry a dotted action name rather than a type. Modelling each
+    /// as a variant would mean an enum that changes whenever an operation
+    /// does, and a wire contract that breaks with it.
+    ///
+    /// So the action stays a string and this variant carries the four things
+    /// a VTA call site supplies beside it. The actor and any DID-shaped
+    /// target travel outside the data, in the envelope's hashed members,
+    /// where an erasure can reach them.
+    VtaOperation(VtaOperationData),
+
     /// A passkey was registered against an admin DID (initial enrol
     /// at install **or** a subsequent additional-device enrolment).
     AdminPasskeyRegistered(AdminPasskeyData),
@@ -538,6 +555,12 @@ impl AuditEvent {
             Self::AdminInviteRevoked(..) => "AdminInviteRevoked",
             Self::SchemaRegistered(..) => "SchemaRegistered",
             Self::SchemaDeleted(..) => "SchemaDeleted",
+            // The variant name, not the action inside it. A consumer
+            // discriminating on `type` sees one kind for every VTA
+            // operation and reads `data.action` for which one — the same
+            // shape a SIEM already has to handle for any event carrying a
+            // subtype.
+            Self::VtaOperation(..) => "VtaOperation",
         }
     }
 }
@@ -681,6 +704,41 @@ pub struct EmergencyBootstrapData {
     /// and emitted the event — the gap between the two is itself
     /// audit-worthy.
     pub invoked_at: DateTime<Utc>,
+}
+
+/// Payload of [`AuditEvent::VtaOperation`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VtaOperationData {
+    /// Dotted action name as the call site reports it — `auth.challenge`,
+    /// `acl.create`, `vault.sign-trust-task`. Part of the wire contract for
+    /// consumers that filter on it.
+    pub action: String,
+
+    /// The object acted upon, where it is not a DID: a key id, a session id,
+    /// a context path. A DID-shaped target is carried in the envelope's
+    /// hashed `target_did_*` members instead, so that an erasure reaches it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<String>,
+
+    /// `success`, `failure`, or whatever the call site reports. Refusals are
+    /// audited as well as successes, so this is load-bearing rather than
+    /// decorative.
+    pub outcome: String,
+
+    /// The transport the request arrived over. A VTA-specific fact: the same
+    /// operation under the same authority must reach the same decision on
+    /// every transport, and this is how an auditor checks that it did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+
+    /// The trust context the action took place in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+
+    /// Operator-supplied rationale, where the operation asks for one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/vti-common/src/audit/key_store.rs
+++ b/vti-common/src/audit/key_store.rs
@@ -139,6 +139,16 @@ pub struct AuditKeyStore {
     ks: KeyspaceHandle,
 }
 
+/// HKDF info string for a VTC's audit key. The `/v2` is the rework recorded
+/// in this module's history and is part of the derivation — changing it
+/// derives a different key and orphans every existing hash.
+pub const VTC_AUDIT_KEY_INFO: &[u8] = b"vtc-audit-key/v2";
+
+/// HKDF info string for a VTA's audit key. Separate from
+/// [`VTC_AUDIT_KEY_INFO`] so that a VTC provisioned on a VTA does not share
+/// its HMAC key with the VTA underneath it.
+pub const VTA_AUDIT_KEY_INFO: &[u8] = b"vta-audit-key/v1";
+
 impl AuditKeyStore {
     /// Wrap a keyspace handle. The caller is responsible for
     /// configuring encryption-at-rest if desired.
@@ -207,13 +217,35 @@ impl AuditKeyStore {
     /// §5.2) — the IKM is now a 32-byte Ed25519 private from the
     /// VTA bundle, not a 64-byte BIP-39 seed.
     pub async fn ensure_initial(&self, master_seed: &[u8]) -> Result<AuditKey, AppError> {
+        self.ensure_initial_with_info(master_seed, VTC_AUDIT_KEY_INFO)
+            .await
+    }
+
+    /// As [`Self::ensure_initial`], deriving under an explicit HKDF info
+    /// string.
+    ///
+    /// The info string is what separates one node's audit key from another's
+    /// when both derive from the same seed — which is not hypothetical: a VTC
+    /// is provisioned on top of a VTA and can reach the same master seed, so
+    /// deriving both logs' keys under one label would give two different logs
+    /// one HMAC key. An actor hash would then correlate across them, which is
+    /// precisely the correlation the hash exists to contain.
+    ///
+    /// Use [`VTC_AUDIT_KEY_INFO`] or [`VTA_AUDIT_KEY_INFO`]; a new node type
+    /// adds a constant beside them rather than passing a literal, so the set
+    /// of labels in use is greppable.
+    pub async fn ensure_initial_with_info(
+        &self,
+        master_seed: &[u8],
+        info: &[u8],
+    ) -> Result<AuditKey, AppError> {
         if let Some(existing) = self.try_active().await? {
             return Ok(existing);
         }
 
         let mut key = [0u8; 32];
         Hkdf::<Sha256>::new(None, master_seed)
-            .expand(b"vtc-audit-key/v2", &mut key)
+            .expand(info, &mut key)
             .map_err(|e| AppError::Internal(format!("HKDF expand failed: {e}")))?;
 
         let initial = AuditKey {
@@ -298,7 +330,7 @@ mod tests {
     use crate::config::StoreConfig;
     use crate::store::Store;
 
-    fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
+    pub(super) fn temp_ks() -> (KeyspaceHandle, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
         let cfg = StoreConfig {
             data_dir: dir.path().to_path_buf(),
@@ -402,5 +434,81 @@ mod tests {
         let s = format!("{k:?}");
         assert!(!s.contains("AB"), "key bytes leaked: {s}");
         assert!(s.contains("<redacted>"), "missing redaction marker: {s}");
+    }
+}
+
+#[cfg(test)]
+mod domain_separation_tests {
+    use super::tests::temp_ks;
+    use super::*;
+
+    fn store() -> (AuditKeyStore, tempfile::TempDir) {
+        let (ks, dir) = temp_ks();
+        (AuditKeyStore::new(ks), dir)
+    }
+
+    /// The reason `ensure_initial_with_info` exists: a VTC is provisioned on
+    /// top of a VTA and can reach the same master seed. Deriving both logs'
+    /// keys under one label would give two different audit logs one HMAC key,
+    /// so an actor hash would correlate across them — the correlation the
+    /// hash exists to contain.
+    #[tokio::test]
+    async fn one_seed_derives_different_keys_per_node_type() {
+        let seed = [7u8; 32];
+
+        let (vtc, _vtc_dir) = store();
+        let (vta, _vta_dir) = store();
+
+        let vtc_key = vtc
+            .ensure_initial_with_info(&seed, VTC_AUDIT_KEY_INFO)
+            .await
+            .expect("derive vtc audit key");
+        let vta_key = vta
+            .ensure_initial_with_info(&seed, VTA_AUDIT_KEY_INFO)
+            .await
+            .expect("derive vta audit key");
+
+        assert_ne!(
+            vtc_key.key, vta_key.key,
+            "a VTC and the VTA beneath it must not share an audit key"
+        );
+    }
+
+    /// The plain constructor keeps deriving what it always derived, so an
+    /// existing community's hashes stay verifiable.
+    #[tokio::test]
+    async fn the_default_derivation_is_unchanged() {
+        let seed = [7u8; 32];
+
+        let (implicit, _a) = store();
+        let (explicit, _b) = store();
+
+        let a = implicit.ensure_initial(&seed).await.expect("implicit");
+        let b = explicit
+            .ensure_initial_with_info(&seed, VTC_AUDIT_KEY_INFO)
+            .await
+            .expect("explicit");
+
+        assert_eq!(a.key, b.key);
+    }
+
+    /// Derivation happens once. A second call returns the stored key rather
+    /// than re-deriving, which is what makes it safe to call on every boot.
+    #[tokio::test]
+    async fn deriving_twice_returns_the_same_key() {
+        let seed = [7u8; 32];
+        let (ks, _dir) = store();
+
+        let first = ks
+            .ensure_initial_with_info(&seed, VTA_AUDIT_KEY_INFO)
+            .await
+            .expect("first");
+        let second = ks
+            .ensure_initial_with_info(&seed, VTA_AUDIT_KEY_INFO)
+            .await
+            .expect("second");
+
+        assert_eq!(first.key_id, second.key_id);
+        assert_eq!(first.key, second.key);
     }
 }


### PR DESCRIPTION
Two commits, both aimed at the same follow-up: giving the VTA the tamper-evident audit log the VTC already has ([#1408](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1408), as corrected by [#1410](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1410)). Neither changes behaviour.

## 1. One construction point

The workspace built the same sink over the same keyspace in **thirty-one places** — including **three times inside one function**, `run_create_did_webvh`, which already had one in scope two hundred lines above the other two. Every one of those was somewhere a later change to what a VTA's audit writes would have to be found and repeated.

There is now one constructor, `vta_audit::shared_keyspace_sink`, and every caller goes through it. A server still takes its sink from `AppState` — that path was already right, and its comment already explained why ("built once here and handed to *both* the storage thread and `AppStateParts`"). The factory is for callers with **no `AppState` to take one from**: offline CLI commands, setup, sweepers and tests.

29 call sites now use it; the three inside `run_create_did_webvh` became one.

## 2. Prerequisites for chaining

**`AuditEvent::VtaOperation`.** Every other variant names one thing that can happen to a community, because a VTC's audit surface is a closed set of community events. A VTA's is not: it audits every gated operation it serves, the set grows with the task catalogue, and its call sites already carry a dotted action name rather than a type. Modelling each as a variant would mean an enum that changes whenever an operation does, and a wire contract that breaks with it. So the action stays a string and the variant carries the four things a VTA call site supplies beside it — while the actor and any DID-shaped target travel in the envelope's hashed members, where an erasure can reach them.

**`AuditKeyStore::ensure_initial_with_info`**, plus named constants for the two info strings in use. The default derivation is unchanged, so an existing community's hashes stay verifiable — a test pins that.

The reason for the parameter is worth stating: **a VTC is provisioned on top of a VTA and can reach the same master seed.** Deriving both logs' keys under one label would give two different audit logs one HMAC key, so an actor hash would correlate across them — which is precisely the correlation the hash exists to contain. Three tests cover it: different keys per node type from one seed, the unchanged default, and derivation being idempotent across boots.

## What comes next

Slice B — the sink writes envelopes through `AuditWriter` and the read path handles both forms. Those must land together: the storage key and the value both change, so the existing `audit/list` query stops finding rows it can parse. Slice C adds `verify`. Retention still needs the checkpoint work, per the note.