### PR TITLE
feat(audit): write the VTA's audit log as a hash chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10228,6 +10228,8 @@ name = "vta-audit"
 version = "0.3.6"
 dependencies = [
  "async-trait",
+ "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -23,8 +23,11 @@ repository.workspace = true
 vti-common = { path = "../vti-common", version = "0.18" }
 vta-sdk = { path = "../vta-sdk", version = "0.36" }
 async-trait = "0.1"
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
+tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/vta-audit/src/lib.rs
+++ b/vta-audit/src/lib.rs
@@ -19,7 +19,8 @@ use vti_common::store::KeyspaceHandle;
 
 pub mod sink;
 pub use sink::{
-    AuditSink, FanOutAuditSink, KeyspaceAuditSink, SharedAuditSink, shared_keyspace_sink,
+    AUDIT_KEY_CREATED, AuditSink, ChainedKeyspaceAuditSink, FanOutAuditSink, KeyspaceAuditSink,
+    SYSTEM_ACTOR, SharedAuditSink, shared_chained_sink, shared_keyspace_sink,
 };
 
 /// Emit a structured audit event to the tracing subsystem — **a log line, and

--- a/vta-audit/src/sink.rs
+++ b/vta-audit/src/sink.rs
@@ -39,6 +39,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use vta_sdk::protocols::audit_management::list::AuditLogEntry;
+use vti_common::audit::event::{AuditEvent, VtaOperationData};
+use vti_common::audit::key_store::AuditKeyStore;
+use vti_common::audit::writer::AuditWriter;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
@@ -102,6 +105,140 @@ impl AuditSink for KeyspaceAuditSink {
     }
 }
 
