### PR TITLE
feat(vta-sdk)!: wire types and crypto for peer identity vetting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,6 +834,14 @@ jobs:
         run: cargo check -p vta-sdk --features attest-verify
       - name: vta-sdk client + sealed-transfer + provision-integration
         run: cargo check -p vta-sdk --features client,sealed-transfer,provision-integration
+      # `vetting` is off by default and no workspace member's *tests* run with it
+      # on, so `cargo test --workspace` never compiles its unit tests — the
+      # all-features clippy step below lints them but runs nothing. Tested, not
+      # checked: what these guard (a card replayed to another vetter, a statement
+      # over a different card, one vetter counted twice) compiles perfectly.
+      # `client` rides along because `trust_task_proof`'s own unit tests need it.
+      - name: vta-sdk vetting
+        run: cargo test -p vta-sdk --features client,vetting --lib vetting
 
       # The *maximal* combination. Every step above narrows the feature set;
       # nothing built the top end, and `clippy`/`check` elsewhere in this

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10488,6 +10488,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "didwebvh-rs",
  "dirs",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "futures-util",
  "getrandom 0.4.3",

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -234,6 +234,19 @@ acl-setup = [
 # suite + the `Secret` signing type. The natural client-side counterpart to the
 # `join-requests` / `credential-exchange` protocol types.
 vp = ["dep:affinidi-data-integrity", "dep:affinidi-secrets-resolver"]
+# Peer identity vetting (`vetting` module): sign and verify the Vetting Card (an
+# r-card VDS) and the Vetting Statement (a DTG `EndorsementCredential`), and
+# count statements against a community's requirements. Verification resolves the
+# signer's DID, so it builds on `proof-verify`; the statement is built with the
+# DTG credentials SDK rather than by hand; the match code hashes with SHA-256;
+# the commitment salt needs a CSPRNG.
+vetting = [
+  "vp",
+  "proof-verify",
+  "dep:dtg-credentials",
+  "dep:sha2",
+  "dep:getrandom",
+]
 # Expose in-memory test fixtures for downstream integration tests.
 # Currently gates: `SessionBackend` mocks (always); `provision_client::test_helpers`
 # (when `provision-client` is also on). Additive, zero-cost when off.
@@ -318,6 +331,8 @@ affinidi-secrets-resolver = { workspace = true, optional = true }
 # published artifact stays slim for non-provisioning consumers; also present as
 # a dev-dependency for the always-on conformance tests below.
 trust-tasks-rs = { workspace = true, optional = true }
+# DTG credential construction for the Vetting Statement (`vetting` feature).
+dtg-credentials = { workspace = true, optional = true }
 ciborium = { version = "0.2", optional = true }
 # Direct OS-CSPRNG access for seed/nonce/bundle-id generation. (hpke 0.14
 # sources its own randomness internally, so this is no longer the bridge

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -197,6 +197,11 @@ mod tsp_demux;
 // credentials into a signed `vp_token` the VTC's join verifier accepts.
 #[cfg(feature = "vp")]
 pub mod vp;
+// Peer identity vetting: building, signing and verifying the Vetting Card and
+// Vetting Statement, and counting statements against a community's
+// requirements. Shapes are in `protocols::vetting`.
+#[cfg(feature = "vetting")]
+pub mod vetting;
 pub mod webvh;
 
 #[cfg(feature = "integration")]

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -116,6 +116,16 @@ pub const JOIN_REQUEST_MANIFEST_TYPE: &str =
 pub const JOIN_REQUEST_MANIFEST_RESPONSE_TYPE: &str =
     "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1#response";
 
+/// Manifest 0.2: 0.1 plus an optional `vetting` requirements object and a
+/// `requirementsDigest` on each criterion. A community answers both versions;
+/// a 0.1 reader simply does not see the new members.
+pub const JOIN_REQUEST_MANIFEST_0_2_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2";
+
+/// `#response` variant of [`JOIN_REQUEST_MANIFEST_0_2_TYPE`].
+pub const JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2#response";
+
 /// One community evidence requirement — a named DCQL Presentation
 /// Definition the applicant may present against.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +136,16 @@ pub struct ManifestCriterion {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub presentation_definition: JsonValue,
+    /// Peer identity vetting this criterion requires (manifest 0.2). Absent on
+    /// a criterion that needs none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
+    pub vetting: Option<super::vetting::VettingRequirements>,
+    /// `digestMultibase` over this criterion without this member (manifest
+    /// 0.2). An applicant records it when it starts gathering, so a change to
+    /// the requirements mid-application is detectable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements_digest: Option<String>,
 }
 
 /// Manifest response: the community's join evidence requirements.

--- a/vta-sdk/src/protocols/mod.rs
+++ b/vta-sdk/src/protocols/mod.rs
@@ -39,6 +39,10 @@ pub mod protocol_management;
 pub mod provision_integration_management;
 pub mod seed_management;
 pub mod vault_management;
+/// Peer identity vetting before joining a community (`spec/vetting/*`,
+/// `spec/vtc/vetting/*`) — serde shapes only; signing and verification are in
+/// `crate::vetting`.
+pub mod vetting;
 pub mod vta_management;
 
 // Standard DIDComm protocol types used across VTA/VTC services

--- a/vta-sdk/src/protocols/vetting.rs
+++ b/vta-sdk/src/protocols/vetting.rs
@@ -95,7 +95,7 @@ pub const VETTING_REQUEST_ERR_METHOD_UNAVAILABLE: &str = "vetting/request:method
 
 /// How a vetter established who the applicant is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum VettingMethod {
     /// Both people in the same place.
@@ -112,9 +112,9 @@ impl VettingMethod {
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::InPerson => "in-person",
+            Self::InPerson => "inPerson",
             Self::Video => "video",
-            Self::PriorAcquaintance => "prior-acquaintance",
+            Self::PriorAcquaintance => "priorAcquaintance",
         }
     }
 
@@ -122,9 +122,9 @@ impl VettingMethod {
     #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
         match s {
-            "in-person" => Some(Self::InPerson),
+            "inPerson" => Some(Self::InPerson),
             "video" => Some(Self::Video),
-            "prior-acquaintance" => Some(Self::PriorAcquaintance),
+            "priorAcquaintance" => Some(Self::PriorAcquaintance),
             _ => None,
         }
     }
