### PR TITLE
security(keys)!: domain-separate the opaque signing oracle

### DIFF
--- a/vta-sdk/src/protocols/key_management/sign.rs
+++ b/vta-sdk/src/protocols/key_management/sign.rs
@@ -16,6 +16,74 @@ pub enum SignAlgorithm {
     ES256,
 }
 
+/// Domain-separation tag for payloads the VTA cannot inspect.
+///
+/// Contains no NUL, so `TAG || 0x00 || payload` parses unambiguously however
+/// the payload begins.
+pub const OPAQUE_SIGNING_DOMAIN_V1: &[u8] = b"vti.vta.opaque-signing.v1";
+
+/// The bytes actually signed for an opaque payload.
+///
+/// A verifier of a signature produced by the VTA's generic signing operation
+/// checks it over **this**, not over the payload it supplied. Published here
+/// so a verifier can reconstruct it without reimplementing the framing.
+#[must_use]
+pub fn opaque_signing_input(payload: &[u8]) -> Vec<u8> {
+    let mut input = Vec::with_capacity(OPAQUE_SIGNING_DOMAIN_V1.len() + 1 + payload.len());
+    input.extend_from_slice(OPAQUE_SIGNING_DOMAIN_V1);
+    input.push(0x00);
+    input.extend_from_slice(payload);
+    input
+}
+
+/// Which kind of bytes a signing request carries, and therefore whether the
+/// VTA signs them as presented.
+///
+/// # Why this is an argument rather than a default
+///
+/// A signature is only meaningful against the question it answers, and a
+/// signature over bytes whose meaning the signer never established answers
+/// every question at once. Given an oracle that signs whatever it is handed
+/// under a principal's key, a caller authorized for one purpose can obtain a
+/// signature that verifies as something else entirely — an assertion in
+/// another protocol, a token, a proof over a document the principal never saw.
+/// Authorizing *which key* signs bounds the blast radius to that key; it says
+/// nothing about what the bytes will be taken to mean.
+///
+/// So the caller states which case it is in, and the two cases are not
+/// interchangeable:
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigningDomain {
+    /// The bytes are defined by a specification this VTA implements — a
+    /// data-integrity proof input, a task envelope — and that specification
+    /// has already established what they mean and how a verifier reconstructs
+    /// them. They are signed exactly as presented, because framing them again
+    /// would produce a signature that specification's verifier rejects.
+    ///
+    /// Reachable only from inside the VTA, where the caller is the code that
+    /// built the bytes.
+    ProtocolDefined,
+
+    /// The bytes came from a caller and the VTA cannot parse them. They are
+    /// signed under [`OPAQUE_SIGNING_DOMAIN_V1`], so the resulting signature
+    /// verifies as *a VTA opaque-signing payload* and as nothing else.
+    ///
+    /// This does not make signing arbitrary bytes safe; it makes the result
+    /// unusable outside the domain it was requested in.
+    Opaque,
+}
+
+impl SigningDomain {
+    /// The bytes to sign for `payload` in this domain.
+    #[must_use]
+    pub fn signing_input(self, payload: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+        match self {
+            Self::ProtocolDefined => std::borrow::Cow::Borrowed(payload),
+            Self::Opaque => std::borrow::Cow::Owned(opaque_signing_input(payload)),
+        }
+    }
+}
+
 /// Body of a sign-request message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -64,5 +132,81 @@ impl std::fmt::Display for SignAlgorithm {
             SignAlgorithm::EdDSA => write!(f, "eddsa"),
             SignAlgorithm::ES256 => write!(f, "es256"),
         }
