### PR TITLE
feat(vtc): name vetters with a revocable vetter role credential

### DIFF
--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -69,10 +69,45 @@ unchanged.
 
 ### 3. Name your vetters
 
-A vetter is a **member holding the role `eligibleVetters.role` names**. For
-`"vetter"`, grant the custom role `custom:vetter` through the usual ACL role
-change. `"custom:vetter"` in the requirements is accepted too, as are the
-standard role names.
+A vetter is a **member the community has named a vetter**. An admin does it
+from the member's page in the admin console ("Grant vetter role"), or with
+`vtc/vetting/vetters/grant/0.1` — `POST /v1/vetting/vetters` over REST, or the
+same Trust Task document over DIDComm or TSP:
+
+```json
+{ "memberDid": "did:…", "validitySeconds": 31536000 }
+```
+
+The community issues the member a **vetter role credential**: an
+`EndorsementCredential` with endorsement
+`{ "type": "CommunityRole", "role": "vetter", "communityDid": "did:…" }`, a
+`credentialStatus` on the community's revocation list, and a validity of one
+year unless `validitySeconds` (one day to two years) says otherwise. It records
+the grant, delivers the credential to the member, and answers with the grant:
+
+```json
+{ "endorsementId": "…", "credentialId": "urn:uuid:…",
+  "validFrom": "…", "validUntil": "…" }
+```
+
+Only an admin may grant, and only to a current member. Granting again while the
+member holds a live grant returns that grant. A grant is audited as
+`VetterGranted`, with a `VecIssued` for the credential.
+
+The vetter shows the credential to applicants: it answers a
+`vetting/request/0.1` with an `eligibilityVp`, a presentation whose `nonce` is
+the request's `id` and whose `domain` is the request's `joinDid`. The
+applicant's client checks it with
+`vta_sdk::vetting::eligibility::verify_eligibility_vp` — the presentation
+answers its own request and holds a role credential this community signed for
+that vetter — so the applicant knows before any session that the vetter's
+statement will count.
+
+`eligibleVetters.role` names the grant: `"vetter"`, or `"custom:vetter"`.
+
+To withdraw a vetter, revoke the grant like any endorsement: "Revoke vetter
+role" in the console, or `DELETE /v1/credentials/endorsements/{endorsementId}`
+(`vtc/endorsements/revoke/0.1`). A member's grants are revoked when they leave.
 
 ## What the community checks at submit
 
@@ -84,7 +119,7 @@ For every identity-vetting statement in the join presentation
 | Proof by the issuer, type, bounded validity, strict endorsement body | `unverified` |
 | Subject is the proven holder of the presentation | `subject-not-applicant` |
 | Endorsement type is the criterion's `statementType` | `wrong-statement-type` |
-| Issuer is a current member with the vetter role, who had joined before issuing, with an unexpired ACL entry | `issuer-not-vetter` |
+| Issuer is a current member, admitted before issuing, holding a vetter grant recorded by the statement's `validFrom`, unexpired then, and not revoked | `issuer-not-vetter` |
 | Statement is for this community | `wrong-community` |
 | Method accepted; required claims verified; within `maxStatementAge`; documentation within any floor | `method-not-accepted`, `claim-not-verified`, `too-old`, `documentation-not-accepted` |
 | One statement per vetter (the most recent) | `same-vetter` |
@@ -156,9 +191,16 @@ audited as `VettingStatementRevoked`, and notices are part of a backup.
 
 - Statements are counted on the VP-submit path. The credential-exchange
   `present` path does not count them yet.
-- "Held the vetter role when issuing" is approximated by "holds it now and had
-  joined by then" — the ACL keeps no role history, so a demoted vetter's
-  statements stop counting.
+- A grant's revocation is read as it stands at submit, not as it stood when a
+  statement was signed: withdrawing a vetter stops every statement they signed
+  counting, including those signed while the grant stood. That errs toward not
+  admitting.
+- The applicant-side eligibility check verifies the vetter role credential but
+  leaves its status list to the caller; a revoked grant is always caught at the
+  community.
+- Delivering the credential to the member is best effort. The community's
+  record is what counts statements, so a vetter whose wallet missed it is still
+  counted; revoke and grant again to re-issue it.
 - Distinct vetters are distinct member DIDs; one person holding two member DIDs
   would count twice.
 - Withdrawal notices are kept indefinitely — there is no retention sweep yet.

--- a/vta-sdk/src/protocols/vetting.rs
+++ b/vta-sdk/src/protocols/vetting.rs
@@ -10,6 +10,14 @@
 //! | `spec/vetting/session/0.1` | vetter → applicant | [`VettingSessionBody`] → [`VettingSessionResponseBody`] |
 //! | `spec/vetting/decline/0.1` | vetter → applicant | [`VettingDeclineBody`] |
 //! | `spec/vtc/vetting/revoke-statement/0.1` | vetter → community | [`RevokeStatementBody`] → [`RevokeStatementResponseBody`] |
+//! | `spec/vtc/vetting/vetters/grant/0.1` | community admin → community | [`VetterGrantBody`] → [`VetterGrantResponseBody`] |
+//!
+//! A vetter is named by a **vetter role credential**: a DTG
+//! `EndorsementCredential` the community issues to the member, with endorsement
+//! `{ type: "CommunityRole", role: "vetter", communityDid }` and a
+//! `credentialStatus` so it can be revoked. The community counts a statement
+//! only from a vetter whose grant it recorded; the vetter presents the same
+//! credential to an applicant (`crate::vetting::eligibility`).
 //!
 //! The Vetting Statement itself travels over the existing
 //! `credential-exchange/issue/0.1`. It is a DTG `EndorsementCredential` whose
@@ -63,6 +71,33 @@ pub const VETTING_REVOKE_STATEMENT_TYPE: &str =
 /// `#response` variant of [`VETTING_REVOKE_STATEMENT_TYPE`].
 pub const VETTING_REVOKE_STATEMENT_RESPONSE_TYPE: &str =
     "https://trusttasks.org/spec/vtc/vetting/revoke-statement/0.1#response";
+/// Community admin → community: name a member as a vetter by issuing them a
+/// revocable vetter role credential.
+pub const VETTING_VETTER_GRANT_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+/// `#response` variant of [`VETTING_VETTER_GRANT_TYPE`].
+pub const VETTING_VETTER_GRANT_RESPONSE_TYPE: &str =
+    "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1#response";
+
+/// `credentialSubject.endorsement.type` of a community role credential — the
+/// role VEC a community issues to a member.
+pub const COMMUNITY_ROLE_ENDORSEMENT_TYPE: &str = "CommunityRole";
+/// The role a vetter role credential names, and the conventional
+/// `eligibleVetters.role`.
+pub const VETTER_ROLE: &str = "vetter";
+
+/// Does a held role name satisfy a required one?
+///
+/// `vetter` and `custom:vetter` are the same role in either direction: the
+/// requirements name it bare, while a VTC's ACL spells a custom role with the
+/// prefix. Every other role must match exactly.
+#[must_use]
+pub fn role_matches(held: &str, required: &str) -> bool {
+    fn bare(role: &str) -> &str {
+        role.strip_prefix("custom:").unwrap_or(role)
+    }
+    held == required || (bare(held) == VETTER_ROLE && bare(required) == VETTER_ROLE)
+}
 
 /// `endorsement.type` of a Vetting Statement.
 pub const IDENTITY_VETTING_ENDORSEMENT_TYPE: &str =
@@ -754,6 +789,54 @@ pub struct RevokeStatementResponseBody {
 }
 
 // ---------------------------------------------------------------------------
+// vtc/vetting/vetters/grant/0.1
+// ---------------------------------------------------------------------------
+
+/// Shortest vetter grant a community may issue: one day.
+pub const MIN_VETTER_GRANT_VALIDITY_SECONDS: u64 = 86_400;
+/// Longest vetter grant a community may issue: two years.
+pub const MAX_VETTER_GRANT_VALIDITY_SECONDS: u64 = 2 * 365 * 86_400;
+/// A grant's validity when the request names none: one year.
+pub const DEFAULT_VETTER_GRANT_VALIDITY_SECONDS: u64 = 365 * 86_400;
+
+/// `vtc/vetting/vetters/grant/0.1` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VetterGrantBody {
+    /// The member to name as a vetter.
+    pub member_did: String,
+    /// How long the grant is valid, from one day to two years; one year when
+    /// absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validity_seconds: Option<u64>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+/// `vtc/vetting/vetters/grant/0.1#response` payload.
+///
+/// Granting converges: while a grant is live and unexpired, asking again
+/// returns it rather than issuing a second.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VetterGrantResponseBody {
+    /// The community's record of the grant — the id its revocation names.
+    pub endorsement_id: String,
+    /// The vetter role credential's `id`.
+    pub credential_id: String,
+    /// The credential's `validFrom`.
+    pub valid_from: DateTime<Utc>,
+    /// The credential's `validUntil`.
+    pub valid_until: DateTime<Utc>,
+    /// Ecosystem-defined extension members (SPEC §4.5.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
 // Shape checks for the remaining payloads
 // ---------------------------------------------------------------------------
 
@@ -871,6 +954,29 @@ impl RevokeStatementBody {
     /// [`ShapeError`] for the first rule broken.
     pub fn check_shape(&self) -> Result<(), ShapeError> {
         shape::statement_id("statementId", &self.statement_id)
+    }
+}
+
+impl VetterGrantBody {
+    /// Check the schema's bounds and patterns.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] for the first rule broken.
+    pub fn check_shape(&self) -> Result<(), ShapeError> {
+        shape::did("memberDid", &self.member_did)?;
+        match self.validity_seconds {
+            Some(s)
+                if !(MIN_VETTER_GRANT_VALIDITY_SECONDS..=MAX_VETTER_GRANT_VALIDITY_SECONDS)
+                    .contains(&s) =>
+            {
+                Err(ShapeError::Field {
+                    field: "validitySeconds",
+                    rule: "must be between one day and two years",
+                })
+            }
+            _ => Ok(()),
+        }
     }
 }
 
