### PR TITLE
feat(cnm-cli): vetting admin commands and a PGP web-of-trust vetter bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "bytes",
  "crypto-common 0.1.7",
  "generic-array",
 ]
@@ -79,6 +80,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-kw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
+dependencies = [
+ "aes 0.8.4",
+]
+
+[[package]]
 name = "affinidi-bbs"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,7 +133,7 @@ dependencies = [
  "multibase",
  "p256 0.14.0",
  "p384 0.14.0",
- "p521",
+ "p521 0.14.0",
  "rand 0.10.2",
  "rand_core 0.6.4",
  "serde",
@@ -441,7 +451,7 @@ checksum = "f7a8d75667f60abd3a3cf57cada307744333187032cee74235daeff93f8471a0"
 dependencies = [
  "aes-gcm 0.11.1",
  "ahash",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "axum",
  "base64 0.23.1",
@@ -959,6 +969,19 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2 0.10.6",
+ "cpufeatures 0.2.17",
+ "password-hash 0.5.0",
+ "zeroize",
+]
+
+[[package]]
+name = "argon2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
@@ -966,7 +989,7 @@ dependencies = [
  "base64ct",
  "blake2 0.11.0",
  "cpufeatures 0.3.1",
- "password-hash",
+ "password-hash 0.6.1",
 ]
 
 [[package]]
@@ -1049,7 +1072,7 @@ dependencies = [
  "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -1065,7 +1088,7 @@ dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.20",
@@ -2050,6 +2073,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfields"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "bls12_381_plus"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2224,15 @@ checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
+]
+
+[[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2234,6 +2297,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d74937895e761d5984206f82ca8ff7725d0fd8021921011921894b41ab1b9f7"
 
 [[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2337,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "cast5"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2311,7 +2393,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2499,6 +2590,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher 0.4.4",
+ "dbl",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,18 +2620,24 @@ name = "cnm-cli"
 version = "0.14.3"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
+ "chrono",
  "clap",
  "dialoguer",
  "dirs",
+ "pgp",
+ "rand 0.8.8",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "vta-cli-common",
  "vta-sdk",
+ "vtc-client",
 ]
 
 [[package]]
@@ -2734,6 +2842,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
@@ -2960,6 +3074,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint 0.5.5",
+ "elliptic-curve 0.13.8",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
+ "sha3 0.10.9",
+ "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,7 +3366,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
@@ -3240,7 +3380,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs 0.7.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
@@ -3317,6 +3457,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.119",
+ "unicode-xid",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3457,6 +3607,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8 0.10.2",
+ "rfc6979 0.4.0",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
 name = "dtg-credentials"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3651,19 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead 0.5.2",
+ "cipher 0.4.4",
+ "cmac",
+ "ctr 0.9.2",
+ "subtle",
+]
 
 [[package]]
 name = "ecdsa"
@@ -3577,6 +3756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
+ "base64ct",
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
@@ -3587,7 +3767,10 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serde_json",
+ "serdect 0.2.0",
  "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -5005,6 +5188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,7 +5628,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
+ "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -5475,6 +5671,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -5581,6 +5786,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.9",
+]
 
 [[package]]
 name = "left-right"
@@ -5996,6 +6204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6264,6 +6482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6316,6 +6543,23 @@ checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.8",
+ "serde",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -6397,6 +6641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -6410,12 +6655,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead 0.5.2",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "subtle",
 ]
 
 [[package]]
@@ -6714,6 +6992,20 @@ dependencies = [
 
 [[package]]
 name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
@@ -6795,6 +7087,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -6912,6 +7215,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
+ "aes-kw",
+ "argon2 0.5.3",
+ "base64 0.22.1",
+ "bitfields",
+ "block-padding 0.3.3",
+ "blowfish",
+ "buffer-redux",
+ "byteorder",
+ "bytes",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "cipher 0.4.4",
+ "const-oid 0.9.6",
+ "crc24",
+ "curve25519-dalek 4.1.3",
+ "cx448",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa 0.16.9",
+ "ed25519-dalek 2.2.0",
+ "elliptic-curve 0.13.8",
+ "flate2",
+ "generic-array",
+ "hex",
+ "hkdf 0.12.4",
+ "idea",
+ "k256 0.13.4",
+ "log",
+ "md-5",
+ "memchr",
+ "nom 8.0.0",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256 0.13.2",
+ "p384 0.13.1",
+ "p521 0.13.3",
+ "rand 0.8.8",
+ "replace_with",
+ "ripemd",
+ "rsa",
+ "sha1 0.10.7",
+ "sha1-checked",
+ "sha2 0.10.9",
+ "sha3 0.10.9",
+ "signature 2.2.0",
+ "smallvec",
+ "snafu",
+ "subtle",
+ "twofish",
+ "x25519-dalek 2.0.1",
+ "zeroize",
+]
+
+[[package]]
 name = "phc"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7023,6 +7395,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
 
 [[package]]
 name = "pkcs8"
@@ -7220,7 +7603,7 @@ dependencies = [
  "elliptic-curve 0.14.1",
  "once_cell",
  "primefield",
- "serdect",
+ "serdect 0.4.3",
  "wnaf",
 ]
 
@@ -7820,6 +8203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7896,6 +8285,15 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7977,6 +8375,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7997,7 +8415,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8239,6 +8657,7 @@ dependencies = [
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -8517,6 +8936,26 @@ dependencies = [
 
 [[package]]
 name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
@@ -8556,6 +8995,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1 0.10.7",
+ "zeroize",
 ]
 
 [[package]]
@@ -8601,12 +9051,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.2",
 ]
 
 [[package]]
@@ -8616,7 +9076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.2",
  "sponge-cursor",
 ]
 
@@ -8627,7 +9087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.2",
  "sponge-cursor",
 ]
 
@@ -8772,6 +9232,27 @@ name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
+name = "snafu"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "socket2"
@@ -9023,7 +9504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf 0.11.3",
  "phf_codegen",
 ]
@@ -9706,8 +10187,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f892c6904b0bd5a9241eac848347abcbbbd2b9f3892bad23ac3e6efab8d6f06a"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.2",
  "sponge-cursor",
