### PR TITLE
feat(vtc): count vetting statements in the join decision

### DIFF
--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -1,0 +1,151 @@
+# Peer identity vetting
+
+A community can require that an applicant be **vetted by existing members**
+before joining: each vetter checks who the applicant is and signs a
+**Vetting Statement**, and the applicant presents enough of them in its join
+presentation. This replaces a web of trust with evidence the community can
+count, without publishing who vouched for whom.
+
+Design: OpenVTC `docs/design/vetting-process.md`. Wire types and verification:
+`vta_sdk::protocols::vetting` and `vta_sdk::vetting`.
+
+## Setting it up
+
+### 1. Register the statement type
+
+Statements are DTG `EndorsementCredential`s whose `endorsement.type` is
+`https://firstperson.network/endorsements/identity-vetting/0.1`. Register it so
+criteria may count it:
+
+```json
+{
+  "type": "https://trusttasks.org/spec/vtc/endorsement-types/register/0.1",
+  "payload": {
+    "typeUri": "https://firstperson.network/endorsements/identity-vetting/0.1",
+    "description": "A member verified this person's identity"
+  }
+}
+```
+
+### 2. Say what you require
+
+Add a `vetting` object to an Accepts criterion (`POST /v1/schemas/accepts`).
+Every number is **your** policy — there are no defaults:
+
+```json
+{
+  "id": "kernel-developer",
+  "description": "Two vetters, at least one in person",
+  "query": { "credentials": [ { "id": "vetting", "format": "ldp_vc",
+             "meta": { "type_values": ["EndorsementCredential"] } } ] },
+  "vetting": {
+    "version": "0.1",
+    "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
+    "minStatements": 2,
+    "minByMethod": { "in-person": 1 },
+    "acceptedMethods": ["in-person", "video", "prior-acquaintance"],
+    "requiredClaims": ["name.legal"],
+    "maxStatementAge": "P120D",
+    "eligibleVetters": { "role": "vetter" },
+    "independence": {
+      "maxByDeclaredRelationship": { "family": 0, "same-employer": 1 },
+      "requireConsistentIdentityCommitment": true
+    }
+  }
+}
+```
+
+The route refuses requirements no applicant could satisfy (`minStatements: 0`,
+a method floor on a method you do not accept, a month-based duration) and a
+`statementType` that is not registered.
+
+What documentation a vetter accepts is **the vetter's decision**. Set
+`acceptedDocumentClasses` only if the community needs a floor; a
+`prior-acquaintance` statement with no documentation is exempt from it.
+
+Applicants read the requirements from `vtc/join-requests/manifest/0.2`, which
+adds `vetting` and a `requirementsDigest` to each criterion. `manifest/0.1` is
+unchanged.
+
+### 3. Name your vetters
+
+A vetter is a **member holding the role `eligibleVetters.role` names**. For
+`"vetter"`, grant the custom role `custom:vetter` through the usual ACL role
+change. `"custom:vetter"` in the requirements is accepted too, as are the
+standard role names.
+
+## What the community checks at submit
+
+For every identity-vetting statement in the join presentation
+(`vtc-service/src/vetting/mod.rs`):
+
+| Check | Not counted as |
+|---|---|
+| Proof by the issuer, type, bounded validity, strict endorsement body | `unverified` |
+| Subject is the proven holder of the presentation | `subject-not-applicant` |
+| Endorsement type is the criterion's `statementType` | `wrong-statement-type` |
+| Issuer is a current member with the vetter role, who had joined before issuing, with an unexpired ACL entry | `issuer-not-vetter` |
+| Statement is for this community | `wrong-community` |
+| Method accepted; required claims verified; within `maxStatementAge`; documentation within any floor | `method-not-accepted`, `claim-not-verified`, `too-old`, `documentation-not-accepted` |
+| One statement per vetter (the most recent) | `same-vetter` |
+
+The criterion applied is the one whose current `requirementsDigest` the
+applicant sent in `extensions.requirementsDigest`, otherwise the first vetting
+criterion.
+
+The count becomes `input.evidence.vetting` for the join policy:
+
+```json
+{
+  "criterion_id": "kernel-developer",
+  "requirements_digest": "z…",
+  "applicant_digest_matches": true,
+  "statements": [ { "id": "urn:uuid:…", "issuer": "did:…", "verified": true,
+                    "eligible": true, "revoked": false, "method": "video",
+                    "declared_relationship": "none", "counted": true, "failures": [] } ],
+  "distinct_counted_vetters": 2,
+  "by_method": { "in-person": 1, "video": 1 },
+  "commitments_consistent": true,
+  "independence_ok": true,
+  "invitation_required": false,
+  "satisfied": true,
+  "needs": []
+}
+```
+
+## What the default policy decides
+
+When `input.evidence.vetting` is present, admission waits on it — neither an
+invitation nor a trusted credential bypasses it:
+
+| Facts | Verdict |
+|---|---|
+| Statements carry different identity commitments | `refer` to `vetting-review` |
+| Something still missing | `request_more`, needs `["vetting"]` |
+| Enough, but a relationship cap is exceeded | `refer` to `vetting-review` |
+| Met, but `invitation: required` and none presented | `request_more`, needs `["vetting:invitation"]` |
+| Met, with a valid invitation | `allow` at the invited role |
+| Met | `allow` as `member` |
+
+A `request_more` whose needs contain `vetting` is expanded by the host into the
+precise shortfall — `vetting:statements:<n>`, `vetting:method:<method>:<n>` — so
+a policy authored in the visual editor, whose `with` is static, still tells the
+applicant exactly what to gather. The conditions are available in the editor
+under the same names.
+
+Without vetting facts the default behaves exactly as before.
+
+## Current limits
+
+- Statements are counted on the VP-submit path. The credential-exchange
+  `present` path does not count them yet.
+- "Held the vetter role when issuing" is approximated by "holds it now and had
+  joined by then" — the ACL keeps no role history, so a demoted vetter's
+  statements stop counting.
+- Distinct vetters are distinct member DIDs; one person holding two member DIDs
+  would count twice.
+- Statement withdrawal (`vtc/vetting/revoke-statement/0.1`) is recorded by the
+  next change in this series; until then `revoked` is always `false`.
+- `requirementsGrace` is not yet applied: an application gathered against
+  superseded requirements is evaluated under the current ones, with
+  `applicant_digest_matches: false` for a policy to act on.

--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -42,13 +42,13 @@ Every number is **your** policy — there are no defaults:
     "version": "0.1",
     "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
     "minStatements": 2,
-    "minByMethod": { "in-person": 1 },
-    "acceptedMethods": ["in-person", "video", "prior-acquaintance"],
+    "minByMethod": { "inPerson": 1 },
+    "acceptedMethods": ["inPerson", "video", "priorAcquaintance"],
     "requiredClaims": ["name.legal"],
     "maxStatementAge": "P120D",
     "eligibleVetters": { "role": "vetter" },
     "independence": {
-      "maxByDeclaredRelationship": { "family": 0, "same-employer": 1 },
+      "maxByDeclaredRelationship": { "family": 0, "sameEmployer": 1 },
       "requireConsistentIdentityCommitment": true
     }
   }
@@ -61,7 +61,7 @@ a method floor on a method you do not accept, a month-based duration) and a
 
 What documentation a vetter accepts is **the vetter's decision**. Set
 `acceptedDocumentClasses` only if the community needs a floor; a
-`prior-acquaintance` statement with no documentation is exempt from it.
+`priorAcquaintance` statement with no documentation is exempt from it.
 
 Applicants read the requirements from `vtc/join-requests/manifest/0.2`, which
 adds `vetting` and a `requirementsDigest` to each criterion. `manifest/0.1` is
@@ -104,7 +104,7 @@ The count becomes `input.evidence.vetting` for the join policy:
                     "eligible": true, "revoked": false, "method": "video",
                     "declared_relationship": "none", "counted": true, "failures": [] } ],
   "distinct_counted_vetters": 2,
-  "by_method": { "in-person": 1, "video": 1 },
+  "by_method": { "inPerson": 1, "video": 1 },
   "commitments_consistent": true,
   "independence_ok": true,
   "invitation_required": false,

--- a/docs/README.md
+++ b/docs/README.md
@@ -156,6 +156,10 @@ How to operate and integrate against a VTC.
   VTA, and wiring a VTC to it.
 - **[Personhood + relationships](03-vtc/personhood-and-graph.md)** —
   personhood assertion, VRC trust graph, custom endorsements.
