### PR TITLE
feat(vtc): advertise vetting requirements in the join manifest

### DIFF
--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -149,6 +149,9 @@ vta-sdk = { path = "../vta-sdk", version = "0.36", features = [
   # `openapi` gates ToSchema on the vta-sdk protocol wire types the VTC
   # surface references (credential-exchange, discovery, etc.).
   "openapi",
+  # Peer identity vetting: validating the requirements a criterion advertises,
+  # the manifest's `requirementsDigest`, and verifying vetting statements.
+  "vetting",
   # Lets `main()` install the rustls aws-lc-rs CryptoProvider at startup.
   "crypto-provider",
 ] }

--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -4307,6 +4307,13 @@
           },
           "query": {
             "description": "The DCQL query, stored as JSON. Structurally validated and every\nreferenced type checked against the registry when stored (see\n[`validate_accepts_query`])."
+          },
+          "vetting": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Peer identity vetting this criterion requires, advertised to applicants\nin the join manifest (0.2). Every number in it is this community's\npolicy. Checked by [`VettingRequirements::validate`] when stored; the\nadmin route additionally requires its `statementType` to be a registered\nendorsement type."
           }
         }
       },
@@ -7732,6 +7739,13 @@
           },
           "query": {
             "$ref": "#/components/schemas/Value"
+          },
+          "vetting": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Peer identity vetting this criterion requires, advertised in the join\nmanifest (0.2). Its `statementType` must be a registered endorsement type."
           }
         }
       },

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -1630,6 +1630,14 @@ export interface components {
              *     [`validate_accepts_query`]).
              */
             query: unknown;