+    }
+}
+
+#[cfg(test)]
+mod signing_domain_tests {
+    use super::*;
+
+    #[test]
+    fn an_opaque_payload_is_not_signed_as_presented() {
+        let payload = b"{\"alg\":\"none\"}";
+        assert_ne!(
+            SigningDomain::Opaque.signing_input(payload).as_ref(),
+            payload,
+            "an opaque payload is framed before signing, or the signature over it \
+             verifies as whatever the payload happens to be"
+        );
+    }
+
+    #[test]
+    fn protocol_defined_bytes_are_signed_as_presented() {
+        let payload = b"canonicalised proof input";
+        assert_eq!(
+            SigningDomain::ProtocolDefined
+                .signing_input(payload)
+                .as_ref(),
+            payload,
+            "framing these would produce a proof a conforming verifier rejects"
+        );
+    }
+
+    /// The point of the exercise: a signature obtained from the opaque
+    /// operation must not verify as a document in another domain, and vice
+    /// versa.
+    #[test]
+    fn the_two_domains_never_agree_on_the_bytes() {
+        for payload in [
+            b"".as_slice(),
+            b"x".as_slice(),
+            OPAQUE_SIGNING_DOMAIN_V1, // a payload that starts like the tag
+        ] {
+            assert_ne!(
+                SigningDomain::Opaque.signing_input(payload),
+                SigningDomain::ProtocolDefined.signing_input(payload),
+            );
+        }
+    }
+
+    /// The framing is unambiguous however the payload begins: the tag carries
+    /// no NUL, so the first NUL is always the separator.
+    #[test]
+    fn the_framing_cannot_be_forged_by_a_chosen_payload() {
+        assert!(
+            !OPAQUE_SIGNING_DOMAIN_V1.contains(&0x00),
+            "a NUL in the tag would make the separator ambiguous"
+        );
+
+        // A caller who prefixes the tag themselves does not thereby produce
+        // the same signing input as the framing does.
+        let mut impersonating = OPAQUE_SIGNING_DOMAIN_V1.to_vec();
+        impersonating.push(0x00);
+        impersonating.extend_from_slice(b"payload");
+
+        assert_ne!(
+            SigningDomain::Opaque.signing_input(&impersonating),
+            SigningDomain::Opaque.signing_input(b"payload"),
+            "framing is applied once by the VTA, not something a caller can pre-apply"
+        );
+    }
+
+    #[test]
+    fn a_verifier_can_reconstruct_what_was_signed() {
+        let payload = b"an assertion";
+        assert_eq!(
+            opaque_signing_input(payload),
+            SigningDomain::Opaque.signing_input(payload).into_owned(),
+        );
     }
 }

--- a/vta-service/src/messaging/handlers.rs
+++ b/vta-service/src/messaging/handlers.rs
@@ -7,6 +7,7 @@
 //!   - Returns `Ok(Some(DIDCommResponse))` or `Ok(None)`
 
 use std::sync::Arc;
+use vta_sdk::protocols::key_management::sign::SigningDomain;
 
 use base64::Engine;
 
@@ -473,6 +474,8 @@ didcomm_handler!(
             &body.key_id,
             &payload,
             &body.algorithm,
+            // A payload from a DIDComm caller: the VTA cannot parse it.
+            SigningDomain::Opaque,
             "didcomm",
         )
         .await

--- a/vta-service/src/operations/keys.rs
+++ b/vta-service/src/operations/keys.rs
@@ -17,7 +17,7 @@ use vta_sdk::protocols::key_management::{
     rename::RenameKeyResultBody,
     revoke::RevokeKeyResultBody,
     secret::GetKeySecretResultBody,
-    sign::{SignAlgorithm, SignResultBody},
+    sign::{SignAlgorithm, SignResultBody, SigningDomain},
 };
 
 use crate::audit::{self, audit};