+]
+
+[[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -10245,7 +10735,7 @@ name = "vta-backup"
 version = "0.3.6"
 dependencies = [
  "aes-gcm 0.11.1",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "base64 0.23.1",
  "chrono",
@@ -10544,7 +11034,7 @@ dependencies = [
  "affinidi-tdk",
  "affinidi-tdk-common",
  "agent-names",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "aws-lc-rs",
  "axum",
@@ -10788,7 +11278,7 @@ dependencies = [
  "affinidi-status-list",
  "affinidi-tdk",
  "affinidi-vc",
- "argon2",
+ "argon2 0.6.0",
  "async-trait",
  "axum",
  "axum-extra",
@@ -11231,7 +11721,7 @@ dependencies = [
  "base64urlsafedata",
  "der-parser 9.0.0",
  "hex",
- "nom",
+ "nom 7.1.3",
  "openssl",
  "openssl-sys",
  "rand 0.9.5",
@@ -11294,7 +11784,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -11677,7 +12167,7 @@ dependencies = [
  "data-encoding",
  "der-parser 9.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -11694,7 +12184,7 @@ dependencies = [
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
@@ -11713,7 +12203,7 @@ dependencies = [
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,12 @@ chrono = { version = "0.4", features = ["serde"] }
 # Random number generation
 rand = "0.10"
 
+# OpenPGP (rPGP). `cnm vetting bootstrap-pgp` reads a PGP web of trust: keyring
+# parsing, certification and cleartext-signature verification. Default features
+# off — the only default is bzip2 compressed-data support, which neither a
+# keyring nor a cleartext-signed message uses.
+pgp = { version = "0.20", default-features = false }
+
 # DID Web with Verifiable History
 didwebvh-rs = "0.6"
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -28,6 +28,15 @@ vta-cli-common = { path = "../vta-cli-common", version = "0.15", features = [
   "agent-names",
 ] }
 affinidi-did-resolver-cache-sdk = { workspace = true }
+# `cnm vetting …` drives the VTC's vetting admin REST surface through the VTC
+# client rather than hand-built requests: it carries the Trust-Task headers,
+# finite HTTP timeouts and typed errors the commands turn into guidance.
+vtc-client = { path = "../vtc-client", version = "0.6" }
+# `cnm vetting bootstrap-pgp`: parse an OpenPGP keyring, verify third-party
+# certifications and cleartext-signed link statements.
+pgp = { workspace = true }
+chrono = { workspace = true }
+ratatui = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 dialoguer = { workspace = true }
 dirs = { workspace = true }
@@ -40,6 +49,13 @@ toml = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+# The bootstrap tests generate a small web of trust with rPGP, whose key
+# generation takes a rand 0.8 RNG (the workspace is on 0.10). A seeded StdRng
+# keeps the keys, and so the fingerprints, the same on every run.
+rand = "0.8"
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/cnm-cli/README.md
+++ b/cnm-cli/README.md
@@ -302,6 +302,23 @@ has unrestricted access across all contexts.
 | --------------------------------------------------------------------------- | -------------------------------------------- |
 | `auth-credential create --role ROLE [--label LABEL] [--contexts ctx1,ctx2]` | Generate a did:key credential with ACL entry |
 
+### Vetting
+
+Peer identity vetting on the community (VTC admin REST; needs a community-admin
+session). Guide: [Peer identity vetting](../docs/03-vtc/vetting.md) §7–8.
+
+| Command | Description |
+| ------- | ----------- |
+| `vetting vetters list` | Every vetter grant: status, origin, validity, endorsement id, profile |
+| `vetting vetters grant <memberDid> [--validity 180d]` | Name a current member a vetter |
+| `vetting vetters revoke <endorsementId>` | Withdraw a vetter grant |
+| `vetting vetters resend <memberDid>` | Deliver a live grant credential again |
+| `vetting auto-grant show` | Automatic-grant configuration and last sweep |
+| `vetting auto-grant set [--enabled BOOL] [--sweep-minutes N] [--validity D]` | Change it (unset flags keep their value) |
+| `vetting branding show` / `set [--display-name] [--accent-color] [--logo-url] [--clear FIELD]` | Community branding on the join manifest |
+| `vetting revocations` | Statement withdrawals and the memberships they touch |
+| `vetting bootstrap-pgp --keyring FILE --roots FPR,… --max-depth N --links DIR [--dry-run] [--validity D]` | Name vetters from an OpenPGP web of trust (run `--dry-run` first) |
+
 ## Additional Resources
 
 - [VTA Service & Architecture](../README.md)

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -3,6 +3,7 @@ mod auth;
 mod backup;
 mod config;
 mod setup;
+mod vetting;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use config::{community_keyring_key, resolve_community};
@@ -165,6 +166,13 @@ enum Commands {
     Audit {
         #[command(subcommand)]
         command: AuditCommands,
+    },
+
+    /// Peer identity vetting: vetter grants, automatic grants, branding,
+    /// statement withdrawals, and seeding vetters from a PGP web of trust.
+    Vetting {
+        #[command(subcommand)]
+        command: vetting::VettingCommands,
     },
 
     /// Sealed-transfer bootstrap (consumer side).
@@ -1287,6 +1295,7 @@ async fn main() {
         Commands::Audit { command } => match command {
             AuditCommands::Verify => audit::cmd_verify(&client, &keyring_key).await,
         },
+        Commands::Vetting { command } => vetting::run(command, &client, &keyring_key).await,
         Commands::Bootstrap { command } => match command {
             BootstrapCommands::Request { out, label } => bootstrap_request(out, label),
             BootstrapCommands::Open {
@@ -1880,6 +1889,81 @@ mod tests {
             command: ContextCommands::List,
         };
         assert!(requires_auth(&cmd));
+    }
+
+    #[test]
+    fn test_requires_auth_vetting_true() {
+        let cmd = Commands::Vetting {
+            command: vetting::VettingCommands::Revocations,
+        };
+        assert!(requires_auth(&cmd));
+    }
+
+    /// The contract's command shapes parse (CONTRACT-vetter-registry §9).
+    #[test]
+    fn vetting_commands_parse_as_documented() {
+        for argv in [
+            vec!["cnm", "vetting", "vetters", "list"],
+            vec![
+                "cnm",
+                "vetting",
+                "vetters",
+                "grant",
+                "did:key:z6Mk",
+                "--validity",
+                "180d",
+            ],
+            vec![
+                "cnm",
+                "vetting",
+                "vetters",
+                "revoke",
+                "3f1c9a52-8c1e-4f2b-9d7a-0b6e5c4d3a21",
+            ],
+            vec!["cnm", "vetting", "vetters", "resend", "did:key:z6Mk"],
+            vec!["cnm", "vetting", "auto-grant", "show"],
+            vec![
+                "cnm",
+                "vetting",
+                "auto-grant",
+                "set",
+                "--enabled",
+                "true",
+                "--sweep-minutes",
+                "30",
+            ],
+            vec![
+                "cnm",
+                "vetting",
+                "branding",
+                "set",
+                "--accent-color",
+                "#1a2b3c",
+                "--clear",
+                "logo-url",
+            ],
+            vec!["cnm", "--json", "vetting", "revocations"],
+            vec![
+                "cnm",
+                "vetting",
+                "bootstrap-pgp",
+                "--keyring",
+                "k.asc",
+                "--roots",
+                "AAAA,BBBB",
+                "--max-depth",
+                "2",
+                "--links",
+                "links",
+                "--dry-run",
+                "--validity",
+                "365d",
+            ],
+        ] {
+            if let Err(e) = Cli::try_parse_from(&argv) {
+                panic!("{argv:?} should parse: {e}");
+            }
+        }
     }
 
     #[test]

--- a/cnm-cli/src/vetting/bootstrap.rs
+++ b/cnm-cli/src/vetting/bootstrap.rs
@@ -1,0 +1,519 @@
+//! `cnm vetting bootstrap-pgp` — seed a community's first vetters from an
+//! OpenPGP web of trust.
+//!
+//! The order is deliberate: everything local (the keyring, the roots, the link
+//! statements) is read and verified before the community is contacted, then
+//! the community's roster is read once, then — only without `--dry-run` — the
+//! grants are made one at a time. A grant that fails is reported and the rest
+//! carry on; nothing is retried here (the community's grant converges, so
+//! running the command again is the retry).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+use ratatui::layout::Constraint;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Cell, Row, Table};
+use serde::Serialize;
+use serde_json::json;
+use vta_cli_common::display::did_cell;
+use vta_cli_common::render::{
+    BOLD, DIM, GREEN, RED, RESET, YELLOW, bin_name, is_full_display, is_json_output,
+    print_full_entry, print_full_list_title, print_json, print_widget,
+};
+use vta_sdk::client::VtaClient;
+
+use super::plan::{Action, PlanRow, Roster, plan};
+use super::wot::{CertStats, Keyring, LinkCheck, check_link, mark_ambiguous, shortest_paths};
+use super::{CliResult, Op, bordered, guidance, header_style, height, parse_grant_validity};
+
+/// Largest link statement read. A clearsigned one-line statement is a few
+/// kilobytes; anything far larger is not one.
+const MAX_LINK_BYTES: u64 = 64 * 1024;
+
+/// `cnm vetting bootstrap-pgp` arguments.
+#[derive(Args, Debug)]
+pub struct BootstrapPgpArgs {
+    /// The OpenPGP keyring: the root keys, the keys that certify, and the
+    /// linked keys. Binary (`gpg --export > keyring.gpg`) or ASCII-armored,
+    /// one or many key blocks.
+    #[arg(long)]
+    pub keyring: PathBuf,
+
+    /// Root key fingerprints, comma-separated: the 40 hex digits
+    /// `gpg --fingerprint` prints (spaces allowed inside quotes).
+    #[arg(long, value_delimiter = ',', required = true)]
+    pub roots: Vec<String>,
+
+    /// Most certification hops from a root a linked key may be: 0 means only
+    /// the root keys themselves, 1 their direct certifications, and so on.
+    #[arg(long)]
+    pub max_depth: u32,
+
+    /// Directory of link statements, one `gpg --clearsign` output per member,
+    /// each carrying the line `openvtc-link: <memberDid>`.
+    #[arg(long)]
+    pub links: PathBuf,
+
+    /// Print what would be granted, and grant nothing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Validity of each grant: `N[s|m|h|d|w]`, one day to two years. The
+    /// community's default of one year when absent.
+    #[arg(long)]
+    pub validity: Option<String>,
+}
+
+/// What the web of trust looked like, for the summary.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Summary {
+    keys: usize,
+    unusable_keys: usize,
+    skipped: Vec<String>,
+    roots: Vec<String>,
+    reachable_keys: usize,
+    within_max_depth: usize,
+    max_depth: u32,
+    #[serde(serialize_with = "serialize_stats")]
+    certifications: CertStats,
+    links: usize,
+}
+
+fn serialize_stats<S: serde::Serializer>(stats: &CertStats, s: S) -> Result<S::Ok, S::Error> {
+    json!({
+        "counted": stats.counted,
+        "expired": stats.expired,
+        "revoked": stats.revoked,
+        "invalid": stats.invalid,
+        "unknownIssuer": stats.unknown_issuer,
+        "unusableIssuer": stats.unusable_issuer,
+    })
+    .serialize(s)
+}
+
+/// The outcome of one grant the command made.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "result", rename_all = "camelCase")]
+enum GrantOutcome {
+    #[serde(rename_all = "camelCase")]
+    Granted {
+        endorsement_id: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    AlreadyGranted {
+        endorsement_id: String,
+    },
+    Failed {
+        error: String,
+    },
+}
+
+pub(super) async fn run(
+    args: BootstrapPgpArgs,
+    client: &VtaClient,
+    keyring_key: &str,
+) -> CliResult {
+    let validity = args
+        .validity
+        .as_deref()
+        .map(|v| parse_grant_validity("--validity", v))
+        .transpose()?;
+    let now = unix_now();
+
+    let bytes = std::fs::read(&args.keyring).map_err(|e| {
+        format!(
+            "could not read --keyring {}: {e}.\nExport one with `gpg --export > keyring.gpg`.",
+            args.keyring.display()
+        )
+    })?;
+    let keyring = Keyring::parse(&bytes, now)?;
+    let roots = keyring.resolve_roots(&args.roots)?;
+    let (edges, stats) = keyring.certifications(now);
+    let reach = shortest_paths(&edges, &roots);
+
+    let statements = read_links(&args.links)?;
+    let mut checks: Vec<LinkCheck> = statements
+        .iter()
+        .map(|(name, text)| match text {
+            Ok(text) => check_link(&keyring, name, text, now),
+            Err(problem) => LinkCheck {
+                source: name.clone(),
+                member_did: None,
+                fingerprint: None,
+                problem: Some(super::wot::LinkProblem::NotCleartextSigned(problem.clone())),
+            },
+        })
+        .collect();
+    mark_ambiguous(&mut checks);
+
+    let vtc = super::connect(client, keyring_key).await?;
+    let members: BTreeSet<String> = vtc
+        .list_members(None)
+        .await
+        .map_err(|e| guidance(e, Op::Members))?
+        .into_iter()
+        .map(|m| m.did)
+        .collect();
+    let live_grants: BTreeMap<String, String> = vtc
+        .list_vetter_grants()
+        .await
+        .map_err(|e| guidance(e, Op::VettersList))?
+        .vetters
+        .into_iter()
+        .filter(|g| g.live)
+        .map(|g| (g.member_did, g.endorsement_id))
+        .collect();
+
+    let rows = plan(
+        &checks,
+        &keyring,
+        &reach,
+        Roster {
+            members: &members,
+            live_grants: &live_grants,
+        },
+        args.max_depth,
+    );
+    let summary = Summary {
+        keys: keyring.keys().len(),
+        unusable_keys: keyring
+            .keys()
+            .iter()
+            .filter(|k| k.problem.is_some())
+            .count(),
+        skipped: keyring.skipped.clone(),
+        roots,
+        reachable_keys: reach.len(),
+        within_max_depth: reach.values().filter(|r| r.depth <= args.max_depth).count(),
+        max_depth: args.max_depth,
+        certifications: stats,
+        links: checks.len(),
+    };
+
+    if args.dry_run {
+        if is_json_output() {
+            print_json(&json!({ "dryRun": true, "summary": summary, "rows": rows }))?;
+        } else {
+            print_summary(&summary);
+            print_rows(&rows, None);
+            let to_grant = rows.iter().filter(|r| r.action == Action::Grant).count();
+            println!(
+                "\n{YELLOW}Dry run — nothing was granted.{RESET} Re-run without --dry-run to \
+                 grant the {to_grant} row(s) marked `grant`."
+            );
+        }
+        return Ok(());
+    }
+
+    let mut outcomes: Vec<Option<GrantOutcome>> = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let (Action::Grant, Some(did)) = (&row.action, &row.member_did) else {
+            outcomes.push(None);
+            continue;
+        };
+        let outcome = match vtc.grant_vetter(did, validity).await {
+            Ok(g) if g.created => GrantOutcome::Granted {
+                endorsement_id: g.grant.endorsement_id,
+            },
+            Ok(g) => GrantOutcome::AlreadyGranted {
+                endorsement_id: g.grant.endorsement_id,
+            },
+            Err(e) => GrantOutcome::Failed {
+                error: guidance(e, Op::Grant { member_did: did }).to_string(),
+            },
+        };
+        outcomes.push(Some(outcome));
+    }
+    let failed = outcomes
+        .iter()
+        .filter(|o| matches!(o, Some(GrantOutcome::Failed { .. })))
+        .count();
+
+    if is_json_output() {
+        let results: Vec<_> = rows
+            .iter()
+            .zip(&outcomes)
+            .map(|(row, outcome)| {
+                let mut value = serde_json::to_value(row).unwrap_or_default();
+                if let Some(outcome) = outcome {
+                    value["grant"] = serde_json::to_value(outcome).unwrap_or_default();
+                }
+                value
+            })
+            .collect();
+        print_json(&json!({ "dryRun": false, "summary": summary, "rows": results }))?;
+    } else {
+        print_summary(&summary);
+        print_rows(&rows, Some(&outcomes));
+        let granted = outcomes
+            .iter()
+            .filter(|o| matches!(o, Some(GrantOutcome::Granted { .. })))
+            .count();
+        println!("\n{GREEN}{granted}{RESET} vetter(s) granted, {RED}{failed}{RESET} failed.");
+    }
+    if failed > 0 {
+        return Err(format!(
+            "{failed} grant(s) failed — see the result column. Fix the cause and run the same \
+             command again: members already granted are skipped."
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Every regular, non-hidden file in `dir`, sorted by name, with its text or
+/// why it could not be read as text.
+fn read_links(dir: &Path) -> CliResult<Vec<(String, Result<String, String>)>> {
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        format!(
+            "could not read --links {}: {e}.\nPass a directory holding one `gpg --clearsign` \
+             link statement per member.",
+            dir.display()
+        )
+    })?;
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let meta = entry.metadata()?;
+        if name.starts_with('.') || !meta.is_file() {
+            continue;
+        }
+        let text = if meta.len() > MAX_LINK_BYTES {
+            Err(format!(
+                "{} bytes is too large for a link statement",
+                meta.len()
+            ))
+        } else {
+            std::fs::read(entry.path())
+                .map_err(|e| e.to_string())
+                .and_then(|b| String::from_utf8(b).map_err(|_| "not UTF-8 text".to_string()))
+        };
+        files.push((name, text));
+    }
+    if files.is_empty() {
+        return Err(format!(
+            "--links {} holds no link statements.\nEach member signs one with their PGP key:\n  \
+             printf 'openvtc-link: <memberDid>\\n' | gpg --clearsign > <name>.asc\nand the files \
+             are collected into this directory.",
+            dir.display()
+        )
+        .into());
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(files)
+}
+
+fn print_summary(s: &Summary) {
+    let c = &s.certifications;
+    println!(
+        "{BOLD}Keyring{RESET}         {} keys ({} unusable: revoked, expired or without a \
+         self-signed user ID)",
+        s.keys, s.unusable_keys
+    );
+    for skipped in &s.skipped {
+        println!("                {DIM}skipped: {skipped}{RESET}");
+    }
+    println!(
+        "{BOLD}Certifications{RESET}  {} counted; ignored {} expired, {} revoked, {} invalid, \
+         {} by keys not in the keyring, {} by unusable keys",
+        c.counted, c.expired, c.revoked, c.invalid, c.unknown_issuer, c.unusable_issuer
+    );
+    println!(
+        "{BOLD}Roots{RESET}           {} — {} keys reachable, {} within --max-depth {}",
+        s.roots.join(", "),
+        s.reachable_keys,
+        s.within_max_depth,
+        s.max_depth
+    );
+    println!("{BOLD}Links{RESET}           {} statements read\n", s.links);
+}
+
+fn print_rows(rows: &[PlanRow], outcomes: Option<&[Option<GrantOutcome>]>) {
+    let result_of = |i: usize| -> String {
+        match outcomes.and_then(|o| o[i].as_ref()) {
+            Some(GrantOutcome::Granted { endorsement_id }) => format!("granted ({endorsement_id})"),
+            Some(GrantOutcome::AlreadyGranted { .. }) => "already granted".into(),
+            Some(GrantOutcome::Failed { .. }) => "failed".into(),
+            None => short_action(&rows[i].action),
+        }
+    };
+
+    if is_full_display() {
+        print_full_list_title("Link statements", rows.len());
+        for (i, row) in rows.iter().enumerate() {
+            print_full_entry(&[
+                ("File", &row.source),
+                ("Member DID", row.member_did.as_deref().unwrap_or("—")),
+                ("Fingerprint", row.fingerprint.as_deref().unwrap_or("—")),
+                ("User ID", row.primary_user_id.as_deref().unwrap_or("—")),
+                ("Depth", &row.depth.map_or("—".into(), |d| d.to_string())),
+                ("Path", &full_path(&row.path)),
+                ("Action", &result_of(i)),
+            ]);
+        }
+    } else {
+        let header = Row::new(vec![
+            "Member DID",
+            "Key",
+            "Primary User ID",
+            "Depth",
+            "Certification Path",
+            "Action",
+        ])
+        .style(header_style())
+        .bottom_margin(1);
+        let table_rows: Vec<Row> = rows
+            .iter()
+            .enumerate()
+            .map(|(i, row)| {
+                let label = result_of(i);
+                let style = match (&row.action, outcomes.and_then(|o| o[i].as_ref())) {
+                    (_, Some(GrantOutcome::Failed { .. })) => Style::default().fg(Color::Red),
+                    (Action::Grant, _) => Style::default().fg(Color::Green),
+                    (Action::AlreadyGranted { .. }, _) => Style::default(),
+                    (Action::InvalidLink { .. }, _) => Style::default().fg(Color::Red),
+                    _ => Style::default().fg(Color::Yellow),
+                };
+                Row::new(vec![
+                    row.member_did
+                        .as_deref()
+                        .map_or_else(|| Cell::from("—"), did_cell),
+                    Cell::from(row.fingerprint.as_deref().map_or("—".into(), short_key)),
+                    Cell::from(row.primary_user_id.clone().unwrap_or_else(|| "—".into())),
+                    Cell::from(row.depth.map_or("—".into(), |d| d.to_string())),
+                    Cell::from(short_path(&row.path)),
+                    Cell::from(label).style(style),
+                ])
+            })
+            .collect();
+        let table = Table::new(
+            table_rows,
+            [
+                Constraint::Min(28),
+                Constraint::Length(16),
+                Constraint::Min(24),
+                Constraint::Length(5),
+                Constraint::Min(24),
+                Constraint::Min(16),
+            ],
+        )
+        .header(header)
+        .column_spacing(2)
+        .block(bordered(format!(" Link statements ({}) ", rows.len())));
+        print_widget(table, height(rows.len()));
+    }
+
+    // The table has room for a label, not a reason. Every row that is not a
+    // plain grant says why here, keyed by file so the operator can find it.
+    let notes: Vec<String> = rows
+        .iter()
+        .enumerate()
+        .filter_map(|(i, row)| {
+            let reason = match (&row.action, outcomes.and_then(|o| o[i].as_ref())) {
+                (_, Some(GrantOutcome::Failed { error })) => error.clone(),
+                (Action::InvalidLink { reason } | Action::TooFar { reason }, _) => reason.clone(),
+                (Action::NotAMember, _) => format!(
+                    "{} is not an active member — they must join before they can vet",
+                    row.member_did.as_deref().unwrap_or("the DID")
+                ),
+                _ => return None,
+            };
+            Some(format!("  {}: {reason}", row.source))
+        })
+        .collect();
+    if !notes.is_empty() {
+        println!("{BOLD}Notes{RESET}");
+        for note in notes {
+            println!("{note}");
+        }
+    }
+    if !is_full_display() {
+        println!(
+            "  {DIM}Keys show their 16-digit key id; `{} --full-display vetting bootstrap-pgp …` \
+             prints full fingerprints, DIDs and paths.{RESET}",
+            bin_name()
+        );
+    }
+}
+
+fn short_action(action: &Action) -> String {
+    match action {
+        Action::Grant => "grant".into(),
+        Action::AlreadyGranted { .. } => "already granted".into(),
+        Action::TooFar { .. } => "too far".into(),
+        Action::NotAMember => "not a member".into(),
+        Action::InvalidLink { .. } => "invalid link".into(),
+    }
+}
+
+/// The long key id: the fingerprint's last 16 hex digits.
+fn short_key(fingerprint: &str) -> String {
+    fingerprint[fingerprint.len().saturating_sub(16)..].to_string()
+}
+
+fn short_path(path: &[String]) -> String {
+    if path.is_empty() {
+        return "—".into();
+    }
+    path.iter()
+        .map(|fp| fp[fp.len().saturating_sub(8)..].to_string())
+        .collect::<Vec<_>>()
+        .join(" → ")
+}
+
+fn full_path(path: &[String]) -> String {
+    if path.is_empty() {
+        "—".into()
+    } else {
+        path.join(" → ")
+    }
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_files_are_read_in_name_order_and_hidden_files_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("b.asc"), "b").unwrap();
+        std::fs::write(dir.path().join("a.asc"), "a").unwrap();
+        std::fs::write(dir.path().join(".DS_Store"), "x").unwrap();
+        std::fs::write(dir.path().join("binary.asc"), [0xff, 0xfe]).unwrap();
+        std::fs::create_dir(dir.path().join("nested")).unwrap();
+        let files = read_links(dir.path()).unwrap();
+        let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, ["a.asc", "b.asc", "binary.asc"]);
+        assert_eq!(files[2].1, Err("not UTF-8 text".to_string()));
+    }
+
+    #[test]
+    fn an_empty_link_directory_shows_how_to_make_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_links(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("gpg --clearsign"), "{err}");
+    }
+
+    #[test]
+    fn keys_and_paths_are_shortened_for_the_table() {
+        let fp = "0123456789ABCDEF0123456789ABCDEF01234567";
+        assert_eq!(short_key(fp), "89ABCDEF01234567");
+        assert_eq!(
+            short_path(&[
+                fp.to_string(),
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF76543210".to_string()
+            ]),
+            "01234567 → 76543210"
+        );
+    }
+}

--- a/cnm-cli/src/vetting/mod.rs
+++ b/cnm-cli/src/vetting/mod.rs
@@ -1,0 +1,1085 @@
+//! `cnm vetting …` — the community-admin side of peer identity vetting.
+//!
+//! Every command drives the VTC's vetting admin REST surface through
+//! [`vtc_client::VtcClient`]: the vetter grants (`/v1/vetting/vetters`), the
+//! automatic-grant configuration (`/v1/vetting/auto-grant`), the community's
+//! branding (`/v1/community/branding`) and the statement withdrawal notices
+//! (`/v1/vetting/revocations`). A grant is withdrawn like any endorsement,
+//! with `DELETE /v1/credentials/endorsements/{endorsementId}`.
+//!
+//! `bootstrap-pgp` seeds the first vetters from an existing OpenPGP web of
+//! trust; its graph and link logic is the pure [`wot`] and [`plan`] pair.
+//!
+//! The routes are REST-only and need a community-admin token, so every command
+//! mints a bearer token for the session's REST base (the same way `cnm backup`
+//! does) and fails with the fix when there is none. There are no retries here:
+//! a failed call is reported, not repeated.
+
+mod bootstrap;
+pub mod plan;
+#[cfg(test)]
+mod test_web;
+pub mod wot;
+
+use chrono::{DateTime, Utc};
+use clap::{Subcommand, ValueEnum};
+use ratatui::layout::Constraint;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Cell, Row, Table};
+use serde_json::{Value, json};
+use vta_cli_common::display::did_cell;
+use vta_cli_common::duration::{humanize_duration, parse_duration_secs};
+use vta_cli_common::render::{
+    BOLD, DIM, GREEN, RESET, YELLOW, bin_name, is_full_display, is_json_output, print_full_entry,
+    print_full_list_title, print_json, print_widget,
+};
+use vta_sdk::client::VtaClient;
+use vtc_client::join_requests::CommunityBranding;
+use vtc_client::vetting::{
+    AutoGrantConfig, AutoGrantStatus, GrantOrigin, MAX_AUTO_GRANT_SWEEP_MINUTES,
+    MAX_VETTER_GRANT_VALIDITY_SECONDS, MIN_AUTO_GRANT_SWEEP_MINUTES,
+    MIN_VETTER_GRANT_VALIDITY_SECONDS, VetterGrantRow,
+};
+use vtc_client::{VtcClient, VtcError};
+
+pub use bootstrap::BootstrapPgpArgs;
+
+use crate::auth;
+
+type CliResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+/// `cnm vetting …`
+#[derive(Subcommand)]
+pub enum VettingCommands {
+    /// Vetter grants: list them, name a member a vetter, withdraw a grant, or
+    /// deliver a grant credential again.
+    Vetters {
+        #[command(subcommand)]
+        command: VetterCommands,
+    },
+
+    /// Automatic vetter grants: the sweep that names vetters by the
+    /// `vetterEligibility` policy.
+    #[command(name = "auto-grant")]
+    AutoGrant {
+        #[command(subcommand)]
+        command: AutoGrantCommands,
+    },
+
+    /// How the community presents itself to an applicant's client
+    /// (`join-requests/manifest/0.2` branding).
+    Branding {
+        #[command(subcommand)]
+        command: BrandingCommands,
+    },
+
+    /// Vetting statement withdrawal notices, and the admissions each touches.
+    Revocations,
+
+    /// Seed vetters from an OpenPGP web of trust.
+    ///
+    /// Members link their OpenPGP key to their member DID with a clearsigned
+    /// statement (`openvtc-link: <memberDid>`). Every active member whose
+    /// linked key is within --max-depth certification hops of a root key, and
+    /// who holds no live grant, is named a vetter. Run with --dry-run first.
+    #[command(name = "bootstrap-pgp")]
+    BootstrapPgp(BootstrapPgpArgs),
+}
+
+/// `cnm vetting vetters …`
+#[derive(Subcommand)]
+pub enum VetterCommands {
+    /// Every vetter grant, newest first.
+    List,
+    /// Name a current member a vetter.
+    Grant {
+        /// The member's DID.
+        member_did: String,
+        /// How long the grant is valid: `N[s|m|h|d|w]`, one day to two years
+        /// (e.g. `180d`). The community's default of one year when absent.
+        #[arg(long)]
+        validity: Option<String>,
+    },
+    /// Withdraw a vetter grant. The vetter's statements stop counting and
+    /// their profile is deleted.
+    Revoke {
+        /// The grant's endorsement id, from `cnm vetting vetters list`.
+        endorsement_id: String,
+    },
+    /// Deliver a vetter's live grant credential again, when their wallet lost
+    /// it. Nothing new is issued.
+    Resend {
+        /// The vetter's member DID.
+        member_did: String,
+    },
+}
+
+/// `cnm vetting auto-grant …`
+#[derive(Subcommand)]
+pub enum AutoGrantCommands {
+    /// The configuration and the last sweep.
+    Show,
+    /// Change the configuration. Values not given keep their current setting.
+    Set {
+        /// Turn the sweep on (`true`) or off (`false`).
+        #[arg(long)]
+        enabled: Option<bool>,
+        /// Minutes between sweeps, 5–1440.
+        #[arg(long)]
+        sweep_minutes: Option<u32>,
+        /// Validity of a grant the sweep issues: `N[s|m|h|d|w]`, one day to
+        /// two years.
+        #[arg(long)]
+        validity: Option<String>,
+    },
+}
+
+/// `cnm vetting branding …`
+#[derive(Subcommand)]
+pub enum BrandingCommands {
+    /// The community's branding.
+    Show,
+    /// Change the branding. Values not given keep their current setting.
+    Set {
+        /// The name an applicant's client shows, 1–128 characters.
+        #[arg(long)]
+        display_name: Option<String>,
+        /// Accent colour, `#rrggbb`.
+        #[arg(long)]
+        accent_color: Option<String>,
+        /// Logo, an `https` URL of at most 2048 characters.
+        #[arg(long)]
+        logo_url: Option<String>,
+        /// Remove a value: `display-name`, `accent-color` or `logo-url`
+        /// (comma-separated or repeated).
+        #[arg(long, value_enum, value_delimiter = ',')]
+        clear: Vec<BrandingField>,
+    },
+}
+
+/// A branding member `--clear` can remove.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum BrandingField {
+    DisplayName,
+    AccentColor,
+    LogoUrl,
+}
+
+/// Run a `cnm vetting` command.
+pub async fn run(command: VettingCommands, client: &VtaClient, keyring_key: &str) -> CliResult {
+    if let VettingCommands::BootstrapPgp(args) = command {
+        // The keyring, roots and links are read and checked before any call to
+        // the community, so a mistake in them costs no round trip.
+        return bootstrap::run(args, client, keyring_key).await;
+    }
+    let vtc = connect(client, keyring_key).await?;
+    match command {
+        VettingCommands::Vetters { command } => match command {
+            VetterCommands::List => cmd_vetters_list(&vtc).await,
+            VetterCommands::Grant {
+                member_did,
+                validity,
+            } => cmd_vetters_grant(&vtc, &member_did, validity.as_deref()).await,
+            VetterCommands::Revoke { endorsement_id } => {
+                cmd_vetters_revoke(&vtc, &endorsement_id).await
+            }
+            VetterCommands::Resend { member_did } => cmd_vetters_resend(&vtc, &member_did).await,
+        },
+        VettingCommands::AutoGrant { command } => match command {
+            AutoGrantCommands::Show => cmd_auto_grant_show(&vtc).await,
+            AutoGrantCommands::Set {
+                enabled,
+                sweep_minutes,
+                validity,
+            } => cmd_auto_grant_set(&vtc, enabled, sweep_minutes, validity.as_deref()).await,
+        },
+        VettingCommands::Branding { command } => match command {
+            BrandingCommands::Show => cmd_branding_show(&vtc).await,
+            BrandingCommands::Set {
+                display_name,
+                accent_color,
+                logo_url,
+                clear,
+            } => {
+                let change = BrandingChange {
+                    display_name,
+                    accent_color,
+                    logo_url,
+                    clear,
+                };
+                cmd_branding_set(&vtc, change).await
+            }
+        },
+        VettingCommands::Revocations => cmd_revocations(&vtc).await,
+        VettingCommands::BootstrapPgp(_) => unreachable!("handled above"),
+    }
+}
+
+/// A community-admin [`VtcClient`] for the session's REST base.
+async fn connect(client: &VtaClient, keyring_key: &str) -> CliResult<VtcClient> {
+    let base = client.rest_url().ok_or_else(|| {
+        format!(
+            "`{bin} vetting` uses the community's admin REST API, and this session has no REST \
+             URL for it.\nPass the VTC's API base before the subcommand: \
+             `{bin} --url https://<vtc-host>/v1 vetting …`",
+            bin = bin_name()
+        )
+    })?;
+    let token = auth::ensure_authenticated(base, keyring_key).await?;
+    let vtc_did = auth::loaded_session(keyring_key)
+        .and_then(|s| s.vta_did)
+        .unwrap_or_default();
+    Ok(VtcClient::with_token(base, &vtc_did, token))
+}
+
+// ---------------------------------------------------------------------------
+// vetters
+// ---------------------------------------------------------------------------
+
+async fn cmd_vetters_list(vtc: &VtcClient) -> CliResult {
+    let list = vtc
+        .list_vetter_grants()
+        .await
+        .map_err(|e| guidance(e, Op::VettersList))?;
+    if is_json_output() {
+        print_json(&list.vetters)?;
+        return Ok(());
+    }
+    if list.vetters.is_empty() {
+        println!("No vetter grants.");
+        println!(
+            "  {DIM}Name a member a vetter with `{} vetting vetters grant <memberDid>`.{RESET}",
+            bin_name()
+        );
+        return Ok(());
+    }
+    let now = Utc::now();
+    if is_full_display() {
+        print_full_list_title("Vetter grants", list.vetters.len());
+        for row in &list.vetters {
+            print_full_entry(&[
+                ("Member", &row.member_did),
+                ("Status", grant_status(row, now)),
+                ("Origin", origin_label(row.origin)),
+                ("Valid from", &date(row.valid_from)),
+                ("Valid until", &row.valid_until.map_or("—".into(), date)),
+                ("Endorsement", &row.endorsement_id),
+                ("Credential", &row.credential_id),
+                ("Profile", &profile_label(row)),
+            ]);
+        }
+        return Ok(());
+    }
+
+    let header = Row::new(vec![
+        "Member",
+        "Status",
+        "Origin",
+        "Valid Until",
+        "Endorsement ID",
+        "Profile",
+    ])
+    .style(header_style())
+    .bottom_margin(1);
+    let rows: Vec<Row> = list
+        .vetters
+        .iter()
+        .map(|row| {
+            let status = grant_status(row, now);
+            let status_style = match status {
+                "live" => Style::default().fg(Color::Green),
+                "revoked" => Style::default().fg(Color::Red),
+                _ => Style::default().fg(Color::Yellow),
+            };
+            Row::new(vec![
+                did_cell(&row.member_did),
+                Cell::from(status).style(status_style),
+                Cell::from(origin_label(row.origin)),
+                Cell::from(row.valid_until.map_or("—".into(), date)),
+                Cell::from(row.endorsement_id.clone()),
+                Cell::from(profile_label(row)),
+            ])
+        })
+        .collect();
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Min(30),
+            Constraint::Length(12),
+            Constraint::Length(7),
+            Constraint::Length(11),
+            Constraint::Length(36),
+            Constraint::Min(20),
+        ],
+    )
+    .header(header)
+    .column_spacing(2)
+    .block(bordered(format!(
+        " Vetter grants ({}) ",
+        list.vetters.len()
+    )));
+    print_widget(table, height(list.vetters.len()));
+    println!(
+        "  {DIM}Withdraw a grant with `{bin} vetting vetters revoke <endorsementId>`; \
+         `{bin} --full-display vetting vetters list` shows every DID in full.{RESET}",
+        bin = bin_name()
+    );
+    Ok(())
+}
+
+async fn cmd_vetters_grant(vtc: &VtcClient, member_did: &str, validity: Option<&str>) -> CliResult {
+    let validity_seconds = validity
+        .map(|v| parse_grant_validity("--validity", v))
+        .transpose()?;
+    let result = vtc
+        .grant_vetter(member_did, validity_seconds)
+        .await
+        .map_err(|e| guidance(e, Op::Grant { member_did }))?;
+    let grant = &result.grant;
+    if is_json_output() {
+        let mut value = serde_json::to_value(grant)?;
+        value["created"] = json!(result.created);
+        print_json(&value)?;
+        return Ok(());
+    }
+    if result.created {
+        println!("{GREEN}✓{RESET} Named {member_did} a vetter.");
+    } else {
+        println!(
+            "{YELLOW}!{RESET} {member_did} already holds a live vetter grant — nothing new was \
+             issued."
+        );
+        if validity_seconds.is_some() {
+            println!(
+                "  {DIM}--validity applies to a new grant only. To change it, revoke this grant \
+                 and grant again.{RESET}"
+            );
+        }
+    }
+    println!("  Endorsement:  {}", grant.endorsement_id);
+    println!("  Credential:   {}", grant.credential_id);
+    println!(
+        "  Valid:        {} → {}",
+        date(grant.valid_from),
+        date(grant.valid_until)
+    );
+    println!(
+        "  {DIM}Withdraw it with `{} vetting vetters revoke {}`.{RESET}",
+        bin_name(),
+        grant.endorsement_id
+    );
+    Ok(())
+}
+
+async fn cmd_vetters_revoke(vtc: &VtcClient, endorsement_id: &str) -> CliResult {
+    let revoked = vtc
+        .revoke_endorsement(endorsement_id)
+        .await
+        .map_err(|e| guidance(e, Op::Revoke { endorsement_id }))?;
+    if is_json_output() {
+        print_json(&revoked)?;
+        return Ok(());
+    }
+    println!(
+        "{GREEN}✓{RESET} Revoked endorsement {} (credential {}) at {}.",
+        revoked.endorsement_id, revoked.revocation.credential_id, revoked.revocation.revoked_at
+    );
+    println!(
+        "  {DIM}A vetter whose grant is revoked no longer counts toward any join, and their \
+         profile is removed from listings.{RESET}"
+    );
+    Ok(())
+}
+
+async fn cmd_vetters_resend(vtc: &VtcClient, member_did: &str) -> CliResult {
+    let sent = vtc
+        .resend_vetter_grant(member_did)
+        .await
+        .map_err(|e| guidance(e, Op::Resend { member_did }))?;
+    if is_json_output() {
+        print_json(&sent)?;
+        return Ok(());
+    }
+    // R1.1: a send the transport accepted is not a delivery, so do not say
+    // "delivered".
+    println!(
+        "{GREEN}✓{RESET} Handed credential {} to the community's messaging transport for \
+         {member_did}.",
+        sent.credential_id
+    );
+    println!("  Valid until:  {}", date(sent.valid_until));
+    println!(
+        "  {DIM}Delivery is not confirmed by the member's wallet; ask the vetter to check it.{RESET}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// auto-grant
+// ---------------------------------------------------------------------------
+
+async fn cmd_auto_grant_show(vtc: &VtcClient) -> CliResult {
+    let status = vtc
+        .auto_grant()
+        .await
+        .map_err(|e| guidance(e, Op::AutoGrantShow))?;
+    print_auto_grant(&status)
+}
+
+async fn cmd_auto_grant_set(
+    vtc: &VtcClient,
+    enabled: Option<bool>,
+    sweep_minutes: Option<u32>,
+    validity: Option<&str>,
+) -> CliResult {
+    if enabled.is_none() && sweep_minutes.is_none() && validity.is_none() {
+        return Err(format!(
+            "nothing to change. Pass at least one of --enabled <true|false>, --sweep-minutes \
+             <{MIN_AUTO_GRANT_SWEEP_MINUTES}–{MAX_AUTO_GRANT_SWEEP_MINUTES}> or --validity \
+             <duration>.\nSee the current configuration with `{} vetting auto-grant show`.",
+            bin_name()
+        )
+        .into());
+    }
+    let validity_seconds = validity
+        .map(|v| parse_grant_validity("--validity", v))
+        .transpose()?;
+    if let Some(m) = sweep_minutes
+        && !(MIN_AUTO_GRANT_SWEEP_MINUTES..=MAX_AUTO_GRANT_SWEEP_MINUTES).contains(&m)
+    {
+        return Err(format!(
+            "--sweep-minutes {m} is out of range: the sweep runs every \
+             {MIN_AUTO_GRANT_SWEEP_MINUTES} to {MAX_AUTO_GRANT_SWEEP_MINUTES} minutes (a day). \
+             Try `--sweep-minutes 60`."
+        )
+        .into());
+    }
+    // PUT replaces the whole configuration and an absent member takes its
+    // default, so start from what is stored: `--sweep-minutes 30` alone must
+    // not quietly switch the sweep off.
+    let current = vtc
+        .auto_grant()
+        .await
+        .map_err(|e| guidance(e, Op::AutoGrantShow))?;
+    let config = merged_auto_grant(&current, enabled, sweep_minutes, validity_seconds);
+    config
+        .check_shape()
+        .map_err(|e| format!("the automatic-grant configuration is out of bounds: {e}"))?;
+    let stored = vtc
+        .configure_auto_grant(&config)
+        .await
+        .map_err(|e| guidance(e, Op::AutoGrantSet))?;
+    if !is_json_output() {
+        println!("{GREEN}✓{RESET} Automatic vetter grants updated.");
+    }
+    print_auto_grant(&stored)
+}
+
+fn merged_auto_grant(
+    current: &AutoGrantStatus,
+    enabled: Option<bool>,
+    sweep_minutes: Option<u32>,
+    validity_seconds: Option<u64>,
+) -> AutoGrantConfig {
+    AutoGrantConfig {
+        enabled: enabled.unwrap_or(current.enabled),
+        sweep_minutes: Some(sweep_minutes.unwrap_or(current.sweep_minutes)),
+        validity_seconds: Some(validity_seconds.unwrap_or(current.validity_seconds)),
+    }
+}
+
+fn print_auto_grant(status: &AutoGrantStatus) -> CliResult {
+    if is_json_output() {
+        print_json(status)?;
+        return Ok(());
+    }
+    let enabled = if status.enabled {
+        format!("{GREEN}on{RESET}")
+    } else {
+        format!("{YELLOW}off{RESET}")
+    };
+    println!("  Enabled:        {enabled}");
+    println!("  Sweep every:    {} minutes", status.sweep_minutes);
+    println!(
+        "  Grant validity: {}",
+        humanize_duration(status.validity_seconds)
+    );
+    match &status.last_sweep {
+        Some(sweep) => println!(
+            "  Last sweep:     {} — {} granted, {} revoked, {} errors",
+            sweep.ran_at.to_rfc3339(),
+            sweep.granted,
+            sweep.revoked,
+            sweep.errors
+        ),
+        None => println!("  Last sweep:     {DIM}none yet{RESET}"),
+    }
+    if !status.enabled {
+        println!(
+            "  {DIM}Turn it on with `{} vetting auto-grant set --enabled true`. Which members it \
+             names is the `vetterEligibility` policy's decision.{RESET}",
+            bin_name()
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// branding
+// ---------------------------------------------------------------------------
+
+async fn cmd_branding_show(vtc: &VtcClient) -> CliResult {
+    let branding = vtc
+        .branding()
+        .await
+        .map_err(|e| guidance(e, Op::BrandingShow))?;
+    print_branding(&branding)
+}
+
+/// The `branding set` flags.
+#[derive(Debug, Default)]
+struct BrandingChange {
+    display_name: Option<String>,
+    accent_color: Option<String>,
+    logo_url: Option<String>,
+    clear: Vec<BrandingField>,
+}
+
+async fn cmd_branding_set(vtc: &VtcClient, change: BrandingChange) -> CliResult {
+    if change.display_name.is_none()
+        && change.accent_color.is_none()
+        && change.logo_url.is_none()
+        && change.clear.is_empty()
+    {
+        return Err(format!(
+            "nothing to change. Pass --display-name, --accent-color, --logo-url or --clear \
+             <field>.\nSee the current branding with `{} vetting branding show`.",
+            bin_name()
+        )
+        .into());
+    }
+    let current = vtc
+        .branding()
+        .await
+        .map_err(|e| guidance(e, Op::BrandingShow))?;
+    let branding = merged_branding(current, change)?;
+    branding.check_shape().map_err(|e| {
+        format!(
+            "the branding is out of bounds: {e}.\nA display name is 1–128 characters, an accent \
+             colour `#rrggbb`, and a logo an https URL of at most 2048 characters."
+        )
+    })?;
+    let stored = vtc
+        .set_branding(&branding)
+        .await
+        .map_err(|e| guidance(e, Op::BrandingSet))?;
+    if !is_json_output() {
+        println!("{GREEN}✓{RESET} Branding updated.");
+    }
+    print_branding(&stored)
+}
+
+/// Apply `change` over `current`. PUT replaces the whole branding, so a value
+/// the operator did not mention is carried over rather than cleared.
+fn merged_branding(
+    mut current: CommunityBranding,
+    change: BrandingChange,
+) -> CliResult<CommunityBranding> {
+    for field in &change.clear {
+        let set = match field {
+            BrandingField::DisplayName => change.display_name.is_some(),
+            BrandingField::AccentColor => change.accent_color.is_some(),
+            BrandingField::LogoUrl => change.logo_url.is_some(),
+        };
+        if set {
+            return Err(format!(
+                "--clear {} and a new value for it were both given; pass one or the other",
+                field
+                    .to_possible_value()
+                    .map(|v| v.get_name().to_string())
+                    .unwrap_or_default()
+            )
+            .into());
+        }
+        match field {
+            BrandingField::DisplayName => current.display_name = None,
+            BrandingField::AccentColor => current.accent_color = None,
+            BrandingField::LogoUrl => current.logo_url = None,
+        }
+    }
+    if change.display_name.is_some() {
+        current.display_name = change.display_name;
+    }
+    if change.accent_color.is_some() {
+        current.accent_color = change.accent_color;
+    }
+    if change.logo_url.is_some() {
+        current.logo_url = change.logo_url;
+    }
+    Ok(current)
+}
+
+fn print_branding(branding: &CommunityBranding) -> CliResult {
+    if is_json_output() {
+        print_json(branding)?;
+        return Ok(());
+    }
+    let unset = format!("{DIM}(not set){RESET}");
+    let show = |v: &Option<String>| v.clone().unwrap_or_else(|| unset.clone());
+    println!("  Display name:  {}", show(&branding.display_name));
+    println!("  Accent colour: {}", show(&branding.accent_color));
+    println!("  Logo URL:      {}", show(&branding.logo_url));
+    if branding.display_name.is_none()
+        && branding.accent_color.is_none()
+        && branding.logo_url.is_none()
+    {
+        println!(
+            "  {DIM}No branding is published on the join manifest. Set it with `{} vetting \
+             branding set --display-name …`.{RESET}",
+            bin_name()
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// revocations
+// ---------------------------------------------------------------------------
+
+async fn cmd_revocations(vtc: &VtcClient) -> CliResult {
+    let notices = vtc
+        .vetting_revocations()
+        .await
+        .map_err(|e| guidance(e, Op::Revocations))?;
+    if is_json_output() {
+        print_json(&notices)?;
+        return Ok(());
+    }
+    if notices.is_empty() {
+        println!("No vetting statement has been withdrawn.");
+        return Ok(());
+    }
+    if is_full_display() {
+        print_full_list_title("Statement withdrawals", notices.len());
+        for n in &notices {
+            print_full_entry(&[
+                ("Recorded", &n.recorded_at.to_rfc3339()),
+                ("Vetter", &n.issuer),
+                ("Statement", &n.statement_id),
+                ("Digest", &n.statement_digest_multibase),
+                ("Reason", n.reason.as_deref().unwrap_or("—")),
+                ("Review", &n.review_state),
+                ("Members", &join_or_dash(&n.affected_members)),
+                ("Join requests", &join_or_dash(&n.affected_join_requests)),
+            ]);
+        }
+        return Ok(());
+    }
+    let header = Row::new(vec![
+        "Recorded",
+        "Vetter",
+        "Statement",
+        "Reason",
+        "Review",
+        "Affected Members",
+    ])
+    .style(header_style())
+    .bottom_margin(1);
+    let rows: Vec<Row> = notices
+        .iter()
+        .map(|n| {
+            let review = if n.review_state == "needsReview" {
+                Cell::from("needs review").style(Style::default().fg(Color::Yellow))
+            } else {
+                Cell::from("no admission")
+            };
+            Row::new(vec![
+                Cell::from(date(n.recorded_at)),
+                did_cell(&n.issuer),
+                Cell::from(n.statement_id.clone()),
+                Cell::from(n.reason.clone().unwrap_or_else(|| "—".into())),
+                review,
+                Cell::from(n.affected_members.len().to_string()),
+            ])
+        })
+        .collect();
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(11),
+            Constraint::Min(30),
+            Constraint::Min(30),
+            Constraint::Length(15),
+            Constraint::Length(13),
+            Constraint::Length(16),
+        ],
+    )
+    .header(header)
+    .column_spacing(2)
+    .block(bordered(format!(
+        " Statement withdrawals ({}) ",
+        notices.len()
+    )));
+    print_widget(table, height(notices.len()));
+    let pending = notices
+        .iter()
+        .filter(|n| n.review_state == "needsReview")
+        .count();
+    if pending > 0 {
+        println!(
+            "  {BOLD}{pending}{RESET} {DIM}withdrawal(s) touch a current membership. \
+             `{} --full-display vetting revocations` names the members and join requests; the \
+             vetting facts a request was decided on are at `GET /v1/join-requests/<id>/vetting`.{RESET}",
+            bin_name()
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Errors that say what to do
+// ---------------------------------------------------------------------------
+
+/// Which call failed, so a status can be read as the operator's situation.
+#[derive(Debug, Clone, Copy)]
+enum Op<'a> {
+    VettersList,
+    Grant { member_did: &'a str },
+    Revoke { endorsement_id: &'a str },
+    Resend { member_did: &'a str },
+    AutoGrantShow,
+    AutoGrantSet,
+    BrandingShow,
+    BrandingSet,
+    Revocations,
+    Members,
+}
+
+impl Op<'_> {
+    /// The route, for a 404 that means the VTC does not serve it at all.
+    fn route(&self) -> &'static str {
+        match self {
+            Self::VettersList | Self::Grant { .. } => "/v1/vetting/vetters",
+            Self::Revoke { .. } => "/v1/credentials/endorsements/{id}",
+            Self::Resend { .. } => "/v1/vetting/vetters/{memberDid}/resend",
+            Self::AutoGrantShow | Self::AutoGrantSet => "/v1/vetting/auto-grant",
+            Self::BrandingShow | Self::BrandingSet => "/v1/community/branding",
+            Self::Revocations => "/v1/vetting/revocations",
+            Self::Members => "/v1/members",
+        }
+    }
+}
+
+/// Turn a client error into an operator error that names the fix.
+fn guidance(err: VtcError, op: Op<'_>) -> Box<dyn std::error::Error> {
+    let bin = bin_name();
+    let message = match err {
+        VtcError::Http { status: 401, .. } => format!(
+            "the VTC refused this session's token (401).\nRe-authenticate with `{bin} auth login \
+             --credential-bundle <bundle>`, or run `{bin} setup` again."
+        ),
+        VtcError::Http { status: 403, .. } => format!(
+            "this identity is not a community admin (403); vetting administration is admin-only.\n\
+             Check the session's DID with `{bin} auth status`, and ask an existing admin to grant \
+             it the admin role."
+        ),
+        VtcError::Http { status, body } => {
+            let detail = human_message(&body);
+            match (op, status) {
+                (Op::Grant { member_did }, 400) => format!(
+                    "the community refused to name {member_did} a vetter: {detail}\n\
+                     Only a current member can be a vetter. Check the DID is the member's DID \
+                     (not their PGP key or email), and if they have applied, approve their join \
+                     request first; then re-run `{bin} vetting vetters grant {member_did}`."
+                ),
+                (Op::Revoke { endorsement_id }, 404) => format!(
+                    "there is no endorsement {endorsement_id}.\nList the vetter grants with \
+                     `{bin} vetting vetters list` and pass the Endorsement ID column (not the \
+                     member DID or credential id)."
+                ),
+                (Op::Revoke { endorsement_id }, 400) => format!(
+                    "`{endorsement_id}` is not an endorsement id: {detail}\nEndorsement ids are \
+                     UUIDs; copy one from `{bin} vetting vetters list`."
+                ),
+                (Op::Resend { member_did }, 404) => format!(
+                    "{member_did} holds no live vetter grant whose credential the community \
+                     kept, so there is nothing to resend.\nGrant one with `{bin} vetting vetters \
+                     grant {member_did}`. A grant recorded before credentials were kept cannot \
+                     be resent: revoke it (`{bin} vetting vetters revoke <endorsementId>`) and \
+                     grant again."
+                ),
+                (Op::Resend { member_did }, 503) => format!(
+                    "the community could not hand the credential to its messaging transport \
+                     ({detail}).\nThe grant still stands. Check the VTC's mediator is configured \
+                     and reachable (`{bin} health`), then re-run `{bin} vetting vetters resend \
+                     {member_did}`."
+                ),
+                (Op::AutoGrantSet, 400) => format!(
+                    "the community refused the automatic-grant configuration: {detail}\n\
+                     --sweep-minutes is {MIN_AUTO_GRANT_SWEEP_MINUTES}–{MAX_AUTO_GRANT_SWEEP_MINUTES} \
+                     and --validity one day to two years."
+                ),
+                (Op::AutoGrantSet, 503) => format!(
+                    "the community refused to change automatic grants because its audit log is \
+                     not configured ({detail}). Configure the VTC's audit writer and retry."
+                ),
+                (Op::BrandingSet, 400) => format!(
+                    "the community refused the branding: {detail}\nA display name is 1–128 \
+                     characters, an accent colour `#rrggbb`, and a logo an https URL of at most \
+                     2048 characters."
+                ),
+                (_, 404) => format!(
+                    "the VTC does not serve {} (404) — it predates the vetter registry.\nUpgrade \
+                     the VTC to a release with peer identity vetting.",
+                    op.route()
+                ),
+                (_, _) => format!("the VTC answered HTTP {status}: {detail}"),
+            }
+        }
+        VtcError::Transport(e) => format!(
+            "could not reach the VTC: {e}.\nCheck the community is up and its URL resolves with \
+             `{bin} health`."
+        ),
+        VtcError::NotAuthenticated => {
+            format!(
+                "no session token for the VTC. Run `{bin} auth login --credential-bundle <bundle>`."
+            )
+        }
+        other => other.to_string(),
+    };
+    message.into()
+}
+
+/// The `message` or `error` of a JSON error body, else the body itself.
+fn human_message(body: &str) -> String {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|v| {
+            ["message", "error", "detail"]
+                .iter()
+                .find_map(|k| v.get(*k).and_then(Value::as_str).map(str::to_string))
+        })
+        .unwrap_or_else(|| {
+            if body.is_empty() {
+                "no detail".into()
+            } else {
+                body.to_string()
+            }
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a grant validity flag and check it against the grant bounds.
+fn parse_grant_validity(flag: &str, value: &str) -> CliResult<u64> {
+    let secs = parse_duration_secs(value)
+        .map_err(|e| format!("{flag} {value}: {e}. Use N[s|m|h|d|w], e.g. `{flag} 365d`"))?;
+    if !(MIN_VETTER_GRANT_VALIDITY_SECONDS..=MAX_VETTER_GRANT_VALIDITY_SECONDS).contains(&secs) {
+        return Err(format!(
+            "{flag} {value} is {}; a vetter grant is valid for one day to two years. Try `{flag} \
+             365d`.",
+            humanize_duration(secs)
+        )
+        .into());
+    }
+    Ok(secs)
+}
+
+fn grant_status(row: &VetterGrantRow, now: DateTime<Utc>) -> &'static str {
+    if row.revoked {
+        "revoked"
+    } else if row.live {
+        "live"
+    } else if row.valid_until.is_some_and(|u| u <= now) {
+        "expired"
+    } else {
+        "not member"
+    }
+}
+
+fn origin_label(origin: GrantOrigin) -> &'static str {
+    match origin {
+        GrantOrigin::Auto => "auto",
+        GrantOrigin::Manual => "manual",
+    }
+}
+
+fn profile_label(row: &VetterGrantRow) -> String {
+    let Some(p) = &row.profile else {
+        return "—".into();
+    };
+    let mut parts = vec![if p.listed { "listed" } else { "unlisted" }.to_string()];
+    if let Some(name) = &p.display_name {
+        parts.push(name.clone());
+    }
+    if let Some(country) = &p.country {
+        parts.push(country.clone());
+    }
+    if p.event_count > 0 {
+        parts.push(format!("{} events", p.event_count));
+    }
+    parts.join(" · ")
+}
+
+fn date(at: DateTime<Utc>) -> String {
+    at.format("%Y-%m-%d").to_string()
+}
+
+fn join_or_dash(items: &[String]) -> String {
+    if items.is_empty() {
+        "—".into()
+    } else {
+        items.join(", ")
+    }
+}
+
+fn header_style() -> Style {
+    Style::default()
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD)
+}
+
+fn bordered(title: String) -> Block<'static> {
+    Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(Color::DarkGray))
+}
+
+fn height(rows: usize) -> u16 {
+    u16::try_from(rows).unwrap_or(u16::MAX - 4) + 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grant_validity_is_bounded_with_a_suggestion() {
+        assert_eq!(
+            parse_grant_validity("--validity", "365d").unwrap(),
+            31_536_000
+        );
+        let err = parse_grant_validity("--validity", "3h")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("one day to two years") && err.contains("365d"),
+            "{err}"
+        );
+        let err = parse_grant_validity("--validity", "3y")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("N[s|m|h|d|w]"), "{err}");
+    }
+
+    #[test]
+    fn auto_grant_set_keeps_what_it_was_not_told_to_change() {
+        let current = AutoGrantStatus {
+            enabled: true,
+            sweep_minutes: 60,
+            validity_seconds: 31_536_000,
+            last_sweep: None,
+        };
+        let config = merged_auto_grant(&current, None, Some(30), None);
+        assert!(
+            config.enabled,
+            "--sweep-minutes alone must not turn the sweep off"
+        );
+        assert_eq!(config.sweep_minutes, Some(30));
+        assert_eq!(config.validity_seconds, Some(31_536_000));
+        let off = merged_auto_grant(&current, Some(false), None, None);
+        assert!(!off.enabled);
+        assert_eq!(off.sweep_minutes, Some(60));
+    }
+
+    #[test]
+    fn branding_set_merges_clears_and_refuses_a_contradiction() {
+        let current = CommunityBranding {
+            display_name: Some("Linux Kernel".into()),
+            accent_color: Some("#1a2b3c".into()),
+            logo_url: Some("https://kernel.example/logo.svg".into()),
+            ext: None,
+        };
+        let merged = merged_branding(
+            current.clone(),
+            BrandingChange {
+                accent_color: Some("#000000".into()),
+                clear: vec![BrandingField::LogoUrl],
+                ..BrandingChange::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(merged.display_name.as_deref(), Some("Linux Kernel"));
+        assert_eq!(merged.accent_color.as_deref(), Some("#000000"));
+        assert!(merged.logo_url.is_none());
+
+        let err = merged_branding(
+            current,
+            BrandingChange {
+                logo_url: Some("https://x.example/l.svg".into()),
+                clear: vec![BrandingField::LogoUrl],
+                ..BrandingChange::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--clear logo-url"), "{err}");
+    }
+
+    #[test]
+    fn errors_name_the_command_that_fixes_them() {
+        let revoke = guidance(
+            VtcError::Http {
+                status: 404,
+                body: r#"{"error":"not found"}"#.into(),
+            },
+            Op::Revoke {
+                endorsement_id: "did:key:zWrong",
+            },
+        )
+        .to_string();
+        assert!(revoke.contains("vetting vetters list"), "{revoke}");
+
+        let resend = guidance(
+            VtcError::Http {
+                status: 404,
+                body: String::new(),
+            },
+            Op::Resend {
+                member_did: "did:key:zCarol",
+            },
+        )
+        .to_string();
+        assert!(
+            resend.contains("vetting vetters grant did:key:zCarol"),
+            "{resend}"
+        );
+
+        let grant = guidance(
+            VtcError::Http {
+                status: 400,
+                body: r#"{"message":"did:key:zX is not a current member"}"#.into(),
+            },
+            Op::Grant {
+                member_did: "did:key:zX",
+            },
+        )
+        .to_string();
+        assert!(
+            grant.contains("is not a current member") && grant.contains("approve their join"),
+            "{grant}"
+        );
+
+        let old_vtc = guidance(
+            VtcError::Http {
+                status: 404,
+                body: String::new(),
+            },
+            Op::AutoGrantShow,
+        )
+        .to_string();
+        assert!(old_vtc.contains("/v1/vetting/auto-grant") && old_vtc.contains("Upgrade"));
+    }
+}

--- a/cnm-cli/src/vetting/plan.rs
+++ b/cnm-cli/src/vetting/plan.rs
@@ -1,0 +1,244 @@
+//! What `cnm vetting bootstrap-pgp` does for each link statement.
+//!
+//! Pure: it combines the verified links, the web of trust's distances and the
+//! community's roster (active members and live vetter grants) into one row per
+//! statement. The command renders the rows for `--dry-run` and grants the
+//! `grant` rows otherwise; nothing here talks to the community.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use super::wot::{Keyring, LinkCheck, Reach};
+
+/// What the bootstrap does, or would do, for one link.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "action", rename_all = "camelCase")]
+pub enum Action {
+    /// A member within `--max-depth` with no live grant: grant them.
+    Grant,
+    /// The member already holds a live vetter grant.
+    #[serde(rename_all = "camelCase")]
+    AlreadyGranted { endorsement_id: String },
+    /// The linked key is unreachable from the roots, or further than
+    /// `--max-depth`.
+    TooFar { reason: String },
+    /// The DID is not an active member of the community.
+    NotAMember,
+    /// The link statement is not trusted.
+    InvalidLink { reason: String },
+}
+
+/// One link statement and what the bootstrap does about it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanRow {
+    /// The link file.
+    pub source: String,
+    /// The DID the statement links, when it could be read.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member_did: Option<String>,
+    /// The linked key's primary fingerprint, when a signature identified it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+    /// The key's primary user ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_user_id: Option<String>,
+    /// Certification hops from the nearest root; absent when unreachable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depth: Option<u32>,
+    /// Fingerprints from a root to the key, both ends included.
+    pub path: Vec<String>,
+    /// What happens.
+    #[serde(flatten)]
+    pub action: Action,
+}
+
+/// What the community knows that the web of trust does not.
+#[derive(Debug, Clone, Copy)]
+pub struct Roster<'a> {
+    /// DIDs of the community's active members.
+    pub members: &'a BTreeSet<String>,
+    /// Member DID → endorsement id of their live vetter grant.
+    pub live_grants: &'a BTreeMap<String, String>,
+}
+
+/// One row per link statement, sorted by member DID then file.
+///
+/// The action is the first that applies, in this order: an untrusted link; a
+/// DID that is not a member (nothing can be granted to a non-member however
+/// well their key is certified); a key unreachable or beyond `max_depth`; a
+/// live grant already held; otherwise `grant`. The same key linking the same
+/// DID in two files is one row.
+pub fn plan(
+    checks: &[LinkCheck],
+    keyring: &Keyring,
+    reach: &BTreeMap<String, Reach>,
+    roster: Roster<'_>,
+    max_depth: u32,
+) -> Vec<PlanRow> {
+    let mut seen: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut ordered: Vec<&LinkCheck> = checks.iter().collect();
+    ordered.sort_by(|a, b| a.source.cmp(&b.source));
+
+    let mut rows = Vec::new();
+    for check in ordered {
+        if check.problem.is_none()
+            && let (Some(did), Some(fp)) = (&check.member_did, &check.fingerprint)
+            && !seen.insert((did.clone(), fp.clone()))
+        {
+            continue;
+        }
+        let key_reach = check.fingerprint.as_ref().and_then(|fp| reach.get(fp));
+        let action = match (&check.problem, &check.member_did) {
+            (Some(problem), _) => Action::InvalidLink {
+                reason: problem.to_string(),
+            },
+            (None, None) => Action::InvalidLink {
+                reason: "no DID".into(),
+            },
+            (None, Some(did)) if !roster.members.contains(did) => Action::NotAMember,
+            (None, Some(did)) => match key_reach {
+                None => Action::TooFar {
+                    reason: "not reachable from any root".into(),
+                },
+                Some(r) if r.depth > max_depth => Action::TooFar {
+                    reason: format!("depth {} exceeds --max-depth {max_depth}", r.depth),
+                },
+                Some(_) => match roster.live_grants.get(did) {
+                    Some(endorsement_id) => Action::AlreadyGranted {
+                        endorsement_id: endorsement_id.clone(),
+                    },
+                    None => Action::Grant,
+                },
+            },
+        };
+        rows.push(PlanRow {
+            source: check.source.clone(),
+            member_did: check.member_did.clone(),
+            fingerprint: check.fingerprint.clone(),
+            primary_user_id: check
+                .fingerprint
+                .as_ref()
+                .and_then(|fp| keyring.get(fp))
+                .and_then(|k| k.primary_user_id.clone()),
+            depth: key_reach.map(|r| r.depth),
+            path: key_reach.map(|r| r.path.clone()).unwrap_or_default(),
+            action,
+        });
+    }
+    rows.sort_by(|a, b| (&a.member_did, &a.source).cmp(&(&b.member_did, &b.source)));
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vetting::test_web::{DAY, link_text, now};
+    use crate::vetting::wot::tests::Web;
+    use crate::vetting::wot::{check_link, mark_ambiguous, shortest_paths};
+
+    /// Links for the web in `wot::tests`, against a community where alice,
+    /// bob, carol and erin are members and bob already vets. Max depth 2.
+    #[test]
+    fn members_within_depth_are_granted_and_everyone_else_is_explained() {
+        let web = Web::new();
+        let ring = web.keyring();
+        let t = now();
+        let roots = ring.resolve_roots(&[web.root.fingerprint()]).unwrap();
+        let (edges, _) = ring.certifications(t);
+        let reach = shortest_paths(&edges, &roots);
+
+        let signed = |p: &crate::vetting::test_web::Person, did: &str| {
+            p.clearsign(&link_text(did), t - DAY, false)
+        };
+        let tampered = signed(&web.bob, "did:key:zBob").replace("zBob", "zBobby");
+        let mut checks = vec![
+            check_link(&ring, "alice.asc", &signed(&web.alice, "did:key:zAlice"), t),
+            check_link(
+                &ring,
+                "alice-copy.asc",
+                &signed(&web.alice, "did:key:zAlice"),
+                t,
+            ),
+            check_link(&ring, "bob.asc", &signed(&web.bob, "did:key:zBob"), t),
+            check_link(&ring, "carol.asc", &signed(&web.carol, "did:key:zCarol"), t),
+            check_link(&ring, "dave.asc", &signed(&web.dave, "did:key:zDave"), t),
+            check_link(&ring, "erin.asc", &signed(&web.erin, "did:key:zErin"), t),
+            check_link(&ring, "mallory.asc", &tampered, t),
+        ];
+        mark_ambiguous(&mut checks);
+
+        let members: BTreeSet<String> = [
+            "did:key:zAlice",
+            "did:key:zBob",
+            "did:key:zCarol",
+            "did:key:zErin",
+        ]
+        .map(String::from)
+        .into();
+        let live_grants = BTreeMap::from([("did:key:zBob".to_string(), "e-bob".to_string())]);
+        let rows = plan(
+            &checks,
+            &ring,
+            &reach,
+            Roster {
+                members: &members,
+                live_grants: &live_grants,
+            },
+            2,
+        );
+
+        let by_did = |did: &str| {
+            rows.iter()
+                .filter(|r| r.member_did.as_deref() == Some(did))
+                .collect::<Vec<_>>()
+        };
+        let alice = by_did("did:key:zAlice");
+        assert_eq!(alice.len(), 1, "a repeated link is one row");
+        assert_eq!(alice[0].action, Action::Grant);
+        assert_eq!(alice[0].depth, Some(1));
+        assert_eq!(
+            alice[0].path,
+            vec![web.root.fingerprint(), web.alice.fingerprint()]
+        );
+        assert_eq!(
+            alice[0].primary_user_id.as_deref(),
+            Some("Alice <alice@kernel.example>")
+        );
+
+        assert_eq!(
+            by_did("did:key:zBob")[0].action,
+            Action::AlreadyGranted {
+                endorsement_id: "e-bob".into()
+            }
+        );
+        assert_eq!(
+            by_did("did:key:zCarol")[0].action,
+            Action::TooFar {
+                reason: "depth 3 exceeds --max-depth 2".into()
+            }
+        );
+        assert_eq!(by_did("did:key:zDave")[0].action, Action::NotAMember);
+        assert_eq!(
+            by_did("did:key:zErin")[0].action,
+            Action::TooFar {
+                reason: "not reachable from any root".into()
+            },
+            "erin's only certification expired"
+        );
+        assert!(matches!(
+            by_did("did:key:zBobby")[0].action,
+            Action::InvalidLink { .. }
+        ));
+
+        // The JSON an automation reads.
+        let json = serde_json::to_value(alice[0]).unwrap();
+        assert_eq!(json["action"], "grant");
+        assert_eq!(json["memberDid"], "did:key:zAlice");
+        assert_eq!(json["depth"], 1);
+        let bob = serde_json::to_value(by_did("did:key:zBob")[0]).unwrap();
+        assert_eq!(bob["action"], "alreadyGranted");
+        assert_eq!(bob["endorsementId"], "e-bob");
+    }
+}

--- a/cnm-cli/src/vetting/test_web.rs
+++ b/cnm-cli/src/vetting/test_web.rs
@@ -1,0 +1,202 @@
+//! A small, generated PGP web of trust for the bootstrap tests.
+//!
+//! Every key is an Ed25519 key generated from a fixed seed; every certification,
+//! revocation and link signature is made here with rPGP, the same crate that
+//! verifies them. Times are relative to the real clock, captured once per test
+//! as [`now`], because rPGP stamps a new key's self-signatures with the real
+//! time.
+
+use pgp::composed::{
+    ArmorOptions, CleartextSignedMessage, KeyType, SecretKeyParamsBuilder, SignedPublicKey,
+    SignedSecretKey, SubkeyParamsBuilder,
+};
+use pgp::crypto::hash::HashAlgorithm;
+use pgp::packet::{SignatureConfig, SignatureType, Subpacket, SubpacketData};
+use pgp::ser::Serialize as _;
+use pgp::types::{Duration, KeyDetails, Password, Tag, Timestamp};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+pub const DAY: u64 = 86_400;
+
+/// The test's clock, in Unix seconds.
+pub fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after 1970")
+        .as_secs()
+}
+
+fn ts(secs: u64) -> Timestamp {
+    Timestamp::from_secs(u32::try_from(secs).expect("timestamp fits u32"))
+}
+
+/// One kernel developer's key.
+pub struct Person {
+    pub secret: SignedSecretKey,
+    pub public: SignedPublicKey,
+}
+
+impl Person {
+    /// A key with one user ID and one signing subkey, created 400 days ago.
+    pub fn new(seed: u64, name: &str) -> Self {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let created = ts(now() - 400 * DAY);
+        let subkey = SubkeyParamsBuilder::default()
+            .key_type(KeyType::Ed25519Legacy)
+            .can_sign(true)
+            .created_at(created)
+            .build()
+            .expect("subkey params");
+        let mut params = SecretKeyParamsBuilder::default();
+        params
+            .key_type(KeyType::Ed25519Legacy)
+            .can_certify(true)
+            .can_sign(true)
+            .created_at(created)
+            .primary_user_id(format!("{name} <{}@kernel.example>", name.to_lowercase()))
+            .subkeys(vec![subkey]);
+        let secret = params
+            .build()
+            .expect("key params")
+            .generate(&mut rng)
+            .expect("generate key");
+        let public = secret.to_public_key();
+        Self { secret, public }
+    }
+
+    pub fn fingerprint(&self) -> String {
+        format!("{:X}", self.public.primary_key.fingerprint())
+    }
+
+    fn config(
+        &self,
+        typ: SignatureType,
+        created: u64,
+        expires_after: Option<u64>,
+    ) -> SignatureConfig {
+        let key = &self.secret.primary_key;
+        let mut config = SignatureConfig::v4(typ, key.algorithm(), HashAlgorithm::Sha256);
+        config.hashed_subpackets = vec![
+            Subpacket::regular(SubpacketData::SignatureCreationTime(ts(created))).unwrap(),
+            Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint())).unwrap(),
+        ];
+        if let Some(after) = expires_after {
+            config.hashed_subpackets.push(
+                Subpacket::regular(SubpacketData::SignatureExpirationTime(Duration::from_secs(
+                    u32::try_from(after).unwrap(),
+                )))
+                .unwrap(),
+            );
+        }
+        config.unhashed_subpackets =
+            vec![Subpacket::regular(SubpacketData::IssuerKeyId(key.legacy_key_id())).unwrap()];
+        config
+    }
+
+    /// A certification by `self` over `other`'s first user ID, made at
+    /// `created`, expiring `expires_after` seconds later when given.
+    pub fn certification_of(
+        &self,
+        other: &Person,
+        created: u64,
+        expires_after: Option<u64>,
+    ) -> pgp::packet::Signature {
+        self.config(SignatureType::CertGeneric, created, expires_after)
+            .sign_certification_third_party(
+                &self.secret.primary_key,
+                &Password::empty(),
+                &other.public.primary_key,
+                Tag::UserId,
+                &other.public.details.users[0].id,
+            )
+            .expect("certify")
+    }
+
+    /// `self` certifies `other`, and `other`'s public key carries it.
+    pub fn certify(&self, other: &mut Person, created: u64, expires_after: Option<u64>) {
+        let sig = self.certification_of(other, created, expires_after);
+        other.public.details.users[0].signatures.push(sig);
+    }
+
+    /// `self` revokes its certification of `other`.
+    pub fn revoke_certification(&self, other: &mut Person, created: u64) {
+        let sig = self
+            .config(SignatureType::CertRevocation, created, None)
+            .sign_certification_third_party(
+                &self.secret.primary_key,
+                &Password::empty(),
+                &other.public.primary_key,
+                Tag::UserId,
+                &other.public.details.users[0].id,
+            )
+            .expect("revoke certification");
+        other.public.details.users[0].signatures.push(sig);
+    }
+
+    /// The key's owner revokes the key.
+    pub fn revoke_key(&mut self, created: u64) {
+        let sig = self
+            .config(SignatureType::KeyRevocation, created, None)
+            .sign_key(
+                &self.secret.primary_key,
+                &Password::empty(),
+                &self.public.primary_key,
+            )
+            .expect("revoke key");
+        self.public.details.revocation_signatures.push(sig);
+    }
+
+    /// What a maintainer's `gpg --clearsign` produces over `text`, signed at
+    /// `created` by the primary key or the signing subkey.
+    pub fn clearsign(&self, text: &str, created: u64, with_subkey: bool) -> String {
+        let msg = if with_subkey {
+            let sub = &self.secret.secret_subkeys[0].key;
+            let mut config =
+                SignatureConfig::v4(SignatureType::Text, sub.algorithm(), HashAlgorithm::Sha256);
+            config.hashed_subpackets = vec![
+                Subpacket::regular(SubpacketData::SignatureCreationTime(ts(created))).unwrap(),
+                Subpacket::regular(SubpacketData::IssuerFingerprint(sub.fingerprint())).unwrap(),
+            ];
+            config.unhashed_subpackets =
+                vec![Subpacket::regular(SubpacketData::IssuerKeyId(sub.legacy_key_id())).unwrap()];
+            CleartextSignedMessage::new(text, config, sub, &Password::empty())
+        } else {
+            let config = self.config(SignatureType::Text, created, None);
+            CleartextSignedMessage::new(text, config, &self.secret.primary_key, &Password::empty())
+        }
+        .expect("clearsign");
+        msg.to_armored_string(ArmorOptions::default())
+            .expect("armor")
+    }
+}
+
+/// The keys concatenated as `gpg --armor --export` blocks.
+pub fn armored_keyring(people: &[&Person]) -> Vec<u8> {
+    people
+        .iter()
+        .map(|p| {
+            p.public
+                .to_armored_string(ArmorOptions::default())
+                .expect("armor key")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .into_bytes()
+}
+
+/// The keys concatenated as one binary `gpg --export`.
+pub fn binary_keyring(people: &[&Person]) -> Vec<u8> {
+    people
+        .iter()
+        .flat_map(|p| p.public.to_bytes().expect("serialise key"))
+        .collect()
+}
+
+/// The link statement text a maintainer signs.
+pub fn link_text(did: &str) -> String {
+    format!(
+        "I link my OpenPGP key to my Linux Kernel community member identity.\n\
+         openvtc-link: {did}\n"
+    )
+}

--- a/cnm-cli/src/vetting/test_web.rs
+++ b/cnm-cli/src/vetting/test_web.rs
@@ -37,11 +37,21 @@ pub struct Person {
     pub public: SignedPublicKey,
 }
 
+/// When every test key was created: 400 days before the first key this process
+/// makes, read once.
+///
+/// An OpenPGP fingerprint covers the key's creation time, so a seed alone does
+/// not fix the key. Reading the clock per key made `Person::new(2, "Alice")`
+/// a different key whenever two calls straddled a second boundary — a keyring
+/// holding both then counted nine keys, not eight.
+static KEYS_CREATED: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| now() - 400 * DAY);
+
 impl Person {
-    /// A key with one user ID and one signing subkey, created 400 days ago.
+    /// A key with one user ID and one signing subkey, created 400 days before
+    /// the process's first key. The same seed is the same key for the whole run.
     pub fn new(seed: u64, name: &str) -> Self {
         let mut rng = StdRng::seed_from_u64(seed);
-        let created = ts(now() - 400 * DAY);
+        let created = ts(*KEYS_CREATED);
         let subkey = SubkeyParamsBuilder::default()
             .key_type(KeyType::Ed25519Legacy)
             .can_sign(true)

--- a/cnm-cli/src/vetting/wot.rs
+++ b/cnm-cli/src/vetting/wot.rs
@@ -1,0 +1,1520 @@
+//! The OpenPGP web of trust `cnm vetting bootstrap-pgp` reads.
+//!
+//! Pure: it parses bytes it is given, verifies signatures, and computes
+//! distances. No network, no filesystem, and no clock of its own — every
+//! validity check takes `now` (Unix seconds) so the tests are deterministic.
+//!
+//! ## What counts
+//!
+//! - A **usable key** has at least one user ID bound by a live self-
+//!   certification, carries no verified key revocation, and has not expired by
+//!   its newest self-signature.
+//! - **Key A certifies key B** when A — itself usable — made a third-party
+//!   certification (signature types 0x10–0x13) over one of B's bound user IDs
+//!   that verifies cryptographically, is exportable, is not expired, was not
+//!   created in the future, and that A has not since revoked (0x30 over the
+//!   same user ID, created no earlier). Anything else is ignored and counted
+//!   in [`CertStats`].
+//! - A key's **depth** is the fewest certification hops from any root key; a
+//!   root is depth 0.
+//! - A **link** is a cleartext-signed message whose signed text has exactly
+//!   one line `openvtc-link: <memberDid>`, signed by exactly one usable
+//!   keyring key (its primary key or a bound signing subkey). The link ties
+//!   that key's primary fingerprint to the DID. A DID claimed by several keys,
+//!   or a key linking several DIDs, is ambiguous and not trusted.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::fmt;
+
+use pgp::composed::{CleartextSignedMessage, PublicOrSecret, SignedPublicKey, SignedPublicSubKey};
+use pgp::crypto::hash::HashAlgorithm;
+use pgp::packet::{Signature, SignatureType};
+use pgp::types::{KeyDetails, Tag};
+
+/// Clock skew tolerated for a signature's creation time.
+pub const CLOCK_SKEW_SECS: u64 = 300;
+
+/// 2019-01-19T00:00:00Z. A SHA-1 or RIPEMD-160 third-party certification made
+/// after this is not trusted — GnuPG's cut-off, adopted because SHA-1
+/// chosen-prefix collisions make a forged certification practical
+/// ("SHA-1 is a Shambles", 2020). Older ones still count, as they do in GnuPG:
+/// much of a long-lived web of trust was signed with SHA-1.
+pub const SHA1_CERTIFICATION_CUTOFF: u64 = 1_547_856_000;
+
+/// The line prefix a link statement carries.
+pub const LINK_PREFIX: &str = "openvtc-link:";
+
+/// Longest DID a link may name.
+const MAX_DID_CHARS: usize = 2048;
+
+/// Why the keyring or the roots could not be used at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WotError {
+    /// Nothing in the file parsed as an OpenPGP public key.
+    NoKeys { detail: String },
+    /// A `--roots` value is not a full fingerprint.
+    BadRoot(String),
+    /// A root fingerprint names no key in the keyring.
+    UnknownRoot(String),
+    /// A root key is in the keyring but cannot certify anything.
+    UnusableRoot {
+        fingerprint: String,
+        problem: KeyProblem,
+    },
+}
+
+impl fmt::Display for WotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoKeys { detail } => write!(
+                f,
+                "the keyring holds no OpenPGP public keys ({detail}).\n\
+                 Export one with `gpg --export > keyring.gpg` (binary) or \
+                 `gpg --armor --export > keyring.asc`, then pass it as --keyring"
+            ),
+            Self::BadRoot(root) => write!(
+                f,
+                "--roots `{root}` is not a full key fingerprint.\n\
+                 Pass the 40-hex-digit fingerprint `gpg --fingerprint <key>` prints \
+                 (spaces are fine); short and long key ids are not accepted because \
+                 they can collide"
+            ),
+            Self::UnknownRoot(root) => write!(
+                f,
+                "root {root} is not in the keyring.\n\
+                 Add it to the export (`gpg --armor --export {root} >> keyring.asc`) \
+                 or correct the fingerprint"
+            ),
+            Self::UnusableRoot {
+                fingerprint,
+                problem,
+            } => write!(
+                f,
+                "root {fingerprint} cannot anchor the web of trust: the key is {problem}.\n\
+                 Choose a root whose key is current, or refresh the keyring so it \
+                 carries the key's latest self-signatures"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WotError {}
+
+/// Why a key cannot certify or be linked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyProblem {
+    /// No user ID is bound by a valid, live self-certification.
+    NoValidUserId,
+    /// The key carries a verified key revocation.
+    Revoked,
+    /// The key's newest self-signature says it has expired.
+    Expired,
+}
+
+impl fmt::Display for KeyProblem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::NoValidUserId => "without a validly self-signed user ID",
+            Self::Revoked => "revoked",
+            Self::Expired => "expired",
+        })
+    }
+}
+
+/// What happened to every third-party certification the graph looked at.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CertStats {
+    /// Certifications that make an edge.
+    pub counted: usize,
+    /// Made by a key that is not in the keyring.
+    pub unknown_issuer: usize,
+    /// Made by a key that is revoked, expired or has no bound user ID.
+    pub unusable_issuer: usize,
+    /// Expired, or created in the future.
+    pub expired: usize,
+    /// Revoked by their issuer.
+    pub revoked: usize,
+    /// Did not verify, or marked non-exportable.
+    pub invalid: usize,
+}
+
+/// One parsed key and what the keyring knows about it.
+#[derive(Debug, Clone)]
+pub struct KeyEntry {
+    /// The primary key's fingerprint, upper-case hex.
+    pub fingerprint: String,
+    /// The primary user ID, when one is bound.
+    pub primary_user_id: Option<String>,
+    /// Why the key is unusable; `None` when it is usable.
+    pub problem: Option<KeyProblem>,
+    key: SignedPublicKey,
+    /// Indices into `key.details.users` of the user IDs a live self-
+    /// certification binds.
+    bound_users: Vec<usize>,
+}
+
+/// A parsed keyring: every key, indexed by fingerprint and key id (primary and
+/// subkey).
+#[derive(Debug)]
+pub struct Keyring {
+    entries: Vec<KeyEntry>,
+    by_fingerprint: HashMap<String, usize>,
+    by_key_id: HashMap<String, Vec<usize>>,
+    subkey_by_fingerprint: HashMap<String, (usize, usize)>,
+    subkey_by_key_id: HashMap<String, Vec<(usize, usize)>>,
+    /// Keys or blocks that could not be read, for the operator.
+    pub skipped: Vec<String>,
+}
+
+impl Keyring {
+    /// Parse a keyring — binary, or ASCII-armored with one or more
+    /// `PUBLIC KEY BLOCK`s — and evaluate every key at `now`.
+    ///
+    /// A key that appears twice (two exports concatenated) is merged: its user
+    /// IDs and their signatures are combined, so a certification carried by
+    /// either copy counts.
+    ///
+    /// # Errors
+    ///
+    /// [`WotError::NoKeys`] when nothing parses as a public key.
+    pub fn parse(bytes: &[u8], now: u64) -> Result<Self, WotError> {
+        let mut skipped = Vec::new();
+        let mut keys: Vec<SignedPublicKey> = Vec::new();
+        let first = bytes.iter().find(|b| !b.is_ascii_whitespace()).copied();
+        match first {
+            None => {
+                return Err(WotError::NoKeys {
+                    detail: "the file is empty".into(),
+                });
+            }
+            Some(b) if b & 0x80 != 0 => {
+                read_keys(
+                    PublicOrSecret::from_bytes_many(bytes),
+                    "binary keyring",
+                    &mut keys,
+                    &mut skipped,
+                );
+            }
+            Some(_) => {
+                let text = String::from_utf8_lossy(bytes);
+                let blocks = armor_blocks(&text);
+                if blocks.is_empty() {
+                    return Err(WotError::NoKeys {
+                        detail: "no `-----BEGIN PGP PUBLIC KEY BLOCK-----` armor found".into(),
+                    });
+                }
+                for (n, block) in blocks.iter().enumerate() {
+                    let label = format!("armor block {}", n + 1);
+                    match PublicOrSecret::from_armor_many(block.as_bytes()) {
+                        Ok((iter, _headers)) => {
+                            read_keys(Ok(iter), &label, &mut keys, &mut skipped);
+                        }
+                        Err(e) => skipped.push(format!("{label}: {e}")),
+                    }
+                }
+            }
+        }
+
+        // Merge duplicate primaries before evaluating anything.
+        let mut merged: Vec<SignedPublicKey> = Vec::new();
+        let mut index: HashMap<String, usize> = HashMap::new();
+        for key in keys {
+            let fp = fingerprint_hex(&key.primary_key);
+            match index.get(&fp) {
+                Some(&i) => merge_key(&mut merged[i], key),
+                None => {
+                    index.insert(fp, merged.len());
+                    merged.push(key);
+                }
+            }
+        }
+        if merged.is_empty() {
+            return Err(WotError::NoKeys {
+                detail: skipped
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "no public key packets".into()),
+            });
+        }
+
+        let mut keyring = Self {
+            entries: Vec::with_capacity(merged.len()),
+            by_fingerprint: HashMap::new(),
+            by_key_id: HashMap::new(),
+            subkey_by_fingerprint: HashMap::new(),
+            subkey_by_key_id: HashMap::new(),
+            skipped,
+        };
+        for key in merged {
+            let i = keyring.entries.len();
+            let fingerprint = fingerprint_hex(&key.primary_key);
+            keyring.by_fingerprint.insert(fingerprint.clone(), i);
+            keyring
+                .by_key_id
+                .entry(hex_upper(key.primary_key.legacy_key_id().as_ref()))
+                .or_default()
+                .push(i);
+            for (j, sub) in key.public_subkeys.iter().enumerate() {
+                keyring
+                    .subkey_by_fingerprint
+                    .insert(fingerprint_hex(&sub.key), (i, j));
+                keyring
+                    .subkey_by_key_id
+                    .entry(hex_upper(sub.key.legacy_key_id().as_ref()))
+                    .or_default()
+                    .push((i, j));
+            }
+            let (problem, bound_users, primary_user_id) = evaluate_key(&key, now);
+            keyring.entries.push(KeyEntry {
+                fingerprint,
+                primary_user_id,
+                problem,
+                key,
+                bound_users,
+            });
+        }
+        Ok(keyring)
+    }
+
+    /// Every key, in keyring order.
+    pub fn keys(&self) -> &[KeyEntry] {
+        &self.entries
+    }
+
+    /// The key with this primary fingerprint (upper-case hex).
+    pub fn get(&self, fingerprint: &str) -> Option<&KeyEntry> {
+        self.by_fingerprint
+            .get(fingerprint)
+            .map(|&i| &self.entries[i])
+    }
+
+    /// Resolve `--roots` values to fingerprints of usable keys in the keyring.
+    ///
+    /// # Errors
+    ///
+    /// The first root that is malformed, absent or unusable.
+    pub fn resolve_roots(&self, roots: &[String]) -> Result<Vec<String>, WotError> {
+        let mut out = BTreeSet::new();
+        for root in roots {
+            let fp = normalize_fingerprint(root).ok_or_else(|| WotError::BadRoot(root.clone()))?;
+            let entry = self
+                .get(&fp)
+                .ok_or_else(|| WotError::UnknownRoot(fp.clone()))?;
+            if let Some(problem) = entry.problem {
+                return Err(WotError::UnusableRoot {
+                    fingerprint: fp,
+                    problem,
+                });
+            }
+            out.insert(fp);
+        }
+        Ok(out.into_iter().collect())
+    }
+
+    /// The certification graph at `now`: for each certifier fingerprint, the
+    /// fingerprints it certifies.
+    pub fn certifications(&self, now: u64) -> (BTreeMap<String, BTreeSet<String>>, CertStats) {
+        let mut edges: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        let mut stats = CertStats::default();
+        for target in &self.entries {
+            if target.problem.is_some() {
+                continue;
+            }
+            let signee = &target.key.primary_key;
+            for &u in &target.bound_users {
+                let user = &target.key.details.users[u];
+                for sig in &user.signatures {
+                    if !is_certification(sig) || issued_by(sig, signee) {
+                        continue;
+                    }
+                    let candidates = self.primary_candidates(sig);
+                    if candidates.is_empty() {
+                        stats.unknown_issuer += 1;
+                        continue;
+                    }
+                    for c in candidates {
+                        let certifier = &self.entries[c];
+                        if certifier.fingerprint == target.fingerprint {
+                            continue;
+                        }
+                        if certifier.problem.is_some() {
+                            stats.unusable_issuer += 1;
+                            continue;
+                        }
+                        let signer = &certifier.key.primary_key;
+                        if !sig.exportable_certification()
+                            || weak_certification_hash(sig)
+                            || sig
+                                .verify_third_party_certification(
+                                    signee,
+                                    signer,
+                                    Tag::UserId,
+                                    &user.id,
+                                )
+                                .is_err()
+                        {
+                            stats.invalid += 1;
+                            continue;
+                        }
+                        if !is_live(sig, now) {
+                            stats.expired += 1;
+                            continue;
+                        }
+                        let created = created_secs(sig);
+                        let revoked = user.signatures.iter().any(|r| {
+                            r.typ() == Some(SignatureType::CertRevocation)
+                                && issued_by(r, signer)
+                                && created_secs(r) >= created
+                                && created_secs(r) <= now + CLOCK_SKEW_SECS
+                                && r.verify_third_party_certification(
+                                    signee,
+                                    signer,
+                                    Tag::UserId,
+                                    &user.id,
+                                )
+                                .is_ok()
+                        });
+                        if revoked {
+                            stats.revoked += 1;
+                            continue;
+                        }
+                        stats.counted += 1;
+                        edges
+                            .entry(certifier.fingerprint.clone())
+                            .or_default()
+                            .insert(target.fingerprint.clone());
+                    }
+                }
+            }
+        }
+        (edges, stats)
+    }
+
+    /// Primary keys a signature names as its issuer — by fingerprint when it
+    /// carries one, otherwise by key id.
+    fn primary_candidates(&self, sig: &Signature) -> Vec<usize> {
+        let by_fp: Vec<usize> = sig
+            .issuer_fingerprint()
+            .iter()
+            .filter_map(|fp| self.by_fingerprint.get(&hex_upper(fp.as_bytes())).copied())
+            .collect();
+        if !by_fp.is_empty() || !sig.issuer_fingerprint().is_empty() {
+            return by_fp;
+        }
+        let mut out: Vec<usize> = sig
+            .issuer_key_id()
+            .iter()
+            .flat_map(|id| {
+                self.by_key_id
+                    .get(&hex_upper(id.as_ref()))
+                    .cloned()
+                    .unwrap_or_default()
+            })
+            .collect();
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+
+    /// `(key, Some(subkey))` or `(key, None)` for every keyring key a
+    /// signature names as its issuer.
+    fn signer_candidates(&self, sig: &Signature) -> Vec<(usize, Option<usize>)> {
+        let mut out = Vec::new();
+        for fp in sig.issuer_fingerprint() {
+            let hex = hex_upper(fp.as_bytes());
+            if let Some(&i) = self.by_fingerprint.get(&hex) {
+                out.push((i, None));
+            }
+            if let Some(&(i, j)) = self.subkey_by_fingerprint.get(&hex) {
+                out.push((i, Some(j)));
+            }
+        }
+        if out.is_empty() {
+            for id in sig.issuer_key_id() {
+                let hex = hex_upper(id.as_ref());
+                for &i in self.by_key_id.get(&hex).into_iter().flatten() {
+                    out.push((i, None));
+                }
+                for &(i, j) in self.subkey_by_key_id.get(&hex).into_iter().flatten() {
+                    out.push((i, Some(j)));
+                }
+            }
+        }
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+}
+
+/// How a key is reached from the roots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reach {
+    /// Certification hops from the nearest root; 0 for a root.
+    pub depth: u32,
+    /// Fingerprints from a root to this key, both ends included.
+    pub path: Vec<String>,
+}
+
+/// Shortest certification paths from `roots` to every key they reach.
+///
+/// Breadth-first over `edges`. Neighbours are visited in fingerprint order and
+/// roots in fingerprint order, so among equally short paths the one reported
+/// is the same on every run.
+pub fn shortest_paths(
+    edges: &BTreeMap<String, BTreeSet<String>>,
+    roots: &[String],
+) -> BTreeMap<String, Reach> {
+    let mut parent: BTreeMap<String, Option<String>> = BTreeMap::new();
+    let mut depth: BTreeMap<String, u32> = BTreeMap::new();
+    let mut queue = VecDeque::new();
+    let mut sorted_roots = roots.to_vec();
+    sorted_roots.sort();
+    for root in sorted_roots {
+        if depth.contains_key(&root) {
+            continue;
+        }
+        depth.insert(root.clone(), 0);
+        parent.insert(root.clone(), None);
+        queue.push_back(root);
+    }
+    while let Some(node) = queue.pop_front() {
+        let d = depth[&node];
+        for next in edges.get(&node).into_iter().flatten() {
+            if depth.contains_key(next) {
+                continue;
+            }
+            depth.insert(next.clone(), d + 1);
+            parent.insert(next.clone(), Some(node.clone()));
+            queue.push_back(next.clone());
+        }
+    }
+    depth
+        .into_iter()
+        .map(|(fp, d)| {
+            let mut path = vec![fp.clone()];
+            let mut cursor = parent.get(&fp).cloned().flatten();
+            while let Some(p) = cursor {
+                cursor = parent.get(&p).cloned().flatten();
+                path.push(p);
+            }
+            path.reverse();
+            (fp, Reach { depth: d, path })
+        })
+        .collect()
+}
+
+/// Why a link statement is not trusted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkProblem {
+    /// The file is not an OpenPGP cleartext-signed message.
+    NotCleartextSigned(String),
+    /// The signed text has no `openvtc-link:` line.
+    NoLinkLine,
+    /// The signed text names more than one DID.
+    SeveralDids(Vec<String>),
+    /// The named DID is not shaped like a DID.
+    BadDid(String),
+    /// No signature names a key in the keyring.
+    UnknownSigner(Vec<String>),
+    /// A signature names a keyring key but does not verify with it (or has
+    /// expired, or its subkey is not bound).
+    BadSignature,
+    /// The only signatures use a digest too weak for a new statement.
+    WeakHash(String),
+    /// The signature verifies, but the signing key is unusable.
+    UnusableSigner {
+        fingerprint: String,
+        problem: KeyProblem,
+    },
+    /// Signatures from more than one key verify.
+    SignedBySeveralKeys(Vec<String>),
+    /// Another verified link names the same DID with a different key.
+    DidClaimedBySeveralKeys(Vec<String>),
+    /// The same key links more than one DID.
+    KeyLinksSeveralDids(Vec<String>),
+}
+
+impl fmt::Display for LinkProblem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotCleartextSigned(e) => write!(
+                f,
+                "not a cleartext-signed message ({e}); sign it with `gpg --clearsign`"
+            ),
+            Self::NoLinkLine => write!(f, "no `{LINK_PREFIX} <memberDid>` line in the signed text"),
+            Self::SeveralDids(dids) => write!(f, "names several DIDs: {}", dids.join(", ")),
+            Self::BadDid(did) => write!(f, "`{did}` is not a DID"),
+            Self::UnknownSigner(ids) => {
+                if ids.is_empty() {
+                    write!(f, "unsigned: the signature names no issuer key")
+                } else {
+                    write!(
+                        f,
+                        "signed by {} which is not in the keyring",
+                        ids.join(", ")
+                    )
+                }
+            }
+            Self::BadSignature => write!(
+                f,
+                "bad signature: it does not verify with the key it names (was the text \
+                 changed after signing, or has the signature or signing subkey expired?)"
+            ),
+            Self::WeakHash(alg) => write!(
+                f,
+                "signed with {alg}, too weak for a new statement; re-sign with \
+                 `gpg --digest-algo SHA256 --clearsign`"
+            ),
+            Self::UnusableSigner {
+                fingerprint,
+                problem,
+            } => write!(f, "signed by {fingerprint}, which is {problem}"),
+            Self::SignedBySeveralKeys(fps) => {
+                write!(f, "signed by several keys: {}", fps.join(", "))
+            }
+            Self::DidClaimedBySeveralKeys(fps) => write!(
+                f,
+                "ambiguous: the DID is claimed by several keys ({})",
+                fps.join(", ")
+            ),
+            Self::KeyLinksSeveralDids(dids) => write!(
+                f,
+                "ambiguous: the key links several DIDs ({})",
+                dids.join(", ")
+            ),
+        }
+    }
+}
+
+/// The outcome of reading one link file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkCheck {
+    /// Where the statement came from (the file name).
+    pub source: String,
+    /// The DID the statement names, when one could be read.
+    pub member_did: Option<String>,
+    /// The linked key's primary fingerprint, when a signature identified one.
+    pub fingerprint: Option<String>,
+    /// Why the link is not trusted; `None` for a trusted link.
+    pub problem: Option<LinkProblem>,
+}
+
+impl LinkCheck {
+    fn failed(source: &str, did: Option<String>, problem: LinkProblem) -> Self {
+        Self {
+            source: source.to_string(),
+            member_did: did,
+            fingerprint: None,
+            problem: Some(problem),
+        }
+    }
+}
+
+/// Read and verify one link statement against the keyring at `now`.
+pub fn check_link(keyring: &Keyring, source: &str, text: &str, now: u64) -> LinkCheck {
+    let msg = match CleartextSignedMessage::from_string(text) {
+        Ok((msg, _headers)) => msg,
+        Err(e) => {
+            return LinkCheck::failed(source, None, LinkProblem::NotCleartextSigned(e.to_string()));
+        }
+    };
+
+    let signed = msg.signed_text();
+    let dids: BTreeSet<String> = signed
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix(LINK_PREFIX))
+        .map(|rest| rest.trim().to_string())
+        .collect();
+    let did = match dids.len() {
+        0 => return LinkCheck::failed(source, None, LinkProblem::NoLinkLine),
+        1 => dids.into_iter().next().expect("one DID"),
+        _ => {
+            return LinkCheck::failed(
+                source,
+                None,
+                LinkProblem::SeveralDids(dids.into_iter().collect()),
+            );
+        }
+    };
+    if !looks_like_did(&did) {
+        return LinkCheck::failed(source, None, LinkProblem::BadDid(did));
+    }
+
+    let mut issuers = BTreeSet::new();
+    let mut named_a_keyring_key = false;
+    let mut weak_hash: Option<HashAlgorithm> = None;
+    // Primary fingerprint → the key's problem, for every key a signature
+    // verified with.
+    let mut verified: BTreeMap<String, Option<KeyProblem>> = BTreeMap::new();
+    for sig in msg.signatures() {
+        for fp in sig.issuer_fingerprint() {
+            issuers.insert(hex_upper(fp.as_bytes()));
+        }
+        if sig.issuer_fingerprint().is_empty() {
+            for id in sig.issuer_key_id() {
+                issuers.insert(hex_upper(id.as_ref()));
+            }
+        }
+        // A link is a new statement: there is no legacy to honour, so no
+        // SHA-1, RIPEMD-160 or MD5 at all.
+        if let Some(alg @ (HashAlgorithm::Md5 | HashAlgorithm::Sha1 | HashAlgorithm::Ripemd160)) =
+            sig.hash_alg()
+        {
+            weak_hash = Some(alg);
+            continue;
+        }
+        if !matches!(sig.typ(), Some(SignatureType::Text | SignatureType::Binary))
+            || !is_live(sig, now)
+        {
+            if !keyring.signer_candidates(sig).is_empty() {
+                named_a_keyring_key = true;
+            }
+            continue;
+        }
+        for (i, sub) in keyring.signer_candidates(sig) {
+            named_a_keyring_key = true;
+            let entry = &keyring.entries[i];
+            let ok = match sub {
+                None => sig
+                    .verify(&entry.key.primary_key, signed.as_bytes())
+                    .is_ok(),
+                Some(j) => {
+                    let subkey = &entry.key.public_subkeys[j];
+                    signing_subkey_bound(&entry.key, subkey, now)
+                        && sig.verify(subkey, signed.as_bytes()).is_ok()
+                }
+            };
+            if ok {
+                verified.insert(entry.fingerprint.clone(), entry.problem);
+            }
+        }
+    }
+
+    match verified.len() {
+        0 if weak_hash.is_some() => LinkCheck::failed(
+            source,
+            Some(did),
+            LinkProblem::WeakHash(weak_hash.map(|a| a.to_string()).unwrap_or_default()),
+        ),
+        0 if named_a_keyring_key => LinkCheck::failed(source, Some(did), LinkProblem::BadSignature),
+        0 => LinkCheck::failed(
+            source,
+            Some(did),
+            LinkProblem::UnknownSigner(issuers.into_iter().collect()),
+        ),
+        1 => {
+            let (fingerprint, problem) = verified.into_iter().next().expect("one key");
+            LinkCheck {
+                source: source.to_string(),
+                member_did: Some(did),
+                problem: problem.map(|problem| LinkProblem::UnusableSigner {
+                    fingerprint: fingerprint.clone(),
+                    problem,
+                }),
+                fingerprint: Some(fingerprint),
+            }
+        }
+        _ => LinkCheck::failed(
+            source,
+            Some(did),
+            LinkProblem::SignedBySeveralKeys(verified.into_keys().collect()),
+        ),
+    }
+}
+
+/// Refuse every trusted link that another trusted link contradicts: a DID
+/// claimed by more than one key, or a key linking more than one DID.
+///
+/// The same key linking the same DID in two files is not a contradiction.
+pub fn mark_ambiguous(checks: &mut [LinkCheck]) {
+    let mut keys_of_did: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut dids_of_key: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for c in checks.iter().filter(|c| c.problem.is_none()) {
+        if let (Some(did), Some(fp)) = (&c.member_did, &c.fingerprint) {
+            keys_of_did
+                .entry(did.clone())
+                .or_default()
+                .insert(fp.clone());
+            dids_of_key
+                .entry(fp.clone())
+                .or_default()
+                .insert(did.clone());
+        }
+    }
+    for c in checks.iter_mut().filter(|c| c.problem.is_none()) {
+        let (Some(did), Some(fp)) = (&c.member_did, &c.fingerprint) else {
+            continue;
+        };
+        let keys = &keys_of_did[did];
+        let dids = &dids_of_key[fp];
+        if keys.len() > 1 {
+            c.problem = Some(LinkProblem::DidClaimedBySeveralKeys(
+                keys.iter().cloned().collect(),
+            ));
+        } else if dids.len() > 1 {
+            c.problem = Some(LinkProblem::KeyLinksSeveralDids(
+                dids.iter().cloned().collect(),
+            ));
+        }
+    }
+}
+
+/// Normalise a fingerprint as an operator types it: spaces and a `0x` prefix
+/// dropped, upper-cased. `None` unless it is 40 (v4) or 64 (v6) hex digits.
+pub fn normalize_fingerprint(input: &str) -> Option<String> {
+    let compact: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+    let hex = compact
+        .strip_prefix("0x")
+        .or_else(|| compact.strip_prefix("0X"))
+        .unwrap_or(&compact)
+        .to_ascii_uppercase();
+    ((hex.len() == 40 || hex.len() == 64) && hex.chars().all(|c| c.is_ascii_hexdigit()))
+        .then_some(hex)
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+type KeyIter<'a> = Box<dyn Iterator<Item = pgp::errors::Result<PublicOrSecret>> + 'a>;
+
+fn read_keys(
+    parsed: pgp::errors::Result<KeyIter<'_>>,
+    label: &str,
+    keys: &mut Vec<SignedPublicKey>,
+    skipped: &mut Vec<String>,
+) {
+    match parsed {
+        Ok(iter) => {
+            for item in iter {
+                match item {
+                    Ok(PublicOrSecret::Public(k)) => keys.push(k),
+                    // A keyring carrying secret material is a mistake worth
+                    // naming, but its public half is still usable.
+                    Ok(PublicOrSecret::Secret(k)) => {
+                        skipped.push(format!(
+                            "{label}: secret key {} — only its public part was read; \
+                             export public keys with `gpg --export`",
+                            fingerprint_hex(&k.primary_key)
+                        ));
+                        keys.push(k.to_public_key());
+                    }
+                    Err(e) => skipped.push(format!("{label}: {e}")),
+                }
+            }
+        }
+        Err(e) => skipped.push(format!("{label}: {e}")),
+    }
+}
+
+/// Each `-----BEGIN PGP … KEY BLOCK-----` … `-----END …-----` span in `text`.
+///
+/// rPGP reads one armor block per call; a keyring built by concatenating
+/// `gpg --armor --export` outputs carries many.
+fn armor_blocks(text: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current: Option<String> = None;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("-----BEGIN PGP ") && trimmed.contains("KEY BLOCK") {
+            current = Some(String::new());
+        }
+        if let Some(block) = current.as_mut() {
+            block.push_str(trimmed);
+            block.push('\n');
+            if trimmed.starts_with("-----END PGP ") {
+                blocks.push(current.take().expect("block"));
+            }
+        }
+    }
+    blocks
+}
+
+fn merge_key(into: &mut SignedPublicKey, from: SignedPublicKey) {
+    for user in from.details.users {
+        match into.details.users.iter_mut().find(|u| u.id == user.id) {
+            Some(existing) => {
+                for sig in user.signatures {
+                    if !existing.signatures.contains(&sig) {
+                        existing.signatures.push(sig);
+                    }
+                }
+            }
+            None => into.details.users.push(user),
+        }
+    }
+    for sig in from.details.revocation_signatures {
+        if !into.details.revocation_signatures.contains(&sig) {
+            into.details.revocation_signatures.push(sig);
+        }
+    }
+    for sig in from.details.direct_signatures {
+        if !into.details.direct_signatures.contains(&sig) {
+            into.details.direct_signatures.push(sig);
+        }
+    }
+    for sub in from.public_subkeys {
+        if !into.public_subkeys.iter().any(|s| s.key == sub.key) {
+            into.public_subkeys.push(sub);
+        }
+    }
+}
+
+/// `(problem, bound user indices, primary user ID)` for a key at `now`.
+fn evaluate_key(
+    key: &SignedPublicKey,
+    now: u64,
+) -> (Option<KeyProblem>, Vec<usize>, Option<String>) {
+    let primary = &key.primary_key;
+    let mut bound = Vec::new();
+    // (created, is_primary, user index) of each bound user's newest self-cert.
+    let mut newest_per_user: Vec<(u64, bool, usize)> = Vec::new();
+    // Newest self-signature overall that can carry a key expiration.
+    let mut newest_self: Option<&Signature> = None;
+
+    for (i, user) in key.details.users.iter().enumerate() {
+        let mut best: Option<&Signature> = None;
+        let mut revoked_at: Option<u64> = None;
+        for sig in user.signatures.iter().filter(|s| issued_by(s, primary)) {
+            if is_certification(sig) {
+                if is_live(sig, now)
+                    && sig
+                        .verify_certification(primary, Tag::UserId, &user.id)
+                        .is_ok()
+                    && best.is_none_or(|b| created_secs(sig) > created_secs(b))
+                {
+                    best = Some(sig);
+                }
+            } else if sig.typ() == Some(SignatureType::CertRevocation)
+                && sig
+                    .verify_certification(primary, Tag::UserId, &user.id)
+                    .is_ok()
+            {
+                revoked_at = Some(revoked_at.unwrap_or(0).max(created_secs(sig)));
+            }
+        }
+        let Some(best) = best else { continue };
+        if revoked_at.is_some_and(|r| r >= created_secs(best)) {
+            continue;
+        }
+        bound.push(i);
+        newest_per_user.push((created_secs(best), best.is_primary(), i));
+        if newest_self.is_none_or(|n| created_secs(best) > created_secs(n)) {
+            newest_self = Some(best);
+        }
+    }
+    for sig in &key.details.direct_signatures {
+        if sig.typ() == Some(SignatureType::Key)
+            && issued_by(sig, primary)
+            && sig.verify_key(primary).is_ok()
+            && newest_self.is_none_or(|n| created_secs(sig) > created_secs(n))
+        {
+            newest_self = Some(sig);
+        }
+    }
+
+    let primary_user_id = newest_per_user
+        .iter()
+        .max_by_key(|(created, is_primary, i)| (*is_primary, *created, std::cmp::Reverse(*i)))
+        .map(|&(_, _, i)| user_id_text(&key.details.users[i].id));
+
+    let revoked = key.details.revocation_signatures.iter().any(|sig| {
+        sig.typ() == Some(SignatureType::KeyRevocation)
+            && issued_by(sig, primary)
+            && sig.verify_key(primary).is_ok()
+    });
+    let problem = if bound.is_empty() {
+        Some(KeyProblem::NoValidUserId)
+    } else if revoked {
+        Some(KeyProblem::Revoked)
+    } else if newest_self
+        .and_then(Signature::key_expiration_time)
+        .is_some_and(|d| {
+            d.as_secs() > 0
+                && u64::from(primary.created_at().as_secs()) + u64::from(d.as_secs()) <= now
+        })
+    {
+        Some(KeyProblem::Expired)
+    } else {
+        None
+    };
+    (problem, bound, primary_user_id)
+}
+
+/// A signing subkey counts when a live binding from the primary verifies, it
+/// is flagged for signing and cross-signed back, it has not expired, and no
+/// subkey revocation verifies.
+fn signing_subkey_bound(key: &SignedPublicKey, subkey: &SignedPublicSubKey, now: u64) -> bool {
+    let primary = &key.primary_key;
+    let revoked = subkey.signatures.iter().any(|sig| {
+        sig.typ() == Some(SignatureType::SubkeyRevocation)
+            && sig.verify_subkey_binding(primary, &subkey.key).is_ok()
+    });
+    if revoked {
+        return false;
+    }
+    subkey.signatures.iter().any(|sig| {
+        sig.typ() == Some(SignatureType::SubkeyBinding)
+            && is_live(sig, now)
+            && sig.key_flags().sign()
+            && sig.verify_subkey_binding(primary, &subkey.key).is_ok()
+            && sig.embedded_signature().is_some_and(|back| {
+                back.verify_primary_key_binding(&subkey.key, primary)
+                    .is_ok()
+            })
+            && sig.key_expiration_time().is_none_or(|d| {
+                d.as_secs() == 0
+                    || u64::from(subkey.key.created_at().as_secs()) + u64::from(d.as_secs()) > now
+            })
+    })
+}
+
+/// MD5 ever, or SHA-1/RIPEMD-160 after [`SHA1_CERTIFICATION_CUTOFF`].
+fn weak_certification_hash(sig: &Signature) -> bool {
+    match sig.hash_alg() {
+        Some(HashAlgorithm::Md5) | None => true,
+        Some(HashAlgorithm::Sha1 | HashAlgorithm::Ripemd160) => {
+            created_secs(sig) > SHA1_CERTIFICATION_CUTOFF
+        }
+        Some(_) => false,
+    }
+}
+
+fn is_certification(sig: &Signature) -> bool {
+    matches!(
+        sig.typ(),
+        Some(
+            SignatureType::CertGeneric
+                | SignatureType::CertPersona
+                | SignatureType::CertCasual
+                | SignatureType::CertPositive
+        )
+    )
+}
+
+fn issued_by(sig: &Signature, key: &impl KeyDetails) -> bool {
+    let fp = key.fingerprint();
+    let id = key.legacy_key_id();
+    sig.issuer_fingerprint().iter().any(|f| **f == fp)
+        || sig.issuer_key_id().iter().any(|k| **k == id)
+}
+
+fn created_secs(sig: &Signature) -> u64 {
+    sig.created().map_or(0, |t| u64::from(t.as_secs()))
+}
+
+/// Created (not in the future) and not expired at `now`.
+fn is_live(sig: &Signature, now: u64) -> bool {
+    let Some(created) = sig.created().map(|t| u64::from(t.as_secs())) else {
+        return false;
+    };
+    if created > now + CLOCK_SKEW_SECS {
+        return false;
+    }
+    sig.signature_expiration_time()
+        .is_none_or(|d| d.as_secs() == 0 || created + u64::from(d.as_secs()) > now)
+}
+
+fn looks_like_did(did: &str) -> bool {
+    let mut parts = did.splitn(3, ':');
+    did.len() <= MAX_DID_CHARS
+        && parts.next() == Some("did")
+        && parts.next().is_some_and(|method| {
+            !method.is_empty()
+                && method
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        })
+        && parts.next().is_some_and(|id| !id.is_empty())
+        && !did.chars().any(|c| c.is_whitespace() || c.is_control())
+}
+
+fn fingerprint_hex(key: &impl KeyDetails) -> String {
+    hex_upper(key.fingerprint().as_bytes())
+}
+
+fn hex_upper(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02X}");
+            s
+        })
+}
+
+fn user_id_text(id: &pgp::packet::UserId) -> String {
+    id.as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| String::from_utf8_lossy(id.id()).into_owned())
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use super::*;
+    use crate::vetting::test_web::{DAY, Person, armored_keyring, binary_keyring, link_text, now};
+
+    /// The web of trust every test here reads:
+    ///
+    /// ```text
+    /// root ──▶ alice ──▶ bob ──▶ carol        depths 1, 2, 3
+    /// root ──▶ dave                           depth 1
+    /// root ─x▶ erin     certification expired         (no edge)
+    /// root ─x▶ victor   certification revoked by root (no edge)
+    /// root ─x▶ xavier   root's certification of alice, copied onto
+    ///                   xavier's user ID: does not verify (no edge)
+    /// uma  ──▶ alice    uma's key is not in the keyring (ignored)
+    /// ```
+    pub(crate) struct Web {
+        pub root: Person,
+        pub alice: Person,
+        pub bob: Person,
+        pub carol: Person,
+        pub dave: Person,
+        pub erin: Person,
+        pub victor: Person,
+        pub xavier: Person,
+        pub uma: Person,
+    }
+
+    impl Web {
+        pub(crate) fn new() -> Self {
+            let t = now();
+            let root = Person::new(1, "Root");
+            let mut alice = Person::new(2, "Alice");
+            let mut bob = Person::new(3, "Bob");
+            let mut carol = Person::new(4, "Carol");
+            let mut dave = Person::new(5, "Dave");
+            let mut erin = Person::new(6, "Erin");
+            let mut victor = Person::new(7, "Victor");
+            let mut xavier = Person::new(8, "Xavier");
+            let uma = Person::new(9, "Uma");
+
+            root.certify(&mut alice, t - 300 * DAY, None);
+            alice.certify(&mut bob, t - 200 * DAY, None);
+            bob.certify(&mut carol, t - 100 * DAY, None);
+            root.certify(&mut dave, t - 300 * DAY, None);
+            // Made a year ago, valid for thirty days.
+            root.certify(&mut erin, t - 300 * DAY, Some(30 * DAY));
+            root.certify(&mut victor, t - 300 * DAY, None);
+            root.revoke_certification(&mut victor, t - 10 * DAY);
+            let copied = root.certification_of(&alice, t - 300 * DAY, None);
+            xavier.public.details.users[0].signatures.push(copied);
+            uma.certify(&mut alice, t - 50 * DAY, None);
+
+            Self {
+                root,
+                alice,
+                bob,
+                carol,
+                dave,
+                erin,
+                victor,
+                xavier,
+                uma,
+            }
+        }
+
+        /// Every key but uma's, as concatenated armored exports.
+        pub(crate) fn keyring(&self) -> Keyring {
+            Keyring::parse(&armored_keyring(&self.exported()), now()).expect("keyring parses")
+        }
+
+        pub(crate) fn exported(&self) -> Vec<&Person> {
+            vec![
+                &self.root,
+                &self.alice,
+                &self.bob,
+                &self.carol,
+                &self.dave,
+                &self.erin,
+                &self.victor,
+                &self.xavier,
+            ]
+        }
+    }
+
+    #[test]
+    fn depths_are_the_shortest_certification_paths_from_the_roots() {
+        let web = Web::new();
+        let ring = web.keyring();
+        assert!(ring.keys().iter().all(|k| k.problem.is_none()));
+        assert_eq!(
+            ring.get(&web.alice.fingerprint())
+                .and_then(|k| k.primary_user_id.as_deref()),
+            Some("Alice <alice@kernel.example>")
+        );
+
+        let roots = ring.resolve_roots(&[web.root.fingerprint()]).unwrap();
+        let (edges, stats) = ring.certifications(now());
+        let reach = shortest_paths(&edges, &roots);
+
+        assert_eq!(reach[&web.root.fingerprint()].depth, 0);
+        assert_eq!(reach[&web.alice.fingerprint()].depth, 1);
+        assert_eq!(reach[&web.dave.fingerprint()].depth, 1);
+        assert_eq!(reach[&web.bob.fingerprint()].depth, 2);
+        let carol = &reach[&web.carol.fingerprint()];
+        assert_eq!(carol.depth, 3);
+        assert_eq!(
+            carol.path,
+            vec![
+                web.root.fingerprint(),
+                web.alice.fingerprint(),
+                web.bob.fingerprint(),
+                web.carol.fingerprint()
+            ]
+        );
+
+        // Rooting at alice instead: root is not reachable (edges point one
+        // way), bob is one hop.
+        let from_alice = shortest_paths(
+            &edges,
+            &ring.resolve_roots(&[web.alice.fingerprint()]).unwrap(),
+        );
+        assert_eq!(from_alice[&web.bob.fingerprint()].depth, 1);
+        assert!(!from_alice.contains_key(&web.root.fingerprint()));
+
+        // Two roots: the nearer one wins.
+        let both = shortest_paths(
+            &edges,
+            &ring
+                .resolve_roots(&[web.root.fingerprint(), web.bob.fingerprint()])
+                .unwrap(),
+        );
+        assert_eq!(both[&web.carol.fingerprint()].depth, 1);
+
+        let _ = stats;
+    }
+
+    #[test]
+    fn expired_revoked_invalid_and_unknown_certifications_make_no_edge() {
+        let web = Web::new();
+        let ring = web.keyring();
+        let roots = ring.resolve_roots(&[web.root.fingerprint()]).unwrap();
+        let (edges, stats) = ring.certifications(now());
+        let reach = shortest_paths(&edges, &roots);
+
+        for (who, why) in [
+            (&web.erin, "an expired certification"),
+            (&web.victor, "a revoked certification"),
+            (&web.xavier, "a certification that does not verify"),
+        ] {
+            assert!(
+                !reach.contains_key(&who.fingerprint()),
+                "{why} must not make an edge"
+            );
+        }
+        assert_eq!(
+            stats,
+            CertStats {
+                counted: 4,
+                unknown_issuer: 1,
+                unusable_issuer: 0,
+                expired: 1,
+                revoked: 1,
+                invalid: 1,
+            }
+        );
+    }
+
+    /// A signature packet with a chosen digest, type and creation time, issued
+    /// by `issuer`. rPGP will not *make* a SHA-1 or MD5 signature with an
+    /// Ed25519 key, so the packet is assembled directly; its signature value
+    /// is filler, which does not matter to a digest rule applied before any
+    /// verification.
+    fn signature_with_digest(
+        issuer: &Person,
+        typ: SignatureType,
+        hash: HashAlgorithm,
+        created: u64,
+    ) -> Signature {
+        use pgp::packet::{SignatureConfig, Subpacket, SubpacketData};
+        use pgp::types::{Mpi, SignatureBytes, Timestamp};
+        let key = &issuer.secret.primary_key;
+        let mut config = SignatureConfig::v4(typ, key.algorithm(), hash);
+        config.hashed_subpackets = vec![
+            Subpacket::regular(SubpacketData::SignatureCreationTime(Timestamp::from_secs(
+                u32::try_from(created).unwrap(),
+            )))
+            .unwrap(),
+            Subpacket::regular(SubpacketData::IssuerFingerprint(key.fingerprint())).unwrap(),
+        ];
+        let filler =
+            SignatureBytes::Mpis(vec![Mpi::from_slice(&[1; 32]), Mpi::from_slice(&[1; 32])]);
+        Signature::from_config(config, [0, 0], filler).expect("signature packet")
+    }
+
+    #[test]
+    fn weak_digests_are_refused_where_a_forgery_would_be_practical() {
+        let t = now();
+        let root = Person::new(1, "Root");
+        let cert =
+            |hash, created| signature_with_digest(&root, SignatureType::CertGeneric, hash, created);
+
+        assert!(
+            weak_certification_hash(&cert(HashAlgorithm::Sha1, SHA1_CERTIFICATION_CUTOFF + DAY)),
+            "a SHA-1 certification after the cut-off does not count"
+        );
+        assert!(weak_certification_hash(&cert(
+            HashAlgorithm::Ripemd160,
+            t - DAY
+        )));
+        assert!(
+            !weak_certification_hash(&cert(HashAlgorithm::Sha1, SHA1_CERTIFICATION_CUTOFF - DAY)),
+            "a SHA-1 certification from before the cut-off still does"
+        );
+        assert!(
+            weak_certification_hash(&cert(
+                HashAlgorithm::Md5,
+                SHA1_CERTIFICATION_CUTOFF - 365 * DAY
+            )),
+            "MD5 never counts"
+        );
+        assert!(!weak_certification_hash(&root.certification_of(
+            &root,
+            t - DAY,
+            None
+        )));
+
+        // A link is a new statement, so SHA-1 is refused outright — with the
+        // command that fixes it.
+        let ring = Keyring::parse(&armored_keyring(&[&root]), t).unwrap();
+        let link = CleartextSignedMessage::new_many(&link_text("did:key:zRoot"), |_| {
+            Ok(vec![signature_with_digest(
+                &root,
+                SignatureType::Text,
+                HashAlgorithm::Sha1,
+                t - DAY,
+            )])
+        })
+        .unwrap()
+        .to_armored_string(pgp::composed::ArmorOptions::default())
+        .unwrap();
+        let check = check_link(&ring, "root.asc", &link, t);
+        assert_eq!(check.problem, Some(LinkProblem::WeakHash("SHA1".into())));
+        assert!(
+            check
+                .problem
+                .unwrap()
+                .to_string()
+                .contains("--digest-algo SHA256")
+        );
+    }
+
+    #[test]
+    fn a_revoked_key_neither_certifies_nor_anchors() {
+        let mut web = Web::new();
+        web.alice.revoke_key(now() - DAY);
+        let ring = web.keyring();
+        assert_eq!(
+            ring.get(&web.alice.fingerprint()).unwrap().problem,
+            Some(KeyProblem::Revoked)
+        );
+        let roots = ring.resolve_roots(&[web.root.fingerprint()]).unwrap();
+        let (edges, stats) = ring.certifications(now());
+        let reach = shortest_paths(&edges, &roots);
+        assert!(!reach.contains_key(&web.alice.fingerprint()));
+        assert!(
+            !reach.contains_key(&web.bob.fingerprint()),
+            "bob was reachable only through alice's now-revoked key"
+        );
+        assert_eq!(stats.unusable_issuer, 1);
+
+        assert_eq!(
+            ring.resolve_roots(&[web.alice.fingerprint()]),
+            Err(WotError::UnusableRoot {
+                fingerprint: web.alice.fingerprint(),
+                problem: KeyProblem::Revoked
+            })
+        );
+    }
+
+    #[test]
+    fn binary_and_armored_keyrings_read_alike_and_duplicates_merge() {
+        let web = Web::new();
+        let t = now();
+        let binary = Keyring::parse(&binary_keyring(&web.exported()), t).unwrap();
+        assert_eq!(binary.keys().len(), 8);
+
+        // Alice exported twice — once bare, once with her certifications —
+        // is one key carrying every certification.
+        let bare_alice = Person::new(2, "Alice");
+        let mut bytes = armored_keyring(&[&bare_alice]);
+        bytes.push(b'\n');
+        bytes.extend(armored_keyring(&web.exported()));
+        let ring = Keyring::parse(&bytes, t).unwrap();
+        assert_eq!(ring.keys().len(), 8);
+        let roots = ring.resolve_roots(&[web.root.fingerprint()]).unwrap();
+        let (edges, _) = ring.certifications(t);
+        assert_eq!(
+            shortest_paths(&edges, &roots)[&web.bob.fingerprint()].depth,
+            2
+        );
+
+        assert!(matches!(
+            Keyring::parse(b"   ", t),
+            Err(WotError::NoKeys { .. })
+        ));
+        assert!(matches!(
+            Keyring::parse(b"hello, not a key", t),
+            Err(WotError::NoKeys { .. })
+        ));
+    }
+
+    #[test]
+    fn roots_must_be_full_fingerprints_of_keyring_keys() {
+        let web = Web::new();
+        let ring = web.keyring();
+        let fp = web.root.fingerprint();
+        let typed = format!(
+            "0x{} {}",
+            fp[..20].to_ascii_lowercase(),
+            fp[20..].to_ascii_lowercase()
+        );
+        assert_eq!(ring.resolve_roots(&[typed]).unwrap(), vec![fp.clone()]);
+        assert!(matches!(
+            ring.resolve_roots(&[fp[24..].to_string()]),
+            Err(WotError::BadRoot(_))
+        ));
+        let absent = "0".repeat(40);
+        assert_eq!(
+            ring.resolve_roots(std::slice::from_ref(&absent)),
+            Err(WotError::UnknownRoot(absent))
+        );
+        assert!(
+            WotError::BadRoot("ABCD".into())
+                .to_string()
+                .contains("gpg --fingerprint")
+        );
+    }
+
+    #[test]
+    fn a_link_verifies_with_the_primary_key_or_a_signing_subkey() {
+        let web = Web::new();
+        let ring = web.keyring();
+        let t = now();
+
+        let by_primary = web
+            .alice
+            .clearsign(&link_text("did:key:zAlice"), t - DAY, false);
+        let check = check_link(&ring, "alice.asc", &by_primary, t);
+        assert_eq!(check.problem, None, "{check:?}");
+        assert_eq!(check.member_did.as_deref(), Some("did:key:zAlice"));
+        assert_eq!(check.fingerprint, Some(web.alice.fingerprint()));
+
+        let by_subkey = web.bob.clearsign(&link_text("did:key:zBob"), t - DAY, true);
+        let check = check_link(&ring, "bob.asc", &by_subkey, t);
+        assert_eq!(check.problem, None, "{check:?}");
+        assert_eq!(
+            check.fingerprint,
+            Some(web.bob.fingerprint()),
+            "a subkey signature links the primary key"
+        );
+    }
+
+    #[test]
+    fn unsigned_badly_signed_and_malformed_links_are_refused() {
+        let web = Web::new();
+        let ring = web.keyring();
+        let t = now();
+        let problem = |text: &str| check_link(&ring, "x.asc", text, t).problem;
+
+        assert!(matches!(
+            problem("openvtc-link: did:key:zAlice\n"),
+            Some(LinkProblem::NotCleartextSigned(_))
+        ));
+
+        let signed = web
+            .alice
+            .clearsign(&link_text("did:key:zAlice"), t - DAY, false);
+        let tampered = signed.replace("did:key:zAlice", "did:key:zMallory");
+        let check = check_link(&ring, "x.asc", &tampered, t);
+        assert_eq!(check.problem, Some(LinkProblem::BadSignature));
+        assert_eq!(check.member_did.as_deref(), Some("did:key:zMallory"));
+
+        let from_the_future =
+            web.alice
+                .clearsign(&link_text("did:key:zAlice"), t + 30 * DAY, false);
+        assert_eq!(problem(&from_the_future), Some(LinkProblem::BadSignature));
+
+        let stranger = web
+            .uma
+            .clearsign(&link_text("did:key:zUma"), t - DAY, false);
+        assert_eq!(
+            problem(&stranger),
+            Some(LinkProblem::UnknownSigner(vec![web.uma.fingerprint()]))
+        );
+
+        let no_line = web.alice.clearsign("I am Alice.\n", t - DAY, false);
+        assert_eq!(problem(&no_line), Some(LinkProblem::NoLinkLine));
+
+        let two = web.alice.clearsign(
+            "openvtc-link: did:key:zA\nopenvtc-link: did:key:zB\n",
+            t - DAY,
+            false,
+        );
+        assert!(matches!(problem(&two), Some(LinkProblem::SeveralDids(_))));
+
+        let not_a_did = web
+            .alice
+            .clearsign("openvtc-link: alice@kernel.org\n", t - DAY, false);
+        assert!(matches!(problem(&not_a_did), Some(LinkProblem::BadDid(_))));
+
+        let mut revoked = Person::new(2, "Alice");
+        revoked.revoke_key(t - DAY);
+        let ring = Keyring::parse(&armored_keyring(&[&revoked]), t).unwrap();
+        let link = revoked.clearsign(&link_text("did:key:zAlice"), t - 2 * DAY, false);
+        assert!(matches!(
+            check_link(&ring, "x.asc", &link, t).problem,
+            Some(LinkProblem::UnusableSigner {
+                problem: KeyProblem::Revoked,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn contradicting_links_are_all_refused() {
+        let web = Web::new();
+        let ring = web.keyring();
+        let t = now();
+        let link = |p: &Person, did: &str, file: &str| {
+            check_link(
+                &ring,
+                file,
+                &p.clearsign(&link_text(did), t - DAY, false),
+                t,
+            )
+        };
+        let mut checks = vec![
+            link(&web.carol, "did:key:zShared", "carol.asc"),
+            link(&web.dave, "did:key:zShared", "dave.asc"),
+            link(&web.erin, "did:key:zErin1", "erin-1.asc"),
+            link(&web.erin, "did:key:zErin2", "erin-2.asc"),
+            link(&web.alice, "did:key:zAlice", "alice.asc"),
+            link(&web.alice, "did:key:zAlice", "alice-again.asc"),
+        ];
+        mark_ambiguous(&mut checks);
+        assert!(matches!(
+            checks[0].problem,
+            Some(LinkProblem::DidClaimedBySeveralKeys(_))
+        ));
+        assert!(matches!(
+            checks[1].problem,
+            Some(LinkProblem::DidClaimedBySeveralKeys(_))
+        ));
+        assert!(matches!(
+            checks[2].problem,
+            Some(LinkProblem::KeyLinksSeveralDids(_))
+        ));
+        assert!(matches!(
+            checks[3].problem,
+            Some(LinkProblem::KeyLinksSeveralDids(_))
+        ));
+        assert_eq!(
+            checks[4].problem, None,
+            "the same link twice is no contradiction"
+        );
+        assert_eq!(checks[5].problem, None);
+    }
+}

--- a/cnm-cli/src/vetting/wot.rs
+++ b/cnm-cli/src/vetting/wot.rs
@@ -1329,6 +1329,15 @@ pub(super) mod tests {
         );
     }
 
+    /// A fingerprint covers the key's creation time: the same seed made in a
+    /// later second must still be the same key, or duplicate exports stop merging.
+    #[test]
+    fn a_seed_is_the_same_key_in_a_later_second() {
+        let first = Person::new(2, "Alice").fingerprint();
+        std::thread::sleep(std::time::Duration::from_millis(1_100));
+        assert_eq!(Person::new(2, "Alice").fingerprint(), first);
+    }
+
     #[test]
     fn binary_and_armored_keyrings_read_alike_and_duplicates_merge() {
         let web = Web::new();

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,21 @@ all-features = true
 version = 2
 ignore = [
 
+  { id = "RUSTSEC-2023-0071", reason = """
+  rsa 0.9 "Marvin Attack": decrypting or signing with an RSA *private* key
+  leaks timing that can recover it. No patched 0.9 release exists.
+
+  The only path is `pgp` (rPGP) -> rsa, used by `cnm vetting bootstrap-pgp`
+  to read an OpenPGP web of trust. That command only *verifies* RSA
+  signatures — certifications and clearsigned link statements — with
+  public keys from a keyring file. It never loads, generates or uses an RSA
+  private key, so there is no secret for the side channel to leak. The
+  workspace's own RSA need (KMS CMS unwrap) stays on aws-lc-rs.
+
+  Drop when rPGP moves to an rsa release with the constant-time rewrite
+  (0.10), or if `cnm` stops reading PGP keyrings.
+  """ },
+
   { id = "RUSTSEC-2026-0258", reason = """
   h2 accepts and queues empty DATA frames without limit, so a stream
   that is not actively drained can grow memory without bound (or panic

--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -265,6 +265,108 @@ characters. `join-requests/manifest/0.2` carries it as `branding` when any is
 set. It is presentation only — `communityDid` identifies the community. Changes
 are audited as `CommunityBrandingUpdated`.
 
+### 7. Administer vetting from the command line
+
+`cnm` drives the same admin REST routes. Every command needs a community-admin
+session (`cnm auth login`) with a REST URL — pass `cnm --url https://<vtc>/v1 …`
+when the session has none. Tables are the default; the global `--json` prints the
+response instead, and `--full-display` prints DIDs and ids unshortened.
+
+| Command | Route | Prints |
+|---|---|---|
+| `cnm vetting vetters list` | `GET /v1/vetting/vetters` | member, status (`live`, `revoked`, `expired`, `not member`), origin (`manual`/`auto`), valid until, endorsement id, profile summary |
+| `cnm vetting vetters grant <memberDid> [--validity 180d]` | `POST /v1/vetting/vetters` | whether a grant was issued or an existing live one returned, its endorsement id, credential id and validity |
+| `cnm vetting vetters revoke <endorsementId>` | `DELETE /v1/credentials/endorsements/{id}` | the revoked credential and when |
+| `cnm vetting vetters resend <memberDid>` | `POST /v1/vetting/vetters/{memberDid}/resend` | the credential handed to the transport (not a delivery receipt) |
+| `cnm vetting auto-grant show` | `GET /v1/vetting/auto-grant` | enabled, sweep interval, grant validity, last sweep |
+| `cnm vetting auto-grant set [--enabled true] [--sweep-minutes 30] [--validity 365d]` | `PUT /v1/vetting/auto-grant` | the stored configuration |
+| `cnm vetting branding show` | `GET /v1/community/branding` | display name, accent colour, logo URL |
+| `cnm vetting branding set [--display-name …] [--accent-color '#1a2b3c'] [--logo-url …] [--clear logo-url]` | `PUT /v1/community/branding` | the stored branding |
+| `cnm vetting revocations` | `GET /v1/vetting/revocations` | each withdrawal: when, vetter, statement, reason, review state, affected members |
+
+Durations are `N[s|m|h|d|w]`; a grant is valid for one day to two years. `set`
+reads the current value first and changes only the flags given, so
+`--sweep-minutes 30` does not turn the sweep off. A refusal names the fix — an
+unknown endorsement id points at `vetters list`, a resend with no live grant at
+`vetters grant`, a non-member at approving their join request first.
+
+### 8. Seed vetters from a PGP web of trust (optional)
+
+A community with an existing OpenPGP web of trust — the Linux kernel's is the
+case this was built for — can name its first vetters from it rather than one by
+one:
+
+```bash
+cnm vetting bootstrap-pgp --keyring kernel-keyring.asc \
+    --roots 'ABAF11C65A2970B130ABE3C479BE3E4300411886,647F28654894E3BD457199BE38DBBDC86092693E' \
+    --max-depth 2 --links ./links --dry-run
+```
+
+**Inputs.**
+
+- `--keyring` — every key that matters: the roots, the keys that certify, and
+  the members' keys. Binary (`gpg --export > keyring.gpg`) or ASCII-armored;
+  concatenated armored exports (`cat keys/*.asc > keyring.asc`) are fine, and a
+  key exported twice is merged.
+- `--roots` — the fingerprints trust starts from, as `gpg --fingerprint`
+  prints them (40 hex digits; spaces allowed inside quotes). Short and long key
+  ids are refused because they collide. A root must be in the keyring and not
+  revoked or expired.
+- `--max-depth` — how many certification hops from a root a member's key may
+  be. `0` is the root keys only; `1` keys a root certified; `2` keys certified
+  by those; and so on.
+- `--links` — a directory of **link statements**, one per member. A statement
+  ties a member's PGP key to their member DID, so the community never has to
+  guess which key belongs to which member.
+
+**Making a link.** The member signs one line with the key they want counted:
+
+```bash
+printf 'openvtc-link: %s\n' 'did:webvh:QmExample:kernel.example:alice' \
+  | gpg --local-user <their-fingerprint> --digest-algo SHA256 --clearsign > alice.asc
+```
+
+and sends `alice.asc` to the admin, who collects the files in one directory. A
+signing subkey is fine — the link counts for its primary key. Text around the
+line is ignored; the signed text must carry exactly one `openvtc-link:` line.
+
+**What counts.**
+
+- A key is **usable** when a valid self-signature binds at least one user ID
+  and it is neither revoked nor expired.
+- Key A **certifies** key B when usable key A made a third-party certification
+  of one of B's user IDs that verifies, is exportable, has not expired, is not
+  dated in the future, and that A has not revoked. SHA-1 and RIPEMD-160
+  certifications made after 2019-01-19 are not trusted (GnuPG's cut-off); MD5
+  never is. Everything else is ignored, and the summary counts why.
+- A key's **depth** is its fewest certification hops from any root.
+- A **link** is trusted when it is a cleartext-signed message whose signature
+  verifies with exactly one usable keyring key (the primary or a bound signing
+  subkey), using SHA-256 or better. A DID claimed by more than one key, or a key
+  linking more than one DID, is ambiguous: every link involved is refused.
+
+**The plan.** `--dry-run` prints a summary (keys, certifications counted and
+ignored, keys within reach) and one row per link:
+
+| Column | |
+|---|---|
+| Member DID | the DID the statement links |
+| Key | the key's id (`--full-display`: the fingerprint) |
+| Primary User ID | as the key states it |
+| Depth, Certification Path | hops from the nearest root, and the keys on the way |
+| Action | `grant`; `already granted`; `too far` (unreachable, or beyond `--max-depth`); `not a member` (they must join first); `invalid link` (with the reason below the table) |
+
+Check the plan, then run the same command without `--dry-run`. Every `grant`
+row is granted (with `--validity` when given, one year otherwise) and the table
+is printed again with each result. Grants are audited as any admin grant is. A
+failed grant is reported and the rest continue; the command exits non-zero.
+Running it again is safe: members already holding a live grant are skipped.
+`--json` prints the summary and rows for a script.
+
+The bootstrap names vetters once; it does not keep the web of trust in sync. A
+key revoked later does not revoke the grant — revoke it with
+`cnm vetting vetters revoke`.
+
 ## What the community checks at submit
 
 For every identity-vetting statement in the join presentation

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -63,7 +63,9 @@
 //! ## Scope
 //!
 //! Authentication, the member roster, the admin join queue, removal, policy,
-//! and the applicant side of the join ceremony
+//! the vetting admin surface (vetter grants, automatic grants, branding and
+//! statement withdrawals — what `cnm vetting` drives), and the applicant side
+//! of the join ceremony
 //! ([`VtcClient::submit_join`] / [`VtcClient::submit_join_as`], which sign
 //! their own document and need no token).
 
@@ -106,11 +108,21 @@ pub mod task {
     pub const POLICY_GET: &str = "https://trusttasks.org/spec/policy/get/0.1";
     pub const POLICY_UPSERT: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
     pub const POLICY_ACTIVATE: &str = "https://trusttasks.org/spec/policy/activate/0.1";
+    pub const VETTING_VETTERS_GRANT: &str =
+        "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+    pub const VETTING_VETTERS_RESEND: &str =
+        "https://trusttasks.org/spec/vtc/vetting/vetters/resend/0.1";
+    pub const ENDORSEMENTS_REVOKE: &str = "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
 }
 
 /// Re-export of the published join-request protocol wire types, so a consumer
 /// driving the join ceremony depends on one crate.
 pub use vta_sdk::protocols::join_requests;
+
+/// Re-export of the peer identity vetting wire types — the vetter grant, the
+/// grant listing and the automatic-grant configuration this client's vetting
+/// admin verbs send and return.
+pub use vta_sdk::protocols::vetting;
 
 /// Errors surfaced by the VTC client.
 #[derive(Debug, thiserror::Error)]
@@ -240,6 +252,80 @@ pub struct RemoveResult {
     /// Wire disposition: `"tombstone"`, `"purge"`, `"historical"`.
     pub disposition: String,
     pub removed: bool,
+}
+
+/// Outcome of naming a member a vetter (`POST /vetting/vetters`).
+///
+/// Granting converges: while the member holds a live grant, asking again
+/// returns that grant rather than issuing a second. `created` says which
+/// happened, so an operator is not told "granted" about a grant that already
+/// stood.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct VetterGrant {
+    /// `true` when this call issued the grant (HTTP 201), `false` when the
+    /// member already held a live one (HTTP 200).
+    pub created: bool,
+    /// The grant.
+    pub grant: vetting::VetterGrantResponseBody,
+}
+
+/// Outcome of revoking an endorsement (`DELETE /credentials/endorsements/{id}`)
+/// — which is how a vetter grant is withdrawn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct EndorsementRevocation {
+    /// The revoked endorsement's id.
+    pub endorsement_id: String,
+    /// The credential the revocation applies to, and when.
+    pub revocation: RevocationDetail,
+    /// The credential's index on the community's revocation status list.
+    pub status_list_index: u32,
+}
+
+/// The credential a revocation applies to, and when it took effect.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct RevocationDetail {
+    /// The revoked credential's `id`.
+    pub credential_id: String,
+    /// When the revocation took effect (RFC 3339).
+    pub revoked_at: String,
+}
+
+/// One vetting statement withdrawal notice, as `GET /vetting/revocations`
+/// reports it, with the admissions it touches.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct VettingRevocation {
+    /// The vetter who withdrew the statement.
+    pub issuer: String,
+    /// The statement's `id`.
+    pub statement_id: String,
+    /// The statement's `digestMultibase`.
+    pub statement_digest_multibase: String,
+    /// The vetter's reason, when given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// When the community recorded the notice.
+    pub recorded_at: DateTime<Utc>,
+    /// `needsReview` when a current member was admitted on the statement, else
+    /// `noAdmission`.
+    pub review_state: String,
+    /// Approved join requests that counted the statement.
+    #[serde(default)]
+    pub affected_join_requests: Vec<String>,
+    /// Of their applicants, those who are current members.
+    #[serde(default)]
+    pub affected_members: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct VettingRevocationList {
+    revocations: Vec<VettingRevocation>,
 }
 
 /// A client bound to one VTC's API base, holding a bearer token once
@@ -857,6 +943,181 @@ impl VtcClient {
         .await
     }
 
+    // -----------------------------------------------------------------------
+    // Peer identity vetting — the community-admin surface
+    // -----------------------------------------------------------------------
+
+    /// Every vetter grant, newest first (`GET /vetting/vetters`). Admin token.
+    ///
+    /// Each row carries the member, validity, revocation, whether it is live,
+    /// whether an admin or the automatic sweep issued it, and the vetter's
+    /// profile summary.
+    pub async fn list_vetter_grants(&self) -> Result<vetting::VetterGrantListResponse, VtcError> {
+        let url = self.api_url(&["vetting", "vetters"])?;
+        let resp = self.untasked(reqwest::Method::GET, url)?.send().await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// Name a current member a vetter (`vtc/vetting/vetters/grant/0.1`, over
+    /// `POST /vetting/vetters`). Admin token.
+    ///
+    /// `validity_seconds` is one day to two years; `None` takes the community's
+    /// default of one year. A member already holding a live grant gets that
+    /// grant back with [`VetterGrant::created`] `false`.
+    pub async fn grant_vetter(
+        &self,
+        member_did: &str,
+        validity_seconds: Option<u64>,
+    ) -> Result<VetterGrant, VtcError> {
+        let url = self.api_url(&["vetting", "vetters"])?;
+        let body = vetting::VetterGrantBody {
+            member_did: member_did.to_string(),
+            validity_seconds,
+            ext: None,
+        };
+        let resp = self
+            .tt(reqwest::Method::POST, url, task::VETTING_VETTERS_GRANT)?
+            .json(&body)
+            .send()
+            .await?;
+        let resp = expect_success(resp).await?;
+        let created = resp.status() == reqwest::StatusCode::CREATED;
+        Ok(VetterGrant {
+            created,
+            grant: resp.json().await?,
+        })
+    }
+
+    /// Revoke an endorsement by id (`vtc/endorsements/revoke/0.1`, over
+    /// `DELETE /credentials/endorsements/{id}`) — how a vetter grant is
+    /// withdrawn. Admin token. Revoking a grant also deletes the vetter's
+    /// profile.
+    pub async fn revoke_endorsement(
+        &self,
+        endorsement_id: &str,
+    ) -> Result<EndorsementRevocation, VtcError> {
+        let url = self.api_url(&["credentials", "endorsements", endorsement_id])?;
+        let resp = self
+            .tt(reqwest::Method::DELETE, url, task::ENDORSEMENTS_REVOKE)?
+            .send()
+            .await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// Deliver a vetter's live grant credential again
+    /// (`vtc/vetting/vetters/resend/0.1`, over
+    /// `POST /vetting/vetters/{memberDid}/resend`). Admin token.
+    ///
+    /// Success means the community handed the credential to its messaging
+    /// transport — not that the member's wallet has it. A member with no live
+    /// grant is a 404; a transport that would not take the delivery is a 503.
+    pub async fn resend_vetter_grant(
+        &self,
+        member_did: &str,
+    ) -> Result<vetting::VetterResendResponseBody, VtcError> {
+        let url = self.api_url(&["vetting", "vetters", member_did, "resend"])?;
+        let resp = self
+            .tt(reqwest::Method::POST, url, task::VETTING_VETTERS_RESEND)?
+            .send()
+            .await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// The automatic vetter-grant configuration and the last sweep
+    /// (`GET /vetting/auto-grant`). Admin token.
+    pub async fn auto_grant(&self) -> Result<vetting::AutoGrantStatus, VtcError> {
+        let url = self.api_url(&["vetting", "auto-grant"])?;
+        let resp = self.untasked(reqwest::Method::GET, url)?.send().await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// Replace the automatic vetter-grant configuration
+    /// (`PUT /vetting/auto-grant`). Admin token. An absent member takes its
+    /// default, so read the current configuration first to change one value.
+    pub async fn configure_auto_grant(
+        &self,
+        config: &vetting::AutoGrantConfig,
+    ) -> Result<vetting::AutoGrantStatus, VtcError> {
+        let url = self.api_url(&["vetting", "auto-grant"])?;
+        let resp = self
+            .untasked(reqwest::Method::PUT, url)?
+            .json(config)
+            .send()
+            .await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// How the community presents itself to an applicant's client
+    /// (`GET /community/branding`). Admin token.
+    pub async fn branding(&self) -> Result<join_requests::CommunityBranding, VtcError> {
+        let url = self.api_url(&["community", "branding"])?;
+        let resp = self.untasked(reqwest::Method::GET, url)?.send().await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// Replace the community's branding (`PUT /community/branding`) and return
+    /// what was stored. Admin token. Every member is optional; an absent member
+    /// is cleared.
+    pub async fn set_branding(
+        &self,
+        branding: &join_requests::CommunityBranding,
+    ) -> Result<join_requests::CommunityBranding, VtcError> {
+        let url = self.api_url(&["community", "branding"])?;
+        let resp = self
+            .untasked(reqwest::Method::PUT, url)?
+            .json(branding)
+            .send()
+            .await?;
+        Ok(expect_success(resp).await?.json().await?)
+    }
+
+    /// Every vetting statement withdrawal notice, newest first, with the
+    /// admissions each touches (`GET /vetting/revocations`). Admin token.
+    pub async fn vetting_revocations(&self) -> Result<Vec<VettingRevocation>, VtcError> {
+        let url = self.api_url(&["vetting", "revocations"])?;
+        let resp = self.untasked(reqwest::Method::GET, url)?.send().await?;
+        let list: VettingRevocationList = expect_success(resp).await?.json().await?;
+        Ok(list.revocations)
+    }
+
+    /// `{base}/<segments…>`, each segment percent-encoded.
+    ///
+    /// A DID or an id interpolated into a path with `format!` is a path the
+    /// caller controls: a `/` or `?` in it would address a different route.
+    /// Pushing segments encodes them, so what is sent is what was meant.
+    fn api_url(&self, segments: &[&str]) -> Result<reqwest::Url, VtcError> {
+        if self.base_url.is_empty() {
+            return Err(VtcError::NoRestTransport("this verb"));
+        }
+        let mut url =
+            reqwest::Url::parse(&self.base_url).map_err(|e| VtcError::Url(e.to_string()))?;
+        url.path_segments_mut()
+            .map_err(|()| VtcError::Url(format!("{} cannot be a base URL", self.base_url)))?
+            .pop_if_empty()
+            .extend(segments);
+        Ok(url)
+    }
+
+    /// Start a bearer-authenticated request to an admin route that has **no**
+    /// Trust Task of its own.
+    ///
+    /// The VTC mounts a few admin REST routes without a `Trust-Task` binding
+    /// (the vetter listing, automatic grants, withdrawals, branding) rather
+    /// than borrow a URI that describes something else. Those are the only
+    /// callers of this; every route that does carry a task goes through
+    /// [`tt`](Self::tt).
+    fn untasked(
+        &self,
+        method: reqwest::Method,
+        url: reqwest::Url,
+    ) -> Result<reqwest::RequestBuilder, VtcError> {
+        if self.base_url.is_empty() {
+            return Err(VtcError::NoRestTransport("this verb"));
+        }
+        let token = self.token()?;
+        Ok(self.http.request(method, url).bearer_auth(token))
+    }
+
     /// Authenticated GET returning JSON, carrying `task` as the Trust-Task URL.
     async fn get_json(&self, path: &str, task: &str) -> Result<serde_json::Value, VtcError> {
         let resp = self
@@ -906,9 +1167,91 @@ impl VtcClient {
     }
 }
 
+/// The response when its status is a success, else [`VtcError::Http`] carrying
+/// the status and the body — the body is where the VTC says what was wrong, so
+/// a caller that turns this into operator guidance needs both.
+async fn expect_success(resp: reqwest::Response) -> Result<reqwest::Response, VtcError> {
+    if resp.status().is_success() {
+        return Ok(resp);
+    }
+    let status = resp.status().as_u16();
+    let body = resp.text().await.unwrap_or_default();
+    Err(VtcError::Http { status, body })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A DID or id placed in a path is one segment, whatever it contains.
+    #[test]
+    fn path_segments_are_encoded_not_interpolated() {
+        let client = VtcClient::with_token("https://vtc.example.com/v1/", "did:web:vtc", "t");
+        let url = client
+            .api_url(&[
+                "vetting",
+                "vetters",
+                "did:webvh:Qm:x.example/../admin?x",
+                "resend",
+            ])
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://vtc.example.com/v1/vetting/vetters/did:webvh:Qm:x.example%2F..%2Fadmin%3Fx/resend"
+        );
+    }
+
+    #[tokio::test]
+    async fn vetting_admin_methods_without_token_are_not_authenticated() {
+        let client = VtcClient::anonymous("https://vtc.example.com/v1", "did:web:vtc");
+        assert!(matches!(
+            client.list_vetter_grants().await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client.grant_vetter("did:key:z", None).await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client.revoke_endorsement("e1").await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client.resend_vetter_grant("did:key:z").await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client.auto_grant().await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client.branding().await,
+            Err(VtcError::NotAuthenticated)
+        ));
+        assert!(matches!(
+            client.vetting_revocations().await,
+            Err(VtcError::NotAuthenticated)
+        ));
+    }
+
+    #[test]
+    fn a_withdrawal_row_deserializes_from_the_vtc_shape() {
+        let rows: VettingRevocationList = serde_json::from_value(serde_json::json!({
+            "revocations": [{
+                "issuer": "did:key:zCarol",
+                "statementId": "urn:uuid:s1",
+                "statementDigestMultibase": "zDigest",
+                "reason": "mistake",
+                "recordedAt": "2026-09-01T00:00:00Z",
+                "reviewState": "needsReview",
+                "affectedJoinRequests": ["3f1c9a52-8c1e-4f2b-9d7a-0b6e5c4d3a21"],
+                "affectedMembers": ["did:key:zAlice"]
+            }]
+        }))
+        .unwrap();
+        assert_eq!(rows.revocations[0].review_state, "needsReview");
+        assert_eq!(rows.revocations[0].affected_members, vec!["did:key:zAlice"]);
+    }
 
     /// A holder on any DID method can name its verification method, which is
     /// the whole point of the general submit path.

--- a/vtc-service/tests/vetting_journey.rs
+++ b/vtc-service/tests/vetting_journey.rs
@@ -1,0 +1,1069 @@
+//! Peer identity vetting, end to end: the journey an admin, two vetters and two
+//! applicants take through a community, as one runnable story.
+//!
+//! Read it top to bottom as documentation of the flow. Every step says who acts
+//! and what crosses the wire; the assertions are what each party can rely on
+//! afterwards. It runs in process against the real router, with `did:key`
+//! identities throughout — the community's own DID included, so an applicant's
+//! client can check the community's signatures with no network.
+//!
+//! 1. **The admin sets up the community**: registers the Vetting Statement
+//!    type and publishes an Accepts criterion that requires two vetters, one of
+//!    them in person.
+//! 2. **The community names vetters**: the admin grants Carol the vetter role;
+//!    a `vetterEligibility` policy that trusts members of 30 days' standing,
+//!    run by the automatic-grant sweep, names Dave (and not Erin, who joined
+//!    last week).
+//! 3. **Vetters publish profiles**, and an applicant finds them by language,
+//!    country and event dates.
+//! 4. **Alice gathers statements**: for each vetter she checks the vetter's
+//!    eligibility presentation (and its revocation status), shows a Vetting
+//!    Card bound to that session, and receives a signed Vetting Statement she
+//!    verifies against her card.
+//! 5. **Alice applies**, presenting both statements and naming the
+//!    requirements she gathered against (`requirementsDigest`); the community
+//!    admits her, and the admin can read the vetting facts it decided on.
+//! 6. **Carol withdraws her statement**; the admin sees the withdrawal touches
+//!    Alice's membership (`needsReview`).
+//! 7. **The admin revokes Dave's grant**: Bob, who gathered a statement from
+//!    Dave before that, sees Dave's credential is now revoked, and the
+//!    community no longer counts Dave's statement.
+//!
+//! Delivering a grant credential again over the community's messaging is the
+//! second test, `a_resend_delivers_the_live_grant_credential_again`, which
+//! needs the in-process DIDComm harness.
+
+use std::sync::Arc;
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::{Duration, Utc};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use uuid::Uuid;
+use vta_sdk::protocols::credential_exchange::{ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody};
+use vta_sdk::protocols::join_requests::JOIN_REQUEST_MANIFEST_0_2_TYPE;
+use vta_sdk::protocols::vetting::{
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, CardClaim, DeclaredRelationship,
+    IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement, VETTING_REVOKE_STATEMENT_TYPE,
+    VETTING_VETTER_LIST_TYPE, VETTING_VETTER_PROFILE_TYPE, VettingMethod,
+};
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::card::{
+    CardDraft, CardExpectations, VerifiedVettingCard, new_commitment_salt, sign_card, verify_card,
+};
+use vta_sdk::vetting::eligibility::{
+    EligibilityExpectations, build_eligibility_vp, verify_eligibility_vp,
+};
+use vta_sdk::vetting::requirements::requirements_digest;
+use vta_sdk::vetting::statement::{StatementDraft, sign_statement, verify_statement};
+use vta_sdk::vetting::status::{StatusCheck, check_credential_status};
+use vtc_service::acl::{VtcAclEntry, VtcRole, store_acl_entry};
+use vtc_service::test_support::{MockVtcDidcomm, TestJoinClient, TestVtc};
+use vti_common::auth::session::{Session, SessionState, store_session};
+
+const RP_ORIGIN: &str = "https://kernel-vtc.example";
+const ADMIN_DID: &str = "did:key:zKernelAdmin";
+
+const COMMUNITY_SEED: [u8; 32] = [0xC0; 32];
+const CAROL_SEED: [u8; 32] = [0x11; 32];
+const DAVE_SEED: [u8; 32] = [0x22; 32];
+const ERIN_SEED: [u8; 32] = [0x33; 32];
+const ALICE_SEED: [u8; 32] = [0xA1; 32];
+const BOB_SEED: [u8; 32] = [0xB0; 32];
+
+const SUBMIT_TASK: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.2";
+const GRANT_TASK: &str = "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+const RESEND_TASK: &str = "https://trusttasks.org/spec/vtc/vetting/vetters/resend/0.1";
+const ENDORSEMENT_REVOKE_TASK: &str = "https://trusttasks.org/spec/vtc/endorsements/revoke/0.1";
+const ENDORSEMENT_TYPE_REGISTER_TASK: &str =
+    "https://trusttasks.org/spec/vtc/endorsement-types/register/0.1";
+const POLICY_UPLOAD_TASK: &str = "https://trusttasks.org/spec/policy/upsert/0.2";
+const POLICY_ACTIVATE_TASK: &str = "https://trusttasks.org/spec/policy/activate/0.1";
+
+/// The community's own policy for naming vetters automatically: any active
+/// member of at least 30 days' standing whose admission is not under review.
+const TENURED_MEMBERS_VET: &str = "package vtc.vetter_eligibility\n\
+import rego.v1\n\
+\n\
+default decision := {\"effect\": \"deny\"}\n\
+\n\
+decision := {\"effect\": \"allow\"} if {\n\
+\tinput.status == \"active\"\n\
+\tinput.underReview == false\n\
+\tinput.tenureDays >= 30\n\
+}\n";
+
+// ---------------------------------------------------------------------------
+// The journey
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_community_vets_applicants_through_members_it_names_vetters() {
+    let community = kernel_community().await;
+    let c = &community;
+
+    // -----------------------------------------------------------------------
+    // 1. The admin sets up the community.
+    // -----------------------------------------------------------------------
+
+    // Statements are endorsements of a registered type…
+    let (status, body) = c
+        .admin(
+            "POST",
+            "/v1/endorsement-types",
+            Some(ENDORSEMENT_TYPE_REGISTER_TASK),
+            Some(json!({
+                "typeUri": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                "description": "A member verified this person's identity",
+            })),
+        )
+        .await;
+    assert!(status.is_success(), "register statement type: {body}");
+
+    // …and the criterion says how many a join needs. Every number is the
+    // community's policy.
+    let (status, body) = c
+        .admin(
+            "POST",
+            "/v1/schemas/accepts",
+            None,
+            Some(json!({
+                "id": "kernel-developer",
+                "description": "Two vetters, at least one in person",
+                "query": { "credentials": [ { "id": "vetting", "format": "ldp_vc",
+                           "meta": { "type_values": ["EndorsementCredential"] } } ] },
+                "vetting": {
+                    "version": "0.1",
+                    "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                    "minStatements": 2,
+                    "minByMethod": { "inPerson": 1 },
+                    "acceptedMethods": ["inPerson", "video"],
+                    "requiredClaims": ["name.legal"],
+                    "maxStatementAge": "P120D",
+                    "eligibleVetters": { "role": "vetter" },
+                    "independence": { "requireConsistentIdentityCommitment": true }
+                }
+            })),
+        )
+        .await;
+    assert_eq!(status, StatusCode::CREATED, "vetting criterion: {body}");
+
+    // -----------------------------------------------------------------------
+    // 2. The community names its vetters.
+    // -----------------------------------------------------------------------
+
+    // Three founding members: Carol and Dave of two months' standing, Erin of
+    // three days'.
+    let carol = Person::new(CAROL_SEED);
+    let dave = Person::new(DAVE_SEED);
+    let erin = Person::new(ERIN_SEED);
+    c.seed_member(&carol.did, 60).await;
+    c.seed_member(&dave.did, 60).await;
+    c.seed_member(&erin.did, 3).await;
+
+    // The admin names Carol a vetter. The community issues her a revocable
+    // vetter role credential and answers with the grant.
+    let (status, carol_grant) = c
+        .admin(
+            "POST",
+            "/v1/vetting/vetters",
+            Some(GRANT_TASK),
+            Some(json!({ "memberDid": carol.did })),
+        )
+        .await;
+    assert_eq!(status, StatusCode::CREATED, "grant Carol: {carol_grant}");
+
+    // The community's own policy names the rest: members of 30 days. The
+    // sweep is off until an admin turns it on.
+    c.activate_vetter_policy(TENURED_MEMBERS_VET).await;
+    let (status, body) = c
+        .admin(
+            "PUT",
+            "/v1/vetting/auto-grant",
+            None,
+            Some(json!({ "enabled": true, "sweepMinutes": 60, "validitySeconds": 180 * 86_400 })),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "auto-grant: {body}");
+    // In production the sweep runs on its timer; here it runs once, now.
+    let sweep = vtc_service::vetting::auto_grant::run_sweep(&c.state)
+        .await
+        .expect("sweep");
+    assert_eq!(
+        (sweep.granted, sweep.revoked, sweep.errors),
+        (1, 0, 0),
+        "Dave is granted; Carol already holds a grant; Erin is too new"
+    );
+
+    let (_, grants) = c.admin("GET", "/v1/vetting/vetters", None, None).await;
+    let grant_of = |did: &str| {
+        grants["vetters"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|g| g["memberDid"] == did)
+            .cloned()
+    };
+    let carol_row = grant_of(&carol.did).expect("Carol's grant is listed");
+    assert_eq!(
+        (carol_row["origin"].as_str(), carol_row["live"].as_bool()),
+        (Some("manual"), Some(true))
+    );
+    let dave_row = grant_of(&dave.did).expect("Dave's grant is listed");
+    assert_eq!(
+        (dave_row["origin"].as_str(), dave_row["live"].as_bool()),
+        (Some("auto"), Some(true))
+    );
+    assert!(
+        grant_of(&erin.did).is_none(),
+        "the policy did not name Erin"
+    );
+
+    // -----------------------------------------------------------------------
+    // 3. Vetters publish profiles; an applicant finds them.
+    // -----------------------------------------------------------------------
+
+    let (status, body) = c
+        .post_document(
+            CAROL_SEED,
+            VETTING_VETTER_PROFILE_TYPE,
+            json!({
+                "listed": true,
+                "displayName": "Carol M.",
+                "languages": ["en", "de-AT"],
+                "location": { "country": "AT", "city": "Vienna" },
+                "methods": ["inPerson", "video"],
+                "acceptsDocumentation": ["passport", "nationalId"],
+                "contactHint": "Ask for a ticket at the kernel-vtc table.",
+                "events": [ { "name": "Kernel Maintainers Summit",
+                              "startDate": day(20), "endDate": day(22),
+                              "location": { "country": "AT", "city": "Vienna" } } ]
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "Carol's profile: {body}");
+    let (status, body) = c
+        .post_document(
+            DAVE_SEED,
+            VETTING_VETTER_PROFILE_TYPE,
+            json!({
+                "listed": true,
+                "displayName": "Dave L.",
+                "languages": ["fr"],
+                "location": { "country": "FR", "city": "Lyon" },
+                "methods": ["video"],
+                "acceptsDocumentation": ["passport"],
+                "events": [ { "name": "Open Source Summit", "startDate": day(60), "endDate": day(61) } ]
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "Dave's profile: {body}");
+
+    // Alice is not a member, but she has a DID, so she may look. Each filter
+    // narrows the listing to the vetter it describes.
+    for (filters, expected) in [
+        (json!({ "language": "de" }), &carol.did),
+        (json!({ "country": "FR" }), &dave.did),
+        (
+            json!({ "eventFrom": day(19), "eventTo": day(25) }),
+            &carol.did,
+        ),
+    ] {
+        let (status, body) = c
+            .post_document(ALICE_SEED, VETTING_VETTER_LIST_TYPE, filters.clone())
+            .await;
+        assert_eq!(status, StatusCode::OK, "list {filters}: {body}");
+        let listed: Vec<&str> = body["payload"]["vetters"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["vetterDid"].as_str().unwrap())
+            .collect();
+        assert_eq!(listed, vec![expected.as_str()], "filters {filters}");
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Alice gathers two statements.
+    // -----------------------------------------------------------------------
+
+    // She reads the requirements from manifest 0.2 and records their digest,
+    // recomputing it to be sure it describes what she received.
+    let (status, manifest) = c
+        .post_document(ALICE_SEED, JOIN_REQUEST_MANIFEST_0_2_TYPE, json!({}))
+        .await;
+    assert_eq!(status, StatusCode::OK, "manifest: {manifest}");
+    let criterion = &manifest["payload"]["criteria"][0];
+    let digest = criterion["requirementsDigest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(requirements_digest(criterion).unwrap(), digest);
+
+    // One commitment salt for the whole application, so every vetter attests
+    // to the same claimed identity.
+    let alice = Applicant::new(ALICE_SEED, "Alice Example");
+
+    // Before any session her client checks each vetter really is one: the
+    // presentation answers her request and carries a role credential this
+    // community signed, and the community's status list says it is live.
+    assert!(matches!(
+        c.check_vetter(&carol, &alice).await,
+        StatusCheck::Active
+    ));
+    assert!(matches!(
+        c.check_vetter(&dave, &alice).await,
+        StatusCheck::Active
+    ));
+
+    // One session per vetter: Carol meets her in person, Dave on video.
+    let from_carol = c
+        .vetting_session(&carol, &alice, VettingMethod::InPerson)
+        .await;
+    let from_dave = c.vetting_session(&dave, &alice, VettingMethod::Video).await;
+
+    // -----------------------------------------------------------------------
+    // 5. Alice applies and is admitted.
+    // -----------------------------------------------------------------------
+
+    let (status, verdict) = c
+        .post_document(
+            ALICE_SEED,
+            SUBMIT_TASK,
+            json!({
+                "vp": {
+                    "type": "VerifiablePresentation",
+                    "holder": alice.did,
+                    "verifiableCredential": [from_carol.clone(), from_dave.clone()],
+                },
+                "registryConsent": false,
+                "extensions": { "requirementsDigest": digest },
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "submit: {verdict}");
+    assert_eq!(
+        verdict["payload"]["verdict"]["effect"], "allow",
+        "{verdict}"
+    );
+    let alice_request = verdict["payload"]["requestId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        vtc_service::members::get_member(&c.state.members_ks, &alice.did)
+            .await
+            .unwrap()
+            .is_some(),
+        "Alice is a member"
+    );
+
+    // The admin reads the facts the decision rested on.
+    let (status, facts) = c
+        .admin(
+            "GET",
+            &format!("/v1/join-requests/{alice_request}/vetting"),
+            None,
+            None,
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{facts}");
+    let vetting = &facts["vetting"];
+    assert_eq!(vetting["satisfied"], true, "{facts}");
+    assert_eq!(vetting["criterionId"], "kernel-developer");
+    assert_eq!(vetting["requirementsDigest"], digest.as_str());
+    assert_eq!(vetting["applicantDigestMatches"], true);
+    assert_eq!(vetting["distinctCountedVetters"], 2);
+    assert_eq!(vetting["byMethod"], json!({ "inPerson": 1, "video": 1 }));
+    assert!(
+        vetting["statements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|s| s["counted"] == true && s["withdrawnNow"] == false),
+        "{facts}"
+    );
+
+    // -----------------------------------------------------------------------
+    // 6. Carol withdraws her statement.
+    // -----------------------------------------------------------------------
+
+    // Carol names the statement by id and digest; only its signer can
+    // withdraw it.
+    let resolver = TrustTaskVmResolver::did_key_only();
+    let carols_statement = verify_statement(&from_carol, Utc::now(), &resolver)
+        .await
+        .unwrap();
+    let (status, body) = c
+        .post_document(
+            CAROL_SEED,
+            VETTING_REVOKE_STATEMENT_TYPE,
+            json!({
+                "statementId": carols_statement.id(),
+                "statementDigestMultibase": carols_statement.digest_multibase(),
+                "reason": "newInformation",
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "withdraw: {body}");
+
+    // The admin sees it touches a standing membership.
+    let (status, revocations) = c.admin("GET", "/v1/vetting/revocations", None, None).await;
+    assert_eq!(status, StatusCode::OK, "{revocations}");
+    let notice = &revocations["revocations"][0];
+    assert_eq!(notice["issuer"], carol.did.as_str());
+    assert_eq!(notice["reviewState"], "needsReview");
+    assert_eq!(notice["affectedMembers"], json!([alice.did]));
+    assert_eq!(notice["affectedJoinRequests"], json!([alice_request]));
+    let (_, facts) = c
+        .admin(
+            "GET",
+            &format!("/v1/join-requests/{alice_request}/vetting"),
+            None,
+            None,
+        )
+        .await;
+    let withdrawn: Vec<&str> = facts["vetting"]["statements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|s| s["withdrawnNow"] == true)
+        .map(|s| s["issuer"].as_str().unwrap())
+        .collect();
+    assert_eq!(withdrawn, vec![carol.did.as_str()]);
+
+    // -----------------------------------------------------------------------
+    // 7. A revoked grant stops a vetter's statement counting.
+    // -----------------------------------------------------------------------
+
+    // Bob gathers his statements while both grants stand.
+    let bob = Applicant::new(BOB_SEED, "Bob Example");
+    let bob_from_carol = c
+        .vetting_session(&carol, &bob, VettingMethod::InPerson)
+        .await;
+    let bob_from_dave = c.vetting_session(&dave, &bob, VettingMethod::Video).await;
+
+    // Then the admin withdraws Dave's grant — the automatic one — by its
+    // endorsement id.
+    let dave_grant = dave_row["endorsementId"].as_str().unwrap();
+    let (status, body) = c
+        .admin(
+            "DELETE",
+            &format!("/v1/credentials/endorsements/{dave_grant}"),
+            Some(ENDORSEMENT_REVOKE_TASK),
+            None,
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "revoke Dave's grant: {body}");
+
+    // Bob's client can see it: Dave's presentation still verifies, but the
+    // community's status list now says his credential is revoked.
+    assert!(matches!(
+        c.check_vetter(&dave, &bob).await,
+        StatusCheck::Revoked
+    ));
+
+    // And the community will not count Dave's statement, whenever it was
+    // signed: Bob is one statement short.
+    let (status, verdict) = c
+        .post_document(
+            BOB_SEED,
+            SUBMIT_TASK,
+            json!({
+                "vp": {
+                    "type": "VerifiablePresentation",
+                    "holder": bob.did,
+                    "verifiableCredential": [bob_from_carol, bob_from_dave],
+                },
+                "registryConsent": false,
+                "extensions": { "requirementsDigest": digest },
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "Bob's submit: {verdict}");
+    assert_eq!(
+        verdict["payload"]["verdict"]["effect"], "requestMore",
+        "{verdict}"
+    );
+    assert_eq!(
+        verdict["payload"]["verdict"]["with"]["needs"],
+        json!(["vetting:statements:1"])
+    );
+    let bob_request = verdict["payload"]["requestId"].as_str().unwrap();
+    let (_, facts) = c
+        .admin(
+            "GET",
+            &format!("/v1/join-requests/{bob_request}/vetting"),
+            None,
+            None,
+        )
+        .await;
+    let daves = facts["vetting"]["statements"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["issuer"] == dave.did.as_str())
+        .expect("Dave's statement is in the facts");
+    assert_eq!(daves["counted"], false, "{facts}");
+    assert_eq!(daves["eligible"], false);
+    assert!(
+        daves["failures"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("issuer-not-vetter")),
+        "{facts}"
+    );
+}
+
+/// A vetter whose wallet lost the grant credential gets the same credential
+/// again — nothing new is issued — while the grant is live, and nothing once
+/// it is revoked.
+///
+/// Delivery needs the community's messaging running, so this runs on the
+/// in-process mediator harness; the vetter is a connected DIDComm peer.
+#[tokio::test]
+async fn a_resend_delivers_the_live_grant_credential_again() {
+    let mock = MockVtcDidcomm::start().await;
+    let vetter = mock.connect_registry_peer().await;
+    let vetter_did = vetter.did().to_string();
+    let state = &mock.vtc.state;
+    let purpose = affinidi_status_list::StatusPurpose::Revocation;
+    vtc_service::status_list::ensure_initial(
+        &state.status_lists_ks,
+        purpose,
+        format!("https://vtc.test/v1/status-lists/{purpose}"),
+    )
+    .await
+    .expect("status list");
+    let token = admin_token(&mock.vtc).await;
+    seed_member_row(&mock.vtc, &vetter_did, 60).await;
+    let router = &mock.vtc.router;
+
+    // The admin names the peer a vetter; the grant credential is pushed to it.
+    let (status, grant) = rest(
+        router,
+        &token,
+        "POST",
+        "/v1/vetting/vetters",
+        Some(GRANT_TASK),
+        Some(json!({ "memberDid": vetter_did })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "grant: {grant}");
+    let delivered = next_issued_credential(&vetter).await;
+    assert_eq!(delivered["id"], grant["credentialId"]);
+
+    // Asked to resend, the community hands the same credential to the
+    // transport again.
+    let resend_uri = format!("/v1/vetting/vetters/{vetter_did}/resend");
+    let (status, resent) = rest(router, &token, "POST", &resend_uri, Some(RESEND_TASK), None).await;
+    assert_eq!(status, StatusCode::OK, "resend: {resent}");
+    assert_eq!(resent["credentialId"], grant["credentialId"]);
+    assert_eq!(resent["validUntil"], grant["validUntil"]);
+    let again = next_issued_credential(&vetter).await;
+    assert_eq!(again, delivered, "the same credential, not a new one");
+
+    // Once the grant is revoked there is nothing to resend.
+    let (status, body) = rest(
+        router,
+        &token,
+        "DELETE",
+        &format!(
+            "/v1/credentials/endorsements/{}",
+            grant["endorsementId"].as_str().unwrap()
+        ),
+        Some(ENDORSEMENT_REVOKE_TASK),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "revoke: {body}");
+    let (status, body) = rest(router, &token, "POST", &resend_uri, Some(RESEND_TASK), None).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "resend after revoke: {body}");
+
+    vetter.shutdown().await;
+    mock.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// The parties
+// ---------------------------------------------------------------------------
+
+/// A member who vets: a `did:key` and its signing secret.
+struct Person {
+    did: String,
+    key: Secret,
+}
+
+impl Person {
+    fn new(seed: [u8; 32]) -> Self {
+        let (did, key) = did_key(seed);
+        Self { did, key }
+    }
+}
+
+/// An applicant: the join DID and one commitment salt per application.
+struct Applicant {
+    did: String,
+    key: Secret,
+    legal_name: &'static str,
+    salt: String,
+}
+
+impl Applicant {
+    fn new(seed: [u8; 32], legal_name: &'static str) -> Self {
+        let (did, key) = did_key(seed);
+        Self {
+            did,
+            key,
+            legal_name,
+            salt: new_commitment_salt().expect("salt"),
+        }
+    }
+}
+
+/// The community under test, with an admin session.
+struct Community {
+    router: axum::Router,
+    state: vtc_service::server::AppState,
+    did: String,
+    admin_token: String,
+    _vtc: TestVtc,
+}
+
+/// A community whose DID is a `did:key`, signing its credentials and status
+/// lists with that key, with the default policies and status lists a daemon
+/// installs at boot.
+async fn kernel_community() -> Community {
+    let (did, key) = did_key(COMMUNITY_SEED);
+    let signer = Arc::new(vtc_service::credentials::LocalSigner::new(did.clone(), key));
+    let vtc = TestVtc::builder()
+        .vtc_did(did.clone())
+        .with_audit(true)
+        .with_public_url(RP_ORIGIN)
+        .with_credential_signer(signer)
+        .build()
+        .await;
+    vtc_service::policy::default::install_defaults(
+        &vtc.state.policies_ks,
+        &vtc.state.active_policies_ks,
+    )
+    .await
+    .expect("default policies");
+    for purpose in [
+        affinidi_status_list::StatusPurpose::Revocation,
+        affinidi_status_list::StatusPurpose::Suspension,
+    ] {
+        vtc_service::status_list::ensure_initial(
+            &vtc.state.status_lists_ks,
+            purpose,
+            format!("{RP_ORIGIN}/v1/status-lists/{purpose}"),
+        )
+        .await
+        .expect("status list");
+    }
+    let admin_token = admin_token(&vtc).await;
+    Community {
+        router: vtc.router.clone(),
+        state: vtc.state.clone(),
+        did,
+        admin_token,
+        _vtc: vtc,
+    }
+}
+
+impl Community {
+    /// An admin REST call. `task` is the route's `Trust-Task`, for the routes
+    /// that carry one.
+    async fn admin(
+        &self,
+        method: &str,
+        uri: &str,
+        task: Option<&str>,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        rest(&self.router, &self.admin_token, method, uri, task, body).await
+    }
+
+    /// A Trust Task document from the holder of `seed`, addressed to this
+    /// community and posted to `/v1/trust-tasks`. The holder's proof over the
+    /// document is its authentication.
+    async fn post_document(
+        &self,
+        seed: [u8; 32],
+        typ: &str,
+        payload: Value,
+    ) -> (StatusCode, Value) {
+        let (did, secret) = did_key(seed);
+        // Whole seconds, `Z`: the community verifies the proof over the
+        // document as it parses it, and a timestamp that does not survive that
+        // round trip unchanged (`+00:00`, sub-second digits) breaks the proof.
+        let now = Utc::now();
+        let stamp = |t: chrono::DateTime<Utc>| t.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        let mut doc = json!({
+            "type": typ,
+            "id": format!("urn:uuid:{}", Uuid::new_v4()),
+            "issuer": did,
+            "recipient": self.did,
+            "issuedAt": stamp(now),
+            "expiresAt": stamp(now + Duration::hours(1)),
+            "payload": payload,
+        });
+        let proof = DataIntegrityProof::sign(&doc, &secret, SignOptions::new())
+            .await
+            .expect("sign document");
+        doc["proof"] = serde_json::to_value(proof).unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/trust-tasks")
+            .header("content-type", "application/json")
+            .body(Body::from(doc.to_string()))
+            .unwrap();
+        read(self.router.clone().oneshot(req).await.expect("oneshot")).await
+    }
+
+    /// A member admitted `days_ago`, as a founding member would be.
+    async fn seed_member(&self, did: &str, days_ago: i64) {
+        seed_member_row(&self._vtc, did, days_ago).await;
+    }
+
+    /// Upload `source` as the `vetterEligibility` policy and activate it.
+    async fn activate_vetter_policy(&self, source: &str) {
+        let (status, body) = self
+            .admin(
+                "POST",
+                "/v1/policies",
+                Some(POLICY_UPLOAD_TASK),
+                Some(json!({
+                    "name": "tenured-members-vet",
+                    "module": source,
+                    "ext": { "org.openvtc.purpose": "vetterEligibility" }
+                })),
+            )
+            .await;
+        assert!(status.is_success(), "upload policy: {body}");
+        let id = body["policy"]["id"].as_str().expect("policy id");
+        let (status, body) = self
+            .admin(
+                "POST",
+                &format!("/v1/policies/{id}/activate"),
+                Some(POLICY_ACTIVATE_TASK),
+                Some(json!({})),
+            )
+            .await;
+        assert_eq!(status, StatusCode::OK, "activate policy: {body}");
+    }
+
+    /// The applicant's pre-session check of a vetter (`vetting/request`): the
+    /// vetter answers with an eligibility presentation over their grant
+    /// credential; the applicant verifies it, then asks the community's status
+    /// list whether the credential still stands.
+    async fn check_vetter(&self, vetter: &Person, applicant: &Applicant) -> StatusCheck {
+        // The request's `id` is the challenge; its `joinDid` the domain.
+        let request_id = format!("urn:uuid:{}", Uuid::new_v4());
+
+        // Vetter: present the role credential the community delivered.
+        let credential = self.grant_credential(&vetter.did).await;
+        let vp = build_eligibility_vp(&vetter.key, vec![credential], &request_id, &applicant.did)
+            .await
+            .expect("eligibility presentation");
+
+        // Applicant: it answers this request, and the community signed it.
+        let resolver = TrustTaskVmResolver::did_key_only();
+        let verified = verify_eligibility_vp(
+            &vp,
+            &EligibilityExpectations {
+                vetter: &vetter.did,
+                community: &self.did,
+                role: "vetter",
+                challenge: &request_id,
+                domain: &applicant.did,
+                now: Utc::now(),
+            },
+            &resolver,
+        )
+        .await
+        .expect("the vetter's eligibility presentation verifies");
+
+        // Applicant: and it has not been revoked. The client owns the fetch;
+        // here it is the community's router.
+        let router = self.router.clone();
+        let fetch = async |url: &str| -> Result<Value, String> {
+            let path = url
+                .strip_prefix(RP_ORIGIN)
+                .ok_or_else(|| format!("unexpected status list URL {url}"))?;
+            let req = Request::builder()
+                .uri(path)
+                .body(Body::empty())
+                .map_err(|e| e.to_string())?;
+            let res = router
+                .clone()
+                .oneshot(req)
+                .await
+                .map_err(|e| e.to_string())?;
+            let (status, body) = read(res).await;
+            if status.is_success() {
+                Ok(body)
+            } else {
+                Err(format!("status list fetch {status}: {body}"))
+            }
+        };
+        check_credential_status(
+            verified
+                .credential_status()
+                .expect("a vetter grant carries a status entry"),
+            &self.did,
+            fetch,
+            &resolver,
+        )
+        .await
+    }
+
+    /// One vetting session between `vetter` and `applicant`, returning the
+    /// statement the applicant keeps.
+    async fn vetting_session(
+        &self,
+        vetter: &Person,
+        applicant: &Applicant,
+        method: VettingMethod,
+    ) -> Value {
+        let resolver = TrustTaskVmResolver::did_key_only();
+        let required = vec!["name.legal".to_string()];
+
+        // Vetter: open the session (`vetting/session`) with a fresh challenge.
+        let session_id = format!("urn:uuid:{}", Uuid::new_v4());
+        let challenge = new_commitment_salt().expect("challenge");
+
+        // Applicant: a card for this vetter and this session only.
+        let card = sign_card(
+            CardDraft {
+                id: format!("urn:uuid:{}", Uuid::new_v4()),
+                publisher: applicant.did.clone(),
+                audience: vetter.did.clone(),
+                community: self.did.clone(),
+                challenge: challenge.clone(),
+                domain: self.did.clone(),
+                issued_at: Utc::now(),
+                validity: Duration::minutes(15),
+                claims: vec![CardClaim {
+                    claim_type: "name.legal".into(),
+                    value: json!(applicant.legal_name),
+                    provenance: "selfAsserted".into(),
+                }],
+                identity_types: required.clone(),
+                salt: applicant.salt.clone(),
+            },
+            &applicant.key,
+        )
+        .await
+        .expect("sign card");
+
+        // Vetter: the card is bound to them and to this session; they check
+        // the person in front of them matches it, then sign the statement.
+        let expectations = CardExpectations {
+            audience: &vetter.did,
+            publisher: &applicant.did,
+            community: &self.did,
+            challenge: &challenge,
+            domain: &self.did,
+            required_claims: &required,
+            now: Utc::now(),
+        };
+        let checked: VerifiedVettingCard = verify_card(&card, &expectations, &resolver)
+            .await
+            .expect("the vetter accepts the card");
+        let now = Utc::now();
+        let statement = sign_statement(
+            StatementDraft {
+                id: format!("urn:uuid:{}", Uuid::new_v4()),
+                issuer: vetter.did.clone(),
+                subject: applicant.did.clone(),
+                endorsement: IdentityVettingEndorsement {
+                    endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
+                    community: self.did.clone(),
+                    method,
+                    document_classes: vec!["passport".into()],
+                    claims_verified: required.clone(),
+                    liveness_confirmed: true,
+                    identity_commitment: checked.card().identity_commitment.clone(),
+                    card_digest_multibase: checked.digest_multibase().to_string(),
+                    declared_relationship: DeclaredRelationship::None,
+                    attestation_text_digest: None,
+                },
+                valid_from: now,
+                valid_until: now + Duration::days(90),
+                task_context: session_id,
+            },
+            &vetter.key,
+        )
+        .await
+        .expect("sign statement");
+
+        // Applicant: the statement verifies and attests to the card she showed.
+        let own_card = verify_card(&card, &expectations, &resolver).await.unwrap();
+        verify_statement(&statement, Utc::now(), &resolver)
+            .await
+            .expect("the statement verifies")
+            .check_against_card(&own_card)
+            .expect("the statement is about the card the applicant showed");
+        statement
+    }
+
+    /// The grant credential the community issued `did`, as the vetter's wallet
+    /// holds it.
+    async fn grant_credential(&self, did: &str) -> Value {
+        vtc_service::endorsements::endorsements_for_subject(
+            &self.state.endorsements_ks,
+            did,
+            COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+        )
+        .await
+        .expect("read grants")
+        .into_iter()
+        .find_map(|g| g.credential)
+        .expect("the grant keeps its credential")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plumbing
+// ---------------------------------------------------------------------------
+
+fn did_key(seed: [u8; 32]) -> (String, Secret) {
+    let mut secret = Secret::generate_ed25519(None, Some(&seed));
+    let pub_mb = secret.get_public_keymultibase().expect("pubkey multibase");
+    let did = format!("did:key:{pub_mb}");
+    secret.id = format!("{did}#{pub_mb}");
+    (did, secret)
+}
+
+fn day(offset: i64) -> String {
+    (Utc::now() + Duration::days(offset))
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+/// An admin ACL row, a session, and a bearer token for it.
+async fn admin_token(vtc: &TestVtc) -> String {
+    let now = vtc_service::auth::session::now_epoch();
+    store_acl_entry(
+        &vtc.state.acl_ks,
+        &VtcAclEntry {
+            did: ADMIN_DID.into(),
+            role: VtcRole::Admin,
+            label: Some("kernel community admin".into()),
+            allowed_contexts: vec![],
+            created_at: now,
+            created_by: "did:key:vtc-install".into(),
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+        },
+    )
+    .await
+    .unwrap();
+    let session_id = "vetting-journey-admin";
+    store_session(
+        &vtc.state.sessions_ks,
+        &Session {
+            session_id: session_id.into(),
+            did: ADMIN_DID.into(),
+            challenge: "test".into(),
+            state: SessionState::Authenticated,
+            created_at: now,
+            last_seen: now,
+            refresh_token: None,
+            refresh_expires_at: None,
+            tee_attested: false,
+            amr: Vec::new(),
+            acr: String::new(),
+            acr_expires_at: None,
+            token_id: None,
+            session_pubkey_b58btc: None,
+        },
+    )
+    .await
+    .unwrap();
+    let claims = vtc.jwt_keys.new_claims(
+        ADMIN_DID.into(),
+        session_id.into(),
+        "admin".into(),
+        vec![],
+        3600,
+        true,
+    );
+    vtc.jwt_keys.encode(&claims).unwrap()
+}
+
+/// A member row and ACL entry for `did`, admitted `days_ago`.
+async fn seed_member_row(vtc: &TestVtc, did: &str, days_ago: i64) {
+    let mut member = vtc_service::members::Member::fresh(did);
+    member.joined_at = Utc::now() - Duration::days(days_ago);
+    vtc_service::members::storage::store_member(&vtc.state.members_ks, &member)
+        .await
+        .expect("store member");
+    store_acl_entry(
+        &vtc.state.acl_ks,
+        &VtcAclEntry {
+            did: did.into(),
+            role: VtcRole::Member,
+            label: None,
+            allowed_contexts: vec![],
+            created_at: vtc_service::auth::session::now_epoch(),
+            created_by: ADMIN_DID.into(),
+            updated_at: None,
+            updated_by: None,
+            expires_at: None,
+        },
+    )
+    .await
+    .expect("store acl");
+}
+
+async fn rest(
+    router: &axum::Router,
+    token: &str,
+    method: &str,
+    uri: &str,
+    task: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"));
+    if let Some(task) = task {
+        req = req.header("Trust-Task", task);
+    }
+    let req = req
+        .body(body.map_or_else(Body::empty, |v| Body::from(v.to_string())))
+        .unwrap();
+    read(router.clone().oneshot(req).await.expect("oneshot")).await
+}
+
+async fn read(res: axum::response::Response) -> (StatusCode, Value) {
+    let status = res.status();
+    let bytes = res.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+/// The next `credential-exchange/issue` pushed to `peer`, unwrapped.
+async fn next_issued_credential(peer: &TestJoinClient) -> Value {
+    let (typ, body) = peer
+        .next_pushed(std::time::Duration::from_secs(30))
+        .await
+        .expect("a credential was pushed to the vetter");
+    assert_eq!(typ, CREDENTIAL_ISSUE_TYPE);
+    let issue: IssueBody = serde_json::from_value(body).expect("issue body");
+    issue
+        .credential_response
+        .expect("credential_response")
+        .credential
+        .expect("credential")
+}

--- a/vtc-service/tests/vtc_client_live.rs
+++ b/vtc-service/tests/vtc_client_live.rs
@@ -58,6 +58,123 @@ fn did_key_from_seed(seed_byte: u8) -> (String, String) {
     (did, multibase::encode(multibase::Base::Base58Btc, &buf))
 }
 
+/// The vetting admin verbs `cnm vetting` is built on, against the real router:
+/// the Trust-Task-bound routes (grant, resend, revoke) and the unbound ones
+/// (listing, automatic grants, branding, withdrawals) each reach their handler,
+/// and the statuses the CLI turns into guidance arrive intact.
+#[tokio::test]
+async fn vetting_admin_verbs_round_trip() {
+    let mock = MockVtc::start().await;
+    let base = format!("{}/v1", mock.base_url());
+    let state = &mock.vtc.state;
+    let purpose = affinidi_status_list::StatusPurpose::Revocation;
+    vtc_service::status_list::ensure_initial(
+        &state.status_lists_ks,
+        purpose,
+        format!("http://vtc.test/v1/status-lists/{purpose}"),
+    )
+    .await
+    .expect("status list");
+
+    let (admin, private_key_multibase) = did_key_from_seed(0x93);
+    store_acl_entry(&state.acl_ks, &admin_entry(&admin))
+        .await
+        .expect("seed admin acl row");
+    let (vetter, _) = did_key_from_seed(0x94);
+    // Admitted yesterday: a grant counts only when it post-dates the member's
+    // admission, so a member and a grant made in the same instant would not
+    // exercise the "already granted" path this test is about.
+    let mut member = vtc_service::members::Member::fresh(&vetter);
+    member.joined_at = chrono::Utc::now() - chrono::Duration::days(1);
+    vtc_service::members::storage::store_member(&state.members_ks, &member)
+        .await
+        .expect("seed member");
+    store_acl_entry(
+        &state.acl_ks,
+        &VtcAclEntry {
+            role: VtcRole::Member,
+            ..admin_entry(&vetter)
+        },
+    )
+    .await
+    .expect("seed member acl row");
+
+    let client = VtcClient::connect(
+        &base,
+        "did:key:z6MkVtcUnderTest",
+        &admin,
+        &private_key_multibase,
+    )
+    .await
+    .expect("connect");
+
+    // Grant converges: the second call returns the first grant.
+    let first = client
+        .grant_vetter(&vetter, Some(30 * 86_400))
+        .await
+        .unwrap();
+    assert!(first.created);
+    let second = client.grant_vetter(&vetter, None).await.unwrap();
+    assert!(!second.created);
+    assert_eq!(second.grant.endorsement_id, first.grant.endorsement_id);
+
+    let grants = client.list_vetter_grants().await.unwrap();
+    assert_eq!(grants.vetters.len(), 1);
+    assert!(grants.vetters[0].live);
+
+    // No messaging in this community: the resend cannot be handed over.
+    assert!(matches!(
+        client.resend_vetter_grant(&vetter).await,
+        Err(vtc_client::VtcError::Http { status: 503, .. })
+    ));
+
+    let status = client.auto_grant().await.unwrap();
+    assert!(!status.enabled);
+    let stored = client
+        .configure_auto_grant(&vtc_client::vetting::AutoGrantConfig {
+            enabled: true,
+            sweep_minutes: Some(30),
+            validity_seconds: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!((stored.enabled, stored.sweep_minutes), (true, 30));
+    assert!(matches!(
+        client
+            .configure_auto_grant(&vtc_client::vetting::AutoGrantConfig {
+                enabled: true,
+                sweep_minutes: Some(1),
+                validity_seconds: None,
+            })
+            .await,
+        Err(vtc_client::VtcError::Http { status: 400, .. })
+    ));
+
+    assert_eq!(client.branding().await.unwrap(), Default::default());
+    let branding = client
+        .set_branding(&vtc_client::join_requests::CommunityBranding {
+            display_name: Some("Kernel".into()),
+            accent_color: Some("#1A2B3C".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(branding.accent_color.as_deref(), Some("#1a2b3c"));
+
+    assert!(client.vetting_revocations().await.unwrap().is_empty());
+
+    let revoked = client
+        .revoke_endorsement(&first.grant.endorsement_id)
+        .await
+        .unwrap();
+    assert_eq!(revoked.endorsement_id, first.grant.endorsement_id);
+    assert_eq!(revoked.revocation.credential_id, first.grant.credential_id);
+    assert!(matches!(
+        client.resend_vetter_grant(&vetter).await,
+        Err(vtc_client::VtcError::Http { status: 404, .. })
+    ));
+}
+
 /// `VtcClient::connect` authenticates against a real VTC, and the token it
 /// returns drives an authenticated call.
 ///


### PR DESCRIPTION
Stacked on #1430 (`feat/vtc-vetter-registry`). Draft.

## What

- **`cnm vetting`** — the admin CLI for the vetter registry (CONTRACT-vetter-registry §9):
  - `vetters list | grant <memberDid> [--validity] | revoke <endorsementId> | resend <memberDid>`
  - `auto-grant show | set [--enabled] [--sweep-minutes] [--validity]`
  - `branding show | set [--display-name] [--accent-color] [--logo-url] [--clear]`
  - `revocations`
  - `bootstrap-pgp --keyring <file> --roots <fpr,…> --max-depth <n> --links <dir> [--dry-run] [--validity]`
- **`vtc-client`** — the vetting admin verbs those commands use: `list_vetter_grants`, `grant_vetter`, `revoke_endorsement`, `resend_vetter_grant`, `auto_grant` / `configure_auto_grant`, `branding` / `set_branding`, `vetting_revocations`.
- **`vtc-service/tests/vetting_journey.rs`** — the whole vetting journey as one commented, in-process test, plus a resend-over-DIDComm test.
- **Docs** — `docs/03-vtc/vetting.md` §7 (commands) and §8 (the PGP bootstrap: inputs, making a link with `gpg --clearsign`, what depth means, dry-run first); `cnm-cli/README.md` reference table.

## How

### CLI

Every command gets a community-admin bearer token for the session's REST base (as `cnm backup` does) and calls `VtcClient`, which uses the SDK's finite-timeout HTTP client. Nothing is retried. Tables by default; `--json` prints the response and `--full-display` prints identifiers unshortened. `auto-grant set` and `branding set` read the stored value first and change only the flags given, because PUT replaces the whole object and an absent member takes its default.

Errors name the fix: 401 → `cnm auth login`; 403 → not an admin; revoking an unknown id → `cnm vetting vetters list`; resending with no live grant → `cnm vetting vetters grant <did>`; resend 503 → messaging not up, the grant still stands; granting a non-member → approve their join request first; a 404 on a list route → the VTC predates the vetter registry. Bounds (validity one day to two years, sweep interval 5–1440 minutes, branding shape) are checked before the call, with a working example in the message.

### `bootstrap-pgp`

Pure logic lives in `cnm-cli/src/vetting/{wot,plan}.rs`; `bootstrap.rs` only does I/O and rendering. Order: local inputs first (keyring, roots, links), then one read of the community's members and grants, then the grants.

1. **Keyring.** Parsed with rPGP, binary or armored (one or many blocks); a key exported twice is merged. A key is *usable* when a live, verifying self-certification binds a user ID and it is neither revoked nor expired.
2. **Graph.** A certifies B when:
   - usable key A made a third-party certification (0x10–0x13) on one of B's bound user IDs;
   - it verifies, is exportable, is not expired or future-dated, and A has not revoked it (0x30, created no earlier);
   - it is not SHA-1 or RIPEMD-160 dated after 2019-01-19 (GnuPG's cut-off), and not MD5.

   Everything else is counted in the summary: expired, revoked, invalid, unknown issuer, unusable issuer.
3. **Depth.** Breadth-first search from the roots, visiting neighbours in fingerprint order, so the reported path is the same on every run. Roots must be full 40/64-hex fingerprints of usable keyring keys; key ids are refused because they collide.
4. **Links.** Each file must be a cleartext-signed message whose signed text has exactly one `openvtc-link: <did>` line. The signature must verify with exactly one usable keyring key (the primary or a bound, cross-signed signing subkey) using SHA-256 or better. If a DID is claimed by several keys, or one key links several DIDs, every link involved is refused.
5. **Plan.** Each row gets the first action that applies: invalid link → not a member → too far (unreachable or beyond `--max-depth`) → already granted → grant. `--dry-run` prints the summary, the table and a notes list with each reason. Without it, every `grant` row is granted with `--validity` and the table is reprinted with results. Failures are reported and the command exits non-zero; running it again skips members who now hold a live grant.

### Journey test

Community DID is a `did:key` (its `LocalSigner` signs credentials and status lists), so the applicant-side SDK checks run offline. Steps, over the real router:

1. The admin registers the statement type and posts the criterion (REST).
2. The admin grants Carol. A `vetterEligibility` policy uploaded over `/v1/policies` (active members of 30 days or more), with the sweep enabled over `PUT /v1/vetting/auto-grant` and run once, names Dave and not Erin.
3. Carol and Dave publish profiles; three over-the-wire listings filter on language, country and an event date range.
4. Alice reads manifest 0.2 and recomputes `requirementsDigest`. For each vetter she:
   - verifies the eligibility VP (`verify_eligibility_vp`);
   - checks the grant on the community's status list through the router (`check_credential_status` → `Active`);
   - signs a per-session card; the vetter verifies it and signs a statement; she verifies the statement against her card.
5. She submits both statements with `extensions.requirementsDigest`. Verdict `allow`; `GET /v1/join-requests/{id}/vetting` shows `satisfied`, 2 distinct vetters, `byMethod` `{inPerson: 1, video: 1}` and `applicantDigestMatches`.
6. Carol withdraws her statement: `/v1/vetting/revocations` shows `needsReview` naming Alice and her request, and the facts show `withdrawnNow`.
7. Bob gathers statements from both vetters, then the admin revokes Dave's grant. Bob's status check returns `Revoked`, and his submit is `requestMore` with `vetting:statements:1`; Dave's statement fails with `issuer-not-vetter`.

Holder documents stay within the `/v1/trust-tasks` governor burst (9 posts).

The second test uses `MockVtcDidcomm`: a grant pushes the credential to the vetter peer, a resend pushes the identical credential, and after revocation a resend is 404.

## Notes for review

- **New dependency: `pgp` (rPGP) 0.20**, MIT OR Apache-2.0, default features off, added only to `cnm-cli`. No OpenPGP crate was in the tree. Sequoia is LGPL-2.0-or-later, which `deny.toml` does not allow. All of rPGP's transitive licences are on the allow list.
- **It brings `rsa` 0.9**, and the workspace guidelines say not to reintroduce `rsa`. That rule exists for RUSTSEC-2023-0071 (Marvin), a timing leak of *private* keys during decryption and signing. The bootstrap only verifies RSA signatures with public keys from a keyring, and kernel keys are largely RSA, so RSA verification is needed. `deny.toml` ignores RUSTSEC-2023-0071 with that reasoning and a drop condition. If you would rather keep `rsa` out of default builds, `bootstrap-pgp` could move behind a `cnm-cli` feature; I did not, because `deny.toml` scans `all-features` anyway.
- **SHA-1 policy is mine, not the library's.** rPGP verifies SHA-1 with collision detection only. I adopted GnuPG's 2019-01-19 cut-off for certifications, because a long-lived web of trust has many older SHA-1 certifications. Links, being new, must use SHA-256 or better.
- **Scope of the bootstrap.** It names vetters once; a key revoked later does not revoke the grant (documented). Trust-signature depth and amount are not interpreted — a trust signature counts as a plain certification. User-attribute (photo ID) certifications are ignored.
- **Found while writing this, fixed on #1430.** `vetters::is_live_for` required `grant.created_at >= member.joined_at`. The grant's `created_at` comes from the credential's second-precision `validFrom`, while `Member::fresh` stamps `joined_at` with `Utc::now()` (sub-second). A member granted in the same second as their admission therefore never held a live grant, and granting again issued a duplicate. `vtc_client_live` hit this with a freshly seeded member; its member is now admitted a day earlier, which is what that test is about anyway. The fix is a separate commit on `feat/vtc-vetter-registry`: membership start is compared at whole seconds, in liveness and in statement eligibility, with a regression test. This branch is rebased onto it.
- No `version =` edits. The `vtc-client` additions are additive; new response structs are `#[non_exhaustive]`.
- The journey test is a new file rather than more of `join_requests.rs`. That fixture's community is `did:webvh`, whose credentials an applicant cannot check offline; the helpers mirror its fixture.

## Test evidence

Stacked PRs get no CI, so these local runs are the evidence. All used `CARGO_TARGET_DIR=.target-vti05 VTC_SKIP_ADMIN_UI_BUILD=1`.

| Check | Result |
|---|---|
| `cargo test --workspace --exclude vtc-service --exclude vtc-client --no-fail-fast` | exit 0 — 117 test binaries, **4202 passed, 0 failed**, 50 ignored |
| `cargo test -p vtc-service -p vtc-client --no-fail-fast` | exit 0 — 60 test binaries, **1603 passed, 0 failed**, 1 ignored. No `admin_ui`/`routing_modes` failures either, despite the skipped UI build. |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0. The first run caught a `cloned_ref_to_slice_refs` lint in a new test, fixed before commit. |
| `cargo fmt --all -- --check` | clean |
| `scripts/check-lockfile-self-pins.sh`, `check-authz-context-types.sh`, `check-nitro-copies-every-member.py`, `check-workspace-version-reqs.py`, `cargo metadata --locked` | all pass |
| `cargo deny check` | **not run** — `cargo-deny` is not installed here. The licence allow list was checked by hand against every package `pgp` brings in; `deny.toml` gains the RUSTSEC-2023-0071 ignore described above. |

The new tests inside those counts:

- `cnm-cli`: 45 unit tests. They include 9 web-of-trust tests (depths, expired/revoked/invalid/unknown certifications, revoked key, binary vs armored keyrings with duplicate merge, root validation, primary and subkey links, bad/unsigned/malformed links, contradicting links, weak digests), one plan test, command parsing, and error guidance.
- `vtc-client`: 3 new unit tests.
- `vtc-service/tests/vtc_client_live.rs::vetting_admin_verbs_round_trip`.
- `vtc-service/tests/vetting_journey.rs`: both tests.