@@ -133,7 +133,7 @@ impl VettingMethod {
 /// The vetter's declared relationship to the applicant. Independence rules in
 /// [`Independence`] cap how many counted statements may carry each value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum DeclaredRelationship {
     /// No prior relationship.
@@ -155,10 +155,10 @@ pub mod documentation {
     /// A passport.
     pub const PASSPORT: &str = "passport";
     /// A national identity card.
-    pub const NATIONAL_ID: &str = "national-id";
+    pub const NATIONAL_ID: &str = "nationalId";
     /// A driver licence.
-    pub const DRIVER_LICENCE: &str = "driver-licence";
-    /// No document: the vetter knows the person (`prior-acquaintance`).
+    pub const DRIVER_LICENCE: &str = "driverLicence";
+    /// No document: the vetter knows the person (`priorAcquaintance`).
     pub const NONE: &str = "none";
 }
 
@@ -181,7 +181,7 @@ pub struct VettingRequirements {
     pub statement_type: String,
     /// Distinct eligible vetters required, counted by member, not by DID.
     pub min_statements: u32,
-    /// Per-method floors, e.g. at least one `in-person`.
+    /// Per-method floors, e.g. at least one `inPerson`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub min_by_method: BTreeMap<VettingMethod, u32>,
     /// Methods that count at all.
@@ -246,7 +246,7 @@ pub struct Independence {
 
 /// Whether a VIC must accompany the vetting statements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum InvitationRequirement {
     /// A VIC is required.
@@ -271,8 +271,23 @@ impl VettingRequirements {
     ///
     /// [`InvalidRequirements`] naming the first problem found.
     pub fn validate(&self) -> Result<(), InvalidRequirements> {
-        if self.statement_type.is_empty() {
-            return Err(InvalidRequirements("statementType is empty".into()));
+        let (major, minor) = self.version.split_once('.').unwrap_or_default();
+        if major.is_empty()
+            || minor.is_empty()
+            || !major
+                .bytes()
+                .chain(minor.bytes())
+                .all(|b| b.is_ascii_digit())
+        {
+            return Err(InvalidRequirements(format!(
+                "version `{}` is not MAJOR.MINOR",
+                self.version
+            )));
+        }
+        if self.statement_type.is_empty() || self.statement_type.chars().count() > 512 {
+            return Err(InvalidRequirements(
+                "statementType is empty or longer than 512 characters".into(),
+            ));
         }
         if self.min_statements == 0 {
             return Err(InvalidRequirements(
@@ -290,8 +305,18 @@ impl VettingRequirements {
                 )));
             }
         }
-        if self.eligible_vetters.role.is_empty() {
-            return Err(InvalidRequirements("eligibleVetters.role is empty".into()));
+        shape::role("eligibleVetters.role", &self.eligible_vetters.role)
+            .map_err(|e| InvalidRequirements(e.to_string()))?;
+        if let Some(classes) = &self.accepted_document_classes {
+            shape::tokens("acceptedDocumentClasses", classes)
+                .map_err(|e| InvalidRequirements(e.to_string()))?;
+        }
+        if let Some(url) = &self.governance_framework_url
+            && (!url.starts_with("https://") || url.chars().count() > 2048)
+        {
+            return Err(InvalidRequirements(
+                "governanceFrameworkUrl must be an https URL of at most 2048 characters".into(),
+            ));
         }
         for (name, value) in [
             ("maxStatementAge", &self.max_statement_age),
@@ -299,7 +324,7 @@ impl VettingRequirements {
             ("requirementsGrace", &self.requirements_grace),
         ] {
             if let Some(v) = value
-                && parse_iso8601_duration(v).is_none()
+                && (v.len() > 32 || parse_iso8601_duration(v).is_none())
             {
                 return Err(InvalidRequirements(format!(
                     "{name} `{v}` is not a supported ISO 8601 duration (weeks, days, hours, minutes, seconds)"
@@ -326,19 +351,24 @@ impl VettingRequirements {
 /// not a limit.
 #[must_use]
 pub fn parse_iso8601_duration(s: &str) -> Option<Duration> {
+    /// Units in the order ISO 8601 writes them. Each may appear at most once,
+    /// and only after the ones before it — `P1D2W` is not a duration.
     fn accumulate(part: &str, units: &[(char, i64)]) -> Option<(i64, bool)> {
         let mut seconds: i64 = 0;
         let mut digits = String::new();
+        let mut next_unit = 0;
         let mut any = false;
         for c in part.chars() {
             if c.is_ascii_digit() {
                 digits.push(c);
                 continue;
             }
-            let (_, multiplier) = units.iter().find(|(unit, _)| *unit == c)?;
+            let offset = units[next_unit..].iter().position(|(unit, _)| *unit == c)?;
+            let (_, multiplier) = units[next_unit + offset];
+            next_unit += offset + 1;
             let n: i64 = digits.parse().ok()?;
             digits.clear();
-            seconds = seconds.checked_add(n.checked_mul(*multiplier)?)?;
+            seconds = seconds.checked_add(n.checked_mul(multiplier)?)?;
             any = true;
         }
         if !digits.is_empty() {
@@ -428,32 +458,58 @@ pub struct VettingRequestBody {
     pub ext: Option<Value>,
 }
 
-/// Why a [`VettingRequestBody`] is not well formed.
+/// Why a payload breaks a rule its Trust Task schema states.
+///
+/// Serde checks member names and types. The bounds and patterns the schemas
+/// also set — lengths, the ticket-code alphabet, BCP 47 tags — are checked by
+/// each type's `check_shape`, which a receiver runs before acting on the
+/// payload and a sender before signing it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
-pub enum RequestShapeError {
+pub enum ShapeError {
     /// Both a ticket and an introduction were supplied.
     #[error("a request carries a ticket or an introduction, not both")]
     TicketAndIntroduction,
     /// `joinDid` differs from the document issuer.
     #[error("joinDid must be the document issuer")]
     JoinDidNotIssuer,
+    /// A member breaks its schema bound or pattern.
+    #[error("`{field}` {rule}")]
+    Field {
+        /// The member, spelled as on the wire.
+        field: &'static str,
+        /// What it has to be.
+        rule: &'static str,
+    },
 }
 
 impl VettingRequestBody {
-    /// Check the rules the schema cannot express.
+    /// Check the rules serde cannot: the schema's bounds and patterns, a ticket
+    /// or an introduction but not both, and `joinDid` = the document issuer.
     ///
     /// # Errors
     ///
-    /// [`RequestShapeError`] for the first rule broken.
-    pub fn check_shape(&self, document_issuer: &str) -> Result<(), RequestShapeError> {
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self, document_issuer: &str) -> Result<(), ShapeError> {
         if self.ticket.is_some() && self.introduction.is_some() {
-            return Err(RequestShapeError::TicketAndIntroduction);
+            return Err(ShapeError::TicketAndIntroduction);
         }
         if self.join_did != document_issuer {
-            return Err(RequestShapeError::JoinDidNotIssuer);
+            return Err(ShapeError::JoinDidNotIssuer);
         }
-        Ok(())
+        shape::did("community", &self.community)?;
+        shape::did("joinDid", &self.join_did)?;
+        match &self.ticket {
+            Some(TicketPresentation::Scanned { ticket_id, secret }) => {
+                shape::ticket_id("ticket.ticketId", ticket_id)?;
+                shape::base64url_32("ticket.secret", secret)?;
+            }
+            Some(TicketPresentation::Code { code }) => shape::ticket_code("ticket.code", code)?,
+            None => {}
+        }
+        shape::languages("languages", &self.languages)?;
+        shape::optional_length("message", self.message.as_deref(), 1000)?;
+        shape::optional_length("availability", self.availability.as_deref(), 256)
     }
 }
 
@@ -463,9 +519,10 @@ impl VettingRequestBody {
 pub struct VettingRequestAcceptedBody {
     /// The vetter's handle for this request; every later task names it.
     pub request_id: String,
-    /// A VP of the vetter's community-issued VMC and `vetter` role VEC, with
-    /// `requestId` as its challenge, so the applicant can confirm eligibility
-    /// before investing in a session.
+    /// A VP of the vetter's community-issued VMC and `vetter` role VEC, with the
+    /// `vetting/request` document's `id` as its challenge — a value the
+    /// applicant chose, so the proof is fresh — letting the applicant confirm
+    /// eligibility before investing in a session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eligibility_vp: Option<Value>,
     /// The documentation this vetter accepts (their own choice, D16).
@@ -592,7 +649,7 @@ pub struct IdentityVettingEndorsement {
     /// How the vetter established identity.
     pub method: VettingMethod,
     /// What the vetter relied on, from their own accepted list; empty with
-    /// `prior-acquaintance`.
+    /// `priorAcquaintance`.
     #[serde(default)]
     pub document_classes: Vec<String>,
     /// Claim types the vetter verified.
@@ -616,7 +673,7 @@ pub struct IdentityVettingEndorsement {
 
 /// Why a vetter declined. Optional — a vetter never has to say.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum DeclineCode {
     /// The vetter could not establish identity.
@@ -654,7 +711,7 @@ pub struct VettingDeclineBody {
 
 /// Why a vetter withdrew a statement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum RevocationReason {
     /// The vetter made a mistake.
@@ -696,6 +753,298 @@ pub struct RevokeStatementResponseBody {
     pub ext: Option<Value>,
 }
 
+// ---------------------------------------------------------------------------
+// Shape checks for the remaining payloads
+// ---------------------------------------------------------------------------
+
+/// The claim type a card, session or statement must never name: portraits are
+/// not carried (design D17).
+pub const PORTRAIT_CLAIM_TYPE: &str = "person.portrait";
+
+impl VettingRequestAcceptedBody {
+    /// Check the schema's bounds and patterns.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        shape::length("requestId", &self.request_id, 128)?;
+        shape::tokens("acceptsDocumentation", &self.accepts_documentation)?;
+        shape::optional_length("sessionHint", self.session_hint.as_deref(), 500)
+    }
+}
+
+impl VettingSessionBody {
+    /// Check the schema's bounds and patterns.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        shape::length("requestId", &self.request_id, 128)?;
+        shape::base64url_32("challenge", &self.challenge)?;
+        shape::did("domain", &self.domain)?;
+        shape::no_portrait(
+            "requiredClaims",
+            self.required_claims.iter().map(String::as_str),
+        )?;
+        shape::no_portrait(
+            "optionalClaims",
+            self.optional_claims.iter().map(String::as_str),
+        )
+    }
+}
+
+impl VettingCard {
+    /// Check the schema's bounds and patterns. The proof is not checked here:
+    /// a card is shaped before it is signed, and verification checks the proof.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        if self.types.len() != VETTING_CARD_TYPES.len()
+            || !VETTING_CARD_TYPES
+                .iter()
+                .all(|t| self.types.iter().any(|s| s == t))
+        {
+            return Err(ShapeError::Field {
+                field: "type",
+                rule: "must be exactly VerifiableDataStructure, RelationshipCard and VettingCard",
+            });
+        }
+        shape::did("publisher", &self.publisher)?;
+        shape::did("audience", &self.audience)?;
+        shape::did("community", &self.community)?;
+        shape::did("domain", &self.domain)?;
+        shape::base64url_32("challenge", &self.challenge)?;
+        shape::base64url_32("commitmentSalt", &self.commitment_salt)?;
+        if self.claims.is_empty() {
+            return Err(ShapeError::Field {
+                field: "claims",
+                rule: "must carry at least one claim",
+            });
+        }
+        for claim in &self.claims {
+            shape::token("claims.provenance", &claim.provenance)?;
+        }
+        shape::no_portrait(
+            "claims.type",
+            self.claims.iter().map(|c| c.claim_type.as_str()),
+        )
+    }
+}
+
+impl IdentityVettingEndorsement {
+    /// Check the schema's bounds and patterns.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        shape::did("community", &self.community)?;
+        shape::tokens("documentClasses", &self.document_classes)?;
+        shape::no_portrait(
+            "claimsVerified",
+            self.claims_verified.iter().map(String::as_str),
+        )
+    }
+}
+
+impl VettingDeclineBody {
+    /// Check the schema's bounds and patterns.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        shape::length("requestId", &self.request_id, 128)?;
+        shape::optional_length("message", self.message.as_deref(), 500)
+    }
+}
+
+impl RevokeStatementBody {
+    /// Check the schema's bounds and patterns.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        shape::statement_id("statementId", &self.statement_id)
+    }
+}
+
+/// The bounds and patterns the vetting schemas set, written out rather than
+/// compiled from regular expressions so the crate takes no regex dependency.
+/// Each function names the schema pattern it implements.
+mod shape {
+    use super::{PORTRAIT_CLAIM_TYPE, ShapeError};
+
+    /// Crockford base32: no `I`, `L`, `O` or `U` (`[0-9A-HJKMNP-TV-Z]`).
+    const CROCKFORD: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+    fn fail(field: &'static str, rule: &'static str) -> Result<(), ShapeError> {
+        Err(ShapeError::Field { field, rule })
+    }
+
+    /// `minLength: 1`, `maxLength: max`, counted in characters as JSON Schema
+    /// counts them.
+    pub(super) fn length(field: &'static str, value: &str, max: usize) -> Result<(), ShapeError> {
+        let n = value.chars().count();
+        if n == 0 || n > max {
+            return fail(field, "is empty or longer than its schema allows");
+        }
+        Ok(())
+    }
+
+    pub(super) fn optional_length(
+        field: &'static str,
+        value: Option<&str>,
+        max: usize,
+    ) -> Result<(), ShapeError> {
+        value.map_or(Ok(()), |v| length(field, v, max))
+    }
+
+    /// `^did:`.
+    pub(super) fn did(field: &'static str, value: &str) -> Result<(), ShapeError> {
+        if value.len() > "did:".len() && value.starts_with("did:") {
+            return Ok(());
+        }
+        fail(field, "must be a DID")
+    }
+
+    /// `^[A-Za-z0-9_-]{43}$` — 32 bytes, base64url without padding.
+    pub(super) fn base64url_32(field: &'static str, value: &str) -> Result<(), ShapeError> {
+        if value.len() == 43
+            && value
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        {
+            return Ok(());
+        }
+        fail(field, "must be 32 bytes, base64url without padding")
+    }
+
+    /// `^[a-z][a-zA-Z0-9]*$`, at most 64 characters — documentation classes
+    /// and provenance values.
+    pub(super) fn token(field: &'static str, value: &str) -> Result<(), ShapeError> {
+        let mut chars = value.chars();
+        if value.len() <= 64
+            && chars.next().is_some_and(|c| c.is_ascii_lowercase())
+            && chars.all(|c| c.is_ascii_alphanumeric())
+        {
+            return Ok(());
+        }
+        fail(
+            field,
+            "must be a lowerCamelCase token of at most 64 characters",
+        )
+    }
+
+    pub(super) fn tokens(field: &'static str, values: &[String]) -> Result<(), ShapeError> {
+        values.iter().try_for_each(|v| token(field, v))
+    }
+
+    /// `maxItems: 16`, `uniqueItems`, each item at most 35 characters of
+    /// `^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$`.
+    pub(super) fn languages(field: &'static str, tags: &[String]) -> Result<(), ShapeError> {
+        if tags.len() > 16 {
+            return fail(field, "lists more than 16 languages");
+        }
+        for (i, tag) in tags.iter().enumerate() {
+            if !language_tag(tag) {
+                return fail(field, "must hold BCP 47 language tags");
+            }
+            if tags[..i].contains(tag) {
+                return fail(field, "repeats a language");
+            }
+        }
+        Ok(())
+    }
+
+    fn language_tag(tag: &str) -> bool {
+        let mut parts = tag.split('-');
+        tag.len() <= 35
+            && parts.next().is_some_and(|primary| {
+                (2..=3).contains(&primary.len()) && primary.bytes().all(|b| b.is_ascii_alphabetic())
+            })
+            && parts.all(|sub| {
+                (1..=8).contains(&sub.len()) && sub.bytes().all(|b| b.is_ascii_alphanumeric())
+            })
+    }
+
+    /// `^[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}$`.
+    pub(super) fn ticket_code(field: &'static str, code: &str) -> Result<(), ShapeError> {
+        if code.len() == 9
+            && code.bytes().enumerate().all(|(i, b)| {
+                if i == 4 {
+                    b == b'-'
+                } else {
+                    CROCKFORD.contains(&b)
+                }
+            })
+        {
+            return Ok(());
+        }
+        fail(field, "must be XXXX-XXXX in Crockford base32")
+    }
+
+    /// `^[A-Za-z0-9._:-]+$`, at most 128 characters.
+    pub(super) fn ticket_id(field: &'static str, id: &str) -> Result<(), ShapeError> {
+        if (1..=128).contains(&id.len())
+            && id
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-'))
+        {
+            return Ok(());
+        }
+        fail(
+            field,
+            "must be 1–128 characters of A–Z, a–z, 0–9, `.`, `_`, `:`, `-`",
+        )
+    }
+
+    /// `^[a-zA-Z][a-zA-Z0-9+.-]*:\S+$`, at most 512 characters — a URI with a
+    /// scheme, such as `urn:uuid:…`. The scheme cannot contain `:`, so the
+    /// first `:` is where it ends.
+    pub(super) fn statement_id(field: &'static str, id: &str) -> Result<(), ShapeError> {
+        let well_formed = id.split_once(':').is_some_and(|(scheme, rest)| {
+            let mut scheme = scheme.chars();
+            scheme.next().is_some_and(|c| c.is_ascii_alphabetic())
+                && scheme.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+                && !rest.is_empty()
+                && !rest.chars().any(char::is_whitespace)
+        });
+        if well_formed && id.chars().count() <= 512 {
+            return Ok(());
+        }
+        fail(field, "must be a URI of at most 512 characters")
+    }
+
+    /// `^[a-zA-Z][a-zA-Z0-9_-]*$`, at most 128 characters.
+    pub(super) fn role(field: &'static str, role: &str) -> Result<(), ShapeError> {
+        let mut chars = role.chars();
+        if role.len() <= 128
+            && chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+            && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return Ok(());
+        }
+        fail(field, "must be a role name of at most 128 characters")
+    }
+
+    /// Portraits are not carried (D17).
+    pub(super) fn no_portrait<'a>(
+        field: &'static str,
+        mut claim_types: impl Iterator<Item = &'a str>,
+    ) -> Result<(), ShapeError> {
+        if claim_types.any(|t| t == PORTRAIT_CLAIM_TYPE) {
+            return fail(field, "must not name person.portrait");
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -706,8 +1055,8 @@ mod tests {
             "version": "0.1",
             "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
             "minStatements": 2,
-            "minByMethod": { "in-person": 1 },
-            "acceptedMethods": ["in-person", "video", "prior-acquaintance"],
+            "minByMethod": { "inPerson": 1 },
+            "acceptedMethods": ["inPerson", "video", "priorAcquaintance"],
             "requiredClaims": ["name.legal"],
             "maxStatementAge": "P120D",
             "eligibleVetters": { "role": "vetter" },
@@ -717,7 +1066,7 @@ mod tests {
     }
 
     #[test]
-    fn requirements_round_trip_in_camel_and_kebab_case() {
+    fn requirements_round_trip_with_camel_case_members_and_values() {
         let req = requirements();
         assert_eq!(req.min_by_method.get(&VettingMethod::InPerson), Some(&1));
         assert_eq!(
@@ -727,8 +1076,8 @@ mod tests {
             Some(&0)
         );
         let back = serde_json::to_value(&req).unwrap();
-        assert_eq!(back["minByMethod"]["in-person"], 1);
-        assert_eq!(back["acceptedMethods"][2], "prior-acquaintance");
+        assert_eq!(back["minByMethod"]["inPerson"], 1);
+        assert_eq!(back["acceptedMethods"][2], "priorAcquaintance");
         // Documentation is the vetter's choice unless a community sets a floor.
         assert!(back.get("acceptedDocumentClasses").is_none());
         req.validate().unwrap();
@@ -751,7 +1100,7 @@ mod tests {
         let mut req = requirements();
         req.accepted_methods = vec![VettingMethod::Video];
         assert!(
-            req.validate().unwrap_err().0.contains("in-person"),
+            req.validate().unwrap_err().0.contains("inPerson"),
             "a floor on a method that never counts is unsatisfiable"
         );
 
@@ -766,7 +1115,9 @@ mod tests {
         assert_eq!(parse_iso8601_duration("P2W"), Duration::try_days(14));
         assert_eq!(parse_iso8601_duration("P1DT12H"), Duration::try_hours(36));
         assert_eq!(parse_iso8601_duration("PT15M"), Duration::try_minutes(15));
-        for bad in ["", "P", "PT", "120D", "P1Y", "P3M", "P1D2", "PTX", "P-1D"] {
+        for bad in [
+            "", "P", "PT", "120D", "P1Y", "P3M", "P1D2", "PTX", "P-1D", "P1D2W", "PT1M1H", "P1D1D",
+        ] {
             assert_eq!(parse_iso8601_duration(bad), None, "{bad:?}");
         }
     }
@@ -783,12 +1134,170 @@ mod tests {
         body.check_shape("did:key:zApplicant").unwrap();
         assert_eq!(
             body.check_shape("did:key:zSomeoneElse"),
-            Err(RequestShapeError::JoinDidNotIssuer)
+            Err(ShapeError::JoinDidNotIssuer)
         );
         body.introduction = Some(json!({}));
         assert_eq!(
             body.check_shape("did:key:zApplicant"),
-            Err(RequestShapeError::TicketAndIntroduction)
+            Err(ShapeError::TicketAndIntroduction)
+        );
+    }
+
+    fn field_of(result: Result<(), ShapeError>) -> &'static str {
+        match result {
+            Err(ShapeError::Field { field, .. }) => field,
+            other => panic!("expected a field error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn request_bounds_follow_the_schema() {
+        let base = || -> VettingRequestBody {
+            serde_json::from_value(json!({
+                "community": "did:web:vtc.example",
+                "joinDid": "did:key:zApplicant",
+                "ticket": { "code": "K7QF-2M9X" },
+                "languages": ["en", "pt-BR", "zh-Hant-TW"],
+                "message": "Hello"
+            }))
+            .unwrap()
+        };
+        let issuer = "did:key:zApplicant";
+        base().check_shape(issuer).unwrap();
+
+        // I, L, O and U are not Crockford characters.
+        let mut b = base();
+        b.ticket = Some(TicketPresentation::Code {
+            code: "K7QF-2M9O".into(),
+        });
+        assert_eq!(field_of(b.check_shape(issuer)), "ticket.code");
+
+        let mut b = base();
+        b.ticket = Some(TicketPresentation::Scanned {
+            ticket_id: "t-1".into(),
+            secret: "too-short".into(),
+        });
+        assert_eq!(field_of(b.check_shape(issuer)), "ticket.secret");
+
+        let mut b = base();
+        b.ticket = Some(TicketPresentation::Scanned {
+            ticket_id: "t 1".into(),
+            secret: "A".repeat(43),
+        });
+        assert_eq!(field_of(b.check_shape(issuer)), "ticket.ticketId");
+
+        let mut b = base();
+        b.languages = vec!["en".into(), "en".into()];
+        assert_eq!(field_of(b.check_shape(issuer)), "languages");
+        b.languages = vec!["english".into()];
+        assert_eq!(field_of(b.check_shape(issuer)), "languages");
+        b.languages = (0..17).map(|i| format!("en-x{i}")).collect();
+        assert_eq!(field_of(b.check_shape(issuer)), "languages");
+
+        let mut b = base();
+        b.message = Some("x".repeat(1001));
+        assert_eq!(field_of(b.check_shape(issuer)), "message");
+        b.message = Some(String::new());
+        assert_eq!(field_of(b.check_shape(issuer)), "message");
+
+        let mut b = base();
+        b.availability = Some("x".repeat(257));
+        assert_eq!(field_of(b.check_shape(issuer)), "availability");
+
+        let mut b = base();
+        b.community = "vtc.example".into();
+        assert_eq!(field_of(b.check_shape(issuer)), "community");
+    }
+
+    #[test]
+    fn reply_and_notice_bounds_follow_the_schema() {
+        let accepted = VettingRequestAcceptedBody {
+            request_id: "r1".into(),
+            eligibility_vp: None,
+            accepts_documentation: vec!["passport".into(), "nationalId".into()],
+            session_hint: Some("Hallway, 3pm".into()),
+            ext: None,
+        };
+        accepted.check_shape().unwrap();
+        let mut a = accepted.clone();
+        a.accepts_documentation = vec!["national-id".into()];
+        assert_eq!(field_of(a.check_shape()), "acceptsDocumentation");
+        let mut a = accepted;
+        a.request_id = "r".repeat(129);
+        assert_eq!(field_of(a.check_shape()), "requestId");
+
+        let session = VettingSessionBody {
+            request_id: "r1".into(),
+            challenge: "A".repeat(43),
+            domain: "did:web:vtc.example".into(),
+            method: VettingMethod::Video,
+            required_claims: vec!["name.legal".into()],
+            optional_claims: vec![],
+            expires_at: Utc::now(),
+            ext: None,
+        };
+        session.check_shape().unwrap();
+        let mut s = session.clone();
+        s.optional_claims = vec![PORTRAIT_CLAIM_TYPE.into()];
+        assert_eq!(field_of(s.check_shape()), "optionalClaims");
+        let mut s = session;
+        s.challenge = "A".repeat(44);
+        assert_eq!(field_of(s.check_shape()), "challenge");
+
+        let decline = VettingDeclineBody {
+            request_id: "r1".into(),
+            code: Some(DeclineCode::NotComfortable),
+            message: Some("x".repeat(501)),
+            ext: None,
+        };
+        assert_eq!(field_of(decline.check_shape()), "message");
+
+        for (id, ok) in [
+            ("urn:uuid:5b0e1c2a-7d4f-4a51-9c6e-2f1b8d3a9e70", true),
+            ("https://vetter.example/statements/1", true),
+            ("statement-1", false),
+            ("urn:uuid:has space", false),
+            ("1urn:x", false),
+            ("urn:", false),
+        ] {
+            let notice = RevokeStatementBody {
+                statement_id: id.into(),
+                statement_digest_multibase: "zDigest".into(),
+                reason: None,
+                ext: None,
+            };
+            assert_eq!(notice.check_shape().is_ok(), ok, "{id}");
+        }
+    }
+
+    #[test]
+    fn requirements_bounds_follow_the_schema() {
+        let mut req = requirements();
+        req.version = "1".into();
+        assert!(req.validate().is_err(), "version is MAJOR.MINOR");
+
+        let mut req = requirements();
+        req.eligible_vetters.role = "vet ter".into();
+        assert!(req.validate().is_err());
+
+        let mut req = requirements();
+        req.accepted_document_classes = Some(vec!["national-id".into()]);
+        assert!(req.validate().is_err(), "documentation is lowerCamelCase");
+        req.accepted_document_classes = Some(vec![documentation::NATIONAL_ID.into()]);
+        req.validate().unwrap();
+
+        let mut req = requirements();
+        req.governance_framework_url = Some("http://gov.example".into());
+        assert!(
+            req.validate().is_err(),
+            "governance text is served over https"
+        );
+
+        let mut req = requirements();
+        req.decision_sla = Some(format!("PT{}S", "1".repeat(30)));
+        assert!(
+            req.validate().is_err(),
+            "durations are at most 32 characters"
         );
     }
 

--- a/vta-sdk/src/protocols/vetting.rs
+++ b/vta-sdk/src/protocols/vetting.rs
@@ -1,0 +1,823 @@
+//! Wire types for peer identity vetting — how an applicant is vetted by
+//! existing members before joining a Verifiable Trust Community.
+//!
+//! Design: OpenVTC `docs/design/vetting-process.md`. Four Trust Tasks carry
+//! the exchange:
+//!
+//! | Type URI | From → to | Payload |
+//! |---|---|---|
+//! | `spec/vetting/request/0.1` | applicant → vetter | [`VettingRequestBody`] → [`VettingRequestAcceptedBody`] |
+//! | `spec/vetting/session/0.1` | vetter → applicant | [`VettingSessionBody`] → [`VettingSessionResponseBody`] |
+//! | `spec/vetting/decline/0.1` | vetter → applicant | [`VettingDeclineBody`] |
+//! | `spec/vtc/vetting/revoke-statement/0.1` | vetter → community | [`RevokeStatementBody`] → [`RevokeStatementResponseBody`] |
+//!
+//! The Vetting Statement itself travels over the existing
+//! `credential-exchange/issue/0.1`. It is a DTG `EndorsementCredential` whose
+//! `endorsement` is an [`IdentityVettingEndorsement`] — no new credential type.
+//!
+//! What a community requires rides its join manifest as a
+//! [`VettingRequirements`] on each criterion. **Every number in it is the
+//! community's policy**: this crate supplies no default statement count,
+//! method floor or age limit, and nothing here should grow one.
+//!
+//! This module is serde only, so any consumer can read the shapes. Building,
+//! signing and verifying the card and the statement live in
+//! `crate::vetting` (feature `vetting`).
+//!
+//! ## Refusals are errors, not responses
+//!
+//! A vetter that will not take a request answers with a framework
+//! `trust-task-error` carrying one of the `VETTING_REQUEST_ERR_*` codes, never
+//! a `#response` with an "outcome" field. One exception is deliberate: a request
+//! whose **short ticket code** is wrong gets no answer at all, so a guesser
+//! learns nothing from the reply (design §8.3).
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Type URIs
+// ---------------------------------------------------------------------------
+
+/// Applicant → vetter: ask to be vetted for one community.
+pub const VETTING_REQUEST_TYPE: &str = "https://trusttasks.org/spec/vetting/request/0.1";
+/// `#response` variant of [`VETTING_REQUEST_TYPE`] — the vetter accepted.
+pub const VETTING_REQUEST_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/spec/vetting/request/0.1#response";
+
+/// Vetter → applicant: open the session. The response carries the signed card.
+pub const VETTING_SESSION_TYPE: &str = "https://trusttasks.org/spec/vetting/session/0.1";
+/// `#response` variant of [`VETTING_SESSION_TYPE`].
+pub const VETTING_SESSION_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/spec/vetting/session/0.1#response";
+
+/// Vetter → applicant: the vetter will not issue a statement.
+pub const VETTING_DECLINE_TYPE: &str = "https://trusttasks.org/spec/vetting/decline/0.1";
+
+/// Vetter → community: withdraw a statement the vetter issued.
+pub const VETTING_REVOKE_STATEMENT_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/vetting/revoke-statement/0.1";
+/// `#response` variant of [`VETTING_REVOKE_STATEMENT_TYPE`].
+pub const VETTING_REVOKE_STATEMENT_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/vetting/revoke-statement/0.1#response";
+
+/// `endorsement.type` of a Vetting Statement.
+pub const IDENTITY_VETTING_ENDORSEMENT_TYPE: &str =
+    "https://firstperson.network/endorsements/identity-vetting/0.1";
+
+/// The `type` members a Vetting Card carries, in order. It is a profile of the
+/// r-card, which is itself a Verifiable Data Structure.
+pub const VETTING_CARD_TYPES: [&str; 3] =
+    ["VerifiableDataStructure", "RelationshipCard", "VettingCard"];
+
+/// Vault `purpose` a holder files received statements under.
+pub const VETTING_VAULT_PURPOSE: &str = "vetting";
+
+/// `vetting/request` refusal: a scanned ticket's secret did not match. Never
+/// sent for a short code — see the module docs.
+pub const VETTING_REQUEST_ERR_INVALID_TICKET: &str = "vetting/request:invalidTicket";
+/// `vetting/request` refusal: the vetter has no capacity.
+pub const VETTING_REQUEST_ERR_CAPACITY: &str = "vetting/request:capacity";
+/// `vetting/request` refusal: the addressee is not currently a vetter for the
+/// named community.
+pub const VETTING_REQUEST_ERR_NOT_ELIGIBLE: &str = "vetting/request:notEligible";
+/// `vetting/request` refusal: the vetter declines, without a reason.
+pub const VETTING_REQUEST_ERR_DECLINED: &str = "vetting/request:declined";
+/// `vetting/request` refusal: the vetter does not offer the requested method.
+pub const VETTING_REQUEST_ERR_METHOD_UNAVAILABLE: &str = "vetting/request:methodUnavailable";
+
+// ---------------------------------------------------------------------------
+// Shared vocabulary
+// ---------------------------------------------------------------------------
+
+/// How a vetter established who the applicant is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum VettingMethod {
+    /// Both people in the same place.
+    InPerson,
+    /// A live video call.
+    Video,
+    /// The vetter already knows the applicant — the Linux kernel's own written
+    /// standard ("worked with you for some period of time").
+    PriorAcquaintance,
+}
+
+impl VettingMethod {
+    /// The wire form, as used in `needs` strings.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InPerson => "in-person",
+            Self::Video => "video",
+            Self::PriorAcquaintance => "prior-acquaintance",
+        }
+    }
+
+    /// Inverse of [`Self::as_str`].
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "in-person" => Some(Self::InPerson),
+            "video" => Some(Self::Video),
+            "prior-acquaintance" => Some(Self::PriorAcquaintance),
+            _ => None,
+        }
+    }
+}
+
+/// The vetter's declared relationship to the applicant. Independence rules in
+/// [`Independence`] cap how many counted statements may carry each value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum DeclaredRelationship {
+    /// No prior relationship.
+    None,
+    /// Worked together in the community.
+    CommunityColleague,
+    /// Same employer.
+    SameEmployer,
+    /// Family.
+    Family,
+    /// Some other personal relationship.
+    OtherPersonal,
+}
+
+/// Well-known documentation values. Documentation is **each vetter's choice**
+/// (design D16), so the wire type is an open string; these are the names
+/// clients should use for the common cases.
+pub mod documentation {
+    /// A passport.
+    pub const PASSPORT: &str = "passport";
+    /// A national identity card.
+    pub const NATIONAL_ID: &str = "national-id";
+    /// A driver licence.
+    pub const DRIVER_LICENCE: &str = "driver-licence";
+    /// No document: the vetter knows the person (`prior-acquaintance`).
+    pub const NONE: &str = "none";
+}
+
+// ---------------------------------------------------------------------------
+// Requirements (manifest 0.2)
+// ---------------------------------------------------------------------------
+
+/// What a criterion in a community's join manifest requires of vetting.
+///
+/// Deliberately **not** `deny_unknown_fields`: this is a shape a client reads
+/// from a community, and a newer community adding a member must not make an
+/// older client unable to read the rest.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VettingRequirements {
+    /// Version of this requirements object's shape (`"0.1"`).
+    pub version: String,
+    /// The endorsement `type` a counted statement carries — normally
+    /// [`IDENTITY_VETTING_ENDORSEMENT_TYPE`].
+    pub statement_type: String,
+    /// Distinct eligible vetters required, counted by member, not by DID.
+    pub min_statements: u32,
+    /// Per-method floors, e.g. at least one `in-person`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub min_by_method: BTreeMap<VettingMethod, u32>,
+    /// Methods that count at all.
+    pub accepted_methods: Vec<VettingMethod>,
+    /// Optional documentation floor. **Absent by default**: each vetter decides
+    /// what documentation they accept (D16).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accepted_document_classes: Option<Vec<String>>,
+    /// Claim types a counted statement must mark verified, and which the
+    /// identity commitment is computed over.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_claims: Vec<String>,
+    /// Claim types an applicant may add to the card.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub optional_claims: Vec<String>,
+    /// ISO 8601 duration; a statement older than this at decision time does
+    /// not count. Absent: no age limit beyond the statement's own `validUntil`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_statement_age: Option<String>,
+    /// How a vetter's eligibility is proven.
+    pub eligible_vetters: EligibleVetters,
+    /// Independence caps.
+    #[serde(default)]
+    pub independence: Independence,
+    /// Whether an invitation credential must accompany the statements. Absent:
+    /// the criterion's `presentationDefinition` alone decides.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invitation: Option<InvitationRequirement>,
+    /// ISO 8601 duration the community commits to deciding a referred
+    /// application within. Clients use it in place of a fixed pending expiry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_sla: Option<String>,
+    /// ISO 8601 duration an application started under an older
+    /// `requirementsDigest` is still evaluated under that version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements_grace: Option<String>,
+    /// Where the governance framework (and the vetter attestation text) lives.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub governance_framework_url: Option<String>,
+}
+
+/// How vetter eligibility is proven.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EligibleVetters {
+    /// The community role a vetter must hold (normally `"vetter"`), evidenced
+    /// by the community-issued role VEC.
+    pub role: String,
+}
+
+/// Independence rules over the counted statements.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Independence {
+    /// At most this many counted statements may declare each relationship.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub max_by_declared_relationship: BTreeMap<DeclaredRelationship, u32>,
+    /// Every statement must carry the same identity commitment.
+    #[serde(default)]
+    pub require_consistent_identity_commitment: bool,
+}
+
+/// Whether a VIC must accompany the vetting statements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum InvitationRequirement {
+    /// A VIC is required.
+    Required,
+    /// A VIC may be presented.
+    Optional,
+    /// No VIC is expected.
+    None,
+}
+
+/// A [`VettingRequirements`] that cannot be evaluated.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid vetting requirements: {0}")]
+pub struct InvalidRequirements(pub String);
+
+impl VettingRequirements {
+    /// Check the requirements can be evaluated as written. A community should
+    /// refuse to publish requirements that fail this, and a client should treat
+    /// a criterion that fails it as unsatisfiable rather than guess.
+    ///
+    /// # Errors
+    ///
+    /// [`InvalidRequirements`] naming the first problem found.
+    pub fn validate(&self) -> Result<(), InvalidRequirements> {
+        if self.statement_type.is_empty() {
+            return Err(InvalidRequirements("statementType is empty".into()));
+        }
+        if self.min_statements == 0 {
+            return Err(InvalidRequirements(
+                "minStatements must be at least 1 — a criterion that needs no statements has no vetting object".into(),
+            ));
+        }
+        if self.accepted_methods.is_empty() {
+            return Err(InvalidRequirements("acceptedMethods is empty".into()));
+        }
+        for method in self.min_by_method.keys() {
+            if !self.accepted_methods.contains(method) {
+                return Err(InvalidRequirements(format!(
+                    "minByMethod names `{}`, which acceptedMethods does not accept",
+                    method.as_str()
+                )));
+            }
+        }
+        if self.eligible_vetters.role.is_empty() {
+            return Err(InvalidRequirements("eligibleVetters.role is empty".into()));
+        }
+        for (name, value) in [
+            ("maxStatementAge", &self.max_statement_age),
+            ("decisionSla", &self.decision_sla),
+            ("requirementsGrace", &self.requirements_grace),
+        ] {
+            if let Some(v) = value
+                && parse_iso8601_duration(v).is_none()
+            {
+                return Err(InvalidRequirements(format!(
+                    "{name} `{v}` is not a supported ISO 8601 duration (weeks, days, hours, minutes, seconds)"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// [`Self::max_statement_age`] as a duration. `None` when absent **or
+    /// unparseable** — call [`Self::validate`] first to tell the two apart.
+    #[must_use]
+    pub fn max_statement_age(&self) -> Option<Duration> {
+        self.max_statement_age
+            .as_deref()
+            .and_then(parse_iso8601_duration)
+    }
+}
+
+/// Parse the subset of ISO 8601 durations these requirements use: `P[n]W`,
+/// `P[n]D` and a `T` part with `H`, `M`, `S`, in any combination
+/// (`P1DT12H`). Years and months are refused — their length depends on the
+/// calendar, and an age limit that means different things on different days is
+/// not a limit.
+#[must_use]
+pub fn parse_iso8601_duration(s: &str) -> Option<Duration> {
+    fn accumulate(part: &str, units: &[(char, i64)]) -> Option<(i64, bool)> {
+        let mut seconds: i64 = 0;
+        let mut digits = String::new();
+        let mut any = false;
+        for c in part.chars() {
+            if c.is_ascii_digit() {
+                digits.push(c);
+                continue;
+            }
+            let (_, multiplier) = units.iter().find(|(unit, _)| *unit == c)?;
+            let n: i64 = digits.parse().ok()?;
+            digits.clear();
+            seconds = seconds.checked_add(n.checked_mul(*multiplier)?)?;
+            any = true;
+        }
+        if !digits.is_empty() {
+            return None;
+        }
+        Some((seconds, any))
+    }
+
+    let rest = s.strip_prefix('P')?;
+    let (date, time) = match rest.split_once('T') {
+        Some((date, time)) => (date, Some(time)),
+        None => (rest, None),
+    };
+    let (date_seconds, date_any) = accumulate(date, &[('W', 604_800), ('D', 86_400)])?;
+    let (time_seconds, time_any) = match time {
+        Some(time) => {
+            let (seconds, any) = accumulate(time, &[('H', 3_600), ('M', 60), ('S', 1)])?;
+            // `PT` with nothing after it is not a duration.
+            if !any {
+                return None;
+            }
+            (seconds, any)
+        }
+        None => (0, false),
+    };
+    if !date_any && !time_any {
+        return None;
+    }
+    Duration::try_seconds(date_seconds.checked_add(time_seconds)?)
+}
+
+// ---------------------------------------------------------------------------
+// vetting/request/0.1
+// ---------------------------------------------------------------------------
+
+/// A Vetting Ticket as presented by the applicant: either the short code the
+/// vetter read out, or the full ticket scanned from their QR.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TicketPresentation {
+    /// The QR form: full-entropy secret, not subject to guess limits.
+    Scanned {
+        #[serde(rename = "ticketId")]
+        ticket_id: String,
+        /// base64url, 32 bytes.
+        secret: String,
+    },
+    /// The spoken form: `XXXX-XXXX`, 40 bits.
+    Code {
+        /// Crockford base32, `XXXX-XXXX`.
+        code: String,
+    },
+}
+
+/// `vetting/request/0.1` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VettingRequestBody {
+    /// The community the applicant wants to be vetted for.
+    pub community: String,
+    /// `requirementsDigest` of the criterion the applicant is gathering for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements_digest: Option<String>,
+    /// The DID the applicant will join with. MUST equal the document `issuer`.
+    pub join_did: String,
+    /// The vetter's ticket. Mutually exclusive with `introduction`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ticket: Option<TicketPresentation>,
+    /// A VIC for this community naming `joinDid`, used as a member
+    /// introduction. Mutually exclusive with `ticket`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub introduction: Option<Value>,
+    /// The method the applicant would prefer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferred_method: Option<VettingMethod>,
+    /// BCP 47 language tags the applicant can be vetted in.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub languages: Vec<String>,
+    /// A short note to the vetter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Free-text availability, for scheduling out of band.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub availability: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// Why a [`VettingRequestBody`] is not well formed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum RequestShapeError {
+    /// Both a ticket and an introduction were supplied.
+    #[error("a request carries a ticket or an introduction, not both")]
+    TicketAndIntroduction,
+    /// `joinDid` differs from the document issuer.
+    #[error("joinDid must be the document issuer")]
+    JoinDidNotIssuer,
+}
+
+impl VettingRequestBody {
+    /// Check the rules the schema cannot express.
+    ///
+    /// # Errors
+    ///
+    /// [`RequestShapeError`] for the first rule broken.
+    pub fn check_shape(&self, document_issuer: &str) -> Result<(), RequestShapeError> {
+        if self.ticket.is_some() && self.introduction.is_some() {
+            return Err(RequestShapeError::TicketAndIntroduction);
+        }
+        if self.join_did != document_issuer {
+            return Err(RequestShapeError::JoinDidNotIssuer);
+        }
+        Ok(())
+    }
+}
+
+/// `vetting/request/0.1#response` payload — the vetter accepted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VettingRequestAcceptedBody {
+    /// The vetter's handle for this request; every later task names it.
+    pub request_id: String,
+    /// A VP of the vetter's community-issued VMC and `vetter` role VEC, with
+    /// `requestId` as its challenge, so the applicant can confirm eligibility
+    /// before investing in a session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eligibility_vp: Option<Value>,
+    /// The documentation this vetter accepts (their own choice, D16).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepts_documentation: Vec<String>,
+    /// Free text: how the vetter proposes to meet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_hint: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// vetting/session/0.1
+// ---------------------------------------------------------------------------
+
+/// `vetting/session/0.1` payload. The vetter sends it when both people are
+/// together. The document's `id` is the session's name: both clients derive
+/// the match code from it, and the statement carries it as `taskContext`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VettingSessionBody {
+    /// The accepted request this session belongs to.
+    pub request_id: String,
+    /// Single-use challenge the card must carry. base64url, 32 bytes.
+    pub challenge: String,
+    /// Binding domain the card must carry — the community DID.
+    pub domain: String,
+    /// The method this session uses.
+    pub method: VettingMethod,
+    /// Claim types the card must carry.
+    pub required_claims: Vec<String>,
+    /// Claim types the card may carry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub optional_claims: Vec<String>,
+    /// After this the applicant's client refuses to present.
+    pub expires_at: DateTime<Utc>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `vetting/session/0.1#response` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VettingSessionResponseBody {
+    /// The signed Vetting Card, exactly as signed.
+    pub card: Value,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// The Vetting Card (a VDS)
+// ---------------------------------------------------------------------------
+
+/// One claim on a Vetting Card.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CardClaim {
+    /// Claim type from the claim-type registry, e.g. `name.legal`.
+    #[serde(rename = "type")]
+    pub claim_type: String,
+    /// The claim value.
+    pub value: Value,
+    /// Where the value came from — `selfAsserted` in V0.
+    pub provenance: String,
+}
+
+/// A Vetting Card: an r-card profile, signed by the applicant's join DID and
+/// bound to one vetter and one session. Carries no document numbers, images or
+/// portraits.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VettingCard {
+    /// [`VETTING_CARD_TYPES`].
+    #[serde(rename = "type")]
+    pub types: Vec<String>,
+    /// `urn:uuid:…`.
+    pub id: String,
+    /// The applicant's join DID — the signer.
+    pub publisher: String,
+    /// r-card version.
+    pub card_version: u32,
+    /// The one vetter this card is for.
+    pub audience: String,
+    /// The community the vetting is for.
+    pub community: String,
+    /// From the session.
+    pub challenge: String,
+    /// From the session.
+    pub domain: String,
+    /// When the card was made.
+    pub issued_at: DateTime<Utc>,
+    /// When it stops being presentable.
+    pub expires_at: DateTime<Utc>,
+    /// The claims shown to the vetter.
+    pub claims: Vec<CardClaim>,
+    /// Salted digest over the identity claims; equal on every card of one
+    /// application.
+    pub identity_commitment: String,
+    /// The per-application salt — disclosed to vetters, never to the community.
+    pub commitment_salt: String,
+    /// Data Integrity proof by `publisher`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// The Vetting Statement's endorsement body
+// ---------------------------------------------------------------------------
+
+/// `credentialSubject.endorsement` of a Vetting Statement.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct IdentityVettingEndorsement {
+    /// [`IDENTITY_VETTING_ENDORSEMENT_TYPE`].
+    #[serde(rename = "type")]
+    pub endorsement_type: String,
+    /// The one community this statement counts for. Not transitive.
+    pub community: String,
+    /// How the vetter established identity.
+    pub method: VettingMethod,
+    /// What the vetter relied on, from their own accepted list; empty with
+    /// `prior-acquaintance`.
+    #[serde(default)]
+    pub document_classes: Vec<String>,
+    /// Claim types the vetter verified.
+    pub claims_verified: Vec<String>,
+    /// The match code was confirmed with the person present.
+    pub liveness_confirmed: bool,
+    /// Copied from the card.
+    pub identity_commitment: String,
+    /// `digestMultibase` of the card the vetter checked.
+    pub card_digest_multibase: String,
+    /// The vetter's declared relationship to the applicant.
+    pub declared_relationship: DeclaredRelationship,
+    /// `digestMultibase` of the attestation text the vetter was shown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attestation_text_digest: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// vetting/decline/0.1
+// ---------------------------------------------------------------------------
+
+/// Why a vetter declined. Optional — a vetter never has to say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum DeclineCode {
+    /// The vetter could not establish identity.
+    CouldNotVerify,
+    /// The documentation did not match the card.
+    DocumentMismatch,
+    /// The match code could not be confirmed with the person.
+    LivenessFailed,
+    /// The vetter is not comfortable attesting.
+    NotComfortable,
+    /// Something else.
+    Other,
+}
+
+/// `vetting/decline/0.1` payload. Declines are never sent to the community.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VettingDeclineBody {
+    /// The request being declined.
+    pub request_id: String,
+    /// Optional reason code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<DeclineCode>,
+    /// Optional note to the applicant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// vtc/vetting/revoke-statement/0.1
+// ---------------------------------------------------------------------------
+
+/// Why a vetter withdrew a statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum RevocationReason {
+    /// The vetter made a mistake.
+    Mistake,
+    /// The vetter learned something new.
+    NewInformation,
+    /// The vetter's signing key was compromised.
+    KeyCompromise,
+    /// Something else.
+    Other,
+}
+
+/// `vtc/vetting/revoke-statement/0.1` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RevokeStatementBody {
+    /// The statement's `id`.
+    pub statement_id: String,
+    /// `digestMultibase` of the statement, so a notice cannot be aimed at a
+    /// different credential that reused the id.
+    pub statement_digest_multibase: String,
+    /// Optional reason; shared with the applicant only if the vetter chooses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<RevocationReason>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `vtc/vetting/revoke-statement/0.1#response` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RevokeStatementResponseBody {
+    /// When the community recorded the notice. Repeating a notice returns the
+    /// original time: revocation converges.
+    pub recorded_at: DateTime<Utc>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn requirements() -> VettingRequirements {
+        serde_json::from_value(json!({
+            "version": "0.1",
+            "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+            "minStatements": 2,
+            "minByMethod": { "in-person": 1 },
+            "acceptedMethods": ["in-person", "video", "prior-acquaintance"],
+            "requiredClaims": ["name.legal"],
+            "maxStatementAge": "P120D",
+            "eligibleVetters": { "role": "vetter" },
+            "independence": { "maxByDeclaredRelationship": { "family": 0 } }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn requirements_round_trip_in_camel_and_kebab_case() {
+        let req = requirements();
+        assert_eq!(req.min_by_method.get(&VettingMethod::InPerson), Some(&1));
+        assert_eq!(
+            req.independence
+                .max_by_declared_relationship
+                .get(&DeclaredRelationship::Family),
+            Some(&0)
+        );
+        let back = serde_json::to_value(&req).unwrap();
+        assert_eq!(back["minByMethod"]["in-person"], 1);
+        assert_eq!(back["acceptedMethods"][2], "prior-acquaintance");
+        // Documentation is the vetter's choice unless a community sets a floor.
+        assert!(back.get("acceptedDocumentClasses").is_none());
+        req.validate().unwrap();
+    }
+
+    #[test]
+    fn requirements_tolerate_members_a_newer_community_adds() {
+        let mut v = serde_json::to_value(requirements()).unwrap();
+        v["vetterDirectory"] = json!(true);
+        let req: VettingRequirements = serde_json::from_value(v).unwrap();
+        req.validate().unwrap();
+    }
+
+    #[test]
+    fn validate_refuses_what_cannot_be_evaluated() {
+        let mut req = requirements();
+        req.min_statements = 0;
+        assert!(req.validate().is_err());
+
+        let mut req = requirements();
+        req.accepted_methods = vec![VettingMethod::Video];
+        assert!(
+            req.validate().unwrap_err().0.contains("in-person"),
+            "a floor on a method that never counts is unsatisfiable"
+        );
+
+        let mut req = requirements();
+        req.max_statement_age = Some("P4M".into());
+        assert!(req.validate().is_err(), "months are calendar-dependent");
+    }
+
+    #[test]
+    fn durations_parse_the_supported_subset_only() {
+        assert_eq!(parse_iso8601_duration("P120D"), Duration::try_days(120));
+        assert_eq!(parse_iso8601_duration("P2W"), Duration::try_days(14));
+        assert_eq!(parse_iso8601_duration("P1DT12H"), Duration::try_hours(36));
+        assert_eq!(parse_iso8601_duration("PT15M"), Duration::try_minutes(15));
+        for bad in ["", "P", "PT", "120D", "P1Y", "P3M", "P1D2", "PTX", "P-1D"] {
+            assert_eq!(parse_iso8601_duration(bad), None, "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn request_shape_rules() {
+        let mut body: VettingRequestBody = serde_json::from_value(json!({
+            "community": "did:web:vtc.example",
+            "joinDid": "did:key:zApplicant",
+            "ticket": { "code": "K7QF-2M9X" }
+        }))
+        .unwrap();
+        assert!(matches!(body.ticket, Some(TicketPresentation::Code { .. })));
+        body.check_shape("did:key:zApplicant").unwrap();
+        assert_eq!(
+            body.check_shape("did:key:zSomeoneElse"),
+            Err(RequestShapeError::JoinDidNotIssuer)
+        );
+        body.introduction = Some(json!({}));
+        assert_eq!(
+            body.check_shape("did:key:zApplicant"),
+            Err(RequestShapeError::TicketAndIntroduction)
+        );
+    }
+
+    #[test]
+    fn scanned_tickets_parse_as_scanned_not_code() {
+        let t: TicketPresentation =
+            serde_json::from_value(json!({ "ticketId": "t1", "secret": "abc" })).unwrap();
+        assert!(matches!(t, TicketPresentation::Scanned { .. }));
+    }
+
+    #[test]
+    fn request_body_refuses_unknown_members() {
+        let err = serde_json::from_value::<VettingRequestBody>(json!({
+            "community": "did:web:vtc.example",
+            "joinDid": "did:key:zApplicant",
+            "tikcet": { "code": "K7QF-2M9X" }
+        }));
+        assert!(err.is_err(), "a typo must be refused, not ignored");
+    }
+
+    #[test]
+    fn method_strings_round_trip() {
+        for m in [
+            VettingMethod::InPerson,
+            VettingMethod::Video,
+            VettingMethod::PriorAcquaintance,
+        ] {
+            assert_eq!(VettingMethod::parse(m.as_str()), Some(m));
+            assert_eq!(serde_json::to_value(m).unwrap(), json!(m.as_str()));
+        }
+    }
+}

--- a/vta-sdk/src/vetting/card.rs
+++ b/vta-sdk/src/vetting/card.rs
@@ -141,6 +141,10 @@ pub async fn sign_card(draft: CardDraft, signer: &Secret) -> Result<Value, Vetti
         commitment_salt: draft.salt,
         proof: None,
     };
+    card.check_shape().map_err(|e| VettingError::Malformed {
+        what: WHAT,
+        detail: e.to_string(),
+    })?;
     let mut value = serde_json::to_value(&card).map_err(|e| VettingError::Sign(e.to_string()))?;
     let proof = affinidi_data_integrity::DataIntegrityProof::sign(
         &value,
@@ -223,12 +227,10 @@ pub async fn verify_card(
             what: WHAT,
             detail: e.to_string(),
         })?;
-    if !card.types.iter().any(|t| t == VETTING_CARD_TYPES[2]) {
-        return Err(VettingError::Malformed {
-            what: WHAT,
-            detail: "type does not include VettingCard".into(),
-        });
-    }
+    card.check_shape().map_err(|e| VettingError::Malformed {
+        what: WHAT,
+        detail: e.to_string(),
+    })?;
     if card.audience != expect.audience {
         return Err(VettingError::Binding("audience"));
     }
@@ -284,6 +286,9 @@ pub(crate) mod tests {
     use crate::vetting::test_support::{did, secret};
 
     pub(crate) const COMMUNITY: &str = "did:web:vtc.example";
+    /// 43 base64url characters, the shape of 32 bytes.
+    pub(crate) const CHALLENGE: &str = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+    const SALT: &str = "saltsaltsaltsaltsaltsaltsaltsaltsaltsaltsal";
 
     pub(crate) fn claims() -> Vec<CardClaim> {
         vec![
@@ -306,13 +311,13 @@ pub(crate) mod tests {
             publisher: did(applicant),
             audience: did(vetter),
             community: COMMUNITY.into(),
-            challenge: "challenge-1".into(),
+            challenge: CHALLENGE.into(),
             domain: COMMUNITY.into(),
             issued_at: now,
             validity: Duration::minutes(15),
             claims: claims(),
             identity_types: vec!["name.legal".into()],
-            salt: "salt-of-this-application".into(),
+            salt: SALT.into(),
         }
     }
 
@@ -326,7 +331,7 @@ pub(crate) mod tests {
             audience: vetter,
             publisher: applicant,
             community: COMMUNITY,
-            challenge: "challenge-1",
+            challenge: CHALLENGE,
             domain: COMMUNITY,
             required_claims: required,
             now,
@@ -449,6 +454,41 @@ pub(crate) mod tests {
             identity_commitment("salt", &claims(), &["person.birthDate".to_string()]),
             Err(VettingError::MissingClaim(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn a_portrait_is_never_signed_onto_a_card() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let mut d = draft(&applicant, &vetter, Utc::now());
+        d.claims.push(CardClaim {
+            claim_type: crate::protocols::vetting::PORTRAIT_CLAIM_TYPE.into(),
+            value: json!("data:image/png;base64,AAAA"),
+            provenance: "selfAsserted".into(),
+        });
+        assert!(matches!(
+            sign_card(d, &applicant).await.unwrap_err(),
+            VettingError::Malformed { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_card_must_carry_exactly_the_card_types() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let now = Utc::now();
+        let mut signed = sign_card(draft(&applicant, &vetter, now), &applicant)
+            .await
+            .unwrap();
+        signed["type"] = json!(["VettingCard"]);
+        let required = vec!["name.legal".to_string()];
+        let (a, v) = (did(&applicant), did(&vetter));
+        let err = verify_card(
+            &signed,
+            &expectations(&a, &v, &required, now),
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, VettingError::Malformed { .. }), "{err:?}");
     }
 
     #[test]

--- a/vta-sdk/src/vetting/card.rs
+++ b/vta-sdk/src/vetting/card.rs
@@ -1,0 +1,460 @@
+//! The Vetting Card: what an applicant shows one vetter.
+//!
+//! A profile of the r-card (a Verifiable Data Structure). The applicant's
+//! client fills the claims from a persona disclosure, then signs the card with
+//! the join DID's key — the same key the final join presentation is signed
+//! with, which is what ties every card, every statement and the join together.
+//!
+//! A card is **bound**: to one vetter (`audience`), one session (`challenge`,
+//! `domain`) and a validity window of at most [`MAX_CARD_VALIDITY`]. It cannot
+//! be replayed to another vetter or into another session.
+//!
+//! ## The identity commitment
+//!
+//! `identityCommitment` = `digestMultibase` over `{salt, claims}` where
+//! `claims` are the card's identity claims (the community's `requiredClaims`)
+//! sorted by type. The applicant uses **one salt per application**, so every
+//! vetter sees the same commitment; the salt goes to vetters inside the card
+//! and never to the community. Each statement repeats the commitment, so the
+//! community can check that all its vetters verified the *same* claimed
+//! identity without learning it — and the salt keeps a low-entropy name from
+//! being recovered by enumeration (dtgwg-cred-spec #38).
+
+use affinidi_data_integrity::{SignOptions, crypto_suites::CryptoSuite};
+use affinidi_secrets_resolver::secrets::Secret;
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{Value, json};
+
+use super::{VettingError, did_of, digest, verify_attached_proof};
+use crate::protocols::vetting::{CardClaim, VETTING_CARD_TYPES, VettingCard};
+use crate::trust_task_proof::TrustTaskVmResolver;
+
+/// Longest a card may be presentable for.
+pub const MAX_CARD_VALIDITY: Duration = Duration::minutes(15);
+
+/// Clock skew tolerated between applicant and vetter.
+pub const CLOCK_SKEW: Duration = Duration::seconds(60);
+
+/// The card's proof purpose: the publisher asserts what the card says.
+pub const CARD_PROOF_PURPOSE: &str = "assertionMethod";
+
+const WHAT: &str = "vetting card";
+
+/// A fresh per-application commitment salt: 32 random bytes, base64url.
+///
+/// # Errors
+///
+/// [`VettingError::Random`] if the platform has no randomness source.
+pub fn new_commitment_salt() -> Result<String, VettingError> {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).map_err(|e| VettingError::Random(e.to_string()))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+/// Compute the identity commitment over `claims` for the claim types in
+/// `identity_types`.
+///
+/// # Errors
+///
+/// [`VettingError::MissingClaim`] if an identity claim is absent;
+/// [`VettingError::Digest`] if canonicalisation fails.
+pub fn identity_commitment(
+    salt: &str,
+    claims: &[CardClaim],
+    identity_types: &[String],
+) -> Result<String, VettingError> {
+    let mut types: Vec<&String> = identity_types.iter().collect();
+    types.sort();
+    types.dedup();
+    let mut selected = Vec::with_capacity(types.len());
+    for claim_type in types {
+        let claim = claims
+            .iter()
+            .find(|c| &c.claim_type == claim_type)
+            .ok_or_else(|| VettingError::MissingClaim(claim_type.clone()))?;
+        selected.push(json!({ "type": claim.claim_type, "value": claim.value }));
+    }
+    digest(&json!({ "salt": salt, "claims": selected }))
+}
+
+/// Everything needed to make a card.
+#[derive(Debug, Clone)]
+pub struct CardDraft {
+    /// `urn:uuid:…`.
+    pub id: String,
+    /// The applicant's join DID.
+    pub publisher: String,
+    /// The vetter's DID.
+    pub audience: String,
+    /// The community DID.
+    pub community: String,
+    /// From the `vetting/session` payload.
+    pub challenge: String,
+    /// From the `vetting/session` payload.
+    pub domain: String,
+    /// Normally now.
+    pub issued_at: DateTime<Utc>,
+    /// At most [`MAX_CARD_VALIDITY`].
+    pub validity: Duration,
+    /// The disclosed claims.
+    pub claims: Vec<CardClaim>,
+    /// The claim types the commitment covers — the session's `requiredClaims`.
+    pub identity_types: Vec<String>,
+    /// The application's salt ([`new_commitment_salt`]).
+    pub salt: String,
+}
+
+/// Build and sign a card. `signer` must be a key of `draft.publisher`.
+///
+/// # Errors
+///
+/// [`VettingError::WrongSigner`] if `signer` is not the publisher's key,
+/// [`VettingError::Expired`] if the validity exceeds [`MAX_CARD_VALIDITY`],
+/// [`VettingError::MissingClaim`] if an identity claim is absent, or
+/// [`VettingError::Sign`].
+pub async fn sign_card(draft: CardDraft, signer: &Secret) -> Result<Value, VettingError> {
+    if did_of(&signer.id) != draft.publisher {
+        return Err(VettingError::WrongSigner {
+            what: WHAT,
+            role: "publisher",
+        });
+    }
+    if draft.validity <= Duration::zero() || draft.validity > MAX_CARD_VALIDITY {
+        return Err(VettingError::Expired(WHAT));
+    }
+    let identity_commitment =
+        identity_commitment(&draft.salt, &draft.claims, &draft.identity_types)?;
+    let card = VettingCard {
+        types: VETTING_CARD_TYPES.iter().map(ToString::to_string).collect(),
+        id: draft.id,
+        publisher: draft.publisher,
+        card_version: 1,
+        audience: draft.audience,
+        community: draft.community,
+        challenge: draft.challenge,
+        domain: draft.domain,
+        issued_at: draft.issued_at,
+        expires_at: draft.issued_at + draft.validity,
+        claims: draft.claims,
+        identity_commitment,
+        commitment_salt: draft.salt,
+        proof: None,
+    };
+    let mut value = serde_json::to_value(&card).map_err(|e| VettingError::Sign(e.to_string()))?;
+    let proof = affinidi_data_integrity::DataIntegrityProof::sign(
+        &value,
+        signer,
+        SignOptions::new()
+            .with_proof_purpose(CARD_PROOF_PURPOSE)
+            .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+    )
+    .await
+    .map_err(|e| VettingError::Sign(e.to_string()))?;
+    value.as_object_mut().expect("card is an object").insert(
+        "proof".into(),
+        serde_json::to_value(proof).map_err(|e| VettingError::Sign(e.to_string()))?,
+    );
+    Ok(value)
+}
+
+/// What a vetter's client expects of the card it receives.
+#[derive(Debug, Clone, Copy)]
+pub struct CardExpectations<'a> {
+    /// The vetter's own DID.
+    pub audience: &'a str,
+    /// The applicant's `joinDid` from the accepted request.
+    pub publisher: &'a str,
+    /// The community named in the request.
+    pub community: &'a str,
+    /// The challenge the vetter sent.
+    pub challenge: &'a str,
+    /// The domain the vetter sent.
+    pub domain: &'a str,
+    /// The session's `requiredClaims`.
+    pub required_claims: &'a [String],
+    /// The verifier's clock.
+    pub now: DateTime<Utc>,
+}
+
+/// A card whose signature, bindings, window and commitment all check.
+#[derive(Debug, Clone)]
+pub struct VerifiedVettingCard {
+    card: VettingCard,
+    digest_multibase: String,
+}
+
+impl VerifiedVettingCard {
+    /// The card's contents.
+    #[must_use]
+    pub fn card(&self) -> &VettingCard {
+        &self.card
+    }
+
+    /// `digestMultibase` of the card, for the statement's
+    /// `cardDigestMultibase`.
+    #[must_use]
+    pub fn digest_multibase(&self) -> &str {
+        &self.digest_multibase
+    }
+
+    /// The claim of `claim_type`, if the card carries one.
+    #[must_use]
+    pub fn claim(&self, claim_type: &str) -> Option<&CardClaim> {
+        self.card.claims.iter().find(|c| c.claim_type == claim_type)
+    }
+}
+
+/// Verify a card received in a `vetting/session#response`.
+///
+/// # Errors
+///
+/// The first failed check: [`VettingError::Malformed`], [`VettingError::Binding`],
+/// [`VettingError::Expired`], [`VettingError::WrongSigner`],
+/// [`VettingError::Proof`], [`VettingError::MissingClaim`] or
+/// [`VettingError::Commitment`].
+pub async fn verify_card(
+    value: &Value,
+    expect: &CardExpectations<'_>,
+    resolver: &TrustTaskVmResolver,
+) -> Result<VerifiedVettingCard, VettingError> {
+    let card: VettingCard =
+        serde_json::from_value(value.clone()).map_err(|e| VettingError::Malformed {
+            what: WHAT,
+            detail: e.to_string(),
+        })?;
+    if !card.types.iter().any(|t| t == VETTING_CARD_TYPES[2]) {
+        return Err(VettingError::Malformed {
+            what: WHAT,
+            detail: "type does not include VettingCard".into(),
+        });
+    }
+    if card.audience != expect.audience {
+        return Err(VettingError::Binding("audience"));
+    }
+    if card.publisher != expect.publisher {
+        return Err(VettingError::Binding("publisher"));
+    }
+    if card.community != expect.community {
+        return Err(VettingError::Binding("community"));
+    }
+    if card.challenge != expect.challenge {
+        return Err(VettingError::Binding("challenge"));
+    }
+    if card.domain != expect.domain {
+        return Err(VettingError::Binding("domain"));
+    }
+    if card.expires_at <= card.issued_at
+        || card.expires_at - card.issued_at > MAX_CARD_VALIDITY
+        || card.issued_at > expect.now + CLOCK_SKEW
+        || expect.now > card.expires_at + CLOCK_SKEW
+    {
+        return Err(VettingError::Expired(WHAT));
+    }
+
+    let signer = verify_attached_proof(WHAT, value, CARD_PROOF_PURPOSE, resolver).await?;
+    if signer != card.publisher {
+        return Err(VettingError::WrongSigner {
+            what: WHAT,
+            role: "publisher",
+        });
+    }
+
+    for required in expect.required_claims {
+        if !card.claims.iter().any(|c| &c.claim_type == required) {
+            return Err(VettingError::MissingClaim(required.clone()));
+        }
+    }
+    let recomputed =
+        identity_commitment(&card.commitment_salt, &card.claims, expect.required_claims)?;
+    if recomputed != card.identity_commitment {
+        return Err(VettingError::Commitment);
+    }
+
+    let digest_multibase = digest(value)?;
+    Ok(VerifiedVettingCard {
+        card,
+        digest_multibase,
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::vetting::test_support::{did, secret};
+
+    pub(crate) const COMMUNITY: &str = "did:web:vtc.example";
+
+    pub(crate) fn claims() -> Vec<CardClaim> {
+        vec![
+            CardClaim {
+                claim_type: "name.legal".into(),
+                value: json!("Alice Example"),
+                provenance: "selfAsserted".into(),
+            },
+            CardClaim {
+                claim_type: "account.handle".into(),
+                value: json!("alice@example.org"),
+                provenance: "selfAsserted".into(),
+            },
+        ]
+    }
+
+    pub(crate) fn draft(applicant: &Secret, vetter: &Secret, now: DateTime<Utc>) -> CardDraft {
+        CardDraft {
+            id: "urn:uuid:card-1".into(),
+            publisher: did(applicant),
+            audience: did(vetter),
+            community: COMMUNITY.into(),
+            challenge: "challenge-1".into(),
+            domain: COMMUNITY.into(),
+            issued_at: now,
+            validity: Duration::minutes(15),
+            claims: claims(),
+            identity_types: vec!["name.legal".into()],
+            salt: "salt-of-this-application".into(),
+        }
+    }
+
+    fn expectations<'a>(
+        applicant: &'a str,
+        vetter: &'a str,
+        required: &'a [String],
+        now: DateTime<Utc>,
+    ) -> CardExpectations<'a> {
+        CardExpectations {
+            audience: vetter,
+            publisher: applicant,
+            community: COMMUNITY,
+            challenge: "challenge-1",
+            domain: COMMUNITY,
+            required_claims: required,
+            now,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_signed_card_verifies_for_its_vetter() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let now = Utc::now();
+        let signed = sign_card(draft(&applicant, &vetter, now), &applicant)
+            .await
+            .unwrap();
+        let required = vec!["name.legal".to_string()];
+        let (a, v) = (did(&applicant), did(&vetter));
+        let verified = verify_card(
+            &signed,
+            &expectations(&a, &v, &required, now),
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(verified.claim("name.legal").unwrap().value, "Alice Example");
+        assert!(verified.digest_multibase().starts_with('z'));
+    }
+
+    #[tokio::test]
+    async fn another_vetter_cannot_use_the_card() {
+        let (applicant, vetter, other) = (secret(1), secret(2), secret(3));
+        let now = Utc::now();
+        let signed = sign_card(draft(&applicant, &vetter, now), &applicant)
+            .await
+            .unwrap();
+        let required = vec!["name.legal".to_string()];
+        let (a, o) = (did(&applicant), did(&other));
+        let err = verify_card(
+            &signed,
+            &expectations(&a, &o, &required, now),
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, VettingError::Binding("audience")));
+    }
+
+    #[tokio::test]
+    async fn an_altered_claim_breaks_the_proof() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let now = Utc::now();
+        let mut signed = sign_card(draft(&applicant, &vetter, now), &applicant)
+            .await
+            .unwrap();
+        signed["claims"][0]["value"] = json!("Mallory Example");
+        let required = vec!["name.legal".to_string()];
+        let (a, v) = (did(&applicant), did(&vetter));
+        let err = verify_card(
+            &signed,
+            &expectations(&a, &v, &required, now),
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, VettingError::Proof { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_stale_card_is_refused() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let then = Utc::now() - Duration::hours(1);
+        let signed = sign_card(draft(&applicant, &vetter, then), &applicant)
+            .await
+            .unwrap();
+        let required = vec!["name.legal".to_string()];
+        let (a, v) = (did(&applicant), did(&vetter));
+        let err = verify_card(
+            &signed,
+            &expectations(&a, &v, &required, Utc::now()),
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, VettingError::Expired(_)));
+    }
+
+    #[tokio::test]
+    async fn only_the_publisher_may_sign() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let err = sign_card(draft(&applicant, &vetter, Utc::now()), &vetter)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VettingError::WrongSigner { .. }));
+    }
+
+    #[tokio::test]
+    async fn validity_is_capped() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let mut d = draft(&applicant, &vetter, Utc::now());
+        d.validity = Duration::hours(2);
+        assert!(matches!(
+            sign_card(d, &applicant).await.unwrap_err(),
+            VettingError::Expired(_)
+        ));
+    }
+
+    #[test]
+    fn commitment_is_stable_across_vetters_and_blind_to_optional_claims() {
+        let identity = vec!["name.legal".to_string()];
+        let a = identity_commitment("salt", &claims(), &identity).unwrap();
+        let only_name = &claims()[..1];
+        assert_eq!(
+            a,
+            identity_commitment("salt", only_name, &identity).unwrap()
+        );
+        assert_ne!(
+            a,
+            identity_commitment("other-salt", &claims(), &identity).unwrap(),
+            "the salt is what stops enumeration"
+        );
+        assert!(matches!(
+            identity_commitment("salt", &claims(), &["person.birthDate".to_string()]),
+            Err(VettingError::MissingClaim(_))
+        ));
+    }
+
+    #[test]
+    fn salts_are_32_random_bytes() {
+        let a = new_commitment_salt().unwrap();
+        assert_eq!(URL_SAFE_NO_PAD.decode(&a).unwrap().len(), 32);
+        assert_ne!(a, new_commitment_salt().unwrap());
+    }
+}

--- a/vta-sdk/src/vetting/match_code.rs
+++ b/vta-sdk/src/vetting/match_code.rs
@@ -17,8 +17,9 @@
 
 use sha2::{Digest, Sha256};
 
-/// Domain separation for the vetting derivation.
-const DOMAIN_TAG: &[u8] = b"openvtc-vetting-match/v1\0";
+/// Domain separation for the vetting derivation, as `vetting/session/0.1`
+/// defines it.
+const DOMAIN_TAG: &[u8] = b"vetting-session-match/v1\0";
 
 /// Crockford base32 — no `I`, `L`, `O` or `U`.
 const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";

--- a/vta-sdk/src/vetting/match_code.rs
+++ b/vta-sdk/src/vetting/match_code.rs
@@ -1,0 +1,93 @@
+//! The match code two people read to each other at the start of a vetting
+//! session.
+//!
+//! Same construction as the VTC's personhood match code
+//! (`vtc-service/src/members/match_code.rs`) — derived from the session
+//! document's `id`, never transmitted as a secret, Crockford base32 so nothing
+//! can be misheard into another valid code — with its **own domain tag**. A
+//! vetting session and a personhood challenge must never read out the same
+//! eight characters, or a code confirmed for one ceremony would look like
+//! confirmation of the other.
+//!
+//! What the code proves: the person in front of the vetter is driving the
+//! client that received *this* session, and therefore controls the join DID
+//! the card is signed by. Nothing verifies it server-side; `challenge` already
+//! binds the card cryptographically. Reading it aloud is how the two humans
+//! bind themselves to that.
+
+use sha2::{Digest, Sha256};
+
+/// Domain separation for the vetting derivation.
+const DOMAIN_TAG: &[u8] = b"openvtc-vetting-match/v1\0";
+
+/// Crockford base32 — no `I`, `L`, `O` or `U`.
+const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/// Derive the `XXXX-XXXX` match code for a `vetting/session` document id.
+#[must_use]
+pub fn vetting_match_code(session_document_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(DOMAIN_TAG);
+    hasher.update(session_document_id.as_bytes());
+    encode(&hasher.finalize())
+}
+
+/// First 40 bits of `digest` → eight Crockford characters, dash after four.
+fn encode(digest: &[u8]) -> String {
+    let bits = digest[..5]
+        .iter()
+        .fold(0u64, |acc, byte| (acc << 8) | u64::from(*byte));
+    let mut out = String::with_capacity(9);
+    for i in 0..8 {
+        if i == 4 {
+            out.push('-');
+        }
+        let shift = 35 - 5 * i;
+        out.push(char::from(CROCKFORD[((bits >> shift) & 0x1f) as usize]));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_is_two_groups_of_four_crockford_characters() {
+        let code = vetting_match_code("urn:uuid:5b0e1c2a-7d4f-4a51-9c6e-2f1b8d3a9e70");
+        assert_eq!(code.len(), 9);
+        assert_eq!(code.as_bytes()[4], b'-');
+        assert!(
+            code.chars()
+                .filter(|c| *c != '-')
+                .all(|c| CROCKFORD.contains(&(c as u8)))
+        );
+    }
+
+    #[test]
+    fn deterministic_and_input_sensitive() {
+        let a = vetting_match_code("urn:uuid:a");
+        assert_eq!(a, vetting_match_code("urn:uuid:a"));
+        assert_ne!(a, vetting_match_code("urn:uuid:b"));
+    }
+
+    #[test]
+    fn forty_bits_fill_eight_characters_exactly() {
+        // 8 × 5 = 40 = 5 bytes. A change that narrowed this would weaken the
+        // confirmation without failing anything else.
+        assert_eq!(encode(&[0xff; 32]), "ZZZZ-ZZZZ");
+        assert_eq!(encode(&[0x00; 32]), "0000-0000");
+    }
+
+    #[test]
+    fn never_collides_with_the_personhood_derivation() {
+        // The personhood code hashes `vtc-personhood-match/v1\0 || id`; for the
+        // same input the two must differ, or one ceremony's spoken confirmation
+        // would pass for the other's.
+        let id = "5b0e1c2a-7d4f-4a51-9c6e-2f1b8d3a9e70";
+        let mut personhood = Sha256::new();
+        personhood.update(b"vtc-personhood-match/v1\0");
+        personhood.update(id.as_bytes());
+        assert_ne!(vetting_match_code(id), encode(&personhood.finalize()));
+    }
+}

--- a/vta-sdk/src/vetting/mod.rs
+++ b/vta-sdk/src/vetting/mod.rs
@@ -1,0 +1,175 @@
+//! Building, signing and verifying the peer-vetting artifacts (feature
+//! `vetting`).
+//!
+//! The wire shapes live in [`crate::protocols::vetting`]; this module is what
+//! gives them meaning:
+//!
+//! - [`card`] — the Vetting Card an applicant signs for one vetter, and the
+//!   verification a vetter's client runs before showing it.
+//! - [`statement`] — the Vetting Statement (a DTG `EndorsementCredential`) a
+//!   vetter signs, and its verification.
+//! - [`requirements`] — the `requirementsDigest`, and the evaluation of a set
+//!   of statements against a community's [`VettingRequirements`]. The applicant's
+//!   client uses it to show progress; the community uses the same counting to
+//!   build the facts its policy decides on.
+//! - [`match_code`] — the code two people read to each other to confirm they
+//!   are in the same session.
+//!
+//! Every verification returns a distinct `Verified*` type (workspace typestate
+//! rule): code that needs a verified card or statement cannot be handed an
+//! unverified one.
+//!
+//! [`VettingRequirements`]: crate::protocols::vetting::VettingRequirements
+
+pub mod card;
+pub mod match_code;
+pub mod requirements;
+pub mod statement;
+
+use affinidi_data_integrity::DataIntegrityProof;
+use serde_json::Value;
+
+use crate::trust_task_proof::TrustTaskVmResolver;
+
+/// Why building or verifying a vetting artifact failed.
+///
+/// [`Display`](std::fmt::Display) is safe to show a counterparty; verifier
+/// internals are only reachable through [`VettingError::cause`], in the same
+/// way as [`crate::trust_task_proof::DiProofError`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum VettingError {
+    /// The artifact does not parse as its type.
+    #[error("malformed {what}")]
+    Malformed {
+        /// Which artifact.
+        what: &'static str,
+        /// Parser detail, for the log.
+        detail: String,
+    },
+    /// A binding member does not match what the verifier expects.
+    #[error("{0} does not match this session")]
+    Binding(&'static str),
+    /// Outside the validity window.
+    #[error("{0} is outside its validity window")]
+    Expired(&'static str),
+    /// Signed by (or to be signed by) someone other than the named party.
+    #[error("{what} is not signed by its {role}")]
+    WrongSigner {
+        /// Which artifact.
+        what: &'static str,
+        /// `publisher` or `issuer`.
+        role: &'static str,
+    },
+    /// No proof, or the proof does not verify.
+    #[error("{what} proof verification failed")]
+    Proof {
+        /// Which artifact.
+        what: &'static str,
+        /// Verifier detail, for the log.
+        detail: String,
+    },
+    /// The identity commitment does not recompute from the card.
+    #[error("identity commitment does not recompute from the card")]
+    Commitment,
+    /// A required claim is absent.
+    #[error("required claim `{0}` is missing")]
+    MissingClaim(String),
+    /// Signing failed.
+    #[error("signing failed")]
+    Sign(String),
+    /// Digest computation failed.
+    #[error("digest computation failed")]
+    Digest(String),
+    /// Randomness was unavailable.
+    #[error("no randomness available")]
+    Random(String),
+}
+
+impl VettingError {
+    /// Underlying detail for the operator's log. Never put this on the wire.
+    #[must_use]
+    pub fn cause(&self) -> Option<&str> {
+        match self {
+            Self::Malformed { detail, .. }
+            | Self::Proof { detail, .. }
+            | Self::Sign(detail)
+            | Self::Digest(detail)
+            | Self::Random(detail) => Some(detail),
+            _ => None,
+        }
+    }
+}
+
+/// The DID before `#` in a verification method or secret id.
+pub(crate) fn did_of(vm: &str) -> &str {
+    vm.split('#').next().unwrap_or_default()
+}
+
+/// Verify the Data Integrity proof on `signed` and return the proof's signer
+/// DID, which the caller binds to the party the artifact names.
+pub(crate) async fn verify_attached_proof(
+    what: &'static str,
+    signed: &Value,
+    expected_purpose: &str,
+    resolver: &TrustTaskVmResolver,
+) -> Result<String, VettingError> {
+    let proof_value = signed.get("proof").ok_or(VettingError::Proof {
+        what,
+        detail: "no proof".into(),
+    })?;
+    let proof: DataIntegrityProof =
+        serde_json::from_value(proof_value.clone()).map_err(|e| VettingError::Proof {
+            what,
+            detail: format!("not a Data Integrity proof: {e}"),
+        })?;
+    if proof.proof_purpose != expected_purpose {
+        return Err(VettingError::Proof {
+            what,
+            detail: format!(
+                "proofPurpose `{}`, expected `{expected_purpose}`",
+                proof.proof_purpose
+            ),
+        });
+    }
+    let mut unsigned = signed.clone();
+    if let Some(map) = unsigned.as_object_mut() {
+        map.remove("proof");
+    }
+    proof
+        .verify(
+            &unsigned,
+            resolver,
+            affinidi_data_integrity::VerifyOptions::new(),
+        )
+        .await
+        .map_err(|e| VettingError::Proof {
+            what,
+            detail: e.to_string(),
+        })?;
+    Ok(did_of(&proof.verification_method).to_string())
+}
+
+/// `digestMultibase` per DTG Credentials §Digest Encoding (JCS without the
+/// top-level `proof`, SHA-256 multihash, base58btc).
+pub(crate) fn digest(value: &Value) -> Result<String, VettingError> {
+    dtg_credentials::digest_multibase_json(value).map_err(|e| VettingError::Digest(e.to_string()))
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use affinidi_secrets_resolver::secrets::Secret;
+
+    /// A `did:key` Ed25519 secret from a fixed seed, `id` = `<did>#<multibase>`.
+    pub fn secret(seed_byte: u8) -> Secret {
+        let seed = [seed_byte; 32];
+        let mut secret = Secret::generate_ed25519(None, Some(&seed));
+        let public = secret.get_public_keymultibase().unwrap();
+        secret.id = format!("did:key:{public}#{public}");
+        secret
+    }
+
+    pub fn did(secret: &Secret) -> String {
+        super::did_of(&secret.id).to_string()
+    }
+}

--- a/vta-sdk/src/vetting/requirements.rs
+++ b/vta-sdk/src/vetting/requirements.rs
@@ -303,13 +303,13 @@ mod tests {
             "version": "0.1",
             "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
             "minStatements": 2,
-            "minByMethod": { "in-person": 1 },
-            "acceptedMethods": ["in-person", "video", "prior-acquaintance"],
+            "minByMethod": { "inPerson": 1 },
+            "acceptedMethods": ["inPerson", "video", "priorAcquaintance"],
             "requiredClaims": ["name.legal"],
             "maxStatementAge": "P120D",
             "eligibleVetters": { "role": "vetter" },
             "independence": {
-                "maxByDeclaredRelationship": { "family": 0, "same-employer": 1 },
+                "maxByDeclaredRelationship": { "family": 0, "sameEmployer": 1 },
                 "requireConsistentIdentityCommitment": true
             }
         }))
@@ -376,7 +376,7 @@ mod tests {
             Utc::now(),
         );
         assert_eq!(e.needs, vec![Need::Method(VettingMethod::InPerson, 1)]);
-        assert_eq!(e.needs[0].to_wire(), "vetting:method:in-person:1");
+        assert_eq!(e.needs[0].to_wire(), "vetting:method:inPerson:1");
     }
 
     #[test]

--- a/vta-sdk/src/vetting/requirements.rs
+++ b/vta-sdk/src/vetting/requirements.rs
@@ -1,0 +1,499 @@
+//! Evaluating vetting statements against a community's requirements.
+//!
+//! One counting rule, used by both sides:
+//!
+//! - the **applicant's client** feeds it what it can verify itself and shows
+//!   the result as a checklist. It is advisory — "meets the published
+//!   requirements", never "approved";
+//! - the **community** feeds it what only it knows (current eligibility,
+//!   revocation notices) and passes the result to its policy as facts. The
+//!   policy decides; this only counts.
+//!
+//! Keeping the counting in one place means the checklist and the verdict cannot
+//! drift apart on what "two distinct vetters" means.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use super::{VettingError, digest};
+use crate::protocols::vetting::{DeclaredRelationship, VettingMethod, VettingRequirements};
+
+/// The member a criterion's `requirementsDigest` sits in, excluded from its own
+/// digest.
+pub const REQUIREMENTS_DIGEST_MEMBER: &str = "requirementsDigest";
+
+/// `digestMultibase` over a manifest criterion without its own
+/// `requirementsDigest`. An applicant records it when it starts gathering; a
+/// changed digest means the requirements changed.
+///
+/// # Errors
+///
+/// [`VettingError::Digest`] if the criterion cannot be canonicalised.
+pub fn requirements_digest(criterion: &Value) -> Result<String, VettingError> {
+    let mut criterion = criterion.clone();
+    if let Some(map) = criterion.as_object_mut() {
+        map.remove(REQUIREMENTS_DIGEST_MEMBER);
+    }
+    digest(&criterion)
+}
+
+/// One statement, reduced to what counting needs.
+#[derive(Debug, Clone)]
+pub struct StatementFacts {
+    /// The statement `id`.
+    pub statement_id: String,
+    /// Who the vetter **is**, not which DID they used: the community passes its
+    /// member id, a client passes the issuer DID. Two statements with the same
+    /// value are one vetter (design D14).
+    pub vetter: String,
+    /// Method.
+    pub method: VettingMethod,
+    /// Claims the vetter verified.
+    pub claims_verified: Vec<String>,
+    /// Documentation the vetter relied on.
+    pub document_classes: Vec<String>,
+    /// Declared relationship.
+    pub declared_relationship: DeclaredRelationship,
+    /// Identity commitment.
+    pub identity_commitment: String,
+    /// `validFrom`.
+    pub valid_from: DateTime<Utc>,
+    /// The statement's community is the one evaluating.
+    pub community_matches: bool,
+    /// The vetter is eligible (held the role at issuance and still does, as
+    /// far as the evaluator can tell).
+    pub eligible: bool,
+    /// A revocation notice exists.
+    pub revoked: bool,
+}
+
+/// Why a statement did not count.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NotCounted {
+    /// The vetter is not an eligible vetter.
+    NotEligible,
+    /// The vetter withdrew it.
+    Revoked,
+    /// Issued for a different community.
+    WrongCommunity,
+    /// The method is not one the community accepts.
+    MethodNotAccepted,
+    /// The documentation is outside a floor the community set.
+    DocumentationNotAccepted,
+    /// A required claim was not verified.
+    ClaimNotVerified(String),
+    /// Older than `maxStatementAge`.
+    TooOld,
+    /// This vetter already has a statement that counts.
+    SameVetter,
+}
+
+impl NotCounted {
+    /// Stable code for facts and logs.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NotEligible => "issuer-not-vetter",
+            Self::Revoked => "revoked",
+            Self::WrongCommunity => "wrong-community",
+            Self::MethodNotAccepted => "method-not-accepted",
+            Self::DocumentationNotAccepted => "documentation-not-accepted",
+            Self::ClaimNotVerified(_) => "claim-not-verified",
+            Self::TooOld => "too-old",
+            Self::SameVetter => "same-vetter",
+        }
+    }
+}
+
+/// Something still missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Need {
+    /// This many more statements from distinct eligible vetters.
+    Statements(u32),
+    /// This many more counted statements by `method`.
+    Method(VettingMethod, u32),
+}
+
+impl Need {
+    /// The `needs` string a verdict carries: `vetting:statements:<n>` or
+    /// `vetting:method:<method>:<n>`. Verdict `needs` are strings on the wire,
+    /// so this is their grammar.
+    #[must_use]
+    pub fn to_wire(self) -> String {
+        match self {
+            Self::Statements(n) => format!("vetting:statements:{n}"),
+            Self::Method(method, n) => format!("vetting:method:{}:{n}", method.as_str()),
+        }
+    }
+
+    /// Parse a `needs` string. `None` for strings that are not vetting needs,
+    /// which a client shows verbatim.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        let rest = s.strip_prefix("vetting:")?;
+        if let Some(n) = rest.strip_prefix("statements:") {
+            return n.parse().ok().map(Self::Statements);
+        }
+        let (method, n) = rest.strip_prefix("method:")?.rsplit_once(':')?;
+        Some(Self::Method(VettingMethod::parse(method)?, n.parse().ok()?))
+    }
+}
+
+/// The outcome of counting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Evaluation {
+    /// Statement ids that count, one per vetter.
+    pub counted: Vec<String>,
+    /// Statement ids that do not, with every reason.
+    pub not_counted: Vec<(String, Vec<NotCounted>)>,
+    /// Counted statements by method.
+    pub by_method: BTreeMap<VettingMethod, u32>,
+    /// Counted statements by declared relationship.
+    pub by_relationship: BTreeMap<DeclaredRelationship, u32>,
+    /// All presented statements carry one identity commitment (or the
+    /// requirements do not ask for consistency).
+    pub commitments_consistent: bool,
+    /// No relationship cap is exceeded.
+    pub independence_ok: bool,
+    /// What is still missing. Empty when the count and method floors are met.
+    pub needs: Vec<Need>,
+}
+
+impl Evaluation {
+    /// Distinct vetters counted.
+    #[must_use]
+    pub fn distinct_vetters(&self) -> usize {
+        self.counted.len()
+    }
+
+    /// The count, method floors, commitment consistency and independence are
+    /// all satisfied. For a community this is an input to policy, not the
+    /// verdict.
+    #[must_use]
+    pub fn satisfied(&self) -> bool {
+        self.needs.is_empty() && self.commitments_consistent && self.independence_ok
+    }
+}
+
+/// Count `statements` against `requirements` at `now`.
+///
+/// Statements from the same vetter count once; the most recent eligible one is
+/// the one kept. Requirements are assumed valid
+/// ([`VettingRequirements::validate`]); an unparseable `maxStatementAge` is
+/// read as the most restrictive interpretation, so nothing counts as young
+/// enough.
+#[must_use]
+pub fn evaluate(
+    requirements: &VettingRequirements,
+    statements: &[StatementFacts],
+    now: DateTime<Utc>,
+) -> Evaluation {
+    let max_age_declared = requirements.max_statement_age.is_some();
+    let max_age = requirements.max_statement_age();
+
+    let mut ordered: Vec<&StatementFacts> = statements.iter().collect();
+    ordered.sort_by_key(|s| std::cmp::Reverse(s.valid_from));
+
+    let mut counted = Vec::new();
+    let mut not_counted = Vec::new();
+    let mut vetters = BTreeSet::new();
+    let mut by_method: BTreeMap<VettingMethod, u32> = BTreeMap::new();
+    let mut by_relationship: BTreeMap<DeclaredRelationship, u32> = BTreeMap::new();
+
+    for s in ordered {
+        let mut reasons = Vec::new();
+        if !s.eligible {
+            reasons.push(NotCounted::NotEligible);
+        }
+        if s.revoked {
+            reasons.push(NotCounted::Revoked);
+        }
+        if !s.community_matches {
+            reasons.push(NotCounted::WrongCommunity);
+        }
+        if !requirements.accepted_methods.contains(&s.method) {
+            reasons.push(NotCounted::MethodNotAccepted);
+        }
+        if let Some(floor) = &requirements.accepted_document_classes {
+            let documented = s.document_classes.iter().any(|d| floor.contains(d));
+            let exempt =
+                s.method == VettingMethod::PriorAcquaintance && s.document_classes.is_empty();
+            if !documented && !exempt {
+                reasons.push(NotCounted::DocumentationNotAccepted);
+            }
+        }
+        for claim in &requirements.required_claims {
+            if !s.claims_verified.contains(claim) {
+                reasons.push(NotCounted::ClaimNotVerified(claim.clone()));
+            }
+        }
+        let too_old = match max_age {
+            Some(age) => now - s.valid_from > age,
+            None => max_age_declared,
+        };
+        if too_old {
+            reasons.push(NotCounted::TooOld);
+        }
+        if reasons.is_empty() && vetters.contains(&s.vetter) {
+            reasons.push(NotCounted::SameVetter);
+        }
+
+        if reasons.is_empty() {
+            vetters.insert(s.vetter.clone());
+            *by_method.entry(s.method).or_default() += 1;
+            *by_relationship.entry(s.declared_relationship).or_default() += 1;
+            counted.push(s.statement_id.clone());
+        } else {
+            not_counted.push((s.statement_id.clone(), reasons));
+        }
+    }
+
+    let commitments_consistent = !requirements
+        .independence
+        .require_consistent_identity_commitment
+        || statements
+            .iter()
+            .map(|s| s.identity_commitment.as_str())
+            .collect::<BTreeSet<_>>()
+            .len()
+            <= 1;
+
+    let independence_ok = requirements
+        .independence
+        .max_by_declared_relationship
+        .iter()
+        .all(|(rel, max)| by_relationship.get(rel).copied().unwrap_or(0) <= *max);
+
+    let mut needs = Vec::new();
+    let have = u32::try_from(counted.len()).unwrap_or(u32::MAX);
+    if have < requirements.min_statements {
+        needs.push(Need::Statements(requirements.min_statements - have));
+    }
+    for (method, floor) in &requirements.min_by_method {
+        let got = by_method.get(method).copied().unwrap_or(0);
+        if got < *floor {
+            needs.push(Need::Method(*method, floor - got));
+        }
+    }
+
+    Evaluation {
+        counted,
+        not_counted,
+        by_method,
+        by_relationship,
+        commitments_consistent,
+        independence_ok,
+        needs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE;
+    use chrono::Duration;
+    use serde_json::json;
+
+    fn requirements() -> VettingRequirements {
+        serde_json::from_value(json!({
+            "version": "0.1",
+            "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+            "minStatements": 2,
+            "minByMethod": { "in-person": 1 },
+            "acceptedMethods": ["in-person", "video", "prior-acquaintance"],
+            "requiredClaims": ["name.legal"],
+            "maxStatementAge": "P120D",
+            "eligibleVetters": { "role": "vetter" },
+            "independence": {
+                "maxByDeclaredRelationship": { "family": 0, "same-employer": 1 },
+                "requireConsistentIdentityCommitment": true
+            }
+        }))
+        .unwrap()
+    }
+
+    fn fact(id: &str, vetter: &str, method: VettingMethod, age_days: i64) -> StatementFacts {
+        StatementFacts {
+            statement_id: id.into(),
+            vetter: vetter.into(),
+            method,
+            claims_verified: vec!["name.legal".into()],
+            document_classes: vec!["passport".into()],
+            declared_relationship: DeclaredRelationship::None,
+            identity_commitment: "zSame".into(),
+            valid_from: Utc::now() - Duration::days(age_days),
+            community_matches: true,
+            eligible: true,
+            revoked: false,
+        }
+    }
+
+    #[test]
+    fn two_distinct_vetters_with_one_in_person_satisfy() {
+        let e = evaluate(
+            &requirements(),
+            &[
+                fact("s1", "carol", VettingMethod::Video, 10),
+                fact("s2", "dave", VettingMethod::InPerson, 3),
+            ],
+            Utc::now(),
+        );
+        assert_eq!(e.distinct_vetters(), 2);
+        assert!(e.satisfied(), "{e:?}");
+    }
+
+    #[test]
+    fn one_vetter_with_two_statements_counts_once() {
+        let e = evaluate(
+            &requirements(),
+            &[
+                fact("old", "carol", VettingMethod::InPerson, 30),
+                fact("new", "carol", VettingMethod::InPerson, 1),
+            ],
+            Utc::now(),
+        );
+        assert_eq!(
+            e.counted,
+            vec!["new".to_string()],
+            "the most recent is kept"
+        );
+        assert_eq!(e.not_counted[0].1, vec![NotCounted::SameVetter]);
+        assert_eq!(e.needs, vec![Need::Statements(1)]);
+    }
+
+    #[test]
+    fn a_method_floor_is_a_need_of_its_own() {
+        let e = evaluate(
+            &requirements(),
+            &[
+                fact("s1", "carol", VettingMethod::Video, 1),
+                fact("s2", "dave", VettingMethod::Video, 1),
+            ],
+            Utc::now(),
+        );
+        assert_eq!(e.needs, vec![Need::Method(VettingMethod::InPerson, 1)]);
+        assert_eq!(e.needs[0].to_wire(), "vetting:method:in-person:1");
+    }
+
+    #[test]
+    fn ineligible_revoked_stale_and_foreign_statements_do_not_count() {
+        let mut ineligible = fact("s1", "a", VettingMethod::InPerson, 1);
+        ineligible.eligible = false;
+        let mut revoked = fact("s2", "b", VettingMethod::InPerson, 1);
+        revoked.revoked = true;
+        let stale = fact("s3", "c", VettingMethod::InPerson, 200);
+        let mut foreign = fact("s4", "d", VettingMethod::InPerson, 1);
+        foreign.community_matches = false;
+        let mut unverified = fact("s5", "e", VettingMethod::InPerson, 1);
+        unverified.claims_verified.clear();
+
+        let e = evaluate(
+            &requirements(),
+            &[ineligible, revoked, stale, foreign, unverified],
+            Utc::now(),
+        );
+        assert!(e.counted.is_empty());
+        let codes: BTreeSet<&str> = e
+            .not_counted
+            .iter()
+            .flat_map(|(_, r)| r.iter().map(NotCounted::code))
+            .collect();
+        for code in [
+            "issuer-not-vetter",
+            "revoked",
+            "too-old",
+            "wrong-community",
+            "claim-not-verified",
+        ] {
+            assert!(codes.contains(code), "missing {code} in {codes:?}");
+        }
+    }
+
+    #[test]
+    fn relationship_caps_are_independence_not_count() {
+        let mut family = fact("s2", "dave", VettingMethod::InPerson, 1);
+        family.declared_relationship = DeclaredRelationship::Family;
+        let e = evaluate(
+            &requirements(),
+            &[fact("s1", "carol", VettingMethod::Video, 1), family],
+            Utc::now(),
+        );
+        assert!(e.needs.is_empty());
+        assert!(!e.independence_ok);
+        assert!(!e.satisfied());
+    }
+
+    #[test]
+    fn different_commitments_mean_different_identities() {
+        let mut other = fact("s2", "dave", VettingMethod::InPerson, 1);
+        other.identity_commitment = "zDifferent".into();
+        let e = evaluate(
+            &requirements(),
+            &[fact("s1", "carol", VettingMethod::Video, 1), other],
+            Utc::now(),
+        );
+        assert!(!e.commitments_consistent);
+        assert!(!e.satisfied());
+    }
+
+    #[test]
+    fn documentation_is_unconstrained_unless_the_community_sets_a_floor() {
+        let mut known = fact("s1", "carol", VettingMethod::PriorAcquaintance, 1);
+        known.document_classes.clear();
+        let mut odd = fact("s2", "dave", VettingMethod::InPerson, 1);
+        odd.document_classes = vec!["library-card".into()];
+
+        let e = evaluate(&requirements(), &[known.clone(), odd.clone()], Utc::now());
+        assert!(e.satisfied(), "each vetter decides (D16): {e:?}");
+
+        let mut floored = requirements();
+        floored.accepted_document_classes = Some(vec!["passport".into()]);
+        let e = evaluate(&floored, &[known, odd], Utc::now());
+        assert_eq!(
+            e.counted,
+            vec!["s1".to_string()],
+            "prior acquaintance is exempt"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_age_limit_counts_nothing() {
+        let mut req = requirements();
+        req.max_statement_age = Some("P1Y".into());
+        let e = evaluate(
+            &req,
+            &[fact("s1", "carol", VettingMethod::InPerson, 0)],
+            Utc::now(),
+        );
+        assert!(e.counted.is_empty());
+    }
+
+    #[test]
+    fn needs_round_trip_through_their_wire_strings() {
+        for need in [
+            Need::Statements(3),
+            Need::Method(VettingMethod::PriorAcquaintance, 1),
+        ] {
+            assert_eq!(Need::parse(&need.to_wire()), Some(need));
+        }
+        assert_eq!(Need::parse("vc:Endorsement"), None);
+        assert_eq!(Need::parse("vetting:method:telepathy:1"), None);
+    }
+
+    #[test]
+    fn the_digest_ignores_itself_and_tracks_everything_else() {
+        let criterion = json!({ "id": "kernel", "vetting": { "minStatements": 2 } });
+        let d = requirements_digest(&criterion).unwrap();
+        let mut with_digest = criterion.clone();
+        with_digest[REQUIREMENTS_DIGEST_MEMBER] = json!(d);
+        assert_eq!(requirements_digest(&with_digest).unwrap(), d);
+
+        let mut changed = criterion;
+        changed["vetting"]["minStatements"] = json!(3);
+        assert_ne!(requirements_digest(&changed).unwrap(), d);
+    }
+}

--- a/vta-sdk/src/vetting/statement.rs
+++ b/vta-sdk/src/vetting/statement.rs
@@ -68,6 +68,13 @@ pub async fn sign_statement(draft: StatementDraft, signer: &Secret) -> Result<Va
             ),
         });
     }
+    draft
+        .endorsement
+        .check_shape()
+        .map_err(|e| VettingError::Malformed {
+            what: WHAT,
+            detail: e.to_string(),
+        })?;
     if draft.valid_until <= draft.valid_from {
         return Err(VettingError::Expired(WHAT));
     }
@@ -245,6 +252,9 @@ pub async fn verify_statement(
     if endorsement.endorsement_type != IDENTITY_VETTING_ENDORSEMENT_TYPE {
         return Err(malformed("endorsement is not identity-vetting".into()));
     }
+    endorsement
+        .check_shape()
+        .map_err(|e| malformed(format!("endorsement: {e}")))?;
     let id = wire
         .id
         .ok_or_else(|| malformed("no id — a statement must be revocable by name".into()))?;
@@ -288,7 +298,7 @@ pub(crate) mod tests {
     use crate::protocols::vetting::{DeclaredRelationship, VettingMethod};
     use crate::vetting::card::{
         CardExpectations, sign_card,
-        tests::{COMMUNITY, draft},
+        tests::{CHALLENGE, COMMUNITY, draft},
         verify_card,
     };
     use crate::vetting::test_support::{did, secret};
@@ -323,7 +333,7 @@ pub(crate) mod tests {
                 audience: &v,
                 publisher: &a,
                 community: COMMUNITY,
-                challenge: "challenge-1",
+                challenge: CHALLENGE,
                 domain: COMMUNITY,
                 required_claims: &required,
                 now,
@@ -377,7 +387,7 @@ pub(crate) mod tests {
         let mut signed = sign_statement(statement_draft(&vetter, &did(&applicant), e), &vetter)
             .await
             .unwrap();
-        signed["credentialSubject"]["endorsement"]["method"] = json!("in-person");
+        signed["credentialSubject"]["endorsement"]["method"] = json!("inPerson");
         let err = verify_statement(&signed, Utc::now(), &TrustTaskVmResolver::did_key_only())
             .await
             .unwrap_err();

--- a/vta-sdk/src/vetting/statement.rs
+++ b/vta-sdk/src/vetting/statement.rs
@@ -1,0 +1,440 @@
+//! The Vetting Statement: what a vetter signs after checking an applicant.
+//!
+//! A DTG `EndorsementCredential` whose `endorsement` is an
+//! [`IdentityVettingEndorsement`]. Why a VEC and not a new credential type: the
+//! VEC is DTG's credential for "one party asserting something about its
+//! counterparty", with a community-defined `endorsement` body — exactly this.
+//!
+//! Issued from the **vetter's member DID** (accountable within the community),
+//! to the applicant's join DID, with a bounded `validUntil` and the session
+//! document's `id` as `taskContext`. Building goes through `dtg-credentials`,
+//! the workspace's DTG SDK; verification parses strictly here so it does not
+//! depend on that crate's internal representation.
+
+use affinidi_secrets_resolver::secrets::Secret;
+use chrono::{DateTime, Utc};
+use dtg_credentials::DTGCredential;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::card::{CLOCK_SKEW, VerifiedVettingCard};
+use super::{VettingError, did_of, digest, verify_attached_proof};
+use crate::protocols::vetting::{IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement};
+use crate::trust_task_proof::TrustTaskVmResolver;
+
+const WHAT: &str = "vetting statement";
+
+/// The DTG credentials context every DTG credential carries.
+const DTG_CONTEXT: &str = "https://firstperson.network/credentials/dtg/v1";
+
+/// Everything needed to issue a statement.
+#[derive(Debug, Clone)]
+pub struct StatementDraft {
+    /// `urn:uuid:…` — what a revocation notice names.
+    pub id: String,
+    /// The vetter's member DID.
+    pub issuer: String,
+    /// The applicant's join DID (the verified card's publisher).
+    pub subject: String,
+    /// The attestation.
+    pub endorsement: IdentityVettingEndorsement,
+    /// Normally now.
+    pub valid_from: DateTime<Utc>,
+    /// `validFrom` + the community's `maxStatementAge`.
+    pub valid_until: DateTime<Utc>,
+    /// The `vetting/session` document's `id`.
+    pub task_context: String,
+}
+
+/// Build and sign a statement. `signer` must be a key of `draft.issuer`.
+///
+/// # Errors
+///
+/// [`VettingError::WrongSigner`], [`VettingError::Malformed`] (wrong endorsement
+/// type), [`VettingError::Expired`] (empty window) or [`VettingError::Sign`].
+pub async fn sign_statement(draft: StatementDraft, signer: &Secret) -> Result<Value, VettingError> {
+    if did_of(&signer.id) != draft.issuer {
+        return Err(VettingError::WrongSigner {
+            what: WHAT,
+            role: "issuer",
+        });
+    }
+    if draft.endorsement.endorsement_type != IDENTITY_VETTING_ENDORSEMENT_TYPE {
+        return Err(VettingError::Malformed {
+            what: WHAT,
+            detail: format!(
+                "endorsement type `{}` is not identity-vetting",
+                draft.endorsement.endorsement_type
+            ),
+        });
+    }
+    if draft.valid_until <= draft.valid_from {
+        return Err(VettingError::Expired(WHAT));
+    }
+    let endorsement =
+        serde_json::to_value(&draft.endorsement).map_err(|e| VettingError::Sign(e.to_string()))?;
+    let mut credential = DTGCredential::new_vec(
+        draft.issuer,
+        draft.subject,
+        draft.valid_from,
+        Some(draft.valid_until),
+        endorsement,
+    )
+    .with_id(draft.id);
+    credential.credential_mut().task_context = Some(draft.task_context);
+    credential
+        .sign(signer, None)
+        .await
+        .map_err(|e| VettingError::Sign(e.to_string()))?;
+    serde_json::to_value(&credential).map_err(|e| VettingError::Sign(e.to_string()))
+}
+
+/// The members of a statement verification reads. Not `deny_unknown_fields`:
+/// a VC may carry members this profile does not use. The endorsement body,
+/// which is what is being attested, is parsed strictly.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireStatement {
+    #[serde(rename = "@context")]
+    context: Vec<String>,
+    #[serde(rename = "type")]
+    types: Vec<String>,
+    id: Option<String>,
+    issuer: WireIssuer,
+    valid_from: DateTime<Utc>,
+    valid_until: Option<DateTime<Utc>>,
+    task_context: Option<String>,
+    credential_subject: WireSubject,
+    credential_status: Option<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum WireIssuer {
+    Id(String),
+    Object { id: String },
+}
+
+#[derive(Deserialize)]
+struct WireSubject {
+    id: String,
+    endorsement: Value,
+}
+
+/// A statement whose proof, type, window and shape all check.
+///
+/// What this does **not** establish: that the issuer is an eligible vetter of
+/// the community, or that the statement has not been withdrawn. Those are facts
+/// only the community holds.
+#[derive(Debug, Clone)]
+pub struct VerifiedVettingStatement {
+    id: String,
+    issuer: String,
+    subject: String,
+    endorsement: IdentityVettingEndorsement,
+    valid_from: DateTime<Utc>,
+    valid_until: DateTime<Utc>,
+    task_context: String,
+    has_status: bool,
+    digest_multibase: String,
+}
+
+impl VerifiedVettingStatement {
+    /// The statement `id`.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    /// The vetter's DID (proven: it signed).
+    #[must_use]
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+    /// The applicant's join DID.
+    #[must_use]
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+    /// The attestation.
+    #[must_use]
+    pub fn endorsement(&self) -> &IdentityVettingEndorsement {
+        &self.endorsement
+    }
+    /// Start of validity.
+    #[must_use]
+    pub fn valid_from(&self) -> DateTime<Utc> {
+        self.valid_from
+    }
+    /// End of validity.
+    #[must_use]
+    pub fn valid_until(&self) -> DateTime<Utc> {
+        self.valid_until
+    }
+    /// The `vetting/session` document id.
+    #[must_use]
+    pub fn task_context(&self) -> &str {
+        &self.task_context
+    }
+    /// Whether the statement names a `credentialStatus` entry to check.
+    #[must_use]
+    pub fn has_status(&self) -> bool {
+        self.has_status
+    }
+    /// `digestMultibase` of the statement — what a revocation notice names.
+    #[must_use]
+    pub fn digest_multibase(&self) -> &str {
+        &self.digest_multibase
+    }
+
+    /// Check this statement was issued over `card`: same subject, community,
+    /// commitment and card digest. The applicant's client runs this before
+    /// filing a statement, so a vetter that attested to a different card is
+    /// caught immediately rather than at the community.
+    ///
+    /// # Errors
+    ///
+    /// [`VettingError::Binding`] naming the member that differs.
+    pub fn check_against_card(&self, card: &VerifiedVettingCard) -> Result<(), VettingError> {
+        let c = card.card();
+        if self.subject != c.publisher {
+            return Err(VettingError::Binding("subject"));
+        }
+        if self.endorsement.community != c.community {
+            return Err(VettingError::Binding("community"));
+        }
+        if self.endorsement.identity_commitment != c.identity_commitment {
+            return Err(VettingError::Binding("identityCommitment"));
+        }
+        if self.endorsement.card_digest_multibase != card.digest_multibase() {
+            return Err(VettingError::Binding("cardDigestMultibase"));
+        }
+        Ok(())
+    }
+}
+
+/// Verify a statement as received — by the applicant on delivery, or by the
+/// community inside a join presentation.
+///
+/// # Errors
+///
+/// The first failed check: [`VettingError::Malformed`], [`VettingError::Expired`],
+/// [`VettingError::Proof`] or [`VettingError::WrongSigner`].
+pub async fn verify_statement(
+    value: &Value,
+    now: DateTime<Utc>,
+    resolver: &TrustTaskVmResolver,
+) -> Result<VerifiedVettingStatement, VettingError> {
+    let malformed = |detail: String| VettingError::Malformed { what: WHAT, detail };
+    let wire: WireStatement =
+        serde_json::from_value(value.clone()).map_err(|e| malformed(e.to_string()))?;
+    for required in [
+        "VerifiableCredential",
+        "DTGCredential",
+        "EndorsementCredential",
+    ] {
+        if !wire.types.iter().any(|t| t == required) {
+            return Err(malformed(format!("type does not include {required}")));
+        }
+    }
+    if !wire.context.iter().any(|c| c == DTG_CONTEXT) {
+        return Err(malformed("missing the DTG credentials context".into()));
+    }
+    let endorsement: IdentityVettingEndorsement =
+        serde_json::from_value(wire.credential_subject.endorsement)
+            .map_err(|e| malformed(format!("endorsement: {e}")))?;
+    if endorsement.endorsement_type != IDENTITY_VETTING_ENDORSEMENT_TYPE {
+        return Err(malformed("endorsement is not identity-vetting".into()));
+    }
+    let id = wire
+        .id
+        .ok_or_else(|| malformed("no id — a statement must be revocable by name".into()))?;
+    let task_context = wire
+        .task_context
+        .ok_or_else(|| malformed("no taskContext naming the session".into()))?;
+    let valid_until = wire
+        .valid_until
+        .ok_or_else(|| malformed("no validUntil — statements are bounded evidence".into()))?;
+    if wire.valid_from > now + CLOCK_SKEW || now > valid_until {
+        return Err(VettingError::Expired(WHAT));
+    }
+    let issuer = match wire.issuer {
+        WireIssuer::Id(id) | WireIssuer::Object { id } => id,
+    };
+
+    let signer = verify_attached_proof(WHAT, value, "assertionMethod", resolver).await?;
+    if signer != issuer {
+        return Err(VettingError::WrongSigner {
+            what: WHAT,
+            role: "issuer",
+        });
+    }
+
+    Ok(VerifiedVettingStatement {
+        id,
+        issuer,
+        subject: wire.credential_subject.id,
+        endorsement,
+        valid_from: wire.valid_from,
+        valid_until,
+        task_context,
+        has_status: wire.credential_status.is_some(),
+        digest_multibase: digest(value)?,
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::protocols::vetting::{DeclaredRelationship, VettingMethod};
+    use crate::vetting::card::{
+        CardExpectations, sign_card,
+        tests::{COMMUNITY, draft},
+        verify_card,
+    };
+    use crate::vetting::test_support::{did, secret};
+    use chrono::Duration;
+    use serde_json::json;
+
+    pub(crate) fn endorsement(commitment: &str, card_digest: &str) -> IdentityVettingEndorsement {
+        IdentityVettingEndorsement {
+            endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
+            community: COMMUNITY.into(),
+            method: VettingMethod::Video,
+            document_classes: vec!["passport".into()],
+            claims_verified: vec!["name.legal".into()],
+            liveness_confirmed: true,
+            identity_commitment: commitment.into(),
+            card_digest_multibase: card_digest.into(),
+            declared_relationship: DeclaredRelationship::CommunityColleague,
+            attestation_text_digest: None,
+        }
+    }
+
+    async fn verified_card(applicant: &Secret, vetter: &Secret) -> VerifiedVettingCard {
+        let now = Utc::now();
+        let signed = sign_card(draft(applicant, vetter, now), applicant)
+            .await
+            .unwrap();
+        let required = vec!["name.legal".to_string()];
+        let (a, v) = (did(applicant), did(vetter));
+        verify_card(
+            &signed,
+            &CardExpectations {
+                audience: &v,
+                publisher: &a,
+                community: COMMUNITY,
+                challenge: "challenge-1",
+                domain: COMMUNITY,
+                required_claims: &required,
+                now,
+            },
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+        .unwrap()
+    }
+
+    pub(crate) fn statement_draft(
+        vetter: &Secret,
+        subject: &str,
+        endorsement: IdentityVettingEndorsement,
+    ) -> StatementDraft {
+        let now = Utc::now();
+        StatementDraft {
+            id: "urn:uuid:statement-1".into(),
+            issuer: did(vetter),
+            subject: subject.into(),
+            endorsement,
+            valid_from: now,
+            valid_until: now + Duration::days(120),
+            task_context: "urn:uuid:session-1".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_statement_verifies_and_binds_to_its_card() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let card = verified_card(&applicant, &vetter).await;
+        let e = endorsement(&card.card().identity_commitment, card.digest_multibase());
+        let signed = sign_statement(statement_draft(&vetter, &did(&applicant), e), &vetter)
+            .await
+            .unwrap();
+        assert_eq!(signed["type"][2], "EndorsementCredential");
+        assert_eq!(signed["taskContext"], "urn:uuid:session-1");
+
+        let verified = verify_statement(&signed, Utc::now(), &TrustTaskVmResolver::did_key_only())
+            .await
+            .unwrap();
+        assert_eq!(verified.issuer(), did(&vetter));
+        assert_eq!(verified.endorsement().method, VettingMethod::Video);
+        verified.check_against_card(&card).unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_altered_endorsement_breaks_the_proof() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let e = endorsement("zCommitment", "zCard");
+        let mut signed = sign_statement(statement_draft(&vetter, &did(&applicant), e), &vetter)
+            .await
+            .unwrap();
+        signed["credentialSubject"]["endorsement"]["method"] = json!("in-person");
+        let err = verify_statement(&signed, Utc::now(), &TrustTaskVmResolver::did_key_only())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VettingError::Proof { .. }), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_statement_over_a_different_card_is_caught() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let card = verified_card(&applicant, &vetter).await;
+        let e = endorsement("zSomeOtherCommitment", card.digest_multibase());
+        let signed = sign_statement(statement_draft(&vetter, &did(&applicant), e), &vetter)
+            .await
+            .unwrap();
+        let verified = verify_statement(&signed, Utc::now(), &TrustTaskVmResolver::did_key_only())
+            .await
+            .unwrap();
+        assert!(matches!(
+            verified.check_against_card(&card),
+            Err(VettingError::Binding("identityCommitment"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn only_the_named_issuer_may_sign() {
+        let (applicant, vetter, other) = (secret(1), secret(2), secret(3));
+        let e = endorsement("zC", "zD");
+        let err = sign_statement(statement_draft(&vetter, &did(&applicant), e), &other)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VettingError::WrongSigner { .. }));
+    }
+
+    #[tokio::test]
+    async fn an_expired_statement_is_refused() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let e = endorsement("zC", "zD");
+        let signed = sign_statement(statement_draft(&vetter, &did(&applicant), e), &vetter)
+            .await
+            .unwrap();
+        let later = Utc::now() + Duration::days(200);
+        let err = verify_statement(&signed, later, &TrustTaskVmResolver::did_key_only())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VettingError::Expired(_)));
+    }
+
+    #[tokio::test]
+    async fn an_unrelated_endorsement_is_not_a_vetting_statement() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let mut e = endorsement("zC", "zD");
+        e.endorsement_type = "SkillEndorsement".into();
+        assert!(matches!(
+            sign_statement(statement_draft(&vetter, &did(&applicant), e), &vetter)
+                .await
+                .unwrap_err(),
+            VettingError::Malformed { .. }
+        ));
+    }
+}

--- a/vta-sdk/tests/payload_ext_census.rs
+++ b/vta-sdk/tests/payload_ext_census.rs
@@ -90,6 +90,30 @@ const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[
          `IssuedCredentialSummary` above.",
     ),
     (
+        "VettingCard",
+        "Not a Trust Task payload: the signed Vetting Card (an r-card VDS) that \
+         rides *inside* `vetting/session/0.1#response`'s `card`. SPEC §4.5.1's \
+         slot belongs to that payload, which carries `ext`. The card itself is \
+         closed on purpose — every member of it is signed by the applicant and \
+         shown to a human vetter, and an extension member the vetter's client \
+         cannot render would be a signed claim nobody looked at. The shared card \
+         schema proposed in dtgwg-trust-tasks-tf closes it the same way.",
+    ),
+    (
+        "CardClaim",
+        "One entry of a `VettingCard`'s `claims`, closed for the same reason as \
+         the card: what is signed must be what is shown.",
+    ),
+    (
+        "IdentityVettingEndorsement",
+        "Not a Trust Task payload: the `endorsement` body of a Vetting Statement \
+         (a DTG `EndorsementCredential`), whose shape the community registers as \
+         the endorsement type's `claimSchema`. It is attested content — a member \
+         a verifier does not recognise would be an attestation it cannot \
+         interpret yet would count — so it is closed, and a new member is a new \
+         endorsement-type version rather than an extension.",
+    ),
+    (
         "LocalProfileEntry",
         "One item of `persona/local/profile/put/1.0`'s `entries` array. The \
          schema closes it to the single `inline` member — that closure is \

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -50,6 +50,8 @@ pub async fn manifest_inner(state: &AppState) -> Result<JoinRequestManifestRespo
             id: c.id,
             description: c.description,
             presentation_definition: c.query,
+            vetting: None,
+            requirements_digest: None,
         })
         .collect();
 

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -997,6 +997,8 @@ fn table() -> Vec<Conformance> {
                     id: "email-verified".into(),
                     description: Some("A verified email credential".into()),
                     presentation_definition: json!({ "credentials": [] }),
+                    vetting: None,
+                    requirements_digest: None,
                 }],
             })
         ),

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -430,6 +430,39 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
         "VPC persona annotation (#1067) — bound ahead of its spec while \
          dtgwg-cred-spec#9 (how a VPC binds to an edge) is open upstream",
     ),
+    // Peer identity vetting — OpenVTC `docs/design/vetting-process.md`. Bound
+    // ahead of their specs by the same mechanism as the persona entry above:
+    // the payload types are in `vta_sdk::protocols::vetting`, and the specs are
+    // proposed upstream in trustoverip/dtgwg-trust-tasks-tf (stacked draft PRs
+    // `spec/vtc-join-manifest-vetting`, `spec/vetting-peer-tasks`,
+    // `spec/vetting-revoke-and-ceremony`). Each count goes to zero when the
+    // trust-tasks-rs release that serves it is taken here.
+    //
+    // `vetting/{request,session,decline}/0.1` — the applicant↔vetter exchange.
+    // Top-level, not `spec/vtc/`: it runs between two people's agents, and no
+    // community service is party to it.
+    (
+        "https://trusttasks.org/spec/vetting/",
+        3,
+        "peer vetting request/session/decline — proposed in dtgwg-trust-tasks-tf \
+         (spec/vetting-peer-tasks)",
+    ),
+    // `vtc/vetting/revoke-statement/0.1` — a vetter withdrawing a statement
+    // from the community that relies on it (design §9.6).
+    (
+        "https://trusttasks.org/spec/vtc/vetting/",
+        1,
+        "vetting statement revocation notice — proposed in dtgwg-trust-tasks-tf \
+         (spec/vetting-revoke-and-ceremony)",
+    ),
+    // `vtc/join-requests/manifest/0.2` — 0.1 plus the per-criterion `vetting`
+    // requirements object and `requirementsDigest`.
+    (
+        "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2",
+        1,
+        "join manifest with vetting requirements — proposed in dtgwg-trust-tasks-tf \
+         (spec/vtc-join-manifest-vetting)",
+    ),
     // Not a dispatchable task: the framework's error envelope is a *response*
     // type, deliberately absent from the task index, so `schema_for` will never
     // resolve it. This entry is permanent — the others are debt.


### PR DESCRIPTION
Adds the shared wire types and crypto for **peer identity vetting** in `vta-sdk`. This is how an applicant gets vetted by existing members before joining a community, replacing the Linux kernel's PGP web of trust.

Design: OpenVTC `docs/design/vetting-process.md` (OpenVTC/openvtc#292). This PR is the base of the VTI stack. Nothing serves or sends these tasks yet; the VTC and OpenVTC PRs build on it.

## What's in it

### `protocols::vetting` (serde only, always compiled)

- Type URIs and payloads for `vetting/request/0.1`, `vetting/session/0.1`, `vetting/decline/0.1` and `vtc/vetting/revoke-statement/0.1`.
- `VettingRequirements`, the per-criterion object a community advertises in its join manifest.
  - Every number in it is **community policy**; this crate supplies no defaults (design D15).
  - `acceptedDocumentClasses` is optional and absent by default, because each vetter decides what documentation they accept (D16).
  - `validate()` refuses requirements that cannot be evaluated: `minStatements: 0`, a method floor on a method that is never accepted, or a calendar-dependent duration such as `P4M`.
- `VettingCard` (an r-card VDS) and `IdentityVettingEndorsement` (the Vetting Statement's `endorsement` body).
- A refusal to vet is a framework `trust-task-error` with a `vetting/request:*` code, never a `#response` carrying an outcome.
- **Aligned with the Trust Task specs** (trustoverip/dtgwg-trust-tasks-tf, follow-up commit):
  - every enum and documentation value is lowerCamelCase (SPEC §4.10): `inPerson`, `priorAcquaintance`, `sameEmployer`, `nationalId`;
  - `check_shape` on each payload enforces the schema bounds and patterns serde cannot: lengths, the Crockford ticket-code alphabet, 32-byte base64url challenges, secrets and salts, BCP 47 language tags, URI statement ids, `did:` members, and no `person.portrait`;
  - `VettingRequirements::validate` adds `MAJOR.MINOR` versions, role names, https governance URLs and the 32-character duration cap;
  - cards and statements are shape-checked both before signing and on receipt. `RequestShapeError` is now `ShapeError`.

### `vetting` module (feature `vetting`)

Every verifier returns a `Verified*` type (typestate rule).

- **`card`:**
  - `sign_card` builds and signs the card. The signer must be the publisher, and validity is capped at 15 minutes.
  - `verify_card` checks audience, publisher, community, challenge and domain, then the time window, the proof by the publisher, required claims, and that the identity commitment recomputes.
  - The **identity commitment** is a salted digest over the required claims. The salt is per application and is disclosed to vetters but never to the community, so the community can check that every vetter verified the same identity without learning it (cf. dtgwg-cred-spec#38).
- **`statement`:**
  - `sign_statement` builds a DTG `EndorsementCredential` through `dtg-credentials`, with `taskContext` naming the session.
  - `verify_statement` parses strictly and requires an `id`, a `taskContext` and a bounded `validUntil`.
  - `check_against_card` lets the applicant confirm a statement was issued over the card they actually presented.
- **`requirements`:**
  - `evaluate` is the one counting rule, shared by the applicant's checklist and the community's policy facts. It counts distinct vetters by *member* rather than by DID (D14), applies method floors and relationship caps, checks commitments are consistent, and records per-statement not-counted reasons.
  - `Need::to_wire` defines the `needs` string grammar (`vetting:statements:<n>`, `vetting:method:<m>:<n>`), so the published verdict shape doesn't change.
  - `requirements_digest` computes the digest over a manifest criterion.
- **`match_code`:** same construction as the personhood match code, with its own domain tag (`vetting-session-match/v1\0`). A test pins that the two never collide.

### Manifest 0.2

`ManifestCriterion` gains optional `vetting` and `requirementsDigest` members. It is a published struct with no `#[non_exhaustive]`, hence the `!`. The VTC fills these in later in the stack; here the two literals set `None`.

## Census and CI

- **`payload_ext_census`:** `VettingCard`, `CardClaim` and `IdentityVettingEndorsement` are added to `NO_EXT_BY_DESIGN`. They are signed or attested content rather than payload roots, and closing them is the point: a member the verifier can't show or interpret would be signed anyway. The payloads that carry them keep `ext`.
- **`trust_task_manifest`:** three counted `UNPUBLISHED_CANONICAL_OK` entries (`spec/vetting/` ×3, `spec/vtc/vetting/` ×1, `manifest/0.2` ×1) cover the URIs bound ahead of their specs. The specs are proposed in trustoverip/dtgwg-trust-tasks-tf, and each count goes to zero when the trust-tasks-rs release that serves it is taken.
- **CI:** new step `cargo test -p vta-sdk --features client,vetting --lib vetting`. `vetting` is off by default, so the workspace test job never compiled these tests. `client` is included because `trust_task_proof`'s own unit tests need it under `proof-verify`, which is an existing gap this PR doesn't widen.

## Run locally

- `cargo test -p vta-sdk --features client,vetting --lib vetting`: 41 passed
- `cargo test -p vta-sdk --no-fail-fast`
- `cargo test -p vtc-service --test trust_task_manifest`
- `cargo clippy -p vta-sdk --all-features --all-targets -- -D warnings`
- `cargo clippy -p vtc-service --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Design notes for review

- **Signing is done by the holder, as the persona DID.** `sign_card` and `sign_statement` take the persona's assertionMethod `Secret` (`did:webvh:…#key-N`), which OpenVTC loads for every persona — derived, imported or VTA-managed — and already uses for reciprocal VMCs, capability grants and personhood proofs. The proof names the persona's verification method, and verification resolves it through the DID document. The VTA's signing tasks don't fit (`keys/derive-and-sign-document` signs as a derived `did:key`; `keys/sign` is domain-separated), and aren't needed. Because the holder has the key, a VTA step-up can't gate the signature: V0 gates it with a client confirmation, recorded as D19.
- **Card digest** uses DTG Digest Encoding: JCS over the card without `proof`.
- **Relationship to trustoverip/dtgwg-cred-spec#47:** that PR proposes replacing `EndorsementCredential` with a new statement type. If it lands, only `statement.rs`'s builder and type check move; the endorsement body carries over.

`../design-docs/` isn't available in this checkout, so the vti-stack-development-guide checklist isn't pasted here. This PR adds no service call.