@@ -1049,6 +1155,78 @@ mod shape {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn the_vetter_role_matches_in_both_spellings_and_nothing_else_does() {
+        assert!(role_matches("vetter", "vetter"));
+        assert!(role_matches("custom:vetter", "vetter"));
+        assert!(role_matches("vetter", "custom:vetter"));
+        assert!(role_matches("custom:vetter", "custom:vetter"));
+        assert!(role_matches("moderator", "moderator"));
+        assert!(!role_matches("custom:moderator", "moderator"));
+        assert!(!role_matches("member", "vetter"));
+        assert!(!role_matches("vetters", "vetter"));
+    }
+
+    #[test]
+    fn a_vetter_grant_is_camel_case_and_closed() {
+        let body: VetterGrantBody = serde_json::from_value(json!({
+            "memberDid": "did:key:zCarol",
+            "validitySeconds": 86_400
+        }))
+        .unwrap();
+        body.check_shape().unwrap();
+        assert!(
+            serde_json::from_value::<VetterGrantBody>(json!({
+                "memberDid": "did:key:zCarol",
+                "role": "admin"
+            }))
+            .is_err(),
+            "the grant names no role: it only ever names a vetter"
+        );
+
+        let response = VetterGrantResponseBody {
+            endorsement_id: "e".into(),
+            credential_id: "urn:uuid:e".into(),
+            valid_from: Utc::now(),
+            valid_until: Utc::now(),
+            ext: None,
+        };
+        let v = serde_json::to_value(&response).unwrap();
+        assert!(v["endorsementId"].is_string() && v["validUntil"].is_string());
+    }
+
+    #[test]
+    fn a_vetter_grant_is_bounded() {
+        let grant = |did: &str, validity: Option<u64>| VetterGrantBody {
+            member_did: did.into(),
+            validity_seconds: validity,
+            ext: None,
+        };
+        assert!(grant("did:key:zCarol", None).check_shape().is_ok());
+        assert!(grant("carol", None).check_shape().is_err());
+        assert!(
+            grant(
+                "did:key:zCarol",
+                Some(MIN_VETTER_GRANT_VALIDITY_SECONDS - 1)
+            )
+            .check_shape()
+            .is_err()
+        );
+        assert!(
+            grant("did:key:zCarol", Some(MAX_VETTER_GRANT_VALIDITY_SECONDS))
+                .check_shape()
+                .is_ok()
+        );
+        assert!(
+            grant(
+                "did:key:zCarol",
+                Some(MAX_VETTER_GRANT_VALIDITY_SECONDS + 1)
+            )
+            .check_shape()
+            .is_err()
+        );
+    }
 
     fn requirements() -> VettingRequirements {
         serde_json::from_value(json!({

--- a/vta-sdk/src/vetting/eligibility.rs
+++ b/vta-sdk/src/vetting/eligibility.rs
@@ -1,0 +1,618 @@
+//! A vetter proving to an applicant that the community named them a vetter.
+//!
+//! A community names a vetter by issuing them a **vetter role credential**: a
+//! DTG `EndorsementCredential` with endorsement
+//! `{ type: "CommunityRole", role: "vetter", communityDid }`, signed by the
+//! community and carrying a `credentialStatus`. The community counts
+//! statements against its own record of the grant; an applicant, who holds no
+//! such record, is shown the credential instead.
+//!
+//! The vetter answers an applicant's `vetting/request/0.1` with a Verifiable
+//! Presentation of it, carried as `eligibilityVp` on the `#response` — before
+//! any session exists (dtgwg-trust-tasks-tf `specs/vetting/request/0.1`,
+//! rule 5). The presentation is bound to that request: `nonce` is the request
+//! document's `id`, and `domain` is the request's `joinDid` — the applicant.
+//! The vetter signs it with `authentication` ([`build_eligibility_vp`]). The
+//! applicant checks that the presentation answers its own request, that its
+//! holder is the vetter it asked, and that the community signed a role
+//! credential for exactly that vetter, for exactly that community, in the role
+//! the requirements name ([`verify_eligibility_vp`]).
+//!
+//! What this does **not** establish: that the grant has not been revoked.
+//! Status-list resolution needs the network and a fetch profile, so it is left
+//! to the caller, who gets the `credentialStatus` from
+//! [`VerifiedEligibility::credential_status`]. A revoked grant also stops the
+//! vetter's statements counting at the community, which is the check that
+//! decides admission.
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions, crypto_suites::CryptoSuite};
+use affinidi_secrets_resolver::secrets::Secret;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::card::CLOCK_SKEW;
+use super::{VettingError, did_of, verify_attached_proof};
+use crate::protocols::vetting::{COMMUNITY_ROLE_ENDORSEMENT_TYPE, role_matches};
+use crate::trust_task_proof::TrustTaskVmResolver;
+
+const VP_WHAT: &str = "eligibility presentation";
+const VEC_WHAT: &str = "vetter role credential";
+
+/// The presentation's proof purpose: the holder authenticates to the applicant.
+pub const ELIGIBILITY_PROOF_PURPOSE: &str = "authentication";
+
+/// The role credential's proof purpose: the community asserts the grant.
+const ROLE_CREDENTIAL_PROOF_PURPOSE: &str = "assertionMethod";
+
+const VC_CONTEXT_V2: &str = "https://www.w3.org/ns/credentials/v2";
+
+/// `(communityDid, role)` of a community role credential, or `None` when
+/// `credential` is not one.
+///
+/// Reads the shape only — nothing here is verified. Use it to pick candidates
+/// out of a wallet before presenting them.
+#[must_use]
+pub fn community_role(credential: &Value) -> Option<(String, String)> {
+    let is_endorsement = match credential.get("type")? {
+        Value::String(t) => t == "EndorsementCredential",
+        Value::Array(types) => types
+            .iter()
+            .any(|t| t.as_str() == Some("EndorsementCredential")),
+        _ => false,
+    };
+    if !is_endorsement {
+        return None;
+    }
+    let endorsement = credential.pointer("/credentialSubject/endorsement")?;
+    if endorsement.get("type")?.as_str()? != COMMUNITY_ROLE_ENDORSEMENT_TYPE {
+        return None;
+    }
+    Some((
+        endorsement.get("communityDid")?.as_str()?.to_string(),
+        endorsement.get("role")?.as_str()?.to_string(),
+    ))
+}
+
+/// Present `credentials` to an applicant, bound to the request being answered.
+///
+/// `challenge` becomes the presentation's `nonce` and must be the `id` of the
+/// applicant's `vetting/request` document; `domain` must be that request's
+/// `joinDid`, the applicant. The holder is the DID of `holder`'s key.
+///
+/// # Errors
+///
+/// [`VettingError::WrongSigner`] if no DID can be read from `holder`'s id, or
+/// [`VettingError::Sign`].
+pub async fn build_eligibility_vp(
+    holder: &Secret,
+    credentials: Vec<Value>,
+    challenge: &str,
+    domain: &str,
+) -> Result<Value, VettingError> {
+    let holder_did = did_of(&holder.id);
+    if holder_did.len() <= "did:".len() || !holder_did.starts_with("did:") {
+        return Err(VettingError::WrongSigner {
+            what: VP_WHAT,
+            role: "holder",
+        });
+    }
+    let mut vp = json!({
+        "@context": [VC_CONTEXT_V2],
+        "type": ["VerifiablePresentation"],
+        "holder": holder_did,
+        "verifiableCredential": credentials,
+        "nonce": challenge,
+        "domain": domain,
+    });
+    let proof = DataIntegrityProof::sign(
+        &vp,
+        holder,
+        SignOptions::new()
+            .with_proof_purpose(ELIGIBILITY_PROOF_PURPOSE)
+            .with_cryptosuite(CryptoSuite::EddsaJcs2022),
+    )
+    .await
+    .map_err(|e| VettingError::Sign(e.to_string()))?;
+    vp.as_object_mut()
+        .expect("presentation is an object")
+        .insert(
+            "proof".into(),
+            serde_json::to_value(proof).map_err(|e| VettingError::Sign(e.to_string()))?,
+        );
+    Ok(vp)
+}
+
+/// What the applicant expects an eligibility presentation to prove.
+#[derive(Debug, Clone, Copy)]
+pub struct EligibilityExpectations<'a> {
+    /// The vetter the request was sent to.
+    pub vetter: &'a str,
+    /// The community the applicant is joining.
+    pub community: &'a str,
+    /// `eligibleVetters.role` from the community's requirements.
+    pub role: &'a str,
+    /// The `id` of the applicant's `vetting/request` document, which the
+    /// presentation's `nonce` must carry.
+    pub challenge: &'a str,
+    /// The applicant's `joinDid` from that request, which the presentation's
+    /// `domain` must carry.
+    pub domain: &'a str,
+    /// Verification time.
+    pub now: DateTime<Utc>,
+}
+
+/// A role credential that makes the presenting vetter eligible.
+///
+/// Only [`verify_eligibility_vp`] builds one. Revocation is not checked: read
+/// [`credential_status`](Self::credential_status) and resolve it.
+#[derive(Debug, Clone)]
+pub struct VerifiedEligibility {
+    credential_id: Option<String>,
+    valid_from: DateTime<Utc>,
+    valid_until: DateTime<Utc>,
+    credential_status: Option<Value>,
+}
+
+impl VerifiedEligibility {
+    /// The role credential's `id`.
+    #[must_use]
+    pub fn credential_id(&self) -> Option<&str> {
+        self.credential_id.as_deref()
+    }
+
+    /// The role credential's `validFrom`.
+    #[must_use]
+    pub fn valid_from(&self) -> DateTime<Utc> {
+        self.valid_from
+    }
+
+    /// The role credential's `validUntil`.
+    #[must_use]
+    pub fn valid_until(&self) -> DateTime<Utc> {
+        self.valid_until
+    }
+
+    /// The role credential's `credentialStatus`, for the caller to resolve.
+    #[must_use]
+    pub fn credential_status(&self) -> Option<&Value> {
+        self.credential_status.as_ref()
+    }
+}
+
+#[derive(Deserialize)]
+struct WirePresentation {
+    #[serde(rename = "type")]
+    types: OneOrMany,
+    holder: String,
+    #[serde(default)]
+    nonce: Option<String>,
+    #[serde(default)]
+    domain: Option<String>,
+    #[serde(rename = "verifiableCredential", default)]
+    credentials: Vec<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum OneOrMany {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl OneOrMany {
+    fn contains(&self, wanted: &str) -> bool {
+        match self {
+            Self::One(t) => t == wanted,
+            Self::Many(ts) => ts.iter().any(|t| t == wanted),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireRoleCredential {
+    id: Option<String>,
+    issuer: WireIssuer,
+    valid_from: DateTime<Utc>,
+    valid_until: Option<DateTime<Utc>>,
+    credential_subject: WireSubject,
+    credential_status: Option<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum WireIssuer {
+    Id(String),
+    Object { id: String },
+}
+
+#[derive(Deserialize)]
+struct WireSubject {
+    id: String,
+}
+
+/// Verify a vetter's eligibility presentation.
+///
+/// Holds when the presentation is signed for `authentication` by its holder,
+/// the holder is `expect.vetter`, `nonce` and `domain` are the request's `id`
+/// and `joinDid`, and
+/// it carries a role credential that `expect.community` signed for
+/// `assertionMethod`, naming `expect.vetter`, for `expect.community`, in a role
+/// that [`role_matches`] `expect.role`, and valid at `expect.now`.
+///
+/// # Errors
+///
+/// The first failed check: [`VettingError::Malformed`],
+/// [`VettingError::WrongSigner`], [`VettingError::Binding`],
+/// [`VettingError::Proof`], [`VettingError::Expired`], or
+/// [`VettingError::NoRoleCredential`] when no credential names this vetter in
+/// this role for this community. When several candidates fail, the first one's
+/// error is returned.
+pub async fn verify_eligibility_vp(
+    vp: &Value,
+    expect: &EligibilityExpectations<'_>,
+    resolver: &TrustTaskVmResolver,
+) -> Result<VerifiedEligibility, VettingError> {
+    let wire: WirePresentation =
+        serde_json::from_value(vp.clone()).map_err(|e| VettingError::Malformed {
+            what: VP_WHAT,
+            detail: e.to_string(),
+        })?;
+    if !wire.types.contains("VerifiablePresentation") {
+        return Err(VettingError::Malformed {
+            what: VP_WHAT,
+            detail: "type does not include VerifiablePresentation".into(),
+        });
+    }
+    if wire.holder != expect.vetter {
+        return Err(VettingError::WrongSigner {
+            what: VP_WHAT,
+            role: "vetter",
+        });
+    }
+    if wire.nonce.as_deref() != Some(expect.challenge) {
+        return Err(VettingError::Binding("nonce"));
+    }
+    if wire.domain.as_deref() != Some(expect.domain) {
+        return Err(VettingError::Binding("domain"));
+    }
+    let signer = verify_attached_proof(VP_WHAT, vp, ELIGIBILITY_PROOF_PURPOSE, resolver).await?;
+    if signer != wire.holder {
+        return Err(VettingError::WrongSigner {
+            what: VP_WHAT,
+            role: "holder",
+        });
+    }
+
+    let mut first_error = None;
+    for credential in &wire.credentials {
+        let Some((community, role)) = community_role(credential) else {
+            continue;
+        };
+        if community != expect.community || !role_matches(&role, expect.role) {
+            continue;
+        }
+        match verify_role_credential(credential, expect, resolver).await {
+            Ok(verified) => return Ok(verified),
+            Err(e) => {
+                first_error.get_or_insert(e);
+            }
+        }
+    }
+    Err(first_error.unwrap_or(VettingError::NoRoleCredential))
+}
+
+async fn verify_role_credential(
+    credential: &Value,
+    expect: &EligibilityExpectations<'_>,
+    resolver: &TrustTaskVmResolver,
+) -> Result<VerifiedEligibility, VettingError> {
+    let malformed = |detail: String| VettingError::Malformed {
+        what: VEC_WHAT,
+        detail,
+    };
+    let wire: WireRoleCredential =
+        serde_json::from_value(credential.clone()).map_err(|e| malformed(e.to_string()))?;
+    let issuer = match wire.issuer {
+        WireIssuer::Id(id) | WireIssuer::Object { id } => id,
+    };
+    if issuer != expect.community {
+        return Err(VettingError::WrongSigner {
+            what: VEC_WHAT,
+            role: "issuer",
+        });
+    }
+    if wire.credential_subject.id != expect.vetter {
+        return Err(VettingError::Binding("credentialSubject"));
+    }
+    let valid_until = wire
+        .valid_until
+        .ok_or_else(|| malformed("no validUntil — a role grant is bounded".into()))?;
+    if wire.valid_from > expect.now + CLOCK_SKEW || expect.now > valid_until + CLOCK_SKEW {
+        return Err(VettingError::Expired(VEC_WHAT));
+    }
+    let signer = verify_attached_proof(
+        VEC_WHAT,
+        credential,
+        ROLE_CREDENTIAL_PROOF_PURPOSE,
+        resolver,
+    )
+    .await?;
+    if signer != issuer {
+        return Err(VettingError::WrongSigner {
+            what: VEC_WHAT,
+            role: "issuer",
+        });
+    }
+    Ok(VerifiedEligibility {
+        credential_id: wire.id,
+        valid_from: wire.valid_from,
+        valid_until,
+        credential_status: wire.credential_status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vetting::test_support::{did, secret};
+    use chrono::Duration;
+    use dtg_credentials::DTGCredential;
+
+    /// The `id` of the `vetting/request` document being answered.
+    const CHALLENGE: &str = "urn:uuid:3f1c9a52-8c1e-4f2b-9d7a-0b6e5c4d3a21";
+    /// That request's `joinDid`: the applicant.
+    const DOMAIN: &str = "did:key:z6MkApplicantJoinDid";
+
+    async fn role_vec(
+        community: &Secret,
+        subject: &str,
+        community_did: &str,
+        role: &str,
+        valid_from: DateTime<Utc>,
+        valid_until: DateTime<Utc>,
+    ) -> Value {
+        let mut credential = DTGCredential::new_vec(
+            did(community),
+            subject.to_string(),
+            valid_from,
+            Some(valid_until),
+            json!({
+                "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+                "role": role,
+                "communityDid": community_did,
+            }),
+        )
+        .with_id("urn:uuid:vetter-grant".to_string());
+        credential.sign(community, None).await.unwrap();
+        serde_json::to_value(&credential).unwrap()
+    }
+
+    async fn live_vec(community: &Secret, vetter: &Secret, role: &str) -> Value {
+        let now = Utc::now();
+        let c = did(community);
+        role_vec(
+            community,
+            &did(vetter),
+            &c,
+            role,
+            now - Duration::days(1),
+            now + Duration::days(364),
+        )
+        .await
+    }
+
+    async fn verify(
+        vp: &Value,
+        vetter: &str,
+        community: &str,
+        role: &str,
+    ) -> Result<VerifiedEligibility, VettingError> {
+        verify_eligibility_vp(
+            vp,
+            &EligibilityExpectations {
+                vetter,
+                community,
+                role,
+                challenge: CHALLENGE,
+                domain: DOMAIN,
+                now: Utc::now(),
+            },
+            &TrustTaskVmResolver::did_key_only(),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn a_vetter_proves_the_community_named_them() {
+        let (community, vetter) = (secret(0xC0), secret(0x11));
+        let vec = live_vec(&community, &vetter, "vetter").await;
+        assert_eq!(
+            community_role(&vec),
+            Some((did(&community), "vetter".to_string()))
+        );
+        let vp = build_eligibility_vp(&vetter, vec![vec], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert_eq!(vp["holder"], did(&vetter));
+        assert_eq!(vp["proof"]["proofPurpose"], ELIGIBILITY_PROOF_PURPOSE);
+
+        let verified = verify(&vp, &did(&vetter), &did(&community), "vetter")
+            .await
+            .unwrap();
+        assert_eq!(verified.credential_id(), Some("urn:uuid:vetter-grant"));
+        assert!(verified.valid_until() > verified.valid_from());
+        assert!(verified.credential_status().is_none());
+        // The requirements may spell the role as the ACL does.
+        verify(&vp, &did(&vetter), &did(&community), "custom:vetter")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_presentation_for_another_session_is_refused() {
+        let (community, vetter) = (secret(0xC0), secret(0x11));
+        let vec = live_vec(&community, &vetter, "vetter").await;
+
+        let other_challenge = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq";
+        let vp = build_eligibility_vp(&vetter, vec![vec.clone()], other_challenge, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::Binding("nonce"))
+        ));
+
+        let vp = build_eligibility_vp(&vetter, vec![vec], CHALLENGE, "did:web:elsewhere")
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::Binding("domain"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_role_credential_from_another_community_does_not_count() {
+        let (community, other, vetter) = (secret(0xC0), secret(0xC1), secret(0x11));
+        let vec = live_vec(&other, &vetter, "vetter").await;
+        let vp = build_eligibility_vp(&vetter, vec![vec], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::NoRoleCredential)
+        ));
+
+        // A credential that *claims* this community but was signed by another.
+        let now = Utc::now();
+        let forged = role_vec(
+            &other,
+            &did(&vetter),
+            &did(&community),
+            "vetter",
+            now - Duration::days(1),
+            now + Duration::days(30),
+        )
+        .await;
+        let vp = build_eligibility_vp(&vetter, vec![forged], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::WrongSigner { role: "issuer", .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_different_role_does_not_count() {
+        let (community, vetter) = (secret(0xC0), secret(0x11));
+        let vec = live_vec(&community, &vetter, "moderator").await;
+        let vp = build_eligibility_vp(&vetter, vec![vec], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::NoRoleCredential)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_tampered_role_credential_is_refused() {
+        let (community, vetter) = (secret(0xC0), secret(0x11));
+        let mut vec = live_vec(&community, &vetter, "vetter").await;
+        vec["validUntil"] = json!((Utc::now() + Duration::days(3650)).to_rfc3339());
+        let vp = build_eligibility_vp(&vetter, vec![vec], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::Proof { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_expired_role_credential_is_refused() {
+        let (community, vetter) = (secret(0xC0), secret(0x11));
+        let now = Utc::now();
+        let vec = role_vec(
+            &community,
+            &did(&vetter),
+            &did(&community),
+            "vetter",
+            now - Duration::days(400),
+            now - Duration::days(1),
+        )
+        .await;
+        let vp = build_eligibility_vp(&vetter, vec![vec], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::Expired(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn someone_else_presenting_a_vetters_credential_is_refused() {
+        let (community, vetter, mallory) = (secret(0xC0), secret(0x11), secret(0x66));
+        let vec = live_vec(&community, &vetter, "vetter").await;
+        let vp = build_eligibility_vp(&mallory, vec![vec.clone()], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&vetter), &did(&community), "vetter").await,
+            Err(VettingError::WrongSigner { role: "vetter", .. })
+        ));
+
+        // Mallory relabels the holder but cannot re-sign as the vetter.
+        let mut relabelled = vp;
+        relabelled["holder"] = json!(did(&vetter));
+        assert!(
+            verify(&relabelled, &did(&vetter), &did(&community), "vetter")
+                .await
+                .is_err()
+        );
+
+        // And a credential naming someone else, presented by its holder.
+        let vp = build_eligibility_vp(&mallory, vec![vec], CHALLENGE, DOMAIN)
+            .await
+            .unwrap();
+        assert!(matches!(
+            verify(&vp, &did(&mallory), &did(&community), "vetter").await,
+            Err(VettingError::Binding("credentialSubject"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_holder_without_a_did_cannot_present() {
+        let mut holder = secret(0x11);
+        holder.id = "key-0".into();
+        assert!(matches!(
+            build_eligibility_vp(&holder, vec![], CHALLENGE, DOMAIN).await,
+            Err(VettingError::WrongSigner { role: "holder", .. })
+        ));
+    }
+
+    #[test]
+    fn only_community_role_endorsements_are_role_credentials() {
+        let vc = |endorsement: Value| {
+            json!({
+                "type": ["VerifiableCredential", "EndorsementCredential"],
+                "credentialSubject": { "id": "did:key:z", "endorsement": endorsement }
+            })
+        };
+        assert!(
+            community_role(&vc(json!({
+                "type": "CommunityRole", "role": "vetter", "communityDid": "did:web:c"
+            })))
+            .is_some()
+        );
+        assert!(community_role(&vc(json!({ "type": "IdentityVetting" }))).is_none());
+        assert!(
+            community_role(&vc(json!({ "type": "CommunityRole", "role": "vetter" }))).is_none()
+        );
+        assert!(community_role(&json!({ "type": ["VerifiableCredential"] })).is_none());
+    }
+}

--- a/vta-sdk/src/vetting/mod.rs
+++ b/vta-sdk/src/vetting/mod.rs
@@ -14,6 +14,8 @@
 //!   build the facts its policy decides on.
 //! - [`match_code`] — the code two people read to each other to confirm they
 //!   are in the same session.
+//! - [`eligibility`] — a vetter presenting the vetter role credential the
+//!   community issued them, and the applicant's check of it.
 //!
 //! Every verification returns a distinct `Verified*` type (workspace typestate
 //! rule): code that needs a verified card or statement cannot be handed an
@@ -22,6 +24,7 @@
 //! [`VettingRequirements`]: crate::protocols::vetting::VettingRequirements
 
 pub mod card;
+pub mod eligibility;
 pub mod match_code;
 pub mod requirements;
 pub mod statement;
@@ -75,6 +78,10 @@ pub enum VettingError {
     /// A required claim is absent.
     #[error("required claim `{0}` is missing")]
     MissingClaim(String),
+    /// An eligibility presentation carries no role credential naming its
+    /// holder, in the required role, for the expected community.
+    #[error("no role credential names this vetter in that role for this community")]
+    NoRoleCredential,
     /// Signing failed.
     #[error("signing failed")]
     Sign(String),

--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -4272,6 +4272,60 @@
           }
         }
       }
+    },
+    "/v1/vetting/vetters": {
+      "post": {
+        "tags": [
+          "vetting"
+        ],
+        "operationId": "vettingVetterGrant",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VetterGrantBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The member already holds a live vetter grant, which is returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VetterGrantResponseBody"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Vetter role granted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VetterGrantResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed body, or the member is not a current member"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "403": {
+            "description": "Caller is not a community admin"
+          }
+        },
+        "security": [
+          {
+            "bearer_jwt": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -9014,6 +9068,66 @@
             "description": "Whether every chainable envelope verified."
           }
         }
+      },
+      "VetterGrantBody": {
+        "type": "object",
+        "description": "`vtc/vetting/vetters/grant/0.1` payload.",
+        "required": [
+          "memberDid"
+        ],
+        "properties": {
+          "ext": {
+            "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
+          },
+          "memberDid": {
+            "type": "string",
+            "description": "The member to name as a vetter."
+          },
+          "validitySeconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "How long the grant is valid, from one day to two years; one year when\nabsent.",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "VetterGrantResponseBody": {
+        "type": "object",
+        "description": "`vtc/vetting/vetters/grant/0.1#response` payload.\n\nGranting converges: while a grant is live and unexpired, asking again\nreturns it rather than issuing a second.",
+        "required": [
+          "endorsementId",
+          "credentialId",
+          "validFrom",
+          "validUntil"
+        ],
+        "properties": {
+          "credentialId": {
+            "type": "string",
+            "description": "The vetter role credential's `id`."
+          },
+          "endorsementId": {
+            "type": "string",
+            "description": "The community's record of the grant — the id its revocation names."
+          },
+          "ext": {
+            "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
+          },
+          "validFrom": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The credential's `validFrom`."
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The credential's `validUntil`."
+          }
+        },
+        "additionalProperties": false
       },
       "VtcRole": {
         "type": "string",

--- a/vtc-service/admin-ui/src/lib/wire-types.ts
+++ b/vtc-service/admin-ui/src/lib/wire-types.ts
@@ -54,6 +54,9 @@ export type MemberEnvelope = Schemas["MemberEnvelope"];
 export type MembersPage = Schemas["Paginated_MemberResponse"];
 export type RemovedMemberRow = Schemas["RemovedMember"];
 export type RemovedMembersResponse = Schemas["RemovedMembersResponse"];
+export type EndorsementRow = Schemas["EndorsementRow"];
+export type EndorsementsPage = Schemas["Paginated_EndorsementRow"];
+export type VetterGrantResponse = Schemas["VetterGrantResponseBody"];
 export type RequestVmcResponse = Schemas["RequestVmcResponse"];
 
 // ── Join requests ───────────────────────────────────────────────────────

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -1606,6 +1606,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/vetting/vetters": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["vettingVetterGrant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -4612,6 +4628,43 @@ export interface components {
             unparseableSkipped: number;
             /** @description Whether every chainable envelope verified. */
             verified: boolean;
+        };
+        /** @description `vtc/vetting/vetters/grant/0.1` payload. */
+        VetterGrantBody: {
+            /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
+            ext?: unknown;
+            /** @description The member to name as a vetter. */
+            memberDid: string;
+            /**
+             * Format: int64
+             * @description How long the grant is valid, from one day to two years; one year when
+             *     absent.
+             */
+            validitySeconds?: number | null;
+        };
+        /**
+         * @description `vtc/vetting/vetters/grant/0.1#response` payload.
+         *
+         *     Granting converges: while a grant is live and unexpired, asking again
+         *     returns it rather than issuing a second.
+         */
+        VetterGrantResponseBody: {
+            /** @description The vetter role credential's `id`. */
+            credentialId: string;
+            /** @description The community's record of the grant — the id its revocation names. */
+            endorsementId: string;
+            /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
+            ext?: unknown;
+            /**
+             * Format: date-time
+             * @description The credential's `validFrom`.
+             */
+            validFrom: string;
+            /**
+             * Format: date-time
+             * @description The credential's `validUntil`.
+             */
+            validUntil: string;
         };
         /**
          * @description One of `admin`, `moderator`, `issuer`, `member`, or                  `custom:<name>` where `<name>` is 1..=64 lowercase                  alphanumerics, `-`, or `_`.
@@ -8498,6 +8551,60 @@ export interface operations {
             };
             /** @description Task failed, e.g. duplicate request (trust-task-error) */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    vettingVetterGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VetterGrantBody"];
+            };
+        };
+        responses: {
+            /** @description The member already holds a live vetter grant, which is returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VetterGrantResponseBody"];
+                };
+            };
+            /** @description Vetter role granted */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VetterGrantResponseBody"];
+                };
+            };
+            /** @description Malformed body, or the member is not a current member */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not a community admin */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/vtc-service/admin-ui/src/plugins/members.tsx
+++ b/vtc-service/admin-ui/src/plugins/members.tsx
@@ -85,15 +85,78 @@ const TRUST_TASK_PURGE =
   "https://trusttasks.org/spec/vtc/members/purge/0.1";
 const TRUST_TASK_REQUEST_VMC =
   "https://trusttasks.org/spec/vtc/members/solicit-vmc/0.1";
+// Naming a vetter issues a revocable vetter role credential; it is withdrawn
+// like any endorsement, so listing and revoking reuse those tasks.
+const TRUST_TASK_VETTER_GRANT =
+  "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+const TRUST_TASK_ENDORSEMENT_LIST =
+  "https://trusttasks.org/spec/vtc/endorsements/list/0.1";
+const TRUST_TASK_ENDORSEMENT_REVOKE =
+  "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
+const COMMUNITY_ROLE = "CommunityRole";
+const VETTER_ROLE = "vetter";
+// The endorsement list has no subject filter; walking it stops here.
+const MAX_ENDORSEMENT_PAGES = 50;
 
 import type {
+  EndorsementRow,
+  EndorsementsPage,
   MemberEnvelope,
   MemberRow,
   MembersPage,
   RemovedMemberRow,
   RemovedMembersResponse,
   RequestVmcResponse,
+  VetterGrantResponse,
 } from "@/lib/wire-types";
+
+/** This member's vetter grants, revoked ones included — picked out of the
+ * endorsement list, which cannot filter by subject. */
+async function fetchVetterGrants(did: string): Promise<EndorsementRow[]> {
+  const grants: EndorsementRow[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_ENDORSEMENT_PAGES; page++) {
+    const q = new URLSearchParams({ limit: "200" });
+    if (cursor) q.set("cursor", cursor);
+    const body: EndorsementsPage = await getJson<EndorsementsPage>(
+      `/v1/credentials/endorsements?${q.toString()}`,
+      { trustTask: TRUST_TASK_ENDORSEMENT_LIST },
+    );
+    grants.push(
+      ...body.items.filter(
+        (e) =>
+          e.typeUri === COMMUNITY_ROLE &&
+          e.subjectDid === did &&
+          (e.claim as { role?: unknown } | null)?.role === VETTER_ROLE,
+      ),
+    );
+    cursor = body.nextCursor ?? null;
+    if (!cursor) break;
+  }
+  return grants;
+}
+
+/** A grant still in force: not revoked and not past its `validUntil`. */
+function isLiveGrant(grant: EndorsementRow): boolean {
+  if (grant.revokedAt) return false;
+  const expires = grant.issued.expiresAt;
+  return !expires || new Date(expires).getTime() > Date.now();
+}
+
+async function grantVetterRole(did: string): Promise<VetterGrantResponse> {
+  return postJson<VetterGrantResponse>(
+    "/v1/vetting/vetters",
+    { memberDid: did },
+    { trustTask: TRUST_TASK_VETTER_GRANT },
+  );
+}
+
+async function revokeVetterRole(endorsementId: string): Promise<void> {
+  await deleteJson<unknown>(
+    `/v1/credentials/endorsements/${encodeURIComponent(endorsementId)}`,
+    { trustTask: TRUST_TASK_ENDORSEMENT_REVOKE },
+  );
+}
 async function fetchMembers(params: {
   cursor: string | null;
   role: string | null;
@@ -519,6 +582,27 @@ function MemberDetail() {
     mutationFn: requestMemberVmc,
   });
 
+  const vetterGrants = useQuery({
+    queryKey: ["member-vetter-grants", decoded],
+    queryFn: () => fetchVetterGrants(decoded),
+    enabled: decoded.length > 0,
+  });
+  const liveGrant = vetterGrants.data?.find(isLiveGrant);
+
+  const invalidateVetterGrants = () => {
+    void queryClient.invalidateQueries({
+      queryKey: ["member-vetter-grants", decoded],
+    });
+  };
+  const grantVetterMutation = useMutation({
+    mutationFn: grantVetterRole,
+    onSuccess: invalidateVetterGrants,
+  });
+  const revokeVetterMutation = useMutation({
+    mutationFn: revokeVetterRole,
+    onSuccess: invalidateVetterGrants,
+  });
+
   return (
     <section className="page">
       <button type="button" className="link" onClick={() => navigate("..")}>
@@ -698,6 +782,100 @@ function MemberDetail() {
                 <code>{query.data.departurePreference}</code>
               </dd>
             </dl>
+          </section>
+
+          <section className="card">
+            <h3>Vetter role</h3>
+            <p className="muted">
+              A vetter's identity-vetting statements count toward an
+              applicant's admission. Granting issues this member a revocable
+              vetter role credential, which they show to applicants.
+            </p>
+            {vetterGrants.isPending && <p className="muted">Loading…</p>}
+            {vetterGrants.isError && (
+              <p className="muted">Could not load this member's grants.</p>
+            )}
+            {vetterGrants.data &&
+              (liveGrant ? (
+                <dl>
+                  <dt>Credential</dt>
+                  <dd>
+                    <code>{liveGrant.issued.credentialId}</code>
+                  </dd>
+                  <dt>Granted</dt>
+                  <dd>
+                    {liveGrant.issued.issuedAt
+                      ? formatDate(liveGrant.issued.issuedAt)
+                      : "—"}
+                  </dd>
+                  <dt>Valid until</dt>
+                  <dd>
+                    {liveGrant.issued.expiresAt
+                      ? formatDate(liveGrant.issued.expiresAt)
+                      : "—"}
+                  </dd>
+                  <dt>Revocation slot</dt>
+                  <dd>{liveGrant.statusListIndex}</dd>
+                </dl>
+              ) : (
+                <p className="muted">Not a vetter.</p>
+              ))}
+
+            {grantVetterMutation.error && (
+              <section className="card error">
+                <h3>Grant failed</h3>
+                <p>{(grantVetterMutation.error as Error).message}</p>
+              </section>
+            )}
+            {revokeVetterMutation.error && (
+              <section className="card error">
+                <h3>Revoke failed</h3>
+                <p>{(revokeVetterMutation.error as Error).message}</p>
+              </section>
+            )}
+
+            <div className="form-actions">
+              {liveGrant ? (
+                <button
+                  type="button"
+                  className="secondary destructive"
+                  disabled={revokeVetterMutation.isPending}
+                  onClick={async () => {
+                    const ok = await confirm({
+                      title: "Revoke vetter role?",
+                      message: `${query.data.did} stops being a vetter. Statements they have already signed stop counting toward joins decided from now on.`,
+                      confirmLabel: "Revoke vetter role",
+                      destructive: true,
+                    });
+                    if (ok) revokeVetterMutation.mutate(liveGrant.endorsementId);
+                  }}
+                >
+                  {revokeVetterMutation.isPending
+                    ? "Revoking…"
+                    : "Revoke vetter role"}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="primary"
+                  disabled={
+                    !vetterGrants.data || grantVetterMutation.isPending
+                  }
+                  onClick={async () => {
+                    const ok = await confirm({
+                      title: "Grant vetter role?",
+                      message: `${query.data.did} will be issued a vetter role credential, valid for a year. Their vetting statements will count toward admissions.`,
+                      confirmLabel: "Grant vetter role",
+                    });
+                    if (ok) grantVetterMutation.mutate(decoded);
+                  }}
+                >
+                  {grantVetterMutation.isPending
+                    ? "Granting…"
+                    : "Grant vetter role"}
+                </button>
+              )}
+            </div>
           </section>
 
           <section className="card">

--- a/vtc-service/src/ceremony/execute.rs
+++ b/vtc-service/src/ceremony/execute.rs
@@ -114,6 +114,10 @@ pub struct DepartOutcome {
     /// the best-effort flip failed (the ACL/Member removal still
     /// committed — a failed flip is logged, not unwound).
     pub revoked_slot: Option<u32>,
+    /// Community role grants (vetter grants) the member held, now revoked:
+    /// slot flipped and row marked. The caller audits each. Best effort, like
+    /// the flip above — a grant that could not be revoked is logged.
+    pub revoked_grants: Vec<crate::endorsements::Endorsement>,
 }
 
 /// Apply an effect plan.
@@ -523,9 +527,14 @@ async fn depart(
         None => None,
     };
 
+    // A departed member is no vetter. Eligibility already requires a current
+    // member, but a grant left live would count again if this DID rejoined.
+    let revoked_grants = crate::vetting::vetters::revoke_on_departure(state, subject_did).await;
+
     Ok(DepartOutcome {
         disposition,
         revoked_slot,
+        revoked_grants,
     })
 }
 

--- a/vtc-service/src/ceremony/orchestrate.rs
+++ b/vtc-service/src/ceremony/orchestrate.rs
@@ -251,6 +251,11 @@ pub async fn purge_member(
             .await?;
     }
 
+    for grant in &outcome.revoked_grants {
+        crate::vetting::vetters::audit_revoked_grant(audit_writer, actor_did, target_did, grant)
+            .await?;
+    }
+
     info!(actor = actor_did, target = target_did, "member purged");
 
     // Tell them. Best-effort and after the fact: the purge is done and durable,
@@ -403,6 +408,11 @@ pub async fn remove_inner(
             }),
         )
         .await?;
+
+    for grant in &outcome.revoked_grants {
+        crate::vetting::vetters::audit_revoked_grant(audit_writer, actor_did, target_did, grant)
+            .await?;
+    }
 
     // M2.14: the executor flipped the revocation bit (best-effort). Emit the
     // audit event for the slot it reported.

--- a/vtc-service/src/endorsements/mod.rs
+++ b/vtc-service/src/endorsements/mod.rs
@@ -26,8 +26,8 @@ use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
 pub use storage::{
-    ENDORSEMENTS_PREFIX, count_live_by_type, delete_endorsement, get_endorsement,
-    list_endorsements, mark_revoked, store_endorsement,
+    ENDORSEMENTS_PREFIX, count_live_by_type, delete_endorsement, endorsements_for_subject,
+    get_endorsement, list_endorsements, mark_revoked, store_endorsement,
 };
 
 /// A stored custom endorsement. The accompanying VEC body
@@ -68,6 +68,10 @@ pub struct Endorsement {
     /// pattern.)
     #[serde(default)]
     pub revoked_at: Option<DateTime<Utc>>,
+    /// The credential's `validUntil`. Absent on rows written before it was
+    /// recorded; those rows' lifetime is unknown here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<DateTime<Utc>>,
 }
 
 impl Endorsement {

--- a/vtc-service/src/endorsements/storage.rs
+++ b/vtc-service/src/endorsements/storage.rs
@@ -79,6 +79,25 @@ pub async fn count_live_by_type(
     Ok(count)
 }
 
+/// Every endorsement of `endorsement_type` naming `subject_did`, revoked ones
+/// included, oldest first. A full scan: the keyspace has no subject index, and
+/// the callers — granting a role, departing, counting a vetting statement —
+/// are rare next to the size of a community's endorsement set.
+pub async fn endorsements_for_subject(
+    ks: &KeyspaceHandle,
+    subject_did: &str,
+    endorsement_type: &str,
+) -> Result<Vec<Endorsement>, AppError> {
+    let pairs = ks.prefix_iter_raw(ENDORSEMENTS_PREFIX.to_vec()).await?;
+    let mut rows: Vec<Endorsement> = pairs
+        .into_iter()
+        .filter_map(|(_k, v)| decode(&v).ok())
+        .filter(|row| row.subject_did == subject_did && row.endorsement_type == endorsement_type)
+        .collect();
+    rows.sort_by_key(|row| row.created_at);
+    Ok(rows)
+}
+
 pub async fn list_endorsements(
     ks: &KeyspaceHandle,
     audit_key: &AuditKey,
@@ -129,7 +148,36 @@ mod tests {
             vec_id: format!("urn:uuid:{id}"),
             created_at: Utc::now(),
             revoked_at: None,
+            valid_until: None,
         }
+    }
+
+    #[tokio::test]
+    async fn endorsements_for_subject_filters_by_subject_and_type() {
+        let (ks, _audit, _dir) = temp_ks().await;
+        let mine = fresh("CommunityRole", "did:webvh:vtc", "did:key:zA");
+        let other_type = fresh("https://example.com/v1/x", "did:webvh:vtc", "did:key:zA");
+        let other_subject = fresh("CommunityRole", "did:webvh:vtc", "did:key:zB");
+        for row in [&mine, &other_type, &other_subject] {
+            store_endorsement(&ks, row).await.unwrap();
+        }
+        mark_revoked(&ks, mine.id).await.unwrap();
+        let rows = endorsements_for_subject(&ks, "did:key:zA", "CommunityRole")
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "revoked rows are returned too");
+        assert_eq!(rows[0].id, mine.id);
+        assert!(rows[0].is_revoked());
+    }
+
+    #[test]
+    fn a_row_written_before_valid_until_still_decodes() {
+        let row = fresh("https://example.com/v1/x", "did:webvh:vtc", "did:key:zS");
+        let mut v = serde_json::to_value(&row).unwrap();
+        assert!(v.get("validUntil").is_none());
+        v.as_object_mut().unwrap().remove("revokedAt");
+        let back: Endorsement = serde_json::from_value(v).unwrap();
+        assert_eq!(back.valid_until, None);
     }
 
     #[tokio::test]

--- a/vtc-service/src/messaging.rs
+++ b/vtc-service/src/messaging.rs
@@ -34,7 +34,7 @@ use vta_sdk::protocols::join_requests::{
 use vta_sdk::protocols::members::{
     MEMBER_VMC_RESPONSE_TYPE, MEMBER_VMC_TYPE, MemberVmcBody, MemberVmcReceiptBody,
 };
-use vta_sdk::protocols::vetting::VETTING_REVOKE_STATEMENT_TYPE;
+use vta_sdk::protocols::vetting::{VETTING_REVOKE_STATEMENT_TYPE, VETTING_VETTER_GRANT_TYPE};
 use vta_sdk::protocols::{PROBLEM_REPORT_TYPE, problem_report_codes as codes};
 
 use crate::ceremony::remove_inner;
@@ -722,8 +722,8 @@ async fn route(msg: &Message, auth_sender: Option<String>, state: &AppState) -> 
         JOIN_REQUEST_STATUS_TYPE => join_request_status_handler(msg, auth_sender, state).await,
         MEMBER_SELF_REMOVE_TYPE => member_self_remove_handler(msg, auth_sender, state).await,
         MEMBER_VMC_TYPE => member_vmc_handler(msg, auth_sender, state).await,
-        VETTING_REVOKE_STATEMENT_TYPE => {
-            vetting_revoke_statement_handler(msg, auth_sender, state).await
+        VETTING_REVOKE_STATEMENT_TYPE | VETTING_VETTER_GRANT_TYPE => {
+            vetting_task_handler(msg, auth_sender, state).await
         }
         CREDENTIAL_REQUEST_TYPE => credential_request_handler(msg, state).await,
         CREDENTIAL_PRESENT_TYPE => credential_present_handler(msg, state).await,
@@ -1128,9 +1128,10 @@ async fn member_self_remove_handler(
 /// VMC. [`receive_member_vmc_inner`](crate::members::inbound_vmc::receive_member_vmc_inner)
 /// verifies the issuer / subject binding + the DI proof and stores it on the
 /// member row. Replies with a receipt, or a threaded problem-report on failure.
-/// `vtc/vetting/revoke-statement/0.1` over DIDComm. The authcrypt sender is the
-/// proven vetter; the document dispatcher does the rest, exactly as over REST.
-async fn vetting_revoke_statement_handler(
+/// `vtc/vetting/revoke-statement/0.1` and `vtc/vetting/vetters/grant/0.1` over
+/// DIDComm. The authcrypt sender is the proven vetter or admin; the document
+/// dispatcher does the rest, exactly as over REST.
+async fn vetting_task_handler(
     msg: &Message,
     auth_sender: Option<String>,
     state: &AppState,

--- a/vtc-service/src/routes/endorsements.rs
+++ b/vtc-service/src/routes/endorsements.rs
@@ -127,8 +127,8 @@ impl From<Endorsement> for EndorsementRow {
             issued: CredentialReference {
                 credential_id: e.vec_id,
                 issued_at: Some(e.created_at),
-                // Not on the stored row; `issue` reports it directly.
-                expires_at: None,
+                // Recorded since rows gained `validUntil`; absent on older rows.
+                expires_at: e.valid_until,
             },
             status_list_index: e.status_list_index,
             claim: e.claim,
@@ -278,6 +278,7 @@ pub async fn issue(
         vec_id: vec_id.clone(),
         created_at: now,
         revoked_at: None,
+        valid_until: Some(valid_until),
     };
     store_endorsement(&state.endorsements_ks, &end).await?;
 

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod rooms;
 mod schemas;
 pub(crate) mod status_lists;
 pub mod trust_tasks;
+mod vetting;
 #[cfg(feature = "website")]
 pub(crate) mod website;
 
@@ -759,6 +760,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         .routes(tt(
             routes!(endorsements::revoke),
             "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1",
+        ))
+        // Naming vetters: an admin issues a revocable vetter role credential
+        // (OpenVTC vetting design §10), withdrawn through endorsements/revoke.
+        .routes(tt(
+            routes!(vetting::grant_vetter),
+            "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1",
         ))
         // GET / PATCH / DELETE on `/members/{did}` each carry their own
         // canonical task. They shared `members/show/1.0` while the

--- a/vtc-service/src/routes/vetting.rs
+++ b/vtc-service/src/routes/vetting.rs
@@ -1,0 +1,43 @@
+//! `/v1/vetting/*` — the community-admin side of peer identity vetting.
+//!
+//! - `POST /v1/vetting/vetters` — name a member a vetter
+//!   (`vtc/vetting/vetters/grant/0.1`). Auth: community Admin. The same task is
+//!   dispatched as a Trust Task document for an admin on DIDComm or TSP; both
+//!   go through [`crate::vetting::vetters::grant`]. A grant is withdrawn with
+//!   `DELETE /v1/credentials/endorsements/{endorsementId}`.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use vta_sdk::protocols::vetting::{VetterGrantBody, VetterGrantResponseBody};
+use vti_common::auth::AuthClaims;
+use vti_common::error::AppError;
+
+use crate::server::AppState;
+
+#[utoipa::path(
+    post, path = "/vetting/vetters",
+    operation_id = "vettingVetterGrant", tag = "vetting",
+    security(("bearer_jwt" = [])),
+    request_body = VetterGrantBody,
+    responses(
+        (status = 201, description = "Vetter role granted", body = VetterGrantResponseBody),
+        (status = 200, description = "The member already holds a live vetter grant, which is returned", body = VetterGrantResponseBody),
+        (status = 400, description = "Malformed body, or the member is not a current member"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not a community admin"),
+    ),
+)]
+pub async fn grant_vetter(
+    auth: AuthClaims,
+    State(state): State<AppState>,
+    Json(body): Json<VetterGrantBody>,
+) -> Result<(StatusCode, Json<VetterGrantResponseBody>), AppError> {
+    let grant = crate::vetting::vetters::grant(&state, &auth.did, &body).await?;
+    let status = if grant.created() {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+    Ok((status, Json(grant.response)))
+}

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -233,6 +233,7 @@ async fn dispatch_typed(
         vetting_wire::VETTING_REVOKE_STATEMENT_TYPE => {
             handle_revoke_statement(state, ctx, doc).await
         }
+        vetting_wire::VETTING_VETTER_GRANT_TYPE => handle_vetter_grant(state, ctx, doc).await,
         // The rooms family. Note what these do not take: no `ctx`, and no auth claims.
         // A room operation is authorized by the authority chain the room itself issued,
         // never by this service's ACL, roster, or the caller's session — invariant I5 of
@@ -373,6 +374,8 @@ pub(crate) const DISPATCHED_URIS: &[&str] = &[
     mem::MEMBER_VMC_TYPE,
     // A vetter withdrawing a statement (OpenVTC vetting design §9.6).
     vetting_wire::VETTING_REVOKE_STATEMENT_TYPE,
+    // An admin naming a vetter — also mounted on REST as `POST /v1/vetting/vetters`.
+    vetting_wire::VETTING_VETTER_GRANT_TYPE,
     PERSONHOOD_CHALLENGE_TYPE,
     PERSONHOOD_ASSERT_TYPE,
     // rooms/* — top-level, not `spec/vtc/*`: a room's protocol is host-neutral, so
@@ -563,6 +566,31 @@ async fn handle_revoke_statement(
                 ext: None,
             },
         ),
+        Err(e) => app_error_to_reject(&doc, &e),
+    }
+}
+
+/// `vtc/vetting/vetters/grant/0.1` — an admin names a member a vetter.
+///
+/// The sender is the proven signer; whether they may grant (community Admin,
+/// read from the ACL row) and whom (a current member) is decided in
+/// [`crate::vetting::vetters::grant`], the same path `POST /v1/vetting/vetters`
+/// takes.
+async fn handle_vetter_grant(
+    state: &AppState,
+    ctx: &JoinAuthCtx,
+    doc: TrustTask<Value>,
+) -> TrustTaskOutcome {
+    let admin_did = match resolve_holder(state, ctx, &doc).await {
+        Ok(did) => did,
+        Err(reject) => return reject,
+    };
+    let body: vetting_wire::VetterGrantBody = match parse_payload(&doc) {
+        Ok(b) => b,
+        Err(reject) => return reject,
+    };
+    match crate::vetting::vetters::grant(state, &admin_did, &body).await {
+        Ok(grant) => success_response(&doc, grant.response),
         Err(e) => app_error_to_reject(&doc, &e),
     }
 }
@@ -978,6 +1006,7 @@ mod tests {
             jr::MEMBER_SELF_REMOVE_TYPE,
             mem::MEMBER_VMC_TYPE,
             vetting_wire::VETTING_REVOKE_STATEMENT_TYPE,
+            vetting_wire::VETTING_VETTER_GRANT_TYPE,
             <pc::Payload as trust_tasks_rs::Payload>::TYPE_URI,
             <pa::Payload as trust_tasks_rs::Payload>::TYPE_URI,
         ];

--- a/vtc-service/src/vetting/mod.rs
+++ b/vtc-service/src/vetting/mod.rs
@@ -14,8 +14,9 @@
 //!    the issuer, type, bounded window, strict endorsement body);
 //! 2. binds it to the applicant (`credentialSubject.id` = the proven holder);
 //! 3. asks whether the issuer is an **eligible vetter** of this community —
-//!    a current member, holding the role the requirements name, who had
-//!    already joined when they issued the statement;
+//!    a current member, who had already joined when they issued the statement,
+//!    holding a vetter role grant ([`vetters`]) in the role the requirements
+//!    name that was recorded by then, unexpired then, and is not revoked now;
 //! 4. counts the survivors with `vta_sdk::vetting::requirements::evaluate`, the
 //!    same rule the applicant's client uses for its checklist.
 //!
@@ -27,6 +28,7 @@
 //! separately signed (VTI-CMP-070): distinct vetters are distinct *members*.
 
 pub mod revocation;
+pub mod vetters;
 
 use std::collections::BTreeMap;
 
@@ -37,13 +39,14 @@ use tracing::warn;
 
 use vta_sdk::protocols::join_requests::ManifestCriterion;
 use vta_sdk::protocols::vetting::{
-    IDENTITY_VETTING_ENDORSEMENT_TYPE, InvitationRequirement, VettingRequirements,
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, IDENTITY_VETTING_ENDORSEMENT_TYPE, InvitationRequirement,
+    VettingRequirements,
 };
 use vta_sdk::vetting::requirements::{REQUIREMENTS_DIGEST_MEMBER, StatementFacts, evaluate};
 use vta_sdk::vetting::statement::verify_statement;
 use vti_common::error::AppError;
 
-use crate::acl::{VtcRole, get_acl_entry};
+use crate::endorsements::endorsements_for_subject;
 use crate::members::storage::get_member;
 use crate::routes::join_requests::manifest::{ManifestVersion, manifest_criterion};
 use crate::schemas::accepts::list_accepts;
@@ -191,7 +194,6 @@ pub async fn vetting_facts(
             verified.issuer(),
             &requirements.eligible_vetters.role,
             verified.valid_from(),
-            now,
         )
         .await?;
         // A withdrawal notice counts only against a statement with the notice's
@@ -346,18 +348,20 @@ fn issuer_of(vc: &JsonValue) -> Option<String> {
     }
 }
 
-/// Is `issuer` an eligible vetter: a current member holding `role`, whose
-/// membership predates the statement, and whose ACL entry has not lapsed.
+/// Is `issuer` an eligible vetter: a current member, whose membership predates
+/// the statement, holding a role grant the community recorded for `role` —
+/// issued during this membership and by the statement's `validFrom`, unexpired
+/// then, and not revoked since ([`vetters::grant_covers`]).
 ///
-/// "Held the role when they issued it" is approximated by "holds it now and had
-/// joined by then": the ACL keeps no role history. A vetter demoted after
-/// issuing therefore stops counting, which errs toward not admitting.
+/// Revocation is read as it stands now, not as it stood at issuance: a grant
+/// withdrawn after a statement was signed stops that statement counting. That
+/// errs toward not admitting, and it is what an operator withdrawing a vetter
+/// they no longer trust means.
 async fn vetter_eligible(
     state: &AppState,
     issuer: &str,
     role: &str,
     issued_at: DateTime<Utc>,
-    now: DateTime<Utc>,
 ) -> Result<bool, AppError> {
     let Some(member) = get_member(&state.members_ks, issuer).await? else {
         return Ok(false);
@@ -365,22 +369,15 @@ async fn vetter_eligible(
     if member.removed_at.is_some() || member.joined_at > issued_at {
         return Ok(false);
     }
-    let Some(acl) = get_acl_entry(&state.acl_ks, issuer).await? else {
-        return Ok(false);
-    };
-    if acl
-        .expires_at
-        .is_some_and(|exp| i64::try_from(exp).unwrap_or(i64::MAX) <= now.timestamp())
-    {
-        return Ok(false);
-    }
-    Ok(role_matches(&acl.role, role))
-}
-
-/// A requirements `role` of `vetter` names the custom role `custom:vetter`; the
-/// wire form itself is accepted too, as are the standard role names.
-fn role_matches(held: &VtcRole, required: &str) -> bool {
-    held.to_string() == required || matches!(held, VtcRole::Custom(name) if name == required)
+    let grants = endorsements_for_subject(
+        &state.endorsements_ks,
+        issuer,
+        COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+    )
+    .await?;
+    Ok(grants
+        .iter()
+        .any(|g| g.created_at >= member.joined_at && vetters::grant_covers(g, role, issued_at)))
 }
 
 #[cfg(test)]
@@ -421,15 +418,6 @@ mod tests {
         assert_eq!(s.criterion_id, "a");
         assert!(!s.applicant_digest_matches);
         assert!(select_criterion(vec![], Some("za")).is_none());
-    }
-
-    #[test]
-    fn role_names_match_in_both_spellings() {
-        let vetter = VtcRole::Custom("vetter".into());
-        assert!(role_matches(&vetter, "vetter"));
-        assert!(role_matches(&vetter, "custom:vetter"));
-        assert!(role_matches(&VtcRole::Moderator, "moderator"));
-        assert!(!role_matches(&VtcRole::Member, "vetter"));
     }
 
     fn facts_with_needs(needs: &[&str]) -> VettingFacts {

--- a/vtc-service/src/vetting/vetters.rs
+++ b/vtc-service/src/vetting/vetters.rs
@@ -1,0 +1,442 @@
+//! Naming vetters (`vtc/vetting/vetters/grant/0.1`).
+//!
+//! OpenVTC vetting design §10. A vetter is a member the community has issued a
+//! **vetter role credential**: a DTG `EndorsementCredential` with endorsement
+//! `{ type: "CommunityRole", role: "vetter", communityDid }`, a revocation slot
+//! on the shared `Revocation` status list, and a bounded validity. The grant is
+//! recorded as an [`Endorsement`] row — the record the join path counts
+//! statements against — and the credential is delivered to the member, who
+//! presents it to applicants (`vta_sdk::vetting::eligibility`).
+//!
+//! A grant is withdrawn through `vtc/endorsements/revoke/0.1` like any other
+//! endorsement, and every grant a member holds is revoked when they depart
+//! ([`revoke_on_departure`]).
+//!
+//! ## Granting converges
+//!
+//! While a member holds a live, unexpired vetter grant, granting again returns
+//! that grant rather than minting a second credential on a second slot. The
+//! check and the issuance run under one lock, so two concurrent grants for the
+//! same member cannot both pass it.
+
+use std::sync::LazyLock;
+
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{Value as JsonValue, json};
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use vta_sdk::protocols::members::ENDORSEMENT_CREDENTIAL_TYPE;
+use vta_sdk::protocols::vetting::{
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, DEFAULT_VETTER_GRANT_VALIDITY_SECONDS, VETTER_ROLE,
+    VetterGrantBody, VetterGrantResponseBody, role_matches,
+};
+use vti_common::audit::{
+    AuditEvent, AuditWriter, CredentialIssuedData, CustomEndorsementRevokedData,
+    StatusListFlippedData, VetterGrantedData,
+};
+use vti_common::error::AppError;
+
+use crate::acl::{VtcRole, get_acl_entry};
+use crate::credentials::CredentialStatusRef;
+use crate::credentials::delivery::deliver_credentials;
+use crate::credentials::dtg::{into_typed, issue_endorsement};
+use crate::endorsements::{Endorsement, endorsements_for_subject, mark_revoked, store_endorsement};
+use crate::members::storage::get_member;
+use crate::server::AppState;
+use crate::status_list;
+
+/// Serialises the live-grant check with the issuance it guards.
+static GRANT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// The outcome of a grant.
+#[derive(Debug)]
+pub struct VetterGrant {
+    /// The wire answer.
+    pub response: VetterGrantResponseBody,
+    /// The credential this call minted, or `None` when an existing live grant
+    /// was returned instead.
+    pub credential: Option<JsonValue>,
+}
+
+impl VetterGrant {
+    /// `true` when this call issued a new grant.
+    pub fn created(&self) -> bool {
+        self.credential.is_some()
+    }
+}
+
+/// Does `grant` name its subject in `role`, unrevoked, and valid at `at`?
+///
+/// `at` is when the grant is relied on — for a vetting statement, its
+/// `validFrom`: a grant recorded after the statement was signed does not make
+/// its issuer retroactively a vetter.
+pub fn grant_covers(grant: &Endorsement, role: &str, at: DateTime<Utc>) -> bool {
+    grant.endorsement_type == COMMUNITY_ROLE_ENDORSEMENT_TYPE
+        && grant.revoked_at.is_none()
+        && grant.created_at <= at
+        && grant.valid_until.is_none_or(|until| until >= at)
+        && grant
+            .claim
+            .get("role")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|held| role_matches(held, role))
+}
+
+/// Name `body.member_did` a vetter on behalf of `actor_did`.
+///
+/// The actor must hold the VTC `Admin` role — read from the ACL row, since a
+/// session token degrades custom roles. The subject must be a current member.
+///
+/// # Errors
+///
+/// [`AppError::Validation`] for a malformed body or a subject who is not a
+/// current member, [`AppError::Forbidden`] for a non-admin actor, and
+/// [`AppError::Internal`] when signing or the status list is unavailable.
+pub async fn grant(
+    state: &AppState,
+    actor_did: &str,
+    body: &VetterGrantBody,
+) -> Result<VetterGrant, AppError> {
+    body.check_shape()
+        .map_err(|e| AppError::Validation(e.to_string()))?;
+    let acl = get_acl_entry(&state.acl_ks, actor_did)
+        .await?
+        .ok_or_else(|| AppError::Forbidden("caller has no ACL row".into()))?;
+    if !matches!(acl.role, VtcRole::Admin) {
+        return Err(AppError::Forbidden(
+            "only a community admin can name a vetter".into(),
+        ));
+    }
+    let audit_writer = state
+        .audit_writer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("audit_writer not initialised".into()))?;
+    let signer = state
+        .credential_signer
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("credential signer not configured".into()))?;
+
+    let _guard = GRANT_LOCK.lock().await;
+
+    let member_did = body.member_did.as_str();
+    let is_current = get_member(&state.members_ks, member_did)
+        .await?
+        .is_some_and(|m| m.removed_at.is_none());
+    if !is_current {
+        return Err(AppError::Validation(format!(
+            "{member_did} is not a current member of this community"
+        )));
+    }
+
+    let now = Utc::now();
+    let existing = endorsements_for_subject(
+        &state.endorsements_ks,
+        member_did,
+        COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+    )
+    .await?
+    .into_iter()
+    .rev()
+    .find(|row| grant_covers(row, VETTER_ROLE, now));
+    if let Some(row) = existing {
+        return Ok(VetterGrant {
+            response: response_for(&row)?,
+            credential: None,
+        });
+    }
+
+    let (slot, list_credential_id) = status_list::with_locked(
+        &state.status_lists_ks,
+        affinidi_status_list::StatusPurpose::Revocation,
+        |row| {
+            let slot = status_list::allocate(row).ok_or_else(|| {
+                AppError::Internal(
+                    "revocation status list is full — cannot allocate a slot for a vetter grant"
+                        .into(),
+                )
+            })?;
+            Ok((slot, row.list_credential_id.clone()))
+        },
+    )
+    .await?;
+    let status_ref = CredentialStatusRef::revocation(list_credential_id, slot);
+
+    let id = Uuid::new_v4();
+    let vec_id = format!("urn:uuid:{id}");
+    let seconds = body
+        .validity_seconds
+        .unwrap_or(DEFAULT_VETTER_GRANT_VALIDITY_SECONDS);
+    let validity = Duration::seconds(
+        i64::try_from(seconds)
+            .map_err(|_| AppError::Validation("validitySeconds is out of range".into()))?,
+    );
+    let credential = issue_endorsement(
+        signer,
+        member_did,
+        json!({
+            "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+            "role": VETTER_ROLE,
+            "communityDid": signer.issuer_did(),
+        }),
+        Some(&vec_id),
+        Some(&status_ref),
+        validity,
+    )
+    .await?;
+    // The row carries the credential's own window, so what the community
+    // counts against and what the member presents cannot disagree.
+    let valid_from = timestamp(&credential, "validFrom")?;
+    let valid_until = timestamp(&credential, "validUntil")?;
+
+    let row = Endorsement {
+        id,
+        endorsement_type: COMMUNITY_ROLE_ENDORSEMENT_TYPE.into(),
+        issuer_did: signer.issuer_did().to_string(),
+        subject_did: member_did.to_string(),
+        claim: json!({ "role": VETTER_ROLE }),
+        status_list_index: slot,
+        vec_id: vec_id.clone(),
+        created_at: valid_from,
+        revoked_at: None,
+        valid_until: Some(valid_until),
+    };
+    store_endorsement(&state.endorsements_ks, &row).await?;
+
+    audit_writer
+        .write(
+            actor_did,
+            Some(member_did),
+            AuditEvent::VetterGranted(VetterGrantedData {
+                endorsement_id: id.to_string(),
+                status_list_index: slot,
+            }),
+        )
+        .await?;
+    audit_writer
+        .write(
+            actor_did,
+            Some(member_did),
+            AuditEvent::VecIssued(CredentialIssuedData {
+                credential_id: vec_id.clone(),
+                credential_type: ENDORSEMENT_CREDENTIAL_TYPE.into(),
+                valid_from: rfc3339(valid_from),
+                valid_until: rfc3339(valid_until),
+                status_list_index: Some(slot),
+            }),
+        )
+        .await?;
+    info!(
+        endorsement_id = %id,
+        member = %member_did,
+        slot,
+        "vetter role granted"
+    );
+
+    // Best effort, after the grant is durable: the record is what counts
+    // statements, so a member whose wallet missed the credential is still a
+    // vetter, and an operator can re-issue it by revoking and granting again.
+    match into_typed(credential.clone(), "vetter role VEC") {
+        Ok(typed) => {
+            if let Err(e) = deliver_credentials(state, member_did, &[&typed]).await {
+                warn!(member = %member_did, error = %e, "vetter role credential not delivered");
+            }
+        }
+        Err(e) => {
+            warn!(member = %member_did, error = %e, "vetter role credential not deliverable");
+        }
+    }
+
+    Ok(VetterGrant {
+        response: response_for(&row)?,
+        credential: Some(credential),
+    })
+}
+
+/// Revoke every live community role grant `subject_did` holds: flip each
+/// slot, then mark the row. Returns the rows revoked, for the caller to audit.
+///
+/// Best effort per grant, like the membership credential's flip on departure:
+/// the member is already gone, so a grant whose flip fails is logged and left
+/// for an operator rather than unwinding the departure. It stops counting
+/// statements regardless, because eligibility requires a current member.
+pub(crate) async fn revoke_on_departure(state: &AppState, subject_did: &str) -> Vec<Endorsement> {
+    // Under the grant lock: a grant that passed its member check just before
+    // the departure has stored its row by now, and one that has not yet run
+    // will find no current member.
+    let _guard = GRANT_LOCK.lock().await;
+    let grants = match endorsements_for_subject(
+        &state.endorsements_ks,
+        subject_did,
+        COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(subject = %subject_did, error = %e, "could not read role grants on departure");
+            return Vec::new();
+        }
+    };
+    let mut revoked = Vec::new();
+    for grant in grants.into_iter().filter(|g| !g.is_revoked()) {
+        let slot = grant.status_list_index;
+        let flipped = status_list::with_locked(
+            &state.status_lists_ks,
+            affinidi_status_list::StatusPurpose::Revocation,
+            move |sl| {
+                status_list::flip(sl, slot, true)
+                    .map_err(|e| AppError::Internal(format!("flip status-list bit {slot}: {e}")))
+            },
+        )
+        .await;
+        if let Err(e) = flipped {
+            warn!(
+                subject = %subject_did,
+                endorsement_id = %grant.id,
+                slot,
+                error = %e,
+                "could not revoke a role grant on departure — operator must revoke it"
+            );
+            continue;
+        }
+        match mark_revoked(&state.endorsements_ks, grant.id).await {
+            Ok(Some(row)) => revoked.push(row),
+            Ok(None) => {}
+            Err(e) => warn!(
+                subject = %subject_did,
+                endorsement_id = %grant.id,
+                error = %e,
+                "role grant's bit flipped but its row was not marked revoked"
+            ),
+        }
+    }
+    revoked
+}
+
+/// The two envelopes a revoked grant is accounted with, as for any revoked
+/// endorsement: `CustomEndorsementRevoked` + `StatusListFlipped`.
+pub(crate) async fn audit_revoked_grant(
+    writer: &AuditWriter,
+    actor_did: &str,
+    subject_did: &str,
+    grant: &Endorsement,
+) -> Result<(), AppError> {
+    writer
+        .write(
+            actor_did,
+            Some(subject_did),
+            AuditEvent::CustomEndorsementRevoked(CustomEndorsementRevokedData {
+                endorsement_id: grant.id.to_string(),
+                endorsement_type: grant.endorsement_type.clone(),
+            }),
+        )
+        .await?;
+    writer
+        .write(
+            actor_did,
+            Some(subject_did),
+            AuditEvent::StatusListFlipped(StatusListFlippedData {
+                purpose: affinidi_status_list::StatusPurpose::Revocation.to_string(),
+                index: grant.status_list_index,
+                revoked: true,
+            }),
+        )
+        .await?;
+    Ok(())
+}
+
+fn response_for(row: &Endorsement) -> Result<VetterGrantResponseBody, AppError> {
+    Ok(VetterGrantResponseBody {
+        endorsement_id: row.id.to_string(),
+        credential_id: row.vec_id.clone(),
+        valid_from: row.created_at,
+        valid_until: row
+            .valid_until
+            .ok_or_else(|| AppError::Internal("vetter grant row has no validUntil".into()))?,
+        ext: None,
+    })
+}
+
+fn timestamp(credential: &JsonValue, member: &str) -> Result<DateTime<Utc>, AppError> {
+    credential
+        .get(member)
+        .and_then(JsonValue::as_str)
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|t| t.with_timezone(&Utc))
+        .ok_or_else(|| AppError::Internal(format!("issued vetter grant has no {member}")))
+}
+
+fn rfc3339(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grant_row(role: &str, created: DateTime<Utc>, until: Option<DateTime<Utc>>) -> Endorsement {
+        let id = Uuid::new_v4();
+        Endorsement {
+            id,
+            endorsement_type: COMMUNITY_ROLE_ENDORSEMENT_TYPE.into(),
+            issuer_did: "did:webvh:vtc".into(),
+            subject_did: "did:key:zCarol".into(),
+            claim: json!({ "role": role }),
+            status_list_index: 1,
+            vec_id: format!("urn:uuid:{id}"),
+            created_at: created,
+            revoked_at: None,
+            valid_until: until,
+        }
+    }
+
+    #[test]
+    fn a_grant_covers_a_statement_signed_while_it_stood() {
+        let now = Utc::now();
+        let g = grant_row(
+            "vetter",
+            now - Duration::days(10),
+            Some(now + Duration::days(10)),
+        );
+        assert!(grant_covers(&g, "vetter", now));
+        assert!(grant_covers(&g, "custom:vetter", now));
+        assert!(!grant_covers(&g, "moderator", now));
+    }
+
+    #[test]
+    fn a_grant_does_not_reach_back_before_it_was_recorded() {
+        let now = Utc::now();
+        let g = grant_row("vetter", now, Some(now + Duration::days(10)));
+        assert!(!grant_covers(&g, "vetter", now - Duration::minutes(1)));
+    }
+
+    #[test]
+    fn an_expired_or_revoked_grant_covers_nothing() {
+        let now = Utc::now();
+        let g = grant_row(
+            "vetter",
+            now - Duration::days(10),
+            Some(now - Duration::days(1)),
+        );
+        assert!(!grant_covers(&g, "vetter", now));
+        assert!(grant_covers(&g, "vetter", now - Duration::days(2)));
+
+        let mut g = grant_row("vetter", now - Duration::days(10), None);
+        assert!(grant_covers(&g, "vetter", now));
+        g.revoked_at = Some(now);
+        assert!(
+            !grant_covers(&g, "vetter", now - Duration::days(5)),
+            "revocation withdraws a grant for statements signed before it too"
+        );
+    }
+
+    #[test]
+    fn only_community_role_rows_are_grants() {
+        let now = Utc::now();
+        let mut g = grant_row("vetter", now - Duration::days(1), None);
+        g.endorsement_type = "https://example.com/v1/skills/rust".into();
+        assert!(!grant_covers(&g, "vetter", now));
+    }
+}

--- a/vtc-service/tests/ceremony_execute.rs
+++ b/vtc-service/tests/ceremony_execute.rs
@@ -199,6 +199,71 @@ async fn no_state_change_is_a_noop() {
     );
 }
 
+/// A departing member's vetter grant is revoked with them — slot flipped and
+/// row marked — and reported back for the caller to audit. Left live, it would
+/// count again were the DID ever readmitted.
+#[tokio::test]
+async fn depart_revokes_the_members_role_grants() {
+    use vtc_service::endorsements::{Endorsement, get_endorsement, store_endorsement};
+
+    let (state, _dir) = build_state().await;
+    let subject = "did:key:zVetter";
+    let admit = EffectPlan::Admit {
+        subject: subject.into(),
+        role: "member".into(),
+        obligations: vec![],
+    };
+    execute::apply(&state, admit, ACTOR_DID)
+        .await
+        .expect("admit");
+
+    let slot = vtc_service::status_list::with_locked(
+        &state.status_lists_ks,
+        StatusPurpose::Revocation,
+        |row| Ok(vtc_service::status_list::allocate(row).expect("a free slot")),
+    )
+    .await
+    .unwrap();
+    let id = uuid::Uuid::new_v4();
+    let now = chrono::Utc::now();
+    store_endorsement(
+        &state.endorsements_ks,
+        &Endorsement {
+            id,
+            endorsement_type: "CommunityRole".into(),
+            issuer_did: "did:webvh:vtc.example.com:abc".into(),
+            subject_did: subject.into(),
+            claim: serde_json::json!({ "role": "vetter" }),
+            status_list_index: slot,
+            vec_id: format!("urn:uuid:{id}"),
+            created_at: now,
+            revoked_at: None,
+            valid_until: Some(now + chrono::Duration::days(365)),
+        },
+    )
+    .await
+    .unwrap();
+
+    let plan = EffectPlan::Depart {
+        subject: subject.into(),
+        disposition: Some("tombstone".into()),
+    };
+    let EffectOutcome::Departed(outcome) = execute::apply(&state, plan, ACTOR_DID)
+        .await
+        .expect("depart")
+    else {
+        panic!("expected Departed");
+    };
+    assert_eq!(outcome.revoked_grants.len(), 1, "{outcome:?}");
+    assert_eq!(outcome.revoked_grants[0].id, id);
+    assert_eq!(outcome.revoked_grants[0].status_list_index, slot);
+    let row = get_endorsement(&state.endorsements_ks, id)
+        .await
+        .unwrap()
+        .expect("the row is kept for audit");
+    assert!(row.is_revoked());
+}
+
 /// Depart removes a member: deletes the ACL row, applies the
 /// disposition (tombstone keeps the row but clears credentials), and
 /// revokes by flipping the member's revocation slot.

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -1929,8 +1929,47 @@ fn did_key_secret(seed: [u8; 32]) -> (String, Secret) {
     (did, secret)
 }
 
-/// A community member holding `role`, admitted a month ago.
-async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
+const VETTER_GRANT_TASK: &str = "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+const ENDORSEMENT_REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
+
+/// Name `did` a vetter through `POST /v1/vetting/vetters`, as the admin.
+async fn grant_vetter(fix: &Fixture, did: &str) -> (StatusCode, Value) {
+    send(
+        &fix.router,
+        "POST",
+        "/v1/vetting/vetters",
+        VETTER_GRANT_TASK,
+        Some(&fix.admin_token),
+        Some(json!({ "memberDid": did })),
+    )
+    .await
+}
+
+/// A community member the admin has named a vetter through a real grant.
+/// Returns the grant's endorsement id.
+async fn seed_vetter(fix: &Fixture, did: &str) -> String {
+    seed_member(fix, did).await;
+    let (status, body) = grant_vetter(fix, did).await;
+    assert_eq!(status, StatusCode::CREATED, "grant vetter: {body}");
+    body["endorsementId"]
+        .as_str()
+        .expect("endorsementId")
+        .to_string()
+}
+
+/// The community's grant rows for `did`.
+async fn grants_of(fix: &Fixture, did: &str) -> Vec<vtc_service::endorsements::Endorsement> {
+    vtc_service::endorsements::endorsements_for_subject(
+        &fix.state.endorsements_ks,
+        did,
+        vta_sdk::protocols::vetting::COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+    )
+    .await
+    .expect("read grants")
+}
+
+/// A community member, admitted a month ago. Holding no vetter grant.
+async fn seed_member(fix: &Fixture, did: &str) {
     let mut member = vtc_service::members::Member::fresh(did);
     member.joined_at = chrono::Utc::now() - chrono::Duration::days(30);
     vtc_service::members::storage::store_member(&fix.members_ks, &member)
@@ -1940,7 +1979,7 @@ async fn seed_member(fix: &Fixture, did: &str, role: VtcRole) {
         &fix.acl_ks,
         &VtcAclEntry {
             did: did.into(),
-            role,
+            role: VtcRole::Member,
             label: None,
             allowed_contexts: vec![],
             created_at: vtc_service::auth::session::now_epoch(),
@@ -1989,14 +2028,25 @@ async fn store_vetting_criterion(fix: &Fixture) {
     .expect("store vetting criterion");
 }
 
-/// A Vetting Statement signed by `vetter` about `applicant`.
+/// A Vetting Statement signed by `vetter` about `applicant`, valid from now —
+/// after any grant the test made first.
 async fn vetting_statement(vetter: &Secret, applicant: &str, n: u8) -> Value {
+    vetting_statement_from(vetter, applicant, n, chrono::Utc::now()).await
+}
+
+/// As [`vetting_statement`], valid from `valid_from`.
+async fn vetting_statement_from(
+    vetter: &Secret,
+    applicant: &str,
+    n: u8,
+    valid_from: chrono::DateTime<chrono::Utc>,
+) -> Value {
     use vta_sdk::protocols::vetting::{
         DeclaredRelationship, IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement,
         VettingMethod,
     };
     use vta_sdk::vetting::statement::{StatementDraft, sign_statement};
-    let now = chrono::Utc::now();
+    let now = valid_from;
     sign_statement(
         StatementDraft {
             id: format!("urn:uuid:statement-{n}"),
@@ -2014,7 +2064,7 @@ async fn vetting_statement(vetter: &Secret, applicant: &str, n: u8) -> Value {
                 declared_relationship: DeclaredRelationship::None,
                 attestation_text_digest: None,
             },
-            valid_from: now - chrono::Duration::minutes(5),
+            valid_from: now,
             valid_until: now + chrono::Duration::days(90),
             task_context: format!("urn:uuid:session-{n}"),
         },
@@ -2039,8 +2089,8 @@ async fn vetted_applicant_with_two_eligible_vetters_is_admitted() {
     let (applicant, _) = did_key_secret(MEMBER_SEED);
     let (carol, carol_key) = did_key_secret([0x11; 32]);
     let (dave, dave_key) = did_key_secret([0x22; 32]);
-    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
-    seed_member(&fix, &dave, VtcRole::Custom("vetter".into())).await;
+    seed_vetter(&fix, &carol).await;
+    seed_vetter(&fix, &dave).await;
 
     let vp = vetting_vp(
         &applicant,
@@ -2068,7 +2118,7 @@ async fn one_statement_short_asks_for_exactly_what_is_missing() {
     store_vetting_criterion(&fix).await;
     let (applicant, _) = did_key_secret(MEMBER_SEED);
     let (carol, carol_key) = did_key_secret([0x11; 32]);
-    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
+    seed_vetter(&fix, &carol).await;
 
     let vp = vetting_vp(
         &applicant,
@@ -2099,8 +2149,8 @@ async fn a_statement_from_a_member_who_is_not_a_vetter_does_not_count() {
     let (applicant, _) = did_key_secret(MEMBER_SEED);
     let (carol, carol_key) = did_key_secret([0x11; 32]);
     let (erin, erin_key) = did_key_secret([0x33; 32]);
-    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
-    seed_member(&fix, &erin, VtcRole::Member).await;
+    seed_vetter(&fix, &carol).await;
+    seed_member(&fix, &erin).await;
 
     let vp = vetting_vp(
         &applicant,
@@ -2128,8 +2178,8 @@ async fn a_withdrawn_statement_stops_counting() {
     let (applicant, _) = did_key_secret(MEMBER_SEED);
     let (carol, carol_key) = did_key_secret([0x11; 32]);
     let (dave, dave_key) = did_key_secret([0x22; 32]);
-    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
-    seed_member(&fix, &dave, VtcRole::Custom("vetter".into())).await;
+    seed_vetter(&fix, &carol).await;
+    seed_vetter(&fix, &dave).await;
     let from_carol = vetting_statement(&carol_key, &applicant, 1).await;
     let from_dave = vetting_statement(&dave_key, &applicant, 2).await;
 
@@ -2156,9 +2206,9 @@ async fn nobody_can_withdraw_a_statement_someone_else_signed() {
     let (carol, carol_key) = did_key_secret([0x11; 32]);
     let (dave, dave_key) = did_key_secret([0x22; 32]);
     let (erin, _) = did_key_secret([0x33; 32]);
-    seed_member(&fix, &carol, VtcRole::Custom("vetter".into())).await;
-    seed_member(&fix, &dave, VtcRole::Custom("vetter".into())).await;
-    seed_member(&fix, &erin, VtcRole::Member).await;
+    seed_vetter(&fix, &carol).await;
+    seed_vetter(&fix, &dave).await;
+    seed_member(&fix, &erin).await;
     let from_carol = vetting_statement(&carol_key, &applicant, 1).await;
     let from_dave = vetting_statement(&dave_key, &applicant, 2).await;
 
@@ -2189,6 +2239,236 @@ async fn a_non_member_cannot_send_a_withdrawal() {
         StatusCode::OK,
         "a stranger's notice must be refused: {body}"
     );
+}
+
+#[tokio::test]
+async fn a_revoked_vetter_grant_stops_a_statement_counting() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    let (dave, dave_key) = did_key_secret([0x22; 32]);
+    seed_vetter(&fix, &carol).await;
+    let daves_grant = seed_vetter(&fix, &dave).await;
+    let from_carol = vetting_statement(&carol_key, &applicant, 1).await;
+    let from_dave = vetting_statement(&dave_key, &applicant, 2).await;
+
+    // Withdrawn after Dave signed: revocation is read as it stands at submit.
+    let (status, body) = send(
+        &fix.router,
+        "DELETE",
+        &format!("/v1/credentials/endorsements/{daves_grant}"),
+        ENDORSEMENT_REVOKE_TASK,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "revoke grant: {body}");
+
+    let (_did, doc) = submit_doc(&vetting_vp(&applicant, vec![from_carol, from_dave])).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(verdict_effect(&body), "requestMore", "got {body}");
+    assert_eq!(
+        body.pointer("/payload/verdict/with/needs"),
+        Some(&json!(["vetting:statements:1"])),
+        "a statement from a vetter whose grant was revoked no longer counts: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_grant_made_after_a_statement_was_signed_does_not_count_it() {
+    let fix = build_fixture().await;
+    store_vetting_criterion(&fix).await;
+    let (applicant, _) = did_key_secret(MEMBER_SEED);
+    let (carol, carol_key) = did_key_secret([0x11; 32]);
+    let (dave, dave_key) = did_key_secret([0x22; 32]);
+    seed_vetter(&fix, &carol).await;
+    seed_member(&fix, &dave).await;
+    let from_carol = vetting_statement(&carol_key, &applicant, 1).await;
+    // Signed an hour before Dave was named a vetter.
+    let from_dave = vetting_statement_from(
+        &dave_key,
+        &applicant,
+        2,
+        chrono::Utc::now() - chrono::Duration::hours(1),
+    )
+    .await;
+    let (status, body) = grant_vetter(&fix, &dave).await;
+    assert_eq!(status, StatusCode::CREATED, "got {body}");
+
+    let (_did, doc) = submit_doc(&vetting_vp(&applicant, vec![from_carol, from_dave])).await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_eq!(status, StatusCode::OK, "got {body}");
+    assert_eq!(verdict_effect(&body), "requestMore", "got {body}");
+    assert_eq!(
+        body.pointer("/payload/verdict/with/needs"),
+        Some(&json!(["vetting:statements:1"])),
+        "a grant does not reach back to a statement signed before it: {body}"
+    );
+}
+
+#[tokio::test]
+async fn a_non_member_cannot_be_named_a_vetter() {
+    let fix = build_fixture().await;
+    let (stranger, _) = did_key_secret([0x44; 32]);
+    let (status, body) = grant_vetter(&fix, &stranger).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {body}");
+    assert!(grants_of(&fix, &stranger).await.is_empty());
+}
+
+/// The grant is also a Trust Task document. A member who is not an admin sends
+/// one and is refused; nothing is issued.
+#[tokio::test]
+async fn only_an_admin_can_name_a_vetter() {
+    let fix = build_fixture().await;
+    let (carol, _) = did_key_secret([0x11; 32]);
+    let (erin, _) = did_key_secret([0x33; 32]);
+    seed_member(&fix, &carol).await;
+    seed_member(&fix, &erin).await;
+    let (_did, doc) = signed_trust_task_seed(
+        &[0x33; 32],
+        VETTER_GRANT_TASK,
+        json!({ "memberDid": carol }),
+    )
+    .await;
+    let (status, body) = post_tt(&fix.router, doc).await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "a member's grant must be refused: {body}"
+    );
+    assert!(grants_of(&fix, &carol).await.is_empty());
+}
+
+/// What the member receives: a vetter role credential with a revocation entry,
+/// which they can present to an applicant who checks it offline with
+/// `vta_sdk::vetting::eligibility`.
+#[tokio::test]
+async fn the_vetter_role_credential_is_revocable_and_verifies_for_an_applicant() {
+    use vta_sdk::protocols::vetting::VetterGrantBody;
+    use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+    use vta_sdk::vetting::eligibility::{
+        EligibilityExpectations, build_eligibility_vp, verify_eligibility_vp,
+    };
+
+    // A did:key community, so the applicant's check resolves without a network.
+    let (community, community_key) = did_key_secret([0xC0; 32]);
+    let signer = Arc::new(vtc_service::credentials::LocalSigner::new(
+        community.clone(),
+        community_key,
+    ));
+    let vtc = TestVtc::builder()
+        .with_audit(true)
+        .with_public_url(RP_ORIGIN)
+        .with_credential_signer(signer)
+        .build()
+        .await;
+    let purpose = affinidi_status_list::StatusPurpose::Revocation;
+    vtc_service::status_list::ensure_initial(
+        &vtc.state.status_lists_ks,
+        purpose,
+        format!("{RP_ORIGIN}/v1/status-lists/{purpose}"),
+    )
+    .await
+    .expect("ensure_initial status list");
+    store_acl_entry(
+        &vtc.state.acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    let (vetter, vetter_key) = did_key_secret([0x11; 32]);
+    vtc_service::members::storage::store_member(
+        &vtc.state.members_ks,
+        &vtc_service::members::Member::fresh(&vetter),
+    )
+    .await
+    .unwrap();
+
+    let grant = vtc_service::vetting::vetters::grant(
+        &vtc.state,
+        ADMIN_DID,
+        &VetterGrantBody {
+            member_did: vetter.clone(),
+            validity_seconds: Some(30 * 86_400),
+            ext: None,
+        },
+    )
+    .await
+    .expect("grant");
+    let credential = grant
+        .credential
+        .expect("a new grant carries its credential");
+    assert_eq!(credential["id"], json!(grant.response.credential_id));
+    assert_eq!(
+        credential["credentialStatus"]["statusPurpose"],
+        "revocation"
+    );
+    assert!(
+        credential["credentialStatus"]["statusListIndex"].is_string(),
+        "{credential}"
+    );
+    assert_eq!(
+        credential["credentialSubject"]["endorsement"],
+        json!({ "type": "CommunityRole", "role": "vetter", "communityDid": community })
+    );
+    assert_eq!(
+        grant.response.valid_until - grant.response.valid_from,
+        chrono::Duration::days(30)
+    );
+
+    // The vetter answers an applicant's `vetting/request`: `nonce` is that
+    // request document's `id`, `domain` its `joinDid`.
+    let (join_did, _) = did_key_secret(MEMBER_SEED);
+    let request_id = "urn:uuid:3f1c9a52-8c1e-4f2b-9d7a-0b6e5c4d3a21";
+    let vp = build_eligibility_vp(&vetter_key, vec![credential], request_id, &join_did)
+        .await
+        .expect("present");
+    let verified = verify_eligibility_vp(
+        &vp,
+        &EligibilityExpectations {
+            vetter: &vetter,
+            community: &community,
+            role: "vetter",
+            challenge: request_id,
+            domain: &join_did,
+            now: chrono::Utc::now(),
+        },
+        &TrustTaskVmResolver::did_key_only(),
+    )
+    .await
+    .expect("the applicant's check accepts the community's credential");
+    assert_eq!(
+        verified.credential_id(),
+        Some(grant.response.credential_id.as_str())
+    );
+    assert!(verified.credential_status().is_some());
+}
+
+#[tokio::test]
+async fn naming_a_vetter_twice_returns_the_same_grant() {
+    let fix = build_fixture().await;
+    let (carol, _) = did_key_secret([0x11; 32]);
+    seed_member(&fix, &carol).await;
+    let (status, first) = grant_vetter(&fix, &carol).await;
+    assert_eq!(status, StatusCode::CREATED, "got {first}");
+    let (status, second) = grant_vetter(&fix, &carol).await;
+    assert_eq!(status, StatusCode::OK, "a live grant is returned: {second}");
+    assert_eq!(first["endorsementId"], second["endorsementId"]);
+    assert_eq!(first["credentialId"], second["credentialId"]);
+    assert_eq!(first["validUntil"], second["validUntil"]);
+    assert_eq!(grants_of(&fix, &carol).await.len(), 1, "one slot, one row");
 }
 
 /// A `vtc/vetting/revoke-statement/0.1` document for `statement`, signed by `seed`.

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -449,11 +449,13 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
     ),
     // `vtc/vetting/revoke-statement/0.1` — a vetter withdrawing a statement
     // from the community that relies on it (design §9.6).
+    // `vtc/vetting/vetters/grant/0.1` — an admin naming a vetter by issuing a
+    // revocable vetter role credential.
     (
         "https://trusttasks.org/spec/vtc/vetting/",
-        1,
-        "vetting statement revocation notice — proposed in dtgwg-trust-tasks-tf \
-         (spec/vetting-revoke-and-ceremony)",
+        2,
+        "vetting statement revocation notice and vetter grant — proposed in \
+         dtgwg-trust-tasks-tf (spec/vetting-revoke-and-ceremony)",
     ),
     // `vtc/join-requests/manifest/0.2` — 0.1 plus the per-criterion `vetting`
     // requirements object and `requirementsDigest`.

--- a/vti-common/src/audit/event.rs
+++ b/vti-common/src/audit/event.rs
@@ -374,6 +374,13 @@ pub enum AuditEvent {
     /// statement stops counting toward any join decided after this.
     VettingStatementRevoked(VettingStatementRevokedData),
 
+    /// A community admin named a member a vetter by issuing them a vetter
+    /// role credential (`vtc/vetting/vetters/grant/0.1`). Paired with a
+    /// `VecIssued` envelope for the same slot. The grant is withdrawn like any
+    /// endorsement — `CustomEndorsementRevoked` + `StatusListFlipped` — and on
+    /// the member's departure.
+    VetterGranted(VetterGrantedData),
+
     /// An operator registered a new custom endorsement type
     /// via `POST /v1/endorsement-types`. Phase 4 M4.8.1 (D4
     /// review). The actor is the admin; the `type_uri` field
@@ -541,6 +548,7 @@ impl AuditEvent {
             Self::CustomEndorsementIssued(..) => "CustomEndorsementIssued",
             Self::CustomEndorsementRevoked(..) => "CustomEndorsementRevoked",
             Self::VettingStatementRevoked(..) => "VettingStatementRevoked",
+            Self::VetterGranted(..) => "VetterGranted",
             Self::EndorsementTypeRegistered(..) => "EndorsementTypeRegistered",
             Self::EndorsementTypeDeleted(..) => "EndorsementTypeDeleted",
             Self::WebsiteFileWritten(..) => "WebsiteFileWritten",
@@ -1356,6 +1364,16 @@ pub struct VettingStatementRevokedData {
     /// `key-compromise`, `other`), when given.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+}
+
+/// Payload for [`AuditEvent::VetterGranted`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VetterGrantedData {
+    /// The endorsement row recording the grant — what a revocation names.
+    pub endorsement_id: String,
+    /// The grant's slot on the `Revocation` status list.
+    pub status_list_index: u32,
 }
 
 /// Payload for [`AuditEvent::EndorsementTypeRegistered`].
@@ -2216,6 +2234,19 @@ mod tests {
     }
 
     #[test]
+    fn vetter_granted_round_trip() {
+        let e = AuditEvent::VetterGranted(VetterGrantedData {
+            endorsement_id: "end-1".into(),
+            status_list_index: 9,
+        });
+        let v = wire_value(&e);
+        assert_eq!(v["type"], "VetterGranted");
+        assert_eq!(v["data"]["endorsementId"], "end-1");
+        assert_eq!(v["data"]["statusListIndex"], 9);
+        round_trip(&e);
+    }
+
+    #[test]
     fn custom_endorsement_issued_round_trip() {
         let e = AuditEvent::CustomEndorsementIssued(CustomEndorsementIssuedData {
             endorsement_id: "end-1".into(),
@@ -2544,6 +2575,13 @@ mod tests {
                     reason: Some("mistake".into()),
                 }),
                 "VettingStatementRevoked",
+            ),
+            (
+                AuditEvent::VetterGranted(VetterGrantedData {
+                    endorsement_id: "end".into(),
+                    status_list_index: 7,
+                }),
+                "VetterGranted",
             ),
             (
                 AuditEvent::EndorsementTypeRegistered(EndorsementTypeRegisteredData {

--- a/vti-common/src/audit/mod.rs
+++ b/vti-common/src/audit/mod.rs
@@ -51,9 +51,9 @@ pub use event::{
     PolicyUploadedData, REDACTED_MARKER, RegistryRecordPolicyOverrideData,
     RegistryStatusChangedData, RegistrySyncOutcomeData, RestartRequestedData, RoleChangedData,
     RoomOperationData, SchemaChangeData, SessionRevokedData, SignedOutData, StatusListFlippedData,
-    VettingStatementRevokedData, VpcAnnotationData, VrcLifecycleData, VrcPublishedData,
-    VrcRevokedData, VrcSupersededData, WebsiteBundleDeployedData, WebsiteFileDeletedData,
-    WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
+    VetterGrantedData, VettingStatementRevokedData, VpcAnnotationData, VrcLifecycleData,
+    VrcPublishedData, VrcRevokedData, VrcSupersededData, WebsiteBundleDeployedData,
+    WebsiteFileDeletedData, WebsiteFileWrittenData, WebsiteGenerationRolledBackData,
 };
 pub use key_store::{AuditKey, AuditKeyStore, KeyId, RotationReason};
 pub use writer::AuditWriter;


### PR DESCRIPTION
Stacked on #1428 (`feat/vtc-vetting-revocation`). A vetter was a member holding the ACL role `custom:vetter`. That is an access-control fact only the community can see: an applicant had no way to know a vetter's statement would count, and the ACL keeps no history, so "held the role when signing" was approximated. This names vetters with a **vetter role credential** instead — issued by the community, recorded, revocable, delivered to the member, verified at join, and presentable to an applicant.

## vta-sdk

`protocols::vetting` (serde, always compiled):

- `COMMUNITY_ROLE_ENDORSEMENT_TYPE = "CommunityRole"`, `VETTER_ROLE = "vetter"`
- `VETTING_VETTER_GRANT_TYPE` = `https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1`, `VETTING_VETTER_GRANT_RESPONSE_TYPE` (`#response`)
- `role_matches(held, required)`: `vetter` ≡ `custom:vetter` in either direction, otherwise exact
- `VetterGrantBody { memberDid, validitySeconds?, ext? }` (closed, `check_shape`: a DID, one day to two years) and `VetterGrantResponseBody { endorsementId, credentialId, validFrom, validUntil, ext? }`
- `MIN_/MAX_/DEFAULT_VETTER_GRANT_VALIDITY_SECONDS`

`vetting::eligibility` (feature `vetting`):

- `community_role(&Value) -> Option<(communityDid, role)>`
- `build_eligibility_vp(holder, credentials, challenge, domain)`: the `vetting/request#response` `eligibilityVp` (dtgwg-trust-tasks-tf#452, request rule 5): `nonce` = the request document's `id`, `domain` = its `joinDid`, `eddsa-jcs-2022`, purpose `authentication`
- `verify_eligibility_vp(vp, &EligibilityExpectations { vetter, community, role, challenge, domain, now }, resolver) -> VerifiedEligibility`. It checks:
  - the VP proof, with signer = holder = vetter;
  - `nonce` and `domain` match the request `id` and `joinDid`;
  - the VP carries a role credential issued by the community, naming the vetter, for that community, in a matching role;
  - that credential's proof, by the issuer (`assertionMethod`);
  - that credential's window, allowing for clock skew.
- The status list is left to the caller, via `credential_status()`.
- New `VettingError::NoRoleCredential` (the enum is `#[non_exhaustive]`).

## vtc-service

- **Grant**: `vtc/vetting/vetters/grant/0.1`, as `POST /v1/vetting/vetters` and as a Trust Task document (dispatcher, so REST `/v1/trust-tasks`, DIDComm and TSP). Both go through `vetting::vetters::grant`:
  - **Auth:** Admin, read from the ACL row. The subject must be a current member.
  - **Credential:** allocates a revocation slot and issues the VEC (`urn:uuid` id, `credentialStatus`, one year by default).
  - **Record:** stores an `Endorsement` row (`CommunityRole`, `{role: "vetter"}`, `validUntil`).
  - **Audit:** `VetterGranted` + `VecIssued`.
  - **Delivery:** best effort.
  - **Converges:** while a grant is live, it is returned (200) instead of a second being issued (201).
- **Revoke**: unchanged — `vtc/endorsements/revoke/0.1` already accepts any row.
- **Departure** revokes the member's grants (flip + mark) and reports them on `DepartOutcome.revoked_grants`. Both leave paths audit `CustomEndorsementRevoked` + `StatusListFlipped`.
- **Eligibility at submit**: the ACL check is gone. A statement counts only when:
  - its issuer is a current member who joined by the statement's `validFrom`;
  - they hold a `CommunityRole` grant for the role that was recorded during this membership and by `validFrom`;
  - that grant was unexpired then and is not revoked now.
- `Endorsement` rows gain `validUntil`; the endorsement list/show now report `issued.expiresAt` from it.
- admin-ui: member page gets a "Vetter role" card — grant, show the live grant, revoke.

Censuses: manifest `spec/vtc/vetting/` 1 → 2, dispatched URIs, audit event names, OpenAPI snapshot + `wire.ts`.

## Test plan

- [x] `cargo test -p vta-sdk --features client,vetting --lib vetting`
- [x] `cargo test -p vtc-service --lib`
- [x] `cargo test -p vtc-service --test join_requests --test endorsements --test ceremony_execute --test openapi_snapshot --test trust_task_manifest`
- [x] `cargo test -p vti-common --lib audit`
- [x] `cargo clippy -p vtc-service -p vta-sdk -p vti-common --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] admin-ui `npx tsc -b --noEmit`
