### PR TITLE
feat(audit): keep the chain verifiable across a retention sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10228,6 +10228,9 @@ name = "vta-audit"
 version = "0.3.6"
 dependencies = [
  "async-trait",
+ "chrono",
+ "hex",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -23,11 +23,14 @@ repository.workspace = true
 vti-common = { path = "../vti-common", version = "0.18" }
 vta-sdk = { path = "../vta-sdk", version = "0.36" }
 async-trait = "0.1"
+chrono = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/vta-audit/src/lib.rs
+++ b/vta-audit/src/lib.rs
@@ -344,11 +344,11 @@ pub async fn cleanup_logs_before(audit_ks: &KeyspaceHandle, cutoff: u64) -> Resu
             // Read before deleting: a chained entry carries the hash the
             // survivors will point back at, and once it is gone so is the
             // only copy of it.
-            if let Ok(Some(raw)) = audit_ks.get_raw(key.clone()).await {
-                if let Ok(env) = serde_json::from_slice::<vti_common::audit::AuditEnvelope>(&raw) {
-                    last_chained_hash = Some(hex::encode(env.entry_hash));
-                    pruned_chained += 1;
-                }
+            if let Ok(Some(raw)) = audit_ks.get_raw(key.clone()).await
+                && let Ok(env) = serde_json::from_slice::<vti_common::audit::AuditEnvelope>(&raw)
+            {
+                last_chained_hash = Some(hex::encode(env.entry_hash));
+                pruned_chained += 1;
             }
             audit_ks.remove(key).await?;
             removed += 1;

--- a/vta-audit/src/lib.rs
+++ b/vta-audit/src/lib.rs
@@ -259,7 +259,59 @@ pub async fn record_consent(
     }
 }
 
+/// Where the retention sweep has pruned to, so that verification can resume.
+///
+/// Deleting the oldest entries of a hash chain leaves the rest unverifiable:
+/// the first surviving entry's `prev_hash` points at something that is gone,
+/// which is **indistinguishable from an entry having been removed by an
+/// attacker** — the case the chain exists to detect. Retention would therefore
+/// break verification permanently, and the first person to run `verify` after
+/// a sweep would get a failure that means nothing.
+///
+/// The watermark is what the sweep leaves behind: the hash it pruned through
+/// and how many chained entries it removed, so a verifier resumes from that
+/// point instead of expecting a chain back to genesis.
+///
+/// # What it is worth
+///
+/// It is stored in the same keyspace as the log, so it is exactly as
+/// trustworthy as that store: an adversary who can delete entries can also
+/// rewrite the watermark to match. It restores verification across an
+/// *honest* sweep, and that is all it claims. Making a pruned prefix
+/// verifiable against an adversary with store access needs the watermark
+/// signed and published outside the store, which is what the VTC's signed
+/// checkpoints do.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PruneWatermark {
+    /// `entry_hash` of the newest chained entry the sweep removed — the
+    /// `prev_hash` the oldest surviving entry points at.
+    pub head: String,
+    /// Chained entries removed by every sweep so far, so a break is still
+    /// reported at its position in the whole log rather than in the remainder.
+    pub pruned_entries: usize,
+    /// When the most recent sweep ran.
+    pub pruned_at: String,
+}
+
+/// Storage key of the watermark.
+///
+/// Outside the `log:` prefix on purpose: the sweep deletes by that prefix, so
+/// a watermark stored under it would be pruned by the sweep that wrote it.
+pub const PRUNE_WATERMARK_KEY: &str = "prune:watermark";
+
+/// Read the retention sweep's watermark, if it has ever run.
+pub async fn prune_watermark(
+    audit_ks: &KeyspaceHandle,
+) -> Result<Option<PruneWatermark>, AppError> {
+    audit_ks.get(PRUNE_WATERMARK_KEY.to_string()).await
+}
+
 /// Remove audit log entries older than `retention_days`.