+            /**
+             * @description Peer identity vetting this criterion requires, advertised to applicants
+             *     in the join manifest (0.2). Every number in it is this community's
+             *     policy. Checked by [`VettingRequirements::validate`] when stored; the
+             *     admin route additionally requires its `statementType` to be a registered
+             *     endorsement type.
+             */
+            vetting?: Record<string, never> | null;
         };
         /**
          * @description `{ entry: … }` — the shape `acl/{grant,show,change-role}/0.1` publish.
@@ -3850,6 +3858,11 @@ export interface components {
             description?: string | null;
             id: string;
             query: components["schemas"]["Value"];
+            /**
+             * @description Peer identity vetting this criterion requires, advertised in the join
+             *     manifest (0.2). Its `statementType` must be a registered endorsement type.
+             */
+            vetting?: Record<string, never> | null;
         };
         RegisterBody: {
             claimSchema?: null | components["schemas"]["Value"];

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -26,9 +26,10 @@ use vta_sdk::protocols::credential_exchange::{
     ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody, PresentBody, RequestBody,
 };
 use vta_sdk::protocols::join_requests::{
-    JOIN_REQUEST_MANIFEST_TYPE, JOIN_REQUEST_STATUS_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
-    JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitReceiptBody, MEMBER_SELF_REMOVE_RECEIPT_TYPE,
-    MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody, SelfRemoveReceiptBody,
+    JOIN_REQUEST_MANIFEST_0_2_TYPE, JOIN_REQUEST_MANIFEST_TYPE, JOIN_REQUEST_STATUS_TYPE,
+    JOIN_REQUEST_SUBMIT_RECEIPT_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitReceiptBody,
+    MEMBER_SELF_REMOVE_RECEIPT_TYPE, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
+    SelfRemoveReceiptBody,
 };
 use vta_sdk::protocols::members::{
     MEMBER_VMC_RESPONSE_TYPE, MEMBER_VMC_TYPE, MemberVmcBody, MemberVmcReceiptBody,
@@ -712,7 +713,11 @@ async fn route(msg: &Message, auth_sender: Option<String>, state: &AppState) -> 
     match msg.typ.as_str() {
         TRUST_PING_TYPE => trust_ping_reply(msg, auth_sender.as_deref()),
         JOIN_REQUEST_SUBMIT_TYPE => join_request_submit_handler(msg, auth_sender, state).await,
-        JOIN_REQUEST_MANIFEST_TYPE => join_request_manifest_handler(msg, state).await,
+        // Both versions go through the document dispatcher, which answers in
+        // the shape the document's own `type` names.
+        JOIN_REQUEST_MANIFEST_TYPE | JOIN_REQUEST_MANIFEST_0_2_TYPE => {
+            join_request_manifest_handler(msg, state).await
+        }
         JOIN_REQUEST_STATUS_TYPE => join_request_status_handler(msg, auth_sender, state).await,
         MEMBER_SELF_REMOVE_TYPE => member_self_remove_handler(msg, auth_sender, state).await,
         MEMBER_VMC_TYPE => member_vmc_handler(msg, auth_sender, state).await,

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -120,7 +120,7 @@ mod tests {
             "version": "0.1",
             "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
             "minStatements": min,
-            "acceptedMethods": ["in-person", "video"],
+            "acceptedMethods": ["inPerson", "video"],
             "eligibleVetters": { "role": "vetter" }
         }))
         .unwrap()

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -1,21 +1,44 @@
-//! `GET /v1/join-requests/manifest` — pre-submit discovery
-//! (`join-requests/manifest/1.0`) + a shared `manifest_inner` the
-//! DIDComm handler calls into.
+//! Pre-submit discovery — the join manifest (`vtc/join-requests/manifest/0.1`
+//! and `/0.2`) — plus a shared `manifest_inner` the Trust Task dispatcher and
+//! the DIDComm handler call into.
 //!
 //! Returns the community's registered Accepts criteria — each a named
 //! DCQL Presentation Definition — plus this VTC's DID, so a prospective
 //! applicant can assemble a presentation before opening a thread. A
 //! stateless, unauthenticated public read: no thread, no challenge, no
 //! audit.
+//!
+//! ## 0.1 and 0.2
+//!
+//! 0.2 adds, per criterion, the peer-vetting requirements the community
+//! registered and a `requirementsDigest` over the criterion. An applicant
+//! records the digest when it starts gathering statements, so a change to the
+//! requirements mid-application is detectable rather than a surprise at submit
+//! (OpenVTC `docs/design/vetting-process.md` §6.3).
+//!
+//! A 0.1 answer carries neither member: the version the applicant asked for
+//! decides the shape, and a 0.1 reader is not handed members its version does
+//! not define.
 
 use axum::Json;
 use axum::extract::State;
 
 use vta_sdk::protocols::join_requests::{JoinRequestManifestResponseBody, ManifestCriterion};
+use vta_sdk::vetting::requirements::requirements_digest;
 use vti_common::error::AppError;
 
-use crate::schemas::accepts::list_accepts;
+use crate::schemas::accepts::{AcceptsCriterion, list_accepts};
 use crate::server::AppState;
+
+/// Which manifest version a caller asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestVersion {
+    /// `vtc/join-requests/manifest/0.1` — criteria only.
+    V0_1,
+    /// `vtc/join-requests/manifest/0.2` — criteria with their vetting
+    /// requirements and a `requirementsDigest`.
+    V0_2,
+}
 
 /// GET /join-requests/manifest — pre-submit discovery of the community's
 /// Accepts criteria. Public, stateless read.
@@ -28,12 +51,15 @@ use crate::server::AppState;
 pub async fn manifest(
     State(state): State<AppState>,
 ) -> Result<Json<JoinRequestManifestResponseBody>, AppError> {
-    Ok(Json(manifest_inner(&state).await?))
+    Ok(Json(manifest_inner(&state, ManifestVersion::V0_1).await?))
 }
 
 /// Shared discovery read for REST + DIDComm: the community's join
