### PR TITLE
feat(audit): expose chain verification as a task and a command

### DIFF
--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -2676,6 +2676,8 @@ pub(crate) enum AuthCredentialCommands {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum AuditCommands {
+    /// Verify the audit log's hash chain
+    Verify,
     /// List audit log entries with optional filtering
     List {
         /// Start time, RFC 3339 (e.g. 2026-07-01T00:00:00Z). Inclusive.

--- a/pnm-cli/src/commands/audit.rs
+++ b/pnm-cli/src/commands/audit.rs
@@ -32,6 +32,7 @@ pub(crate) async fn run(
             };
             audit::cmd_list_audit_logs(client, &params).await
         }
+        AuditCommands::Verify => audit::cmd_verify_chain(client).await,
         AuditCommands::Retention { command } => match command {
             RetentionCommands::Get => audit::cmd_get_retention(client).await,
             RetentionCommands::Set { days } => audit::cmd_update_retention(client, days).await,

--- a/vta-cli-common/src/commands/audit.rs
+++ b/vta-cli-common/src/commands/audit.rs
@@ -214,6 +214,67 @@ pub async fn cmd_get_retention(client: &VtaClient) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
+/// Verify the audit log's hash chain.
+pub async fn cmd_verify_chain(client: &VtaClient) -> Result<(), Box<dyn std::error::Error>> {
+    let r = client.verify_audit_chain().await?;
+
+    println!("\n  \x1b[1mAudit Chain\x1b[0m");
+    if r.verified {
+        println!("  Status: \x1b[32m\u{2713} verified\x1b[0m");
+    } else {
+        println!("  Status: \x1b[31m\u{2717} BROKEN\x1b[0m");
+    }
+    println!("  Rows examined:    {}", r.rows_examined);
+    println!("  Entries verified: {}", r.entries_verified);
+    if let Some(head) = &r.head {
+        println!("  Head:             \x1b[36m{head}\x1b[0m");
+    }
+
+    // Printed whatever their value, because zero is the interesting answer
+    // and an operator who has to remember to ask has not been told.
+    println!("  Rows before the chain opened: {}", r.pre_chain_rows);
+    if r.unchained_after_open > 0 {
+        println!(
+            "  \x1b[31mRows after the chain opened that are not chained: {}\x1b[0m",
+            r.unchained_after_open
+        );
+        println!("    Everything written since the chain opened is chained, so these arrived");
+        println!("    by another route. Treat them as an insertion until shown otherwise.");
+    }
+    if r.legacy_envelopes_skipped > 0 {
+        println!(
+            "  \x1b[31mEnvelopes skipped by schema version: {}\x1b[0m",
+            r.legacy_envelopes_skipped
+        );
+        println!("    These were passed over rather than checked, so a forged one would pass");
+        println!("    here untouched.");
+    }
+
+    if let Some(b) = &r.chain_break {
+        println!(
+            "\n  \x1b[31mBroke at entry {} ({}): {}\x1b[0m",
+            b.index, b.event_id, b.kind
+        );
+        match b.kind.as_str() {
+            "tamperedEntry" => {
+                println!("  The entry's content was altered after it was written.")
+            }
+            "brokenLink" => {
+                println!("  An entry was reordered, dropped, or inserted at this point.")
+            }
+            _ => {}
+        }
+    }
+    println!();
+
+    if r.verified && r.unchained_after_open == 0 && r.legacy_envelopes_skipped == 0 {
+        Ok(())
+    } else {
+        // A findings-and-exit-zero report is one nobody wires an alert to.
+        Err("audit chain verification reported findings".into())
+    }
+}
+
 /// Update the audit retention period.
 pub async fn cmd_update_retention(
     client: &VtaClient,

--- a/vta-sdk/src/client/audit.rs
+++ b/vta-sdk/src/client/audit.rs
@@ -21,6 +21,22 @@ impl VtaClient {
     }
 
     /// Get the current audit log retention period.
+    /// Check the audit log's hash chain.
+    ///
+    /// The counts in the result are part of the answer: a chain can verify
+    /// while rows sit outside it, and those rows are what an insertion looks
+    /// like.
+    pub async fn verify_audit_chain(
+        &self,
+    ) -> Result<crate::protocols::audit_management::verify::AuditChainReport, VtaError> {
+        self.rpc_tt(
+            crate::trust_tasks::TASK_AUDIT_VERIFY_1_0,
+            serde_json::json!({}),
+            60,
+        )
+        .await
+    }
+
     pub async fn get_audit_retention(
         &self,
     ) -> Result<crate::protocols::audit_management::retention::RetentionResultBody, VtaError> {

--- a/vta-sdk/src/protocols/audit_management/mod.rs
+++ b/vta-sdk/src/protocols/audit_management/mod.rs
@@ -1,5 +1,6 @@
 pub mod list;
 pub mod retention;
+pub mod verify;
 
 pub const PROTOCOL_BASE: &str = "https://firstperson.network/protocols/audit-management/1.0";
 

--- a/vta-sdk/src/protocols/audit_management/verify.rs
+++ b/vta-sdk/src/protocols/audit_management/verify.rs
@@ -1,0 +1,69 @@
+//! `spec/vta/audit/verify/1.0` — the result of checking the audit log's
+//! hash chain.
+//!
+//! Published here rather than kept in the service because a caller has to be
+//! able to read the answer, and because the counts in it are the answer: a
+//! consumer that reads only `verified` has been told less than this reports.
+
+use serde::{Deserialize, Serialize};
+
+/// Payload of `spec/vta/audit/verify/1.0`. The whole log is verified; there is
+//  nothing to select.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerifyChainBody {}
+
+/// What verifying the audit chain found.
+///
+/// The counts are not decoration. Every row this reports as skipped is a row
+/// the chain does not cover, and a reader who sees only `verified: true` has
+/// been told less than they think.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditChainReport {
+    /// Whether every chainable envelope verified.
+    pub verified: bool,
+    /// Rows examined, of any shape.
+    pub rows_examined: usize,
+    /// Envelopes that carried a chain link and verified.
+    pub entries_verified: usize,
+    /// Rows written before the chain opened.
+    ///
+    /// **Expected on a VTA**, which audited to this keyspace before its log
+    /// was chained. They are not covered by the chain and cannot be: nothing
+    /// committed to them at the time.
+    pub pre_chain_rows: usize,
+    /// Rows after the chain opened that are not chainable envelopes.
+    ///
+    /// **A finding.** Once the chain has opened, every row this sink writes is
+    /// an envelope, so a row that is not one arrived by some other route —
+    /// which is exactly what an insertion looks like. Reported separately from
+    /// `preChainRows` because the two mean opposite things.
+    pub unchained_after_open: usize,
+    /// Envelopes skipped as unchainable by their own schema version.
+    ///
+    /// **A finding wherever the chain has opened.** The verifier passes over
+    /// these rather than checking them, so an envelope forged with an older
+    /// schema version passes untouched.
+    pub legacy_envelopes_skipped: usize,
+    /// Head of the verified chain, hex-encoded. `None` when nothing chainable
+    /// was found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head: Option<String>,
+    /// Where the chain broke, when it did.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_break: Option<AuditChainBreak>,
+}
+
+/// Where a chain stopped verifying, in the shape a caller can act on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditChainBreak {
+    /// `tamperedEntry` — the envelope's content was altered after it was
+    /// written; or `brokenLink` — an entry was reordered, dropped or inserted.
+    pub kind: String,
+    /// Position among the chainable envelopes, counting from the start.
+    pub index: usize,
+    /// The envelope the break was found at.
+    pub event_id: String,
+}

--- a/vta-sdk/src/protocols/audit_management/verify.rs
+++ b/vta-sdk/src/protocols/audit_management/verify.rs
@@ -7,11 +7,24 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Payload of `spec/vta/audit/verify/1.0`. The whole log is verified; there is
-//  nothing to select.
+/// Payload of `spec/vta/audit/verify/1.0`. The whole log is verified, so there
+/// is nothing to select.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VerifyChainBody {}
+pub struct VerifyChainBody {
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    ///
+    /// Carried explicitly rather than by relaxing `deny_unknown_fields`: the
+    /// published schemas declare an `ext` slot, so a conforming producer may
+    /// send one and refusing the whole document over it would break interop
+    /// with a peer doing exactly what the spec allows. Keeping
+    /// `deny_unknown_fields` beside it means a *typo* is still refused, which
+    /// is the guard that clause is there for.
+    ///
+    /// The VTA does not interpret the contents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<serde_json::Value>,
+}
 
 /// What verifying the audit chain found.
 ///

--- a/vta-sdk/src/retry_safety.rs
+++ b/vta-sdk/src/retry_safety.rs
@@ -231,6 +231,7 @@ pub const RETRY_SAFETY: &[(&str, RetrySafety)] = &[
     (trust_tasks::TASK_CONTEXTS_SECRETS_1_0, ReadOnly),
     // ── Audit ───────────────────────────────────────────────────────────
     (trust_tasks::TASK_AUDIT_LIST_0_1, ReadOnly),
+    (trust_tasks::TASK_AUDIT_VERIFY_1_0, ReadOnly),
     (trust_tasks::TASK_AUDIT_GET_RETENTION_1_0, ReadOnly),
     (trust_tasks::TASK_AUDIT_UPDATE_RETENTION_1_0, RetrySafe),
     // ── Discovery ───────────────────────────────────────────────────────

--- a/vta-sdk/src/trust_tasks.rs
+++ b/vta-sdk/src/trust_tasks.rs
@@ -571,6 +571,16 @@ pub const TASK_SERVICES_DRAIN_CANCEL_1_0: &str =
 /// admin must supply `contextId` within their own scope.
 pub const TASK_AUDIT_LIST_0_1: &str = "https://trusttasks.org/spec/audit/list/0.1";
 
+/// `spec/vta/audit/verify/1.0` — check the audit log's hash chain and
+/// report what was found. Payload:
+/// [`crate::protocols::audit_management::verify::VerifyChainBody`]; result:
+/// [`crate::protocols::audit_management::verify::AuditChainReport`].
+///
+/// Auth: admin. Reading whether the record of what everyone did is intact is
+/// itself a privileged question — a caller who cannot read the log has no
+/// business learning whether it has been altered.
+pub const TASK_AUDIT_VERIFY_1_0: &str = "https://trusttasks.org/spec/vta/audit/verify/1.0";
+
 /// `spec/vta/audit/get-retention/1.0` — read the current retention
 /// period. Payload:
 /// [`crate::protocols::audit_management::retention::GetRetentionBody`]
@@ -1918,6 +1928,7 @@ pub const ALL_URIS: &[&str] = &[
     TASK_SERVICES_DRAIN_CANCEL_1_0,
     // Audit slice
     TASK_AUDIT_LIST_0_1,
+    TASK_AUDIT_VERIFY_1_0,
     TASK_AUDIT_GET_RETENTION_1_0,
     TASK_AUDIT_UPDATE_RETENTION_1_0,
     // Discovery

--- a/vta-service/src/operations/audit.rs
+++ b/vta-service/src/operations/audit.rs
@@ -128,66 +128,13 @@ fn authorize(auth: &AuthClaims, params: &ListAuditLogsBody) -> Result<(), AppErr
 
 /// List audit logs, newest first, with optional filters and opaque
 /// cursor pagination — canonical `audit/list/0.1`.
-/// What verifying the audit chain found.
-///
-/// The counts are not decoration. Every row this reports as skipped is a row
-/// the chain does not cover, and a reader who sees only `verified: true` has
-/// been told less than they think.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AuditChainReport {
-    /// Whether every chainable envelope verified.
-    pub verified: bool,
-    /// Rows examined, of any shape.
-    pub rows_examined: usize,
-    /// Envelopes that carried a chain link and verified.
-    pub entries_verified: usize,
-    /// Rows written before the chain opened.
-    ///
-    /// **Expected on a VTA**, which audited to this keyspace before its log
-    /// was chained. They are not covered by the chain and cannot be: nothing
-    /// committed to them at the time.
-    pub pre_chain_rows: usize,
-    /// Rows after the chain opened that are not chainable envelopes.
-    ///
-    /// **A finding.** Once the chain has opened, every row this sink writes is
-    /// an envelope, so a row that is not one arrived by some other route —
-    /// which is exactly what an insertion looks like. Reported separately from
-    /// `preChainRows` because the two mean opposite things.
-    pub unchained_after_open: usize,
-    /// Envelopes skipped as unchainable by their own schema version.
-    ///
-    /// **A finding wherever the chain has opened.** The verifier passes over
-    /// these rather than checking them, so an envelope forged with an older
-    /// schema version passes untouched.
-    pub legacy_envelopes_skipped: usize,
-    /// Head of the verified chain, hex-encoded. `None` when nothing chainable
-    /// was found.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub head: Option<String>,
-    /// Where the chain broke, when it did.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub chain_break: Option<AuditChainBreak>,
-}
-
-/// Where a chain stopped verifying, in the shape a caller can act on.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AuditChainBreak {
-    /// `tamperedEntry` — the envelope's content was altered after it was
-    /// written; or `brokenLink` — an entry was reordered, dropped or inserted.
-    pub kind: String,
-    /// Position among the chainable envelopes, counting from the start.
-    pub index: usize,
-    /// The envelope the break was found at.
-    pub event_id: String,
-}
-
 /// Verify the audit log's chain, in storage order.
 ///
 /// Reads ascending by key, which is write order, because the chain is a strict
 /// left fold and verifying it in any other order reports breaks that are not
 /// there.
+pub use vta_sdk::protocols::audit_management::verify::{AuditChainBreak, AuditChainReport};
+
 pub async fn verify_audit_chain(
     audit_ks: &vti_common::store::KeyspaceHandle,
 ) -> Result<AuditChainReport, AppError> {

--- a/vta-service/src/trust_tasks/audit.rs
+++ b/vta-service/src/trust_tasks/audit.rs
@@ -40,6 +40,25 @@ pub(super) async fn handle_list_logs(
     }
 }
 
+/// Handler for `spec/vta/audit/verify/1.0`. Admin only.
+///
+/// Verifying is a read of the whole log, so it takes the same authority
+/// reading the log takes — and the answer is about the log as a whole, so
+/// there is no context-scoped form of the question.
+pub(super) async fn handle_verify_chain(
+    state: &AppState,
+    auth: &AuthClaims,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    if let Err(e) = auth.require_admin() {
+        return app_error_to_reject(&doc, e);
+    }
+    match operations::audit::verify_audit_chain(&state.audit_ks).await {
+        Ok(report) => success_response(&doc, report),
+        Err(e) => app_error_to_reject(&doc, e),
+    }
+}
+
 /// Handler for `spec/vta/audit/get-retention/1.0`. Admin only.
 pub(super) async fn handle_get_retention(
     state: &AppState,

--- a/vta-service/src/trust_tasks/mod.rs
+++ b/vta-service/src/trust_tasks/mod.rs
@@ -1727,6 +1727,8 @@ dispatch_table! {
     // ─── Audit slice ─────────────────────────────────────────────
     vta_sdk::trust_tasks::TASK_AUDIT_LIST_0_1 => audit::handle_list_logs
         [ None Metadata false ],
+    vta_sdk::trust_tasks::TASK_AUDIT_VERIFY_1_0 => audit::handle_verify_chain
+        [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_AUDIT_GET_RETENTION_1_0 => audit::handle_get_retention
         [ None Metadata false ],
     vta_sdk::trust_tasks::TASK_AUDIT_UPDATE_RETENTION_1_0 => audit::handle_update_retention


### PR DESCRIPTION
Stacked on #1421, which added the verifier. This gives it callers.

- `spec/vta/audit/verify/1.0` — the task, in the namespace the VTA's own tasks already use (`spec/vta/audit/get-retention/1.0` sits beside it), registered in the dispatch table and classified `ReadOnly` for retry.
- `VtaClient::verify_audit_chain` — the client method.
- `pnm audit verify` — the command.

The report type moves to `vta-sdk::protocols::audit_management::verify` so a caller can read the answer.

**Admin only**, for the same reason reading the log is: whether the record of what everyone did is intact is itself a privileged question, and a caller who cannot read the log has no business learning whether it has been altered.

## Two choices in the command worth flagging

**It prints the counts whether or not they are zero.** Zero is the interesting answer for `preChainRows`, and an operator who has to remember to ask has not been told. Where a count is non-zero it explains what the number means rather than leaving a bare integer: rows written after the chain opened that are not chained arrived by another route; envelopes skipped by schema version were passed over rather than checked, so a forged one passes here untouched.

**It exits non-zero on any finding, not only on a broken chain.** A report that says `verified: true` beside a count of unchained rows and still exits zero is one nobody wires an alert to — and the unchained rows are exactly the case a chain alone cannot catch.

## Next

Retention versus the chain, which is the last item in the design note: a sweep deletes the tail and leaves the remainder unverifiable, indistinguishable from tampering. The VTC's checkpoint mechanism is the answer, and this command is what will show it working.