### PR TITLE
ci: pass workflow inputs to run steps through env and validate them

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,14 +95,19 @@ jobs:
       # --entrypoint is required for the Nitro image, whose ENTRYPOINT is the
       # vsock-proxy setup script rather than the binary.
       - name: Smoke-test the runtime image
+        env:
+          BINARY: ${{ matrix.binary }}
+          IMAGE: ${{ matrix.tag }}
         run: |
-          docker run --rm --entrypoint ${{ matrix.binary }} ${{ matrix.tag }} --help > /dev/null
+          docker run --rm --entrypoint "$BINARY" "$IMAGE" --help > /dev/null
           echo "binary starts and links cleanly"
 
       - name: Assert the image does not run as root
         if: matrix.expect_non_root
+        env:
+          IMAGE: ${{ matrix.tag }}
         run: |
-          uid="$(docker run --rm --entrypoint id ${{ matrix.tag }} -u)"
+          uid="$(docker run --rm --entrypoint id "$IMAGE" -u)"
           if [ "$uid" = "0" ]; then
             echo "::error::image runs as root (uid 0); expected the unprivileged 'vta' user"
             exit 1

--- a/.github/workflows/join-didcomm-soak.yml
+++ b/.github/workflows/join-didcomm-soak.yml
@@ -40,11 +40,13 @@ on:
       runs:
         description: "Iterations per stream (stops at the first failure)"
         required: false
-        default: "40"
+        type: number
+        default: 40
       parallel:
         description: "Concurrent streams — this is what recreates CI contention"
         required: false
-        default: "4"
+        type: number
+        default: 4
       log:
         description: "RUST_LOG filter for the run"
         required: false
@@ -80,10 +82,19 @@ jobs:
         env:
           RUST_LOG: ${{ inputs.log }}
           VTC_SKIP_ADMIN_UI_BUILD: "1"
+          # Dispatch inputs reach the script as environment variables, never
+          # as text spliced into it, and are checked before anything uses them.
+          # The bounds keep `streams * runs` and the stream fan-out sane.
+          RUNS: ${{ inputs.runs }}
+          STREAMS: ${{ inputs.parallel }}
         run: |
           set -uo pipefail
-          runs="${{ inputs.runs }}"
-          streams="${{ inputs.parallel }}"
+          [[ "$RUNS" =~ ^[1-9][0-9]{0,3}$ ]] \
+            || { echo "::error::runs must be an integer from 1 to 9999"; exit 1; }
+          [[ "$STREAMS" =~ ^[1-9][0-9]?$ ]] \
+            || { echo "::error::parallel must be an integer from 1 to 99"; exit 1; }
+          runs="$RUNS"
+          streams="$STREAMS"
           bin=$(cargo test -p vtc-service --features didcomm-harness --test join_didcomm \
                   --no-run --message-format=json 2>/dev/null \
                 | jq -r 'select(.executable != null and (.target.name == "join_didcomm")) | .executable' \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,6 +121,19 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # Checked before the Trusted Publishing exchange below, so a malformed
+      # `package` fails the run before a registry token exists. The value is
+      # read from the environment, never spliced into the script, and `[[ =~ ]]`
+      # anchors the whole string (a line-oriented `grep` would accept a value
+      # whose first line is a crate name).
+      - name: Validate the recovery input
+        if: inputs.package != ''
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          [[ "$PACKAGE" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$ ]] \
+            || { echo "::error::package must be a crate name"; exit 1; }
+
       - name: Authenticate to crates.io (Trusted Publishing)
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
@@ -135,9 +148,10 @@ jobs:
       # would be accepted by YAML and silently ignored.
       - name: Publish one crate
         if: inputs.package != ''
-        run: cargo publish -p "${{ inputs.package }}"
+        run: cargo publish -p "$PACKAGE"
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          PACKAGE: ${{ inputs.package }}
 
       - name: Run release-plz
         # Skipped when recovering a single crate — that run has already done


### PR DESCRIPTION

## Summary

Three `run:` scripts substituted `${{ }}` expressions straight into the script
text. This changes each one to read the value from an environment variable set in
the step's `env:`, and validates the two `workflow_dispatch` inputs before they are
used. `pr-title.yml` already uses this pattern for the PR title.

## Changes

### `join-didcomm-soak.yml`

- `inputs.runs` and `inputs.parallel` are passed as `RUNS` and `STREAMS` in the Soak
  step's `env:`.
- The script checks `RUNS` against `^[1-9][0-9]{0,3}$` and `STREAMS` against
  `^[1-9][0-9]?$`, and exits with an `::error::` otherwise.
- Both inputs are declared `type: number`, keeping the defaults of 40 and 4.
- `inputs.log` was already passed via `env: RUST_LOG` and is unchanged.

### `publish.yml` (`release-plz-release`)

- New step `Validate the recovery input`, which runs only when `package` is
  non-empty. It sits **before** `Authenticate to crates.io (Trusted Publishing)`, so
  a malformed value fails the run before a registry token is minted.
- The check is `[[ "$PACKAGE" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$ ]]`. `[[ =~ ]]`
  anchors the whole value, whereas `printf | grep -E` is line-oriented and would
  accept a multi-line value whose first line matches.
- `Publish one crate` now runs `cargo publish -p "$PACKAGE"`, with `PACKAGE` in the
  step's `env:`.

### `docker.yml`

- `matrix.binary` and `matrix.tag` are passed as `BINARY` / `IMAGE` via `env:` and
  quoted. They are static matrix values, but after this no `run:` body in
  `.github/workflows/` contains a `${{ }}` expression.

A scan of every workflow found no other `inputs.*`, `github.event.*` or
`github.head_ref` inside `run:`. `ci.yml` uses `github.head_ref` only in a job-level
`if:`. The repo has no composite actions.

## Testing

- All six workflow files parse as YAML. A PyYAML walk of every `run:` body finds zero
  `${{ }}` expressions.
- Rendered the new Soak body and ran it with `bash --noprofile --norc -eo pipefail`,
  with `cargo`, `jq`, `nproc` and the test binary stubbed:

  | `RUNS` / `STREAMS` | Result |
  |---|---|
  | `40"; touch /tmp/sec4045_pwned; echo "` / `4` | `::error::runs must be an integer from 1 to 9999`, exit 1, no file created |
  | `40` / `$(touch /tmp/sec4045_pwned)` | `::error::parallel must be ...`, exit 1 |
  | `0`, empty, `40\n<cmd>` / `4` | exit 1 |
  | `40` / `4` (the defaults) | `soaking: 4 concurrent streams x 40 iterations = 160 runs` ... `no reproduction in 160 runs across 4 streams`, exit 0 |

- The validation step accepts `vta-sdk` and `vta_sdk2`. It rejects, with exit 1, a
  value containing quotes and `;`, `vta-sdk\n<cmd>`, `-Zunstable`, and a 65-character
  name.
- `Publish one crate` with a stubbed `cargo` receives a hostile value as one literal
  argument (`argv[x"; touch ...; echo "]`), and no command runs.

Not run: `actionlint` / `zizmor`, which were not available locally. A manual dispatch
of `join_didcomm soak` with the defaults after merge will confirm the `type: number`
inputs render as before.