-/// evidence requirements.
-pub async fn manifest_inner(state: &AppState) -> Result<JoinRequestManifestResponseBody, AppError> {
+/// evidence requirements, in the shape `version` defines.
+pub async fn manifest_inner(
+    state: &AppState,
+    version: ManifestVersion,
+) -> Result<JoinRequestManifestResponseBody, AppError> {
     let community_did = state
         .config
         .read()
@@ -46,17 +72,103 @@ pub async fn manifest_inner(state: &AppState) -> Result<JoinRequestManifestRespo
     let criteria = list_accepts(&state.schemas_ks)
         .await?
         .into_iter()
-        .map(|c| ManifestCriterion {
-            id: c.id,
-            description: c.description,
-            presentation_definition: c.query,
-            vetting: None,
-            requirements_digest: None,
-        })
-        .collect();
+        .map(|c| manifest_criterion(c, version))
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(JoinRequestManifestResponseBody {
         community_did,
         criteria,
     })
+}
+
+/// Project a stored criterion into the manifest shape `version` defines.
+///
+/// The 0.2 digest is computed over the criterion exactly as it is delivered,
+/// minus the digest member, so an applicant recomputes it from what it
+/// received with [`requirements_digest`] and gets the same value.
+pub fn manifest_criterion(
+    stored: AcceptsCriterion,
+    version: ManifestVersion,
+) -> Result<ManifestCriterion, AppError> {
+    let mut criterion = ManifestCriterion {
+        id: stored.id,
+        description: stored.description,
+        presentation_definition: stored.query,
+        vetting: None,
+        requirements_digest: None,
+    };
+    if version == ManifestVersion::V0_2 {
+        criterion.vetting = stored.vetting;
+        let delivered = serde_json::to_value(&criterion)
+            .map_err(|e| AppError::Internal(format!("manifest criterion encode: {e}")))?;
+        let digest = requirements_digest(&delivered)
+            .map_err(|e| AppError::Internal(format!("requirements digest: {e:?}")))?;
+        criterion.requirements_digest = Some(digest);
+    }
+    Ok(criterion)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+    use vta_sdk::protocols::vetting::VettingRequirements;
+
+    fn requirements(min: u32) -> VettingRequirements {
+        serde_json::from_value(json!({
+            "version": "0.1",
+            "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
+            "minStatements": min,
+            "acceptedMethods": ["in-person", "video"],
+            "eligibleVetters": { "role": "vetter" }
+        }))
+        .unwrap()
+    }
+
+    fn stored(vetting: Option<VettingRequirements>) -> AcceptsCriterion {
+        AcceptsCriterion {
+            id: "kernel-developer".into(),
+            query: json!({ "credentials": [{ "id": "vetting", "format": "ldp_vc" }] }),
+            description: Some("Two vetters".into()),
+            vetting,
+            created_at: Utc::now(),
+            created_by_did: "did:key:zAdmin".into(),
+        }
+    }
+
+    #[test]
+    fn a_0_1_answer_carries_no_vetting_members() {
+        let c = manifest_criterion(stored(Some(requirements(2))), ManifestVersion::V0_1).unwrap();
+        let v = serde_json::to_value(&c).unwrap();
+        assert!(v.get("vetting").is_none());
+        assert!(v.get("requirementsDigest").is_none());
+    }
+
+    #[test]
+    fn a_0_2_digest_recomputes_from_what_the_applicant_receives() {
+        let c = manifest_criterion(stored(Some(requirements(2))), ManifestVersion::V0_2).unwrap();
+        let received = serde_json::to_value(&c).unwrap();
+        assert_eq!(received["vetting"]["minStatements"], 2);
+        assert_eq!(
+            received["requirementsDigest"].as_str().unwrap(),
+            requirements_digest(&received).unwrap(),
+            "the digest must be checkable by the applicant from the delivered criterion"
+        );
+    }
+
+    #[test]
+    fn changing_the_requirements_changes_the_digest() {
+        let two = manifest_criterion(stored(Some(requirements(2))), ManifestVersion::V0_2).unwrap();
+        let three =
+            manifest_criterion(stored(Some(requirements(3))), ManifestVersion::V0_2).unwrap();
+        assert_ne!(two.requirements_digest, three.requirements_digest);
+    }
+
+    #[test]
+    fn a_criterion_without_vetting_still_gets_a_digest_under_0_2() {
+        let c = manifest_criterion(stored(None), ManifestVersion::V0_2).unwrap();
+        assert!(c.vetting.is_none());
+        assert!(c.requirements_digest.is_some());
+    }
 }

--- a/vtc-service/src/routes/schemas.rs
+++ b/vtc-service/src/routes/schemas.rs
@@ -21,6 +21,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::info;
+use vta_sdk::protocols::vetting::VettingRequirements;
 use vti_common::audit::{AuditEvent, SchemaChangeData};
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
@@ -200,6 +201,11 @@ pub struct RegisterAcceptsBody {
     pub query: JsonValue,
     #[serde(default)]
     pub description: Option<String>,
+    /// Peer identity vetting this criterion requires, advertised in the join
+    /// manifest (0.2). Its `statementType` must be a registered endorsement type.
+    #[serde(default)]
+    #[schema(value_type = Option<Object>)]
+    pub vetting: Option<VettingRequirements>,
 }
 
 /// `POST /v1/schemas/accepts` — register (or update) an Accepts criterion. The
@@ -226,10 +232,27 @@ pub async fn register_accepts(
             "accepts criterion id cannot be empty".into(),
         ));
     }
