### PR TITLE
feat(vtc): let a vetter withdraw a vetting statement

### DIFF
--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -135,6 +135,23 @@ under the same names.
 
 Without vetting facts the default behaves exactly as before.
 
+## Withdrawing a statement
+
+A vetter withdraws a statement they issued with
+`vtc/vetting/revoke-statement/0.1`:
+
+```json
+{ "statementId": "urn:uuid:…", "statementDigestMultibase": "z…", "reason": "mistake" }
+```
+
+The sender must be a member. The notice is keyed by the **authenticated sender**,
+the statement id and the statement digest (compared on its decoded bytes), and
+counts only against a presented statement with all three — so a notice can
+only ever withdraw a statement its sender signed. A withdrawn statement reads as
+`revoked` and fails with `revoked` in `input.evidence.vetting.statements`.
+Repeating a notice returns the original `recordedAt`. The first notice is
+audited as `VettingStatementRevoked`, and notices are part of a backup.
+
 ## Current limits
 
 - Statements are counted on the VP-submit path. The credential-exchange
@@ -144,8 +161,9 @@ Without vetting facts the default behaves exactly as before.
   statements stop counting.
 - Distinct vetters are distinct member DIDs; one person holding two member DIDs
   would count twice.
-- Statement withdrawal (`vtc/vetting/revoke-statement/0.1`) is recorded by the
-  next change in this series; until then `revoked` is always `false`.
+- Withdrawal notices are kept indefinitely — there is no retention sweep yet.
+- A withdrawal after admission is recorded and audited but does not yet open a
+  review of the membership it helped grant.
 - `requirementsGrace` is not yet applied: an application gathered against
   superseded requirements is evaluated under the current ones, with
   `applicant_digest_matches: false` for a policy to act on.

--- a/vtc-service/src/backup.rs
+++ b/vtc-service/src/backup.rs
@@ -361,6 +361,7 @@ fn backed_up_handle<'a>(state: &'a AppState, name: &str) -> Option<&'a KeyspaceH
         x if x == ENDORSEMENT_TYPES => &state.endorsement_types_ks,
         x if x == SCHEMAS => &state.schemas_ks,
         x if x == ENDORSEMENTS => &state.endorsements_ks,
+        x if x == VETTING_REVOCATIONS => &state.vetting_revocations_ks,
         // A room's records are backed up like any other community state. On a
         // sealed tier they are ciphertext this service cannot read, and that is
         // no reason to skip them: the host is trusted for availability

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -34,6 +34,7 @@ use vta_sdk::protocols::join_requests::{
 use vta_sdk::protocols::members::{
     MEMBER_VMC_RESPONSE_TYPE, MEMBER_VMC_TYPE, MemberVmcBody, MemberVmcReceiptBody,
 };
+use vta_sdk::protocols::vetting::VETTING_REVOKE_STATEMENT_TYPE;
 use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, problem_report_codes as codes};
 
 use crate::ceremony::remove_inner;
@@ -721,6 +722,9 @@ async fn route(msg: &Message, auth_sender: Option<String>, state: &AppState) -> 
         JOIN_REQUEST_STATUS_TYPE => join_request_status_handler(msg, auth_sender, state).await,
         MEMBER_SELF_REMOVE_TYPE => member_self_remove_handler(msg, auth_sender, state).await,
         MEMBER_VMC_TYPE => member_vmc_handler(msg, auth_sender, state).await,
+        VETTING_REVOKE_STATEMENT_TYPE => {
+            vetting_revoke_statement_handler(msg, auth_sender, state).await
+        }
         CREDENTIAL_REQUEST_TYPE => credential_request_handler(msg, state).await,
         CREDENTIAL_PRESENT_TYPE => credential_present_handler(msg, state).await,
         _ => unhandled_message(msg),
