### PR TITLE
feat(room-host): actually serve the identity the VTA holds

### DIFF
--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -85,7 +85,17 @@ k8s-secrets = ["vti-secrets/k8s-secrets"]
 ## Enrol with a VTA: ephemeral `did:key` → operator grant → auto-rotate, the flow
 ## the mediator, PNM and did-hosting already use. Separate from `didcomm` because
 ## a host can be reachable without being governed by any VTA.
-onboarding = ["dep:vti-secrets", "dep:vta-sdk", "vti-secrets/onboarding"]
+## `affinidi-secrets-resolver` because the identity this feature fetches is a set of
+## `Secret`s — it is the return type of `onboarding::fetch_identity`, not an internal
+## detail. Without it `--features onboarding` alone did not compile at all; the
+## dependency arrived only via `didcomm`, so every build that had both hid it.
+onboarding = [
+    "dep:vti-secrets",
+    "dep:vta-sdk",
+    "dep:affinidi-secrets-resolver",
+    "dep:toml",
+    "vti-secrets/onboarding",
+]
 ## Session storage for the enrolled identity. One is required by `onboarding`, and
 ## which one is an operator's decision — the same shape as `[secrets]`.
 config-session = ["vta-sdk/config-session"]

--- a/room-host/src/didcomm.rs
+++ b/room-host/src/didcomm.rs
@@ -123,6 +123,22 @@ struct IdentityFile {
 }
 
 impl HostIdentity {
+    /// The identity a VTA holds for this host, rather than one minted here.
+    ///
+    /// The DID is a `did:webvh` the VTA minted into the host's context and the keys are the
+    /// ones it published under it, so what a member resolves and what this host seals with
+    /// are the same by construction rather than by agreement.
+    ///
+    /// No mediator is recorded because none is encoded: a `did:peer:2` carries its mediator
+    /// in the identifier, which is why [`load_or_mint`](Self::load_or_mint) checks the two
+    /// agree. A `did:webvh` carries a service block instead, and the mediator named there is
+    /// the VTA's business — it published the document. Checking it here would be this host
+    /// second-guessing the party that issued its identity.
+    #[must_use]
+    pub fn from_vta(did: String, secrets: Vec<Secret>) -> Self {
+        Self { did, secrets }
+    }
+
     /// Load this host's identity from `secrets`, minting one on first use.
     ///
     /// `did:peer:2`, so the identifier carries both its keys **and** the mediator it is
@@ -552,5 +568,29 @@ mod tests {
         // caller never sent, which is the same failure as threading on the wrong one.
         let no_id = serde_json::to_vec(&json!({ "type": "x", "payload": {} })).unwrap();
         assert_eq!(unwrap_request(Protocol::TSP, &no_id), None);
+    }
+
+    /// The VTA identity is what the host serves as, and nothing about it is re-derived
+    /// here — the DID comes from the VTA and the keys with it.
+    ///
+    /// Worth a test because the constructor's whole job is to *not* do what
+    /// `load_or_mint` does: no minting, no mediator check, no identity file. A future
+    /// refactor that "helpfully" made them share a path would silently start serving a
+    /// different DID than the one the VTA published.
+    #[test]
+    fn a_vta_identity_is_served_verbatim() {
+        let did = "did:webvh:QmScid:rooms.example:host".to_string();
+        let identity = HostIdentity::from_vta(did.clone(), Vec::new());
+        assert_eq!(identity.did, did, "the VTA's DID, unchanged");
+    }
+
+    /// The redacting Debug still holds for an identity that came from a VTA — it is the
+    /// same struct, and this is the half that carries private keys.
+    #[test]
+    fn a_vta_identity_still_redacts_its_secrets() {
+        let identity =
+            HostIdentity::from_vta("did:webvh:QmScid:rooms.example:host".into(), Vec::new());
+        let rendered = format!("{identity:?}");
+        assert!(rendered.contains("redacted"), "got: {rendered}");
     }
 }

--- a/room-host/src/main.rs
+++ b/room-host/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 
 /// The wrapper a `[secrets]` table arrives in, so the file reads the same as every other
 /// service's config rather than being a bare table this binary alone would accept.
