### PR TITLE
feat(vtc-admin-ui): vetting panels for vetters, registry, auto-grants and join requests

### DIFF
--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -195,6 +195,12 @@ and `updatedAt` — nothing else. With an event filter the earliest matching
 event comes first; otherwise vetters are ordered by `displayName` (vetters
 without one last), then by DID, by code point.
 
+An admin session reads the same listing with `POST /v1/vetting/vetters/list`
+(`Trust-Task: …/vtc/vetting/vetters/list/0.1`), whose body and answer are the
+task's payloads. Over `POST /v1/trust-tasks` the listing names its caller by the
+document proof, which a browser session cannot sign; the admin console's
+**Vetting → Registry preview** uses this route to show what applicants see.
+
 A vetter hands out tickets as a QR code carrying a **ticket URI**, encoded and
 decoded with `vta_sdk::vetting::ticket_uri`:
 
@@ -366,6 +372,27 @@ Running it again is safe: members already holding a live grant are skipped.
 The bootstrap names vetters once; it does not keep the web of trust in sync. A
 key revoked later does not revoke the grant — revoke it with
 `cnm vetting vetters revoke`.
+
+## In the admin console
+
+- **Vetting → Vetters** lists every grant with its origin, validity and profile
+  summary; grants a current member the role for one day to two years; resends a
+  grant's credential; and revokes a grant.
+- **Vetting → Registry preview** shows the listing as applicants see it, with
+  the same filters.
+- **Vetting → Automatic grants** sets the sweep, shows the last one, and links
+  to the `vetterEligibility` policy under **Ceremonies → Other policies**.
+- **Vetting → Withdrawals** lists withdrawal notices with their review state,
+  linking to the join requests and members they touch.
+- **Vetting → Requirements** shows each criterion's vetting requirements and
+  `requirementsDigest` as the join manifest publishes them, read from
+  `GET /v1/join-requests/manifest` — the manifest 0.2 answer for an admin
+  session, under the same task. It is read-only: criteria are registered with
+  `POST /v1/schemas/accepts`.
+- A join request's page shows the vetting facts it was decided on, statement
+  by statement; the **Community profile** page edits the branding; the
+  dashboard counts pending requests with vetting facts and withdrawals to
+  review.
 
 ## What the community checks at submit
 

--- a/vta-sdk/src/protocols/vetting.rs
+++ b/vta-sdk/src/protocols/vetting.rs
@@ -911,15 +911,18 @@ pub struct VetterLocation {
 
 /// An event a vetter will attend and vet at — a conference, a summit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct VetterEvent {
     /// The event's name; 1–200 characters.
     pub name: String,
     /// First day, `YYYY-MM-DD`.
     #[serde(with = "date_only")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, format = Date))]
     pub start_date: NaiveDate,
     /// Last day, `YYYY-MM-DD`; not before `startDate`, at most 31 days after it.
     #[serde(with = "date_only")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, format = Date))]
     pub end_date: NaiveDate,
     /// Where it is held.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -989,6 +992,7 @@ pub const MAX_VETTER_LIST_CURSOR_CHARS: usize = 512;
 /// `vtc/vetting/vetters/list/0.1` payload. Every filter is optional; filters
 /// combine with AND.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct VetterListBody {
     /// A BCP 47 tag. Matches a listed tag equal to it, or one it is a prefix of
@@ -1014,6 +1018,7 @@ pub struct VetterListBody {
         skip_serializing_if = "Option::is_none",
         with = "optional_date_only"
     )]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, format = Date))]
     pub event_from: Option<NaiveDate>,
     /// See [`Self::event_from`].
     #[serde(
@@ -1021,6 +1026,7 @@ pub struct VetterListBody {
         skip_serializing_if = "Option::is_none",
         with = "optional_date_only"
     )]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, format = Date))]
     pub event_to: Option<NaiveDate>,
     /// Case-insensitive substring of a listed event's name; at most 200
     /// characters.
@@ -1048,6 +1054,7 @@ impl VetterListBody {
 /// One vetter in a listing: the published profile, the DID and the grant's
 /// expiry — nothing else about the member.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ListedVetter {
     /// The vetter's DID — where a `vetting/request` goes.
@@ -1080,6 +1087,7 @@ pub struct ListedVetter {
 
 /// `vtc/vetting/vetters/list/0.1#response` payload.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct VetterListResponseBody {
     /// This page, in the listing's order.

--- a/vtc-service/admin-ui/README.md
+++ b/vtc-service/admin-ui/README.md
@@ -54,7 +54,13 @@ plugins ship as a JS bundle that calls
 ```sh
 npm install          # one-time
 npm run build        # produces dist/
+npm run lint         # wire types match openapi.json, then tsc
+npm test             # component + unit tests (Vitest, jsdom)
 ```
+
+Tests sit beside what they test as `*.test.ts(x)` and render components
+through `src/test/render.tsx`, which supplies the providers `main.tsx` does and
+a table-driven `fetch` mock. `cargo build` does not run them.
 
 `cargo build` (from `vtc-service/`) runs `npm install && npm run
 build` automatically via `build.rs`. To skip the build (e.g. in

--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -2268,6 +2268,39 @@
         ]
       }
     },
+    "/v1/join-requests/manifest": {
+      "get": {
+        "tags": [
+          "join-requests"
+        ],
+        "summary": "GET /join-requests/manifest — the join manifest (0.2) as applicants receive\nit, for an admin session.",
+        "description": "Applicants read the manifest as a Trust Task document over\n`POST /v1/trust-tasks`. The admin console reads the same answer here, under\nthe same `vtc/join-requests/manifest/0.2` task, to show each criterion's\nvetting requirements and `requirementsDigest` — criteria are registered\nthrough `/v1/schemas/accepts`, which carries no digest.",
+        "operationId": "joinRequestManifestShow",
+        "responses": {
+          "200": {
+            "description": "The join manifest (0.2): each criterion with its vetting requirements and requirementsDigest, and the branding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JoinRequestManifestResponseBody"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "403": {
+            "description": "Caller is not an admin"
+          }
+        },
+        "security": [
+          {
+            "bearer_jwt": []
+          }
+        ]
+      }
+    },
     "/v1/join-requests/query": {
       "post": {
         "tags": [
@@ -4580,6 +4613,52 @@
           },
           "403": {
             "description": "Caller is not a community admin"
+          }
+        },
+        "security": [
+          {
+            "bearer_jwt": []
+          }
+        ]
+      }
+    },
+    "/v1/vetting/vetters/list": {
+      "post": {
+        "tags": [
+          "vetting"
+        ],
+        "summary": "The public vetter listing, as applicants see it.",
+        "description": "The body and the answer are `vtc/vetting/vetters/list/0.1`'s, and both go\nthrough [`crate::vetting::profiles::list`], so the console previews exactly\nwhat `POST /v1/trust-tasks` returns to an applicant with the same filters.",
+        "operationId": "vettingVetterListing",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VetterListBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A page of listed vetters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VetterListResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A filter breaks its bounds, or the cursor was issued for other filters"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token"
+          },
+          "403": {
+            "description": "Caller is not an admin"
           }
         },
         "security": [
@@ -6987,6 +7066,36 @@
           }
         }
       },
+      "JoinRequestManifestResponseBody": {
+        "type": "object",
+        "description": "Manifest response: the community's join evidence requirements.",
+        "required": [
+          "communityDid",
+          "criteria"
+        ],
+        "properties": {
+          "branding": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CommunityBranding",
+                "description": "How the community presents itself to an applicant's client (manifest\n0.2). Absent when the community has set none, and always absent from a\n0.1 answer."
+              }
+            ]
+          },
+          "communityDid": {
+            "type": "string"
+          },
+          "criteria": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ManifestCriterion"
+            }
+          }
+        }
+      },
       "JoinRequestVetting": {
         "type": "object",
         "description": "The vetting facts a join request was decided on — the policy's\n`input.evidence.vetting`, in lowerCamelCase.",
@@ -7358,6 +7467,132 @@
               "$ref": "#/components/schemas/RegisteredCredential"
             },
             "description": "`credentials`, the name `auth/passkey/list/0.1` publishes. It was\n`passkeys` until #1112 — the same object under a name the schema does\nnot define, so no conforming client could find it."
+          }
+        }
+      },
+      "ListedVetter": {
+        "type": "object",
+        "description": "One vetter in a listing: the published profile, the DID and the grant's\nexpiry — nothing else about the member.",
+        "required": [
+          "vetterDid",
+          "languages",
+          "methods",
+          "acceptsDocumentation",
+          "events",
+          "grantValidUntil",
+          "updatedAt"
+        ],
+        "properties": {
+          "acceptsDocumentation": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "See [`VetterProfileBody::accepts_documentation`]."
+          },
+          "availability": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "See [`VetterProfileBody::availability`]."
+          },
+          "contactHint": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "See [`VetterProfileBody::contact_hint`]."
+          },
+          "displayName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "See [`VetterProfileBody::display_name`]."
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VetterEvent"
+            },
+            "description": "The profile's events that have not ended (`endDate` ≥ today, UTC)."
+          },
+          "grantValidUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the vetter's grant expires."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "See [`VetterProfileBody::languages`]."
+          },
+          "location": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VetterLocation",
+                "description": "See [`VetterProfileBody::location`]."
+              }
+            ]
+          },
+          "methods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VettingMethod"
+            },
+            "description": "See [`VetterProfileBody::methods`]."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the profile was last published."
+          },
+          "vetterDid": {
+            "type": "string",
+            "description": "The vetter's DID — where a `vetting/request` goes."
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManifestCriterion": {
+        "type": "object",
+        "description": "One community evidence requirement — a named DCQL Presentation\nDefinition the applicant may present against.",
+        "required": [
+          "id",
+          "presentationDefinition"
+        ],
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "presentationDefinition": {
+            "$ref": "#/components/schemas/Value"
+          },
+          "requirementsDigest": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`digestMultibase` over this criterion without this member (manifest\n0.2). An applicant records it when it starts gathering, so a change to\nthe requirements mid-application is detectable."
+          },
+          "vetting": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Peer identity vetting this criterion requires (manifest 0.2). Absent on\na criterion that needs none."
           }
         }
       },
@@ -9720,6 +9955,50 @@
           }
         }
       },
+      "VetterEvent": {
+        "type": "object",
+        "description": "An event a vetter will attend and vet at — a conference, a summit.",
+        "required": [
+          "name",
+          "startDate",
+          "endDate"
+        ],
+        "properties": {
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Last day, `YYYY-MM-DD`; not before `startDate`, at most 31 days after it."
+          },
+          "location": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VetterLocation",
+                "description": "Where it is held."
+              }
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The event's name; 1–200 characters."
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "description": "First day, `YYYY-MM-DD`."
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The event's page; `https`, at most 2048 characters."
+          }
+        },
+        "additionalProperties": false
+      },
       "VetterGrantBody": {
         "type": "object",
         "description": "`vtc/vetting/vetters/grant/0.1` payload.",
@@ -9866,6 +10145,146 @@
             "description": "The credential's `validUntil`; absent on a row that did not record it."
           }
         }