+- **[Peer identity vetting](03-vtc/vetting.md)** — requiring existing
+  members to vet an applicant: vetting requirements in the join manifest,
+  what the host checks in each statement, and what the default join policy
+  decides.
 - **[Website + admin UX](03-vtc/website-and-admin.md)** — public
   community website (live + managed modes), embedded admin SPA,
   routing modes.

--- a/vtc-service/admin-ui/src/lib/rule-ir.ts
+++ b/vtc-service/admin-ui/src/lib/rule-ir.ts
@@ -45,6 +45,13 @@ export interface ExplainFacts {
   state?: { subject_member?: { role?: string } | null };
   evidence?: {
     invitation?: { verified?: boolean; consumed?: boolean };
+    vetting?: {
+      satisfied?: boolean;
+      commitments_consistent?: boolean;
+      independence_ok?: boolean;
+      invitation_required?: boolean;
+      needs?: string[];
+    };
     presentation?: {
       credentials?: Array<{
         type?: string;
@@ -78,6 +85,13 @@ export interface ConditionDef {
   test: (facts: ExplainFacts, arg?: string) => boolean;
 }
 
+/** Shared by every vetting condition that depends on the invitation
+ * requirement. Identical rule bodies may be emitted more than once — Rego
+ * treats repeated boolean rule definitions as one. */
+const VETTING_INVITATION_HELPERS =
+  "vetting_invitation_missing if {\n\tinput.evidence.vetting.satisfied == true\n\tinput.evidence.vetting.invitation_required == true\n\tnot vetting_invitation_held\n}\n\n" +
+  "vetting_invitation_held if {\n\tinput.evidence.invitation.verified\n\tnot input.evidence.invitation.consumed\n}";
+
 const HELPERS: Record<string, string> = {
   cred_held:
     'cred_held(t) if {\n\tsome c in input.evidence.presentation.credentials\n\tc.type == t\n\tc.status == "valid"\n}',
@@ -90,6 +104,19 @@ const HELPERS: Record<string, string> = {
   agreed:
     "agreed(tag) if {\n\tinput.evidence.request.agreements[tag] == true\n}",
   target_role: "target_role := input.evidence.request.target_role",
+  vetting_inconsistent:
+    "vetting_inconsistent if {\n\tinput.evidence.vetting.commitments_consistent == false\n}",
+  vetting_incomplete:
+    "vetting_incomplete if {\n\tinput.evidence.vetting.commitments_consistent == true\n\tcount(input.evidence.vetting.needs) > 0\n}",
+  vetting_not_independent:
+    "vetting_not_independent if {\n\tinput.evidence.vetting.commitments_consistent == true\n\tcount(input.evidence.vetting.needs) == 0\n\tinput.evidence.vetting.independence_ok == false\n}",
+  vetting_invitation_missing: VETTING_INVITATION_HELPERS,
+  vetting_satisfied:
+    "vetting_satisfied if {\n\tinput.evidence.vetting.satisfied == true\n\tnot vetting_invitation_missing\n}\n\n" +
+    VETTING_INVITATION_HELPERS,
+  vetting_ok:
+    "vetting_ok if not input.evidence.vetting\n\nvetting_ok if {\n\tinput.evidence.vetting.satisfied == true\n\tnot vetting_invitation_missing\n}\n\n" +
+    VETTING_INVITATION_HELPERS,
 };
 
 const SHARED: ConditionDef[] = [
@@ -114,7 +141,68 @@ const SHARED: ConditionDef[] = [
   },
 ];
 
+/** Client-side mirror of the `vetting_invitation_missing` helper. */
+const vettingInvitationMissing = (f: ExplainFacts) =>
+  f.evidence?.vetting?.satisfied === true &&
+  f.evidence?.vetting?.invitation_required === true &&
+  !(
+    f.evidence?.invitation?.verified === true &&
+    f.evidence?.invitation?.consumed !== true
+  );
+
+const vettingSatisfied = (f: ExplainFacts) =>
+  f.evidence?.vetting?.satisfied === true && !vettingInvitationMissing(f);
+
 const JOIN: ConditionDef[] = [
+  // Peer identity vetting. The daemon verifies and counts the statements;
+  // these read its verdicts (OpenVTC docs/design/vetting-process.md §10).
+  {
+    id: "vetting_inconsistent",
+    label: "vetters verified different identities",
+    expr: () => "vetting_inconsistent",
+    helper: "vetting_inconsistent",
+    test: (f) => f.evidence?.vetting?.commitments_consistent === false,
+  },
+  {
+    id: "vetting_incomplete",
+    label: "vetting is incomplete",
+    expr: () => "vetting_incomplete",
+    helper: "vetting_incomplete",
+    test: (f) =>
+      f.evidence?.vetting?.commitments_consistent === true &&
+      (f.evidence?.vetting?.needs?.length ?? 0) > 0,
+  },
+  {
+    id: "vetting_not_independent",
+    label: "vetters are not independent enough",
+    expr: () => "vetting_not_independent",
+    helper: "vetting_not_independent",
+    test: (f) =>
+      f.evidence?.vetting?.commitments_consistent === true &&
+      (f.evidence?.vetting?.needs?.length ?? 0) === 0 &&
+      f.evidence?.vetting?.independence_ok === false,
+  },
+  {
+    id: "vetting_invitation_missing",
+    label: "vetting is met but an invitation is required",
+    expr: () => "vetting_invitation_missing",
+    helper: "vetting_invitation_missing",
+    test: vettingInvitationMissing,
+  },
+  {
+    id: "vetting_satisfied",
+    label: "vetting requirements are met",
+    expr: () => "vetting_satisfied",
+    helper: "vetting_satisfied",
+    test: vettingSatisfied,
+  },
+  {
+    id: "vetting_ok",
+    label: "no vetting is required, or it is met",
+    expr: () => "vetting_ok",
+    helper: "vetting_ok",
+    test: (f) => !f.evidence?.vetting || vettingSatisfied(f),
+  },
   {
     id: "has_valid_invitation",
     label: "holds a valid invitation",

--- a/vtc-service/policies/default/join.rego
+++ b/vtc-service/policies/default/join.rego
@@ -9,14 +9,17 @@
 # the request as Pending for admin review, `deny` rejects it, and
 # `request_more` defers pending more evidence.
 #
-# Default posture: a submission presenting a **valid, trusted, unconsumed
-# invitation** (VIC) auto-admits as a member — the community explicitly
-# invited this DID, so no human review is needed; a submission with a
-# **trusted, valid** credential also auto-admits; everything else is
-# referred to the moderator queue for human review (the request lands
-# Pending — the same gate the pre-pipeline `policies.open` default
-# produced). Operators replace this with their own decision policy (e.g.
-# admit only on an invitation, require a code-of-conduct agreement).
+# Default posture: when the community's join criterion requires **peer
+# identity vetting**, admission waits on it — the vetting rules below decide,
+# and neither an invitation nor a trusted credential bypasses them. Otherwise
+# a submission presenting a **valid, trusted, unconsumed invitation** (VIC)
+# auto-admits as a member — the community explicitly invited this DID, so no
+# human review is needed; a submission with a **trusted, valid** credential
+# also auto-admits; everything else is referred to the moderator queue for
+# human review (the request lands Pending — the same gate the pre-pipeline
+# `policies.open` default produced). Operators replace this with their own
+# decision policy (e.g. admit only on an invitation, require a code-of-conduct
+# agreement).
 #
 # The privilege ceiling is host-enforced around this policy: a `join`
 # verdict may never grant `admin`.
@@ -29,10 +32,41 @@ import rego.v1
 # reads the header to render it in plain English, show a decision
 # trace, and open it in the route-card editor. Keep it in step with the
 # body if you hand-edit the Rego.
-# @vtc-rule-ir: eyJwdXJwb3NlIjoiam9pbiIsInJvdXRlcyI6W3sibmFtZSI6IlZhbGlkIGludml0YXRpb24iLCJ3aGVuIjp7ImFsbCI6WyJoYXNfdmFsaWRfaW52aXRhdGlvbiJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsicm9sZSI6Im1lbWJlciJ9fX0seyJuYW1lIjoiVHJ1c3RlZCBjcmVkZW50aWFsIiwid2hlbiI6eyJhbGwiOlsiaG9sZHNfYW55X3RydXN0ZWQiXX0sInRoZW4iOnsiZWZmZWN0IjoiYWxsb3ciLCJ3aXRoIjp7InJvbGUiOiJtZW1iZXIifX19LHsibmFtZSI6Ik1vZGVyYXRvciByZXZpZXciLCJ3aGVuIjp7ImFsbCI6WyJhbHdheXMiXX0sInRoZW4iOnsiZWZmZWN0IjoicmVmZXIiLCJ3aXRoIjp7InF1ZXVlIjoibW9kZXJhdG9yIn19fV19
+# @vtc-rule-ir: eyJwdXJwb3NlIjoiam9pbiIsInJvdXRlcyI6W3sibmFtZSI6IlZldHRlcnMgdmVyaWZpZWQgZGlmZmVyZW50IGlkZW50aXRpZXMiLCJ3aGVuIjp7ImFsbCI6WyJ2ZXR0aW5nX2luY29uc2lzdGVudCJdfSwidGhlbiI6eyJlZmZlY3QiOiJyZWZlciIsIndpdGgiOnsicXVldWUiOiJ2ZXR0aW5nLXJldmlldyJ9fX0seyJuYW1lIjoiVmV0dGluZyBpbmNvbXBsZXRlIiwid2hlbiI6eyJhbGwiOlsidmV0dGluZ19pbmNvbXBsZXRlIl19LCJ0aGVuIjp7ImVmZmVjdCI6InJlcXVlc3RfbW9yZSIsIndpdGgiOnsibmVlZHMiOlsidmV0dGluZyJdfX19LHsibmFtZSI6IlZldHRlcnMgbm90IGluZGVwZW5kZW50Iiwid2hlbiI6eyJhbGwiOlsidmV0dGluZ19ub3RfaW5kZXBlbmRlbnQiXX0sInRoZW4iOnsiZWZmZWN0IjoicmVmZXIiLCJ3aXRoIjp7InF1ZXVlIjoidmV0dGluZy1yZXZpZXcifX19LHsibmFtZSI6IlZldHRpbmcgbmVlZHMgYW4gaW52aXRhdGlvbiIsIndoZW4iOnsiYWxsIjpbInZldHRpbmdfaW52aXRhdGlvbl9taXNzaW5nIl19LCJ0aGVuIjp7ImVmZmVjdCI6InJlcXVlc3RfbW9yZSIsIndpdGgiOnsibmVlZHMiOlsidmV0dGluZzppbnZpdGF0aW9uIl19fX0seyJuYW1lIjoiVmFsaWQgaW52aXRhdGlvbiIsIndoZW4iOnsiYWxsIjpbImhhc192YWxpZF9pbnZpdGF0aW9uIiwidmV0dGluZ19vayJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsicm9sZSI6Im1lbWJlciJ9fX0seyJuYW1lIjoiVmV0dGVkIiwid2hlbiI6eyJhbGwiOlsidmV0dGluZ19zYXRpc2ZpZWQiXX0sInRoZW4iOnsiZWZmZWN0IjoiYWxsb3ciLCJ3aXRoIjp7InJvbGUiOiJtZW1iZXIifX19LHsibmFtZSI6IlRydXN0ZWQgY3JlZGVudGlhbCIsIndoZW4iOnsiYWxsIjpbImhvbGRzX2FueV90cnVzdGVkIiwidmV0dGluZ19vayJdfSwidGhlbiI6eyJlZmZlY3QiOiJhbGxvdyIsIndpdGgiOnsicm9sZSI6Im1lbWJlciJ9fX0seyJuYW1lIjoiTW9kZXJhdG9yIHJldmlldyIsIndoZW4iOnsiYWxsIjpbImFsd2F5cyJdfSwidGhlbiI6eyJlZmZlY3QiOiJyZWZlciIsIndpdGgiOnsicXVldWUiOiJtb2RlcmF0b3IifX19XX0=
 
 # structural totality — unmatched submissions go to moderator review
 default decision := {"effect": "refer", "with": {"queue": "moderator"}}
+
+# ---- Peer identity vetting (OpenVTC docs/design/vetting-process.md §10) ----
+#
+# `input.evidence.vetting` is present only when the criterion requires vetting.
+# The host has already verified every statement, checked each issuer is an
+# eligible vetter, and counted them against the community's own requirements;
+# these rules decide on that count. The four outcomes are mutually exclusive by
+# construction, and `satisfied` is the host's conjunction of "no needs",
+# "commitments consistent" and "independence ok".
+
+# The vetters did not all verify the same claimed identity.
+decision := {"effect": "refer", "with": {"queue": "vetting-review"}} if {
+	vetting_inconsistent
+}
+
+# Not enough yet. The host expands the generic `vetting` need into the precise
+# shortfall (`vetting:statements:<n>`, `vetting:method:<m>:<n>`).
+decision := {"effect": "request_more", "with": {"needs": ["vetting"]}} if {
+	vetting_incomplete
+}
+
+# Enough statements, but more of them share a declared relationship with the
+# applicant than the community allows.
+decision := {"effect": "refer", "with": {"queue": "vetting-review"}} if {
+	vetting_not_independent
+}
+
+# Vetting is met but the requirements also ask for an invitation.
+decision := {"effect": "request_more", "with": {"needs": ["vetting:invitation"]}} if {
+	vetting_invitation_missing
+}
 
 # A valid, trusted, unconsumed invitation (VIC) auto-admits at the role the
 # invitation grants — the community (or a trusted third party) explicitly
@@ -44,6 +78,13 @@ default decision := {"effect": "refer", "with": {"queue": "moderator"}}
 # default `member`); the host's privilege ceiling still forbids `admin` on join.
 decision := {"effect": "allow", "with": {"role": invited_role}} if {
 	has_valid_invitation
+	vetting_ok
+}
+
+# Vetting met, no invitation: admit as a member.
+decision := {"effect": "allow", "with": {"role": "member"}} if {
+	vetting_satisfied
+	not has_valid_invitation
 }
 
 # A presented credential from a trusted issuer auto-admits as a member.
@@ -51,6 +92,7 @@ decision := {"effect": "allow", "with": {"role": "member"}} if {
 	some c in input.evidence.presentation.credentials
 	c.issuer_trusted
 	c.status == "valid"
+	vetting_ok
 }
 
 has_valid_invitation if {
@@ -68,3 +110,34 @@ invited_role := role if {
 	startswith(s, "role:")
 	role := substring(s, 5, -1)
 }
+
+vetting_inconsistent if {
+	input.evidence.vetting.commitments_consistent == false
+}
+
+vetting_incomplete if {
+	input.evidence.vetting.commitments_consistent == true
+	count(input.evidence.vetting.needs) > 0
+}
+
+vetting_not_independent if {
+	input.evidence.vetting.commitments_consistent == true
+	count(input.evidence.vetting.needs) == 0
+	input.evidence.vetting.independence_ok == false
+}
+
+vetting_invitation_missing if {
+	input.evidence.vetting.satisfied == true
+	input.evidence.vetting.invitation_required == true
+	not has_valid_invitation
+}
+
+vetting_satisfied if {
+	input.evidence.vetting.satisfied == true
+	not vetting_invitation_missing
+}
+
+# No vetting is required, or the vetting required is met.
+vetting_ok if not input.evidence.vetting
+
+vetting_ok if vetting_satisfied

--- a/vtc-service/src/ceremony/evaluate.rs
+++ b/vtc-service/src/ceremony/evaluate.rs
@@ -135,6 +135,7 @@ cred_trusted(t) if {
                 thread_id: None,
             },
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: Some(Presentation {
                     verified: true,

--- a/vtc-service/src/ceremony/facts.rs
+++ b/vtc-service/src/ceremony/facts.rs
@@ -216,6 +216,11 @@ pub struct Evidence {
     /// Phase 1; tightened to per-purpose typed requests later.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request: Option<JsonValue>,
+    /// Peer identity vetting evidence — the host's verification and count of
+    /// the vetting statements a join presentation carried, when the criterion
+    /// requires vetting. Absent otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vetting: Option<crate::vetting::VettingFacts>,
 }
 
 /// A verified invitation credential (VIC). All fields are
@@ -407,6 +412,7 @@ mod tests {
                 thread_id: None,
             },
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: Some(Presentation {
                     verified: true,
@@ -478,6 +484,7 @@ mod tests {
                 thread_id: None,
             },
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: None,
                 request: Some(json!({ "fields_requested": ["did", "role", "joined_at"] })),
@@ -546,6 +553,7 @@ mod tests {
                 thread_id: Some("urn:uuid:this-exchange".into()),
             },
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: Some(Presentation {
                     verified: true,

--- a/vtc-service/src/ceremony/invariant.rs
+++ b/vtc-service/src/ceremony/invariant.rs
@@ -159,6 +159,7 @@ mod tests {
                 thread_id: None,
             },
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: None,
                 request: Some(request),

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -153,6 +153,7 @@ async fn assemble_role_change_facts(
                 subject_member.as_ref(),
             )),
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: None,
                 request: Some(json!({ "target_role": target_role, "step_up": step_up })),
@@ -500,6 +501,7 @@ async fn assemble_leave_facts(
             subject_did: subject_did.to_string(),
             subject_member: Some(member_state(subject_role.to_string(), subject_member)),
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: None,
                 request,

--- a/vtc-service/src/join/orchestrate.rs
+++ b/vtc-service/src/join/orchestrate.rs
@@ -38,6 +38,7 @@ use crate::join::{
 };
 use crate::policy::{PolicyPurpose, extract::extract_vp_claims, load_active_compiled};
 use crate::server::AppState;
+use crate::vetting::VettingFacts;
 
 pub const JOIN_REQUEST_SUBMIT_DOMAIN_TAG: &[u8] = b"vtc-join-request/v1\0";
 
@@ -217,7 +218,21 @@ pub async fn submit_inner(
     // No thread: this is a synchronous REST submission, not a trust task
     // exchange. Nothing here can be `sameExchange`, which is the honest answer
     // — there is no exchange to be the same as.
-    let verdict = decide_join(state, &applicant_did, presentation, invitation, None).await?;
+    // Peer vetting: verify and count any identity-vetting statements against the
+    // criterion the applicant gathered for (OpenVTC vetting design §10). `None`
+    // when no published criterion requires vetting.
+    let vetting =
+        crate::vetting::vetting_facts(state, &applicant_did, &vp, &extensions, chrono::Utc::now())
+            .await?;
+    let verdict = decide_join(
+        state,
+        &applicant_did,
+        presentation,
+        invitation,
+        vetting,
+        None,
+    )
+    .await?;
 
     // 6. Realize the verdict (store + audit + auto-admit on allow). On an
     // invitation-driven admit the VIC is burned in the single-use ledger.
@@ -250,10 +265,20 @@ pub async fn decide_join(
     applicant_did: &str,
     presentation: Presentation,
     invitation: Option<Invitation>,
+    vetting: Option<VettingFacts>,
     thread_id: Option<&str>,
 ) -> Result<Verdict, AppError> {
-    let facts =
-        assemble_join_facts(state, applicant_did, presentation, invitation, thread_id).await?;
+    // Kept to expand a generic `vetting` need after the policy decides.
+    let vetting_for_needs = vetting.clone();
+    let facts = assemble_join_facts(
+        state,
+        applicant_did,
+        presentation,
+        invitation,
+        vetting,
+        thread_id,
+    )
+    .await?;
     let verified = VerifiedFacts::assemble(facts)?;
     let policy = load_active_compiled(
         &state.active_policies_ks,
@@ -261,7 +286,11 @@ pub async fn decide_join(
         PolicyPurpose::Join,
     )
     .await?;
-    crate::ceremony::decide(&verified, &policy)
+    let mut verdict = crate::ceremony::decide(&verified, &policy)?;
+    if let Verdict::RequestMore(more) = &mut verdict {
+        crate::vetting::expand_needs(&mut more.needs, vetting_for_needs.as_ref());
+    }
+    Ok(verdict)
 }
 
 /// Realize a join [`Verdict`]: build + persist the [`JoinRequest`], auto-admit on
@@ -467,6 +496,7 @@ async fn assemble_join_facts(
     applicant_did: &str,
     presentation: Presentation,
     invitation: Option<Invitation>,
+    vetting: Option<VettingFacts>,
     thread_id: Option<&str>,
 ) -> Result<Facts, AppError> {
     // The applicant proved holder-binding (route-layer for the VP path,
@@ -483,6 +513,7 @@ async fn assemble_join_facts(
             subject_did: applicant_did.to_string(),
             subject_member: None,
             evidence: Evidence {
+                vetting,
                 invitation,
                 presentation: Some(presentation),
                 request: None,

--- a/vtc-service/src/lib.rs
+++ b/vtc-service/src/lib.rs
@@ -54,6 +54,7 @@ pub mod store;
 pub mod supervisor;
 pub mod transport_capability;
 pub mod trust_tasks;
+pub mod vetting;
 pub mod webauthn;
 pub mod website;
 

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -718,7 +718,7 @@ mod tests {
             "applicant_digest_matches": true,
             "statements": [],
             "distinct_counted_vetters": 2,
-            "by_method": { "in-person": 1, "video": 1 },
+            "by_method": { "inPerson": 1, "video": 1 },
             "commitments_consistent": consistent,
             "independence_ok": independent,
             "invitation_required": false,
@@ -793,7 +793,7 @@ mod tests {
                     "presentation": { "credentials": [
                         { "type": "WitnessCredential", "issuer_trusted": true, "status": "valid" }
                     ]},
-                    "vetting": vetting_facts(true, true, &["vetting:method:in-person:1"]),
+                    "vetting": vetting_facts(true, true, &["vetting:method:inPerson:1"]),
                 }
             })),
             json!({ "effect": "request_more", "with": { "needs": ["vetting"] } }),

--- a/vtc-service/src/policy/default.rs
+++ b/vtc-service/src/policy/default.rs
@@ -698,6 +698,144 @@ mod tests {
         );
     }
 
+    // ── Peer identity vetting (OpenVTC docs/design/vetting-process.md §10) ──
+
+    fn join_decision(input: serde_json::Value) -> serde_json::Value {
+        let c = compile_default(PolicyPurpose::Join);
+        evaluate(&c, "data.vtc.join.decision", input)
+            .unwrap()
+            .pointer("/result/0/expressions/0/value")
+            .cloned()
+            .expect("join decision value")
+    }
+
+    /// Host-assembled vetting facts. `satisfied` is derived here the way the
+    /// host derives it, so no test can hand the policy an impossible state.
+    fn vetting_facts(consistent: bool, independent: bool, needs: &[&str]) -> serde_json::Value {
+        json!({
+            "criterion_id": "kernel-developer",
+            "requirements_digest": "zDigest",
+            "applicant_digest_matches": true,
+            "statements": [],
+            "distinct_counted_vetters": 2,
+            "by_method": { "in-person": 1, "video": 1 },
+            "commitments_consistent": consistent,
+            "independence_ok": independent,
+            "invitation_required": false,
+            "satisfied": consistent && independent && needs.is_empty(),
+            "needs": needs,
+        })
+    }
+
+    fn valid_invitation(scopes: &[&str]) -> serde_json::Value {
+        json!({
+            "verified": true,
+            "issuer": "did:webvh:acme.example",
+            "issuer_trusted": true,
+            "consumed": false,
+            "scopes": scopes,
+        })
+    }
+
+    #[test]
+    fn join_default_admits_when_vetting_is_satisfied() {
+        assert_eq!(
+            join_decision(json!({ "evidence": { "vetting": vetting_facts(true, true, &[]) } })),
+            json!({ "effect": "allow", "with": { "role": "member" } }),
+        );
+    }
+
+    #[test]
+    fn join_default_asks_for_more_vetting_with_the_generic_need() {
+        // The host replaces "vetting" with the precise shortfall after deciding.
+        assert_eq!(
+            join_decision(json!({
+                "evidence": { "vetting": vetting_facts(true, true, &["vetting:statements:1"]) }
+            })),
+            json!({ "effect": "request_more", "with": { "needs": ["vetting"] } }),
+        );
+    }
+
+    #[test]
+    fn join_default_refers_when_vetters_verified_different_identities() {
+        assert_eq!(
+            join_decision(json!({ "evidence": { "vetting": vetting_facts(false, true, &[]) } })),
+            json!({ "effect": "refer", "with": { "queue": "vetting-review" } }),
+        );
+    }
+
+    #[test]
+    fn join_default_refers_when_vetters_are_not_independent() {
+        assert_eq!(
+            join_decision(json!({ "evidence": { "vetting": vetting_facts(true, false, &[]) } })),
+            json!({ "effect": "refer", "with": { "queue": "vetting-review" } }),
+        );
+    }
+
+    #[test]
+    fn join_default_invitation_does_not_bypass_required_vetting() {
+        assert_eq!(
+            join_decision(json!({
+                "evidence": {
+                    "invitation": valid_invitation(&[]),
+                    "vetting": vetting_facts(true, true, &["vetting:statements:2"]),
+                }
+            })),
+            json!({ "effect": "request_more", "with": { "needs": ["vetting"] } }),
+        );
+    }
+
+    #[test]
+    fn join_default_trusted_credential_does_not_bypass_required_vetting() {
+        assert_eq!(
+            join_decision(json!({
+                "evidence": {
+                    "presentation": { "credentials": [
+                        { "type": "WitnessCredential", "issuer_trusted": true, "status": "valid" }
+                    ]},
+                    "vetting": vetting_facts(true, true, &["vetting:method:in-person:1"]),
+                }
+            })),
+            json!({ "effect": "request_more", "with": { "needs": ["vetting"] } }),
+        );
+    }
+
+    #[test]
+    fn join_default_asks_for_a_required_invitation_once_vetting_is_met() {
+        let mut facts = vetting_facts(true, true, &[]);
+        facts["invitation_required"] = json!(true);
+        assert_eq!(
+            join_decision(json!({ "evidence": { "vetting": facts } })),
+            json!({ "effect": "request_more", "with": { "needs": ["vetting:invitation"] } }),
+        );
+    }
+
+    #[test]
+    fn join_default_met_vetting_with_an_invitation_admits_at_the_invited_role() {
+        let mut facts = vetting_facts(true, true, &[]);
+        facts["invitation_required"] = json!(true);
+        assert_eq!(
+            join_decision(json!({
+                "evidence": { "invitation": valid_invitation(&["role:maintainer"]), "vetting": facts }
+            })),
+            json!({ "effect": "allow", "with": { "role": "maintainer" } }),
+        );
+    }
+
+    #[test]
+    fn join_default_without_vetting_facts_is_unchanged() {
+        // A community whose criteria require no vetting keeps the pre-vetting
+        // behaviour exactly: invitation admits, everything else is referred.
+        assert_eq!(
+            join_decision(json!({ "evidence": { "invitation": valid_invitation(&[]) } })),
+            json!({ "effect": "allow", "with": { "role": "member" } }),
+        );
+        assert_eq!(
+            join_decision(json!({ "evidence": {} })),
+            json!({ "effect": "refer", "with": { "queue": "moderator" } }),
+        );
+    }
+
     #[test]
     fn removal_default_allows_admin_removing_member() {
         // The removal default is now the leave-ceremony decision spine:

--- a/vtc-service/src/routes/directory.rs
+++ b/vtc-service/src/routes/directory.rs
@@ -183,6 +183,7 @@ async fn assemble_directory_facts(
             subject_did: subject_did.to_string(),
             subject_member,
             evidence: Evidence {
+                vetting: None,
                 invitation: None,
                 presentation: None,
                 request,

--- a/vtc-service/src/routes/join_requests/present.rs
+++ b/vtc-service/src/routes/join_requests/present.rs
@@ -105,7 +105,17 @@ pub async fn present_and_decide_join(
     // 3 + 4. Decide under the active join policy, then realize the verdict. The
     // credential-exchange path carries no VIC (invitations ride the VP-submit
     // path), so no invitation fact and nothing to consume.
-    let verdict = decide_join(state, &applicant_did, presentation, None, Some(thread_id)).await?;
+    // No vetting facts on this path yet: identity-vetting statements are counted
+    // on the VP-submit path, which is the one the OpenVTC client presents them on.
+    let verdict = decide_join(
+        state,
+        &applicant_did,
+        presentation,
+        None,
+        None,
+        Some(thread_id),
+    )
+    .await?;
     let vp_claims = vp_claims_from_set(&set);
     realize_join_verdict(
         state,

--- a/vtc-service/src/vetting/mod.rs
+++ b/vtc-service/src/vetting/mod.rs
@@ -71,7 +71,7 @@ pub struct VettingFacts {
     pub statements: Vec<VettingStatementFact>,
     /// Distinct eligible vetters counted.
     pub distinct_counted_vetters: u32,
-    /// Counted statements by method (`in-person`, `video`, …).
+    /// Counted statements by method (`inPerson`, `video`, …).
     pub by_method: BTreeMap<String, u32>,
     /// All counted-eligible statements carry one identity commitment.
     pub commitments_consistent: bool,
@@ -98,7 +98,7 @@ pub struct VettingStatementFact {
     pub eligible: bool,
     /// The issuer has withdrawn the statement.
     pub revoked: bool,
-    /// `in-person` / `video` / `prior-acquaintance`.
+    /// `inPerson` / `video` / `priorAcquaintance`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
     /// The vetter's declared relationship to the applicant.
@@ -389,7 +389,7 @@ mod tests {
                     "version": "0.1",
                     "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
                     "minStatements": min,
-                    "acceptedMethods": ["in-person"],
+                    "acceptedMethods": ["inPerson"],
                     "eligibleVetters": { "role": "vetter" }
                 }))
                 .unwrap(),
@@ -442,14 +442,14 @@ mod tests {
     #[test]
     fn a_generic_vetting_need_becomes_the_precise_shortfall() {
         let mut needs = vec!["agreed:code-of-conduct".into(), NEED_VETTING.into()];
-        let f = facts_with_needs(&["vetting:statements:1", "vetting:method:in-person:1"]);
+        let f = facts_with_needs(&["vetting:statements:1", "vetting:method:inPerson:1"]);
         expand_needs(&mut needs, Some(&f));
         assert_eq!(
             needs,
             vec![
                 "agreed:code-of-conduct",
                 "vetting:statements:1",
-                "vetting:method:in-person:1"
+                "vetting:method:inPerson:1"
             ]
         );
     }

--- a/vtc-service/src/vetting/mod.rs
+++ b/vtc-service/src/vetting/mod.rs
@@ -1,0 +1,478 @@
+//! Peer identity vetting, community side: turning the vetting statements a join
+//! presentation carries into the facts `join.rego` decides on.
+//!
+//! Design: OpenVTC `docs/design/vetting-process.md` §10.
+//!
+//! ## What the host establishes, and what policy decides
+//!
+//! The raw submit path verifies the presentation's holder binding and none of
+//! the credentials inside it (see `join::orchestrate::presentation_from_vp`), so
+//! nothing here trusts a statement because it arrived. For each identity-vetting
+//! `EndorsementCredential` in the VP this module:
+//!
+//! 1. verifies it (`vta_sdk::vetting::statement::verify_statement` — proof by
+//!    the issuer, type, bounded window, strict endorsement body);
+//! 2. binds it to the applicant (`credentialSubject.id` = the proven holder);
+//! 3. asks whether the issuer is an **eligible vetter** of this community —
+//!    a current member, holding the role the requirements name, who had
+//!    already joined when they issued the statement;
+//! 4. counts the survivors with `vta_sdk::vetting::requirements::evaluate`, the
+//!    same rule the applicant's client uses for its checklist.
+//!
+//! The result is [`VettingFacts`]. Policy reads `satisfied`,
+//! `commitments_consistent`, `independence_ok` and `needs` and decides; the
+//! host never admits on vetting by itself.
+//!
+//! Independence is established from evidence, not from statements merely being
+//! separately signed (VTI-CMP-070): distinct vetters are distinct *members*.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::warn;
+
+use vta_sdk::protocols::join_requests::ManifestCriterion;
+use vta_sdk::protocols::vetting::{
+    IDENTITY_VETTING_ENDORSEMENT_TYPE, InvitationRequirement, VettingRequirements,
+};
+use vta_sdk::vetting::requirements::{REQUIREMENTS_DIGEST_MEMBER, StatementFacts, evaluate};
+use vta_sdk::vetting::statement::verify_statement;
+use vti_common::error::AppError;
+
+use crate::acl::{VtcRole, get_acl_entry};
+use crate::members::storage::get_member;
+use crate::routes::join_requests::manifest::{ManifestVersion, manifest_criterion};
+use crate::schemas::accepts::list_accepts;
+use crate::server::AppState;
+
+/// The generic need a policy returns when vetting is incomplete. The host
+/// expands it into the precise shortfall ([`expand_needs`]), which a visually
+/// authored policy cannot express because its `with` is static.
+pub const NEED_VETTING: &str = "vetting";
+
+/// The need returned when the requirements demand an invitation and none was
+/// presented.
+pub const NEED_INVITATION: &str = "vetting:invitation";
+
+/// What the host established about the vetting evidence of one join request.
+/// Every member is a host verdict; policy reads it and decides.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VettingFacts {
+    /// The criterion whose requirements were applied.
+    pub criterion_id: String,
+    /// That criterion's current `requirementsDigest`.
+    pub requirements_digest: String,
+    /// The applicant named this digest in its submission — it gathered its
+    /// statements against the requirements as they stand now.
+    pub applicant_digest_matches: bool,
+    /// Every identity-vetting statement the presentation carried.
+    pub statements: Vec<VettingStatementFact>,
+    /// Distinct eligible vetters counted.
+    pub distinct_counted_vetters: u32,
+    /// Counted statements by method (`in-person`, `video`, …).
+    pub by_method: BTreeMap<String, u32>,
+    /// All counted-eligible statements carry one identity commitment.
+    pub commitments_consistent: bool,
+    /// No declared-relationship cap is exceeded.
+    pub independence_ok: bool,
+    /// The requirements demand an invitation credential alongside.
+    pub invitation_required: bool,
+    /// Count, method floors, commitment consistency and independence all hold.
+    pub satisfied: bool,
+    /// What is still missing, in the `vetting:*` wire grammar.
+    pub needs: Vec<String>,
+}
+
+/// One presented statement, as the host saw it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VettingStatementFact {
+    /// The statement `id`, when it could be read.
+    pub id: Option<String>,
+    /// The issuer DID, when it could be read.
+    pub issuer: Option<String>,
+    /// Proof, type, window and body all verified.
+    pub verified: bool,
+    /// The issuer is an eligible vetter of this community.
+    pub eligible: bool,
+    /// The issuer has withdrawn the statement.
+    pub revoked: bool,
+    /// `in-person` / `video` / `prior-acquaintance`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// The vetter's declared relationship to the applicant.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub declared_relationship: Option<String>,
+    /// It counted toward the requirements.
+    pub counted: bool,
+    /// Why it did not count (stable codes).
+    #[serde(default)]
+    pub failures: Vec<String>,
+}
+
+/// Build the vetting facts for a join presentation, or `None` when no
+/// criterion this community publishes requires vetting.
+///
+/// `extensions` is the submission's `extensions` object; an applicant names the
+/// `requirementsDigest` it gathered against there.
+pub async fn vetting_facts(
+    state: &AppState,
+    applicant_did: &str,
+    vp: &JsonValue,
+    extensions: &JsonValue,
+    now: DateTime<Utc>,
+) -> Result<Option<VettingFacts>, AppError> {
+    let mut projected = Vec::new();
+    for stored in list_accepts(&state.schemas_ks).await? {
+        if stored.vetting.is_some() {
+            projected.push(manifest_criterion(stored, ManifestVersion::V0_2)?);
+        }
+    }
+    let applicant_digest = extensions
+        .get(REQUIREMENTS_DIGEST_MEMBER)
+        .and_then(JsonValue::as_str);
+    let Some(selected) = select_criterion(projected, applicant_digest) else {
+        return Ok(None);
+    };
+    let requirements = &selected.requirements;
+
+    let community_did = state
+        .config
+        .read()
+        .await
+        .vtc_did
+        .clone()
+        .unwrap_or_default();
+    let resolver = state.trust_task_vm_resolver();
+
+    let mut to_count = Vec::new();
+    let mut statements = Vec::new();
+    for vc in vetting_credentials(vp) {
+        let id = vc.get("id").and_then(JsonValue::as_str).map(str::to_string);
+        let issuer = issuer_of(vc);
+        let verified = match verify_statement(vc, now, &resolver).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    applicant = %applicant_did,
+                    statement = id.as_deref().unwrap_or("<no id>"),
+                    error = %e,
+                    cause = e.cause().unwrap_or(""),
+                    "vetting statement did not verify — not counted"
+                );
+                statements.push(VettingStatementFact {
+                    id,
+                    issuer,
+                    verified: false,
+                    eligible: false,
+                    revoked: false,
+                    method: None,
+                    declared_relationship: None,
+                    counted: false,
+                    failures: vec!["unverified".into()],
+                });
+                continue;
+            }
+        };
+
+        let endorsement = verified.endorsement();
+        let mut failures = Vec::new();
+        if verified.subject() != applicant_did {
+            failures.push("subject-not-applicant".to_string());
+        }
+        if endorsement.endorsement_type != requirements.statement_type {
+            failures.push("wrong-statement-type".to_string());
+        }
+        let eligible = vetter_eligible(
+            state,
+            verified.issuer(),
+            &requirements.eligible_vetters.role,
+            verified.valid_from(),
+            now,
+        )
+        .await?;
+        // Withdrawal notices are recorded by `vtc/vetting/revoke-statement`;
+        // until that store exists every verified statement reads as standing.
+        let revoked = false;
+
+        let fact = VettingStatementFact {
+            id: Some(verified.id().to_string()),
+            issuer: Some(verified.issuer().to_string()),
+            verified: true,
+            eligible,
+            revoked,
+            method: Some(endorsement.method.as_str().to_string()),
+            declared_relationship: serde_json::to_value(endorsement.declared_relationship)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string)),
+            counted: false,
+            failures,
+        };
+        // A statement about someone else, or of a type this criterion does not
+        // count, is not evidence about this applicant at all — keep it out of the
+        // count *and* out of the commitment-consistency check.
+        if fact.failures.is_empty() {
+            to_count.push(StatementFacts {
+                statement_id: verified.id().to_string(),
+                vetter: verified.issuer().to_string(),
+                method: endorsement.method,
+                claims_verified: endorsement.claims_verified.clone(),
+                document_classes: endorsement.document_classes.clone(),
+                declared_relationship: endorsement.declared_relationship,
+                identity_commitment: endorsement.identity_commitment.clone(),
+                valid_from: verified.valid_from(),
+                community_matches: endorsement.community == community_did,
+                eligible,
+                revoked,
+            });
+        }
+        statements.push(fact);
+    }
+
+    let evaluation = evaluate(requirements, &to_count, now);
+    for fact in &mut statements {
+        let Some(id) = fact.id.as_deref() else {
+            continue;
+        };
+        if evaluation.counted.iter().any(|c| c == id) {
+            fact.counted = true;
+        } else if let Some((_, reasons)) = evaluation.not_counted.iter().find(|(nc, _)| nc == id) {
+            fact.failures
+                .extend(reasons.iter().map(|r| r.code().to_string()));
+        }
+    }
+
+    Ok(Some(VettingFacts {
+        criterion_id: selected.criterion_id,
+        requirements_digest: selected.digest,
+        applicant_digest_matches: selected.applicant_digest_matches,
+        statements,
+        distinct_counted_vetters: u32::try_from(evaluation.distinct_vetters()).unwrap_or(u32::MAX),
+        by_method: evaluation
+            .by_method
+            .iter()
+            .map(|(m, n)| (m.as_str().to_string(), *n))
+            .collect(),
+        commitments_consistent: evaluation.commitments_consistent,
+        independence_ok: evaluation.independence_ok,
+        invitation_required: matches!(
+            requirements.invitation,
+            Some(InvitationRequirement::Required)
+        ),
+        satisfied: evaluation.satisfied(),
+        needs: evaluation.needs.iter().map(|n| n.to_wire()).collect(),
+    }))
+}
+
+/// Replace a policy's generic [`NEED_VETTING`] with the precise shortfall the
+/// facts record. A policy authored in the visual editor can only return a
+/// static `needs` list; this is where it becomes something an applicant can act
+/// on. Leaves `needs` untouched when there are no vetting facts, or when the
+/// facts record no specific shortfall (e.g. only an independence concern).
+pub fn expand_needs(needs: &mut Vec<String>, facts: Option<&VettingFacts>) {
+    let Some(facts) = facts else {
+        return;
+    };
+    if facts.needs.is_empty() {
+        return;
+    }
+    if let Some(pos) = needs.iter().position(|n| n == NEED_VETTING) {
+        needs.splice(pos..=pos, facts.needs.iter().cloned());
+    }
+}
+
+/// The criterion a submission is evaluated under.
+#[derive(Debug, Clone, PartialEq)]
+struct Selected {
+    criterion_id: String,
+    requirements: VettingRequirements,
+    digest: String,
+    applicant_digest_matches: bool,
+}
+
+/// Pick the criterion: the one whose current digest the applicant named, else
+/// the first vetting criterion (criteria are listed in id order). A community
+/// with more than one vetting criterion should expect applicants to name one.
+fn select_criterion(
+    projected: Vec<ManifestCriterion>,
+    applicant_digest: Option<&str>,
+) -> Option<Selected> {
+    let named = applicant_digest.and_then(|d| {
+        projected
+            .iter()
+            .position(|c| c.requirements_digest.as_deref() == Some(d))
+    });
+    let (index, matches) = match named {
+        Some(i) => (i, true),
+        None => (0, false),
+    };
+    let chosen = projected.into_iter().nth(index)?;
+    Some(Selected {
+        criterion_id: chosen.id,
+        requirements: chosen.vetting?,
+        digest: chosen.requirements_digest.unwrap_or_default(),
+        applicant_digest_matches: matches,
+    })
+}
+
+/// Identity-vetting endorsement credentials in a VP's `verifiableCredential`.
+fn vetting_credentials(vp: &JsonValue) -> impl Iterator<Item = &JsonValue> {
+    vp.get("verifiableCredential")
+        .and_then(JsonValue::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|vc| {
+            vc.pointer("/credentialSubject/endorsement/type")
+                .and_then(JsonValue::as_str)
+                == Some(IDENTITY_VETTING_ENDORSEMENT_TYPE)
+        })
+}
+
+fn issuer_of(vc: &JsonValue) -> Option<String> {
+    match vc.get("issuer")? {
+        JsonValue::String(s) => Some(s.clone()),
+        JsonValue::Object(o) => o.get("id")?.as_str().map(str::to_string),
+        _ => None,
+    }
+}
+
+/// Is `issuer` an eligible vetter: a current member holding `role`, whose
+/// membership predates the statement, and whose ACL entry has not lapsed.
+///
+/// "Held the role when they issued it" is approximated by "holds it now and had
+/// joined by then": the ACL keeps no role history. A vetter demoted after
+/// issuing therefore stops counting, which errs toward not admitting.
+async fn vetter_eligible(
+    state: &AppState,
+    issuer: &str,
+    role: &str,
+    issued_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<bool, AppError> {
+    let Some(member) = get_member(&state.members_ks, issuer).await? else {
+        return Ok(false);
+    };
+    if member.removed_at.is_some() || member.joined_at > issued_at {
+        return Ok(false);
+    }
+    let Some(acl) = get_acl_entry(&state.acl_ks, issuer).await? else {
+        return Ok(false);
+    };
+    if acl
+        .expires_at
+        .is_some_and(|exp| i64::try_from(exp).unwrap_or(i64::MAX) <= now.timestamp())
+    {
+        return Ok(false);
+    }
+    Ok(role_matches(&acl.role, role))
+}
+
+/// A requirements `role` of `vetter` names the custom role `custom:vetter`; the
+/// wire form itself is accepted too, as are the standard role names.
+fn role_matches(held: &VtcRole, required: &str) -> bool {
+    held.to_string() == required || matches!(held, VtcRole::Custom(name) if name == required)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn criterion(id: &str, min: u32) -> ManifestCriterion {
+        ManifestCriterion {
+            id: id.into(),
+            description: None,
+            presentation_definition: json!({}),
+            vetting: Some(
+                serde_json::from_value(json!({
+                    "version": "0.1",
+                    "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                    "minStatements": min,
+                    "acceptedMethods": ["in-person"],
+                    "eligibleVetters": { "role": "vetter" }
+                }))
+                .unwrap(),
+            ),
+            requirements_digest: Some(format!("z{id}")),
+        }
+    }
+
+    #[test]
+    fn the_criterion_the_applicant_named_is_the_one_applied() {
+        let s = select_criterion(vec![criterion("a", 1), criterion("b", 2)], Some("zb")).unwrap();
+        assert_eq!(s.criterion_id, "b");
+        assert!(s.applicant_digest_matches);
+        assert_eq!(s.requirements.min_statements, 2);
+    }
+
+    #[test]
+    fn an_unknown_or_absent_digest_falls_back_to_the_first_and_says_so() {
+        let s = select_criterion(vec![criterion("a", 1), criterion("b", 2)], Some("zold")).unwrap();
+        assert_eq!(s.criterion_id, "a");
+        assert!(!s.applicant_digest_matches);
+        assert!(select_criterion(vec![], Some("za")).is_none());
+    }
+
+    #[test]
+    fn role_names_match_in_both_spellings() {
+        let vetter = VtcRole::Custom("vetter".into());
+        assert!(role_matches(&vetter, "vetter"));
+        assert!(role_matches(&vetter, "custom:vetter"));
+        assert!(role_matches(&VtcRole::Moderator, "moderator"));
+        assert!(!role_matches(&VtcRole::Member, "vetter"));
+    }
+
+    fn facts_with_needs(needs: &[&str]) -> VettingFacts {
+        VettingFacts {
+            criterion_id: "a".into(),
+            requirements_digest: "za".into(),
+            applicant_digest_matches: true,
+            statements: vec![],
+            distinct_counted_vetters: 1,
+            by_method: BTreeMap::new(),
+            commitments_consistent: true,
+            independence_ok: true,
+            invitation_required: false,
+            satisfied: false,
+            needs: needs.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn a_generic_vetting_need_becomes_the_precise_shortfall() {
+        let mut needs = vec!["agreed:code-of-conduct".into(), NEED_VETTING.into()];
+        let f = facts_with_needs(&["vetting:statements:1", "vetting:method:in-person:1"]);
+        expand_needs(&mut needs, Some(&f));
+        assert_eq!(
+            needs,
+            vec![
+                "agreed:code-of-conduct",
+                "vetting:statements:1",
+                "vetting:method:in-person:1"
+            ]
+        );
+    }
+
+    #[test]
+    fn needs_are_left_alone_without_facts_or_a_specific_shortfall() {
+        let mut needs = vec![NEED_VETTING.to_string()];
+        expand_needs(&mut needs, None);
+        assert_eq!(needs, vec![NEED_VETTING]);
+        expand_needs(&mut needs, Some(&facts_with_needs(&[])));
+        assert_eq!(needs, vec![NEED_VETTING]);
+    }
+
+    #[test]
+    fn only_identity_vetting_endorsements_are_picked_out_of_a_presentation() {
+        let vp = json!({
+            "verifiableCredential": [
+                { "credentialSubject": { "endorsement": { "type": IDENTITY_VETTING_ENDORSEMENT_TYPE } } },
+                { "credentialSubject": { "endorsement": { "type": "SkillEndorsement" } } },
+                { "type": ["VerifiableCredential", "InvitationCredential"] },
+                "eyJhbGciOi.jwt.vc"
+            ]
+        });
+        assert_eq!(vetting_credentials(&vp).count(), 1);
+    }
+}

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1974,7 +1974,7 @@ async fn store_vetting_criterion(fix: &Fixture) {
                     "version": "0.1",
                     "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
                     "minStatements": 2,
-                    "acceptedMethods": ["in-person", "video"],
+                    "acceptedMethods": ["inPerson", "video"],
                     "requiredClaims": ["name.legal"],
                     "eligibleVetters": { "role": "vetter" },
                     "independence": { "requireConsistentIdentityCommitment": true }

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1917,6 +1917,211 @@ async fn manifest_0_2_advertises_vetting_requirements_and_their_digest() {
 }
 
 // ---------------------------------------------------------------------------
+// Peer identity vetting — statements counted at submit (OpenVTC vetting design §10)
+// ---------------------------------------------------------------------------
+
+/// A `did:key` secret from a fixed seed, as `signed_trust_task_seed` builds one.
+fn did_key_secret(seed: [u8; 32]) -> (String, Secret) {
+    let mut secret = Secret::generate_ed25519(None, Some(&seed));
+    let pub_mb = secret.get_public_keymultibase().expect("pubkey multibase");
+    let did = format!("did:key:{pub_mb}");
+    secret.id = format!("{did}#{pub_mb}");
+    (did, secret)
+}
+
+/// A community member holding `role`, admitted a month ago.
+async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
+    let mut member = vtc_service::members::Member::fresh(did);
+    member.joined_at = chrono::Utc::now() - chrono::Duration::days(30);
+    vtc_service::members::storage::store_member(&fix.members_ks, &member)
+        .await
+        .expect("store member");
+    store_acl_entry(
+        &fix.acl_ks,
+        &VtcAclEntry {
+            did: did.into(),
+            role,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: ADMIN_DID.into(),
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("store acl");
+}
+
+/// Two distinct eligible vetters, video or in person, `name.legal` verified.
+async fn store_vetting_criterion(fix: &Fixture) {
+    use vtc_service::schemas::accepts::{AcceptsCriterion, store_accepts};
+    store_accepts(
+        &fix.state.schemas_ks,
+        &AcceptsCriterion {
+            id: "kernel-developer".into(),
+            query: json!({
+                "credentials": [{
+                    "id": "vetting",
+                    "format": "ldp_vc",
+                    "meta": { "type_values": ["EndorsementCredential"] }
+                }]
+            }),
+            description: Some("Two vetters".into()),
+            vetting: Some(
+                serde_json::from_value(json!({
+                    "version": "0.1",
+                    "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                    "minStatements": 2,
+                    "acceptedMethods": ["in-person", "video"],
+                    "requiredClaims": ["name.legal"],
+                    "eligibleVetters": { "role": "vetter" },
+                    "independence": { "requireConsistentIdentityCommitment": true }
+                }))
+                .unwrap(),
+            ),
+            created_at: chrono::Utc::now(),
+            created_by_did: ADMIN_DID.into(),
+        },
+    )
+    .await
+    .expect("store vetting criterion");
+}
+
+/// A Vetting Statement signed by `vetter` about `applicant`.
+async fn vetting_statement(vetter: &Secret, applicant: &str, n: u8) -> Value {
+    use vta_sdk::protocols::vetting::{
+        DeclaredRelationship, IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement,
+        VettingMethod,
+    };
+    use vta_sdk::vetting::statement::{StatementDraft, sign_statement};
+    let now = chrono::Utc::now();
+    sign_statement(
+        StatementDraft {
+            id: format!("urn:uuid:statement-{n}"),
+            issuer: vetter.id.split('#').next().unwrap().to_string(),
+            subject: applicant.to_string(),
+            endorsement: IdentityVettingEndorsement {
+                endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
+                community: vtc_service::test_support::TEST_VTC_DID.into(),
+                method: VettingMethod::Video,
+                document_classes: vec!["passport".into()],
+                claims_verified: vec!["name.legal".into()],
+                liveness_confirmed: true,
+                identity_commitment: "zSameIdentity".into(),
+                card_digest_multibase: format!("zCard{n}"),
+                declared_relationship: DeclaredRelationship::None,
+                attestation_text_digest: None,
+            },
+            valid_from: now - chrono::Duration::minutes(5),
+            valid_until: now + chrono::Duration::days(90),
+            task_context: format!("urn:uuid:session-{n}"),
+        },
+        vetter,
+    )
+    .await
+    .expect("sign vetting statement")
+}
+
+fn vetting_vp(applicant: &str, statements: Vec<Value>) -> Value {
+    json!({
+        "type": "VerifiablePresentation",
+        "holder": applicant,
+        "verifiableCredential": statements,
+    })
+}
+
+#[tokio::test]
+async fn vetted_applicant_with_two_eligible_vetters_is_admitted() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    let (dave, dave_key) = did_key_secret([0x22; 32]);
+    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
+    seed_member(&fix, &dave, VtcRole::Custom("vetter".into())).await;
+
+    let vp = vetting_vp(
+        &applicant,
+        vec![
+            vetting_statement(&carol_key, &applicant, 1).await,
+            vetting_statement(&dave_key, &applicant, 2).await,
+        ],
+    );
+    let (_did, doc) = submit_doc(&vp).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(verdict_effect(&body), "allow", "got {body}");
+    assert!(
+        get_member(&fix.members_ks, &applicant)
+            .await
+            .unwrap()
+            .is_some(),
+        "an allowed vetted join admits the applicant"
+    );
+}
+
+#[tokio::test]
+async fn one_statement_short_asks_for_exactly_what_is_missing() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
+
+    let vp = vetting_vp(
+        &applicant,
+        vec![vetting_statement(&carol_key, &applicant, 1).await],
+    );
+    let (_did, doc) = submit_doc(&vp).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    // The wire spells the effect lowerCamelCase; Rego authors it `request_more`.
+    assert_eq!(verdict_effect(&body), "requestMore", "got {body}");
+    assert_eq!(
+        body.pointer("/payload/verdict/with/needs"),
+        Some(&json!(["vetting:statements:1"])),
+        "the host expands the policy's generic need into the shortfall: {body}"
+    );
+    assert!(
+        get_member(&fix.members_ks, &applicant)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn a_statement_from_a_member_who_is_not_a_vetter_does_not_count() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    let (erin, erin_key) = did_key_secret([0x33; 32]);
+    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
+    seed_member(&fix, &erin, VtcRole::Member).await;
+
+    let vp = vetting_vp(
+        &applicant,
+        vec![
+            vetting_statement(&carol_key, &applicant, 1).await,
+            vetting_statement(&erin_key, &applicant, 2).await,
+        ],
+    );
+    let (_did, doc) = submit_doc(&vp).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    // The wire spells the effect lowerCamelCase; Rego authors it `request_more`.
+    assert_eq!(verdict_effect(&body), "requestMore", "got {body}");
+    assert_eq!(
+        body.pointer("/payload/verdict/with/needs"),
+        Some(&json!(["vetting:statements:1"])),
+        "{body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Status — applicant poll (join-requests/status/1.0)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Stacked on #1426.

The community now **counts presented vetting statements when it decides a join**. Before this, join policy had no way to see them. This is the decision half of vetted admission (OpenVTC `docs/design/vetting-process.md` §10).

## What the host establishes

The raw submit path verifies the VP's holder binding and none of the credentials inside it, so nothing here trusts a statement just because it arrived. `vtc-service/src/vetting/mod.rs` checks each identity-vetting `EndorsementCredential` in the join VP:

1. **Verifies it** with `vta_sdk::vetting::statement::verify_statement`: proof by the issuer, credential type, bounded validity and a strict endorsement body. Proofs by a `did:webvh` issuer resolve through the VTC's DID cache (`AppState::trust_task_vm_resolver`).
2. **Binds it to the applicant:** the statement's subject must be the proven holder.
3. **Checks vetter eligibility:** the issuer is a current member holding the role `eligibleVetters.role` names (`vetter` matches `custom:vetter`), had joined before issuing, and has an ACL entry that hasn't lapsed.
4. **Counts the survivors** with `vta_sdk::vetting::requirements::evaluate`, the same rule the applicant's client uses for its checklist. Distinct vetters are distinct *members* (VTI-CMP-070).

The criterion applied is the one whose current `requirementsDigest` the applicant sent in `extensions`; failing that, the first vetting criterion. The result goes to the join policy as `input.evidence.vetting`: per-statement verdicts with stable failure codes, counts, `commitments_consistent`, `independence_ok`, `satisfied` and `needs`.

## What the default policy decides

When vetting is required, **neither an invitation nor a trusted credential bypasses it**. There are four mutually exclusive vetting outcomes:

| Facts | Verdict |
|---|---|
| Vetters verified different identity commitments | `refer` → `vetting-review` |
| Still short | `request_more`, needs `["vetting"]` |
| Enough, but a relationship cap is exceeded | `refer` → `vetting-review` |
| Met, but an invitation is required and absent | `request_more`, needs `["vetting:invitation"]` |

With vetting met, the request is admitted as `member`, or at the invited role if a valid invitation is present. With no vetting facts, the default behaves exactly as before; a test pins that.

**The needs string.** A visually authored policy has a static `with`, so it can only say `needs: ["vetting"]`. After `decide`, `decide_join` expands that into the precise shortfall, e.g. `vetting:statements:1`. That is what the applicant's status poll then shows.

**Visual editor.** The admin console's rule-IR catalogue (`admin-ui/src/lib/rule-ir.ts`) gains the matching conditions:
- `vetting_inconsistent`
- `vetting_incomplete`
- `vetting_not_independent`
- `vetting_invitation_missing`
- `vetting_satisfied`
- `vetting_ok`

Each comes with its helper Rego and a client-side mirror. The default `join.rego`'s `@vtc-rule-ir` header is regenerated from those routes, so the editor renders it and can recompile it.

## Also

- **`Evidence` gains a `vetting` slot.** The other eight constructors pass `None`.
- **Credential-exchange `present` path:** passes no vetting facts yet; this is recorded in the operator doc's limits.
- **New operator guide:** `docs/03-vtc/vetting.md` covers registering the type and a criterion, naming vetters, what is checked, and the default decisions and limits.

## Tests

- **`vetting::tests`:** criterion selection by digest and fallback, role spellings, needs expansion, and statement pick-out.
- **`policy::default::tests`:** each vetting outcome; an invitation and a trusted credential each fail to bypass required vetting; a required invitation is asked for once vetting is met; an invited role holds with vetting met; behaviour without vetting facts is unchanged.
- **`tests/join_requests.rs`**, end to end over `POST /v1/trust-tasks` with real signed statements:
  - two eligible vetters → `allow` and the applicant is admitted;
  - one statement → `requestMore` on the wire (`request_more` in Rego), with needs exactly `["vetting:statements:1"]`;
  - a statement from a member without the vetter role doesn't count.
- **Local runs:** the full `vtc-service` lib suite (981 passed), `join_requests`, `openapi_snapshot`, `trust_task_manifest`, `cargo clippy -p vtc-service --all-targets -D warnings`, `cargo fmt --check`, and `tsc -b --noEmit` for the console.

## Known limits (V0, documented)

- **Role history:** "held the vetter role when issuing" is approximated by "holds it now and had joined by then". The ACL keeps no role history, so a demoted vetter's statements stop counting.
- **Withdrawn statements:** `revoked` is always `false` until the revocation-notice change later in this stack.
- **`requirementsGrace`:** not yet applied. `applicant_digest_matches: false` is surfaced so a policy can act on it.