+///
+/// Records a [`PruneWatermark`] when it removes chained entries, so the
+/// remainder still verifies. Without that, retention and tamper-evidence are
+/// mutually exclusive.
 pub async fn cleanup_expired_logs(
     audit_ks: &KeyspaceHandle,
     retention_days: u32,
@@ -269,20 +321,53 @@ pub async fn cleanup_expired_logs(
         .unwrap_or_default()
         .as_secs()
         .saturating_sub(retention_days as u64 * 86400);
+    cleanup_logs_before(audit_ks, cutoff).await
+}
 
-    let cutoff_key = format!("log:{:020}:", cutoff);
+/// [`cleanup_expired_logs`] with the cutoff supplied rather than derived from
+/// the clock.
+///
+/// Separate so the sweep can be exercised against a known boundary: derived
+/// from `now`, the only reachable boundaries in a test are "everything
+/// written a whole day ago", which nothing in a test was, and "nothing".
+pub async fn cleanup_logs_before(audit_ks: &KeyspaceHandle, cutoff: u64) -> Result<u64, AppError> {
+    let cutoff_key = format!("log:{cutoff:020}:");
     let keys = audit_ks.prefix_keys("log:").await?;
 
     let mut removed = 0u64;
+    let mut pruned_chained = 0usize;
+    let mut last_chained_hash: Option<String> = None;
+
     for key in keys {
-        let key_str = String::from_utf8_lossy(&key);
-        if key_str.as_ref() < cutoff_key.as_str() {
+        let key_str = String::from_utf8_lossy(&key).into_owned();
+        if key_str.as_str() < cutoff_key.as_str() {
+            // Read before deleting: a chained entry carries the hash the
+            // survivors will point back at, and once it is gone so is the
+            // only copy of it.
+            if let Ok(Some(raw)) = audit_ks.get_raw(key.clone()).await {
+                if let Ok(env) = serde_json::from_slice::<vti_common::audit::AuditEnvelope>(&raw) {
+                    last_chained_hash = Some(hex::encode(env.entry_hash));
+                    pruned_chained += 1;
+                }
+            }
             audit_ks.remove(key).await?;
             removed += 1;
         } else {
             // Keys are sorted — once we pass the cutoff, stop
             break;
         }
+    }
+
+    if let Some(head) = last_chained_hash {
+        let previous = prune_watermark(audit_ks).await?;
+        let watermark = PruneWatermark {
+            head,
+            pruned_entries: previous.map_or(0, |w| w.pruned_entries) + pruned_chained,
+            pruned_at: chrono::Utc::now().to_rfc3339(),
+        };
+        audit_ks
+            .insert(PRUNE_WATERMARK_KEY.to_string(), &watermark)
+            .await?;
     }
 
     Ok(removed)

--- a/vta-cli-common/src/commands/audit.rs
+++ b/vta-cli-common/src/commands/audit.rs
@@ -230,6 +230,16 @@ pub async fn cmd_verify_chain(client: &VtaClient) -> Result<(), Box<dyn std::err
         println!("  Head:             \x1b[36m{head}\x1b[0m");
     }
 
+    if r.resumed_from_prune {
+        println!(
+            "  Resumed from the retention watermark: \x1b[36m{}\x1b[0m entries pruned",
+            r.pruned_entries
+        );
+        println!("    Those entries were not verified by this run and cannot be — they are");
+        println!("    gone. What holds is that the survivors continue a chain that ran");
+        println!("    through the watermark, which lives in the same store as the log.");
+    }
+
     // Printed whatever their value, because zero is the interesting answer
     // and an operator who has to remember to ask has not been told.
     println!("  Rows before the chain opened: {}", r.pre_chain_rows);

--- a/vta-sdk/src/protocols/audit_management/verify.rs
+++ b/vta-sdk/src/protocols/audit_management/verify.rs
@@ -66,6 +66,17 @@ pub struct AuditChainReport {
     /// Where the chain broke, when it did.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chain_break: Option<AuditChainBreak>,
+    /// Whether verification started from the retention sweep's watermark
+    /// rather than from the opening of the chain.
+    ///
+    /// **The pruned entries were not verified by this run**, and could not be:
+    /// they are gone. What the watermark establishes is that the surviving
+    /// entries continue a chain that ran through it — which is a weaker claim
+    /// than verifying the whole log, and it rests on the watermark itself,
+    /// which lives in the same store as the log.
+    pub resumed_from_prune: bool,
+    /// Chained entries the retention sweep has removed over the log's life.
+    pub pruned_entries: usize,
 }
 
 /// Where a chain stopped verifying, in the shape a caller can act on.

--- a/vta-service/src/operations/audit.rs
+++ b/vta-service/src/operations/audit.rs
@@ -143,7 +143,20 @@ pub async fn verify_audit_chain(
     let mut pairs = audit_ks.prefix_iter_raw("log:").await?;
     pairs.sort_by(|(a, _), (b, _)| a.cmp(b)); // ascending: write order
 
-    let mut verifier = ChainVerifier::new();
+    // Retention deletes the oldest entries, so the oldest survivor points back
+    // at something that is gone. Resuming from the sweep's watermark is what
+    // tells an intact-but-pruned log apart from one an entry was removed from
+    // — without it the two are the same failure.
+    let watermark = vta_audit::prune_watermark(audit_ks).await?;
+    let resumed = watermark.as_ref().and_then(|w| {
+        let raw = hex::decode(&w.head).ok()?;
+        let head: [u8; 32] = raw.try_into().ok()?;
+        Some((head, w.pruned_entries))
+    });
+    let mut verifier = match resumed {
+        Some((head, index)) => ChainVerifier::resume(head, index),
+        None => ChainVerifier::new(),
+    };
     let mut report = AuditChainReport {
         verified: true,
         rows_examined: pairs.len(),
@@ -153,8 +166,12 @@ pub async fn verify_audit_chain(
         legacy_envelopes_skipped: 0,
         head: None,
         chain_break: None,
+        resumed_from_prune: resumed.is_some(),
+        pruned_entries: watermark.as_ref().map_or(0, |w| w.pruned_entries),
     };
-    let mut chain_opened = false;
+    // A pruned log has no entry before the watermark, so the first survivor is
+    // a continuation rather than an opening.
+    let mut chain_opened = resumed.is_some();
 
     for (key, value) in &pairs {
         let env = match serde_json::from_slice::<vti_common::audit::AuditEnvelope>(value) {
@@ -417,14 +434,12 @@ pub async fn update_retention(
 }
 
 #[cfg(test)]
-mod verify_tests {
-    use super::*;
-    use vta_audit::{AuditSink, ChainedKeyspaceAuditSink};
+pub(crate) mod verify_tests_support {
     use vta_sdk::protocols::audit_management::list::AuditLogEntry;
     use vti_common::config::StoreConfig;
     use vti_common::store::{KeyspaceHandle, Store};
 
-    fn keyspaces() -> (KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
+    pub(crate) fn keyspaces() -> (KeyspaceHandle, KeyspaceHandle, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open(&StoreConfig {
             data_dir: dir.path().to_path_buf(),
@@ -437,7 +452,7 @@ mod verify_tests {
         )
     }
 
-    fn entry(action: &str) -> AuditLogEntry {
+    pub(crate) fn entry(action: &str) -> AuditLogEntry {
         AuditLogEntry {
             id: uuid::Uuid::new_v4().to_string(),
             timestamp: 1_700_000_000,
@@ -450,6 +465,13 @@ mod verify_tests {
             detail: None,
         }
     }
+}
+
+#[cfg(test)]
+mod verify_tests {
+    use super::verify_tests_support::{entry, keyspaces};
+    use super::*;
+    use vta_audit::{AuditSink, ChainedKeyspaceAuditSink};
 
     /// A pre-chain row is expected and is not a finding: the VTA audited to
     /// this keyspace before its log was chained, and nothing committed to
@@ -549,5 +571,90 @@ mod verify_tests {
         let brk = report.chain_break.expect("a break is reported");
         assert_eq!(brk.kind, "tamperedEntry");
         assert_eq!(brk.event_id, env.event_id.to_string());
+    }
+}
+
+#[cfg(test)]
+mod retention_tests {
+    use super::verify_tests_support::{entry, keyspaces};
+    use super::*;
+    use vta_audit::{AuditSink, ChainedKeyspaceAuditSink};
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    /// Retention and tamper-evidence have to coexist. A sweep deletes the
+    /// oldest entries, so the oldest survivor points back at something that is
+    /// gone — which is what a removed entry looks like. The watermark is what
+    /// tells the two apart.
+    #[tokio::test]
+    async fn a_pruned_log_still_verifies() {
+        let (audit_ks, key_ks, _dir) = keyspaces();
+        let sink = ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks);
+        for i in 0..5 {
+            sink.record(&entry(&format!("op.{i}")))
+                .await
+                .expect("record");
+        }
+
+        // A cutoff one second ahead of everything written so far, so the
+        // sweep prunes all of it. Derived from `now`, the sweep's only
+        // reachable boundaries in a test are a whole day ago and nothing.
+        let cutoff = now_secs() + 1;
+        let removed = vta_audit::cleanup_logs_before(&audit_ks, cutoff)
+            .await
+            .expect("sweep");
+        assert!(removed > 0, "the sweep must actually have pruned something");
+
+        sink.record(&entry("op.after-the-sweep"))
+            .await
+            .expect("record after sweep");
+
+        let report = verify_audit_chain(&audit_ks).await.expect("verify");
+        assert!(
+            report.verified,
+            "a pruned log must still verify: {:?}",
+            report.chain_break
+        );
+        assert!(report.resumed_from_prune);
+        assert_eq!(report.pruned_entries, removed as usize);
+    }
+
+    /// The watermark must not become a way to hide a removal. An entry taken
+    /// out *after* the sweep still breaks the chain.
+    #[tokio::test]
+    async fn a_removal_after_the_sweep_is_still_caught() {
+        let (audit_ks, key_ks, _dir) = keyspaces();
+        let sink = ChainedKeyspaceAuditSink::new(audit_ks.clone(), key_ks);
+        for i in 0..3 {
+            sink.record(&entry(&format!("op.{i}")))
+                .await
+                .expect("record");
+        }
+        vta_audit::cleanup_logs_before(&audit_ks, now_secs() + 1)
+            .await
+            .expect("sweep");
+
+        for i in 0..3 {
+            sink.record(&entry(&format!("later.{i}")))
+                .await
+                .expect("record");
+        }
+
+        // Remove one of the survivors, which is exactly what the chain is for.
+        let mut pairs = audit_ks.prefix_iter_raw("log:").await.expect("scan");
+        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let victim = pairs[1].0.clone();
+        audit_ks.remove(victim).await.expect("remove a survivor");
+
+        let report = verify_audit_chain(&audit_ks).await.expect("verify");
+        assert!(
+            !report.verified,
+            "removing an entry after the sweep must still break the chain"
+        );
     }
 }


### PR DESCRIPTION
Stacked on #1421. The last item in the audit-chaining note, and the one with a deadline attached: it only bites after the retention period has elapsed once.

## The problem

Retention deletes the oldest entries. The oldest survivor then points back at something that is gone — **which is exactly what an entry removed by an attacker looks like**. So retention and tamper-evidence were mutually exclusive, and the first person to run `pnm audit verify` after a sweep would have got a failure that means nothing.

## The fix

The sweep leaves a **watermark**: the hash it pruned through, and how many chained entries it removed. Verification resumes from there rather than expecting a chain back to the opening — `ChainVerifier::resume` already existed for exactly this.

The watermark is stored outside the `log:` prefix, because the sweep deletes by that prefix and would otherwise prune the watermark it just wrote.

## What the report now says, and why

`resumedFromPrune` and `prunedEntries`, surfaced in `pnm audit verify`, because **the claim is weaker than "verified" looks**:

> The pruned entries were not verified by this run and cannot be — they are gone. What holds is that the survivors continue a chain that ran through the watermark.

And the watermark lives in the same store as the log, so an adversary who can delete entries can rewrite it to match. **It restores verification across an honest sweep, which is what retention needs, and nothing more.** Signing it and publishing it outside the store is the stronger answer, and is what the VTC's checkpoints do — worth doing, and a separate change.

## A testability seam

`cleanup_logs_before(ks, cutoff)` beside `cleanup_expired_logs(ks, days)`. Derived from the clock, the only boundaries reachable in a test are "a whole day ago" — which nothing in a test is — and "nothing". The first version of the test asserted a sweep had pruned something and failed, correctly: at zero days' retention it had pruned nothing, because entries written this second are not older than now.

## Tests

- a pruned log still verifies, resumes from the watermark, and reports the count;
- **a removal after the sweep is still caught** — the watermark must not become a way to hide one.