+      },
+      "VetterListBody": {
+        "type": "object",
+        "description": "`vtc/vetting/vetters/list/0.1` payload. Every filter is optional; filters\ncombine with AND.",
+        "properties": {
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Case-insensitive exact match on `location.city`."
+          },
+          "country": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO 3166-1 alpha-2, uppercase."
+          },
+          "cursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The `nextCursor` of the previous page; at most 512 characters."
+          },
+          "eventFrom": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "description": "With `eventTo`, a date range a listed event must overlap; an open end is\nunbounded."
+          },
+          "eventName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Case-insensitive substring of a listed event's name; at most 200\ncharacters."
+          },
+          "eventTo": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date",
+            "description": "See [`Self::event_from`]."
+          },
+          "ext": {
+            "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
+          },
+          "language": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A BCP 47 tag. Matches a listed tag equal to it, or one it is a prefix of\nat a subtag boundary (`de` matches `de-AT`). Compared case-insensitively."
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Page size, 1–100; 50 when absent.",
+            "minimum": 0
+          },
+          "method": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VettingMethod",
+                "description": "A method the vetter offers."
+              }
+            ]
+          },
+          "region": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Case-insensitive exact match on `location.region`."
+          }
+        },
+        "additionalProperties": false
+      },
+      "VetterListResponseBody": {
+        "type": "object",
+        "description": "`vtc/vetting/vetters/list/0.1#response` payload.",
+        "required": [
+          "vetters"
+        ],
+        "properties": {
+          "nextCursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Pass as `cursor`, with the same filters, for the next page; absent on\nthe last."
+          },
+          "vetters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListedVetter"
+            },
+            "description": "This page, in the listing's order."
+          }
+        },
+        "additionalProperties": false
+      },
+      "VetterLocation": {
+        "type": "object",
+        "description": "Where a vetter is, or where an event is held.",
+        "required": [
+          "country"
+        ],
+        "properties": {
+          "city": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "City; 1–128 characters."
+          },
+          "country": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2, uppercase."
+          },
+          "region": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Region, state or province; 1–128 characters."
+          }
+        },
+        "additionalProperties": false
       },
       "VetterProfileSummary": {
         "type": "object",

--- a/vtc-service/admin-ui/package-lock.json
+++ b/vtc-service/admin-ui/package-lock.json
@@ -20,13 +20,31 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.3",
         "@types/qrcode": "^1.5.5",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.0",
+        "jsdom": "^26.1.0",
         "openapi-typescript": "^7.13.0",
         "typescript": "^5.7.2",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "vitest": "^4.1.11"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,6 +70,131 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -114,6 +257,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.2",
@@ -454,6 +604,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.4",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
@@ -480,6 +637,54 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -490,6 +695,38 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.1.2",
@@ -557,6 +794,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -608,6 +958,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -632,6 +1002,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/change-case": {
@@ -677,6 +1057,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -690,12 +1077,40 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -724,6 +1139,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -740,11 +1172,58 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -808,6 +1287,33 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -820,6 +1326,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/index-to-position": {
@@ -843,6 +1362,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
@@ -882,6 +1408,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-schema-traverse": {
@@ -1164,6 +1730,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lucide-react": {
       "version": "0.469.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
@@ -1171,6 +1744,26 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -1210,6 +1803,27 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/openapi-typescript": {
@@ -1297,6 +1911,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1305,6 +1932,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1374,6 +2008,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -1411,6 +2083,13 @@
       "peerDependencies": {
         "react": "^19.2.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.18.2",
@@ -1509,6 +2188,33 @@
         "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -1527,6 +2233,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1536,6 +2249,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -1576,6 +2303,30 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1591,6 +2342,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -1720,11 +2527,179 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -1739,6 +2714,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "4.0.3",

--- a/vtc-service/admin-ui/package.json
+++ b/vtc-service/admin-ui/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "npm run wire:check && tsc -b --noEmit",
+    "test": "vitest run",
     "wire:generate": "openapi-typescript openapi.json -o src/lib/wire.ts",
     "wire:check": "openapi-typescript openapi.json -o /tmp/vtc-wire-check.ts && diff -q src/lib/wire.ts /tmp/vtc-wire-check.ts"
   },
@@ -25,13 +26,17 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.3",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",
+    "jsdom": "^26.1.0",
     "openapi-typescript": "^7.13.0",
     "typescript": "^5.7.2",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "js-yaml": "^4.3.2"

--- a/vtc-service/admin-ui/src/lib/api.ts
+++ b/vtc-service/admin-ui/src/lib/api.ts
@@ -281,6 +281,18 @@ export const deleteJson = <T>(
 export const getJsonExempt = <T>(path: string): Promise<T> =>
   request<T>(path, { method: "GET" });
 
+// The daemon also mounts a handful of admin REST routes with no Trust Task
+// binding at all, because no published task describes them: the vetter grant
+// listing, automatic vetter grants, vetting withdrawal notices, a join
+// request's vetting facts, and community branding. Sending them a task URI
+// would claim a contract that does not exist, so they use these helpers too —
+// and the smell is intended: each call site names why its route has no task.
+export const putJsonExempt = <T>(path: string, body: unknown): Promise<T> =>
+  request<T>(path, {
+    method: "PUT",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
 // `/health` and `GET /v1/rooms` are the daemon's two Trust-Task-exempt
 // endpoints, for unrelated reasons: `/health` predates the router, and the
 // rooms listing is the host's own view of what it stores — every `rooms/*`

--- a/vtc-service/admin-ui/src/lib/format.ts
+++ b/vtc-service/admin-ui/src/lib/format.ts
@@ -41,8 +41,8 @@ export function shorten(value: string, head = 8, tail = 4): string {
  * differently, every DID has to be re-identified on the way across.
  *
  * The vectors below are asserted in `shorten_did_matches_shared_vectors`
- * (`vta-sdk/src/display_name/mod.rs`), which is the authority — this console
- * has no test runner. Change either implementation and check both:
+ * (`vta-sdk/src/display_name/mod.rs`), which is the authority. Change either
+ * implementation and check both:
  *
  *   "alice"                                        -> "alice"
  *   "did:webvh:QmXkAbCdEfGhIjKlMnOp:webvh.storm.ws:glenn-vta"

--- a/vtc-service/admin-ui/src/lib/vetting.test.ts
+++ b/vtc-service/admin-ui/src/lib/vetting.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  brandingBody,
+  buildListBody,
+  describeSeconds,
+  EMPTY_LIST_DRAFT,
+  explainFailure,
+  explainNeed,
+  factsHeadline,
+  filterGrants,
+  grantState,
+  isLanguageTag,
+  parseIsoDuration,
+  statementVerdict,
+  summarizeRequirements,
+  sweepMinutesError,
+  validateBranding,
+  validateRequirements,
+  validityDaysError,
+  type VettingRequirements,
+} from "@/lib/vetting";
+import type {
+  JoinRequestVetting,
+  JoinRequestVettingStatement,
+  VetterGrantRow,
+} from "@/lib/wire-types";
+
+const REQUIREMENTS: VettingRequirements = {
+  version: "0.1",
+  statementType: "https://firstperson.network/endorsements/identity-vetting/0.1",
+  minStatements: 2,
+  minByMethod: { inPerson: 1 },
+  acceptedMethods: ["inPerson", "video", "priorAcquaintance"],
+  requiredClaims: ["name.legal"],
+  maxStatementAge: "P120D",
+  eligibleVetters: { role: "vetter" },
+  independence: {
+    maxByDeclaredRelationship: { family: 0, sameEmployer: 1 },
+    requireConsistentIdentityCommitment: true,
+  },
+};
+
+function statement(
+  patch: Partial<JoinRequestVettingStatement> = {},
+): JoinRequestVettingStatement {
+  return {
+    id: "urn:uuid:1",
+    issuer: "did:key:zCarol",
+    method: "inPerson",
+    declaredRelationship: "none",
+    verified: true,
+    eligible: true,
+    revoked: false,
+    withdrawnNow: false,
+    counted: true,
+    failures: [],
+    ...patch,
+  };
+}
+
+function facts(patch: Partial<JoinRequestVetting> = {}): JoinRequestVetting {
+  return {
+    criterionId: "kernel-developer",
+    requirementsDigest: "zDigest",
+    applicantDigestMatches: true,
+    statements: [statement()],
+    distinctCountedVetters: 2,
+    byMethod: { inPerson: 1, video: 1 },
+    commitmentsConsistent: true,
+    independenceOk: true,
+    invitationRequired: false,
+    satisfied: true,
+    needs: [],
+    recordedAt: "2026-09-01T00:00:00Z",
+    ...patch,
+  };
+}
+
+describe("validateRequirements mirrors VettingRequirements::validate", () => {
+  it("accepts the documented example", () => {
+    expect(validateRequirements(REQUIREMENTS)).toEqual([]);
+  });
+
+  it("refuses what no applicant could satisfy", () => {
+    const problems = validateRequirements({
+      ...REQUIREMENTS,
+      minStatements: 0,
+      acceptedMethods: ["video"],
+      minByMethod: { inPerson: 1 },
+    });
+    expect(problems).toHaveLength(2);
+    expect(problems[0]).toMatch(/at least 1 statement/);
+    expect(problems[1]).toMatch(/in person statements, which this criterion does not accept/);
+  });
+
+  it("refuses calendar durations and malformed versions", () => {
+    const problems = validateRequirements({
+      ...REQUIREMENTS,
+      version: "1",
+      maxStatementAge: "P3M",
+      decisionSla: "PT",
+    });
+    expect(problems.some((p) => p.includes('"1" is not'))).toBe(true);
+    expect(problems.some((p) => p.includes('maximum statement age "P3M"'))).toBe(true);
+    expect(problems.some((p) => p.includes('decision deadline "PT"'))).toBe(true);
+  });
+
+  it("checks the role, document classes, URL and independence members", () => {
+    const problems = validateRequirements({
+      ...REQUIREMENTS,
+      eligibleVetters: { role: "custom:vetter" },
+      acceptedDocumentClasses: ["Passport"],
+      governanceFrameworkUrl: "http://example.org/gf",
+      independence: { maxByDeclaredRelationship: { cousin: 1 } },
+      invitation: "sometimes",
+    });
+    expect(problems).toHaveLength(5);
+  });
+
+  it("names an empty or missing method list", () => {
+    expect(validateRequirements({ ...REQUIREMENTS, acceptedMethods: [] })).toEqual([
+      "Accept at least one vetting method.",
+    ]);
+    expect(validateRequirements(null)).toEqual([
+      "The vetting requirements must be an object.",
+    ]);
+  });
+});
+
+describe("parseIsoDuration mirrors parse_iso8601_duration", () => {
+  it.each([
+    ["P120D", 120 * 86_400],
+    ["P2W", 14 * 86_400],
+    ["P1DT12H", 129_600],
+    ["PT90M", 5_400],
+    ["PT1H30M15S", 5_415],
+  ])("reads %s", (input, seconds) => {
+    expect(parseIsoDuration(input)).toBe(seconds);
+  });
+
+  it.each(["P", "PT", "P1M", "P1Y", "P1D2W", "P1DT", "120D", "PD", "P1DT1H1H"])(
+    "refuses %s",
+    (input) => {
+      expect(parseIsoDuration(input)).toBeNull();
+    },
+  );
+
+  it("describes seconds in days and hours", () => {
+    expect(describeSeconds(129_600)).toBe("1 day 12 hours");
+    expect(describeSeconds(120 * 86_400)).toBe("120 days");
+  });
+});
+
+describe("statement outcomes", () => {
+  it("says a counted statement counted", () => {
+    expect(statementVerdict(statement())).toEqual({
+      tone: "ok",
+      label: "Counted",
+      reasons: [],
+    });
+  });
+
+  it("flags a counted statement withdrawn after the decision", () => {
+    const verdict = statementVerdict(statement({ withdrawnNow: true }));
+    expect(verdict.tone).toBe("warn");
+    expect(verdict.reasons[0]?.code).toBe("withdrawnNow");
+  });
+
+  it("explains every failure and keeps the code", () => {
+    const verdict = statementVerdict(
+      statement({ counted: false, failures: ["issuer-not-vetter", "too-old"] }),
+    );
+    expect(verdict.tone).toBe("bad");
+    expect(verdict.reasons.map((r) => r.code)).toEqual([
+      "issuer-not-vetter",
+      "too-old",
+    ]);
+    expect(verdict.reasons[1]?.text).toBe("It is older than this criterion allows.");
+  });
+
+  it("derives reasons from the flags when facts carry none", () => {
+    const verdict = statementVerdict(
+      statement({ counted: false, verified: false, revoked: true }),
+    );
+    expect(verdict.reasons.map((r) => r.code)).toEqual(["unverified", "revoked"]);
+  });
+
+  it("does not hide an unknown failure code", () => {
+    expect(explainFailure("new-reason")).toEqual({
+      code: "new-reason",
+      text: "It did not count, for a reason this console does not recognise.",
+    });
+  });
+});
+
+describe("needs", () => {
+  it("reads the vetting grammar", () => {
+    expect(explainNeed("vetting:statements:1").text).toBe(
+      "Statements from 1 more eligible vetter.",
+    );
+    expect(explainNeed("vetting:method:inPerson:2").text).toBe(
+      "2 more counted statements made in person.",
+    );
+    expect(explainNeed("vetting:invitation").text).toMatch(/^An invitation/);
+  });
+
+  it("shows anything else verbatim", () => {
+    expect(explainNeed("agreed:code-of-conduct")).toEqual({
+      code: "agreed:code-of-conduct",
+      text: "agreed:code-of-conduct",
+    });
+    expect(explainNeed("vetting:method:telepathy:1").text).toBe(
+      "vetting:method:telepathy:1",
+    );
+  });
+});
+
+describe("factsHeadline follows the default policy's order", () => {
+  it("leads with different identities over a shortfall", () => {
+    expect(
+      factsHeadline(
+        facts({
+          satisfied: false,
+          commitmentsConsistent: false,
+          needs: ["vetting:statements:1"],
+        }),
+      ).title,
+    ).toBe("Vetters verified different identities");
+  });
+
+  it("reports a shortfall, then an independence cap", () => {
+    expect(
+      factsHeadline(facts({ satisfied: false, needs: ["vetting:statements:1"] }))
+        .tone,
+    ).toBe("warn");
+    expect(
+      factsHeadline(facts({ satisfied: false, independenceOk: false })).title,
+    ).toMatch(/share a relationship/);
+  });
+
+  it("confirms a satisfied request", () => {
+    expect(factsHeadline(facts()).detail).toMatch(/^2 distinct vetters counted/);
+  });
+});
+
+describe("requirements summary", () => {
+  it("writes the example in sentences", () => {
+    const lines = summarizeRequirements(REQUIREMENTS);
+    expect(lines).toContain("Statements from at least 2 distinct eligible vetters.");
+    expect(lines).toContain("At least 1 of them made in person.");
+    expect(lines).toContain("A statement counts for 120 days after it is made.");
+    expect(lines).toContain(
+      'No counted statements from vetters declaring "Family member".',
+    );
+    expect(lines).toContain("Each vetter decides which documents they accept.");
+  });
+});
+
+describe("grant bounds and states", () => {
+  it("bounds validity to one day through two years", () => {
+    expect(validityDaysError("365")).toBeNull();
+    expect(validityDaysError("0")).toMatch(/outside/);
+    expect(validityDaysError("731")).toMatch(/outside/);
+    expect(validityDaysError("1.5")).toMatch(/whole number/);
+    expect(validityDaysError("")).toMatch(/^Enter days/);
+  });
+
+  it("bounds the sweep to 5 through 1440 minutes", () => {
+    expect(sweepMinutesError("60")).toBeNull();
+    expect(sweepMinutesError("4")).toMatch(/outside/);
+  });
+
+  const row = (patch: Partial<VetterGrantRow>): VetterGrantRow => ({
+    endorsementId: "e1",
+    memberDid: "did:key:zCarol",
+    credentialId: "urn:uuid:c1",
+    validFrom: "2026-01-01T00:00:00Z",
+    validUntil: "2027-01-01T00:00:00Z",
+    revoked: false,
+    live: true,
+    origin: "manual",
+    ...patch,
+  });
+  const now = Date.parse("2026-09-11T00:00:00Z");
+
+  it("tells revoked, expired and departed grants apart", () => {
+    expect(grantState(row({}), now)).toBe("live");
+    expect(grantState(row({ live: false, revoked: true }), now)).toBe("revoked");
+    expect(
+      grantState(row({ live: false, validUntil: "2026-01-02T00:00:00Z" }), now),
+    ).toBe("expired");
+    expect(grantState(row({ live: false }), now)).toBe("inactive");
+  });
+
+  it("filters by state, origin and name", () => {
+    const rows = [
+      row({ endorsementId: "a" }),
+      row({ endorsementId: "b", origin: "auto", live: false, revoked: true }),
+      row({
+        endorsementId: "c",
+        memberDid: "did:key:zDan",
+        profile: {
+          listed: true,
+          displayName: "Carol M.",
+          languages: [],
+          methods: [],
+          eventCount: 0,
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
+      }),
+    ];
+    const ids = (f: Parameters<typeof filterGrants>[1]) =>
+      filterGrants(rows, f, now).map((r) => r.endorsementId);
+    expect(ids({ state: "live", origin: "all", search: "" })).toEqual(["a", "c"]);
+    expect(ids({ state: "all", origin: "auto", search: "" })).toEqual(["b"]);
+    expect(ids({ state: "all", origin: "all", search: "carol m" })).toEqual(["c"]);
+  });
+});
+
+describe("listing filters mirror VetterListBody::check_shape", () => {
+  it("omits empty filters and upper-cases the country", () => {
+    const { body, errors } = buildListBody({
+      ...EMPTY_LIST_DRAFT,
+      language: " de ",
+      country: "at",
+      method: "video",
+    });
+    expect(errors).toEqual({});
+    expect(body).toEqual({ language: "de", country: "AT", method: "video" });
+  });
+
+  it("refuses a bad tag, country and an inverted range", () => {
+    const { errors } = buildListBody({
+      ...EMPTY_LIST_DRAFT,
+      language: "german!",
+      country: "AUT",
+      eventFrom: "2026-10-07",
+      eventTo: "2026-10-05",
+    });
+    expect(Object.keys(errors).sort()).toEqual(["country", "eventTo", "language"]);
+  });
+
+  it("reads BCP 47 tags as the daemon does", () => {
+    expect(isLanguageTag("de-AT")).toBe(true);
+    expect(isLanguageTag("zh-Hant-TW")).toBe(true);
+    expect(isLanguageTag("d")).toBe(false);
+    expect(isLanguageTag("de_AT")).toBe(false);
+  });
+});
+
+describe("branding mirrors CommunityBranding::check_shape", () => {
+  it("accepts a complete branding and lower-cases the colour", () => {
+    const draft = {
+      displayName: "Linux Kernel",
+      accentColor: "#1A2B3C",
+      logoUrl: "https://kernel.example.org/logo.svg",
+    };
+    expect(validateBranding(draft)).toEqual({});
+    expect(brandingBody(draft, { ext: { a: 1 } })).toEqual({
+      displayName: "Linux Kernel",
+      accentColor: "#1a2b3c",
+      logoUrl: "https://kernel.example.org/logo.svg",
+      ext: { a: 1 },
+    });
+  });
+
+  it("clears empty members", () => {
+    expect(brandingBody({ displayName: " ", accentColor: "", logoUrl: "" })).toEqual(
+      {},
+    );
+  });
+
+  it("explains each refusal", () => {
+    const errors = validateBranding({
+      displayName: "x".repeat(129),
+      accentColor: "#12345",
+      logoUrl: "http://kernel.example.org/logo.svg",
+    });
+    expect(errors.displayName).toMatch(/129 characters/);
+    expect(errors.accentColor).toMatch(/six hex digits/);
+    expect(errors.logoUrl).toMatch(/https:\/\//);
+    expect(
+      validateBranding({
+        displayName: "",
+        accentColor: "",
+        logoUrl: "https://kernel.example.org/my logo.svg",
+      }).logoUrl,
+    ).toMatch(/spaces/);
+  });
+});

--- a/vtc-service/admin-ui/src/lib/vetting.ts
+++ b/vtc-service/admin-ui/src/lib/vetting.ts
@@ -1,0 +1,848 @@
+// Peer identity vetting, in the words an admin deciding a join request needs.
+//
+// The daemon records vetting in its own vocabulary: failure codes
+// (`issuer-not-vetter`), needs in the `vetting:*` grammar
+// (`vetting:method:inPerson:1`), method and relationship tokens. This module
+// turns each into a sentence and keeps the code beside it, so a panel says
+// what happened while an admin who needs the exact value — to search the audit
+// trail, or to write a policy — can still find it.
+//
+// It also mirrors the checks the daemon runs on what the console sends, so a
+// form can say what is wrong before a request is refused:
+//
+//   - `validateRequirements` is `VettingRequirements::validate` plus the serde
+//     rules on its members (`vta-sdk/src/protocols/vetting.rs`).
+//   - `validateBranding` is `CommunityBranding::check_shape`
+//     (`vta-sdk/src/protocols/join_requests.rs`).
+//   - `buildListBody` is `VetterListBody::check_shape`.
+//   - the grant and sweep bounds are `MIN_/MAX_VETTER_GRANT_VALIDITY_SECONDS`
+//     and `MIN_/MAX_AUTO_GRANT_SWEEP_MINUTES`.
+//
+// The daemon stays the authority: it runs every one of these again, and makes
+// the one check this module cannot — that a `statementType` is a registered
+// endorsement type.
+
+import type {
+  CommunityBranding,
+  JoinRequestVetting,
+  JoinRequestVettingStatement,
+  VetterGrantRow,
+  VetterListBody,
+  VettingMethod,
+  VettingRevocationRow,
+} from "@/lib/wire-types";
+
+// ── Methods and relationships ───────────────────────────────────────────
+
+export const VETTING_METHODS: readonly VettingMethod[] = [
+  "inPerson",
+  "video",
+  "priorAcquaintance",
+];
+
+const METHOD_LABELS: Record<VettingMethod, string> = {
+  inPerson: "In person",
+  video: "Video call",
+  priorAcquaintance: "Prior acquaintance",
+};
+
+/** How a statement was made, as it reads after "made …". */
+const METHOD_PHRASES: Record<VettingMethod, string> = {
+  inPerson: "in person",
+  video: "over video",
+  priorAcquaintance: "by a vetter who already knew the applicant",
+};
+
+export function isVettingMethod(value: unknown): value is VettingMethod {
+  return (
+    typeof value === "string" &&
+    (VETTING_METHODS as readonly string[]).includes(value)
+  );
+}
+
+/** A method's name; an unknown token is shown as it came. */
+export function methodLabel(method: string): string {
+  return isVettingMethod(method) ? METHOD_LABELS[method] : method;
+}
+
+export const DECLARED_RELATIONSHIPS = [
+  "none",
+  "communityColleague",
+  "sameEmployer",
+  "family",
+  "otherPersonal",
+] as const;
+export type DeclaredRelationship = (typeof DECLARED_RELATIONSHIPS)[number];
+
+const RELATIONSHIP_LABELS: Record<DeclaredRelationship, string> = {
+  none: "No prior relationship",
+  communityColleague: "Community colleague",
+  sameEmployer: "Same employer",
+  family: "Family member",
+  otherPersonal: "Other personal relationship",
+};
+
+function isRelationship(value: string): value is DeclaredRelationship {
+  return (DECLARED_RELATIONSHIPS as readonly string[]).includes(value);
+}
+
+export function relationshipLabel(value: string | null | undefined): string {
+  if (!value) return "Not declared";
+  return isRelationship(value) ? RELATIONSHIP_LABELS[value] : value;
+}
+
+// ── Statement outcomes ──────────────────────────────────────────────────
+
+/** A sentence for the admin, and the daemon's own code for it. */
+export interface Explained {
+  text: string;
+  code: string;
+}
+
+const FAILURE_TEXT: Record<string, string> = {
+  unverified: "Its proof, type, validity dates or contents did not verify.",
+  "subject-not-applicant":
+    "It vouches for someone other than the applicant who presented it.",
+  "wrong-statement-type": "It is not the kind of statement this criterion counts.",
+  "issuer-not-vetter":
+    "Its signer was not an eligible vetter: a current member holding an unrevoked vetter grant from before they signed.",
+  revoked: "Its vetter withdrew it before the decision.",
+  "wrong-community": "It was made for a different community.",
+  "method-not-accepted": "This criterion does not accept the vetting method it records.",
+  "documentation-not-accepted":
+    "The documents its vetter checked are not ones this criterion accepts.",
+  "claim-not-verified":
+    "Its vetter did not verify every claim this criterion requires.",
+  "too-old": "It is older than this criterion allows.",
+  "same-vetter":
+    "Its vetter has a more recent statement here, and each vetter counts once.",
+};
+
+export function explainFailure(code: string): Explained {
+  return {
+    code,
+    text:
+      FAILURE_TEXT[code] ??
+      "It did not count, for a reason this console does not recognise.",
+  };
+}
+
+export type Tone = "ok" | "warn" | "bad";
+
+export interface StatementVerdict {
+  tone: Tone;
+  label: string;
+  reasons: Explained[];
+}
+
+const WITHDRAWN_SINCE: Explained = {
+  code: "withdrawnNow",
+  text: "Its vetter has withdrawn it since the decision.",
+};
+
+/** Whether one presented statement counted, and every reason it did not. */
+export function statementVerdict(
+  statement: JoinRequestVettingStatement,
+): StatementVerdict {
+  if (statement.counted) {
+    return statement.withdrawnNow
+      ? {
+          tone: "warn",
+          label: "Counted, since withdrawn",
+          reasons: [
+            {
+              ...WITHDRAWN_SINCE,
+              text: `${WITHDRAWN_SINCE.text} An admission it helped grant may need review.`,
+            },
+          ],
+        }
+      : { tone: "ok", label: "Counted", reasons: [] };
+  }
+  // The daemon lists every reason; the flags are a fallback for facts recorded
+  // with none, so a statement never reads "not counted" without a why.
+  const codes = statement.failures.length
+    ? statement.failures
+    : [
+        ...(statement.verified ? [] : ["unverified"]),
+        ...(statement.eligible ? [] : ["issuer-not-vetter"]),
+        ...(statement.revoked ? ["revoked"] : []),
+      ];
+  const reasons = codes.map(explainFailure);
+  if (statement.withdrawnNow && !statement.revoked) reasons.push(WITHDRAWN_SINCE);
+  return { tone: "bad", label: "Not counted", reasons };
+}
+
+// ── What is still needed ────────────────────────────────────────────────
+
+const plural = (n: number, one: string, many = `${one}s`) =>
+  `${n} ${n === 1 ? one : many}`;
+
+/** One entry of a verdict's `needs`, in plain words. */
+export function explainNeed(raw: string): Explained {
+  const statements = /^vetting:statements:(\d+)$/.exec(raw);
+  if (statements) {
+    const n = Number(statements[1]);
+    return {
+      code: raw,
+      text: `Statements from ${plural(n, "more eligible vetter")}.`,
+    };
+  }
+  const method = /^vetting:method:([A-Za-z]+):(\d+)$/.exec(raw);
+  if (method && isVettingMethod(method[1])) {
+    const n = Number(method[2]);
+    return {
+      code: raw,
+      text: `${plural(n, "more counted statement")} made ${METHOD_PHRASES[method[1]]}.`,
+    };
+  }
+  if (raw === "vetting:invitation") {
+    return {
+      code: raw,
+      text: "An invitation. The vetting is met, and this criterion also requires an invitation credential.",
+    };
+  }
+  if (raw === "vetting") {
+    return { code: raw, text: "More vetting, without a stated amount." };
+  }
+  return { code: raw, text: raw };
+}
+
+export interface FactsHeadline {
+  tone: Tone;
+  title: string;
+  detail: string;
+}
+
+/**
+ * The one line an admin reads first, in the order the default join policy
+ * weighs the facts: different identities, then a shortfall, then an
+ * independence cap, then an outstanding invitation.
+ */
+export function factsHeadline(facts: JoinRequestVetting): FactsHeadline {
+  if (facts.satisfied) {
+    return {
+      tone: "ok",
+      title: "Vetting requirements met",
+      detail: `${plural(facts.distinctCountedVetters, "distinct vetter")} counted, the vetters agree on who the applicant is, and the independence rules hold.`,
+    };
+  }
+  if (!facts.commitmentsConsistent) {
+    return {
+      tone: "bad",
+      title: "Vetters verified different identities",
+      detail:
+        "The counted statements do not describe the same person. Find out why before admitting this applicant.",
+    };
+  }
+  if (facts.needs.length > 0) {
+    return {
+      tone: "warn",
+      title: "Vetting is incomplete",
+      detail: "The applicant has not yet gathered enough counted statements.",
+    };
+  }
+  if (!facts.independenceOk) {
+    return {
+      tone: "warn",
+      title: "Too many vetters share a relationship with the applicant",
+      detail:
+        "There are enough statements, but more of them declare the same relationship than this criterion allows.",
+    };
+  }
+  return {
+    tone: "warn",
+    title: "Vetting requirements not met",
+    detail: facts.invitationRequired
+      ? "This criterion also requires an invitation credential."
+      : "The recorded facts do not satisfy the criterion.",
+  };
+}
+
+// ── Durations ───────────────────────────────────────────────────────────
+
+type Units = ReadonlyArray<readonly [string, number]>;
+
+function accumulate(
+  part: string,
+  units: Units,
+): { seconds: number; any: boolean } | null {
+  let seconds = 0;
+  let digits = "";
+  let next = 0;
+  let any = false;
+  for (const c of part) {
+    if (c >= "0" && c <= "9") {
+      digits += c;
+      continue;
+    }
+    // Each unit at most once, and only after the ones before it.
+    const offset = units.slice(next).findIndex(([unit]) => unit === c);
+    if (offset === -1 || digits === "") return null;
+    seconds += Number(digits) * units[next + offset]![1];
+    next += offset + 1;
+    digits = "";
+    any = true;
+  }
+  return digits === "" ? { seconds, any } : null;
+}
+
+/**
+ * Seconds in an ISO 8601 duration, or `null` for one the daemon refuses.
+ * `parse_iso8601_duration`: weeks and days, then a `T` part with hours,
+ * minutes and seconds. Years and months are refused — their length depends on
+ * the calendar.
+ */
+export function parseIsoDuration(value: string): number | null {
+  if (!value.startsWith("P")) return null;
+  const rest = value.slice(1);
+  const t = rest.indexOf("T");
+  const date = accumulate(t === -1 ? rest : rest.slice(0, t), [
+    ["W", 604_800],
+    ["D", 86_400],
+  ]);
+  if (!date) return null;
+  let timeSeconds = 0;
+  let timeAny = false;
+  if (t !== -1) {
+    const time = accumulate(rest.slice(t + 1), [
+      ["H", 3_600],
+      ["M", 60],
+      ["S", 1],
+    ]);
+    if (!time || !time.any) return null;
+    timeSeconds = time.seconds;
+    timeAny = true;
+  }
+  if (!date.any && !timeAny) return null;
+  const total = date.seconds + timeSeconds;
+  return Number.isSafeInteger(total) ? total : null;
+}
+
+/** `10368000` → `120 days`; `129600` → `1 day 12 hours`. */
+export function describeSeconds(total: number): string {
+  const days = Math.floor(total / 86_400);
+  const hours = Math.floor((total % 86_400) / 3_600);
+  const minutes = Math.floor((total % 3_600) / 60);
+  const seconds = total % 60;
+  const parts = [
+    days ? plural(days, "day") : "",
+    hours ? plural(hours, "hour") : "",
+    minutes ? plural(minutes, "minute") : "",
+    seconds ? plural(seconds, "second") : "",
+  ].filter(Boolean);
+  return parts.length ? parts.join(" ") : "0 seconds";
+}
+
+// ── Vetting requirements (manifest 0.2) ─────────────────────────────────
+
+/**
+ * A criterion's `vetting` object. The daemon publishes this member as an
+ * opaque object in its OpenAPI document (`value_type = Object`), so there is no
+ * generated type to alias: it is read as `unknown`, and `validateRequirements`
+ * is what makes it this shape.
+ */
+export interface VettingRequirements {
+  version: string;
+  statementType: string;
+  minStatements: number;
+  minByMethod?: Partial<Record<VettingMethod, number>>;
+  acceptedMethods: VettingMethod[];
+  acceptedDocumentClasses?: string[];
+  requiredClaims?: string[];
+  optionalClaims?: string[];
+  maxStatementAge?: string;
+  eligibleVetters: { role: string };
+  independence?: {
+    maxByDeclaredRelationship?: Partial<Record<DeclaredRelationship, number>>;
+    requireConsistentIdentityCommitment?: boolean;
+  };
+  invitation?: "required" | "optional" | "none";
+  decisionSla?: string;
+  requirementsGrace?: string;
+  governanceFrameworkUrl?: string;
+}
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+const chars = (s: string) => [...s].length;
+const isCount = (v: unknown): v is number =>
+  typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 4_294_967_295;
+const isStringArray = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.every((s) => typeof s === "string");
+
+const ROLE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const TOKEN = /^[a-z][a-zA-Z0-9]*$/;
+
+const DURATION_NAMES = {
+  maxStatementAge: "The maximum statement age",
+  decisionSla: "The decision deadline",
+  requirementsGrace: "The requirements grace period",
+} as const;
+
+/**
+ * Every problem with a `vetting` requirements object, as sentences an admin can
+ * act on; empty when the daemon would accept it (bar the endorsement-type
+ * registration only the daemon can check).
+ */
+export function validateRequirements(value: unknown): string[] {
+  if (!isObject(value)) {
+    return ["The vetting requirements must be an object."];
+  }
+  const problems: string[] = [];
+  const v = value;
+
+  if (typeof v.version !== "string" || !/^[0-9]+\.[0-9]+$/.test(v.version)) {
+    problems.push(
+      `Set version to MAJOR.MINOR, like "0.1"${
+        typeof v.version === "string" ? `; "${v.version}" is not` : ""
+      }.`,
+    );
+  }
+
+  if (
+    typeof v.statementType !== "string" ||
+    v.statementType === "" ||
+    chars(v.statementType) > 512
+  ) {
+    problems.push(
+      "Set statementType to the endorsement type a counted statement carries, up to 512 characters.",
+    );
+  }
+
+  if (!isCount(v.minStatements) || v.minStatements === 0) {
+    problems.push(
+      v.minStatements === 0
+        ? "Require at least 1 statement. A criterion that needs no vetting should have no vetting requirements."
+        : "Set minStatements to a whole number of at least 1.",
+    );
+  }
+
+  const accepted: VettingMethod[] = [];
+  if (!Array.isArray(v.acceptedMethods) || v.acceptedMethods.length === 0) {
+    problems.push("Accept at least one vetting method.");
+  } else {
+    for (const m of v.acceptedMethods) {
+      if (isVettingMethod(m)) accepted.push(m);
+      else problems.push(unknownMethod(m));
+    }
+  }
+
+  if (v.minByMethod !== undefined) {
+    if (!isObject(v.minByMethod)) {
+      problems.push("minByMethod must map a method to a minimum count.");
+    } else {
+      for (const [method, n] of Object.entries(v.minByMethod)) {
+        if (!isVettingMethod(method)) {
+          problems.push(unknownMethod(method));
+        } else if (accepted.length > 0 && !accepted.includes(method)) {
+          // With no usable method list the problem is already named above;
+          // repeating it once per floor would bury it.
+          problems.push(
+            `A minimum is set for ${METHOD_LABELS[method].toLowerCase()} statements, which this criterion does not accept. Accept the method, or remove its minimum.`,
+          );
+        }
+        if (!isCount(n)) {
+          problems.push(`The minimum for ${method} must be a whole number.`);
+        }
+      }
+    }
+  }
+
+  const role = isObject(v.eligibleVetters) ? v.eligibleVetters.role : undefined;
+  if (typeof role !== "string" || !ROLE.test(role) || role.length > 128) {
+    problems.push(
+      "Set eligibleVetters.role to the role a vetter holds, like \"vetter\": a letter, then letters, digits, _ or -, up to 128 characters.",
+    );
+  }
+
+  if (v.acceptedDocumentClasses !== undefined) {
+    const classes = v.acceptedDocumentClasses;
+    if (
+      !isStringArray(classes) ||
+      classes.some((c) => !TOKEN.test(c) || c.length > 64)
+    ) {
+      problems.push(
+        "Write each accepted document class as a lowerCamelCase token, like passport or nationalId, up to 64 characters.",
+      );
+    }
+  }
+
+  for (const member of ["requiredClaims", "optionalClaims"] as const) {
+    if (v[member] !== undefined && !isStringArray(v[member])) {
+      problems.push(`${member} must be a list of claim types.`);
+    }
+  }
+
+  if (v.governanceFrameworkUrl !== undefined) {
+    const url = v.governanceFrameworkUrl;
+    if (
+      typeof url !== "string" ||
+      !url.startsWith("https://") ||
+      chars(url) > 2048
+    ) {
+      problems.push(
+        "The governance framework address must be an https:// URL of at most 2048 characters.",
+      );
+    }
+  }
+
+  for (const [member, name] of Object.entries(DURATION_NAMES)) {
+    const d = v[member];
+    if (d === undefined) continue;
+    if (typeof d !== "string" || d.length > 32 || parseIsoDuration(d) === null) {
+      problems.push(
+        `${name}${typeof d === "string" ? ` "${d}"` : ""} is not a duration the community can apply. Use weeks, days, hours, minutes or seconds, like P120D; months and years vary in length.`,
+      );
+    }
+  }
+
+  if (v.independence !== undefined) {
+    const ind = v.independence;
+    if (!isObject(ind)) {
+      problems.push("independence must be an object.");
+    } else {
+      const caps = ind.maxByDeclaredRelationship;
+      if (caps !== undefined) {
+        if (!isObject(caps)) {
+          problems.push(
+            "maxByDeclaredRelationship must map a relationship to a maximum count.",
+          );
+        } else {
+          for (const [rel, n] of Object.entries(caps)) {
+            if (!isRelationship(rel)) {
+              problems.push(
+                `"${rel}" is not a declared relationship. Use ${DECLARED_RELATIONSHIPS.join(", ")}.`,
+              );
+            }
+            if (!isCount(n)) {
+              problems.push(`The cap for ${rel} must be a whole number.`);
+            }
+          }
+        }
+      }
+      const consistent = ind.requireConsistentIdentityCommitment;
+      if (consistent !== undefined && typeof consistent !== "boolean") {
+        problems.push("requireConsistentIdentityCommitment must be true or false.");
+      }
+    }
+  }
+
+  if (
+    v.invitation !== undefined &&
+    !["required", "optional", "none"].includes(v.invitation as string)
+  ) {
+    problems.push('Set invitation to "required", "optional" or "none".');
+  }
+
+  return problems;
+}
+
+function unknownMethod(method: unknown): string {
+  return `${JSON.stringify(method)} is not a vetting method. Use inPerson, video or priorAcquaintance.`;
+}
+
+/** Valid requirements, in sentences, in the order an applicant meets them. */
+export function summarizeRequirements(r: VettingRequirements): string[] {
+  const lines = [
+    `Statements from at least ${plural(r.minStatements, "distinct eligible vetter")}.`,
+  ];
+  for (const method of VETTING_METHODS) {
+    const n = r.minByMethod?.[method];
+    if (n) lines.push(`At least ${n} of them made ${METHOD_PHRASES[method]}.`);
+  }
+  lines.push(
+    `Methods that count: ${r.acceptedMethods.map(methodLabel).join(", ")}.`,
+  );
+  lines.push(`Vetters hold the "${r.eligibleVetters.role}" role.`);
+  if (r.requiredClaims?.length) {
+    lines.push(`Each vetter verifies: ${r.requiredClaims.join(", ")}.`);
+  }
+  lines.push(
+    r.acceptedDocumentClasses
+      ? `Vetters may rely only on: ${r.acceptedDocumentClasses.join(", ") || "no documents"}.`
+      : "Each vetter decides which documents they accept.",
+  );
+  const age = r.maxStatementAge ? parseIsoDuration(r.maxStatementAge) : null;
+  if (age !== null) {
+    lines.push(`A statement counts for ${describeSeconds(age)} after it is made.`);
+  }
+  for (const rel of DECLARED_RELATIONSHIPS) {
+    const cap = r.independence?.maxByDeclaredRelationship?.[rel];
+    if (cap === undefined) continue;
+    lines.push(
+      cap === 0
+        ? `No counted statements from vetters declaring "${RELATIONSHIP_LABELS[rel]}".`
+        : `At most ${plural(cap, "counted statement")} from vetters declaring "${RELATIONSHIP_LABELS[rel]}".`,
+    );
+  }
+  if (r.independence?.requireConsistentIdentityCommitment) {
+    lines.push("Every vetter must have verified the same identity.");
+  }
+  if (r.invitation === "required") {
+    lines.push("An invitation credential is required as well.");
+  } else if (r.invitation === "optional") {
+    lines.push("An invitation credential may be presented.");
+  }
+  const sla = r.decisionSla ? parseIsoDuration(r.decisionSla) : null;
+  if (sla !== null) {
+    lines.push(
+      `A referred application is decided within ${describeSeconds(sla)}.`,
+    );
+  }
+  const grace = r.requirementsGrace ? parseIsoDuration(r.requirementsGrace) : null;
+  if (grace !== null) {
+    lines.push(
+      `Applications started under earlier requirements keep them for ${describeSeconds(grace)} (not yet applied by this community).`,
+    );
+  }
+  return lines;
+}
+
+// ── Vetter grants ───────────────────────────────────────────────────────
+
+export const DAY_SECONDS = 86_400;
+/** `MIN_VETTER_GRANT_VALIDITY_SECONDS`, in days. */
+export const MIN_GRANT_VALIDITY_DAYS = 1;
+/** `MAX_VETTER_GRANT_VALIDITY_SECONDS` (two 365-day years), in days. */
+export const MAX_GRANT_VALIDITY_DAYS = 730;
+/** `MIN_/MAX_AUTO_GRANT_SWEEP_MINUTES`. */
+export const MIN_SWEEP_MINUTES = 5;
+export const MAX_SWEEP_MINUTES = 1440;
+
+/** An integer field's problem, or null. */
+function wholeNumberError(
+  raw: string,
+  min: number,
+  max: number,
+  what: string,
+  range: string,
+): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return `Enter ${what}, from ${range}.`;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n)) return `Enter a whole number of ${what}, from ${range}.`;
+  if (n < min || n > max) return `Choose ${range}; ${n} is outside that.`;
+  return null;
+}
+
+export function validityDaysError(raw: string): string | null {
+  return wholeNumberError(
+    raw,
+    MIN_GRANT_VALIDITY_DAYS,
+    MAX_GRANT_VALIDITY_DAYS,
+    "days",
+    "1 to 730 days (two years)",
+  );
+}
+
+export function sweepMinutesError(raw: string): string | null {
+  return wholeNumberError(
+    raw,
+    MIN_SWEEP_MINUTES,
+    MAX_SWEEP_MINUTES,
+    "minutes",
+    "5 to 1440 minutes (a day)",
+  );
+}
+
+export type GrantState = "live" | "revoked" | "expired" | "inactive";
+
+export const GRANT_STATE_LABELS: Record<GrantState, string> = {
+  live: "Live",
+  revoked: "Revoked",
+  expired: "Expired",
+  inactive: "Not in force",
+};
+
+/** Why a grant is or is not in force. `live` is the daemon's own verdict. */
+export function grantState(row: VetterGrantRow, now = Date.now()): GrantState {
+  if (row.live) return "live";
+  if (row.revoked) return "revoked";
+  if (row.validUntil && Date.parse(row.validUntil) <= now) return "expired";
+  // Unrevoked and unexpired, yet not live: its holder is not a current member.
+  return "inactive";
+}
+
+export interface GrantFilter {
+  state: GrantState | "all";
+  origin: "auto" | "manual" | "all";
+  search: string;
+}
+
+export function filterGrants(
+  rows: readonly VetterGrantRow[],
+  filter: GrantFilter,
+  now = Date.now(),
+): VetterGrantRow[] {
+  const needle = filter.search.trim().toLowerCase();
+  return rows.filter(
+    (row) =>
+      (filter.state === "all" || grantState(row, now) === filter.state) &&
+      (filter.origin === "all" || row.origin === filter.origin) &&
+      (!needle ||
+        row.memberDid.toLowerCase().includes(needle) ||
+        (row.profile?.displayName ?? "").toLowerCase().includes(needle)),
+  );
+}
+
+// ── Withdrawals ─────────────────────────────────────────────────────────
+
+const REASON_LABELS: Record<string, string> = {
+  mistake: "The vetter made a mistake",
+  newInformation: "The vetter learned something new",
+  keyCompromise: "The vetter's signing key was compromised",
+  other: "Another reason",
+};
+
+export function withdrawalReason(row: VettingRevocationRow): string {
+  if (!row.reason) return "No reason given";
+  return REASON_LABELS[row.reason] ?? row.reason;
+}
+
+// ── Registry listing filters ────────────────────────────────────────────
+
+export interface ListDraft {
+  language: string;
+  country: string;
+  region: string;
+  city: string;
+  method: VettingMethod | "";
+  eventFrom: string;
+  eventTo: string;
+  eventName: string;
+}
+
+export const EMPTY_LIST_DRAFT: ListDraft = {
+  language: "",
+  country: "",
+  region: "",
+  city: "",
+  method: "",
+  eventFrom: "",
+  eventTo: "",
+  eventName: "",
+};
+
+export type ListDraftErrors = Partial<Record<keyof ListDraft, string>>;
+
+/** `shape::language_tag`: `^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$`, ≤ 35. */
+export function isLanguageTag(tag: string): boolean {
+  return tag.length <= 35 && /^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$/.test(tag);
+}
+
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** The listing request for a filter form, and what is wrong with it. */
+export function buildListBody(draft: ListDraft): {
+  body: VetterListBody;
+  errors: ListDraftErrors;
+} {
+  const body: VetterListBody = {};
+  const errors: ListDraftErrors = {};
+
+  const language = draft.language.trim();
+  if (language) {
+    if (isLanguageTag(language)) body.language = language;
+    else errors.language = "Enter a language tag, like de or de-AT.";
+  }
+  // The listing compares countries in upper case; typing `at` means `AT`.
+  const country = draft.country.trim().toUpperCase();
+  if (country) {
+    if (/^[A-Z]{2}$/.test(country)) body.country = country;
+    else errors.country = "Enter a two-letter country code, like AT.";
+  }
+  for (const key of ["region", "city"] as const) {
+    const value = draft[key].trim();
+    if (!value) continue;
+    if (chars(value) > 128) {
+      errors[key] = `Shorten this to 128 characters or fewer.`;
+    } else {
+      body[key] = value;
+    }
+  }
+  if (draft.method) body.method = draft.method;
+  for (const key of ["eventFrom", "eventTo"] as const) {
+    const value = draft[key];
+    if (!value) continue;
+    if (DATE.test(value)) body[key] = value;
+    else errors[key] = "Enter a date as YYYY-MM-DD.";
+  }
+  if (body.eventFrom && body.eventTo && body.eventTo < body.eventFrom) {
+    errors.eventTo = "The end of the range is before its start. Change one of the dates.";
+  }
+  const eventName = draft.eventName.trim();
+  if (eventName) {
+    if (chars(eventName) > 200) {
+      errors.eventName = "Shorten the event name to 200 characters or fewer.";
+    } else {
+      body.eventName = eventName;
+    }
+  }
+  return { body, errors };
+}
+
+// ── Community branding ──────────────────────────────────────────────────
+
+export interface BrandingDraft {
+  displayName: string;
+  accentColor: string;
+  logoUrl: string;
+}
+
+export type BrandingErrors = Partial<Record<keyof BrandingDraft, string>>;
+
+export const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+export function brandingDraft(branding: CommunityBranding): BrandingDraft {
+  return {
+    displayName: branding.displayName ?? "",
+    accentColor: branding.accentColor ?? "",
+    logoUrl: branding.logoUrl ?? "",
+  };
+}
+
+export function validateBranding(draft: BrandingDraft): BrandingErrors {
+  const errors: BrandingErrors = {};
+  const name = draft.displayName.trim();
+  if (chars(name) > 128) {
+    errors.displayName = `The display name is ${chars(name)} characters. Shorten it to 128 or fewer.`;
+  }
+  const color = draft.accentColor.trim();
+  if (color && !HEX_COLOR.test(color)) {
+    errors.accentColor = "Enter the colour as # and six hex digits, like #1a7f6e.";
+  }
+  const url = draft.logoUrl.trim();
+  if (url) {
+    if (!url.startsWith("https://")) {
+      errors.logoUrl =
+        "Use an https:// address. Clients refuse to fetch a logo over plain http.";
+    } else if (url.length <= "https://".length) {
+      errors.logoUrl = "Add the rest of the address after https://.";
+    } else if (/[\s\u0000-\u001f\u007f-\u009f]/.test(url)) {
+      errors.logoUrl = "Remove the spaces from the logo address.";
+    } else if (chars(url) > 2048) {
+      errors.logoUrl = `The address is ${chars(url)} characters. Use one of 2048 or fewer.`;
+    }
+  }
+  return errors;
+}
+
+/**
+ * The `PUT /v1/community/branding` body for a draft. The PUT replaces the whole
+ * branding, so an `ext` the console does not edit is carried over rather than
+ * dropped; an empty member is left out, which clears it.
+ */
+export function brandingBody(
+  draft: BrandingDraft,
+  current?: CommunityBranding,
+): CommunityBranding {
+  const body: CommunityBranding = {};
+  const name = draft.displayName.trim();
+  const color = draft.accentColor.trim();
+  const url = draft.logoUrl.trim();
+  if (name) body.displayName = name;
+  if (color) body.accentColor = color.toLowerCase();
+  if (url) body.logoUrl = url;
+  if (current?.ext != null) body.ext = current.ext;
+  return body;
+}

--- a/vtc-service/admin-ui/src/lib/wire-types.ts
+++ b/vtc-service/admin-ui/src/lib/wire-types.ts
@@ -69,6 +69,13 @@ export type AutoGrantConfig = Schemas["AutoGrantConfig"];
 export type AutoGrantSweep = Schemas["AutoGrantSweep"];
 export type VettingRevocationList = Schemas["VettingRevocationListResponse"];
 export type VettingRevocationRow = Schemas["VettingRevocationRow"];
+export type RevocationReviewState = Schemas["RevocationReviewState"];
+export type VettingMethod = Schemas["VettingMethod"];
+export type VetterListBody = Schemas["VetterListBody"];
+export type VetterListResponse = Schemas["VetterListResponseBody"];
+export type ListedVetter = Schemas["ListedVetter"];
+export type VetterEvent = Schemas["VetterEvent"];
+export type VetterLocation = Schemas["VetterLocation"];
 export type CommunityBranding = Schemas["CommunityBranding"];
 export type RequestVmcResponse = Schemas["RequestVmcResponse"];
 
@@ -79,6 +86,8 @@ export type JoinRequestsPage = Schemas["Paginated_JoinRequest"];
 export type JoinRequestVettingResponse = Schemas["JoinRequestVettingResponse"];
 export type JoinRequestVetting = Schemas["JoinRequestVetting"];
 export type JoinRequestVettingStatement = Schemas["JoinRequestVettingStatement"];
+export type JoinManifest = Schemas["JoinRequestManifestResponseBody"];
+export type ManifestCriterion = Schemas["ManifestCriterion"];
 export type DecideResponse = Schemas["DecideResponse"];
 
 // ── Audit ───────────────────────────────────────────────────────────────

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -873,6 +873,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/join-requests/manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GET /join-requests/manifest — the join manifest (0.2) as applicants receive
+         *     it, for an admin session.
+         * @description Applicants read the manifest as a Trust Task document over
+         *     `POST /v1/trust-tasks`. The admin console reads the same answer here, under
+         *     the same `vtc/join-requests/manifest/0.2` task, to show each criterion's
+         *     vetting requirements and `requirementsDigest` — criteria are registered
+         *     through `/v1/schemas/accepts`, which carries no digest.
+         */
+        get: operations["joinRequestManifestShow"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/join-requests/query": {
         parameters: {
             query?: never;
@@ -1693,6 +1718,28 @@ export interface paths {
         get: operations["vettingVetterList"];
         put?: never;
         post: operations["vettingVetterGrant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/vetting/vetters/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * The public vetter listing, as applicants see it.
+         * @description The body and the answer are `vtc/vetting/vetters/list/0.1`'s, and both go
+         *     through [`crate::vetting::profiles::list`], so the console previews exactly
+         *     what `POST /v1/trust-tasks` returns to an applicant with the same filters.
+         */
+        post: operations["vettingVetterListing"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3128,6 +3175,12 @@ export interface components {
         JoinRequestEnvelope: {
             request: components["schemas"]["JoinRequest"];
         };
+        /** @description Manifest response: the community's join evidence requirements. */
+        JoinRequestManifestResponseBody: {
+            branding?: null | components["schemas"]["CommunityBranding"];
+            communityDid: string;
+            criteria: components["schemas"]["ManifestCriterion"][];
+        };
         /**
          * @description The vetting facts a join request was decided on — the policy's
          *     `input.evidence.vetting`, in lowerCamelCase.
@@ -3288,6 +3341,59 @@ export interface components {
              *     not define, so no conforming client could find it.
              */
             credentials: components["schemas"]["RegisteredCredential"][];
+        };
+        /**
+         * @description One vetter in a listing: the published profile, the DID and the grant's
+         *     expiry — nothing else about the member.
+         */
+        ListedVetter: {
+            /** @description See [`VetterProfileBody::accepts_documentation`]. */
+            acceptsDocumentation: string[];
+            /** @description See [`VetterProfileBody::availability`]. */
+            availability?: string | null;
+            /** @description See [`VetterProfileBody::contact_hint`]. */
+            contactHint?: string | null;
+            /** @description See [`VetterProfileBody::display_name`]. */
+            displayName?: string | null;
+            /** @description The profile's events that have not ended (`endDate` ≥ today, UTC). */
+            events: components["schemas"]["VetterEvent"][];
+            /**
+             * Format: date-time
+             * @description When the vetter's grant expires.
+             */
+            grantValidUntil: string;
+            /** @description See [`VetterProfileBody::languages`]. */
+            languages: string[];
+            location?: null | components["schemas"]["VetterLocation"];
+            /** @description See [`VetterProfileBody::methods`]. */
+            methods: components["schemas"]["VettingMethod"][];
+            /**
+             * Format: date-time
+             * @description When the profile was last published.
+             */
+            updatedAt: string;
+            /** @description The vetter's DID — where a `vetting/request` goes. */
+            vetterDid: string;
+        };
+        /**
+         * @description One community evidence requirement — a named DCQL Presentation
+         *     Definition the applicant may present against.
+         */
+        ManifestCriterion: {
+            description?: string | null;
+            id: string;
+            presentationDefinition: components["schemas"]["Value"];
+            /**
+             * @description `digestMultibase` over this criterion without this member (manifest
+             *     0.2). An applicant records it when it starts gathering, so a change to
+             *     the requirements mid-application is detectable.
+             */
+            requirementsDigest?: string | null;
+            /**
+             * @description Peer identity vetting this criterion requires (manifest 0.2). Absent on
+             *     a criterion that needs none.
+             */
+            vetting?: Record<string, never> | null;
         };
         /**
          * @description `{ member: … }` — the shape `vtc/members/show/0.1` publishes. The row was
@@ -4874,6 +4980,24 @@ export interface components {
             /** @description Whether every chainable envelope verified. */
             verified: boolean;
         };
+        /** @description An event a vetter will attend and vet at — a conference, a summit. */
+        VetterEvent: {
+            /**
+             * Format: date
+             * @description Last day, `YYYY-MM-DD`; not before `startDate`, at most 31 days after it.
+             */
+            endDate: string;
+            location?: null | components["schemas"]["VetterLocation"];
+            /** @description The event's name; 1–200 characters. */
+            name: string;
+            /**
+             * Format: date
+             * @description First day, `YYYY-MM-DD`.
+             */
+            startDate: string;
+            /** @description The event's page; `https`, at most 2048 characters. */
+            url?: string | null;
+        };
         /** @description `vtc/vetting/vetters/grant/0.1` payload. */
         VetterGrantBody: {
             /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
@@ -4949,6 +5073,68 @@ export interface components {
              * @description The credential's `validUntil`; absent on a row that did not record it.
              */
             validUntil?: string | null;
+        };
+        /**
+         * @description `vtc/vetting/vetters/list/0.1` payload. Every filter is optional; filters
+         *     combine with AND.
+         */
+        VetterListBody: {
+            /** @description Case-insensitive exact match on `location.city`. */
+            city?: string | null;
+            /** @description ISO 3166-1 alpha-2, uppercase. */
+            country?: string | null;
+            /** @description The `nextCursor` of the previous page; at most 512 characters. */
+            cursor?: string | null;
+            /**
+             * Format: date
+             * @description With `eventTo`, a date range a listed event must overlap; an open end is
+             *     unbounded.
+             */
+            eventFrom?: string | null;
+            /**
+             * @description Case-insensitive substring of a listed event's name; at most 200
+             *     characters.
+             */
+            eventName?: string | null;
+            /**
+             * Format: date
+             * @description See [`Self::event_from`].
+             */
+            eventTo?: string | null;
+            /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
+            ext?: unknown;
+            /**
+             * @description A BCP 47 tag. Matches a listed tag equal to it, or one it is a prefix of
+             *     at a subtag boundary (`de` matches `de-AT`). Compared case-insensitively.
+             */
+            language?: string | null;
+            /**
+             * Format: int32
+             * @description Page size, 1–100; 50 when absent.
+             */
+            limit?: number | null;
+            method?: null | components["schemas"]["VettingMethod"];
+            /** @description Case-insensitive exact match on `location.region`. */
+            region?: string | null;
+        };
+        /** @description `vtc/vetting/vetters/list/0.1#response` payload. */
+        VetterListResponseBody: {
+            /**
+             * @description Pass as `cursor`, with the same filters, for the next page; absent on
+             *     the last.
+             */
+            nextCursor?: string | null;
+            /** @description This page, in the listing's order. */
+            vetters: components["schemas"]["ListedVetter"][];
+        };
+        /** @description Where a vetter is, or where an event is held. */
+        VetterLocation: {
+            /** @description City; 1–128 characters. */
+            city?: string | null;
+            /** @description ISO 3166-1 alpha-2, uppercase. */
+            country: string;
+            /** @description Region, state or province; 1–128 characters. */
+            region?: string | null;
         };
         /** @description What an admin sees of a vetter's published profile. */
         VetterProfileSummary: {
@@ -7154,6 +7340,40 @@ export interface operations {
             };
         };
     };
+    joinRequestManifestShow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The join manifest (0.2): each criterion with its vetting requirements and requirementsDigest, and the branding */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JoinRequestManifestResponseBody"];
+                };
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not an admin */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     send_query: {
         parameters: {
             query?: never;
@@ -9236,6 +9456,51 @@ export interface operations {
                 content?: never;
             };
             /** @description Caller is not a community admin */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    vettingVetterListing: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VetterListBody"];
+            };
+        };
+        responses: {
+            /** @description A page of listed vetters */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VetterListResponseBody"];
+                };
+            };
+            /** @description A filter breaks its bounds, or the cursor was issued for other filters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not an admin */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/vtc-service/admin-ui/src/plugins/ceremonies.tsx
+++ b/vtc-service/admin-ui/src/plugins/ceremonies.tsx
@@ -15,7 +15,7 @@
 
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 import { getJson, postJson } from "@/lib/api";
 import { useConfirm } from "@/components/ConfirmDialog";
@@ -181,7 +181,17 @@ export function Ceremonies() {
   // The daemon is the source of truth for the ceremony registry.
   const query = useQuery({ queryKey: ["ceremonies"], queryFn: fetchCeremonies });
   const ceremonies = query.data ?? [];
-  const [active, setActive] = useState<string>("");
+  // `?purpose=<purpose>` opens that purpose's policy. Other panels link here
+  // (the vetter settings link to `vetterEligibility`) rather than growing a
+  // policy editor of their own.
+  const [searchParams] = useSearchParams();
+  const requested = searchParams.get("purpose");
+  const requestedOther = OTHER_PURPOSES.find((p) => p === requested);
+  const requestedCeremony = CEREMONY_PURPOSES.find((p) => p === requested);
+  // An unknown purpose falls back to the first ceremony, as no parameter does.
+  const [active, setActive] = useState<string>(
+    requestedOther ? "other" : (requestedCeremony ?? ""),
+  );
 
   // Default to the first ceremony once the registry loads.
   useEffect(() => {
@@ -245,7 +255,7 @@ export function Ceremonies() {
       </div>
 
       {active === "other" ? (
-        <OtherPolicies />
+        <OtherPolicies initial={requestedOther} />
       ) : ceremony ? (
         <CeremonyPanel key={ceremony.purpose} ceremony={ceremony} />
       ) : null}
@@ -945,8 +955,8 @@ function UploadPolicyForm({
   );
 }
 
-function OtherPolicies() {
-  const [purpose, setPurpose] = useState<Purpose>(OTHER_PURPOSES[0]!);
+function OtherPolicies({ initial }: { initial?: Purpose }) {
+  const [purpose, setPurpose] = useState<Purpose>(initial ?? OTHER_PURPOSES[0]!);
   return (
     <>
       <p className="cer-sub" style={{ marginTop: "var(--space-5)" }}>

--- a/vtc-service/admin-ui/src/plugins/dashboard.tsx
+++ b/vtc-service/admin-ui/src/plugins/dashboard.tsx
@@ -1,9 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { ExternalLink } from "lucide-react";
+import { Link } from "react-router-dom";
 
 import { CopyButton } from "@/components/CopyButton";
 import { fetchHealth, fetchBuildInfo, fetchDiagnostics } from "@/lib/api";
 import { formatDuration } from "@/lib/format";
+import {
+  fetchPendingWithVetting,
+  fetchRevocations,
+  vettingKeys,
+} from "@/plugins/vetting/api";
 
 export function Dashboard() {
   const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
@@ -18,6 +24,19 @@ export function Dashboard() {
     queryKey: ["diagnostics"],
     queryFn: fetchDiagnostics,
   });
+  // Vetting work waiting on an admin: pending join requests that carry vetting
+  // facts, and withdrawn statements a current membership rests on.
+  const pendingVetting = useQuery({
+    queryKey: vettingKeys.pendingWithVetting,
+    queryFn: fetchPendingWithVetting,
+  });
+  const withdrawals = useQuery({
+    queryKey: vettingKeys.revocations,
+    queryFn: fetchRevocations,
+  });
+  const needsReview = withdrawals.data?.filter(
+    (r) => r.reviewState === "needsReview",
+  ).length;
 
   const status = health.data?.status;
   const mediatorDid = diagnostics.data?.mediatorDid;
@@ -172,6 +191,54 @@ export function Dashboard() {
             }
           />
         )}
+        <StatTile
+          label="Awaiting a vetting decision"
+          value={
+            pendingVetting.data
+              ? `${pendingVetting.data.count}${pendingVetting.data.more ? "+" : ""}`
+              : pendingVetting.error
+                ? "—"
+                : "…"
+          }
+          foot={
+            pendingVetting.error
+              ? "Could not check pending join requests"
+              : pendingVetting.data
+                ? pendingVetting.data.count
+                  ? "pending join requests with vetting facts"
+                  : "no join request is waiting"
+                : undefined
+          }
+          tone={
+            pendingVetting.error || pendingVetting.data?.count
+              ? "warn"
+              : pendingVetting.data
+                ? "ok"
+                : "neutral"
+          }
+          to="/join-requests"
+        />
+        <StatTile
+          label="Withdrawn statements"
+          value={needsReview ?? (withdrawals.error ? "—" : "…")}
+          foot={
+            withdrawals.error
+              ? "Could not load withdrawal notices"
+              : needsReview === undefined
+                ? undefined
+                : needsReview
+                  ? `${needsReview === 1 ? "admission" : "admissions"} to review`
+                  : "no admission to review"
+          }
+          tone={
+            withdrawals.error || needsReview
+              ? "warn"
+              : needsReview === 0
+                ? "ok"
+                : "neutral"
+          }
+          to="/vetting/withdrawals"
+        />
       </div>
 
       {/* The document-versus-binary comparison, always shown rather than only
@@ -386,15 +453,18 @@ function StatTile({
   foot,
   tone = "neutral",
   mono = false,
+  to,
 }: {
   label: string;
   value: React.ReactNode;
   foot?: string;
   tone?: "ok" | "warn" | "neutral";
   mono?: boolean;
+  /** Where acting on the tile happens; makes the whole tile a link. */
+  to?: string;
 }) {
-  return (
-    <div className="stat-tile">
+  const body = (
+    <>
       <span className="stat-tile-label">{label}</span>
       <span className={`stat-tile-value${mono ? " mono" : ""}`}>{value}</span>
       {foot && (
@@ -404,6 +474,13 @@ function StatTile({
           {foot}
         </span>
       )}
-    </div>
+    </>
+  );
+  return to ? (
+    <Link to={to} className="stat-tile">
+      {body}
+    </Link>
+  ) : (
+    <div className="stat-tile">{body}</div>
   );
 }

--- a/vtc-service/admin-ui/src/plugins/index.ts
+++ b/vtc-service/admin-ui/src/plugins/index.ts
@@ -12,6 +12,7 @@
 // awkward, the API is wrong.
 
 import {
+  BadgeCheck,
   ClipboardList,
   DoorOpen,
   Inbox,
@@ -41,6 +42,7 @@ import { Recognition } from "@/plugins/recognition";
 import { Relationships } from "@/plugins/relationshipsGraph";
 import { Rooms } from "@/plugins/rooms";
 import { Sessions } from "@/plugins/sessions";
+import { Vetting } from "@/plugins/vetting";
 
 export function registerBuiltinPlugins(): void {
   registerPlugin({
@@ -65,6 +67,14 @@ export function registerBuiltinPlugins(): void {
     path: "/join-requests",
     iconComponent: Inbox,
     reactComponent: JoinRequests,
+  });
+
+  registerPlugin({
+    id: "vetting",
+    label: "Vetting",
+    path: "/vetting",
+    iconComponent: BadgeCheck,
+    reactComponent: Vetting,
   });
 
   registerPlugin({

--- a/vtc-service/admin-ui/src/plugins/joinRequests.tsx
+++ b/vtc-service/admin-ui/src/plugins/joinRequests.tsx
@@ -19,6 +19,11 @@ import { useConfirm } from "@/components/ConfirmDialog";
 import { formatIso as formatDate } from "@/lib/format";
 import { useNameBook } from "@/lib/names";
 import { NamedDid } from "@/components/NamedDid";
+import { factsHeadline } from "@/lib/vetting";
+import {
+  JoinRequestVettingCard,
+  useJoinRequestVetting,
+} from "@/plugins/vetting/JoinRequestVetting";
 
 const TRUST_TASK_SUBMIT =
   "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
@@ -236,6 +241,15 @@ function JoinRequestDetail() {
     },
   });
 
+  // Read here as well as in the card (react-query shares the one request) so
+  // the approval prompt can say when vetting is not met.
+  const vetting = useJoinRequestVetting(id);
+  const vettingFacts = vetting.data?.vetting;
+  const vettingNote =
+    vettingFacts && !vettingFacts.satisfied
+      ? ` Vetting is not met: ${factsHeadline(vettingFacts).title.toLowerCase()}.`
+      : "";
+
   const rejectMutation = useMutation({
     mutationFn: reject,
     onSuccess: () => {
@@ -281,6 +295,8 @@ function JoinRequestDetail() {
             </dl>
           </section>
 
+          <JoinRequestVettingCard id={id} />
+
           {query.data.status === "pending" && (
             <section className="card">
               <h3>Decide</h3>
@@ -314,7 +330,7 @@ function JoinRequestDetail() {
                   onClick={async () => {
                     const ok = await confirm({
                       title: "Approve join request?",
-                      message: `${query.data.applicantDid} gets an ACL + member row, and credentials (VMC + role VEC) are issued.`,
+                      message: `${query.data.applicantDid} gets an ACL + member row, and credentials (VMC + role VEC) are issued.${vettingNote}`,
                       confirmLabel: "Approve",
                     });
                     if (ok) approveMutation.mutate(id);

--- a/vtc-service/admin-ui/src/plugins/profile.tsx
+++ b/vtc-service/admin-ui/src/plugins/profile.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Field } from "@/components/Field";
 import { getJson, putJson } from "@/lib/api";
+import { CommunityBrandingCard } from "@/plugins/vetting/BrandingCard";
 
 const TRUST_TASK =
   "https://trusttasks.org/spec/vtc/community/profile/show/0.1";
@@ -241,6 +242,8 @@ export function Profile() {
           </button>
         </div>
       </form>
+
+      <CommunityBrandingCard />
     </section>
   );
 }

--- a/vtc-service/admin-ui/src/plugins/vetting/AutoGrantPanel.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/AutoGrantPanel.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AutoGrantPanel } from "@/plugins/vetting/AutoGrantPanel";
+import { type MockRoute, mockFetch, renderWithProviders } from "@/test/render";
+
+const STATUS = {
+  enabled: false,
+  sweepMinutes: 60,
+  validitySeconds: 31_536_000,
+  lastSweep: {
+    ranAt: "2026-09-11T08:00:00Z",
+    granted: 2,
+    revoked: 1,
+    errors: 1,
+  },
+};
+
+const ROUTES: MockRoute[] = [
+  { path: "/v1/vetting/auto-grant", body: STATUS },
+  { path: "/v1/policies/active", body: { bindings: [] } },
+  {
+    method: "PUT",
+    path: "/v1/vetting/auto-grant",
+    body: ({ body }) => ({ ...(body as object), lastSweep: STATUS.lastSweep }),
+  },
+];
+
+describe("AutoGrantPanel", () => {
+  it("shows the last sweep and links to the eligibility policy editor", async () => {
+    mockFetch(ROUTES);
+    renderWithProviders(<AutoGrantPanel />);
+
+    expect(await screen.findByText("2 members")).toBeTruthy();
+    expect(screen.getByText("The sweep could not act on 1 member.")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "View or edit the policy" }).getAttribute("href"),
+    ).toBe("/ceremonies?purpose=vetterEligibility");
+    expect(await screen.findByText("No revision of this policy is active.")).toBeTruthy();
+  });
+
+  it("will not save an out-of-range sweep, then saves valid settings", async () => {
+    const requests = mockFetch(ROUTES);
+    renderWithProviders(<AutoGrantPanel />);
+
+    const minutes = await screen.findByLabelText("Sweep every (minutes)");
+    const save = screen.getByRole("button", { name: "Save settings" }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("switch", { name: /Name vetters automatically/ }));
+    fireEvent.change(minutes, { target: { value: "2" } });
+    expect(
+      screen.getByText("Choose 5 to 1440 minutes (a day); 2 is outside that."),
+    ).toBeTruthy();
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(minutes, { target: { value: "30" } });
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(requests.some((r) => r.method === "PUT")).toBe(true));
+    const put = requests.find((r) => r.method === "PUT")!;
+    expect(put.body).toEqual({
+      enabled: true,
+      sweepMinutes: 30,
+      validitySeconds: 31_536_000,
+    });
+    expect(put.headers.get("Trust-Task")).toBeNull();
+    expect(
+      await screen.findByText(
+        "Automatic grants are on. The sweep runs every 30 minutes.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/AutoGrantPanel.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/AutoGrantPanel.tsx
@@ -1,0 +1,279 @@
+// Automatic vetter grants — the sweep's settings and its last result.
+//
+// Who the sweep names is the `vetterEligibility` policy's call. That policy is
+// edited where every other policy is — the Ceremonies surface, under "Other
+// policies" — so this panel links there rather than growing an editor of its
+// own.
+
+import { type FormEvent, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+
+import { formatIso } from "@/lib/format";
+import { fetchActivePolicy } from "@/lib/policies-api";
+import { useToast } from "@/lib/toast";
+import { DAY_SECONDS, sweepMinutesError, validityDaysError } from "@/lib/vetting";
+import type { AutoGrantStatus } from "@/lib/wire-types";
+
+import { fetchAutoGrant, saveAutoGrant, vettingKeys } from "./api";
+import { describedBy, errorMessage, FormField, LoadError } from "./ui";
+
+/** Opens the `vetterEligibility` policy in the Ceremonies plugin. */
+export const ELIGIBILITY_POLICY_PATH = "/ceremonies?purpose=vetterEligibility";
+
+interface Draft {
+  enabled: boolean;
+  sweepMinutes: string;
+  validityDays: string;
+}
+
+const draftOf = (status: AutoGrantStatus): Draft => ({
+  enabled: status.enabled,
+  sweepMinutes: String(status.sweepMinutes),
+  validityDays: String(status.validitySeconds / DAY_SECONDS),
+});
+
+export function AutoGrantPanel() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const status = useQuery({
+    queryKey: vettingKeys.autoGrant,
+    queryFn: fetchAutoGrant,
+  });
+  // Same key the Ceremonies policy manager uses, so the two share one read.
+  const policy = useQuery({
+    queryKey: ["active-policy", "vetterEligibility"],
+    queryFn: () => fetchActivePolicy("vetterEligibility"),
+  });
+  const [draft, setDraft] = useState<Draft | null>(null);
+
+  useEffect(() => {
+    if (status.data && draft === null) setDraft(draftOf(status.data));
+  }, [status.data, draft]);
+
+  const save = useMutation({
+    mutationFn: saveAutoGrant,
+    onSuccess: (next) => {
+      queryClient.setQueryData(vettingKeys.autoGrant, next);
+      setDraft(draftOf(next));
+      toast.push(
+        "success",
+        next.enabled
+          ? `Automatic grants are on. The sweep runs every ${next.sweepMinutes} minutes.`
+          : "Automatic grants are off. Grants the sweep already issued stay until they expire or you revoke them.",
+      );
+    },
+  });
+
+  if (status.error) {
+    return (
+      <LoadError what="the automatic grant settings" error={status.error} />
+    );
+  }
+  if (!status.data || !draft) {
+    return (
+      <section className="card">
+        <h3>Automatic vetter grants</h3>
+        <p className="muted">Loading…</p>
+      </section>
+    );
+  }
+
+  const minutesError = sweepMinutesError(draft.sweepMinutes);
+  const daysError = validityDaysError(draft.validityDays);
+  const saved = draftOf(status.data);
+  const dirty =
+    draft.enabled !== saved.enabled ||
+    draft.sweepMinutes.trim() !== saved.sweepMinutes ||
+    draft.validityDays.trim() !== saved.validityDays;
+  const invalid = Boolean(minutesError || daysError);
+  const last = status.data.lastSweep;
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!dirty || invalid) return;
+    save.mutate({
+      enabled: draft.enabled,
+      sweepMinutes: Number(draft.sweepMinutes),
+      validitySeconds: Number(draft.validityDays) * DAY_SECONDS,
+    });
+  };
+
+  return (
+    <>
+      <form
+        className="card"
+        onSubmit={onSubmit}
+        aria-labelledby="auto-grant-title"
+        noValidate
+      >
+        <h3 id="auto-grant-title">Automatic vetter grants</h3>
+        <p className="lead">
+          When this is on, the community checks every active member against the
+          vetter eligibility policy on a schedule. It names a vetter each member
+          the policy allows, and revokes the grants it issued itself when the
+          policy stops allowing a member. It never revokes a grant an admin made.
+        </p>
+
+        <label className="switch-field" htmlFor="auto-grant-enabled">
+          <input
+            id="auto-grant-enabled"
+            type="checkbox"
+            role="switch"
+            checked={draft.enabled}
+            onChange={(e) => setDraft({ ...draft, enabled: e.target.checked })}
+          />
+          <span className="switch-text">
+            <strong>Name vetters automatically</strong>
+            <span className="muted">
+              {draft.enabled
+                ? "On: the sweep runs on the schedule below."
+                : "Off: only admins name vetters."}
+            </span>
+          </span>
+        </label>
+
+        <div className="filter-grid">
+          <FormField
+            id="auto-grant-minutes"
+            label="Sweep every (minutes)"
+            hint="From 5 minutes to 1440 (once a day)."
+            error={minutesError}
+          >
+            <input
+              id="auto-grant-minutes"
+              type="number"
+              inputMode="numeric"
+              min={5}
+              max={1440}
+              step={1}
+              value={draft.sweepMinutes}
+              onChange={(e) => setDraft({ ...draft, sweepMinutes: e.target.value })}
+              aria-invalid={Boolean(minutesError)}
+              aria-describedby={describedBy("auto-grant-minutes", true, minutesError)}
+            />
+          </FormField>
+          <FormField
+            id="auto-grant-days"
+            label="Automatic grants last (days)"
+            hint="From 1 day to 730 (two years). A grant an admin makes sets its own validity."
+            error={daysError}
+          >
+            <input
+              id="auto-grant-days"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={730}
+              step={1}
+              value={draft.validityDays}
+              onChange={(e) => setDraft({ ...draft, validityDays: e.target.value })}
+              aria-invalid={Boolean(daysError)}
+              aria-describedby={describedBy("auto-grant-days", true, daysError)}
+            />
+          </FormField>
+        </div>
+
+        {save.error && (
+          <section className="card error" role="alert">
+            <h3>Could not save the automatic grant settings</h3>
+            <p>{errorMessage(save.error)}</p>
+            <p className="muted">
+              The settings are unchanged. Correct the values and save again.
+            </p>
+          </section>
+        )}
+
+        <div className="form-actions">
+          <button
+            type="submit"
+            className="primary"
+            disabled={!dirty || invalid || save.isPending}
+          >
+            {save.isPending ? "Saving…" : "Save settings"}
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            disabled={!dirty || save.isPending}
+            onClick={() => {
+              setDraft(saved);
+              save.reset();
+            }}
+          >
+            Discard changes
+          </button>
+        </div>
+      </form>
+
+      <section className="card" aria-labelledby="auto-grant-last-title">
+        <h3 id="auto-grant-last-title">Last sweep</h3>
+        {last ? (
+          <>
+            <dl>
+              <dt>Finished</dt>
+              <dd>{formatIso(last.ranAt)}</dd>
+              <dt>Granted</dt>
+              <dd>
+                {last.granted} {last.granted === 1 ? "member" : "members"}
+              </dd>
+              <dt>Revoked</dt>
+              <dd>
+                {last.revoked} automatic {last.revoked === 1 ? "grant" : "grants"}
+              </dd>
+              <dt>Undecided</dt>
+              <dd>
+                {last.errors} {last.errors === 1 ? "member" : "members"}
+              </dd>
+            </dl>
+            {last.errors > 0 && (
+              <p className="finding warn">
+                <strong>
+                  The sweep could not act on {last.errors}{" "}
+                  {last.errors === 1 ? "member" : "members"}.
+                </strong>
+                <span className="muted">
+                  The policy answered neither allow nor deny, or granting or
+                  revoking failed. Check the vetter eligibility policy, then the
+                  audit trail for VetterAutoGrantSwept.
+                </span>
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="muted">
+            No sweep has run yet.
+            {status.data.enabled ? "" : " Turn automatic grants on to start it."}
+          </p>
+        )}
+      </section>
+
+      <section className="card" aria-labelledby="auto-grant-policy-title">
+        <h3 id="auto-grant-policy-title">Who the sweep names</h3>
+        <p>
+          The <code>vetterEligibility</code> policy (package{" "}
+          <code>vtc.vetter_eligibility</code>) decides, member by member. It sees
+          each member's status, roles, days since joining, how they were
+          admitted, whether a statement behind their admission has been
+          withdrawn, and how many vetting steps separate them from a founding
+          member. The shipped policy allows only founding members who are not
+          under review.
+        </p>
+        <p className="muted">
+          {policy.isPending
+            ? "Loading the active policy…"
+            : policy.error
+              ? `Could not read the active policy: ${errorMessage(policy.error)}`
+              : policy.data
+                ? `Active: version ${policy.data.version}, updated ${formatIso(policy.data.updatedAt)}.`
+                : "No revision of this policy is active."}
+        </p>
+        <div className="form-actions">
+          <Link className="button secondary" to={ELIGIBILITY_POLICY_PATH}>
+            View or edit the policy
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/BrandingCard.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/BrandingCard.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CommunityBrandingCard, readableTextOn } from "@/plugins/vetting/BrandingCard";
+import { mockFetch, renderWithProviders } from "@/test/render";
+
+describe("CommunityBrandingCard", () => {
+  it("previews the branding and saves it with the colour in lower case", async () => {
+    const requests = mockFetch([
+      { path: "/v1/community/branding", body: {} },
+      {
+        method: "PUT",
+        path: "/v1/community/branding",
+        body: ({ body }) => body,
+      },
+    ]);
+    renderWithProviders(<CommunityBrandingCard />);
+
+    const save = (await screen.findByRole("button", {
+      name: "Save branding",
+    })) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Linux Kernel" },
+    });
+    fireEvent.change(screen.getByLabelText("Pick the accent colour"), {
+      target: { value: "#1a2b3c" },
+    });
+    const hex = screen.getByLabelText("Accent colour") as HTMLInputElement;
+    expect(hex.value).toBe("#1a2b3c");
+    fireEvent.change(hex, { target: { value: "#1A2B3C" } });
+    fireEvent.change(screen.getByLabelText("Logo URL"), {
+      target: { value: "https://kernel.example.org/logo.svg" },
+    });
+
+    const preview = screen.getByTestId("branding-preview");
+    expect(within(preview).getByText("Linux Kernel")).toBeTruthy();
+    expect(preview.textContent).toMatch(/kernel\.example\.org/);
+
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+    await waitFor(() => expect(requests.some((r) => r.method === "PUT")).toBe(true));
+    const put = requests.find((r) => r.method === "PUT")!;
+    expect(put.body).toEqual({
+      displayName: "Linux Kernel",
+      accentColor: "#1a2b3c",
+      logoUrl: "https://kernel.example.org/logo.svg",
+    });
+    expect(await screen.findByText(/^Saved the branding/)).toBeTruthy();
+  });
+
+  it("explains invalid values and will not save them", async () => {
+    mockFetch([{ path: "/v1/community/branding", body: { displayName: "Kernel" } }]);
+    renderWithProviders(<CommunityBrandingCard />);
+
+    await screen.findByDisplayValue("Kernel");
+    fireEvent.change(screen.getByLabelText("Accent colour"), {
+      target: { value: "#12345" },
+    });
+    fireEvent.change(screen.getByLabelText("Logo URL"), {
+      target: { value: "http://kernel.example.org/logo.svg" },
+    });
+
+    expect(
+      screen.getByText("Enter the colour as # and six hex digits, like #1a7f6e."),
+    ).toBeTruthy();
+    expect(screen.getByText(/^Use an https:\/\/ address/)).toBeTruthy();
+    expect(screen.getByLabelText("Logo URL").getAttribute("aria-invalid")).toBe("true");
+    expect(
+      (screen.getByRole("button", { name: "Save branding" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("picks readable text for the accent colour", () => {
+    expect(readableTextOn("#ffffff")).toBe("#000000");
+    expect(readableTextOn("#0d1320")).toBe("#ffffff");
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/BrandingCard.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/BrandingCard.tsx
@@ -1,0 +1,269 @@
+// Community branding — the name, accent colour and logo an applicant's client
+// shows for this community (`join-requests/manifest/0.2`'s `branding`).
+//
+// Rendered on the Community profile page. Presentation only: clients identify
+// the community by its DID. The preview sketches the result without fetching
+// the logo, because this console's content security policy only loads images
+// from the daemon itself — and because fetching it is exactly what reveals a
+// visitor to the logo's host, which the form warns about.
+
+import { type FormEvent, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useToast } from "@/lib/toast";
+import {
+  brandingBody,
+  brandingDraft,
+  HEX_COLOR,
+  validateBranding,
+  type BrandingDraft,
+  type BrandingErrors,
+} from "@/lib/vetting";
+
+import { fetchBranding, saveBranding, vettingKeys } from "./api";
+import { describedBy, errorMessage, FormField, LoadError } from "./ui";
+
+/** What the colour picker shows before a valid colour is entered. */
+const PICKER_FALLBACK = "#0d9488";
+
+/** Black or white, whichever reads better on `hex` (WCAG relative luminance). */
+export function readableTextOn(hex: string): "#000000" | "#ffffff" {
+  const n = Number.parseInt(hex.slice(1), 16);
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const luminance =
+    0.2126 * channel((n >> 16) & 255) +
+    0.7152 * channel((n >> 8) & 255) +
+    0.0722 * channel(n & 255);
+  return luminance > 0.179 ? "#000000" : "#ffffff";
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}
+
+export function CommunityBrandingCard() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const query = useQuery({ queryKey: vettingKeys.branding, queryFn: fetchBranding });
+  const [draft, setDraft] = useState<BrandingDraft | null>(null);
+
+  useEffect(() => {
+    if (query.data && draft === null) setDraft(brandingDraft(query.data));
+  }, [query.data, draft]);
+
+  const save = useMutation({
+    mutationFn: saveBranding,
+    onSuccess: (stored) => {
+      queryClient.setQueryData(vettingKeys.branding, stored);
+      setDraft(brandingDraft(stored));
+      toast.push(
+        "success",
+        "Saved the branding. Applicants' clients show it the next time they read the join manifest.",
+      );
+    },
+  });
+
+  if (query.error) {
+    return <LoadError what="the community branding" error={query.error} />;
+  }
+  if (!query.data || !draft) {
+    return (
+      <section className="card">
+        <h3>Branding for applicants</h3>
+        <p className="muted">Loading…</p>
+      </section>
+    );
+  }
+
+  const current = query.data;
+  const errors = validateBranding(draft);
+  const invalid = Object.keys(errors).length > 0;
+  const dirty =
+    JSON.stringify(brandingBody(draft)) !==
+    JSON.stringify(brandingBody(brandingDraft(current)));
+  const color = draft.accentColor.trim();
+  const nameLength = [...draft.displayName.trim()].length;
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!dirty || invalid) return;
+    save.mutate(brandingBody(draft, current));
+  };
+
+  return (
+    <form
+      className="card"
+      onSubmit={onSubmit}
+      aria-labelledby="branding-title"
+      noValidate
+    >
+      <h3 id="branding-title">Branding for applicants</h3>
+      <p className="lead">
+        How applicants' clients show this community when someone considers
+        joining. It is presentation only: clients identify the community by its
+        DID, never by its name or logo. Leave a field empty to publish none.
+      </p>
+
+      <div className="branding-layout">
+        <div className="form-stack">
+          <FormField
+            id="branding-name"
+            label="Display name"
+            hint={`${nameLength} of 128 characters.`}
+            error={errors.displayName}
+          >
+            <input
+              id="branding-name"
+              type="text"
+              value={draft.displayName}
+              placeholder="Linux Kernel"
+              onChange={(e) => setDraft({ ...draft, displayName: e.target.value })}
+              aria-invalid={Boolean(errors.displayName)}
+              aria-describedby={describedBy("branding-name", true, errors.displayName)}
+            />
+          </FormField>
+
+          <FormField
+            id="branding-color"
+            label="Accent colour"
+            hint="# and six hex digits. Pick one, or type it."
+            error={errors.accentColor}
+          >
+            <div className="color-row">
+              <input
+                type="color"
+                aria-label="Pick the accent colour"
+                value={HEX_COLOR.test(color) ? color.toLowerCase() : PICKER_FALLBACK}
+                onChange={(e) => setDraft({ ...draft, accentColor: e.target.value })}
+              />
+              <input
+                id="branding-color"
+                type="text"
+                value={draft.accentColor}
+                placeholder="#1a7f6e"
+                spellCheck={false}
+                autoComplete="off"
+                onChange={(e) => setDraft({ ...draft, accentColor: e.target.value })}
+                aria-invalid={Boolean(errors.accentColor)}
+                aria-describedby={describedBy("branding-color", true, errors.accentColor)}
+              />
+            </div>
+          </FormField>
+
+          <FormField
+            id="branding-logo"
+            label="Logo URL"
+            hint="An https:// address. Applicants' clients load the logo from its host, so that host can see when, and from which network address, each applicant looked."
+            error={errors.logoUrl}
+          >
+            <input
+              id="branding-logo"
+              type="url"
+              value={draft.logoUrl}
+              placeholder="https://community.example.org/logo.svg"
+              spellCheck={false}
+              onChange={(e) => setDraft({ ...draft, logoUrl: e.target.value })}
+              aria-invalid={Boolean(errors.logoUrl)}
+              aria-describedby={describedBy("branding-logo", true, errors.logoUrl)}
+            />
+          </FormField>
+        </div>
+
+        <BrandingPreview draft={draft} errors={errors} />
+      </div>
+
+      {save.error && (
+        <section className="card error" role="alert">
+          <h3>Could not save the branding</h3>
+          <p>{errorMessage(save.error)}</p>
+          <p className="muted">
+            Applicants still see the branding saved before. Correct the fields
+            and save again.
+          </p>
+        </section>
+      )}
+
+      <div className="form-actions">
+        <button
+          type="submit"
+          className="primary"
+          disabled={!dirty || invalid || save.isPending}
+        >
+          {save.isPending ? "Saving…" : "Save branding"}
+        </button>
+        <button
+          type="button"
+          className="secondary"
+          disabled={!dirty || save.isPending}
+          onClick={() => {
+            setDraft(brandingDraft(current));
+            save.reset();
+          }}
+        >
+          Discard changes
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function BrandingPreview({
+  draft,
+  errors,
+}: {
+  draft: BrandingDraft;
+  errors: BrandingErrors;
+}) {
+  const color = draft.accentColor.trim();
+  const accent = color && !errors.accentColor ? color.toLowerCase() : null;
+  const name = draft.displayName.trim();
+  const logoUrl = draft.logoUrl.trim();
+  const logoHost = logoUrl && !errors.logoUrl ? hostOf(logoUrl) : null;
+
+  return (
+    <figure className="branding-preview">
+      <div
+        className="branding-preview-card"
+        style={accent ? { borderTopColor: accent } : undefined}
+        data-testid="branding-preview"
+      >
+        <div className="branding-preview-logo">
+          {logoHost ? (
+            <span>
+              Logo from
+              <br />
+              {logoHost}
+            </span>
+          ) : (
+            <span>No logo</span>
+          )}
+        </div>
+        <div>
+          <div className="branding-preview-name">{name || "No display name"}</div>
+          <div className="muted">Asks to vet you before you join</div>
+        </div>
+        <span
+          className="branding-preview-cta"
+          style={
+            accent
+              ? { background: accent, borderColor: accent, color: readableTextOn(accent) }
+              : undefined
+          }
+        >
+          Request to join
+        </span>
+      </div>
+      <figcaption className="muted">
+        A sketch of an applicant's client. The logo is not loaded here: this
+        console only loads images from its own daemon.
+      </figcaption>
+    </figure>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/JoinRequestVetting.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/JoinRequestVetting.test.tsx
@@ -1,0 +1,95 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { JoinRequestVetting } from "@/lib/wire-types";
+import { JoinRequestVettingCard } from "@/plugins/vetting/JoinRequestVetting";
+import { mockFetch, NAME_BOOK_ROUTES, renderWithProviders } from "@/test/render";
+
+const ID = "5f0c2a1e-8d4b-4a51-9d7e-2b7f4c3e9a10";
+
+const FACTS: JoinRequestVetting = {
+  criterionId: "kernel-developer",
+  requirementsDigest: "zQmRequirementsDigest",
+  applicantDigestMatches: false,
+  statements: [
+    {
+      id: "urn:uuid:counted",
+      issuer: "did:key:z6MkCarol",
+      method: "inPerson",
+      declaredRelationship: "none",
+      verified: true,
+      eligible: true,
+      revoked: false,
+      withdrawnNow: false,
+      counted: true,
+      failures: [],
+    },
+    {
+      id: "urn:uuid:refused",
+      issuer: "did:key:z6MkMallory",
+      method: "video",
+      declaredRelationship: "family",
+      verified: true,
+      eligible: false,
+      revoked: false,
+      withdrawnNow: false,
+      counted: false,
+      failures: ["issuer-not-vetter"],
+    },
+  ],
+  distinctCountedVetters: 1,
+  byMethod: { inPerson: 1 },
+  commitmentsConsistent: true,
+  independenceOk: true,
+  invitationRequired: false,
+  satisfied: false,
+  needs: ["vetting:statements:1"],
+  recordedAt: "2026-09-01T10:00:00Z",
+};
+
+describe("JoinRequestVettingCard", () => {
+  it("says what counted, what did not and why, and keeps the codes", async () => {
+    mockFetch([
+      { path: `/v1/join-requests/${ID}/vetting`, body: { requestId: ID, vetting: FACTS } },
+      ...NAME_BOOK_ROUTES,
+    ]);
+    renderWithProviders(<JoinRequestVettingCard id={ID} />);
+
+    expect(await screen.findByText("Vetting is incomplete")).toBeTruthy();
+    expect(screen.getByText("Statements from 1 more eligible vetter.")).toBeTruthy();
+    expect(screen.getByText("vetting:statements:1")).toBeTruthy();
+    expect(screen.getByText(/^Its signer was not an eligible vetter/)).toBeTruthy();
+    expect(screen.getByText("issuer-not-vetter")).toBeTruthy();
+    expect(screen.getByText("Counted")).toBeTruthy();
+    expect(screen.getByText("Not counted")).toBeTruthy();
+    expect(screen.getByText("Family member")).toBeTruthy();
+    expect(screen.getByText("In person 1")).toBeTruthy();
+    expect(screen.getByText("zQmRequirementsDigest")).toBeTruthy();
+    expect(
+      screen.getByText(/gathered statements for different requirements/),
+    ).toBeTruthy();
+  });
+
+  it("says so when no vetting criterion applied", async () => {
+    mockFetch([
+      { path: `/v1/join-requests/${ID}/vetting`, body: { requestId: ID } },
+      ...NAME_BOOK_ROUTES,
+    ]);
+    renderWithProviders(<JoinRequestVettingCard id={ID} />);
+    expect(await screen.findByText(/^No vetting criterion applied/)).toBeTruthy();
+  });
+
+  it("names a failed read and what to do", async () => {
+    mockFetch([
+      {
+        path: `/v1/join-requests/${ID}/vetting`,
+        status: 404,
+        body: { error: "join request not found" },
+      },
+      ...NAME_BOOK_ROUTES,
+    ]);
+    renderWithProviders(<JoinRequestVettingCard id={ID} />);
+    expect(await screen.findByText("Could not load the vetting facts.")).toBeTruthy();
+    expect(screen.getByText(/join request not found Reload the page/)).toBeTruthy();
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/JoinRequestVetting.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/JoinRequestVetting.tsx
@@ -1,0 +1,274 @@
+// The vetting facts a join request was decided on, for the admin deciding it.
+//
+// `GET /v1/join-requests/{id}/vetting` returns what the daemon counted at the
+// decision — the policy's `input.evidence.vetting` — plus whether each
+// statement has been withdrawn since. Every verdict is shown in words, with
+// the daemon's code beside it for the admin who needs to search for it.
+
+import { useQuery } from "@tanstack/react-query";
+import { Check, X } from "lucide-react";
+
+import { CopyButton } from "@/components/CopyButton";
+import { NamedDid } from "@/components/NamedDid";
+import { formatIso, shorten } from "@/lib/format";
+import { type NameBook, useNameBook } from "@/lib/names";
+import {
+  explainNeed,
+  factsHeadline,
+  methodLabel,
+  relationshipLabel,
+  statementVerdict,
+} from "@/lib/vetting";
+import type {
+  JoinRequestVetting,
+  JoinRequestVettingStatement,
+} from "@/lib/wire-types";
+
+import { fetchJoinRequestVetting, vettingKeys } from "./api";
+import { errorMessage, ExplainedText, FINDING_CLASS, ToneChip } from "./ui";
+
+export function useJoinRequestVetting(id: string) {
+  return useQuery({
+    queryKey: vettingKeys.joinRequest(id),
+    queryFn: () => fetchJoinRequestVetting(id),
+    enabled: id.length > 0,
+  });
+}
+
+export function JoinRequestVettingCard({ id }: { id: string }) {
+  const query = useJoinRequestVetting(id);
+  return (
+    <section className="card" aria-labelledby="join-vetting-title">
+      <h3 id="join-vetting-title">Vetting</h3>
+      {query.isPending && <p className="muted">Loading the vetting facts…</p>}
+      {query.error && (
+        <p className="finding error" role="alert">
+          <strong>Could not load the vetting facts.</strong>
+          <span className="muted">
+            {errorMessage(query.error)} Reload the page to try again.
+          </span>
+        </p>
+      )}
+      {query.data && !query.data.vetting && (
+        <p className="muted">
+          No vetting criterion applied to this request, so no vetting statements
+          were counted.
+        </p>
+      )}
+      {query.data?.vetting && <VettingFacts facts={query.data.vetting} />}
+    </section>
+  );
+}
+
+export function VettingFacts({ facts }: { facts: JoinRequestVetting }) {
+  const book = useNameBook();
+  const headline = factsHeadline(facts);
+  const byMethod = Object.entries(facts.byMethod)
+    .filter(([, n]) => n > 0)
+    .map(([method, n]) => `${methodLabel(method)} ${n}`);
+  const needs = facts.needs.map(explainNeed);
+
+  return (
+    <>
+      <p className={FINDING_CLASS[headline.tone]}>
+        <strong>{headline.title}</strong>
+        <span className="muted">{headline.detail}</span>
+      </p>
+
+      <dl>
+        <dt>Criterion</dt>
+        <dd>
+          <code>{facts.criterionId}</code>
+        </dd>
+        <dt>Requirements digest</dt>
+        <dd>
+          <code>{facts.requirementsDigest}</code>
+          <CopyButton
+            value={facts.requirementsDigest}
+            label="Copy requirements digest"
+            successMessage="Requirements digest copied"
+          />
+          {!facts.applicantDigestMatches && (
+            <span className="vet-note warn" title="applicantDigestMatches: false">
+              The applicant gathered statements for different requirements than
+              these. The request was evaluated under the requirements above.
+            </span>
+          )}
+        </dd>
+        <dt>Counted vetters</dt>
+        <dd>
+          {facts.distinctCountedVetters} distinct{" "}
+          {facts.distinctCountedVetters === 1 ? "vetter" : "vetters"}
+        </dd>
+        <dt>By method</dt>
+        <dd>{byMethod.length ? byMethod.join(" · ") : "None counted"}</dd>
+        <dt>Same identity</dt>
+        <dd title="commitmentsConsistent">
+          {facts.commitmentsConsistent
+            ? "Yes: the vetters verified the same identity"
+            : "No: the vetters verified different identities"}
+        </dd>
+        <dt>Independence</dt>
+        <dd title="independenceOk">
+          {facts.independenceOk
+            ? "Holds: no relationship limit is exceeded"
+            : "Exceeded: too many statements declare the same relationship"}
+        </dd>
+        <dt>Invitation</dt>
+        <dd title="invitationRequired">
+          {facts.invitationRequired ? "Required by this criterion" : "Not required"}
+        </dd>
+        <dt>Recorded</dt>
+        <dd>{formatIso(facts.recordedAt)}</dd>
+      </dl>
+
+      <div>
+        <h4 className="vet-subhead">Still needed</h4>
+        {needs.length === 0 ? (
+          <p className="muted">Nothing is missing.</p>
+        ) : (
+          <ul className="vet-list">
+            {needs.map((need) => (
+              <li key={need.code}>
+                <ExplainedText item={need} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div>
+        <h4 className="vet-subhead">
+          Statements presented ({facts.statements.length})
+        </h4>
+        {facts.statements.length === 0 ? (
+          <p className="muted">
+            The presentation carried no identity-vetting statements.
+          </p>
+        ) : (
+          <div className="table-scroll">
+            <table className="data-table vet-statements">
+              <thead>
+                <tr>
+                  <th>Vetter</th>
+                  <th>Method</th>
+                  <th>Relationship to applicant</th>
+                  <th>Checks</th>
+                  <th>Outcome</th>
+                </tr>
+              </thead>
+              <tbody>
+                {facts.statements.map((statement, i) => (
+                  <StatementRow
+                    key={statement.id ?? `statement-${i}`}
+                    statement={statement}
+                    book={book}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+function StatementRow({
+  statement,
+  book,
+}: {
+  statement: JoinRequestVettingStatement;
+  book: NameBook;
+}) {
+  const verdict = statementVerdict(statement);
+  return (
+    <tr>
+      <td>
+        {statement.issuer ? (
+          <NamedDid book={book} did={statement.issuer} />
+        ) : (
+          <span className="muted">Signer unknown</span>
+        )}
+        {statement.id && (
+          <div className="muted">
+            <code title={statement.id}>{shorten(statement.id, 16, 6)}</code>
+          </div>
+        )}
+      </td>
+      <td>
+        {statement.method ? (
+          <span title={statement.method}>{methodLabel(statement.method)}</span>
+        ) : (
+          <span className="muted">Not stated</span>
+        )}
+      </td>
+      <td>
+        <span title={statement.declaredRelationship ?? undefined}>
+          {relationshipLabel(statement.declaredRelationship)}
+        </span>
+      </td>
+      <td>
+        <ul className="vet-checks">
+          <CheckItem
+            ok={statement.verified}
+            yes="Verified"
+            no="Did not verify"
+            code="verified"
+          />
+          <CheckItem
+            ok={statement.eligible}
+            yes="Eligible vetter"
+            no="Not an eligible vetter"
+            code="eligible"
+          />
+          <CheckItem
+            ok={!statement.revoked && !statement.withdrawnNow}
+            yes="Not withdrawn"
+            no={
+              statement.revoked
+                ? "Withdrawn before the decision"
+                : "Withdrawn since the decision"
+            }
+            code={statement.revoked ? "revoked" : "withdrawnNow"}
+          />
+        </ul>
+      </td>
+      <td>
+        <ToneChip tone={verdict.tone}>{verdict.label}</ToneChip>
+        {verdict.reasons.length > 0 && (
+          <ul className="vet-list">
+            {verdict.reasons.map((reason) => (
+              <li key={reason.code}>
+                <ExplainedText item={reason} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function CheckItem({
+  ok,
+  yes,
+  no,
+  code,
+}: {
+  ok: boolean;
+  yes: string;
+  no: string;
+  code: string;
+}) {
+  return (
+    <li className={ok ? "vet-check ok" : "vet-check bad"} title={code}>
+      {ok ? (
+        <Check size={14} aria-hidden="true" />
+      ) : (
+        <X size={14} aria-hidden="true" />
+      )}{" "}
+      {ok ? yes : no}
+    </li>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/RegistryPreview.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/RegistryPreview.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RegistryPreview } from "@/plugins/vetting/RegistryPreview";
+import { mockFetch, renderWithProviders } from "@/test/render";
+
+const LIST_TASK = "https://trusttasks.org/spec/vtc/vetting/vetters/list/0.1";
+
+const CAROL = {
+  vetterDid: "did:key:z6MkCarolCarolCarolCarolCarolCarolCarol",
+  displayName: "Carol M.",
+  languages: ["en", "de-AT"],
+  location: { country: "AT", city: "Vienna" },
+  methods: ["inPerson", "video"],
+  acceptsDocumentation: ["passport", "none"],
+  contactHint: "Ask at the kernel-vtc table.",
+  events: [
+    {
+      name: "Kernel Maintainers Meetup",
+      startDate: "2026-10-05",
+      endDate: "2026-10-07",
+      url: "https://events.example.org/kmm",
+    },
+  ],
+  grantValidUntil: "2027-01-01T00:00:00Z",
+  updatedAt: "2026-09-01T00:00:00Z",
+};
+
+type ListRequest = { country?: string; cursor?: string };
+
+describe("RegistryPreview", () => {
+  it("sends the filters an applicant would, with the country in upper case", async () => {
+    const requests = mockFetch([
+      {
+        method: "POST",
+        path: "/v1/vetting/vetters/list",
+        body: ({ body }) => ({
+          vetters: (body as ListRequest).country === "AT" ? [CAROL] : [],
+        }),
+      },
+    ]);
+    renderWithProviders(<RegistryPreview />);
+
+    expect(await screen.findByText("No vetter is listed")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Language"), { target: { value: "de" } });
+    fireEvent.change(screen.getByLabelText("Country"), { target: { value: "at" } });
+    fireEvent.change(screen.getByLabelText("Method"), { target: { value: "video" } });
+    fireEvent.click(screen.getByRole("button", { name: "Show vetters" }));
+
+    expect(await screen.findByText("Carol M.")).toBeTruthy();
+    expect(screen.getByText("Ask at the kernel-vtc table.")).toBeTruthy();
+    expect(screen.getByText("Vienna, AT")).toBeTruthy();
+    const last = requests.at(-1)!;
+    expect(last.body).toEqual({
+      language: "de",
+      country: "AT",
+      method: "video",
+      limit: 25,
+    });
+    expect(last.headers.get("Trust-Task")).toBe(LIST_TASK);
+  });
+
+  it("names a malformed filter and does not send it", async () => {
+    const requests = mockFetch([
+      { method: "POST", path: "/v1/vetting/vetters/list", body: { vetters: [] } },
+    ]);
+    renderWithProviders(<RegistryPreview />);
+    await screen.findByText("No vetter is listed");
+    const sent = requests.length;
+
+    fireEvent.change(screen.getByLabelText("Country"), {
+      target: { value: "Austria" },
+    });
+    fireEvent.change(screen.getByLabelText("Events from"), {
+      target: { value: "2026-10-07" },
+    });
+    fireEvent.change(screen.getByLabelText("Events to"), {
+      target: { value: "2026-10-01" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Show vetters" }));
+
+    expect(screen.getByText("Enter a two-letter country code, like AT.")).toBeTruthy();
+    expect(screen.getByText(/The end of the range is before its start/)).toBeTruthy();
+    expect(screen.getByLabelText("Country").getAttribute("aria-invalid")).toBe("true");
+    expect(requests.length).toBe(sent);
+  });
+
+  it("pages with the cursor the listing returned", async () => {
+    const requests = mockFetch([
+      {
+        method: "POST",
+        path: "/v1/vetting/vetters/list",
+        body: ({ body }) =>
+          (body as ListRequest).cursor === "page-2"
+            ? { vetters: [{ ...CAROL, displayName: "Zed" }] }
+            : { vetters: [CAROL], nextCursor: "page-2" },
+      },
+    ]);
+    renderWithProviders(<RegistryPreview />);
+
+    await screen.findByText("Carol M.");
+    fireEvent.click(screen.getByRole("button", { name: /Next page/ }));
+    expect(await screen.findByText("Zed")).toBeTruthy();
+    expect(screen.getByText("Page 2")).toBeTruthy();
+    await waitFor(() =>
+      expect((requests.at(-1)!.body as ListRequest).cursor).toBe("page-2"),
+    );
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/RegistryPreview.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/RegistryPreview.tsx
@@ -1,0 +1,350 @@
+// Registry preview — the vetter listing as an applicant receives it.
+//
+// `POST /v1/vetting/vetters/list` is the admin-session route onto the same
+// `vtc/vetting/vetters/list/0.1` listing an applicant sends to
+// `POST /v1/trust-tasks`; both run one function on the daemon. So an admin can
+// check that a vetter is findable, with the filters an applicant would use,
+// before pointing applicants at them.
+
+import { type FormEvent, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, ArrowRight, BadgeCheck, ExternalLink } from "lucide-react";
+
+import { CopyButton } from "@/components/CopyButton";
+import { shortenDid } from "@/lib/format";
+import {
+  buildListBody,
+  EMPTY_LIST_DRAFT,
+  methodLabel,
+  VETTING_METHODS,
+  type ListDraft,
+} from "@/lib/vetting";
+import type {
+  ListedVetter,
+  VetterListBody,
+  VetterLocation,
+  VettingMethod,
+} from "@/lib/wire-types";
+
+import { fetchListing, vettingKeys } from "./api";
+import { describedBy, errorMessage, errorStatus, formatDay, FormField } from "./ui";
+
+const PAGE_SIZES = [10, 25, 50, 100];
+const DEFAULT_PAGE_SIZE = 25;
+
+function placeName(location?: VetterLocation | null): string | null {
+  if (!location) return null;
+  return [location.city, location.region, location.country]
+    .filter(Boolean)
+    .join(", ");
+}
+
+export function RegistryPreview() {
+  const [draft, setDraft] = useState<ListDraft>(EMPTY_LIST_DRAFT);
+  const [limit, setLimit] = useState(DEFAULT_PAGE_SIZE);
+  const [applied, setApplied] = useState<VetterListBody>({
+    limit: DEFAULT_PAGE_SIZE,
+  });
+  // `nextCursor`s of the pages before this one; empty on the first page.
+  const [cursors, setCursors] = useState<string[]>([]);
+  const [attempted, setAttempted] = useState(false);
+
+  const { body, errors } = buildListBody(draft);
+  const shown = attempted ? errors : {};
+  const cursor = cursors.at(-1) ?? null;
+  const filtered = Object.keys(applied).some((k) => k !== "limit");
+
+  const query = useQuery({
+    queryKey: vettingKeys.listing(applied, cursor),
+    queryFn: () => fetchListing(cursor ? { ...applied, cursor } : applied),
+    placeholderData: (previous) => previous,
+  });
+
+  const update =
+    (key: keyof ListDraft) =>
+    (e: { target: { value: string } }) =>
+      setDraft({ ...draft, [key]: e.target.value });
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setAttempted(true);
+    if (Object.keys(errors).length > 0) return;
+    // A cursor is only good for the filters it was issued with.
+    setApplied({ ...body, limit });
+    setCursors([]);
+  };
+
+  const onClear = () => {
+    setDraft(EMPTY_LIST_DRAFT);
+    setAttempted(false);
+    setApplied({ limit });
+    setCursors([]);
+  };
+
+  const text = (
+    key: "language" | "country" | "region" | "city" | "eventName",
+    label: string,
+    hint: string,
+    placeholder: string,
+  ) => {
+    const id = `registry-${key}`;
+    return (
+      <FormField id={id} label={label} hint={hint} error={shown[key]}>
+        <input
+          id={id}
+          type="text"
+          value={draft[key]}
+          placeholder={placeholder}
+          autoComplete="off"
+          spellCheck={false}
+          onChange={update(key)}
+          aria-invalid={Boolean(shown[key])}
+          aria-describedby={describedBy(id, true, shown[key])}
+        />
+      </FormField>
+    );
+  };
+
+  return (
+    <>
+      <form
+        className="card"
+        onSubmit={onSubmit}
+        aria-labelledby="registry-title"
+        noValidate
+      >
+        <h3 id="registry-title">What applicants see</h3>
+        <p className="lead">
+          Applicants look for a vetter in this list. It shows members who hold a
+          live vetter grant and chose to list their profile, and discloses
+          nothing beyond that profile, their DID and when their grant expires.
+          Filter it the way an applicant can.
+        </p>
+
+        <div className="filter-grid">
+          {text("language", "Language", "A language tag. de also finds de-AT.", "de")}
+          {text("country", "Country", "Two letters, like AT.", "AT")}
+          {text("region", "Region", "The whole name; case is ignored.", "Tyrol")}
+          {text("city", "City", "The whole name; case is ignored.", "Vienna")}
+          <FormField id="registry-method" label="Method">
+            <select
+              id="registry-method"
+              value={draft.method}
+              onChange={(e) =>
+                setDraft({ ...draft, method: e.target.value as VettingMethod | "" })
+              }
+            >
+              <option value="">Any method</option>
+              {VETTING_METHODS.map((m) => (
+                <option key={m} value={m}>
+                  {methodLabel(m)}
+                </option>
+              ))}
+            </select>
+          </FormField>
+          <FormField
+            id="registry-eventFrom"
+            label="Events from"
+            hint="Leave empty for no start."
+            error={shown.eventFrom}
+          >
+            <input
+              id="registry-eventFrom"
+              type="date"
+              value={draft.eventFrom}
+              onChange={update("eventFrom")}
+              aria-invalid={Boolean(shown.eventFrom)}
+              aria-describedby={describedBy("registry-eventFrom", true, shown.eventFrom)}
+            />
+          </FormField>
+          <FormField
+            id="registry-eventTo"
+            label="Events to"
+            hint="Leave empty for no end."
+            error={shown.eventTo}
+          >
+            <input
+              id="registry-eventTo"
+              type="date"
+              value={draft.eventTo}
+              onChange={update("eventTo")}
+              aria-invalid={Boolean(shown.eventTo)}
+              aria-describedby={describedBy("registry-eventTo", true, shown.eventTo)}
+            />
+          </FormField>
+          {text("eventName", "Event name", "Any part of the name.", "Maintainers Meetup")}
+          <FormField id="registry-limit" label="Vetters per page">
+            <select
+              id="registry-limit"
+              value={limit}
+              onChange={(e) => setLimit(Number(e.target.value))}
+            >
+              {PAGE_SIZES.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </FormField>
+        </div>
+        <p className="muted">
+          An event filter matches a vetter with an event that has not ended and
+          overlaps the dates. With an event filter, the earliest matching event
+          comes first; otherwise vetters are listed by display name.
+        </p>
+
+        <div className="form-actions">
+          <button type="submit" className="primary">
+            Show vetters
+          </button>
+          <button type="button" className="secondary" onClick={onClear}>
+            Clear filters
+          </button>
+        </div>
+      </form>
+
+      <section
+        className="card"
+        aria-labelledby="registry-results-title"
+        aria-busy={query.isFetching}
+      >
+        <h3 id="registry-results-title">Listed vetters</h3>
+        {query.error && (
+          <p className="finding error" role="alert">
+            <strong>
+              {errorStatus(query.error) === 400
+                ? "The listing refused these filters."
+                : "Could not load the listing."}
+            </strong>
+            <span className="muted">{errorMessage(query.error)}</span>
+          </p>
+        )}
+        {query.isPending && <p className="muted">Loading…</p>}
+        {query.data && query.data.vetters.length === 0 && (
+          <div className="empty-state">
+            <span className="empty-icon" aria-hidden="true">
+              <BadgeCheck />
+            </span>
+            <h4>
+              {filtered
+                ? "No listed vetter matches these filters"
+                : "No vetter is listed"}
+            </h4>
+            <p>
+              Only members with a live vetter grant who published a listed
+              profile appear. A vetter publishes their profile from their own
+              client.
+              {filtered ? " Clear the filters to see every listed vetter." : ""}
+            </p>
+          </div>
+        )}
+        {query.data && query.data.vetters.length > 0 && (
+          <ul className="vet-registry">
+            {query.data.vetters.map((vetter) => (
+              <li key={vetter.vetterDid} className="vet-listing">
+                <ListedVetterCard vetter={vetter} />
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="pagination">
+          <button
+            type="button"
+            className="secondary"
+            disabled={cursors.length === 0}
+            onClick={() => setCursors(cursors.slice(0, -1))}
+          >
+            <ArrowLeft size={12} aria-hidden="true" /> Previous page
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            disabled={!query.data?.nextCursor}
+            onClick={() => {
+              const next = query.data?.nextCursor;
+              if (next) setCursors([...cursors, next]);
+            }}
+          >
+            Next page <ArrowRight size={12} aria-hidden="true" />
+          </button>
+          <span className="muted">Page {cursors.length + 1}</span>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function ListedVetterCard({ vetter }: { vetter: ListedVetter }) {
+  const where = placeName(vetter.location);
+  return (
+    <article>
+      <header>
+        <h4>{vetter.displayName ?? "No display name"}</h4>
+        <code title={vetter.vetterDid}>{shortenDid(vetter.vetterDid)}</code>
+        <CopyButton
+          value={vetter.vetterDid}
+          label="Copy vetter DID"
+          successMessage="Vetter DID copied"
+        />
+      </header>
+      <dl>
+        <dt>Where</dt>
+        <dd>{where ?? <span className="muted">No location published</span>}</dd>
+        <dt>Languages</dt>
+        <dd>{vetter.languages.length ? vetter.languages.join(", ") : "None listed"}</dd>
+        <dt>Methods</dt>
+        <dd>{vetter.methods.map(methodLabel).join(", ")}</dd>
+        <dt>Documents</dt>
+        <dd>
+          {vetter.acceptsDocumentation.length
+            ? vetter.acceptsDocumentation.join(", ")
+            : "None listed"}
+        </dd>
+        {vetter.availability && (
+          <>
+            <dt>Availability</dt>
+            <dd>{vetter.availability}</dd>
+          </>
+        )}
+        {vetter.contactHint && (
+          <>
+            <dt>Getting a ticket</dt>
+            <dd>{vetter.contactHint}</dd>
+          </>
+        )}
+        <dt>Grant valid until</dt>
+        <dd>{formatDay(vetter.grantValidUntil)}</dd>
+        <dt>Profile updated</dt>
+        <dd>{formatDay(vetter.updatedAt)}</dd>
+      </dl>
+      {vetter.events.length > 0 && (
+        <>
+          <h5 className="vet-subhead">Upcoming events</h5>
+          <ul className="vet-list">
+            {vetter.events.map((event) => {
+              const eventWhere = placeName(event.location);
+              return (
+                <li key={`${event.name}-${event.startDate}`}>
+                  {event.name},{" "}
+                  {event.startDate === event.endDate
+                    ? event.startDate
+                    : `${event.startDate} to ${event.endDate}`}
+                  {eventWhere ? `, ${eventWhere}` : ""}
+                  {event.url && (
+                    <>
+                      {" "}
+                      <a href={event.url} target="_blank" rel="noopener noreferrer">
+                        Event page <ExternalLink size={12} aria-hidden="true" />
+                      </a>
+                    </>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </article>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/RequirementsPanel.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/RequirementsPanel.test.tsx
@@ -1,0 +1,63 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RequirementsPanel } from "@/plugins/vetting/RequirementsPanel";
+import { mockFetch, renderWithProviders } from "@/test/render";
+
+const REQUIREMENTS = {
+  version: "0.1",
+  statementType: "https://firstperson.network/endorsements/identity-vetting/0.1",
+  minStatements: 2,
+  minByMethod: { inPerson: 1 },
+  acceptedMethods: ["inPerson", "video", "priorAcquaintance"],
+  requiredClaims: ["name.legal"],
+  maxStatementAge: "P120D",
+  eligibleVetters: { role: "vetter" },
+  independence: {
+    maxByDeclaredRelationship: { family: 0, sameEmployer: 1 },
+    requireConsistentIdentityCommitment: true,
+  },
+};
+
+describe("RequirementsPanel", () => {
+  it("shows each criterion's requirements in words with its digest", async () => {
+    const requests = mockFetch([
+      {
+        path: "/v1/join-requests/manifest",
+        body: {
+          communityDid: "did:web:vtc.example.org",
+          criteria: [
+            {
+              id: "kernel-developer",
+              description: "Two vetters, at least one in person",
+              presentationDefinition: {},
+              vetting: REQUIREMENTS,
+              requirementsDigest: "zQmKernelDigest",
+            },
+            {
+              id: "legacy",
+              presentationDefinition: {},
+              vetting: { ...REQUIREMENTS, minStatements: 0 },
+              requirementsDigest: "zQmLegacyDigest",
+            },
+            { id: "open-door", presentationDefinition: {} },
+          ],
+        },
+      },
+    ]);
+    renderWithProviders(<RequirementsPanel />);
+
+    expect(
+      await screen.findByText("Statements from at least 2 distinct eligible vetters."),
+    ).toBeTruthy();
+    expect(screen.getByText("At least 1 of them made in person.")).toBeTruthy();
+    expect(screen.getByText("zQmKernelDigest")).toBeTruthy();
+    expect(screen.getByText(/^Require at least 1 statement/)).toBeTruthy();
+    expect(screen.getByText("This criterion requires no vetting.")).toBeTruthy();
+
+    await waitFor(() => expect(requests.length).toBeGreaterThan(0));
+    expect(requests[0]!.headers.get("Trust-Task")).toBe(
+      "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2",
+    );
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/RequirementsPanel.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/RequirementsPanel.tsx
@@ -1,0 +1,147 @@
+// Requirements — the vetting each join criterion asks of an applicant, and its
+// requirements digest, as the join manifest publishes them.
+//
+// Read-only on purpose: this console has no criteria editor. Criteria are
+// registered through `POST /v1/schemas/accepts`, where the daemon checks the
+// requirements before storing them. The panel still runs the same checks
+// (`validateRequirements`), so a criterion stored before a rule existed shows
+// what would be refused if it were saved again.
+
+import { useQuery } from "@tanstack/react-query";
+import { ExternalLink } from "lucide-react";
+
+import { CopyButton } from "@/components/CopyButton";
+import {
+  summarizeRequirements,
+  validateRequirements,
+  type VettingRequirements,
+} from "@/lib/vetting";
+
+import { fetchManifest, type ManifestCriterion, vettingKeys } from "./api";
+import { LoadError } from "./ui";
+
+export function RequirementsPanel() {
+  const query = useQuery({ queryKey: vettingKeys.manifest, queryFn: fetchManifest });
+  const criteria = query.data?.criteria ?? [];
+
+  return (
+    <>
+      <section className="card" aria-labelledby="requirements-title">
+        <h3 id="requirements-title">Published vetting requirements</h3>
+        <p className="lead">
+          Applicants read these from the join manifest. This console does not
+          edit criteria: register or change one with{" "}
+          <code>POST /v1/schemas/accepts</code>, and the daemon checks its vetting
+          requirements before storing them. A criterion's requirements digest
+          changes whenever its requirements do; an applicant records it when they
+          start gathering statements, so a change mid-application is visible.
+        </p>
+        {query.isPending && <p className="muted">Loading the join manifest…</p>}
+        {query.data && criteria.length === 0 && (
+          <p className="muted">
+            No criteria are registered, so applicants are asked for no evidence.
+          </p>
+        )}
+      </section>
+      {query.error && <LoadError what="the join manifest" error={query.error} />}
+      {criteria.map((criterion) => (
+        <CriterionCard key={criterion.id} criterion={criterion} />
+      ))}
+    </>
+  );
+}
+
+function CriterionCard({ criterion }: { criterion: ManifestCriterion }) {
+  const titleId = `criterion-${criterion.id}`;
+  const hasVetting = criterion.vetting !== undefined && criterion.vetting !== null;
+  const problems = hasVetting ? validateRequirements(criterion.vetting) : [];
+  const requirements =
+    hasVetting && problems.length === 0
+      ? // The OpenAPI document types `vetting` as an opaque object; the
+        // validator above is what establishes this shape.
+        (criterion.vetting as unknown as VettingRequirements)
+      : null;
+
+  return (
+    <section className="card" aria-labelledby={titleId}>
+      <h3 id={titleId}>
+        Criterion <code>{criterion.id}</code>
+      </h3>
+      {criterion.description && <p>{criterion.description}</p>}
+
+      {!hasVetting ? (
+        <p className="muted">This criterion requires no vetting.</p>
+      ) : (
+        <>
+          {problems.length > 0 && (
+            <div className="finding error" role="alert">
+              <strong>
+                The daemon would refuse these requirements if they were saved
+                today.
+              </strong>
+              <ul className="vet-list">
+                {problems.map((problem) => (
+                  <li key={problem}>{problem}</li>
+                ))}
+              </ul>
+              <span className="muted">
+                Register the criterion again with corrected requirements.
+              </span>
+            </div>
+          )}
+          {requirements && (
+            <ul className="vet-list">
+              {summarizeRequirements(requirements).map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          )}
+          <dl>
+            <dt>Requirements digest</dt>
+            <dd>
+              {criterion.requirementsDigest ? (
+                <>
+                  <code>{criterion.requirementsDigest}</code>
+                  <CopyButton
+                    value={criterion.requirementsDigest}
+                    label="Copy requirements digest"
+                    successMessage="Requirements digest copied"
+                  />
+                </>
+              ) : (
+                <span className="muted">Not published</span>
+              )}
+            </dd>
+            {requirements && (
+              <>
+                <dt>Statement type</dt>
+                <dd>
+                  <code>{requirements.statementType}</code>
+                </dd>
+              </>
+            )}
+            {requirements?.governanceFrameworkUrl && (
+              <>
+                <dt>Governance framework</dt>
+                <dd>
+                  <a
+                    href={requirements.governanceFrameworkUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {requirements.governanceFrameworkUrl}{" "}
+                    <ExternalLink size={12} aria-hidden="true" />
+                  </a>
+                </dd>
+              </>
+            )}
+          </dl>
+          <details>
+            <summary>Requirements as published</summary>
+            <pre>{JSON.stringify(criterion.vetting, null, 2)}</pre>
+          </details>
+        </>
+      )}
+    </section>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/VettersPanel.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/VettersPanel.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { VetterGrantRow } from "@/lib/wire-types";
+import { VettersPanel } from "@/plugins/vetting/VettersPanel";
+import { type MockRoute, mockFetch, renderWithProviders } from "@/test/render";
+
+const CAROL = "did:key:z6MkCarolCarolCarolCarolCarolCarolCarol";
+const DAN = "did:key:z6MkDanDanDanDanDanDanDanDanDanDanDanDan";
+const ERIN = "did:key:z6MkErinErinErinErinErinErinErinErin";
+
+const GRANTS: VetterGrantRow[] = [
+  {
+    endorsementId: "grant-carol",
+    memberDid: CAROL,
+    credentialId: "urn:uuid:carol",
+    validFrom: "2026-01-01T00:00:00Z",
+    validUntil: "2099-01-01T00:00:00Z",
+    revoked: false,
+    live: true,
+    origin: "manual",
+    profile: {
+      listed: true,
+      displayName: "Carol M.",
+      country: "AT",
+      languages: ["en", "de-AT"],
+      methods: ["inPerson"],
+      eventCount: 1,
+      updatedAt: "2026-02-01T00:00:00Z",
+    },
+  },
+  {
+    endorsementId: "grant-dan",
+    memberDid: DAN,
+    credentialId: "urn:uuid:dan",
+    validFrom: "2025-01-01T00:00:00Z",
+    validUntil: "2099-01-01T00:00:00Z",
+    revoked: true,
+    revokedAt: "2026-03-01T00:00:00Z",
+    live: false,
+    origin: "auto",
+  },
+];
+
+const member = (did: string, label: string) => ({
+  did,
+  label,
+  role: "member",
+  joinedAt: "2025-01-01T00:00:00Z",
+  personhood: false,
+  publishConsent: false,
+  departurePreference: "tombstone",
+  extensions: {},
+});
+
+function routes(extra: MockRoute[] = []): MockRoute[] {
+  return [
+    { path: "/v1/vetting/vetters", body: { vetters: GRANTS } },
+    {
+      path: "/v1/vetting/auto-grant",
+      body: { enabled: false, sweepMinutes: 60, validitySeconds: 31_536_000 },
+    },
+    {
+      path: "/v1/members",
+      body: { items: [member(CAROL, "Carol"), member(ERIN, "Erin")] },
+    },
+    { path: "/v1/acl", body: { entries: [], truncated: false } },
+    ...extra,
+  ];
+}
+
+describe("VettersPanel", () => {
+  it("lists grants and filters them by status and origin", async () => {
+    mockFetch(routes());
+    renderWithProviders(<VettersPanel />);
+
+    expect(await screen.findByText("Carol M.")).toBeTruthy();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Live")).toBeTruthy();
+    expect(within(table).getByText("Revoked")).toBeTruthy();
+    expect(within(table).getByText("Automatic")).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Status"), {
+      target: { value: "revoked" },
+    });
+    expect(within(table).queryByText("Carol M.")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Granted by"), {
+      target: { value: "manual" },
+    });
+    expect(within(table).getByText("No grant matches these filters")).toBeTruthy();
+  });
+
+  it("revokes only after a confirmation that says the statements stop counting", async () => {
+    const requests = mockFetch(
+      routes([
+        {
+          method: "DELETE",
+          path: "/v1/credentials/endorsements/grant-carol",
+          body: { revoked: true },
+        },
+      ]),
+    );
+    renderWithProviders(<VettersPanel />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Revoke vetter role for / }),
+    );
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toMatch(
+      /stops counting toward join requests decided from now on/,
+    );
+    expect(requests.some((r) => r.method === "DELETE")).toBe(false);
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Revoke vetter role" }));
+    await waitFor(() =>
+      expect(requests.some((r) => r.method === "DELETE")).toBe(true),
+    );
+    const revoke = requests.find((r) => r.method === "DELETE")!;
+    expect(revoke.url).toBe("/v1/credentials/endorsements/grant-carol");
+    expect(revoke.headers.get("Trust-Task")).toBe(
+      "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1",
+    );
+  });
+
+  it("explains a resend the daemon cannot deliver", async () => {
+    mockFetch(
+      routes([
+        {
+          method: "POST",
+          path: `/v1/vetting/vetters/${encodeURIComponent(CAROL)}/resend`,
+          status: 404,
+          body: { error: "no live vetter grant" },
+        },
+      ]),
+    );
+    renderWithProviders(<VettersPanel />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Resend vetter credential to / }),
+    );
+    expect(await screen.findByText("Could not resend the credential")).toBeTruthy();
+    expect(
+      screen.getByText(/Revoke the grant and grant the role again/),
+    ).toBeTruthy();
+  });
+
+  it("refuses a validity beyond two years, then grants within the bounds", async () => {
+    const requests = mockFetch(
+      routes([
+        {
+          method: "POST",
+          path: "/v1/vetting/vetters",
+          status: 201,
+          body: {
+            endorsementId: "grant-erin",
+            credentialId: "urn:uuid:erin",
+            validFrom: "2026-09-12T00:00:00Z",
+            validUntil: "2026-10-12T00:00:00Z",
+          },
+        },
+      ]),
+    );
+    renderWithProviders(<VettersPanel />);
+
+    await screen.findByText("Carol M.");
+    const select = screen.getByLabelText("Member");
+    await waitFor(() => expect(within(select).queryByText(/Erin/)).toBeTruthy());
+    // Carol already holds a live grant, so she is not offered.
+    expect(within(select).queryByText(/Carol/)).toBeNull();
+
+    fireEvent.change(select, { target: { value: ERIN } });
+    fireEvent.change(screen.getByLabelText("Valid for"), {
+      target: { value: "custom" },
+    });
+    fireEvent.change(screen.getByLabelText("Days"), { target: { value: "731" } });
+    expect(
+      screen.getByText("Choose 1 to 730 days (two years); 731 is outside that."),
+    ).toBeTruthy();
+    expect(screen.getByLabelText("Days").getAttribute("aria-invalid")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Grant vetter role" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Days"), { target: { value: "30" } });
+    fireEvent.click(screen.getByRole("button", { name: "Grant vetter role" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Grant vetter role" }));
+
+    await waitFor(() =>
+      expect(
+        requests.some((r) => r.method === "POST" && r.url === "/v1/vetting/vetters"),
+      ).toBe(true),
+    );
+    const grant = requests.find(
+      (r) => r.method === "POST" && r.url === "/v1/vetting/vetters",
+    )!;
+    expect(grant.body).toEqual({ memberDid: ERIN, validitySeconds: 30 * 86_400 });
+    expect(grant.headers.get("Trust-Task")).toBe(
+      "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1",
+    );
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/VettersPanel.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/VettersPanel.tsx
@@ -1,0 +1,575 @@
+// Vetters — every vetter grant, and what an admin does with them: name a
+// member a vetter, send a grant's credential again, revoke a grant.
+//
+// `live` comes from the daemon (`GET /v1/vetting/vetters`), so this panel
+// never decides whether a grant is in force; `grantState` only says why one
+// that is not live is not.
+
+import { type FormEvent, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { BadgeCheck } from "lucide-react";
+
+import { useConfirm } from "@/components/ConfirmDialog";
+import { NamedDid } from "@/components/NamedDid";
+import { formatIso, shortenDid } from "@/lib/format";
+import { useNameBook } from "@/lib/names";
+import { useToast } from "@/lib/toast";
+import {
+  DAY_SECONDS,
+  filterGrants,
+  GRANT_STATE_LABELS,
+  grantState,
+  methodLabel,
+  validityDaysError,
+  type GrantFilter,
+  type GrantState,
+  type Tone,
+} from "@/lib/vetting";
+import type {
+  MemberRow,
+  VetterGrantRow,
+  VetterProfileSummary,
+} from "@/lib/wire-types";
+
+import {
+  fetchActiveMembers,
+  fetchAutoGrant,
+  fetchGrants,
+  grantVetter,
+  resendGrant,
+  revokeGrant,
+  vettingKeys,
+} from "./api";
+import {
+  describedBy,
+  errorMessage,
+  errorStatus,
+  formatDay,
+  FormField,
+  LoadError,
+  memberPath,
+  ToneChip,
+} from "./ui";
+
+const STATE_TONE: Record<GrantState, Tone | "neutral"> = {
+  live: "ok",
+  revoked: "bad",
+  expired: "warn",
+  inactive: "neutral",
+};
+
+const VALIDITY_PRESETS = [
+  { value: "30", label: "30 days" },
+  { value: "90", label: "90 days" },
+  { value: "365", label: "1 year" },
+  { value: "730", label: "2 years (the longest allowed)" },
+  { value: "custom", label: "Another number of days" },
+] as const;
+
+function resendErrorText(err: unknown, name: string): string {
+  switch (errorStatus(err)) {
+    case 404:
+      return `${name} holds no live grant whose credential the community kept. Revoke the grant and grant the role again to issue a new credential.`;
+    case 503:
+      return "The credential could not be handed to the messaging transport. Check the mediator on the dashboard, then try again.";
+    default:
+      return errorMessage(err);
+  }
+}
+
+export function VettersPanel() {
+  const queryClient = useQueryClient();
+  const book = useNameBook();
+  const toast = useToast();
+  const confirm = useConfirm();
+  const grants = useQuery({ queryKey: vettingKeys.grants, queryFn: fetchGrants });
+  const autoGrant = useQuery({
+    queryKey: vettingKeys.autoGrant,
+    queryFn: fetchAutoGrant,
+  });
+  const [filter, setFilter] = useState<GrantFilter>({
+    state: "all",
+    origin: "all",
+    search: "",
+  });
+
+  const rows = useMemo(
+    () => filterGrants(grants.data ?? [], filter),
+    [grants.data, filter],
+  );
+  const liveDids = useMemo(
+    () =>
+      new Set((grants.data ?? []).filter((g) => g.live).map((g) => g.memberDid)),
+    [grants.data],
+  );
+
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: ["vetting"] });
+    void queryClient.invalidateQueries({ queryKey: ["member-vetter-grants"] });
+  };
+
+  const revoke = useMutation({
+    mutationFn: (row: VetterGrantRow) => revokeGrant(row.endorsementId),
+    onSuccess: (_res, row) => {
+      toast.push(
+        "success",
+        `Revoked ${book.nameOrDid(row.memberDid)}'s vetter role. Their statements no longer count.`,
+      );
+      refresh();
+    },
+  });
+
+  const resend = useMutation({
+    mutationFn: (row: VetterGrantRow) => resendGrant(row.memberDid),
+    onSuccess: (res, row) => {
+      toast.push(
+        "success",
+        `Sent ${book.nameOrDid(row.memberDid)} their vetter credential again. It is valid until ${formatDay(res.validUntil)}.`,
+      );
+    },
+  });
+
+  const onRevoke = async (row: VetterGrantRow) => {
+    const name = book.nameOrDid(row.memberDid);
+    const ok = await confirm({
+      title: `Revoke ${name}'s vetter role?`,
+      message:
+        `Every statement ${name} signed stops counting toward join requests decided from now on, including statements made while they were a vetter. ` +
+        `Their vetter credential is marked revoked and their published vetter profile is deleted.` +
+        (autoGrant.data?.enabled
+          ? " Automatic grants are on: if the vetter eligibility policy still allows them, the next sweep names them a vetter again."
+          : ""),
+      confirmLabel: "Revoke vetter role",
+      destructive: true,
+    });
+    if (ok) revoke.mutate(row);
+  };
+
+  const isBusy = (row: VetterGrantRow) =>
+    (revoke.isPending && revoke.variables?.endorsementId === row.endorsementId) ||
+    (resend.isPending && resend.variables?.endorsementId === row.endorsementId);
+
+  return (
+    <>
+      <GrantForm liveDids={liveDids} onGranted={refresh} />
+
+      <section className="card" aria-labelledby="vetters-title">
+        <h3 id="vetters-title">Vetter grants</h3>
+        <div className="toolbar">
+          <FormField id="vetters-state" label="Status" className="field inline">
+            <select
+              id="vetters-state"
+              value={filter.state}
+              onChange={(e) =>
+                setFilter({
+                  ...filter,
+                  state: e.target.value as GrantFilter["state"],
+                })
+              }
+            >
+              <option value="all">All grants</option>
+              <option value="live">Live</option>
+              <option value="revoked">Revoked</option>
+              <option value="expired">Expired</option>
+              <option value="inactive">Not in force (holder left)</option>
+            </select>
+          </FormField>
+          <FormField id="vetters-origin" label="Granted by" className="field inline">
+            <select
+              id="vetters-origin"
+              value={filter.origin}
+              onChange={(e) =>
+                setFilter({
+                  ...filter,
+                  origin: e.target.value as GrantFilter["origin"],
+                })
+              }
+            >
+              <option value="all">Anyone</option>
+              <option value="manual">An admin</option>
+              <option value="auto">The automatic sweep</option>
+            </select>
+          </FormField>
+          <FormField id="vetters-search" label="Search" className="field inline">
+            <input
+              id="vetters-search"
+              type="search"
+              placeholder="Display name or DID"
+              value={filter.search}
+              onChange={(e) => setFilter({ ...filter, search: e.target.value })}
+            />
+          </FormField>
+        </div>
+
+        {grants.error && <LoadError what="the vetter grants" error={grants.error} />}
+        {revoke.error && (
+          <section className="card error" role="alert">
+            <h3>Could not revoke the vetter role</h3>
+            <p>{errorMessage(revoke.error)}</p>
+            <p className="muted">
+              The grant is unchanged. Reload the list to see its current state,
+              then try again.
+            </p>
+          </section>
+        )}
+        {resend.error && resend.variables && (
+          <section className="card error" role="alert">
+            <h3>Could not resend the credential</h3>
+            <p>
+              {resendErrorText(
+                resend.error,
+                book.nameOrDid(resend.variables.memberDid),
+              )}
+            </p>
+          </section>
+        )}
+
+        <div className="table-scroll">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Member</th>
+                <th>Status</th>
+                <th>Validity</th>
+                <th>Vetter profile</th>
+                <th>
+                  <span className="visually-hidden">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {grants.isPending && (
+                <tr>
+                  <td colSpan={5}>Loading…</td>
+                </tr>
+              )}
+              {grants.data && rows.length === 0 && (
+                <tr>
+                  <td colSpan={5}>
+                    <div className="empty-state">
+                      <span className="empty-icon" aria-hidden="true">
+                        <BadgeCheck />
+                      </span>
+                      <h4>
+                        {grants.data.length === 0
+                          ? "No vetters yet"
+                          : "No grant matches these filters"}
+                      </h4>
+                      <p>
+                        {grants.data.length === 0
+                          ? "Grant a member the vetter role above, or turn on automatic grants."
+                          : "Change the status, origin or search to see more grants."}
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              )}
+              {rows.map((row) => {
+                const state = grantState(row);
+                const name = book.nameOrDid(row.memberDid);
+                const busy = isBusy(row);
+                return (
+                  <tr key={row.endorsementId}>
+                    <td>
+                      <Link to={memberPath(row.memberDid)}>
+                        <NamedDid book={book} did={row.memberDid} />
+                      </Link>
+                    </td>
+                    <td>
+                      <ToneChip tone={STATE_TONE[state]}>
+                        {GRANT_STATE_LABELS[state]}
+                      </ToneChip>
+                      <span
+                        className="chip"
+                        title={
+                          row.origin === "auto"
+                            ? "Issued by the automatic sweep"
+                            : "Granted by an admin"
+                        }
+                      >
+                        {row.origin === "auto" ? "Automatic" : "Manual"}
+                      </span>
+                    </td>
+                    <td>
+                      {formatDay(row.validFrom)} to{" "}
+                      {row.validUntil ? (
+                        formatDay(row.validUntil)
+                      ) : (
+                        <span className="muted">no end recorded</span>
+                      )}
+                      {row.revokedAt && (
+                        <div className="muted">Revoked {formatIso(row.revokedAt)}</div>
+                      )}
+                    </td>
+                    <td>
+                      <ProfileSummary profile={row.profile} />
+                    </td>
+                    <td>
+                      {row.live && (
+                        <div className="row-actions">
+                          <button
+                            type="button"
+                            className="secondary sm"
+                            disabled={busy}
+                            aria-label={`Resend vetter credential to ${name}`}
+                            onClick={() => resend.mutate(row)}
+                          >
+                            {resend.isPending &&
+                            resend.variables?.endorsementId === row.endorsementId
+                              ? "Resending…"
+                              : "Resend"}
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary destructive sm"
+                            disabled={busy}
+                            aria-label={`Revoke vetter role for ${name}`}
+                            onClick={() => void onRevoke(row)}
+                          >
+                            {revoke.isPending &&
+                            revoke.variables?.endorsementId === row.endorsementId
+                              ? "Revoking…"
+                              : "Revoke"}
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function ProfileSummary({ profile }: { profile?: VetterProfileSummary | null }) {
+  if (!profile) return <span className="muted">No profile published</span>;
+  const details = [
+    profile.country,
+    profile.languages?.join(", "),
+    profile.methods?.map(methodLabel).join(", "),
+    `${profile.eventCount} ${profile.eventCount === 1 ? "event" : "events"}`,
+  ].filter(Boolean);
+  return (
+    <div>
+      <ToneChip
+        tone={profile.listed ? "ok" : "neutral"}
+        title={
+          profile.listed
+            ? "Applicants can find this vetter"
+            : "Kept, but left out of the listing applicants see"
+        }
+      >
+        {profile.listed ? "Listed" : "Unlisted"}
+      </ToneChip>
+      {profile.displayName && <strong>{profile.displayName}</strong>}
+      <div className="muted">{details.join(" · ")}</div>
+      <div className="muted">Updated {formatDay(profile.updatedAt)}</div>
+    </div>
+  );
+}
+
+function memberOptionLabel(member: MemberRow): string {
+  const did = shortenDid(member.did);
+  return `${member.label ? `${member.label} · ${did}` : did} (${member.role})`;
+}
+
+function GrantForm({
+  liveDids,
+  onGranted,
+}: {
+  liveDids: ReadonlySet<string>;
+  onGranted: () => void;
+}) {
+  const book = useNameBook();
+  const toast = useToast();
+  const confirm = useConfirm();
+  const members = useQuery({
+    queryKey: vettingKeys.activeMembers,
+    queryFn: fetchActiveMembers,
+  });
+  const [search, setSearch] = useState("");
+  const [memberDid, setMemberDid] = useState("");
+  const [preset, setPreset] = useState<string>("365");
+  const [customDays, setCustomDays] = useState("");
+  const [attempted, setAttempted] = useState(false);
+
+  const days = preset === "custom" ? customDays : preset;
+  const daysError = validityDaysError(days);
+  const memberError = memberDid ? null : "Choose the member to name a vetter.";
+  const shownMemberError = attempted ? memberError : null;
+  const shownDaysError =
+    preset === "custom" && (attempted || customDays !== "") ? daysError : null;
+
+  const needle = search.trim().toLowerCase();
+  const eligible = (members.data ?? []).filter((m) => !liveDids.has(m.did));
+  const candidates = eligible.filter(
+    (m) =>
+      m.did === memberDid ||
+      !needle ||
+      m.did.toLowerCase().includes(needle) ||
+      (m.label ?? "").toLowerCase().includes(needle),
+  );
+
+  const grant = useMutation({
+    mutationFn: grantVetter,
+    onSuccess: (res, vars) => {
+      toast.push(
+        "success",
+        `Named ${book.nameOrDid(vars.memberDid)} a vetter until ${formatDay(res.validUntil)}. If their wallet does not receive the credential, resend it from the list below.`,
+      );
+      setMemberDid("");
+      setSearch("");
+      setAttempted(false);
+      onGranted();
+    },
+  });
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setAttempted(true);
+    if (memberError || daysError) return;
+    const n = Number(days);
+    const name = book.nameOrDid(memberDid);
+    const until = new Date(Date.now() + n * DAY_SECONDS * 1000).toLocaleDateString();
+    const ok = await confirm({
+      title: `Name ${name} a vetter?`,
+      message: `${name} receives a vetter role credential valid until ${until}. While it is live, the identity-vetting statements they sign count toward applicants' admissions. You can revoke it at any time.`,
+      confirmLabel: "Grant vetter role",
+    });
+    if (ok) grant.mutate({ memberDid, validitySeconds: n * DAY_SECONDS });
+  };
+
+  return (
+    <form
+      className="card"
+      onSubmit={(e) => void onSubmit(e)}
+      aria-labelledby="grant-title"
+      noValidate
+    >
+      <h3 id="grant-title">Grant the vetter role</h3>
+      <p className="lead">
+        A vetter checks who an applicant is and signs a statement the community
+        counts toward their admission. Name members you trust to do that.
+      </p>
+
+      <div className="filter-grid">
+        <FormField
+          id="grant-search"
+          label="Find a member"
+          hint="Narrows the member list by name or DID."
+        >
+          <input
+            id="grant-search"
+            type="search"
+            placeholder="Name or DID"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-describedby="grant-search-hint"
+          />
+        </FormField>
+        <FormField
+          id="grant-member"
+          label="Member"
+          hint={
+            members.data
+              ? `${eligible.length} of ${members.data.length} current members can be named. Members who already hold a live grant are left out.`
+              : undefined
+          }
+          error={shownMemberError}
+        >
+          <select
+            id="grant-member"
+            value={memberDid}
+            disabled={members.isPending}
+            onChange={(e) => setMemberDid(e.target.value)}
+            aria-invalid={Boolean(shownMemberError)}
+            aria-describedby={describedBy(
+              "grant-member",
+              Boolean(members.data),
+              shownMemberError,
+            )}
+          >
+            <option value="">
+              {members.isPending
+                ? "Loading members…"
+                : candidates.length
+                  ? "Choose a member"
+                  : "No member matches"}
+            </option>
+            {candidates.map((m) => (
+              <option key={m.did} value={m.did}>
+                {memberOptionLabel(m)}
+              </option>
+            ))}
+          </select>
+        </FormField>
+        <FormField
+          id="grant-validity"
+          label="Valid for"
+          hint="From 1 day to 2 years. Applicants' clients stop accepting the credential when it expires."
+        >
+          <select
+            id="grant-validity"
+            value={preset}
+            onChange={(e) => setPreset(e.target.value)}
+            aria-describedby="grant-validity-hint"
+          >
+            {VALIDITY_PRESETS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </FormField>
+        {preset === "custom" && (
+          <FormField id="grant-days" label="Days" error={shownDaysError}>
+            <input
+              id="grant-days"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={730}
+              step={1}
+              value={customDays}
+              onChange={(e) => setCustomDays(e.target.value)}
+              aria-invalid={Boolean(shownDaysError)}
+              aria-describedby={describedBy("grant-days", false, shownDaysError)}
+            />
+          </FormField>
+        )}
+      </div>
+
+      {members.error && (
+        <p className="finding error" role="alert">
+          <strong>Could not load the member list.</strong>
+          <span className="muted">
+            {errorMessage(members.error)} Reload the page to try again.
+          </span>
+        </p>
+      )}
+      {grant.error && (
+        <section className="card error" role="alert">
+          <h3>Could not grant the vetter role</h3>
+          <p>{errorMessage(grant.error)}</p>
+          {errorStatus(grant.error) === 400 && (
+            <p className="muted">
+              Only a current member can be named a vetter, for 1 day to 2 years.
+              Check the member is still listed under Members.
+            </p>
+          )}
+        </section>
+      )}
+
+      <div className="form-actions">
+        <button type="submit" className="primary" disabled={grant.isPending}>
+          {grant.isPending ? "Granting…" : "Grant vetter role"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/WithdrawalsPanel.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/WithdrawalsPanel.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { VettingRevocationRow } from "@/lib/wire-types";
+import { WithdrawalsPanel } from "@/plugins/vetting/WithdrawalsPanel";
+import { mockFetch, NAME_BOOK_ROUTES, renderWithProviders } from "@/test/render";
+
+const REQUEST_ID = "5f0c2a1e-8d4b-4a51-9d7e-2b7f4c3e9a10";
+const ERIN = "did:key:z6MkErinErinErinErinErinErinErinErin";
+
+const ROWS: VettingRevocationRow[] = [
+  {
+    issuer: "did:key:z6MkCarolCarolCarolCarolCarolCarolCarol",
+    statementId: "urn:uuid:3b5b2d7e-1c9f-4f55-8b0e-0f8c1a2b3c4d",
+    statementDigestMultibase: "zQmStatementDigest",
+    reason: "newInformation",
+    recordedAt: "2026-09-10T12:00:00Z",
+    reviewState: "needsReview",
+    affectedJoinRequests: [REQUEST_ID],
+    affectedMembers: [ERIN],
+  },
+  {
+    issuer: "did:key:z6MkDanDanDanDanDanDanDanDanDanDanDanDan",
+    statementId: "urn:uuid:9a9a9a9a-0000-4000-8000-000000000000",
+    statementDigestMultibase: "zQmOther",
+    recordedAt: "2026-09-09T12:00:00Z",
+    reviewState: "noAdmission",
+    affectedJoinRequests: [],
+    affectedMembers: [],
+  },
+];
+
+describe("WithdrawalsPanel", () => {
+  it("links a withdrawal that needs review to the admission it touches", async () => {
+    mockFetch([
+      { path: "/v1/vetting/revocations", body: { revocations: ROWS } },
+      ...NAME_BOOK_ROUTES,
+    ]);
+    renderWithProviders(<WithdrawalsPanel />);
+
+    expect(
+      await screen.findByText("1 withdrawal touches a current membership."),
+    ).toBeTruthy();
+    expect(screen.getByText("The vetter learned something new")).toBeTruthy();
+    expect(screen.getByText("No reason given")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: /^Join request 5f0c2a1e/ }).getAttribute("href"),
+    ).toBe(`/join-requests/${REQUEST_ID}`);
+    expect(
+      screen.getByRole("link", { name: /^Member / }).getAttribute("href"),
+    ).toBe(`/members/${encodeURIComponent(ERIN)}`);
+
+    fireEvent.change(screen.getByLabelText("Show"), {
+      target: { value: "needsReview" },
+    });
+    expect(screen.queryByText("No reason given")).toBeNull();
+  });
+
+  it("says when no vetter has withdrawn anything", async () => {
+    mockFetch([
+      { path: "/v1/vetting/revocations", body: { revocations: [] } },
+      ...NAME_BOOK_ROUTES,
+    ]);
+    renderWithProviders(<WithdrawalsPanel />);
+    expect(await screen.findByText("No vetter has withdrawn a statement")).toBeTruthy();
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/WithdrawalsPanel.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/WithdrawalsPanel.tsx
@@ -1,0 +1,176 @@
+// Withdrawals — statements their vetters have taken back, and the admissions
+// that counted them.
+//
+// `needsReview` is advisory: nothing records that an admin reviewed an
+// admission, and a withdrawal suspends no one. The panel says so, and links
+// straight to the join requests and members an admin has to look at.
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { Undo2 } from "lucide-react";
+
+import { CopyButton } from "@/components/CopyButton";
+import { NamedDid } from "@/components/NamedDid";
+import { formatIso, shorten } from "@/lib/format";
+import { useNameBook } from "@/lib/names";
+import { withdrawalReason } from "@/lib/vetting";
+import type { RevocationReviewState } from "@/lib/wire-types";
+
+import { fetchRevocations, vettingKeys } from "./api";
+import { FormField, joinRequestPath, LoadError, memberPath, ToneChip } from "./ui";
+
+export function WithdrawalsPanel() {
+  const book = useNameBook();
+  const query = useQuery({
+    queryKey: vettingKeys.revocations,
+    queryFn: fetchRevocations,
+  });
+  const [review, setReview] = useState<RevocationReviewState | "all">("all");
+
+  const all = query.data ?? [];
+  const rows = all.filter((r) => review === "all" || r.reviewState === review);
+  const needing = all.filter((r) => r.reviewState === "needsReview").length;
+
+  return (
+    <section className="card" aria-labelledby="withdrawals-title">
+      <h3 id="withdrawals-title">Withdrawn statements</h3>
+      <p className="lead">
+        A vetter can withdraw a statement they signed. When a current member was
+        admitted with that statement counted, decide whether their admission
+        still stands: withdrawing a statement does not suspend anyone, and
+        nothing here records that you reviewed it.
+      </p>
+
+      {needing > 0 && (
+        <p className="finding warn">
+          <strong>
+            {needing} {needing === 1 ? "withdrawal touches" : "withdrawals touch"}{" "}
+            a current membership.
+          </strong>
+          <span className="muted">
+            Open each affected member and join request below to review the
+            admission.
+          </span>
+        </p>
+      )}
+
+      <div className="toolbar">
+        <FormField id="withdrawals-review" label="Show" className="field inline">
+          <select
+            id="withdrawals-review"
+            value={review}
+            onChange={(e) =>
+              setReview(e.target.value as RevocationReviewState | "all")
+            }
+          >
+            <option value="all">All withdrawals</option>
+            <option value="needsReview">Needs review</option>
+            <option value="noAdmission">No current member affected</option>
+          </select>
+        </FormField>
+      </div>
+
+      {query.error && <LoadError what="the withdrawal notices" error={query.error} />}
+
+      <div className="table-scroll">
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Recorded</th>
+              <th>Vetter</th>
+              <th>Statement</th>
+              <th>Reason</th>
+              <th>Review</th>
+              <th>Affected</th>
+            </tr>
+          </thead>
+          <tbody>
+            {query.isPending && (
+              <tr>
+                <td colSpan={6}>Loading…</td>
+              </tr>
+            )}
+            {query.data && rows.length === 0 && (
+              <tr>
+                <td colSpan={6}>
+                  <div className="empty-state">
+                    <span className="empty-icon" aria-hidden="true">
+                      <Undo2 />
+                    </span>
+                    <h4>
+                      {all.length === 0
+                        ? "No vetter has withdrawn a statement"
+                        : "No withdrawal matches this filter"}
+                    </h4>
+                    <p>
+                      {all.length === 0
+                        ? "Withdrawals appear here when a vetter takes back a statement they signed."
+                        : "Show all withdrawals to see the rest."}
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            )}
+            {rows.map((row) => (
+              <tr key={`${row.issuer}|${row.statementId}`}>
+                <td>{formatIso(row.recordedAt)}</td>
+                <td>
+                  <NamedDid book={book} did={row.issuer} />
+                </td>
+                <td>
+                  <code title={row.statementId}>{shorten(row.statementId, 16, 6)}</code>
+                  <CopyButton
+                    value={row.statementId}
+                    label="Copy statement id"
+                    successMessage="Statement id copied"
+                  />
+                  <details>
+                    <summary className="muted">Digest</summary>
+                    <code>{row.statementDigestMultibase}</code>
+                  </details>
+                </td>
+                <td>
+                  <span title={row.reason ?? undefined}>{withdrawalReason(row)}</span>
+                </td>
+                <td>
+                  {row.reviewState === "needsReview" ? (
+                    <ToneChip tone="warn" title="needsReview">
+                      Needs review
+                    </ToneChip>
+                  ) : (
+                    <ToneChip tone="neutral" title="noAdmission">
+                      No current member affected
+                    </ToneChip>
+                  )}
+                </td>
+                <td>
+                  {row.affectedJoinRequests.length === 0 ? (
+                    <span className="muted">No approved join request counted it</span>
+                  ) : (
+                    <ul className="vet-list">
+                      {row.affectedJoinRequests.map((id) => (
+                        <li key={id}>
+                          <Link to={joinRequestPath(id)}>
+                            Join request <code>{id.slice(0, 8)}</code>
+                          </Link>
+                        </li>
+                      ))}
+                      {row.affectedMembers.map((did) => (
+                        <li key={did}>
+                          <Link to={memberPath(did)}>
+                            Member <NamedDid book={book} did={did} />
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/api.ts
+++ b/vtc-service/admin-ui/src/plugins/vetting/api.ts
@@ -1,0 +1,196 @@
+// Vetting admin API — what the vetting panels, the join-request detail and the
+// dashboard read and write.
+//
+// Three of these routes carry a Trust Task binding and are called with it:
+// grant, resend, and the vetter listing. The rest are admin REST the daemon
+// mounts with no binding, because no published task describes them — the grant
+// listing, automatic grants, withdrawal notices, a join request's vetting facts
+// and community branding — so they go through the `*Exempt` helpers instead of
+// borrowing a task URI that names something else.
+
+import {
+  deleteJson,
+  getJson,
+  getJsonExempt,
+  postJson,
+  putJsonExempt,
+} from "@/lib/api";
+import type {
+  AutoGrantConfig,
+  AutoGrantStatus,
+  CommunityBranding,
+  JoinManifest,
+  JoinRequestsPage,
+  ManifestCriterion,
+  JoinRequestVettingResponse,
+  MemberRow,
+  MembersPage,
+  VetterGrantList,
+  VetterGrantResponse,
+  VetterGrantRow,
+  VetterListBody,
+  VetterListResponse,
+  VetterResendResponse,
+  VettingRevocationList,
+  VettingRevocationRow,
+} from "@/lib/wire-types";
+
+const TASK_VETTER_GRANT =
+  "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+const TASK_VETTER_RESEND =
+  "https://trusttasks.org/spec/vtc/vetting/vetters/resend/0.1";
+const TASK_VETTER_LIST =
+  "https://trusttasks.org/spec/vtc/vetting/vetters/list/0.1";
+const TASK_ENDORSEMENT_REVOKE =
+  "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
+const TASK_MEMBERS_LIST = "https://trusttasks.org/spec/vtc/members/list/0.1";
+const TASK_JOIN_REQUESTS_LIST =
+  "https://trusttasks.org/spec/vtc/join-requests/list/0.1";
+export const TASK_MANIFEST_V0_2 =
+  "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2";
+
+/** Query keys. Everything under `["vetting"]` is refreshed after a change. */
+export const vettingKeys = {
+  grants: ["vetting", "grants"] as const,
+  autoGrant: ["vetting", "auto-grant"] as const,
+  revocations: ["vetting", "revocations"] as const,
+  manifest: ["vetting", "manifest"] as const,
+  activeMembers: ["vetting", "active-members"] as const,
+  pendingWithVetting: ["vetting", "pending-with-vetting"] as const,
+  listing: (body: VetterListBody, cursor: string | null) =>
+    ["vetting", "listing", body, cursor] as const,
+  joinRequest: (id: string) => ["join-request-vetting", id] as const,
+  branding: ["community-branding"] as const,
+};
+
+// ── Grants ──────────────────────────────────────────────────────────────
+
+export async function fetchGrants(): Promise<VetterGrantRow[]> {
+  const body = await getJsonExempt<VetterGrantList>("/v1/vetting/vetters");
+  return body.vetters;
+}
+
+export const grantVetter = (args: {
+  memberDid: string;
+  validitySeconds: number;
+}): Promise<VetterGrantResponse> =>
+  postJson<VetterGrantResponse>("/v1/vetting/vetters", args, {
+    trustTask: TASK_VETTER_GRANT,
+  });
+
+/** A grant is withdrawn like any endorsement. */
+export const revokeGrant = (endorsementId: string): Promise<unknown> =>
+  deleteJson<unknown>(
+    `/v1/credentials/endorsements/${encodeURIComponent(endorsementId)}`,
+    { trustTask: TASK_ENDORSEMENT_REVOKE },
+  );
+
+export const resendGrant = (memberDid: string): Promise<VetterResendResponse> =>
+  postJson<VetterResendResponse>(
+    `/v1/vetting/vetters/${encodeURIComponent(memberDid)}/resend`,
+    undefined,
+    { trustTask: TASK_VETTER_RESEND },
+  );
+
+const MAX_MEMBER_PAGES = 10;
+
+/** Current members, for choosing whom to name a vetter. */
+export async function fetchActiveMembers(): Promise<MemberRow[]> {
+  const members: MemberRow[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_MEMBER_PAGES; page++) {
+    const q = new URLSearchParams({ limit: "200" });
+    if (cursor) q.set("cursor", cursor);
+    const body: MembersPage = await getJson<MembersPage>(
+      `/v1/members?${q.toString()}`,
+      { trustTask: TASK_MEMBERS_LIST },
+    );
+    members.push(...body.items);
+    cursor = body.nextCursor ?? null;
+    if (!cursor) break;
+  }
+  return members;
+}
+
+// ── The public listing ──────────────────────────────────────────────────
+
+export const fetchListing = (body: VetterListBody): Promise<VetterListResponse> =>
+  postJson<VetterListResponse>("/v1/vetting/vetters/list", body, {
+    trustTask: TASK_VETTER_LIST,
+    requires: ["vetters"],
+  });
+
+// ── Automatic grants, withdrawals, join-request facts, branding ─────────
+
+export const fetchAutoGrant = (): Promise<AutoGrantStatus> =>
+  getJsonExempt<AutoGrantStatus>("/v1/vetting/auto-grant");
+
+export const saveAutoGrant = (config: AutoGrantConfig): Promise<AutoGrantStatus> =>
+  putJsonExempt<AutoGrantStatus>("/v1/vetting/auto-grant", config);
+
+export async function fetchRevocations(): Promise<VettingRevocationRow[]> {
+  const body = await getJsonExempt<VettingRevocationList>(
+    "/v1/vetting/revocations",
+  );
+  return body.revocations;
+}
+
+export const fetchJoinRequestVetting = (
+  id: string,
+): Promise<JoinRequestVettingResponse> =>
+  getJsonExempt<JoinRequestVettingResponse>(
+    `/v1/join-requests/${encodeURIComponent(id)}/vetting`,
+  );
+
+export const fetchBranding = (): Promise<CommunityBranding> =>
+  getJsonExempt<CommunityBranding>("/v1/community/branding");
+
+export const saveBranding = (branding: CommunityBranding): Promise<CommunityBranding> =>
+  putJsonExempt<CommunityBranding>("/v1/community/branding", branding);
+
+export interface PendingWithVetting {
+  /** Pending join requests on the first page that carry vetting facts. */
+  count: number;
+  /** More pending requests exist than were checked. */
+  more: boolean;
+}
+
+/**
+ * Pending join requests that were decided on vetting facts and now wait for an
+ * admin. The request list does not say which carry facts, so the first page
+ * of pending requests is checked one by one — bounded at 50 reads.
+ */
+export async function fetchPendingWithVetting(): Promise<PendingWithVetting> {
+  const page = await getJson<JoinRequestsPage>(
+    "/v1/join-requests?status=pending&limit=50",
+    { trustTask: TASK_JOIN_REQUESTS_LIST },
+  );
+  const withFacts = await Promise.all(
+    page.items.map((r) =>
+      fetchJoinRequestVetting(r.id).then(
+        (res) => Boolean(res.vetting),
+        () => false,
+      ),
+    ),
+  );
+  return {
+    count: withFacts.filter(Boolean).length,
+    more: Boolean(page.nextCursor),
+  };
+}
+
+// ── The join manifest ───────────────────────────────────────────────────
+
+export type { JoinManifest, ManifestCriterion };
+
+/**
+ * `join-requests/manifest/0.2` as applicants receive it — each criterion with
+ * its vetting requirements and `requirementsDigest` — from the admin route that
+ * answers under the same task. A criterion's `vetting` is an opaque object in
+ * the OpenAPI document; `validateRequirements` reads it.
+ */
+export const fetchManifest = (): Promise<JoinManifest> =>
+  getJson<JoinManifest>("/v1/join-requests/manifest", {
+    trustTask: TASK_MANIFEST_V0_2,
+    requires: ["criteria"],
+  });

--- a/vtc-service/admin-ui/src/plugins/vetting/index.test.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/index.test.tsx
@@ -1,0 +1,30 @@
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Vetting } from "@/plugins/vetting";
+import { mockFetch, NAME_BOOK_ROUTES, renderWithProviders } from "@/test/render";
+
+describe("Vetting plugin", () => {
+  it("opens the section in the URL and marks its link as the current page", async () => {
+    mockFetch([
+      { path: "/v1/vetting/revocations", body: { revocations: [] } },
+      ...NAME_BOOK_ROUTES,
+    ]);
+    renderWithProviders(<Vetting />, {
+      route: "/vetting/withdrawals",
+      path: "/vetting/*",
+    });
+
+    expect(await screen.findByText("No vetter has withdrawn a statement")).toBeTruthy();
+    const nav = screen.getByRole("navigation", { name: "Vetting sections" });
+    expect(
+      within(nav).getByRole("link", { name: "Withdrawals" }).getAttribute("aria-current"),
+    ).toBe("page");
+    expect(
+      within(nav).getByRole("link", { name: "Vetters" }).getAttribute("aria-current"),
+    ).toBeNull();
+    expect(
+      within(nav).getByRole("link", { name: "Registry preview" }).getAttribute("href"),
+    ).toBe("/vetting/registry");
+  });
+});

--- a/vtc-service/admin-ui/src/plugins/vetting/index.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/index.tsx
@@ -1,0 +1,67 @@
+// Vetting plugin — naming vetters, what applicants see, automatic grants,
+// withdrawn statements and the published requirements.
+//
+// Two more pieces live beside the surfaces they belong to: a join request's
+// vetting facts on its detail page (`JoinRequestVetting.tsx`), and community
+// branding on the Community profile page (`BrandingCard.tsx`).
+//
+// Section links are absolute: the shell mounts plugins on `path/*`, where a
+// relative link outside the descendant `<Routes>` would resolve against the
+// current section rather than the plugin root.
+
+import { NavLink, Route, Routes } from "react-router-dom";
+
+import { AutoGrantPanel } from "./AutoGrantPanel";
+import { RegistryPreview } from "./RegistryPreview";
+import { RequirementsPanel } from "./RequirementsPanel";
+import { VETTING_PATH } from "./ui";
+import { VettersPanel } from "./VettersPanel";
+import { WithdrawalsPanel } from "./WithdrawalsPanel";
+
+const SECTIONS = [
+  { path: "", label: "Vetters" },
+  { path: "/registry", label: "Registry preview" },
+  { path: "/auto-grant", label: "Automatic grants" },
+  { path: "/withdrawals", label: "Withdrawals" },
+  { path: "/requirements", label: "Requirements" },
+] as const;
+
+export function Vetting() {
+  return (
+    <section className="page">
+      <h2>Vetting</h2>
+      <p className="lead">
+        Choose which members vet applicants, check what applicants see when they
+        look for a vetter, and follow up when a vetter withdraws a statement.
+      </p>
+
+      <nav className="subnav" aria-label="Vetting sections">
+        {SECTIONS.map((section) => (
+          <NavLink
+            key={section.label}
+            to={`${VETTING_PATH}${section.path}`}
+            end={section.path === ""}
+          >
+            {section.label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <Routes>
+        <Route index element={<VettersPanel />} />
+        <Route path="registry" element={<RegistryPreview />} />
+        <Route path="auto-grant" element={<AutoGrantPanel />} />
+        <Route path="withdrawals" element={<WithdrawalsPanel />} />
+        <Route path="requirements" element={<RequirementsPanel />} />
+        <Route
+          path="*"
+          element={
+            <p className="muted">
+              There is no such vetting section. Choose one of the sections above.
+            </p>
+          }
+        />
+      </Routes>
+    </section>
+  );
+}

--- a/vtc-service/admin-ui/src/plugins/vetting/ui.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/ui.tsx
@@ -1,0 +1,144 @@
+// Small pieces the vetting panels share: status chips, a plain-words
+// explanation with its code, labelled form fields with a hint and an error,
+// and the paths other plugins are reached by.
+
+import type { ReactNode } from "react";
+
+import type { Explained, Tone } from "@/lib/vetting";
+
+/** Where the vetting plugin is mounted (`src/plugins/index.ts`). */
+export const VETTING_PATH = "/vetting";
+
+export const memberPath = (did: string) => `/members/${encodeURIComponent(did)}`;
+export const joinRequestPath = (id: string) =>
+  `/join-requests/${encodeURIComponent(id)}`;
+
+/** A date without its time, for validity windows and profile updates. */
+export function formatDay(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString();
+}
+
+export function errorMessage(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message: unknown }).message;
+    if (typeof message === "string" && message) return message;
+  }
+  return String(err);
+}
+
+export function errorStatus(err: unknown): number | undefined {
+  if (err && typeof err === "object" && "status" in err) {
+    const status = (err as { status: unknown }).status;
+    if (typeof status === "number") return status;
+  }
+  return undefined;
+}
+
+const CHIP_CLASS: Record<Tone | "neutral", string> = {
+  ok: "chip success",
+  warn: "chip warning",
+  bad: "chip danger",
+  neutral: "chip",
+};
+
+export const FINDING_CLASS: Record<Tone, string> = {
+  ok: "finding ok",
+  warn: "finding warn",
+  bad: "finding error",
+};
+
+export function ToneChip({
+  tone,
+  title,
+  children,
+}: {
+  tone: Tone | "neutral";
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span className={CHIP_CLASS[tone]} title={title}>
+      {children}
+    </span>
+  );
+}
+
+/** The sentence, with the daemon's code shown after it and on hover. */
+export function ExplainedText({ item }: { item: Explained }) {
+  return (
+    <span title={item.code}>
+      {item.text}
+      {item.code !== item.text && (
+        <>
+          {" "}
+          <code className="explained-code">{item.code}</code>
+        </>
+      )}
+    </span>
+  );
+}
+
+/**
+ * A labelled control with an optional hint and error, tied to the control by
+ * `id`. The control itself sets `aria-describedby={describedBy(…)}` and
+ * `aria-invalid`, so a screen reader reads the error with the field.
+ */
+export function FormField({
+  id,
+  label,
+  hint,
+  error,
+  className = "field",
+  children,
+}: {
+  id: string;
+  label: string;
+  hint?: ReactNode;
+  error?: string | null;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={className}>
+      <label className="field-label" htmlFor={id}>
+        {label}
+      </label>
+      {children}
+      {hint && (
+        <span className="field-hint" id={`${id}-hint`}>
+          {hint}
+        </span>
+      )}
+      {error && (
+        <span className="field-error" id={`${id}-error`}>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function describedBy(
+  id: string,
+  hint: boolean,
+  error?: string | null,
+): string | undefined {
+  const ids = [hint ? `${id}-hint` : "", error ? `${id}-error` : ""].filter(
+    Boolean,
+  );
+  return ids.length ? ids.join(" ") : undefined;
+}
+
+export function LoadError({ what, error }: { what: string; error: unknown }) {
+  return (
+    <section className="card error" role="alert">
+      <h3>Could not load {what}</h3>
+      <p>{errorMessage(error)}</p>
+      <p className="muted">
+        Reload the page to try again. If it keeps failing, sign in again: your
+        session may have ended.
+      </p>
+    </section>
+  );
+}

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -2716,3 +2716,269 @@ dd .copy-icon-btn {
   color: var(--text);
   border-color: var(--text-faint);
 }
+
+/* ── Vetting ─────────────────────────────────────────────────── */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Section links inside a plugin page. */
+.subnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  border-bottom: 1px solid var(--border);
+}
+.subnav a {
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: -1px;
+  color: var(--text-muted);
+  font-weight: 500;
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+.subnav a:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.subnav a.active {
+  color: var(--text);
+  border-bottom-color: var(--brand);
+}
+.subnav a:focus-visible,
+a.stat-tile:focus-visible,
+a.button:focus-visible,
+.switch-field input:focus-visible,
+.color-row input[type="color"]:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+a.button {
+  text-decoration: none;
+}
+a.button.secondary {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+a.button.secondary:hover {
+  background: var(--bg-hover);
+}
+
+a.stat-tile {
+  color: inherit;
+  text-decoration: none;
+  transition: border-color var(--motion-fast);
+}
+a.stat-tile:hover {
+  border-color: var(--brand);
+}
+
+.field-hint {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+.field-error {
+  color: var(--danger);
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+input[aria-invalid="true"],
+select[aria-invalid="true"] {
+  border-color: var(--danger);
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+  gap: var(--space-3) var(--space-4);
+  align-items: start;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.explained-code {
+  color: var(--text-faint);
+  font-size: var(--text-xs);
+}
+
+.vet-list {
+  margin: var(--space-1) 0 0;
+  padding-left: 1.1em;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.vet-subhead {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+.vet-note {
+  display: block;
+  margin-top: var(--space-1);
+  font-size: var(--text-sm);
+  word-break: normal;
+}
+.vet-note.warn {
+  color: var(--warning);
+}
+.vet-checks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--text-sm);
+}
+.vet-check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+}
+.vet-check.ok svg {
+  color: var(--success);
+}
+.vet-check.bad {
+  color: var(--danger);
+}
+
+.vet-registry {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  gap: var(--space-3);
+}
+.vet-listing {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+}
+.vet-listing article {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.vet-listing header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+.vet-listing h4 {
+  margin: 0;
+  font-size: var(--text-md);
+}
+
+.switch-field {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  cursor: pointer;
+}
+.switch-field input {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 2px;
+  accent-color: var(--brand);
+  cursor: pointer;
+}
+.switch-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.color-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.color-row input[type="color"] {
+  flex: none;
+  width: 44px;
+  height: 36px;
+  padding: 2px;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+.color-row input[type="text"] {
+  max-width: 10rem;
+  font-family: var(--font-mono);
+}
+
+.branding-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem);
+  gap: var(--space-5);
+  align-items: start;
+}
+@media (max-width: 800px) {
+  .branding-layout {
+    grid-template-columns: 1fr;
+  }
+}
+.branding-preview {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.branding-preview-card {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-top: 4px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+}
+.branding-preview-logo {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  overflow: hidden;
+  text-align: center;
+  word-break: break-all;
+  font-size: 9px;
+  line-height: 1.2;
+  color: var(--text-faint);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-md);
+}
+.branding-preview-name {
+  font-size: var(--text-md);
+  font-weight: 600;
+}
+.branding-preview-cta {
+  grid-column: 1 / -1;
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  padding: 0 var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+}

--- a/vtc-service/admin-ui/src/test/render.tsx
+++ b/vtc-service/admin-ui/src/test/render.tsx
@@ -1,0 +1,114 @@
+// Rendering and fetch mocking for component tests.
+//
+// `renderWithProviders` wraps a component in what `main.tsx` gives the app —
+// react-query, toasts, the confirmation dialog, a router — so a panel renders
+// as it does in the console. `mockFetch` answers the console's requests from a
+// table and records each one, so a test can assert what was sent: the method,
+// the path, the body, the `Trust-Task` header.
+
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { vi } from "vitest";
+
+import { ConfirmDialogProvider } from "@/components/ConfirmDialog";
+import { ToastProvider } from "@/lib/toast";
+
+export interface MockRoute {
+  method?: string;
+  /** Exact path (a query string is ignored), or a pattern over path + query. */
+  path: string | RegExp;
+  status?: number;
+  /** The JSON answer, or a function of the request that returns it. */
+  body?: object | ((request: { url: string; body: unknown }) => unknown);
+}
+
+export interface RecordedRequest {
+  method: string;
+  url: string;
+  body: unknown;
+  headers: Headers;
+}
+
+export function mockFetch(routes: MockRoute[]): RecordedRequest[] {
+  const requests: RecordedRequest[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const method = (init.method ?? "GET").toUpperCase();
+      const body =
+        typeof init.body === "string" ? (JSON.parse(init.body) as unknown) : undefined;
+      requests.push({ method, url, body, headers: new Headers(init.headers) });
+
+      const route = routes.find(
+        (r) =>
+          (r.method ?? "GET") === method &&
+          (typeof r.path === "string"
+            ? url.split("?")[0] === r.path
+            : r.path.test(url)),
+      );
+      if (!route) {
+        return json({ error: `no mock for ${method} ${url}` }, 404);
+      }
+      const payload =
+        typeof route.body === "function"
+          ? (route.body as (r: { url: string; body: unknown }) => unknown)({
+              url,
+              body,
+            })
+          : route.body;
+      return json(payload ?? {}, route.status ?? 200);
+    }),
+  );
+  return requests;
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Members and ACL answers for `useNameBook`, which most panels call. */
+export const NAME_BOOK_ROUTES: MockRoute[] = [
+  { path: "/v1/members", body: { items: [] } },
+  { path: "/v1/acl", body: { entries: [], truncated: false } },
+];
+
+/**
+ * `path` is the route the component is mounted on, as the shell mounts a
+ * plugin on `/<plugin>/*`; a component with descendant `<Routes>` needs it to
+ * match its sections.
+ */
+export function renderWithProviders(
+  ui: ReactElement,
+  { route = "/", path = "*" }: { route?: string; path?: string } = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <ConfirmDialogProvider>
+          <MemoryRouter initialEntries={[route]}>
+            <Routes>
+              <Route path={path} element={ui} />
+            </Routes>
+          </MemoryRouter>
+        </ConfirmDialogProvider>
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}

--- a/vtc-service/admin-ui/src/test/setup.ts
+++ b/vtc-service/admin-ui/src/test/setup.ts
@@ -1,0 +1,13 @@
+// Shared test setup. Testing Library only unmounts between tests on its own
+// when Vitest globals are on; they are off here (tests import `describe` and
+// `it` explicitly, so `tsc` checks them like any other module), so unmount
+// explicitly.
+
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+  // `mockFetch` stubs `fetch`; put the real one back for the next test.
+  vi.unstubAllGlobals();
+});

--- a/vtc-service/admin-ui/vitest.config.ts
+++ b/vtc-service/admin-ui/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config.ts";
+
+// Component and unit tests for the console. They run in jsdom against the
+// same `@/` alias and React plugin the build uses, so a test imports a plugin
+// exactly as `src/plugins/index.ts` does. `npm test` runs them once; the Rust
+// build does not, so run it before pushing a console change.
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      include: ["src/**/*.test.{ts,tsx}"],
+      setupFiles: ["src/test/setup.ts"],
+    },
+  }),
+);

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -25,10 +25,36 @@ use axum::extract::State;
 
 use vta_sdk::protocols::join_requests::{JoinRequestManifestResponseBody, ManifestCriterion};
 use vta_sdk::vetting::requirements::requirements_digest;
+use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
 use crate::schemas::accepts::{AcceptsCriterion, list_accepts};
 use crate::server::AppState;
+
+/// GET /join-requests/manifest — the join manifest (0.2) as applicants receive
+/// it, for an admin session.
+///
+/// Applicants read the manifest as a Trust Task document over
+/// `POST /v1/trust-tasks`. The admin console reads the same answer here, under
+/// the same `vtc/join-requests/manifest/0.2` task, to show each criterion's
+/// vetting requirements and `requirementsDigest` — criteria are registered
+/// through `/v1/schemas/accepts`, which carries no digest.
+#[utoipa::path(
+    get, path = "/join-requests/manifest",
+    operation_id = "joinRequestManifestShow", tag = "join-requests",
+    security(("bearer_jwt" = [])),
+    responses(
+        (status = 200, description = "The join manifest (0.2): each criterion with its vetting requirements and requirementsDigest, and the branding", body = JoinRequestManifestResponseBody),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn admin_manifest(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<JoinRequestManifestResponseBody>, AppError> {
+    Ok(Json(manifest_inner(&state, ManifestVersion::V0_2).await?))
+}
 
 /// Which manifest version a caller asked for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/vtc-service/src/routes/mod.rs
+++ b/vtc-service/src/routes/mod.rs
@@ -782,6 +782,12 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
             routes!(vetting::resend_vetter),
             "https://trusttasks.org/spec/vtc/vetting/vetters/resend/0.1",
         ))
+        // The public listing, as an admin session reads it: the same task and
+        // payload an applicant sends, so the console previews what they see.
+        .routes(tt(
+            routes!(vetting::list_listed_vetters),
+            "https://trusttasks.org/spec/vtc/vetting/vetters/list/0.1",
+        ))
         .routes(routes!(vetting::list_vetters))
         .routes(routes!(vetting::get_auto_grant, vetting::put_auto_grant))
         .routes(routes!(vetting::list_revocations))
@@ -821,6 +827,13 @@ fn build_api_chain(_routing: &RoutingConfig, trust_xff: bool) -> OpenApiRouter<A
         // The vetting facts a request was decided on — admin REST with no Trust
         // Task of its own.
         .routes(routes!(join_requests::read::show_join_request_vetting))
+        // The join manifest (0.2) for an admin session: the answer applicants get
+        // from `POST /v1/trust-tasks`, under the same task, for the console's
+        // view of the published vetting requirements and their digests.
+        .routes(tt(
+            routes!(join_requests::manifest::admin_manifest),
+            "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2",
+        ))
         // One decision endpoint, one task: `decide/0.1` carries
         // `{ decision: approved | rejected, reason? }`, superseding the
         // retired `approve/0.1` + `reject/0.1` pair (clean cutover — the

--- a/vtc-service/src/routes/vetting.rs
+++ b/vtc-service/src/routes/vetting.rs
@@ -14,9 +14,13 @@
 //!   configuration and the last sweep.
 //! - `GET /v1/vetting/revocations` — vetting statement withdrawal notices, with
 //!   the admissions each one touches.
+//! - `POST /v1/vetting/vetters/list` — the public vetter listing
+//!   (`vtc/vetting/vetters/list/0.1`) for an admin session, so the console can
+//!   show what applicants see. Over `POST /v1/trust-tasks` the listing names its
+//!   caller by the document proof, which a browser session cannot sign.
 //!
-//! The listing, auto-grant and revocations routes are admin REST with no Trust
-//! Task of their own, so they are mounted without a binding.
+//! The grant listing, auto-grant and revocations routes are admin REST with no
+//! Trust Task of their own, so they are mounted without a binding.
 
 use std::collections::{BTreeSet, HashMap};
 
@@ -28,7 +32,7 @@ use serde::Serialize;
 use uuid::Uuid;
 use vta_sdk::protocols::vetting::{
     AutoGrantConfig, AutoGrantStatus, VetterGrantBody, VetterGrantListResponse,
-    VetterGrantResponseBody, VetterResendResponseBody,
+    VetterGrantResponseBody, VetterListBody, VetterListResponseBody, VetterResendResponseBody,
 };
 use vti_common::auth::{AdminAuth, AuthClaims};
 use vti_common::error::AppError;
@@ -107,6 +111,31 @@ pub async fn resend_vetter(
     Ok(Json(
         vetters::resend_as_admin(&state, &auth.did, &member_did).await?,
     ))
+}
+
+/// The public vetter listing, as applicants see it.
+///
+/// The body and the answer are `vtc/vetting/vetters/list/0.1`'s, and both go
+/// through [`crate::vetting::profiles::list`], so the console previews exactly
+/// what `POST /v1/trust-tasks` returns to an applicant with the same filters.
+#[utoipa::path(
+    post, path = "/vetting/vetters/list",
+    operation_id = "vettingVetterListing", tag = "vetting",
+    security(("bearer_jwt" = [])),
+    request_body = VetterListBody,
+    responses(
+        (status = 200, description = "A page of listed vetters", body = VetterListResponseBody),
+        (status = 400, description = "A filter breaks its bounds, or the cursor was issued for other filters"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Caller is not an admin"),
+    ),
+)]
+pub async fn list_listed_vetters(
+    _admin: AdminAuth,
+    State(state): State<AppState>,
+    Json(body): Json<VetterListBody>,
+) -> Result<Json<VetterListResponseBody>, AppError> {
+    Ok(Json(crate::vetting::profiles::list(&state, &body).await?))
 }
 
 /// The automatic vetter-grant configuration and the last sweep.

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -2683,6 +2683,45 @@ async fn a_vetter_publishes_a_profile_that_applicants_find_by_filter() {
     assert_eq!(row["profile"]["eventCount"], 2);
 }
 
+const VETTER_LIST_TASK: &str = "https://trusttasks.org/spec/vtc/vetting/vetters/list/0.1";
+
+/// The listing through `POST /v1/vetting/vetters/list`, as the admin console
+/// reads it.
+async fn admin_listing(fix: &Fixture, filters: Value) -> (StatusCode, Value) {
+    send(
+        &fix.router,
+        "POST",
+        "/v1/vetting/vetters/list",
+        VETTER_LIST_TASK,
+        Some(&fix.admin_token),
+        Some(filters),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn an_admin_session_previews_exactly_the_listing_applicants_see() {
+    let fix = build_fixture().await;
+    let (carol, _) = did_key_secret([0x12; 32]);
+    seed_vetter(&fix, &carol).await;
+    let (status, body) = publish_profile(&fix, [0x12; 32], carols_profile(true)).await;
+    assert_eq!(status, StatusCode::OK, "publish: {body}");
+
+    let filters = json!({ "language": "de", "method": "video" });
+    let (status, preview) = admin_listing(&fix, filters.clone()).await;
+    assert_eq!(status, StatusCode::OK, "{preview}");
+    assert_eq!(listed_dids(&preview), vec![carol]);
+    assert_eq!(
+        preview,
+        list_vetters(&fix, filters).await,
+        "the console must show what an applicant is sent"
+    );
+
+    // The listing's own bounds apply: a lower-case country is refused.
+    let (status, body) = admin_listing(&fix, json!({ "country": "at" })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+}
+
 #[tokio::test]
 async fn listings_page_in_order_with_cursors_bound_to_their_filters() {
     let fix = build_fixture().await;
@@ -2930,6 +2969,21 @@ async fn branding_is_published_on_manifest_0_2_only() {
         tt_payload(&body)["branding"],
         json!({ "displayName": "Kernel", "accentColor": "#1a2b3c" })
     );
+
+    // The admin console reads the same manifest 0.2 over its own route, under
+    // the same task: what it shows is what an applicant is sent.
+    let (status, admin_view) = send(
+        &fix.router,
+        "GET",
+        "/v1/join-requests/manifest",
+        JOIN_REQUEST_MANIFEST_0_2_TYPE,
+        Some(&fix.admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{admin_view}");
+    assert_eq!(admin_view, tt_payload(&body));
+
     let (_did, doc) = signed_trust_task(MANIFEST_TASK, json!({})).await;
     let (_status, body) = post_tt(&fix.router, doc).await;
     assert!(tt_payload(&body).get("branding").is_none(), "{body}");


### PR DESCRIPTION
Stacked on #1430 (`feat/vtc-vetter-registry`). Draft.

## What

Admin console panels for peer identity vetting, built on the REST surface #1430 added.

| Where | What it does |
|---|---|
| **Join requests → a request** | New *Vetting* card: the criterion and requirements digest; each presented statement (vetter, method, declared relationship, verified / eligible / withdrawn, counted or every reason it did not); distinct counted vetters; per-method counts; whether the vetters agree on the identity; whether independence holds; and what is still needed. Plain words come first, with the daemon's code (`issuer-not-vetter`, `vetting:method:inPerson:1`) shown beside it and on hover. The Approve confirmation says when vetting is not met. Approve and Reject are otherwise unchanged. |
| **Vetting → Vetters** | Every grant: live, revoked, expired or not in force; manual or automatic; validity; profile summary. Filter by status, origin, or name/DID. Grant a current member for 30 days, 90 days, 1 year, 2 years, or a custom 1–730 days; members already holding a live grant are left out. Resend a grant's credential, with the 404 and 503 causes explained. Revoke after a confirmation that every statement the vetter signed stops counting and their profile is deleted, and that the sweep may name them again when automatic grants are on. |
| **Vetting → Registry preview** | The `vtc/vetting/vetters/list/0.1` listing with its filters (language, country, region, city, method, event date range, event name, page size) and cursor paging, shown as applicants see it. Filters are checked the way `VetterListBody::check_shape` checks them before sending, and the country is upper-cased. |
| **Vetting → Automatic grants** | `enabled`, `sweepMinutes` (5–1440) and grant validity in days (1–730). Shows the last sweep (granted, revoked, undecided — with guidance when undecided > 0) and the active `vetterEligibility` revision. Links to edit that policy in **Ceremonies → Other policies** (`/ceremonies?purpose=vetterEligibility`), rather than adding a second policy editor. |
| **Vetting → Withdrawals** | Withdrawal notices with reason and review state. *Needs review* rows link to the affected join requests and members. The panel states plainly that review is advisory and suspends no one. |
| **Vetting → Requirements** | **Criteria are not editable in the console today**, so this is a read-only view, as the brief allows. For each criterion it shows the vetting requirements in sentences, the copyable `requirementsDigest`, the statement type, the governance link and the raw object, all from the manifest 0.2 answer. The requirements also go through a TypeScript mirror of `VettingRequirements::validate`, so a stored criterion the daemon would now refuse is flagged with what to fix. The validator is ready for a future criteria editor. |
| **Community profile** | *Branding for applicants*: display name with a character count; accent colour as a colour picker plus a `#rrggbb` hex field; logo URL (`https://` only, ≤ 2048 characters). Includes a live preview and a note that applicants' clients fetch the logo, so its host can see them. |
| **Dashboard** | Two linked tiles: pending join requests that carry vetting facts, and withdrawals needing review. |

## How

- A new plugin in `src/plugins/vetting/`, registered after *Join requests*. The vetting vocabulary and the client-side validators live in `src/lib/vetting.ts`.
- Every response shape aliases a generated wire type. The only exception is a criterion's `vetting` object, which the OpenAPI document publishes as opaque; `validateRequirements` reads it.
- Unbound admin REST routes (grant list, auto-grant, revocations, join-request vetting, branding) go through `getJsonExempt` or a new `putJsonExempt`, rather than borrowing a task URI. Bound routes send their task.
- Keyboard and screen readers:
  - Controls are labelled, with `aria-describedby` hints and errors and `aria-invalid`.
  - The section nav marks the current page.
  - Destructive actions use the existing `ConfirmDialog`.
  - Buttons say when an action is pending.

### Rust / API changes (minimal)

The console's only REST credential is its session. The Trust Task forms of two reads identify the caller only by the document proof, which a browser session cannot sign, so the brief's "callable with an authenticated admin session" does not hold for the listing. Two admin routes, each bound to the same task the applicant uses and running the same function:

- **`POST /v1/vetting/vetters/list`**, bound to `…/vtc/vetting/vetters/list/0.1`. Takes `VetterListBody`, returns `VetterListResponseBody`, and calls `vetting::profiles::list`.
- **`GET /v1/join-requests/manifest`**, bound to `…/vtc/join-requests/manifest/0.2`. Returns `manifest_inner(V0_2)`. My first version posted an unsigned manifest document to `/v1/trust-tasks` with a header no route enforces, and `every_admin_ui_task_is_enforced_by_a_route` rightly failed it.

`VetterListBody`, `VetterListResponseBody`, `ListedVetter` and `VetterEvent` now derive `utoipa::ToSchema` under `openapi`, and `openapi.json` and `wire.ts` are regenerated.

Integration tests assert each admin answer equals what an applicant is sent:
- `an_admin_session_previews_exactly_the_listing_applicants_see`
- a manifest assertion added to the branding test

`docs/03-vtc/vetting.md` documents both routes and the console panels.

### Test setup (new)

The admin UI had no test runner. This adds:
- Vitest 4, jsdom 26 and Testing Library, run with `npm test`.
- `vitest.config.ts`.
- `src/test/render.tsx`: the app providers, plus a table-driven `fetch` mock that records method, path, body and `Trust-Task`.

`cargo build` does not run these tests.

## Notes for review

- **Lockfile.** npm 10.9.2 crashes when adding these packages to this lockfile (`Cannot read properties of null (reading 'edgesOut')`, in arborist `#loadPeerSet`), so the lockfile was written with npm 11. Checked: a plain `npm install` with npm 10, which is what `build.rs` runs, is then a no-op and leaves the lockfile byte-identical.
- **Doc/code mismatch, not changed here.** `vetting.md` says `eligibleVetters.role` may be `"custom:vetter"`, but `shape::role` (`^[a-zA-Z][a-zA-Z0-9_-]*$`) refuses the colon, so `VettingRequirements::validate` rejects it. The console mirrors the code.
- **Logo preview.** The console's CSP is `img-src 'self' data:`, so the preview shows where the logo goes and its host rather than loading it. I did not relax the CSP.
- **Dashboard count.** The tile reads vetting facts for the first 50 pending requests, one read each, and shows `N+` when more are pending.
- **Ceremonies.** It now honours `?purpose=`; unknown values fall back to the first ceremony, as before.
- **Not checked visually.** Nothing was checked by eye against a running daemon; component tests cover the behaviour.

## Test evidence

Run locally, since stacked PRs get no CI. `CARGO_TARGET_DIR` was shared, and the real admin-UI build was used: `VTC_SKIP_ADMIN_UI_BUILD` was unset.

| Command | Result |
|---|---|
| `npm ci` / `npm install` (npm 10, as `build.rs`) | up to date, lockfile unchanged |
| `npm run lint` (`wire:check` + `tsc -b --noEmit`) | pass |
| `npx tsc -b --noEmit` | pass |
| `npm run wire:check` | pass |
| `npm test` | 9 files, **60 passed** |
| `npm run build` | pass |
| `cargo test -p vtc-service --no-fail-fast` (full) | **1580 passed, 1 failed** (`every_admin_ui_task_is_enforced_by_a_route`: the manifest header, fixed as above) |
| Affected binaries after the fix, run once more with the UI build: `--lib`, `join_requests`, `trust_task_manifest`, `openapi_snapshot`, `openapi_response_census`, `routing_modes`, `website_task_gating` | 1007 (+1 ignored), 78, 8, 4, 6, 9, 4 — **all passed** |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo clippy -p vtc-service --all-targets -- -D warnings` | pass |
| `cargo fmt --all -- --check` | pass |