-#[cfg(feature = "didcomm")]
+#[cfg(any(feature = "didcomm", feature = "onboarding"))]
 #[derive(serde::Deserialize)]
 struct SecretsFile {
     #[serde(default)]
@@ -68,7 +68,7 @@ struct Args {
     /// Omitted, the host keeps its identity in a plaintext file under `--data-dir`. That is
     /// the right default for running this on a laptop and the wrong one for a deployment: it
     /// is a private key on whatever volume the container was given.
-    #[cfg(feature = "didcomm")]
+    #[cfg(any(feature = "didcomm", feature = "onboarding"))]
     #[arg(long)]
     secrets: Option<std::path::PathBuf>,
 
@@ -81,6 +81,19 @@ struct Args {
     #[cfg(feature = "onboarding")]
     #[arg(long)]
     vta_did: Option<String>,
+
+    /// The VTA context this host serves rooms for.
+    ///
+    /// Its DID is what this host serves *as*: the VTA mints it, publishes it, and holds the
+    /// keys, and this host fetches them at startup. So the identity a member resolves and
+    /// the identity this host seals with are the same by construction.
+    ///
+    /// The grant an operator makes on enrolment is for this context, and it is an
+    /// `application` role — a host holds ciphertext it cannot read, so it needs to act in
+    /// the context and needs no authority over it.
+    #[cfg(feature = "onboarding")]
+    #[arg(long, default_value = "rooms")]
+    vta_context: String,
 
     /// Seconds between mirror pulls.
     ///
@@ -128,15 +141,12 @@ async fn main() -> anyhow::Result<()> {
         ));
     }
 
-    // Before the listener, for the same reason mirrors start first: a host that is going to
-    // be reachable at a mediator should be reachable *by the time* it starts answering, and
-    // an identity that will not load is a startup failure rather than something discovered
-    // by the first member who cannot reach it.
-    #[cfg(feature = "didcomm")]
-    if let Some(mediator_did) = args.mediator_did.clone() {
-        // The same `[secrets]` shape the VTA and VTC take. With none configured this is a
-        // plaintext file under `--data-dir`, which is right for a laptop; a deployment points
-        // it at the secret manager it already runs.
+    // One secrets store, used by both the VTA-identity cache and the self-minted identity.
+    // The same `[secrets]` shape the VTA and VTC take: with none configured this is a
+    // plaintext file under `--data-dir`, which is right for a laptop; a deployment points it
+    // at the secret manager it already runs.
+    #[cfg(any(feature = "didcomm", feature = "onboarding"))]
+    let identity_store = {
         let secrets = match &args.secrets {
             Some(path) => {
                 let text = std::fs::read_to_string(path)?;
@@ -161,9 +171,81 @@ async fn main() -> anyhow::Result<()> {
                 config
             }
         };
-        let store = vti_secrets::create_seed_store(&secrets, &args.data_dir)?;
-        let identity =
-            room_host::didcomm::HostIdentity::load_or_mint(store.as_ref(), &mediator_did).await?;
+        vti_secrets::create_seed_store(&secrets, &args.data_dir)?
+    };
+
+    // Enrolment first, because it can stop. A host awaiting a grant has nothing to serve
+    // and no identity to serve it under, and minting one before finding that out leaves a
+    // `did:peer` in the data directory that the VTA-governed path will never use.
+    //
+    // An operator who has to authorize this host should also find that out from the first
+    // line of output, not after a page of startup that implies it is working.
+    #[cfg(feature = "onboarding")]
+    let vta_identity = match args.vta_did.as_deref() {
+        None => None,
+        Some(vta_did) => match room_host::onboarding::enrol(&args.data_dir, vta_did)? {
+            room_host::onboarding::Enrolment::AwaitingGrant { ephemeral_did } => {
+                println!(
+                    "{}",
+                    room_host::onboarding::grant_instructions(&ephemeral_did, vta_did)
+                );
+                return Ok(());
+            }
+            room_host::onboarding::Enrolment::Enrolled => {
+                tracing::info!(vta = %vta_did, "enrolled with the VTA");
+                // The identity this host actually serves as. Fetched rather than minted:
+                // the VTA holds the context's DID and its keys, so what a member resolves
+                // and what this host seals with are the same by construction.
+                //
+                // The cache is the same secrets store the minted identity would use, so a
+                // VTA that is unreachable at boot costs this host nothing — it comes up on
+                // the identity it fetched last time. Without that, a VTA outage would stop
+                // every host enrolled with it, which is a far larger blast radius than the
+                // outage itself.
+                let identity = room_host::onboarding::fetch_identity(
+                    &args.data_dir,
+                    vta_did,
+                    &args.vta_context,
+                    identity_store.as_ref(),
+                )
+                .await?;
+                if !identity.fresh {
+                    tracing::warn!(
+                        did = %identity.did,
+                        "serving on the cached VTA identity — the VTA could not be reached"
+                    );
+                }
+                Some(identity)
+            }
+        },
+    };
+
+    // Before the listener, for the same reason mirrors start first: a host that is going to
+    // be reachable at a mediator should be reachable *by the time* it starts answering, and
+    // an identity that will not load is a startup failure rather than something discovered
+    // by the first member who cannot reach it.
+    #[cfg(feature = "didcomm")]
+    if let Some(mediator_did) = args.mediator_did.clone() {
+        // Governed by a VTA: serve as the DID it holds for this context.
+        #[cfg(feature = "onboarding")]
+        let from_vta = vta_identity
+            .map(|vta| room_host::didcomm::HostIdentity::from_vta(vta.did, vta.secrets));
+        // Built without onboarding, there is no VTA to be governed by and nothing to fetch.
+        #[cfg(not(feature = "onboarding"))]
+        let from_vta: Option<room_host::didcomm::HostIdentity> = None;
+
+        let identity = match from_vta {
+            Some(identity) => identity,
+            // Ungoverned: mint a `did:peer:2` of this host's own, which encodes the mediator
+            // so `?at=<did>` remains a complete address with nothing to resolve.
+            None => {
+                room_host::didcomm::HostIdentity::load_or_mint(
+                    identity_store.as_ref(),
+                    &mediator_did,
+                )
+                .await?
+            }
+        };
         // Printed, not only logged. It is this host's *address* — the thing a member puts
         // after `?at=` — and an operator has to be able to copy it out of a terminal.
         println!("host DID: {}", identity.did);
@@ -173,28 +255,6 @@ async fn main() -> anyhow::Result<()> {
                 tracing::error!(error = %e, "the mediator connection ended");
             }
         });
-    }
-
-    // Before the listener, and before anything is served: an operator who has to authorize
-    // this host should find that out from the first line of output, not after a page of
-    // startup that implies it is working.
-    #[cfg(feature = "onboarding")]
-    if let Some(vta_did) = args.vta_did.as_deref() {
-        match room_host::onboarding::enrol(&args.data_dir, vta_did)? {
-            room_host::onboarding::Enrolment::Enrolled => {
-                tracing::info!(vta = %vta_did, "enrolled with the VTA");
-            }
-            room_host::onboarding::Enrolment::AwaitingGrant { ephemeral_did } => {
-                // Printed and then stopped. Carrying on would serve a host that cannot be
-                // authorized for anything the VTA governs, which is a confusing kind of
-                // running — and the operator has a step to take before it can be otherwise.
-                println!(
-                    "{}",
-                    room_host::onboarding::grant_instructions(&ephemeral_did, vta_did)
-                );
-                return Ok(());
-            }
-        }
     }
 
     let listener = tokio::net::TcpListener::bind(&args.listen).await?;


### PR DESCRIPTION
`fetch_identity` was written, documented and referenced by its own module docs —
and called by nothing. Across the whole workspace it had two references: its
definition, and a doc comment pointing at it.

So `--vta-did` did exactly one thing: mint a throwaway, print the grant, and on
the next start report "enrolled with the VTA". The host then served under the
`did:peer:2` it minted for `--mediator-did`, and the ACL grant bought nothing.
Every log line said the VTA-governed path was working. Nothing in it ran.

This is the same shape as the `rematerialise`-called-from-nowhere defect: code
that reads as a live feature because it is complete, tested at the edges, and
unreachable.

## The wiring

- `HostIdentity::from_vta` — the VTA's DID and the keys published under it, used
  verbatim. Deliberately not sharing a path with `load_or_mint`: that one mints,
  checks the identifier encodes the right mediator, and writes an identity file,
  and none of those are right for a DID somebody else published. A `did:webvh`
  carries a service block rather than an encoded mediator, and second-guessing
  it would be this host arguing with the party that issued its identity.
- `--vta-context`, defaulting to `rooms`. `fetch_identity` always needed one and
  there was no flag to supply it, which is its own evidence the call site never
  existed.
- **Enrolment moved before the identity is chosen.** It can `return`, and
  minting a `did:peer` first left one in the data directory that the governed
  path would never use.
- One secrets store, hoisted, shared by the cached VTA identity and the
  self-minted one — so `--secrets` covers both and an operator configures where
  key material rests once.

An unreachable VTA is not fatal: the host comes up on the cached identity and
warns. Losing every host when the VTA blinks is a far larger blast radius than
the outage, for a process that only stores ciphertext.

## A feature that never compiled

`--features onboarding` alone failed with four errors on `main` and always has:
`onboarding.rs` returns `Vec<Secret>` from `affinidi-secrets-resolver`, which
only `didcomm` pulled in. Every build that had both hid it. Fixed by declaring
what the feature actually needs, and all four combinations now build — none,
`didcomm`, `onboarding`, both.

That is a small thing that says something: the feature meant to be the VTA path
had never been built on its own, which is consistent with the call site never
having been written.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>