### PR TITLE
feat(audit): give the VTA an audit key of its own

### DIFF
--- a/vta-keyspaces/src/lib.rs
+++ b/vta-keyspaces/src/lib.rs
@@ -49,6 +49,14 @@ pub const CONTEXTS: &str = "contexts";
 pub const DID_TEMPLATES: &str = "did_templates";
 /// Audit log.
 pub const AUDIT: &str = "audit";
+/// The keyed-hash keys the audit log commits actor and target identifiers
+/// under, and their history.
+///
+/// Separate from [`AUDIT`] because the two have opposite lifetimes: entries
+/// are erased when their retention expires, and a key must outlive every entry
+/// that references it or those entries stop being checkable against a
+/// candidate identifier.
+pub const AUDIT_KEY: &str = "audit_key";
 /// Imported secret material (KEK-wrapped). Named `imported_secrets`, **not**
 /// `imported` — the latter was a long-standing test-only typo that operated on
 /// an empty keyspace disjoint from production. Always reference this const.
@@ -255,6 +263,7 @@ pub const ALL: &[&str] = &[
     CONTEXTS,
     DID_TEMPLATES,
     AUDIT,
+    AUDIT_KEY,
     IMPORTED_SECRETS,
     CACHE,
     VAULT,
@@ -287,6 +296,11 @@ pub const BACKED_UP: &[&str] = &[
     ACL,
     CONTEXTS,
     AUDIT,
+    // Without the keys, a restored audit log still verifies as a chain and
+    // still says what happened, but no entry can be checked against a
+    // candidate identifier again — the commitments become opaque. The key is
+    // generated rather than derived, so nothing else reproduces it.
+    AUDIT_KEY,
     IMPORTED_SECRETS,
     WEBVH,
     CONSENT,
@@ -489,7 +503,7 @@ pub const fn did_delete_effect(keyspace: &str) -> Option<DidDeleteEffect> {
         // ---- Not keyed to a DID ------------------------------------------
         // The audit log is deliberately here: it is append-only, and the record
         // that a DID was deleted is the one thing that must survive deleting it.
-        b"audit" => Unrelated,
+        b"audit" | b"audit_key" => Unrelated,
         b"did_templates" | b"sealed_nonces" | b"backup_bundles" => Unrelated,
         b"drains" | b"bootstrap" | b"idempotency" => Unrelated,
 

--- a/vti-common/src/audit/key_store.rs
+++ b/vti-common/src/audit/key_store.rs
@@ -260,6 +260,48 @@ impl AuditKeyStore {
         Ok(initial)
     }
 
+    /// Establish an initial key from the OS random source rather than from a
+    /// seed. Idempotent, like [`Self::ensure_initial`].
+    ///
+    /// # Why a node would prefer this
+    ///
+    /// The key's job is to be a stable handle for actor and target
+    /// identifiers: it has to exist before the first write, stay retrievable
+    /// while any envelope references it, and be rotatable. Nothing about that
+    /// requires it to be derivable.
+    ///
+    /// What derivation adds is a second copy of the key wherever the seed is.
+    /// A node whose recovery story is a mnemonic therefore has an audit key
+    /// that anyone holding the mnemonic can recompute — and since the
+    /// commitment exists so that an erasure can null the plaintext while the
+    /// row stays correlatable, that makes the erasure reversible by brute
+    /// force over the identifiers the node has seen. Generating the key
+    /// instead confines that to whoever holds the key material.
+    ///
+    /// The cost is that the key is not regenerable: if the keyspace holding it
+    /// is lost and envelopes survive elsewhere, their actor hashes can no
+    /// longer be checked against a candidate. Keep this keyspace in the backup
+    /// set.
+    pub async fn ensure_initial_random(&self) -> Result<AuditKey, AppError> {
+        if let Some(existing) = self.try_active().await? {
+            return Ok(existing);
+        }
+
+        let mut key = [0u8; 32];
+        rand::fill(&mut key);
+
+        let initial = AuditKey {
+            key_id: KeyId::new(),
+            key,
+            valid_from: Utc::now(),
+            valid_until: None,
+            rotation_reason: RotationReason::Initial,
+        };
+        self.persist(&initial).await?;
+        self.set_active(&initial.key_id).await?;
+        Ok(initial)
+    }
+
     /// Rotate the active key. The previous key gets `valid_until: now`
     /// and a fresh-random successor is generated + activated.
     /// Returns the new active key.
@@ -471,6 +513,46 @@ mod domain_separation_tests {
         assert_ne!(
             vtc_key.key, vta_key.key,
             "a VTC and the VTA beneath it must not share an audit key"
+        );
+    }
+
+    /// A generated key is idempotent the same way a derived one is: it is
+    /// established once and returned unchanged after that, so a node can call
+    /// it on every start.
+    #[tokio::test]
+    async fn a_generated_key_is_established_once() {
+        let (ks, _dir) = store();
+
+        let first = ks.ensure_initial_random().await.expect("first");
+        let second = ks.ensure_initial_random().await.expect("second");
+
+        assert_eq!(first.key_id, second.key_id);
+        assert_eq!(first.key, second.key);
+    }
+
+    /// The property that makes a generated key worth preferring: nothing
+    /// outside the key store reproduces it. Two nodes that share a seed —
+    /// a VTC and the VTA beneath it — still get unrelated keys.
+    #[tokio::test]
+    async fn a_generated_key_is_not_reproducible_from_the_seed() {
+        let seed = [7u8; 32];
+
+        let (generated_ks, _a) = store();
+        let (derived_ks, _b) = store();
+
+        let generated = generated_ks.ensure_initial_random().await.unwrap();
+        let derived = derived_ks
+            .ensure_initial_with_info(&seed, VTA_AUDIT_KEY_INFO)
+            .await
+            .unwrap();
+
+        assert_ne!(generated.key, derived.key);
+
+        let (other_ks, _c) = store();
+        let other = other_ks.ensure_initial_random().await.unwrap();
+        assert_ne!(
+            generated.key, other.key,
+            "two generated keys are unrelated to each other as well"
         );
     }
 


### PR DESCRIPTION
Next step of the audit-chaining work ([#1415](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1415) settled the design). Two pieces, both inert until the sink uses them.

## `ensure_initial_random`

Establishes an initial key from the OS random source rather than from a seed, idempotently, so a node can call it on every start.

The reasoning, per #1415: the key's job is to be a **stable handle** for actor and target identifiers — exist before the first write, stay retrievable while any envelope references it, be rotatable. Nothing about that requires it to be derivable.

What derivation *adds* is a second copy of the key wherever the seed is. A node whose recovery story is a mnemonic therefore has an audit key that anyone holding the mnemonic can recompute — and since the commitment exists precisely so an erasure can null the plaintext while the row stays correlatable, **that makes the erasure reversible by brute force** over the identifiers the node has seen.

Two tests: a generated key is established once and returned unchanged after; and it is not reproducible from the seed, nor from another generated key.

## The keyspace

`audit_key`, registered in `ALL` and in the **backed-up** set.

Backed up because the key is not regenerable — that is the cost of generating rather than deriving. Without it a restored audit log still verifies as a chain and still says what happened, but no entry can be checked against a candidate identifier again: the commitments become opaque.

Separate from `audit` because the two have **opposite lifetimes**: entries are erased when their retention expires, and a key must outlive every entry that references it. Neither cascades on a DID deletion, for the reason the audit log already does not — the record that a DID was deleted is the one thing that must survive deleting it.

## Next

The sink. It ensures the key on first write — which is what makes the genesis entry work: the first entry in the chain is the creation of the key that chains it, written by the same call that creates it.