+    // A criterion that counts statements of a type the community does not
+    // recognise could never be satisfied — refuse it here, where the operator
+    // can act on the error, rather than at an applicant's submit.
+    if let Some(vetting) = &body.vetting
+        && !crate::endorsement_types::storage::type_exists(
+            &state.endorsement_types_ks,
+            &vetting.statement_type,
+        )
+        .await?
+    {
+        return Err(AppError::Validation(format!(
+            "vetting.statementType `{}` is not a registered endorsement type — register it \
+             with vtc/endorsement-types/register first",
+            vetting.statement_type
+        )));
+    }
     let criterion = AcceptsCriterion {
         id: id.to_string(),
         query: body.query,
         description: body.description,
+        vetting: body.vetting,
         created_at: Utc::now(),
         created_by_did: auth.0.did.clone(),
     };

--- a/vtc-service/src/schemas/accepts.rs
+++ b/vtc-service/src/schemas/accepts.rs
@@ -24,6 +24,7 @@ use affinidi_openid4vp::DcqlQuery;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use vta_sdk::protocols::vetting::VettingRequirements;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
@@ -55,6 +56,14 @@ pub struct AcceptsCriterion {
     /// Free-form description shown in admin UIs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Peer identity vetting this criterion requires, advertised to applicants
+    /// in the join manifest (0.2). Every number in it is this community's
+    /// policy. Checked by [`VettingRequirements::validate`] when stored; the
+    /// admin route additionally requires its `statementType` to be a registered
+    /// endorsement type.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<Object>)]
+    pub vetting: Option<VettingRequirements>,
     pub created_at: DateTime<Utc>,
     /// Admin DID that registered the criterion (audit correlation).
     pub created_by_did: String,
@@ -99,13 +108,19 @@ pub async fn validate_accepts_query(
 }
 
 /// Validate + store an Accepts criterion. The query is validated against the
-/// registry first; a criterion with a malformed query or a dangling type
-/// reference is **not** stored.
+/// registry first, and any vetting requirements must be evaluable; a criterion
+/// with a malformed query, a dangling type reference or requirements no
+/// applicant could satisfy is **not** stored.
 pub async fn store_accepts(
     schemas_ks: &KeyspaceHandle,
     criterion: &AcceptsCriterion,
 ) -> Result<(), AppError> {
     validate_accepts_query(schemas_ks, &criterion.query).await?;
+    if let Some(vetting) = &criterion.vetting {
+        vetting
+            .validate()
+            .map_err(|e| AppError::Validation(e.to_string()))?;
+    }
     schemas_ks
         .insert(
             String::from_utf8(key(&criterion.id)).expect("ascii key"),
@@ -196,6 +211,7 @@ mod tests {
                 }]
             }),
             description: Some("join evidence".into()),
+            vetting: None,
             created_at: Utc::now(),
             created_by_did: "did:key:zAdmin".into(),
         }
@@ -246,6 +262,7 @@ mod tests {
             // Empty `credentials` is invalid DCQL.
             query: json!({ "credentials": [] }),
             description: None,
+            vetting: None,
             created_at: Utc::now(),
             created_by_did: "did:key:zAdmin".into(),
         };