@@ -1124,6 +1128,26 @@ async fn member_self_remove_handler(
 /// VMC. [`receive_member_vmc_inner`](crate::members::inbound_vmc::receive_member_vmc_inner)
 /// verifies the issuer / subject binding + the DI proof and stores it on the
 /// member row. Replies with a receipt, or a threaded problem-report on failure.
+/// `vtc/vetting/revoke-statement/0.1` over DIDComm. The authcrypt sender is the
+/// proven vetter; the document dispatcher does the rest, exactly as over REST.
+async fn vetting_revoke_statement_handler(
+    msg: &Message,
+    auth_sender: Option<String>,
+    state: &AppState,
+) -> Option<Reply> {
+    let thid = msg.id.clone();
+    let Some(vetter_did) = auth_sender else {
+        return Some(unauthorized_reply(thid));
+    };
+    let body = match inbound_doc_bytes(msg) {
+        Ok(b) => b,
+        Err(e) => return Some(problem_report(thid, codes::INTERNAL, e)),
+    };
+    let ctx = JoinAuthCtx::didcomm(vetter_did);
+    let outcome = dispatch_trust_task_core(state, &ctx, &body).await;
+    tt_didcomm_reply(outcome, thid)
+}
+
 async fn member_vmc_handler(
     msg: &Message,
     auth_sender: Option<String>,

--- a/vtc-service/src/server.rs
+++ b/vtc-service/src/server.rs
@@ -107,6 +107,9 @@ pub struct AppState {
     /// Operator-uploaded endorsement type registry (Phase 4
     /// M4.8.0). Only registered types are issuable.
     pub endorsement_types_ks: KeyspaceHandle,
+    /// Vetting statement withdrawal notices, keyed by issuer + statement id +
+    /// digest (`crate::vetting::revocation`).
+    pub vetting_revocations_ks: KeyspaceHandle,
     /// Credential-type schema store (Phase 2 task 2.2): the Issues / Accepts
     /// registry binding each type to a DTG catalog type + JSON Schema.
     pub schemas_ks: KeyspaceHandle,
@@ -456,6 +459,7 @@ pub async fn run(
     let relationships_ks = store.keyspace(keyspaces::RELATIONSHIPS)?;
     let relationships_by_did_ks = store.keyspace(keyspaces::RELATIONSHIPS_BY_DID)?;
     let endorsement_types_ks = store.keyspace(keyspaces::ENDORSEMENT_TYPES)?;
+    let vetting_revocations_ks = store.keyspace(keyspaces::VETTING_REVOCATIONS)?;
     let schemas_ks = store.keyspace(keyspaces::SCHEMAS)?;
     // Seed the schema store with the built-in catalog Issues types (idempotent;
     // never overwrites operator edits) so the registry reflects what the VTC
@@ -729,6 +733,7 @@ pub async fn run(
         relationships_ks,
         relationships_by_did_ks,
         endorsement_types_ks,
+        vetting_revocations_ks,
         schemas_ks,
         endorsements_ks,
         rooms_ks,

--- a/vtc-service/src/store/keyspaces.rs
+++ b/vtc-service/src/store/keyspaces.rs
@@ -73,6 +73,10 @@ pub const INVITATIONS: &str = "invitations";
 /// `Guaranteed` sends so delivery-critical work survives a restart.
 /// Ephemeral, re-driven from live state — excluded from backup.
 pub const OUTBOX: &str = "outbox";
+/// Vetting statement withdrawal notices (`vtc/vetting/revoke-statement/0.1`):
+/// one row per (issuer, statement id, statement digest), written when a vetter
+/// withdraws a statement and read whenever presented statements are counted.
+pub const VETTING_REVOCATIONS: &str = "vetting_revocations";
 
 /// Every keyspace the daemon opens, in `AppState` field order. The
 /// setup wizard pre-creates exactly this set; `server::run` opens
@@ -106,6 +110,7 @@ pub const ALL: &[&str] = &[
     CONSUMED_INVITATIONS,
     INVITATIONS,
     OUTBOX,
+    VETTING_REVOCATIONS,
 ];
 
 /// Keyspaces captured by `POST /v1/backup/export` (P3.9). These hold
@@ -146,6 +151,9 @@ pub const BACKED_UP: &[&str] = &[
     // Issued-invitation registry — durable so revocation + listing
     // survive a restore.
     INVITATIONS,
+    // A withdrawn vetting statement must stay withdrawn across a restore, or a
+    // restored community would count a statement its vetter took back.
+    VETTING_REVOCATIONS,
 ];
 
 /// Keyspaces deliberately omitted from backup (P3.9): ephemeral auth,
@@ -175,7 +183,7 @@ mod tests {
     /// keyspace is added to one without the other, this trips.
     #[test]
     fn all_matches_app_state_keyspace_count() {
-        assert_eq!(ALL.len(), 28, "ALL must list every AppState keyspace");
+        assert_eq!(ALL.len(), 29, "ALL must list every AppState keyspace");
     }
 
     /// The backup census (P3.9): every keyspace is either backed up or

--- a/vtc-service/src/test_support.rs
+++ b/vtc-service/src/test_support.rs
@@ -226,6 +226,9 @@ impl TestVtcBuilder {
         let endorsement_types_ks = store
             .keyspace("endorsement_types")
             .expect("endorsement_types ks");
+        let vetting_revocations_ks = store
+            .keyspace("vetting_revocations")
+            .expect("vetting_revocations ks");
         let schemas_ks = store.keyspace("schemas").expect("schemas ks");
         let endorsements_ks = store.keyspace("endorsements").expect("endorsements ks");
         let rooms_ks = store.keyspace("rooms").expect("rooms ks");
@@ -360,6 +363,7 @@ impl TestVtcBuilder {
             relationships_ks,
             relationships_by_did_ks,
             endorsement_types_ks,
+            vetting_revocations_ks,
             schemas_ks,
             endorsements_ks,
             rooms_ks,

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -62,6 +62,9 @@ use vta_sdk::protocols::join_requests::{
     self as jr, JoinRequestStatusBody, JoinRequestSubmitBody, VerdictResponse,
 };
 use vta_sdk::protocols::members::{self as mem, MemberVmcBody, MemberVmcReceiptBody};
+use vta_sdk::protocols::vetting::{
+    self as vetting_wire, RevokeStatementBody, RevokeStatementResponseBody,
+};
 
 use vti_rooms::wire as rooms_wire;
 
@@ -227,6 +230,9 @@ async fn dispatch_typed(
         jr::JOIN_REQUEST_STATUS_TYPE => handle_status(state, ctx, doc).await,
         jr::MEMBER_SELF_REMOVE_TYPE => handle_self_remove(state, ctx, doc).await,
         mem::MEMBER_VMC_TYPE => handle_member_vmc(state, ctx, doc).await,
+        vetting_wire::VETTING_REVOKE_STATEMENT_TYPE => {
+            handle_revoke_statement(state, ctx, doc).await
+        }
         // The rooms family. Note what these do not take: no `ctx`, and no auth claims.
         // A room operation is authorized by the authority chain the room itself issued,
         // never by this service's ACL, roster, or the caller's session — invariant I5 of
@@ -365,6 +371,8 @@ pub(crate) const DISPATCHED_URIS: &[&str] = &[
     jr::JOIN_REQUEST_STATUS_TYPE,
     jr::MEMBER_SELF_REMOVE_TYPE,
     mem::MEMBER_VMC_TYPE,
+    // A vetter withdrawing a statement (OpenVTC vetting design §9.6).
+    vetting_wire::VETTING_REVOKE_STATEMENT_TYPE,
     PERSONHOOD_CHALLENGE_TYPE,
     PERSONHOOD_ASSERT_TYPE,
     // rooms/* — top-level, not `spec/vtc/*`: a room's protocol is host-neutral, so
@@ -525,6 +533,38 @@ fn outcome_to_verdict(outcome: &JoinSubmitOutcome) -> Result<VerdictResponse, Ap
         ),
     };
     Ok(verdict)
+}
+
+// ─── vetting statement withdrawal ──────────────────────────────────────────
+
+/// `vtc/vetting/revoke-statement/0.1` — a vetter withdraws a statement.
+///
+/// The sender is the proven signer (REST document proof or DIDComm authcrypt).
+/// What a notice may do, and who may send one, is decided in
+/// [`crate::vetting::revocation::withdraw`].
+async fn handle_revoke_statement(
+    state: &AppState,
+    ctx: &JoinAuthCtx,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let vetter_did = match resolve_holder(state, ctx, &doc).await {
+        Ok(did) => did,
+        Err(reject) => return reject,
+    };
+    let body: RevokeStatementBody = match parse_payload(&doc) {
+        Ok(b) => b,
+        Err(reject) => return reject,
+    };
+    match crate::vetting::revocation::withdraw(state, &vetter_did, &body).await {
+        Ok(notice) => success_response(
+            &doc,
+            RevokeStatementResponseBody {
+                recorded_at: notice.recorded_at,
+                ext: None,
+            },
+        ),
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
 }
 
 // ─── manifest (public) ─────────────────────────────────────────────────────
@@ -937,6 +977,7 @@ mod tests {
             jr::JOIN_REQUEST_STATUS_TYPE,
             jr::MEMBER_SELF_REMOVE_TYPE,
             mem::MEMBER_VMC_TYPE,
+            vetting_wire::VETTING_REVOKE_STATEMENT_TYPE,
             <pc::Payload as trust_tasks_rs::Payload>::TYPE_URI,
             <pa::Payload as trust_tasks_rs::Payload>::TYPE_URI,
         ];

--- a/vtc-service/src/vetting/mod.rs
+++ b/vtc-service/src/vetting/mod.rs
@@ -26,6 +26,8 @@
 //! Independence is established from evidence, not from statements merely being
 //! separately signed (VTI-CMP-070): distinct vetters are distinct *members*.
 
+pub mod revocation;
+
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
@@ -192,9 +194,16 @@ pub async fn vetting_facts(
             now,
         )
         .await?;
-        // Withdrawal notices are recorded by `vtc/vetting/revoke-statement`;
-        // until that store exists every verified statement reads as standing.
-        let revoked = false;
+        // A withdrawal notice counts only against a statement with the notice's
+        // own issuer, id and digest, so nobody can withdraw a statement they did
+        // not sign.
+        let revoked = revocation::is_revoked(
+            &state.vetting_revocations_ks,
+            verified.issuer(),
+            verified.id(),
+            verified.digest_multibase(),
+        )
+        .await?;
 
         let fact = VettingStatementFact {
             id: Some(verified.id().to_string()),

--- a/vtc-service/src/vetting/revocation.rs
+++ b/vtc-service/src/vetting/revocation.rs
@@ -1,0 +1,277 @@
+//! Withdrawal of vetting statements (`vtc/vetting/revoke-statement/0.1`).
+//!
+//! OpenVTC vetting design §9.6. A vetter who made a mistake, learned something
+//! new, or lost control of their key tells the community — the one party that
+//! relies on the statement — directly. The VTA's own `credentials/revoke` only
+//! marks its local record, so without this nothing a verifier reads would
+//! change.
+//!
+//! ## What a notice can do
+//!
+//! A notice is keyed by **issuer + statement id + statement digest** and counts
+//! only against a presented statement with all three. The issuer half is the
+//! authenticated sender, never a member of the body, so a notice can withdraw
+//! only a statement its sender signed: a notice about someone else's statement
+//! is recorded under the wrong issuer and matches nothing. The digest half
+//! binds it to one credential rather than to an id another credential could
+//! reuse, and is compared on its decoded bytes, as DTG Credentials requires.
+//!
+//! Only members may send one. Vetters are members, and it keeps the store from
+//! being a sink anyone who can reach the service can write to.
+//!
+//! Recording converges: a repeated notice returns the time the first was
+//! recorded and writes nothing.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::info;
+
+use vta_sdk::protocols::vetting::{RevocationReason, RevokeStatementBody};
+use vti_common::audit::{AuditEvent, VettingStatementRevokedData};
+use vti_common::error::AppError;
+use vti_common::store::KeyspaceHandle;
+
+use crate::members::storage::get_member;
+use crate::server::AppState;
+
+/// Domain separation for notice keys.
+const KEY_DOMAIN: &[u8] = b"vtc-vetting-revocation/v1\0";
+
+/// A recorded withdrawal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationNotice {
+    /// The vetter who withdrew it — the authenticated sender.
+    pub issuer: String,
+    /// The statement's `id`.
+    pub statement_id: String,
+    /// The statement's `digestMultibase`, as sent.
+    pub statement_digest_multibase: String,
+    /// The vetter's reason, when given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<RevocationReason>,
+    /// When the first notice was recorded.
+    pub recorded_at: DateTime<Utc>,
+}
+
+/// The storage key: a domain-separated hash over the issuer, the statement id,
+/// and the digest's algorithm and decoded bytes — two encodings of one digest
+/// are one key.
+fn notice_key(
+    issuer: &str,
+    statement_id: &str,
+    digest_multibase: &str,
+) -> Result<String, AppError> {
+    let (algorithm, digest) = dtg_credentials::decode_digest_multibase(digest_multibase)
+        .map_err(|e| AppError::Validation(format!("statementDigestMultibase: {e}")))?;
+    let mut hasher = Sha256::new();
+    hasher.update(KEY_DOMAIN);
+    hasher.update(issuer.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(statement_id.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(algorithm.to_be_bytes());
+    hasher.update(&digest);
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Has `issuer` withdrawn the statement with this id and digest?
+///
+/// A digest that does not decode cannot name a notice, so it reads as not
+/// withdrawn; statements reaching this have been verified, and their digest is
+/// computed here rather than taken from the wire.
+pub async fn is_revoked(
+    ks: &KeyspaceHandle,
+    issuer: &str,
+    statement_id: &str,
+    digest_multibase: &str,
+) -> Result<bool, AppError> {
+    let Ok(key) = notice_key(issuer, statement_id, digest_multibase) else {
+        return Ok(false);
+    };
+    Ok(ks.get_raw(key.as_bytes()).await?.is_some())
+}
+
+/// Record a notice from `issuer`, or return the one already recorded. The
+/// boolean is `true` when this call wrote it.
+pub async fn record(
+    ks: &KeyspaceHandle,
+    issuer: &str,
+    body: &RevokeStatementBody,
+    now: DateTime<Utc>,
+) -> Result<(RevocationNotice, bool), AppError> {
+    if body.statement_id.trim().is_empty() {
+        return Err(AppError::Validation("statementId is empty".into()));
+    }
+    let key = notice_key(issuer, &body.statement_id, &body.statement_digest_multibase)?;
+    if let Some(bytes) = ks.get_raw(key.as_bytes()).await? {
+        let existing = serde_json::from_slice(&bytes)
+            .map_err(|e| AppError::Internal(format!("revocation notice decode: {e}")))?;
+        return Ok((existing, false));
+    }
+    let notice = RevocationNotice {
+        issuer: issuer.to_string(),
+        statement_id: body.statement_id.clone(),
+        statement_digest_multibase: body.statement_digest_multibase.clone(),
+        reason: body.reason,
+        recorded_at: now,
+    };
+    ks.insert(key, &notice).await?;
+    Ok((notice, true))
+}
+
+/// Handle a withdrawal from `vetter_did`, the authenticated sender: refuse a
+/// non-member, record the notice, and audit it the first time.
+pub async fn withdraw(
+    state: &AppState,
+    vetter_did: &str,
+    body: &RevokeStatementBody,
+) -> Result<RevocationNotice, AppError> {
+    if get_member(&state.members_ks, vetter_did).await?.is_none() {
+        return Err(AppError::Forbidden(
+            "only a member of this community can withdraw a vetting statement".into(),
+        ));
+    }
+    let (notice, created) =
+        record(&state.vetting_revocations_ks, vetter_did, body, Utc::now()).await?;
+    if created {
+        if let Some(writer) = state.audit_writer.as_ref() {
+            writer
+                .write(
+                    vetter_did,
+                    None,
+                    AuditEvent::VettingStatementRevoked(VettingStatementRevokedData {
+                        statement_id: notice.statement_id.clone(),
+                        statement_digest_multibase: notice.statement_digest_multibase.clone(),
+                        reason: notice
+                            .reason
+                            .and_then(|r| serde_json::to_value(r).ok())
+                            .and_then(|v| v.as_str().map(str::to_string)),
+                    }),
+                )
+                .await?;
+        }
+        info!(statement = %notice.statement_id, "vetting statement withdrawn");
+    }
+    Ok(notice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use vti_common::config::StoreConfig;
+    use vti_common::store::Store;
+
+    async fn ks() -> (tempfile::TempDir, Store, KeyspaceHandle) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(&StoreConfig {
+            data_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+        let ks = store.keyspace("vetting_revocations").unwrap();
+        (dir, store, ks)
+    }
+
+    fn body(id: &str, digest: &str) -> RevokeStatementBody {
+        RevokeStatementBody {
+            statement_id: id.into(),
+            statement_digest_multibase: digest.into(),
+            reason: Some(RevocationReason::Mistake),
+            ext: None,
+        }
+    }
+
+    fn digest_of(v: serde_json::Value) -> String {
+        dtg_credentials::digest_multibase_json(&v).unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_notice_withdraws_only_its_own_issuers_statement() {
+        let (_d, _s, ks) = ks().await;
+        let digest = digest_of(json!({ "statement": 1 }));
+        record(
+            &ks,
+            "did:key:zCarol",
+            &body("urn:uuid:s1", &digest),
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            is_revoked(&ks, "did:key:zCarol", "urn:uuid:s1", &digest)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !is_revoked(&ks, "did:key:zMallory", "urn:uuid:s1", &digest)
+                .await
+                .unwrap(),
+            "a notice is keyed by its sender — it cannot reach another issuer's statement"
+        );
+        let other = digest_of(json!({ "statement": 2 }));
+        assert!(
+            !is_revoked(&ks, "did:key:zCarol", "urn:uuid:s1", &other)
+                .await
+                .unwrap(),
+            "a different credential reusing the id is not withdrawn"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeating_a_notice_converges_on_the_first() {
+        let (_d, _s, ks) = ks().await;
+        let digest = digest_of(json!({ "statement": 1 }));
+        let first_time = Utc::now() - chrono::Duration::hours(1);
+        let (first, created) = record(
+            &ks,
+            "did:key:zCarol",
+            &body("urn:uuid:s1", &digest),
+            first_time,
+        )
+        .await
+        .unwrap();
+        assert!(created);
+        let (again, created) = record(
+            &ks,
+            "did:key:zCarol",
+            &body("urn:uuid:s1", &digest),
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+        assert!(!created);
+        assert_eq!(again.recorded_at, first.recorded_at);
+    }
+
+    #[tokio::test]
+    async fn a_malformed_digest_is_refused_and_names_nothing() {
+        let (_d, _s, ks) = ks().await;
+        let err = record(
+            &ks,
+            "did:key:zCarol",
+            &body("urn:uuid:s1", "not-multibase"),
+            Utc::now(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(
+            !is_revoked(&ks, "did:key:zCarol", "urn:uuid:s1", "not-multibase")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_statement_id_is_refused() {
+        let (_d, _s, ks) = ks().await;
+        let digest = digest_of(json!({ "statement": 1 }));
+        assert!(matches!(
+            record(&ks, "did:key:zCarol", &body("  ", &digest), Utc::now()).await,
+            Err(AppError::Validation(_))
+        ));
+    }
+}

--- a/vtc-service/src/vetting/revocation.rs
+++ b/vtc-service/src/vetting/revocation.rs
@@ -101,9 +101,8 @@ pub async fn record(
     body: &RevokeStatementBody,
     now: DateTime<Utc>,
 ) -> Result<(RevocationNotice, bool), AppError> {
-    if body.statement_id.trim().is_empty() {
-        return Err(AppError::Validation("statementId is empty".into()));
-    }
+    body.check_shape()
+        .map_err(|e| AppError::Validation(e.to_string()))?;
     let key = notice_key(issuer, &body.statement_id, &body.statement_digest_multibase)?;
     if let Some(bytes) = ks.get_raw(key.as_bytes()).await? {
         let existing = serde_json::from_slice(&bytes)

--- a/vtc-service/tests/emergency_bootstrap.rs
+++ b/vtc-service/tests/emergency_bootstrap.rs
@@ -323,6 +323,7 @@ async fn build_fixture(public_url: Option<&str>) -> Fixture {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        vetting_revocations_ks: store.keyspace("vetting_revocations").unwrap(),
         schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         rooms_ks: rooms_ks.clone(),

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -2121,6 +2121,92 @@ async fn a_statement_from_a_member_who_is_not_a_vetter_does_not_count() {
     );
 }
 
+#[tokio::test]
+async fn a_withdrawn_statement_stops_counting() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    let (dave, dave_key) = did_key_secret([0x22; 32]);
+    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
+    seed_member(&fix, &dave, VtcRole::Custom("vetter".into())).await;
+    let from_carol = vetting_statement(&carol_key, &applicant, 1).await;
+    let from_dave = vetting_statement(&dave_key, &applicant, 2).await;
+
+    let (status, body) = post_tt(&fix.router, withdrawal_doc([0x11; 32], &from_carol).await).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert!(tt_payload(&body)["recordedAt"].is_string(), "{body}");
+
+    let (_did, doc) = submit_doc(&vetting_vp(&applicant, vec![from_carol, from_dave])).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(verdict_effect(&body), "requestMore", "got {body}");
+    assert_eq!(
+        body.pointer("/payload/verdict/with/needs"),
+        Some(&json!(["vetting:statements:1"])),
+        "the withdrawn statement no longer counts: {body}"
+    );
+}
+
+#[tokio::test]
+async fn nobody_can_withdraw_a_statement_someone_else_signed() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    let (dave, dave_key) = did_key_secret([0x22; 32]);
+    let (erin, _) = did_key_secret([0x33; 32]);
+    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
+    seed_member(&fix, &dave, VtcRole::Custom("vetter".into())).await;
+    seed_member(&fix, &erin, VtcRole::Member).await;
+    let from_carol = vetting_statement(&carol_key, &applicant, 1).await;
+    let from_dave = vetting_statement(&dave_key, &applicant, 2).await;
+
+    // Erin is a member, so the notice is accepted — and recorded under Erin,
+    // where it matches no statement Erin signed.
+    let (status, body) = post_tt(&fix.router, withdrawal_doc([0x33; 32], &from_carol).await).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+
+    let (_did, doc) = submit_doc(&vetting_vp(&applicant, vec![from_carol, from_dave])).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(
+        verdict_effect(&body),
+        "allow",
+        "Carol's statement still counts: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_non_member_cannot_send_a_withdrawal() {
+    let fix = build_fixture().await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (_carol, carol_key) = did_key_secret([0x11; 32]);
+    let statement = vetting_statement(&carol_key, &applicant, 1).await;
+    let (status, body) = post_tt(&fix.router, withdrawal_doc([0x44; 32], &statement).await).await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "a stranger's notice must be refused: {body}"
+    );
+}
+
+/// A `vtc/vetting/revoke-statement/0.1` document for `statement`, signed by `seed`.
+async fn withdrawal_doc(seed: [u8; 32], statement: &Value) -> Value {
+    let digest = dtg_credentials::digest_multibase_json(statement).expect("statement digest");
+    let (_did, doc) = signed_trust_task_seed(
+        &seed,
+        vta_sdk::protocols::vetting::VETTING_REVOKE_STATEMENT_TYPE,
+        json!({
+            "statementId": statement["id"],
+            "statementDigestMultibase": digest,
+            "reason": "mistake",
+        }),
+    )
+    .await;
+    doc
+}
+
 // ---------------------------------------------------------------------------
 // Status — applicant poll (join-requests/status/1.0)
 // ---------------------------------------------------------------------------

--- a/vtc-service/tests/passkey_state.rs
+++ b/vtc-service/tests/passkey_state.rs
@@ -98,6 +98,7 @@ fn build_state(public_url: Option<&str>) -> (AppState, tempfile::TempDir) {
         relationships_ks: relationships_ks.clone(),
         relationships_by_did_ks: relationships_by_did_ks.clone(),
         endorsement_types_ks: endorsement_types_ks.clone(),
+        vetting_revocations_ks: store.keyspace("vetting_revocations").unwrap(),
         schemas_ks: store.keyspace("schemas").unwrap(),
         endorsements_ks: endorsements_ks.clone(),
         rooms_ks: rooms_ks.clone(),

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -369,6 +369,11 @@ pub enum AuditEvent {
     /// status-list audit surface stays uniform.
     CustomEndorsementRevoked(CustomEndorsementRevokedData),
 
+    /// A vetter withdrew a vetting statement they had issued
+    /// (`vtc/vetting/revoke-statement/0.1`). The actor is the vetter; the
+    /// statement stops counting toward any join decided after this.
+    VettingStatementRevoked(VettingStatementRevokedData),
+
     /// An operator registered a new custom endorsement type
     /// via `POST /v1/endorsement-types`. Phase 4 M4.8.1 (D4
     /// review). The actor is the admin; the `type_uri` field
@@ -535,6 +540,7 @@ impl AuditEvent {
             Self::PersonhoodRevoked(..) => "PersonhoodRevoked",
             Self::CustomEndorsementIssued(..) => "CustomEndorsementIssued",
             Self::CustomEndorsementRevoked(..) => "CustomEndorsementRevoked",
+            Self::VettingStatementRevoked(..) => "VettingStatementRevoked",
             Self::EndorsementTypeRegistered(..) => "EndorsementTypeRegistered",
             Self::EndorsementTypeDeleted(..) => "EndorsementTypeDeleted",
             Self::WebsiteFileWritten(..) => "WebsiteFileWritten",
@@ -1335,6 +1341,21 @@ pub struct CustomEndorsementIssuedData {
 pub struct CustomEndorsementRevokedData {
     pub endorsement_id: String,
     pub endorsement_type: String,
+}
+
+/// Payload for [`AuditEvent::VettingStatementRevoked`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VettingStatementRevokedData {
+    /// The withdrawn statement's `id`.
+    pub statement_id: String,
+    /// Its `digestMultibase`, so the record names one credential, not an id
+    /// another credential could reuse.
+    pub statement_digest_multibase: String,
+    /// The vetter's stated reason (`mistake`, `new-information`,
+    /// `key-compromise`, `other`), when given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Payload for [`AuditEvent::EndorsementTypeRegistered`].
@@ -2515,6 +2536,14 @@ mod tests {
                     endorsement_type: "https://x/v1/t".into(),
                 }),
                 "CustomEndorsementRevoked",
+            ),
+            (
+                AuditEvent::VettingStatementRevoked(VettingStatementRevokedData {
+                    statement_id: "urn:uuid:statement".into(),
+                    statement_digest_multibase: "zQmStatement".into(),
+                    reason: Some("mistake".into()),
+                }),
+                "VettingStatementRevoked",
             ),
             (
                 AuditEvent::EndorsementTypeRegistered(EndorsementTypeRegisteredData {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -51,9 +51,9 @@ pub use event::{
     PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
     RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
     RoomOperationData, SchemaChangeData, SessionRevokedData, SignedOutData, StatusListFlippedData,
-    VpcAnnotationData, VrcLifecycleData, VrcPublishedData, VrcRevokedData, VrcSupersededData,
-    WebsiteBundleDeployedData, WebsiteFileDeletedData, WebsiteFileWrittenData,
-    WebsiteGenerationRolledBackData,
+    VettingStatementRevokedData, VpcAnnotationData, VrcLifecycleData, VrcPublishedData,
+    VrcRevokedData, VrcSupersededData, WebsiteBundleDeployedData, WebsiteFileDeletedData,
+    WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
Stacked on #1427.

A vetter can now **withdraw a vetting statement** they issued, and a withdrawn statement stops counting. This implements OpenVTC `docs/design/vetting-process.md` §9.6 (decision D18).

## Why here, and not a status list

The VTA's `credentials/revoke` only marks its local record, so nothing a verifier reads would change. A status list per vetter would also be a poor fit: one holding a handful of one vetter's statements gives no herd privacy (VTI-CRD-011/012).

The party that relies on a statement is the community, so the vetter tells the community directly. VTA-hosted status lists shared across issuers remain the V1 answer, for when statements have to be checked outside their community.

## What it does

- **Trust Task:** `vtc/vetting/revoke-statement/0.1` is served over the document endpoint, DIDComm and TSP. The payload is `{statementId, statementDigestMultibase, reason?}` and the response is `{recordedAt}`.
- **Who can withdraw what:** a notice is keyed by the **authenticated sender**, the statement id and the digest, and counts only against a presented statement with all three.
  - So a notice can only ever withdraw a statement its sender signed. A notice about someone else's statement is recorded under the wrong issuer and matches nothing; a test pins this.
  - The digest is compared on its decoded bytes (`dtg_credentials::decode_digest_multibase`), as DTG Credentials requires.
- **Senders must be members.** Vetters are members, and this keeps the store from becoming a sink anyone on the network can write to.
- **Idempotent:** a repeated notice returns the original `recordedAt` and writes nothing.
- **Audited:** the first recording writes a new `AuditEvent::VettingStatementRevoked` (vti-common; the enum is `#[non_exhaustive]`, so this isn't breaking). The actor is the vetter, and the payload carries the statement id, digest and reason.
- **Durable:** notices get a new `vetting_revocations` keyspace, which is **backed up**. A withdrawn statement must stay withdrawn across a restore. It is added to `ALL`, `BACKED_UP`, `backed_up_handle`, `AppState` and the test fixture, with the keyspace and backup censuses updated.
- **Counted:** `vetting_facts` now reads `revoked` from the store in place of the placeholder `false`. The existing counting rule already refuses a revoked statement, reporting `revoked`.

## Tests

- **`vetting::revocation::tests`:**
  - a notice withdraws only its own issuer's statement, and not a different credential reusing the id;
  - repeating a notice keeps the first recording time;
  - a malformed digest is refused and names nothing;
  - an empty id is refused.
- **`tests/join_requests.rs`**, end to end:
  - Carol withdraws her statement, and the application drops to `requestMore` / `vetting:statements:1`;
  - a notice from Erin about Carol's statement changes nothing, and the application is still `allow`;
  - a non-member's notice is refused.
- **Censuses:** the vti-common audit event census includes the new variant; the keyspace count moves 28 → 29; the backup partition and handle census, the dispatcher census and `trust_task_manifest` all pass. The `spec/vtc/vetting/` unpublished count stays 1, since it's the same URI.

## Not in this PR (documented in `docs/03-vtc/vetting.md`)

- **No retention sweep:** notices are kept indefinitely.
- **No post-admission review:** a withdrawal after admission is recorded and audited, but doesn't open a review of the membership it helped grant. That arrives with the lineage/cascade-review work in V1.
