### PR TITLE
docs: record where the VTA's audit key should come from

### DIFF
--- a/docs/05-design-notes/vta-audit-chaining.md
+++ b/docs/05-design-notes/vta-audit-chaining.md
@@ -95,6 +95,43 @@ to ask "was this redacted row's actor this DID?", which is the question that
 survives an erasure — not a substitute for showing the actor while it is still
 there.
 
+## Where the audit key comes from
+
+Stage 1 says "derive the audit key from the master seed on boot, mirroring
+`vtc-service/src/server.rs`". A VTA can do that — the server holds the seed
+store and already reaches it during boot — but it is worth asking whether it
+should, because the seed is not the only source available and it is not
+obviously the best one.
+
+**A randomly generated key is the better default here.** The key's whole job is
+to be a stable HMAC handle for actor and target identifiers: it needs to exist
+before the first write, to be retrievable for as long as any envelope
+references it, and to be rotatable. It does not need to be derivable from
+anything. The key store already stores keys, keeps their history and rotates
+them, so a random initial key fits the model it already has.
+
+What derivation buys, and what it costs:
+
+| | Derived from the seed | Randomly generated |
+|---|---|---|
+| Availability at first write | Depends on the seed store answering. For a remote backend — a cloud secret manager, Vault — that is a network call that can fail at boot, and the VTC's answer to that failure is an `Option<AuditWriter>` that falls back to unchained rows | Available from the first boot, with no dependency to fail |
+| Recovery when the `audit_key` keyspace is lost | Regenerable from the mnemonic, which matters if envelopes were shipped off-node (a fan-out sink to a SIEM) and only the local key store was lost | Gone. Mitigated by keeping `audit_key` in the backup set, which leaves the gap at "backups lost, mnemonic survives" |
+| Who can recompute an actor hash | Anyone who holds the mnemonic, forever. A redaction that nulls the plaintext is then reversible by brute force for the seed holder, and the candidate space is small — the identifiers this node has seen | Whoever holds the key material |
+
+The third row is the one that decides it. VTI-AUD-005 exists so that an erasure
+removes personal data while the record stays verifiable. Deriving the audit key
+from the master seed means the mnemonic is also an audit-key backup, so the
+erasure is undone by whoever holds the recovery phrase — which, for a stack
+whose recovery story *is* the mnemonic, is a wide set.
+
+This makes a VTA's key source differ from a VTC's. That is a deliberate
+difference rather than an inconsistency, and the reasoning above applies to a
+VTC equally; moving it is a separate change, and its rotation machinery is the
+path if the working group wants to.
+
+**What this needs:** an `ensure_initial_random` beside `ensure_initial_with_info`
+on the key store, and `audit_key` in the VTA's backed-up keyspaces.
+
 ## Retention versus the chain
 
 `cleanup_expired_logs` deletes rows older than the retention period. Deleting

--- a/docs/05-design-notes/vta-audit-chaining.md
+++ b/docs/05-design-notes/vta-audit-chaining.md
@@ -114,7 +114,7 @@ What derivation buys, and what it costs:
 
 | | Derived from the seed | Randomly generated |
 |---|---|---|
-| Availability at first write | Depends on the seed store answering. For a remote backend — a cloud secret manager, Vault — that is a network call that can fail at boot, and the VTC's answer to that failure is an `Option<AuditWriter>` that falls back to unchained rows | Available from the first boot, with no dependency to fail |
+| Availability at first write | Not an issue either way — see *The first entry* below | Not an issue either way |
 | Recovery when the `audit_key` keyspace is lost | Regenerable from the mnemonic, which matters if envelopes were shipped off-node (a fan-out sink to a SIEM) and only the local key store was lost | Gone. Mitigated by keeping `audit_key` in the backup set, which leaves the gap at "backups lost, mnemonic survives" |
 | Who can recompute an actor hash | Anyone who holds the mnemonic, forever. A redaction that nulls the plaintext is then reversible by brute force for the seed holder, and the candidate space is small — the identifiers this node has seen | Whoever holds the key material |
 
@@ -131,6 +131,33 @@ path if the working group wants to.
 
 **What this needs:** an `ensure_initial_random` beside `ensure_initial_with_info`
 on the key store, and `audit_key` in the VTA's backed-up keyspaces.
+
+## The first entry
+
+There is no window before the key exists that needs auditing, because there is
+nothing a VTA can do before its seed is loaded. It holds no keys, can sign
+nothing, has no ACL to consult and no context to act in. The audit surface
+begins where the seed does.
+
+So **the first entry in the chain is the creation of the key that chains it.**
+Written the moment the key exists, committing to its id, it is a genesis that
+describes itself: a verifier reading the log from the start learns which key
+the following entries are hashed under, from an entry hashed under that same
+key.
+
+The same shape covers rotation. A rotation is an audited event, and the natural
+place for it is the first entry of the new key's era, so that each key's
+segment of the chain opens with the record of why the key changed.
+
+One class of event stays outside the chain: a failure to obtain the seed at
+all. It cannot be chained, because the key that would chain it does not exist —
+and this is the one moment where that is acceptable, since a node that cannot
+load its seed is a node that is not serving. It belongs in the log stream,
+which the `audit!` macro already writes to, and a reader should understand the
+chained log as beginning at the first moment the node could act.
+
+*Recorded from a review question: what would we even be auditing before the
+seed is there?*
 
 ## Retention versus the chain
 


### PR DESCRIPTION
Stacked on #1413. One section in the audit-chaining note, replacing stage 1's assumption that the VTA derives its audit key from the master seed "mirroring the VTC".

**A correction first.** The first version of this PR claimed a VTA *cannot* derive the key at boot, because a sealed VTA has no seed until an operator unseals. That was wrong: the seal is an **offline-CLI guard** that refuses state-mutating commands, enforced in `main.rs`, not a runtime secret lock — and the server reaches the seed store during boot already. Thanks to @glenngore for the question that prompted the check.

The real question turns out to be about privacy, not availability.

## Derive, or generate?

The audit key's job is to be a stable HMAC handle for actor and target identifiers: it must exist before the first write, stay retrievable while any envelope references it, and be rotatable. **It does not need to be derivable from anything**, and the key store already stores, rotates and keeps history.

| | Derived from the seed | Randomly generated |
|---|---|---|
| Availability at first write | Depends on the seed store answering — for a cloud secret manager or Vault that is a network call that can fail at boot, and the VTC's answer to that failure is an `Option<AuditWriter>` falling back to unchained rows | Available from first boot, no dependency to fail |
| Recovery if the `audit_key` keyspace is lost | Regenerable from the mnemonic — matters if envelopes were shipped off-node to a SIEM and only the local key store was lost | Gone. Mitigated by keeping `audit_key` in the backup set, leaving the gap at "backups lost, mnemonic survives" |
| **Who can recompute an actor hash** | **Anyone holding the mnemonic, forever** | Whoever holds the key material |

**The third row decides it.** VTI-AUD-005 exists so an erasure removes personal data while the record stays verifiable. Deriving the audit key from the master seed makes the mnemonic an audit-key backup — so the erasure is undone by whoever holds the recovery phrase, by brute force over a small candidate space (the identifiers this node has seen). For a stack whose recovery story *is* the mnemonic, that is a wide set.

So: **random, for the VTA.**

This makes the VTA's key source differ from the VTC's. That is deliberate rather than inconsistent — and the same reasoning applies to a VTC, whose rotation machinery is the path if the working group wants to move it.

## What it needs

`ensure_initial_random` beside the `ensure_initial_with_info` added in #1412, and `audit_key` in the VTA's backed-up keyspaces.