@@ -253,5 +270,42 @@ mod tests {
             .await
             .expect_err("invalid DCQL must be rejected");
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+    }
+
+    fn vetting(min: u32) -> VettingRequirements {
+        serde_json::from_value(json!({
+            "version": "0.1",
+            "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
+            "minStatements": min,
+            "acceptedMethods": ["in-person"],
+            "eligibleVetters": { "role": "vetter" }
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn stores_and_returns_a_criterion_with_vetting_requirements() {
+        let (_d, _s, ks) = ks().await;
+        register_membership(&ks).await;
+        let mut c = criterion("kernel", MEMBERSHIP_VCT);
+        c.vetting = Some(vetting(2));
+        store_accepts(&ks, &c)
+            .await
+            .expect("evaluable requirements store");
+        let got = get_accepts(&ks, "kernel").await.unwrap().unwrap();
+        assert_eq!(got.vetting, Some(vetting(2)));
+    }
+
+    #[tokio::test]
+    async fn refuses_vetting_requirements_no_applicant_could_satisfy() {
+        let (_d, _s, ks) = ks().await;
+        register_membership(&ks).await;
+        let mut c = criterion("kernel", MEMBERSHIP_VCT);
+        c.vetting = Some(vetting(0));
+        let err = store_accepts(&ks, &c)
+            .await
+            .expect_err("minStatements 0 is refused");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(get_accepts(&ks, "kernel").await.unwrap().is_none());
     }
 }

--- a/vtc-service/src/schemas/accepts.rs
+++ b/vtc-service/src/schemas/accepts.rs
@@ -277,7 +277,7 @@ mod tests {
             "version": "0.1",
             "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
             "minStatements": min,
-            "acceptedMethods": ["in-person"],
+            "acceptedMethods": ["inPerson"],
             "eligibleVetters": { "role": "vetter" }
         }))
         .unwrap()

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -66,6 +66,7 @@ use vta_sdk::protocols::members::{self as mem, MemberVmcBody, MemberVmcReceiptBo
 use vti_rooms::wire as rooms_wire;
 
 use crate::join::{JoinSubmitOutcome, JoinTransport};
+use crate::routes::join_requests::manifest::ManifestVersion;
 use crate::server::AppState;
 
 pub(crate) use helpers::TrustTaskOutcome;
@@ -219,7 +220,10 @@ async fn dispatch_typed(
 ) -> TrustTaskOutcome {
     match type_uri {
         jr::JOIN_REQUEST_SUBMIT_TYPE => handle_submit(state, ctx, doc).await,
-        jr::JOIN_REQUEST_MANIFEST_TYPE => handle_manifest(state, doc).await,
+        jr::JOIN_REQUEST_MANIFEST_TYPE => handle_manifest(state, doc, ManifestVersion::V0_1).await,
+        jr::JOIN_REQUEST_MANIFEST_0_2_TYPE => {
+            handle_manifest(state, doc, ManifestVersion::V0_2).await
+        }
         jr::JOIN_REQUEST_STATUS_TYPE => handle_status(state, ctx, doc).await,
         jr::MEMBER_SELF_REMOVE_TYPE => handle_self_remove(state, ctx, doc).await,
         mem::MEMBER_VMC_TYPE => handle_member_vmc(state, ctx, doc).await,
@@ -356,6 +360,8 @@ fn unsupported_type_or_version(doc: &TrustTask<Value>, type_uri: &str) -> TrustT
 pub(crate) const DISPATCHED_URIS: &[&str] = &[
     jr::JOIN_REQUEST_SUBMIT_TYPE,
     jr::JOIN_REQUEST_MANIFEST_TYPE,
+    // 0.2 adds the per-criterion vetting requirements and `requirementsDigest`.
+    jr::JOIN_REQUEST_MANIFEST_0_2_TYPE,
     jr::JOIN_REQUEST_STATUS_TYPE,
     jr::MEMBER_SELF_REMOVE_TYPE,
     mem::MEMBER_VMC_TYPE,
@@ -523,8 +529,14 @@ fn outcome_to_verdict(outcome: &JoinSubmitOutcome) -> Result<VerdictResponse, Ap
 
 // ─── manifest (public) ─────────────────────────────────────────────────────
 
-async fn handle_manifest(state: &AppState, doc: TrustTask<Value>) -> TrustTaskOutcome {
-    match crate::routes::join_requests::manifest::manifest_inner(state).await {
+/// Both manifest versions share one read; the version the document names
+/// decides the shape of the answer.
+async fn handle_manifest(
+    state: &AppState,
+    doc: TrustTask<Value>,
+    version: ManifestVersion,
+) -> TrustTaskOutcome {
+    match crate::routes::join_requests::manifest::manifest_inner(state, version).await {
         Ok(body) => success_response(&doc, body),
         Err(e) => app_error_to_reject(&doc, &e),
     }
@@ -921,6 +933,7 @@ mod tests {
         let declared = [
             jr::JOIN_REQUEST_SUBMIT_TYPE,
             jr::JOIN_REQUEST_MANIFEST_TYPE,
+            jr::JOIN_REQUEST_MANIFEST_0_2_TYPE,
             jr::JOIN_REQUEST_STATUS_TYPE,
             jr::MEMBER_SELF_REMOVE_TYPE,
             mem::MEMBER_VMC_TYPE,

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -172,6 +172,7 @@ async fn seed_join_ceremony(mock: &MockVtcDidcomm) -> String {
                 }]
             }),
             description: Some("Join evidence".into()),
+            vetting: None,
             created_at: chrono::Utc::now(),
             created_by_did: ADMIN_DID.into(),
         },

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1514,6 +1514,7 @@ async fn admin_query_send_prepares_a_dcql_query_and_issues_a_challenge() {
             }]
         }),
         description: Some("present a MembershipCredential to join".into()),
+        vetting: None,
         created_at: chrono::Utc::now(),
         created_by_did: ADMIN_DID.into(),
     };
@@ -1815,6 +1816,7 @@ async fn store_join_criterion(fix: &Fixture) {
             }]
         }),
         description: Some("present a MembershipCredential to join".into()),
