### PR TITLE
chore(release): unstick the 18 crates still baselined on the broken commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,7 +2515,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "clap",
@@ -7058,7 +7058,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10225,7 +10225,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "tokio",
@@ -10237,7 +10237,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2",
@@ -10267,7 +10267,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10293,7 +10293,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10326,7 +10326,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10410,7 +10410,7 @@ dependencies = [
 
 [[package]]
 name = "vta-persona"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -10429,7 +10429,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "hex",
  "multibase",
@@ -10449,7 +10449,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10515,7 +10515,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -10622,7 +10622,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -10693,7 +10693,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -10727,7 +10727,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10748,7 +10748,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10850,7 +10850,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10925,7 +10925,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10952,7 +10952,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10997,7 +10997,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.14.2"
+version = "0.14.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.15", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -22,7 +22,7 @@ vti-rooms-dtg = { path = "../vti-rooms-dtg" }
 # The room client, for pulling from a write-primary. Host-neutral despite the
 # name: a mirror reads its primary exactly as any member would, because that is
 # the only way to read a room.
-vtc-client = { path = "../vtc-client", version = "0.5" }
+vtc-client = { path = "../vtc-client", version = "0.6" }
 
 axum = { workspace = true }
 # CORS only, and only when an operator asks for it — see `router_with_origins`.
@@ -63,7 +63,7 @@ affinidi-messaging-core = { workspace = true, optional = true }
 vti-secrets = { path = "../vti-secrets", version = "0.3", optional = true }
 # The session store behind `onboarding` — which backend is an operator's choice,
 # exactly as `[secrets]` is.
-vta-sdk = { path = "../vta-sdk", version = "0.35", optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.36", optional = true }
 # Reading the `[secrets]` table out of a config file.
 toml = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,7 +21,7 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.18" }
-vta-sdk = { path = "../vta-sdk", version = "0.35" }
+vta-sdk = { path = "../vta-sdk", version = "0.36" }
 async-trait = "0.1"
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -32,7 +32,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 # a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
 # own and was borrowing one from its cipher.
 rand = { workspace = true }
-vta-sdk = { path = "../vta-sdk", version = "0.35" }
+vta-sdk = { path = "../vta-sdk", version = "0.36" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.4" }
 vta-config = { path = "../vta-config", version = "0.4" }

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.15.0"
+version = "0.15.1"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = [
   "client",
   "sealed-transfer",
   "provision-integration",
@@ -30,7 +30,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 # and `room-host`'s own example drives itself with this crate. Taking a second
 # copy of the `rooms/*` wire types into this crate is what the type duplication
 # in `vtc-client` was deleted to avoid.
-vtc-client = { path = "../vtc-client", version = "0.5" }
+vtc-client = { path = "../vtc-client", version = "0.6" }
 affinidi-crypto = { workspace = true }
 chrono = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.35", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.36", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -38,7 +38,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4" }
 vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-persona"
 description = "VTA persona store — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose"
 readme = "README.md"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 # Published for the same reason vta-vault is: `vta-service` is published, and a
 # crate cannot go to crates.io without its whole dependency closure. Nothing

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.4" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.35", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.36", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -193,7 +193,7 @@ vta-policy = { path = "../vta-policy", version = "0.3" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.2", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -393,7 +393,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vta-config = { path = "../vta-config", version = "0.4" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.5"
+version = "0.5.6"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -34,7 +34,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.6"
+version = "0.2.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -22,7 +22,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18" }
-vta-sdk = { path = "../vta-sdk", version = "0.35" }
+vta-sdk = { path = "../vta-sdk", version = "0.36" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.5.6"
+version = "0.6.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -38,7 +38,7 @@ tsp = ["didcomm", "vta-sdk/tsp"]
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["session"] }
 
 # The room's wire types, and — under the `mls` feature — its group-key and
 # sealing layers, which this crate re-exports rather than owning. A VTA needs

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -136,7 +136,7 @@ vti-common = { path = "../vti-common", version = "0.18", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.18.2"
+version = "0.18.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.35", default-features = false, features = [
+vta-sdk = { path = "../vta-sdk", version = "0.36", default-features = false, features = [
   # The Trust-Task proof verifier lives there now; this crate re-exports it.
   "proof-verify",
 ] }

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms-dtg"
 description = "The DTG-credential chain verifier for data rooms"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -45,7 +45,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { version = "0.4", optional = true }
 multibase = { workspace = true, optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = ["didcomm"], optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = ["didcomm"], optional = true }
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ tokio = { workspace = true }
 zeroize = { version = "1" }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.35", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.36", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION
release-plz has produced no Release PR since `chore: release (#1336)`. It
baselines each crate on the commit where its published version was set, clones
the repo there and lists the packaged files — and for 19 crates that commit is
`f43d26eb`, whose tree does not resolve: it bumped `vta-sdk` to 0.35.0 and left
`room-host` requiring `vta-sdk = "0.34"`.

Nothing that edits `main` can reach that commit. The only exit is to publish a
newer version of each stuck crate, so its baseline moves past it. #1406 proved
this on `vta-sdk`: the next run got further and failed on `vti-common` instead,
which is the mechanism confirming itself one crate at a time. This does the
remaining 18 in one commit.

## The versions are not arbitrary

Publishing 18 crates means choosing 18 bumps without the semver checks
release-plz would have applied, so `scripts/semver-report.sh` was run against
the workspace first — the repo's own tool, answering the question release-plz
could not. Two crates broke, and only two:

- **`vta-sdk` 0.35.1 -> 0.36.0.** `pub_module_level_const_missing`:
  `TASK_SEEDS_EXPORT_MNEMONIC_1_0` was removed in #1404. A patch here would have
  published an API removal as non-breaking.
- **`vtc-client` 0.5.6 -> 0.6.0.** `enum_variant_added`: `VtcError::Session` and
  `VtcError::NoRestTransport` on an exhaustive enum, from #1399.

The other 16 report "no semver update required" and take a patch.

## The two minor bumps move requirements too

`^0.35` does not match 0.36.0, so every intra-workspace requirement on `vta-sdk`
and `vtc-client` moves with them — 21 manifests. Leaving one behind is precisely
the defect that caused all of this, so `scripts/check-workspace-version-reqs.py`
(#1409, merged this afternoon) was run against the result: 31 members agree.
That guard was written for this failure and its first real use is verifying the
recovery from it.

`cargo metadata` resolves, `cargo build --workspace --all-targets` is clean, 34
test suites pass, and the lockfile self-pin guard is satisfied.

## What this does not do

It does not stop it happening again — #1409 does that, by failing a PR that
leaves a requirement behind. And it does not fix release-plz skipping the
optional dependency at #1336, which is worth reporting upstream: its own config
says it maintains a `publish = false` member's requirements, and in that commit
it updated `room-host`'s non-optional `vti-rooms` requirement while leaving the
optional `vta-sdk` one behind.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>