+/// The actor recorded for events the node performs on its own behalf, where
+/// there is no caller to name.
+pub const SYSTEM_ACTOR: &str = "urn:vti:vta:system";
+
+/// The action recorded for the entry that opens a chain.
+pub const AUDIT_KEY_CREATED: &str = "audit.key.created";
+
+/// The `audit` keyspace, written as a hash chain.
+///
+/// Same keyspace and same storage-key format as [`KeyspaceAuditSink`], so the
+/// read and retention paths keep working and rows written before this existed
+/// keep their place in time order. What changes is the value: an envelope that
+/// commits to its predecessor, and that commits to the actor under a keyed
+/// hash so an erasure can remove the plaintext without breaking the chain.
+///
+/// # The first entry
+///
+/// A chain has to start somewhere, and the honest place is the creation of the
+/// key that chains it. The key is established on the first write — there is
+/// nothing to audit before a node can act, and a node cannot act before it has
+/// somewhere to record what it did — so the first entry this sink writes is
+/// the record of that key coming into existence, committing to its id. A
+/// verifier reading from the start learns which key the following entries are
+/// hashed under, from an entry hashed under that same key.
+#[derive(Clone)]
+pub struct ChainedKeyspaceAuditSink {
+    keyspace: KeyspaceHandle,
+    key_store: AuditKeyStore,
+    writer: AuditWriter,
+    /// Runs the establish-key-then-open-the-chain sequence once per process,
+    /// so concurrent first writes cannot both open it.
+    opened: Arc<tokio::sync::OnceCell<()>>,
+}
+
+impl ChainedKeyspaceAuditSink {
+    pub fn new(keyspace: KeyspaceHandle, key_keyspace: KeyspaceHandle) -> Self {
+        let key_store = AuditKeyStore::new(key_keyspace);
+        let writer = AuditWriter::new(keyspace.clone(), key_store.clone())
+            // The keyspace already has an ordering and rows that use it, so
+            // the seconds stay the leading field: the retention sweep compares
+            // keys against `log:{cutoff:020}:` and stops at the first row past
+            // it, and a different leading field would make every chained row
+            // sort past every cutoff and never expire.
+            //
+            // The nanoseconds are the tiebreaker, and they are not optional.
+            // Whole seconds put two entries written in the same second in
+            // uuid order, so a verifier reading the log in key order sees them
+            // out of chain order and reports a break in a chain that is
+            // intact. That is the worst kind of false alarm: it looks exactly
+            // like the thing it exists to detect.
+            .with_storage_key(|env| {
+                format!(
+                    "log:{:020}:{:09}:{}",
+                    env.timestamp.timestamp().max(0),
+                    env.timestamp.timestamp_subsec_nanos(),
+                    env.event_id
+                )
+                .into_bytes()
+            });
+        Self {
+            keyspace,
+            key_store,
+            writer,
+            opened: Arc::new(tokio::sync::OnceCell::new()),
+        }
+    }
+
+    /// The keyspace behind this sink, for the read and retention paths.
+    pub fn keyspace(&self) -> &KeyspaceHandle {
+        &self.keyspace
+    }
+
+    /// Establish the key if there is none, and open the chain with the record
+    /// of its creation. Idempotent within a process and across restarts: a key
+    /// that already exists was already recorded when it was created.
+    async fn ensure_open(&self) -> Result<(), AppError> {
+        let already_established = self.key_store.try_active().await?.is_some();
+        if already_established {
+            return Ok(());
+        }
+
+        let key = self.key_store.ensure_initial_random().await?;
+        self.writer
+            .write(
+                SYSTEM_ACTOR,
+                None,
+                AuditEvent::VtaOperation(VtaOperationData {
+                    action: AUDIT_KEY_CREATED.to_string(),
+                    resource: Some(key.key_id.as_uuid().to_string()),
+                    outcome: "success".to_string(),
+                    channel: None,
+                    context_id: None,
+                    detail: None,
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AuditSink for ChainedKeyspaceAuditSink {
+    async fn record(&self, entry: &AuditLogEntry) -> Result<(), AppError> {
+        self.opened
+            .get_or_try_init(|| self.ensure_open())
+            .await
+            .map(|_| ())?;
+
+        // A resource that is a DID travels in the envelope's hashed members,
+        // where an erasure can reach it. Anything else — a key id, a session
+        // id, a context path — is not personal data and stays in the event.
+        let (target, resource) = match entry.resource.as_deref() {
+            Some(r) if r.starts_with("did:") => (Some(r), None),
+            other => (None, other),
+        };
+
+        self.writer
+            .write(
+                &entry.actor,
+                target,
+                AuditEvent::VtaOperation(VtaOperationData {
+                    action: entry.action.clone(),
+                    resource: resource.map(str::to_string),
+                    outcome: entry.outcome.clone(),
+                    channel: entry.channel.clone(),
+                    context_id: entry.context_id.clone(),
+                    detail: entry.detail.clone(),
+                }),
+            )
+            .await
+            .map(|_| ())
+    }
+}
+
 /// Build the shared sink every caller should use.
 ///
 /// One construction point, so that changing what a VTA's audit writes is one
@@ -116,6 +253,23 @@ impl AuditSink for KeyspaceAuditSink {
 #[must_use]
 pub fn shared_keyspace_sink(keyspace: KeyspaceHandle) -> SharedAuditSink {
     Arc::new(KeyspaceAuditSink::new(keyspace))
+}
+
+/// Build the shared sink for a caller that can reach the audit-key keyspace —
+/// which is every caller that has the store open, and therefore every caller
+/// that should be using this one.
+///
+/// [`shared_keyspace_sink`] remains for the paths that genuinely cannot: a
+/// test that has only the one keyspace, and any caller holding a handle rather
+/// than a store. What it writes is unchained, and a chain that resumes after
+/// it treats those rows the way it treats rows written before chaining
+/// existed.
+#[must_use]
+pub fn shared_chained_sink(
+    keyspace: KeyspaceHandle,
+    key_keyspace: KeyspaceHandle,
+) -> SharedAuditSink {
+    Arc::new(ChainedKeyspaceAuditSink::new(keyspace, key_keyspace))
 }
 
 /// Write every entry to several sinks.
@@ -253,5 +407,157 @@ mod tests {
         assert!(fan.record(&entry("acl.grant")).await.is_ok());
         assert_eq!(a.seen.lock().unwrap().len(), 1);
         assert_eq!(b.seen.lock().unwrap().len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod chained_sink_tests {
+    use super::*;
+    use vti_common::audit::verify_chain;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    fn keyspaces() -> (KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .expect("store");
+        (
+            store.keyspace("audit").expect("audit"),
+            store.keyspace("audit_key").expect("audit_key"),
+            dir,
+        )
+    }
+
+    fn entry(action: &str, actor: &str, resource: Option<&str>) -> AuditLogEntry {
+        AuditLogEntry {
+            id: uuid::Uuid::new_v4().to_string(),
+            timestamp: 1_700_000_000,
+            action: action.to_string(),
+            actor: actor.to_string(),
+            resource: resource.map(str::to_string),
+            outcome: "success".to_string(),
+            channel: Some("rest".to_string()),
+            context_id: Some("acme/eng".to_string()),
+            detail: None,
+        }
+    }
+
+    async fn envelopes(ks: &KeyspaceHandle) -> Vec<vti_common::audit::AuditEnvelope> {
+        let pairs = ks.prefix_iter_raw("log:").await.expect("scan");
+        pairs
+            .iter()
+            .filter_map(|(_, v)| serde_json::from_slice(v).ok())
+            .collect()
+    }
+
+    /// The first entry is the creation of the key that chains it, so a
+    /// verifier reading from the start learns which key the entries after it
+    /// are hashed under.
+    #[tokio::test]
+    async fn the_chain_opens_with_the_creation_of_its_own_key() {
+        let (audit_ks, key_ks, _dir) = keyspaces();
+        let sink = ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks);
+
+        sink.record(&entry("auth.challenge", "did:key:z6MkA", None))
+            .await
+            .expect("record");
+
+        let found = envelopes(&audit_ks).await;
+        assert_eq!(
+            found.len(),
+            2,
+            "the key's creation, then the caller's event"
+        );
+
+        let opening = &found[0];
+        match &opening.event {
+            vti_common::audit::event::AuditEvent::VtaOperation(op) => {
+                assert_eq!(op.action, AUDIT_KEY_CREATED);
+                assert_eq!(
+                    op.resource.as_deref(),
+                    Some(opening.audit_key_id.as_uuid().to_string().as_str()),
+                    "the opening entry names the key it is hashed under"
+                );
+            }
+            other => panic!("unexpected opening event: {other:?}"),
+        }
+        assert_eq!(opening.actor_did_plain.as_deref(), Some(SYSTEM_ACTOR));
+    }
+
+    #[tokio::test]
+    async fn writes_chain_to_one_another() {
+        let (audit_ks, key_ks, _dir) = keyspaces();
+        let sink = ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks);
+
+        for action in ["auth.challenge", "acl.create", "keys.sign"] {
+            sink.record(&entry(action, "did:key:z6MkA", None))
+                .await
+                .expect("record");
+        }
+
+        let found = envelopes(&audit_ks).await;
+        assert_eq!(found.len(), 4, "three events plus the opening entry");
+        verify_chain(&found).expect("the log verifies as a chain");
+    }
+
+    /// The key is established once. A restart does not open a second chain.
+    #[tokio::test]
+    async fn a_second_sink_over_the_same_keyspace_continues_the_chain() {
+        let (audit_ks, key_ks, _dir) = keyspaces();
+
+        ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks.clone())
+            .record(&entry("auth.challenge", "did:key:z6MkA", None))
+            .await
+            .expect("first sink");
+
+        ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks)
+            .record(&entry("acl.create", "did:key:z6MkB", None))
+            .await
+            .expect("second sink");
+
+        let found = envelopes(&audit_ks).await;
+        assert_eq!(found.len(), 3, "one opening entry, not two");
+        verify_chain(&found).expect("the chain survives the restart");
+    }
+
+    /// A DID-shaped resource travels in the hashed members, where an erasure
+    /// can reach it. Anything else is not personal data and stays put.
+    #[tokio::test]
+    async fn a_did_resource_becomes_a_hashed_target() {
+        let (audit_ks, key_ks, _dir) = keyspaces();
+        let sink = ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks);
+
+        sink.record(&entry(
+            "acl.create",
+            "did:key:zAdmin",
+            Some("did:key:zSubject"),
+        ))
+        .await
+        .expect("did resource");
+        sink.record(&entry("keys.sign", "did:key:zAdmin", Some("key-3f2a")))
+            .await
+            .expect("opaque resource");
+
+        let found = envelopes(&audit_ks).await;
+        let did_row = &found[1];
+        assert_eq!(
+            did_row.target_did_plain.as_deref(),
+            Some("did:key:zSubject")
+        );
+        assert!(did_row.target_did_hash.is_some());
+
+        let key_row = &found[2];
+        assert!(
+            key_row.target_did_plain.is_none(),
+            "a key id is not an identifier to commit to"
+        );
+        match &key_row.event {
+            vti_common::audit::event::AuditEvent::VtaOperation(op) => {
+                assert_eq!(op.resource.as_deref(), Some("key-3f2a"));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 }

--- a/vta-service/src/operations/audit.rs
+++ b/vta-service/src/operations/audit.rs
@@ -128,6 +128,65 @@ fn authorize(auth: &AuthClaims, params: &ListAuditLogsBody) -> Result<(), AppErr
 
 /// List audit logs, newest first, with optional filters and opaque
 /// cursor pagination — canonical `audit/list/0.1`.
+/// Read one stored row, in either shape the audit keyspace holds.
+///
+/// A VTA's audit keyspace holds rows written before the log was chained and
+/// envelopes written since, under the same key format and interleaved by time.
+/// A reader that knows only one shape does not fail loudly — it skips what it
+/// cannot parse — so a reader that knew only the older shape would report a
+/// log that stops at the moment chaining began.
+fn read_row(value: &[u8]) -> Option<AuditLogEntry> {
+    if let Ok(row) = serde_json::from_slice::<AuditLogEntry>(value) {
+        return Some(row);
+    }
+    serde_json::from_slice::<vti_common::audit::AuditEnvelope>(value)
+        .ok()
+        .map(|env| flatten(&env))
+}
+
+/// An envelope in the shape the query and the response speak.
+///
+/// The actor is the plaintext where it is still there. A redacted row has
+/// none, and the empty actor is the honest answer: the identifier was erased,
+/// and what survives is a commitment that answers *was it this DID?* rather
+/// than *who was it?* — which is what an erasure is supposed to leave behind.
+fn flatten(env: &vti_common::audit::AuditEnvelope) -> AuditLogEntry {
+    use vti_common::audit::event::AuditEvent;
+
+    let (action, resource, outcome, channel, context_id, detail) = match &env.event {
+        AuditEvent::VtaOperation(op) => (
+            op.action.clone(),
+            op.resource.clone(),
+            op.outcome.clone(),
+            op.channel.clone(),
+            op.context_id.clone(),
+            op.detail.clone(),
+        ),
+        other => (
+            other.variant_name().to_string(),
+            None,
+            String::new(),
+            None,
+            None,
+            None,
+        ),
+    };
+
+    AuditLogEntry {
+        id: env.event_id.to_string(),
+        timestamp: u64::try_from(env.timestamp.timestamp()).unwrap_or(0),
+        action,
+        actor: env.actor_did_plain.clone().unwrap_or_default(),
+        // A DID-shaped resource travels in the envelope's hashed members, so
+        // it comes back from there rather than from the event.
+        resource: resource.or_else(|| env.target_did_plain.clone()),
+        outcome,
+        channel,
+        context_id,
+        detail,
+    }
+}
+
 pub async fn list_audit_logs(
     audit_ks: &KeyspaceHandle,
     auth: &AuthClaims,
@@ -177,16 +236,15 @@ pub async fn list_audit_logs(
     let mut idx = start;
     while entries.len() < limit && idx < pairs.len() {
         let (key, value) = &pairs[idx];
-        match serde_json::from_slice::<AuditLogEntry>(value) {
-            Ok(row) => {
+        match read_row(value) {
+            Some(row) => {
                 if matches(params, &row) {
                     entries.push(AuditEnvelope::from(&row));
                     last_seen_key = Some(key.clone());
                 }
             }
-            Err(err) => {
+            None => {
                 tracing::warn!(
-                    error = %err,
                     key = %String::from_utf8_lossy(key),
                     "skipping unparseable audit row",
                 );

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -420,6 +420,7 @@ pub async fn build_app_state(
     let contexts_ks = apply_encryption(store.keyspace(crate::keyspaces::CONTEXTS)?);
     let did_templates_ks = apply_encryption(store.keyspace(crate::keyspaces::DID_TEMPLATES)?);
     let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
+    let audit_key_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT_KEY)?);
     let imported_ks = apply_encryption(store.keyspace(crate::keyspaces::IMPORTED_SECRETS)?);
     let internal_ks = apply_encryption(store.keyspace(crate::keyspaces::INTERNAL_KEYS)?);
     let cache_ks = apply_encryption(store.keyspace(crate::keyspaces::CACHE)?);
@@ -519,7 +520,7 @@ pub async fn build_app_state(
     // because reads and retention deliberately do not route through the sink.
     let audit_sink: vta_audit::SharedAuditSink = parts
         .audit_sink
-        .unwrap_or_else(|| vta_audit::shared_keyspace_sink(audit_ks.clone()));
+        .unwrap_or_else(|| vta_audit::shared_chained_sink(audit_ks.clone(), audit_key_ks.clone()));
 
     Ok(AppState {
         keys_ks,
@@ -845,6 +846,7 @@ pub async fn run(
         let sessions_ks = apply_encryption(store.keyspace(crate::keyspaces::SESSIONS)?);
         let acl_ks = apply_encryption(store.keyspace(crate::keyspaces::ACL)?);
         let audit_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT)?);
+        let audit_key_ks = apply_encryption(store.keyspace(crate::keyspaces::AUDIT_KEY)?);
         let consent_ks = apply_encryption(store.keyspace(crate::keyspaces::CONSENT)?);
         let idempotency_ks = apply_encryption(store.keyspace(crate::keyspaces::IDEMPOTENCY)?);
         let task_consent_ks = apply_encryption(store.keyspace(crate::keyspaces::TASK_CONSENT)?);
@@ -933,7 +935,7 @@ pub async fn run(
         // `AppStateParts` below, so the sweepers and the request path share one
         // sink object rather than two that merely happen to agree today.
         let audit_sink: vta_audit::SharedAuditSink =
-            vta_audit::shared_keyspace_sink(audit_ks.clone());
+            vta_audit::shared_chained_sink(audit_ks.clone(), audit_key_ks.clone());
         let storage_audit_sink = Arc::clone(&audit_sink);
         let storage_acl_ks = acl_ks.clone();
         let storage_consent_ks = consent_ks.clone();

--- a/vta-service/tests/audit_sink.rs
+++ b/vta-service/tests/audit_sink.rs
@@ -114,8 +114,13 @@ async fn an_installed_sink_receives_the_row_and_the_keyspace_does_not() {
 
 #[tokio::test]
 async fn the_default_sink_is_still_the_keyspace() {
-    // The other half of the contract: a deployment that installs nothing gets
-    // exactly the behaviour it had before this seam existed.
+    // The other half of the contract: a deployment that installs nothing still
+    // writes to the keyspace the retrieval and retention APIs read.
+    //
+    // It writes *two* rows for one call, and that is the default sink working:
+    // the log is a hash chain now, and the first entry in it is the creation
+    // of the key that chains it. Asserting a count of one would be asserting
+    // that the chain has no beginning.
     let (state, _dir) = state_with_sink(None).await;
 
     vta_audit::record(
@@ -132,9 +137,34 @@ async fn the_default_sink_is_still_the_keyspace() {
 
     assert_eq!(
         keyspace_rows(&state).await,
-        1,
+        2,
         "with no sink installed the row must land in the audit keyspace, which \
-         is what the retrieval and retention APIs read"
+         is what the retrieval and retention APIs read — beside the entry that \
+         opens the chain"
+    );
+
+    // The row that matters is the caller's, and it is stored as itself: the
+    // action it was recorded under, and the actor beside the commitment to it.
+    let rows = state
+        .audit_ks
+        .prefix_iter_raw("log:")
+        .await
+        .expect("scan audit keyspace");
+    let found = rows.iter().any(|(_, v)| {
+        serde_json::from_slice::<vti_common::audit::AuditEnvelope>(v)
+            .ok()
+            .is_some_and(|env| {
+                env.actor_did_plain.as_deref() == Some("did:key:zTestAdmin")
+                    && matches!(
+                        &env.event,
+                        vti_common::audit::event::AuditEvent::VtaOperation(op)
+                            if op.action == "acl.grant"
+                    )
+            })
+    });
+    assert!(
+        found,
+        "the caller's row must be stored as a readable envelope"
     );
 }
 

--- a/vti-common/src/audit/key_store.rs
+++ b/vti-common/src/audit/key_store.rs
@@ -328,7 +328,10 @@ impl AuditKeyStore {
     }
 
     /// Look up the active marker without raising if it's absent.
-    async fn try_active(&self) -> Result<Option<AuditKey>, AppError> {
+    /// Public so a caller can ask whether a key has been established without
+    /// establishing one — the question a sink asks before deciding whether
+    /// this write is the one that opens the chain.
+    pub async fn try_active(&self) -> Result<Option<AuditKey>, AppError> {
         let id_bytes = match self.ks.get_raw(ACTIVE_MARKER_KEY.to_vec()).await? {
             Some(b) => b,
             None => return Ok(None),


### PR DESCRIPTION
Stacked on #1419. This is the piece that actually closes **VTI-AUD-004** and **VTI-AUD-005** for the VTA — the sink and the read path, which had to land together.

## What changes

The sink writes envelopes through the shared writer rather than flat rows. Each entry commits to its predecessor, and the actor and any DID-shaped target are committed under a keyed hash **with the plaintext beside them** — so an erasure nulls the plaintext, the row stays correlatable, and the chain digest (which excludes the plaintext members) still verifies.

**The chain opens with the creation of the key that chains it** — your design. The key is established on the first write, because there is nothing to audit before a node can act and a node cannot act before it has somewhere to record what it did. So the first entry is the record of that key coming into existence, committing to its id: a verifier reading from the start learns which key the following entries are hashed under, from an entry hashed under that same key.

A DID-shaped resource becomes the hashed target; anything else — a key id, a session id, a context path — is not personal data and stays in the event.

## The bug the tests found

The storage key needed a **nanosecond tiebreaker**, and the reason is worth recording.

Whole seconds put two entries written in the same second into *uuid order*. A verifier reading the log in key order then sees them out of chain order and **reports a break in a chain that is intact** — a false alarm indistinguishable from the thing the chain exists to detect. Review would not have caught it; three tests failed with `BrokenLink { index: 0 }` and that is what it turned out to be.

The seconds stay the **leading** field, because `cleanup_expired_logs` compares keys against `log:{cutoff:020}:` and stops at the first row past it. A different leading field would make every chained row sort past every cutoff and never expire.

## The read path

`audit/list` now accepts both shapes. This is why the two halves could not be split: a reader that knows only one shape **does not fail loudly** — it logs "skipping unparseable audit row" and moves on — so shipping the sink alone would have produced a log that silently appears to stop at the moment chaining began.

## Tests

Four on the sink: the chain opens with its own key's creation; writes chain to one another and `verify_chain` passes; a second sink over the same keyspace continues the chain rather than opening a second one (the restart path); and a DID resource becomes a hashed target while a key id does not.

## Still open

Retention versus the chain — deleting the tail leaves the remainder unverifiable, which the note covers and the checkpoint mechanism answers. And the `verify` surface: chaining nobody can check is a hash column, not tamper-evidence.