+        vetting: None,
         created_at: chrono::Utc::now(),
         created_by_did: ADMIN_DID.into(),
     };
@@ -1850,6 +1852,68 @@ async fn manifest_is_empty_when_no_criteria_registered() {
     let payload = tt_payload(&body);
     assert_eq!(payload["communityDid"], VTC_DID);
     assert_eq!(payload["criteria"].as_array().unwrap().len(), 0);
+}
+
+/// Manifest 0.2 advertises a criterion's vetting requirements with a digest the
+/// applicant can recompute from what it received; 0.1 keeps its own shape.
+#[tokio::test]
+async fn manifest_0_2_advertises_vetting_requirements_and_their_digest() {
+    use vta_sdk::protocols::join_requests::JOIN_REQUEST_MANIFEST_0_2_TYPE;
+    use vta_sdk::vetting::requirements::requirements_digest;
+    use vtc_service::schemas::accepts::{AcceptsCriterion, store_accepts};
+
+    let fix = build_fixture().await;
+    let criterion = AcceptsCriterion {
+        id: "kernel-developer".into(),
+        query: json!({
+            "credentials": [{
+                "id": "vetting",
+                "format": "ldp_vc",
+                "meta": { "type_values": ["EndorsementCredential"] }
+            }]
+        }),
+        description: Some("Two vetters, one in person".into()),
+        vetting: Some(
+            serde_json::from_value(json!({
+                "version": "0.1",
+                "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
+                "minStatements": 2,
+                "minByMethod": { "in-person": 1 },
+                "acceptedMethods": ["in-person", "video"],
+                "eligibleVetters": { "role": "vetter" }
+            }))
+            .unwrap(),
+        ),
+        created_at: chrono::Utc::now(),
+        created_by_did: ADMIN_DID.into(),
+    };
+    store_accepts(&fix.state.schemas_ks, &criterion)
+        .await
+        .expect("store vetting criterion");
+
+    let mut doc = manifest_doc();
+    doc["type"] = json!(JOIN_REQUEST_MANIFEST_0_2_TYPE);
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let c = &tt_payload(&body)["criteria"][0];
+    assert_eq!(c["vetting"]["minStatements"], 2);
+    assert_eq!(c["vetting"]["minByMethod"]["in-person"], 1);
+    assert_eq!(
+        c["requirementsDigest"]
+            .as_str()
+            .expect("0.2 carries a digest"),
+        requirements_digest(c).unwrap(),
+        "the applicant must be able to recompute the digest from the criterion it received"
+    );
+
+    let (status, body) = post_tt(&fix.router, manifest_doc()).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    let c = &tt_payload(&body)["criteria"][0];
+    assert!(c.get("vetting").is_none(), "0.1 keeps its shape: {c}");
+    assert!(
+        c.get("requirementsDigest").is_none(),
+        "0.1 keeps its shape: {c}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1878,8 +1878,8 @@ async fn manifest_0_2_advertises_vetting_requirements_and_their_digest() {
                 "version": "0.1",
                 "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
                 "minStatements": 2,
-                "minByMethod": { "in-person": 1 },
-                "acceptedMethods": ["in-person", "video"],
+                "minByMethod": { "inPerson": 1 },
+                "acceptedMethods": ["inPerson", "video"],
                 "eligibleVetters": { "role": "vetter" }
             }))
             .unwrap(),