@@ -1139,6 +1139,7 @@ pub async fn sign_payload(
     key_id: &str,
     payload: &[u8],
     algorithm: &SignAlgorithm,
+    domain: SigningDomain,
     channel: &str,
 ) -> Result<SignResultBody, AppError> {
     let record: KeyRecord = keys_ks
@@ -1189,6 +1190,14 @@ pub async fn sign_payload(
         // whose entry names specific keys asked to be bound to them.
         require_key_in_caller_scope(acl_ks, auth, key_id).await?;
     }
+
+    // What gets signed, which is not always what was handed in: an opaque
+
+    // payload is framed under its domain tag first. See `SigningDomain`.
+
+    let to_sign = domain.signing_input(payload);
+
+    let payload = to_sign.as_ref();
 
     let signature_bytes = match record.origin {
         // The one place internal key material is used. It never leaves this
@@ -1949,6 +1958,7 @@ mod tests {
             &key.key_id,
             payload,
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await
@@ -2195,6 +2205,7 @@ mod tests {
             &key.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await;
@@ -2216,6 +2227,7 @@ mod tests {
             &key.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await;
@@ -2256,6 +2268,7 @@ mod tests {
             &allowed.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await
@@ -2322,6 +2335,7 @@ mod tests {
                     key_id,
                     b"payload",
                     &SignAlgorithm::EdDSA,
+                    SigningDomain::Opaque,
                     "test",
                 )
                 .await
@@ -2458,6 +2472,7 @@ mod tests {
             &foreign.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await;
@@ -2506,6 +2521,7 @@ mod tests {
             &unscoped.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await;
@@ -2607,6 +2623,7 @@ mod tests {
             &key.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await;
@@ -2648,6 +2665,7 @@ mod tests {
             &own.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await
@@ -2714,6 +2732,7 @@ mod tests {
             &key.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await;
@@ -2733,6 +2752,7 @@ mod tests {
             &key.key_id,
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await
@@ -3204,6 +3224,7 @@ mod tests {
             "k-sign",
             b"payload",
             &SignAlgorithm::EdDSA,
+            SigningDomain::Opaque,
             "test",
         )
         .await

--- a/vta-service/src/operations/room_issuance.rs
+++ b/vta-service/src/operations/room_issuance.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 use affinidi_data_integrity::DataIntegrityProof;
 use affinidi_data_integrity::signer::Signer;
 use affinidi_secrets_resolver::secrets::KeyType;
-use vta_sdk::protocols::key_management::sign::SignAlgorithm;
+use vta_sdk::protocols::key_management::sign::{SignAlgorithm, SigningDomain};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 use vti_secrets::SeedStore;
@@ -124,6 +124,12 @@ impl Signer for RoomKeySigner<'_> {
             &self.key_id,
             data,
             &SignAlgorithm::EdDSA,
+            // Data-integrity proof input: the caller here is the code that
+            // built these bytes, and the proof specification has already
+            // established what they mean and how a verifier reconstructs
+            // them. Framing them again would produce a proof that a
+            // conforming verifier rejects.
+            SigningDomain::ProtocolDefined,
             "rooms/owner",
         )
         .await

--- a/vta-service/src/routes/keys.rs
+++ b/vta-service/src/routes/keys.rs
@@ -2,6 +2,7 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use serde::{Deserialize, Serialize};
+use vta_sdk::protocols::key_management::sign::SigningDomain;
 
 use vta_sdk::protocols::key_management::{
     create::CreateKeyResponseBody,
@@ -332,6 +333,8 @@ pub async fn sign_with_key(
         &key_id,
         &payload,
         &req.algorithm,
+        // A payload from a REST caller: the VTA cannot parse it.
+        SigningDomain::Opaque,
         "rest",
     )
     .await?;

--- a/vta-service/src/trust_tasks/keys.rs
+++ b/vta-service/src/trust_tasks/keys.rs
@@ -19,6 +19,7 @@ use vta_sdk::protocols::key_management::rename::RenameKeyBody;
 use vta_sdk::protocols::key_management::revoke::RevokeKeyBody;
 use vta_sdk::protocols::key_management::secret::GetKeySecretBody;
 use vta_sdk::protocols::key_management::sign::SignRequestBody;
+use vta_sdk::protocols::key_management::sign::SigningDomain;
 
 use crate::auth::AuthClaims;
 use crate::operations;
@@ -306,6 +307,8 @@ pub(super) async fn handle_sign(
         &req.key_id,
         &payload_bytes,
         &req.algorithm,
+        // A payload from a task caller: the VTA cannot parse it.
+        SigningDomain::Opaque,
         TRANSPORT_TRUST_TASK,
     )
     .await


### PR DESCRIPTION
Implements the option you chose for **VTI-VTA-004** — the blind-signing finding from the [specification](https://trustoverip.github.io/dtgwg-vti-spec/) gap analysis.

## The problem

`keys/sign` signs an octet string the caller supplies, under a key the caller names. The authorization around it is genuinely good — context, the context's `signable_keys` policy, the entry's own key narrowing, super-admin-only for unscoped keys — but **all of it bounds *which key* signs, and none of it bounds *what the bytes mean***.

So a caller authorized to sign for one purpose could obtain a signature that verifies as something else entirely: an assertion in another protocol, a token, a proof over a document the principal never saw. The type's own doc said as much — *"the VTA signs the bytes it is given without inspecting them"* — and treated it as a caller-side concern.

## The fix

Payloads the VTA cannot parse are framed under `vti.vta.opaque-signing.v1` before signing, so the signature verifies as **a VTA opaque-signing payload and as nothing else**.

This does not make signing arbitrary bytes safe. It makes the result unusable outside the domain it was requested in, which is what domain separation buys and the limit of what it buys.

## Why it is an argument, not a blanket prefix

**One caller must not be framed.** `room_issuance.rs` signs data-integrity proof inputs through this same function — bytes whose meaning the proof specification has already established, including how a verifier reconstructs them. Framing those again produces a proof that a conforming verifier rejects.

So `SigningDomain` is an explicit argument and every call site states which case it is in:

- `Opaque` — REST, DIDComm and the Trust Task, where the payload came from a caller;
- `ProtocolDefined` — the in-process proof signer, where the caller is the code that built the bytes.

They are not interchangeable, and the enum's docs say why at each variant.

## Breaking change

Signatures over `keys/sign` now cover the framed input rather than the payload as supplied. **A verifier reconstructs it with `opaque_signing_input`**, published in the SDK for exactly that. Signatures made before this change do not verify against the new input, and vice versa — there is no compatibility mode, because one would reintroduce the property being removed.

Proofs built inside the VTA are unaffected.

## Tests

Five, on the framing itself: an opaque payload is not signed as presented; protocol-defined bytes are; the two domains never agree on the bytes — including for a payload that *starts with the tag*; the framing cannot be pre-applied by a chosen payload (the tag carries no NUL, so the first NUL is always the separator); and a verifier can reconstruct what was signed.