@@ -1897,7 +1897,7 @@ async fn manifest_0_2_advertises_vetting_requirements_and_their_digest() {
     assert_eq!(status, StatusCode::OK, "got {body}");
     let c = &tt_payload(&body)["criteria"][0];
     assert_eq!(c["vetting"]["minStatements"], 2);
-    assert_eq!(c["vetting"]["minByMethod"]["in-person"], 1);
+    assert_eq!(c["vetting"]["minByMethod"]["inPerson"], 1);
     assert_eq!(
         c["requirementsDigest"]
             .as_str()


### PR DESCRIPTION
Stacked on #1425.

A community can now **advertise what vetting it requires** before anyone applies. This is the first VTC half of vetted admission (OpenVTC `docs/design/vetting-process.md` §6).

## What changes

- **Stored criteria carry vetting requirements.**
  - `AcceptsCriterion` gains an optional `vetting` (`vta_sdk::protocols::vetting::VettingRequirements`).
  - `store_accepts` refuses requirements that `VettingRequirements::validate` says no applicant could satisfy: `minStatements: 0`, a method floor on a method that isn't accepted, or a month-based duration.
  - `POST /v1/schemas/accepts` additionally refuses a `statementType` that isn't a registered endorsement type, where the operator can act on the error. Otherwise it would only surface at an applicant's submit.
- **Manifest 0.2.**
  - `vtc/join-requests/manifest/0.2` is served beside 0.1: over the Trust Task document endpoint, over DIDComm, and in `DISPATCHED_URIS`.
  - A 0.2 criterion carries its `vetting` object and a `requirementsDigest`, computed over the criterion **exactly as delivered** minus the digest itself. An applicant recomputes it with `vta_sdk::vetting::requirements::requirements_digest` and records it when it starts gathering statements, so a mid-application change is detectable (design §6.3).
  - A 0.1 answer keeps its own shape and carries neither member. The version the document names decides.

Every number in the requirements is the community's policy (design D15). There are no defaults here, and documentation is left to each vetter unless a community sets `acceptedDocumentClasses` (D16).

## Not in this PR

- **Counting presented vetting statements:** the next PR in the stack does this. It adds verification into facts and the `join.rego` module.
- **Admin console form for `vetting`:** the API accepts it, and the console can follow.

## Tests

- **`routes::join_requests::manifest::tests`:**
  - a 0.1 answer carries no vetting members;
  - a 0.2 digest recomputes from what the applicant receives;
  - changing the requirements changes the digest;
  - a criterion without vetting still gets a 0.2 digest.
- **`schemas::accepts::tests`:** evaluable requirements round-trip, and unsatisfiable ones are refused and not stored.
- **`tests/join_requests.rs::manifest_0_2_advertises_vetting_requirements_and_their_digest`:** end to end over `POST /v1/trust-tasks`, for both versions.
- **Dispatcher census:** `dispatcher_routes_every_dispatched_uri` lists the new URI.

Run locally, all green:
- `cargo test -p vtc-service --lib -- manifest accepts dispatcher`
- `cargo test -p vtc-service --test join_requests manifest`
- `cargo test -p vtc-service --test trust_task_manifest`
- `cargo clippy -p vtc-service --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

`../design-docs/` isn't available in this checkout, so the vti-stack-development-guide checklist isn't pasted. This PR adds a read to an existing public task and no outbound call.
