### PR TITLE
security(vta-sdk)!: vet DID-advertised VTA endpoints and bind cached tokens to their origin

### DIFF
--- a/cnm-cli/clippy.toml
+++ b/cnm-cli/clippy.toml
@@ -1,0 +1,6 @@
+# Every HTTP call from this CLI goes through `vta_sdk::http::rest_client()`,
+# which carries request/connect timeouts and refuses to follow a redirect off
+# the original origin. A bare client has neither.
+disallowed-methods = [
+  { path = "reqwest::Client::new", reason = "use vta_sdk::http::rest_client() (timeouts, same-origin redirects)" },
+]

--- a/cnm-cli/src/audit.rs
+++ b/cnm-cli/src/audit.rs
@@ -19,6 +19,9 @@ use crate::auth;
 /// `vti_common::trust_task::HEADER_NAME`).
 const TRUST_TASK_HEADER: &str = "Trust-Task";
 const VERIFY_TASK: &str = "https://trusttasks.org/spec/audit/verify/0.1";
+/// Largest verification report read into memory. The report is a handful of
+/// counters and identifiers; this is generous headroom.
+const MAX_VERIFY_RESPONSE_BYTES: usize = 1024 * 1024;
 
 /// `cnm audit verify` — walk the community's audit chain and report.
 ///
@@ -33,14 +36,18 @@ pub async fn cmd_verify(
         .ok_or("VTC audit verify requires a REST connection to the VTC")?;
     let token = auth::ensure_authenticated(base, keyring_key).await?;
 
-    let resp = reqwest::Client::new()
+    // The SDK client: finite timeouts, and no redirect off the VTC's origin.
+    let resp = vta_sdk::http::rest_client()
         .get(format!("{base}/audit/verify"))
         .bearer_auth(&token)
         .header(TRUST_TASK_HEADER, VERIFY_TASK)
         .send()
         .await?;
     let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
+    let bytes = vta_sdk::http::read_body_capped(resp, MAX_VERIFY_RESPONSE_BYTES)
+        .await
+        .map_err(|e| format!("VTC audit verify ({status}): {e}"))?;
+    let text = String::from_utf8_lossy(&bytes);
     if !status.is_success() {
         return Err(format!("VTC audit verify failed ({status}): {text}").into());
     }

--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -26,6 +26,10 @@ use crate::auth;
 const TRUST_TASK_HEADER: &str = "Trust-Task";
 const EXPORT_TASK: &str = "https://trusttasks.org/spec/vtc/backup/export/0.1";
 const IMPORT_TASK: &str = "https://trusttasks.org/spec/vtc/backup/import/0.1";
+/// Largest VTC backup response read into memory. Matches the VTC's cap on a
+/// backup import request body, so an export larger than this could not be
+/// restored anyway.
+const MAX_BACKUP_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
 
 /// Authenticated REST POST to a VTC `/v1/backup/*` route. `client.rest_url()`
 /// already carries the `/v1` mount, so the path here is relative to it.
@@ -41,7 +45,8 @@ async fn authed_post(
         .ok_or("VTC backup requires a REST connection to the VTC")?;
     // Refresh / mint a REST bearer token for the VTC (aud = "VTC").
     let token = auth::ensure_authenticated(base, keyring_key).await?;
-    let resp = reqwest::Client::new()
+    // The SDK client: finite timeouts, and no redirect off the VTC's origin.
+    let resp = vta_sdk::http::rest_client()
         .post(format!("{base}{path}"))
         .bearer_auth(&token)
         .header(TRUST_TASK_HEADER, task)
@@ -49,7 +54,10 @@ async fn authed_post(
         .send()
         .await?;
     let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
+    let bytes = vta_sdk::http::read_body_capped(resp, MAX_BACKUP_RESPONSE_BYTES)
+        .await
+        .map_err(|e| format!("VTC backup request ({status}): {e}"))?;
+    let text = String::from_utf8_lossy(&bytes);
     if !status.is_success() {
         // Surface the server's error body verbatim — it carries the
         // actionable message (short password, vtc_did mismatch, …).

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -70,6 +70,18 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = TransportOpt::Auto, global = true)]
     transport: TransportOpt,
 
+    /// Accept a VTA REST endpoint on a private network (RFC 1918, IPv6
+    /// unique-local, carrier-grade NAT, `*.internal` / `*.local` names) when
+    /// it comes from a DID document. Off by default: such an endpoint must
+    /// otherwise be a public host, or loopback for local development.
+    #[arg(
+        long,
+        global = true,
+        env = "VTA_ALLOW_PRIVATE_ENDPOINTS",
+        value_parser = clap::builder::FalseyValueParser::new()
+    )]
+    allow_private_endpoints: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -920,6 +932,9 @@ async fn main() {
     install_force_exit_handler();
 
     let cli = Cli::parse();
+
+    // DID-advertised VTA endpoints are public-only unless the operator opts in.
+    vta_sdk::http::set_allow_private_endpoints(cli.allow_private_endpoints);
 
     // Propagate --full-display to the shared render module so list
     // commands from vta-cli-common pick it up.

--- a/pnm-cli/clippy.toml
+++ b/pnm-cli/clippy.toml
@@ -1,0 +1,6 @@
+# Every HTTP call from this CLI goes through `vta_sdk::http::rest_client()`,
+# which carries request/connect timeouts and refuses to follow a redirect off
+# the original origin. A bare client has neither.
+disallowed-methods = [
+  { path = "reqwest::Client::new", reason = "use vta_sdk::http::rest_client() (timeouts, same-origin redirects)" },
+]

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -364,15 +364,23 @@ pub async fn run_connect(
     // `did:key:z6Mk…` string.
     let body = BootstrapRequest::new(ed_pub, nonce, None);
 
+    // Largest bootstrap response read into memory: one armored bundle plus an
+    // attestation document, a few KiB in practice.
+    const MAX_BOOTSTRAP_RESPONSE_BYTES: usize = 1024 * 1024;
+
     let url = format!("{}/bootstrap/request", vta_url.trim_end_matches('/'));
-    let client = reqwest::Client::new();
+    // The SDK client: finite timeouts, and no redirect off the VTA's origin.
+    let client = vta_sdk::http::rest_client();
     let resp = client.post(&url).json(&body).send().await?;
     let status = resp.status();
+    let bytes = vta_sdk::http::read_body_capped(resp, MAX_BOOTSTRAP_RESPONSE_BYTES)
+        .await
+        .map_err(|e| format!("bootstrap request ({status}): {e}"))?;
     if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
+        let body = String::from_utf8_lossy(&bytes);
         return Err(format!("bootstrap request failed ({status}): {body}").into());
     }
-    let wire: BootstrapResponseWire = resp.json().await?;
+    let wire: BootstrapResponseWire = serde_json::from_slice(&bytes)?;
 
     // Optional client-side digest verification. Attestation + TLS give the
     // primary integrity anchor; this is a belt-and-suspenders check the

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -84,6 +84,18 @@ pub(crate) struct Cli {
     #[arg(long, value_enum, default_value_t = TransportOpt::Auto, global = true)]
     pub(crate) transport: TransportOpt,
 
+    /// Accept a VTA REST endpoint on a private network (RFC 1918, IPv6
+    /// unique-local, carrier-grade NAT, `*.internal` / `*.local` names) when
+    /// it comes from a DID document. Off by default: such an endpoint must
+    /// otherwise be a public host, or loopback for local development.
+    #[arg(
+        long,
+        global = true,
+        env = "VTA_ALLOW_PRIVATE_ENDPOINTS",
+        value_parser = clap::builder::FalseyValueParser::new()
+    )]
+    pub(crate) allow_private_endpoints: bool,
+
     #[command(subcommand)]
     pub(crate) command: Commands,
 }

--- a/pnm-cli/src/main.rs
+++ b/pnm-cli/src/main.rs
@@ -57,6 +57,9 @@ async fn main() {
 
     let cli = Cli::parse();
 
+    // DID-advertised VTA endpoints are public-only unless the operator opts in.
+    vta_sdk::http::set_allow_private_endpoints(cli.allow_private_endpoints);
+
     // Propagate --full-display to the shared render module so any list
     // command — including ones reached via the shared vta-cli-common
     // handlers — picks up the setting without threading a bool through

--- a/vta-sdk/src/http.rs
+++ b/vta-sdk/src/http.rs
@@ -4,14 +4,29 @@
 //! blackholed VTA (a half-open load balancer, a SIGSTOPped process, a firewall
 //! silently dropping packets) would hang the caller forever. Every REST client
 //! in the SDK is built here so the timeouts are applied uniformly.
+//!
+//! This module is also the SDK's one egress-policy chokepoint: the address
+//! classifier ([`classify_ip`], [`classify_host`]), the foreign-fetch guard
+//! ([`guard_public_url`]) and the VTA-endpoint guard ([`guard_vta_endpoint`]).
+//!
+//! The classifier mirrors the one in `affinidi-did-web` (`ip_is_blocked` /
+//! `host_is_blocked` / `GuardedResolver`). A shared `affinidi-net-guard` crate is
+//! planned to hold that implementation once; when it is published, replace the
+//! classifier and resolver below with re-exports from it and keep these public
+//! names as shims.
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 /// Default total-request timeout for a VTA REST call.
 const DEFAULT_REST_TIMEOUT_SECS: u64 = 30;
 /// Default TCP/TLS connect timeout.
 const DEFAULT_REST_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Upper bound on same-origin redirects a REST call will follow (reqwest's own
+/// default limit).
+const MAX_REST_REDIRECTS: usize = 10;
 
 /// A `reqwest::Client` with finite request + connect timeouts.
 ///
@@ -19,6 +34,13 @@ const DEFAULT_REST_CONNECT_TIMEOUT_SECS: u64 = 10;
 /// (positive integers, seconds); anything missing/zero/unparseable falls back to
 /// the defaults. Use this instead of `reqwest::Client::new()` for any REST call
 /// to a VTA so a wedged peer surfaces as a timeout error, not an unbounded hang.
+///
+/// Redirects are followed only while they stay on the origin (scheme, host and
+/// port) of the original request. A VTA's REST API has no reason to send a
+/// client elsewhere, and following a cross-origin `3xx` would let whoever
+/// answers the first request point an authenticated client at an arbitrary
+/// host, including internal ones. A cross-origin redirect is returned to the
+/// caller as the `3xx` response itself, which callers treat as a failure.
 ///
 /// Panics only if the TLS backend cannot initialize — the same condition under
 /// which `reqwest::Client::new()` already panics, so this is not a new failure
@@ -35,8 +57,34 @@ pub fn rest_client() -> reqwest::Client {
             "VTA_REST_CONNECT_TIMEOUT_SECS",
             DEFAULT_REST_CONNECT_TIMEOUT_SECS,
         ))
+        .redirect(same_origin_redirect_policy())
         .build()
         .expect("reqwest client with timeouts (TLS backend init)")
+}
+
+/// Follow a redirect only while it stays on the original request's origin.
+fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() > MAX_REST_REDIRECTS {
+            return attempt.error("too many redirects");
+        }
+        let same_origin = attempt
+            .previous()
+            .first()
+            .is_some_and(|original| same_origin(original, attempt.url()));
+        if same_origin {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    })
+}
+
+/// Scheme, host and port (with the scheme's default port filled in) all match.
+fn same_origin(a: &reqwest::Url, b: &reqwest::Url) -> bool {
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
 }
 
 /// Read a positive-integer seconds value from `var`, falling back to `default`.
@@ -47,6 +95,231 @@ fn env_secs(var: &str, default: u64) -> Duration {
         .filter(|&n| n > 0)
         .unwrap_or(default);
     Duration::from_secs(secs)
+}
+
+// ── Address classification ───────────────────────────────────────────────────
+
+/// What an IP address is, for egress decisions.
+///
+/// Produced by [`classify_ip`]. Only [`IpClass::Public`] is globally routable;
+/// every other class names why an address is not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IpClass {
+    /// Globally routable.
+    Public,
+    /// `127.0.0.0/8`, `::1`.
+    Loopback,
+    /// RFC 1918 (`10/8`, `172.16/12`, `192.168/16`) and IPv6 unique-local
+    /// `fc00::/7`.
+    Private,
+    /// `100.64.0.0/10`, carrier-grade NAT (RFC 6598). Also where many overlay
+    /// networks and Kubernetes pod ranges live.
+    SharedAddressSpace,
+    /// `169.254.0.0/16` and `fe80::/10`. Includes the cloud instance-metadata
+    /// address `169.254.169.254`.
+    LinkLocal,
+    /// A cloud instance-metadata address outside link-local: AWS IMDSv6
+    /// `fd00:ec2::254` and Alibaba Cloud `100.100.100.200`.
+    Metadata,
+    /// `0.0.0.0/8` ("this network") and `::`.
+    Unspecified,
+    /// `255.255.255.255`.
+    Broadcast,
+    /// `224.0.0.0/4`, `ff00::/8`.
+    Multicast,
+    /// `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`, `2001:db8::/32`.
+    Documentation,
+    /// `198.18.0.0/15`, `2001:2::/48`.
+    Benchmarking,
+    /// Other special-purpose space that is not globally routable:
+    /// `192.0.0.0/24`, `240.0.0.0/4`, deprecated site-local `fec0::/10`,
+    /// discard-only `100::/64`, Teredo `2001::/32`, local-use NAT64
+    /// `64:ff9b:1::/48`.
+    Reserved,
+}
+
+impl IpClass {
+    /// Whether this class is globally routable.
+    pub fn is_public(self) -> bool {
+        self == IpClass::Public
+    }
+
+    /// Short human-readable description, for error messages.
+    pub fn describe(self) -> &'static str {
+        match self {
+            IpClass::Public => "public",
+            IpClass::Loopback => "loopback",
+            IpClass::Private => "private-network",
+            IpClass::SharedAddressSpace => "carrier-grade NAT",
+            IpClass::LinkLocal => "link-local",
+            IpClass::Metadata => "cloud metadata",
+            IpClass::Unspecified => "unspecified",
+            IpClass::Broadcast => "broadcast",
+            IpClass::Multicast => "multicast",
+            IpClass::Documentation => "documentation",
+            IpClass::Benchmarking => "benchmarking",
+            IpClass::Reserved => "reserved",
+        }
+    }
+}
+
+/// Classify an IP address.
+///
+/// IPv6 addresses that embed an IPv4 destination are classified by that
+/// destination: IPv4-mapped `::ffff:a.b.c.d`, IPv4-compatible `::a.b.c.d`,
+/// NAT64 `64:ff9b::/96` and 6to4 `2002::/16`. Without that, `::ffff:127.0.0.1`
+/// reaches loopback while looking like an ordinary IPv6 address.
+pub fn classify_ip(addr: IpAddr) -> IpClass {
+    match addr {
+        IpAddr::V4(a) => classify_ipv4(a),
+        IpAddr::V6(a) => classify_ipv6(a),
+    }
+}
+
+fn classify_ipv4(a: Ipv4Addr) -> IpClass {
+    let o = a.octets();
+    if o[0] == 0 {
+        IpClass::Unspecified
+    } else if a.is_loopback() {
+        IpClass::Loopback
+    } else if o == [100, 100, 100, 200] {
+        IpClass::Metadata
+    } else if a.is_private() {
+        IpClass::Private
+    } else if o[0] == 100 && (64..128).contains(&o[1]) {
+        IpClass::SharedAddressSpace
+    } else if a.is_link_local() {
+        IpClass::LinkLocal
+    } else if a.is_broadcast() {
+        IpClass::Broadcast
+    } else if a.is_multicast() {
+        IpClass::Multicast
+    } else if a.is_documentation() {
+        IpClass::Documentation
+    } else if o[0] == 198 && (o[1] & 0xfe) == 18 {
+        IpClass::Benchmarking
+    } else if (o[0] == 192 && o[1] == 0 && o[2] == 0) || o[0] >= 240 {
+        IpClass::Reserved
+    } else {
+        IpClass::Public
+    }
+}
+
+fn classify_ipv6(a: Ipv6Addr) -> IpClass {
+    if a.is_unspecified() {
+        return IpClass::Unspecified;
+    }
+    if a.is_loopback() {
+        return IpClass::Loopback;
+    }
+    if let Some(v4) = embedded_ipv4(a) {
+        return classify_ipv4(v4);
+    }
+    let s = a.segments();
+    if a == Ipv6Addr::new(0xfd00, 0x0ec2, 0, 0, 0, 0, 0, 0x0254) {
+        IpClass::Metadata
+    } else if a.is_multicast() {
+        IpClass::Multicast
+    } else if (s[0] & 0xfe00) == 0xfc00 {
+        IpClass::Private
+    } else if (s[0] & 0xffc0) == 0xfe80 {
+        IpClass::LinkLocal
+    } else if s[0] == 0x2001 && s[1] == 0x0db8 {
+        IpClass::Documentation
+    } else if s[0] == 0x2001 && s[1] == 0x0002 && s[2] == 0 {
+        IpClass::Benchmarking
+    } else if (s[0] & 0xffc0) == 0xfec0
+        || (s[0] == 0x2001 && s[1] == 0)
+        || (s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0x0001)
+        || (s[0] == 0x0100 && s[1..4] == [0, 0, 0])
+    {
+        IpClass::Reserved
+    } else {
+        IpClass::Public
+    }
+}
+
+/// The IPv4 destination embedded in an IPv6 address, if it has one:
+/// IPv4-mapped, IPv4-compatible, NAT64 well-known prefix, or 6to4.
+fn embedded_ipv4(a: Ipv6Addr) -> Option<Ipv4Addr> {
+    // `to_ipv4` would report `::1` as the compatible form of `0.0.0.1`.
+    if a.is_loopback() || a.is_unspecified() {
+        return None;
+    }
+    // `to_ipv4`, unlike `to_ipv4_mapped`, also covers the compatible form.
+    if let Some(v4) = a.to_ipv4() {
+        return Some(v4);
+    }
+    let s = a.segments();
+    if s[0] == 0x0064 && s[1] == 0xff9b && s[2..6] == [0, 0, 0, 0] {
+        return Some(Ipv4Addr::from((u32::from(s[6]) << 16) | u32::from(s[7])));
+    }
+    if s[0] == 0x2002 {
+        return Some(Ipv4Addr::from((u32::from(s[1]) << 16) | u32::from(s[2])));
+    }
+    None
+}
+
+/// What a URL host is, for egress decisions. Produced by [`classify_host`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HostClass {
+    /// An IP literal, with its class.
+    Ip(IpClass),
+    /// Exactly `localhost` (a trailing root dot is ignored).
+    Localhost,
+    /// A name that only means something on a local or private network:
+    /// `*.localhost`, `*.local` (mDNS), `*.internal`, `*.home.arpa`, and
+    /// single-label names.
+    LocalName,
+    /// A well-known cloud instance-metadata hostname.
+    MetadataName,
+    /// An ordinary DNS name. Its addresses are only known at connect time.
+    Domain,
+}
+
+/// Hostnames that serve cloud instance metadata.
+const METADATA_NAMES: &[&str] = &[
+    "metadata",
+    "metadata.google.internal",
+    "metadata.goog",
+    "instance-data",
+    "instance-data.ec2.internal",
+];
+
+/// Classify a parsed URL host.
+///
+/// Takes the host from [`reqwest::Url::host`], after WHATWG parsing, so the
+/// alternative IPv4 spellings (`2130706433`, `0x7f.1`, `127.1`, …) already
+/// arrive as the canonical address.
+pub fn classify_host(host: &url::Host<&str>) -> HostClass {
+    match host {
+        url::Host::Ipv4(a) => HostClass::Ip(classify_ipv4(*a)),
+        url::Host::Ipv6(a) => HostClass::Ip(classify_ipv6(*a)),
+        url::Host::Domain(d) => classify_domain(d),
+    }
+}
+
+fn classify_domain(domain: &str) -> HostClass {
+    // A trailing root dot survives URL parsing, so `localhost.` must normalise
+    // to `localhost` before the comparisons below.
+    let d = domain.trim_end_matches('.').to_ascii_lowercase();
+    if d == "localhost" {
+        HostClass::Localhost
+    } else if METADATA_NAMES.contains(&d.as_str()) {
+        HostClass::MetadataName
+    } else if d.is_empty()
+        || !d.contains('.')
+        || d.ends_with(".localhost")
+        || d.ends_with(".local")
+        || d.ends_with(".internal")
+        || d.ends_with(".home.arpa")
+    {
+        HostClass::LocalName
+    } else {
+        HostClass::Domain
+    }
 }
 
 // ── Foreign fetch: attacker-influenceable URLs (status lists, etc.) ──────────
@@ -71,7 +344,8 @@ pub const DEFAULT_MAX_FOREIGN_BODY: usize = 2 * 1024 * 1024;
 /// error types (e.g. `AppError`, `RecognitionError`).
 #[derive(Debug, thiserror::Error)]
 pub enum ForeignFetchError {
-    /// The URL failed [`guard_public_url`] (bad scheme, userinfo, non-public IP).
+    /// The URL failed [`guard_public_url`] or [`guard_vta_endpoint`] (bad
+    /// scheme, userinfo, non-public host).
     #[error("{0}")]
     Blocked(String),
     /// The response body exceeded the caller's cap.
@@ -89,13 +363,24 @@ pub enum ForeignFetchError {
 ///   URL. Following redirects would let a public URL `302` to an internal target
 ///   (`127.0.0.1`, `169.254.169.254`) past the guard. With no follow, a
 ///   redirecting host yields a non-2xx the caller treats as failure.
+/// - **guarded DNS resolver** — a hostname is resolved once, the answers are
+///   vetted, and the connection goes to those vetted addresses. A name with any
+///   non-public answer fails the request, which also closes the DNS-rebinding
+///   window between a check and the connect.
+/// - **`no_proxy`** — with `HTTP(S)_PROXY` honoured, the proxy would resolve the
+///   target name and the resolver above would never see it.
 /// - **`timeout` / `connect_timeout`** — bounded so a hung host can't pin a
 ///   request open.
+///
+/// IP-literal hosts never reach the resolver (the connector dials them
+/// directly), which is why [`guard_public_url`] must still run first.
 ///
 /// Body size is capped per-fetch by [`read_body_capped`] (reqwest has none).
 static FOREIGN_FETCH_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        .dns_resolver(PublicOnlyResolver)
+        .no_proxy()
         .timeout(FOREIGN_FETCH_TIMEOUT)
         .connect_timeout(FOREIGN_FETCH_TIMEOUT)
         .build()
@@ -106,6 +391,65 @@ static FOREIGN_FETCH_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
 /// `reqwest::Client::new()` — for any fetch of an attacker-influenceable URL.
 pub fn foreign_fetch_client() -> reqwest::Client {
     FOREIGN_FETCH_CLIENT.clone()
+}
+
+/// Refusal raised by [`PublicOnlyResolver`] when a hostname resolves to an
+/// address that is not globally routable. Travels out through `reqwest`'s error
+/// chain.
+#[derive(Debug)]
+struct BlockedAddress {
+    host: String,
+    detail: String,
+}
+
+impl std::fmt::Display for BlockedAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "refusing to connect to {}: {}", self.host, self.detail)
+    }
+}
+
+impl std::error::Error for BlockedAddress {}
+
+/// A DNS resolver that refuses to hand back a non-public address.
+#[derive(Debug, Clone, Copy)]
+struct PublicOnlyResolver;
+
+impl reqwest::dns::Resolve for PublicOnlyResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        Box::pin(async move {
+            let host = name.as_str().to_owned();
+            // Port 0: reqwest substitutes the URL's port over whatever we return.
+            let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
+                .collect();
+            let vetted = vet_resolved(&host, addrs)
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
+            Ok(Box::new(vetted.into_iter()) as reqwest::dns::Addrs)
+        })
+    }
+}
+
+/// Fail closed on the whole name: a name with even one non-public answer, or
+/// with no answers at all, is not one we are willing to connect to.
+fn vet_resolved(host: &str, addrs: Vec<SocketAddr>) -> Result<Vec<SocketAddr>, BlockedAddress> {
+    if addrs.is_empty() {
+        return Err(BlockedAddress {
+            host: host.to_owned(),
+            detail: "name resolved to no addresses".into(),
+        });
+    }
+    if let Some(bad) = addrs.iter().find(|a| !classify_ip(a.ip()).is_public()) {
+        return Err(BlockedAddress {
+            host: host.to_owned(),
+            detail: format!(
+                "name resolves to non-public {} address {}",
+                classify_ip(bad.ip()).describe(),
+                bad.ip()
+            ),
+        });
+    }
+    Ok(addrs)
 }
 
 /// Read a response body into memory, refusing anything larger than `max` bytes.
@@ -131,15 +475,14 @@ pub async fn read_body_capped(
 
 /// Refuse a URL that isn't a plain public HTTPS target before fetching it.
 ///
-/// Rejects: non-`https` schemes, embedded userinfo, and IP-literal hosts in
-/// loopback / private / link-local / unspecified / multicast / documentation
-/// ranges (IPv4) or loopback / unspecified / multicast / ULA `fc00::/7` /
-/// link-local `fe80::/10` (IPv6) — including cloud-metadata `169.254.169.254`.
+/// Rejects: non-`https` schemes, embedded userinfo, IP-literal hosts in any
+/// non-public class of [`classify_ip`] (including IPv4 embedded in IPv6 and
+/// cloud metadata addresses), and the local-only names of [`classify_host`]
+/// (`localhost`, `*.localhost`, `*.local`, `*.internal`, `*.home.arpa`,
+/// single-label names, metadata hostnames).
 ///
-/// Reaching an internal service by *DNS name* can't be prevented here without a
-/// TOCTOU-prone resolve-at-parse-time; operators behind internal DNS need a
-/// network-level egress filter for full protection. This cuts off the
-/// bulk-attack vectors.
+/// An ordinary hostname passes here. Its addresses are vetted at connect time
+/// by the resolver on [`foreign_fetch_client`], so fetch through that client.
 pub fn guard_public_url(url: &str) -> Result<(), ForeignFetchError> {
     let parsed = reqwest::Url::parse(url)
         .map_err(|e| ForeignFetchError::Blocked(format!("invalid url {url}: {e}")))?;
@@ -154,42 +497,172 @@ pub fn guard_public_url(url: &str) -> Result<(), ForeignFetchError> {
             "url must not contain userinfo".into(),
         ));
     }
-    let host_str = parsed
-        .host_str()
+    let host = parsed
+        .host()
         .ok_or_else(|| ForeignFetchError::Blocked("url missing host".into()))?;
-    // `host_str()` returns IPv6 hosts bracketed (`[::1]`); strip before parsing.
-    // Domain hosts don't parse as an IP and correctly fall through to allow.
-    let host_normalised = host_str
-        .strip_prefix('[')
-        .and_then(|s| s.strip_suffix(']'))
-        .unwrap_or(host_str);
-    if let Ok(ip) = host_normalised.parse::<std::net::IpAddr>() {
-        use std::net::IpAddr;
-        let private = match ip {
-            IpAddr::V4(v4) => {
-                v4.is_loopback()
-                    || v4.is_private()
-                    || v4.is_link_local()
-                    || v4.is_broadcast()
-                    || v4.is_unspecified()
-                    || v4.is_multicast()
-                    || v4.is_documentation()
-            }
-            IpAddr::V6(v6) => {
-                v6.is_loopback()
-                    || v6.is_unspecified()
-                    || v6.is_multicast()
-                    || (v6.segments()[0] & 0xfe00 == 0xfc00) // ULA fc00::/7
-                    || (v6.segments()[0] & 0xffc0 == 0xfe80) // link-local fe80::/10
-            }
-        };
-        if private {
-            return Err(ForeignFetchError::Blocked(format!(
-                "url points at non-public IP {ip}"
-            )));
+    match classify_host(&host) {
+        HostClass::Domain | HostClass::Ip(IpClass::Public) => Ok(()),
+        HostClass::Ip(class) => Err(ForeignFetchError::Blocked(format!(
+            "url points at non-public {} IP {host}",
+            class.describe()
+        ))),
+        HostClass::Localhost | HostClass::LocalName | HostClass::MetadataName => Err(
+            ForeignFetchError::Blocked(format!("url points at non-public host name {host}")),
+        ),
+    }
+}
+
+// ── VTA endpoints advertised in a DID document ───────────────────────────────
+
+/// Environment variable that permits private-network VTA endpoints. Truthy
+/// values: `1`, `true`, `yes`, `on` (case-insensitive).
+pub const ALLOW_PRIVATE_ENDPOINTS_ENV: &str = "VTA_ALLOW_PRIVATE_ENDPOINTS";
+
+/// Process-wide opt-in set by a CLI flag; see [`set_allow_private_endpoints`].
+static ALLOW_PRIVATE_ENDPOINTS: AtomicBool = AtomicBool::new(false);
+
+/// Permit private-network VTA endpoints for the rest of this process.
+///
+/// For binaries that expose the opt-in as a flag (`--allow-private-endpoints`).
+/// [`EndpointPolicy::process_default`] honours it alongside
+/// [`ALLOW_PRIVATE_ENDPOINTS_ENV`].
+pub fn set_allow_private_endpoints(allow: bool) {
+    ALLOW_PRIVATE_ENDPOINTS.store(allow, Ordering::Relaxed);
+}
+
+/// Which VTA endpoints [`guard_vta_endpoint`] accepts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct EndpointPolicy {
+    /// Accept RFC 1918, IPv6 unique-local and carrier-grade NAT addresses, and
+    /// local-only names (`*.internal`, `*.local`, single-label names, …).
+    pub allow_private: bool,
+}
+
+impl EndpointPolicy {
+    /// Public hosts only, plus loopback. The default.
+    pub const fn public_only() -> Self {
+        Self {
+            allow_private: false,
         }
     }
-    Ok(())
+
+    /// Also accept private-network hosts.
+    pub const fn private_allowed() -> Self {
+        Self {
+            allow_private: true,
+        }
+    }
+
+    /// The policy for this process: private endpoints are allowed when
+    /// [`set_allow_private_endpoints`] was called with `true`, or when
+    /// [`ALLOW_PRIVATE_ENDPOINTS_ENV`] is set to a truthy value.
+    pub fn process_default() -> Self {
+        let from_env = std::env::var(ALLOW_PRIVATE_ENDPOINTS_ENV)
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false);
+        Self {
+            allow_private: from_env || ALLOW_PRIVATE_ENDPOINTS.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// The loopback hosts that may be dialled over plain `http://`: exactly
+/// `localhost`, any address in `127.0.0.0/8`, and `::1`.
+///
+/// Matches `is_loopback_host` in `vta-webvh`'s webvh client. IPv4-mapped forms
+/// such as `::ffff:127.0.0.1` are deliberately not included.
+fn is_loopback_host(host: &url::Host<&str>) -> bool {
+    match host {
+        url::Host::Domain(d) => d.trim_end_matches('.').eq_ignore_ascii_case("localhost"),
+        url::Host::Ipv4(ip) => ip.is_loopback(),
+        url::Host::Ipv6(ip) => ip.is_loopback(),
+    }
+}
+
+/// Vet a VTA REST endpoint taken from a DID document before any request is
+/// made to it.
+///
+/// - The scheme must be `https`, or `http` when the host is loopback
+///   (`localhost`, `127.0.0.0/8`, `::1`) for local development.
+/// - Always refused: userinfo, schemes other than `http`/`https`, link-local
+///   and cloud-metadata addresses and names, unspecified, broadcast, multicast,
+///   documentation, benchmarking and reserved addresses, and any IPv6 address
+///   embedding a non-public IPv4 destination.
+/// - Private-network hosts (RFC 1918, unique-local, carrier-grade NAT,
+///   `*.internal`/`*.local`/single-label names) only when
+///   `policy.allow_private` is set. The error names the opt-in.
+///
+/// An ordinary hostname is accepted: its addresses are not known here.
+pub fn guard_vta_endpoint(
+    url: &str,
+    policy: EndpointPolicy,
+) -> Result<reqwest::Url, ForeignFetchError> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| ForeignFetchError::Blocked(format!("invalid VTA endpoint URL: {e}")))?;
+    let scheme = parsed.scheme();
+    if scheme != "https" && scheme != "http" {
+        return Err(ForeignFetchError::Blocked(format!(
+            "VTA endpoint uses unsupported scheme `{scheme}://`; only https:// (or http:// \
+             to a loopback host) is accepted"
+        )));
+    }
+    // Checked before anything that echoes the URL, so credentials never land in
+    // an error message.
+    if parsed.username() != "" || parsed.password().is_some() {
+        return Err(ForeignFetchError::Blocked(
+            "VTA endpoint must not embed credentials (userinfo) in the URL".into(),
+        ));
+    }
+    let host = parsed
+        .host()
+        .ok_or_else(|| ForeignFetchError::Blocked("VTA endpoint URL has no host".into()))?;
+    let origin = parsed.origin().ascii_serialization();
+
+    if is_loopback_host(&host) {
+        return Ok(parsed);
+    }
+    if scheme == "http" {
+        return Err(ForeignFetchError::Blocked(format!(
+            "refusing plaintext http:// VTA endpoint {origin}: only a loopback host \
+             (localhost, 127.0.0.0/8, ::1) may use http://; advertise an https:// endpoint"
+        )));
+    }
+
+    let embeds_ipv4 = matches!(host, url::Host::Ipv6(a) if embedded_ipv4(a).is_some());
+    let private_reason = match classify_host(&host) {
+        HostClass::Domain | HostClass::Ip(IpClass::Public) => return Ok(parsed),
+        HostClass::Ip(class @ (IpClass::Private | IpClass::SharedAddressSpace)) if !embeds_ipv4 => {
+            class.describe()
+        }
+        HostClass::LocalName => "private-network name",
+        HostClass::Ip(class) => {
+            return Err(ForeignFetchError::Blocked(format!(
+                "VTA endpoint {origin} is a {} address, which is never accepted",
+                class.describe()
+            )));
+        }
+        HostClass::Localhost | HostClass::MetadataName => {
+            return Err(ForeignFetchError::Blocked(format!(
+                "VTA endpoint {origin} is a reserved host name, which is never accepted"
+            )));
+        }
+    };
+    if policy.allow_private {
+        Ok(parsed)
+    } else {
+        Err(ForeignFetchError::Blocked(format!(
+            "VTA endpoint {origin} is a {private_reason} host; endpoints advertised in a \
+             DID document must be public by default. If this VTA is meant to be reached \
+             over a private network, set {ALLOW_PRIVATE_ENDPOINTS_ENV}=1 or pass \
+             --allow-private-endpoints"
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -255,5 +728,371 @@ mod tests {
     #[test]
     fn guard_blocks_garbage() {
         guard_public_url("not a url").expect_err("garbage blocked");
+    }
+
+    // ── Classifier conformance vectors ──────────────────────────────────────
+
+    const IP_BLOCK: &[&str] = &[
+        "127.0.0.1",
+        "127.255.255.254",
+        "0.0.0.0",
+        "0.1.2.3",
+        "10.0.0.1",
+        "172.16.0.1",
+        "172.31.255.255",
+        "192.168.0.1",
+        "169.254.169.254",
+        "169.254.170.2",
+        "100.64.0.1",
+        "100.100.100.200",
+        "100.127.255.254",
+        "192.0.0.1",
+        "198.18.0.1",
+        "198.19.255.255",
+        "192.0.2.1",
+        "198.51.100.1",
+        "203.0.113.1",
+        "224.0.0.1",
+        "239.255.255.250",
+        "240.0.0.1",
+        "255.255.255.255",
+        "::1",
+        "::",
+        "::ffff:127.0.0.1",
+        "::ffff:7f00:1",
+        "::ffff:169.254.169.254",
+        "::127.0.0.1",
+        "64:ff9b::7f00:1",
+        "64:ff9b::a9fe:a9fe",
+        "64:ff9b:1::a00:1",
+        "2002:7f00:1::1",
+        "2001:0:4136:e378::1",
+        "fc00::1",
+        "fd00::1",
+        "fd00:ec2::254",
+        "fe80::1",
+        "febf::1",
+        "fec0::1",
+        "ff02::1",
+        "2001:db8::1",
+        "100::1",
+    ];
+
+    const IP_ALLOW: &[&str] = &[
+        "8.8.8.8",
+        "1.1.1.1",
+        "11.0.0.1",
+        "100.63.255.255",
+        "100.128.0.0",
+        "172.15.255.255",
+        "172.32.0.1",
+        "169.253.255.255",
+        "192.169.0.1",
+        "198.20.0.1",
+        "2606:4700:4700::1111",
+        "2001:4860:4860::8888",
+        "64:ff9b::808:808",
+    ];
+
+    #[test]
+    fn classifier_blocks_every_non_public_vector() {
+        for v in IP_BLOCK {
+            let ip: IpAddr = v.parse().unwrap();
+            assert!(
+                !classify_ip(ip).is_public(),
+                "{v} must not classify as public"
+            );
+        }
+    }
+
+    #[test]
+    fn classifier_allows_every_public_vector() {
+        for v in IP_ALLOW {
+            let ip: IpAddr = v.parse().unwrap();
+            assert_eq!(classify_ip(ip), IpClass::Public, "{v} must be public");
+        }
+    }
+
+    #[test]
+    fn classifier_names_the_class() {
+        let c = |s: &str| classify_ip(s.parse().unwrap());
+        assert_eq!(c("169.254.169.254"), IpClass::LinkLocal);
+        assert_eq!(c("100.100.100.200"), IpClass::Metadata);
+        assert_eq!(c("fd00:ec2::254"), IpClass::Metadata);
+        assert_eq!(c("::ffff:10.0.0.1"), IpClass::Private);
+        assert_eq!(c("64:ff9b::a9fe:a9fe"), IpClass::LinkLocal);
+        assert_eq!(c("100.64.0.1"), IpClass::SharedAddressSpace);
+        assert_eq!(c("fd00::1"), IpClass::Private);
+        assert_eq!(c("198.18.0.1"), IpClass::Benchmarking);
+    }
+
+    /// Alternative IPv4 spellings, IPv6-embedded loopback, and userinfo tricks.
+    /// The ones the WHATWG parser rejects outright are just as refused.
+    #[test]
+    fn guard_public_url_blocks_url_vectors() {
+        for u in [
+            "https://2130706433/",
+            "https://0x7f000001/",
+            "https://017700000001/",
+            "https://0177.0.0.1/",
+            "https://0x7f.0.0.1/",
+            "https://127.1/",
+            "https://127.0.1/",
+            "https://0/",
+            "https://169.254.169.254./",
+            "https://%31%32%37.0.0.1/",
+            "https://①②⑦.0.0.1/",
+            "https://127。0。0。1/",
+            "https://[::ffff:127.0.0.1]/",
+            "https://[0:0:0:0:0:ffff:7f00:1]/",
+            "https://[::1]:8443/",
+            "https://example.com@127.0.0.1/",
+            "https://127.0.0.1\\@example.com/",
+            "https://user:pass@example.com/",
+            "https://100.100.100.200/",
+            // Invalid under WHATWG parsing.
+            "https://0x100000000/",
+            "https://1.2.3.4.5/",
+            "https://[fe80::1%25en0]/",
+        ] {
+            assert!(guard_public_url(u).is_err(), "{u} must be refused");
+        }
+    }
+
+    #[test]
+    fn guard_public_url_blocks_local_names() {
+        for u in [
+            "https://localhost/",
+            "https://LOCALHOST./",
+            "https://svc.localhost/",
+            "https://printer.local/",
+            "https://kube-dns.kube-system.svc.cluster.local/",
+            "https://metadata.google.internal/",
+            "https://router.home.arpa/",
+            "https://metadata/",
+        ] {
+            assert!(guard_public_url(u).is_err(), "{u} must be refused");
+        }
+        for u in [
+            "https://example.com/",
+            "https://example.com./",
+            "https://localhost.example.com/",
+        ] {
+            assert!(guard_public_url(u).is_ok(), "{u} must be allowed");
+        }
+    }
+
+    #[test]
+    fn guard_public_url_blocks_non_https_schemes() {
+        for u in [
+            "http://example.com/",
+            "ws://example.com/",
+            "ftp://example.com/",
+            "file:///etc/passwd",
+            "gopher://example.com/",
+            "data:text/plain,x",
+            "javascript:alert(1)",
+            "blob:https://x/y",
+        ] {
+            assert!(guard_public_url(u).is_err(), "{u} must be refused");
+        }
+    }
+
+    // ── DNS answers (stubbed) ───────────────────────────────────────────────
+
+    fn socks(ips: &[&str]) -> Vec<SocketAddr> {
+        ips.iter()
+            .map(|s| SocketAddr::new(s.parse().unwrap(), 0))
+            .collect()
+    }
+
+    #[test]
+    fn resolver_vets_every_answer() {
+        assert!(vet_resolved("a.test", socks(&["93.184.216.34"])).is_ok());
+        assert!(vet_resolved("b.test", socks(&["127.0.0.1"])).is_err());
+        assert!(vet_resolved("c.test", socks(&["93.184.216.34", "10.0.0.1"])).is_err());
+        assert!(vet_resolved("d.test", socks(&["::ffff:169.254.169.254"])).is_err());
+        assert!(vet_resolved("e.test", socks(&["64:ff9b::7f00:1"])).is_err());
+        assert!(vet_resolved("f.test", Vec::new()).is_err());
+    }
+
+    #[tokio::test]
+    async fn resolver_refuses_a_name_resolving_to_loopback() {
+        use reqwest::dns::Resolve;
+        let name: reqwest::dns::Name = "localhost".parse().unwrap();
+        let result = PublicOnlyResolver.resolve(name).await;
+        assert!(result.is_err(), "localhost resolves to loopback; must fail");
+    }
+
+    // ── guard_vta_endpoint ──────────────────────────────────────────────────
+
+    const PUBLIC: EndpointPolicy = EndpointPolicy::public_only();
+    const PRIVATE: EndpointPolicy = EndpointPolicy::private_allowed();
+
+    #[test]
+    fn vta_endpoint_accepts_public_https_and_loopback_http() {
+        for u in [
+            "https://vta.example.com",
+            "https://vta.example.com:8443/api",
+            "https://8.8.8.8",
+            "http://localhost:8000/",
+            "http://localhost:3000/tenant/vta",
+            "http://127.0.0.1:9099/",
+            "http://127.0.0.1:8100",
+            "http://[::1]:7037/",
+            "https://localhost:8443",
+        ] {
+            assert!(
+                guard_vta_endpoint(u, PUBLIC).is_ok(),
+                "{u} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn vta_endpoint_refuses_always_blocked_targets_even_with_opt_in() {
+        for u in [
+            "http://169.254.169.254/latest/meta-data/",
+            "https://169.254.169.254/",
+            "https://[fe80::1]/",
+            "https://[fd00:ec2::254]/",
+            "https://100.100.100.200/",
+            "https://metadata.google.internal/",
+            "https://0.0.0.0/",
+            "https://[::]/",
+            "https://224.0.0.1/",
+            "https://255.255.255.255/",
+            "https://192.0.2.1/",
+            "https://[::ffff:127.0.0.1]/",
+            "https://[::ffff:10.0.0.5]/",
+            "https://user:pw@vta.example",
+            "https://user@vta.example",
+            "ftp://vta.example/",
+            "file:///etc/passwd",
+            "http://10.0.0.5/",
+            "http://vta.example.com/",
+            "http://localhost.example.com/",
+            "not a url",
+        ] {
+            assert!(
+                guard_vta_endpoint(u, PRIVATE).is_err(),
+                "{u} must be refused even with private endpoints allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn vta_endpoint_private_hosts_need_the_opt_in() {
+        for u in [
+            "https://10.0.0.5",
+            "https://192.168.1.10:8100",
+            "https://[fd00::1]/",
+            "https://100.64.0.1/",
+            "https://vta.internal/",
+            "https://vta.corp.local/",
+            "https://vta:8100/",
+        ] {
+            let err = guard_vta_endpoint(u, PUBLIC).expect_err(u).to_string();
+            assert!(
+                err.contains(ALLOW_PRIVATE_ENDPOINTS_ENV)
+                    && err.contains("--allow-private-endpoints"),
+                "{u}: the refusal must name the opt-in, got: {err}"
+            );
+            assert!(
+                guard_vta_endpoint(u, PRIVATE).is_ok(),
+                "{u} must be accepted with the opt-in"
+            );
+        }
+    }
+
+    #[test]
+    fn vta_endpoint_refusal_never_echoes_credentials() {
+        let err = guard_vta_endpoint("https://user:s3cret@10.0.0.5/", PRIVATE)
+            .unwrap_err()
+            .to_string();
+        assert!(!err.contains("s3cret"), "{err}");
+    }
+
+    // ── REST redirect policy ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rest_client_stops_at_a_cross_origin_redirect() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let target = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&target)
+            .await;
+
+        let origin = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/start"))
+            .respond_with(
+                ResponseTemplate::new(302).insert_header("location", format!("{}/x", target.uri())),
+            )
+            .mount(&origin)
+            .await;
+
+        let resp = rest_client()
+            .get(format!("{}/start", origin.uri()))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(
+            resp.status().as_u16(),
+            302,
+            "cross-origin redirect must not be followed"
+        );
+        // `target` verifies its `expect(0)` on drop.
+    }
+
+    #[tokio::test]
+    async fn rest_client_follows_a_same_origin_redirect() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/old"))
+            .respond_with(ResponseTemplate::new(308).insert_header("location", "/new"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/new"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("moved"))
+            .mount(&server)
+            .await;
+
+        let resp = rest_client()
+            .get(format!("{}/old", server.uri()))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(resp.status().as_u16(), 200);
+        assert_eq!(resp.text().await.unwrap(), "moved");
+    }
+
+    #[test]
+    fn same_origin_compares_scheme_host_and_effective_port() {
+        let u = |s: &str| reqwest::Url::parse(s).unwrap();
+        assert!(same_origin(
+            &u("https://a.example/x"),
+            &u("https://a.example:443/y")
+        ));
+        assert!(!same_origin(
+            &u("https://a.example/"),
+            &u("http://a.example/")
+        ));
+        assert!(!same_origin(
+            &u("https://a.example/"),
+            &u("https://b.example/")
+        ));
+        assert!(!same_origin(
+            &u("https://a.example/"),
+            &u("https://a.example:8443/")
+        ));
     }
 }

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -32,6 +32,14 @@ struct Session {
     vta_did: Option<String>,
     access_token: Option<String>,
     access_expires_at: Option<u64>,
+    /// Origin (`scheme://host[:port]`) of the base URL `access_token` was
+    /// issued for. A cached token is reused only for a request to that same
+    /// origin; anything else re-authenticates, so a changed `#vta-rest`
+    /// endpoint never receives a token minted for a different server. `None`
+    /// on sessions written before this field existed, which therefore
+    /// re-authenticate once.
+    #[serde(default)]
+    token_origin: Option<String>,
     /// Marks a session whose `client_did` was minted locally with no live
     /// VTA to register it against — the user has been told to ask their
     /// admin to run `vta acl create --did <did>`. On the first successful
@@ -242,6 +250,7 @@ impl SessionStore {
             vta_did: Some(bundle.vta_did.clone()),
             access_token: None,
             access_expires_at: None,
+            token_origin: None,
             needs_rotation: false,
         };
         self.save_session(key, &session)?;
@@ -258,6 +267,7 @@ impl SessionStore {
 
         session.access_token = Some(token.access_token);
         session.access_expires_at = Some(token.access_expires_at);
+        session.token_origin = url_origin(base_url);
         self.save_session(key, &session)?;
 
         Ok(LoginResult {
@@ -285,6 +295,7 @@ impl SessionStore {
             vta_did: Some(vta_did.to_string()),
             access_token: None,
             access_expires_at: None,
+            token_origin: None,
             needs_rotation: false,
         };
         self.save_session(key, &session)
@@ -310,6 +321,7 @@ impl SessionStore {
             vta_did: Some(vta_did.to_string()),
             access_token: None,
             access_expires_at: None,
+            token_origin: None,
             needs_rotation: true,
         };
         self.save_session(key, &session)
@@ -349,6 +361,7 @@ impl SessionStore {
             vta_did: None,
             access_token: None,
             access_expires_at: None,
+            token_origin: None,
             needs_rotation: false,
         };
         self.save_session(key, &session)
@@ -438,7 +451,8 @@ impl SessionStore {
     /// Ensure we have a valid access token. Returns the token string.
     ///
     /// If no credentials are stored, returns an error.
-    /// If a cached token is still valid (>30s remaining), returns it.
+    /// If a cached token is still valid (>30s remaining) and was issued for the
+    /// same origin as `base_url`, returns it.
     /// Otherwise, performs a full challenge-response authentication.
     ///
     /// When the loaded session is flagged `needs_rotation`, the first
@@ -469,13 +483,26 @@ impl SessionStore {
         // Check cached token — but only if we're not pending rotation.
         // A cached token on a pending-rotation session means we rotated in
         // a previous call already, which `rotate_key` handled atomically.
+        //
+        // It must also have been issued for the origin being called. A token is
+        // a bearer credential: if `base_url` now points somewhere else (a
+        // changed `#vta-rest` advertisement, a different `--url`), returning it
+        // would hand that server a live token for this VTA.
+        let requested_origin = url_origin(base_url);
         if !session.needs_rotation
             && let (Some(token), Some(expires_at)) =
                 (&session.access_token, session.access_expires_at)
             && now_epoch() + 30 < expires_at
         {
-            debug!(expires_in = expires_at - now_epoch(), "using cached token");
-            return Ok(token.clone());
+            if requested_origin.is_some() && session.token_origin == requested_origin {
+                debug!(expires_in = expires_at - now_epoch(), "using cached token");
+                return Ok(token.clone());
+            }
+            debug!(
+                cached_origin = ?session.token_origin,
+                requested_origin = ?requested_origin,
+                "cached token belongs to a different origin; re-authenticating"
+            );
         }
 
         debug!("cached token expired or missing, performing challenge-response");
@@ -538,6 +565,7 @@ impl SessionStore {
             .map_err(|e| format!("rotate: new DID failed challenge-response after swap: {e}"))?;
             session.access_token = Some(new_token_result.access_token.clone());
             session.access_expires_at = Some(new_token_result.access_expires_at);
+            session.token_origin = requested_origin.clone();
             self.save_session(key, &session)?;
 
             return Ok(new_token_result.access_token);
@@ -546,6 +574,7 @@ impl SessionStore {
         let token = result.access_token.clone();
         session.access_token = Some(result.access_token);
         session.access_expires_at = Some(result.access_expires_at);
+        session.token_origin = requested_origin;
         self.save_session(key, &session)?;
         debug!("new token cached");
 
@@ -844,7 +873,7 @@ impl SessionStore {
                 // diagnose, so demand a real advertisement or an explicit
                 // `--url`.
                 None => rest_url_from_did_doc(&session_vta_did)
-                    .await
+                    .await?
                     .ok_or_else(|| no_rest_endpoint_error(&session_vta_did))?,
             };
             debug!(url = %url, "connecting via REST (forced --transport rest)");
@@ -1595,8 +1624,20 @@ async fn rotate_key_over_client(
         vta_did: session.vta_did.clone(),
         access_token: None,
         access_expires_at: None,
+        token_origin: None,
         needs_rotation: false,
     })
+}
+
+/// The origin (`scheme://host[:port]`) of `base_url`, used to bind a cached
+/// token to the server it was issued for. `None` for anything unparseable or
+/// without a tuple origin; `None` never matches, so such a URL always
+/// re-authenticates.
+fn url_origin(base_url: &str) -> Option<String> {
+    match url::Url::parse(base_url).ok()?.origin() {
+        origin @ url::Origin::Tuple(..) => Some(origin.ascii_serialization()),
+        url::Origin::Opaque(_) => None,
+    }
 }
 
 // ── Challenge-response auth ─────────────────────────────────────────
@@ -2182,9 +2223,35 @@ pub async fn resolve_vta_endpoint(
 ///   deployment. With a resolver parameter a test seeds a document via
 ///   `DIDCacheClient::add_did_document` and asserts what discovery makes of it,
 ///   in-process and with no network.
+///
+/// # Endpoint policy
+///
+/// Every REST URL this returns, whether advertised in `#vta-rest` or
+/// synthesized from the DID's domain, has passed
+/// [`guard_vta_endpoint`](crate::http::guard_vta_endpoint) under
+/// [`EndpointPolicy::process_default`](crate::http::EndpointPolicy::process_default).
+/// A refused URL is an error that names the opt-in. That holds even when the
+/// document also advertises a mediator transport: the REST URL travels onward
+/// in every variant, so it is refused rather than silently dropped.
 pub async fn resolve_vta_endpoint_with_resolver(
     vta_did: &str,
     did_resolver: &DIDCacheClient,
+) -> Result<VtaEndpoint, Box<dyn std::error::Error>> {
+    resolve_vta_endpoint_with_resolver_and_policy(
+        vta_did,
+        did_resolver,
+        crate::http::EndpointPolicy::process_default(),
+    )
+    .await
+}
+
+/// [`resolve_vta_endpoint_with_resolver`] under an explicit
+/// [`EndpointPolicy`](crate::http::EndpointPolicy) instead of the process
+/// default.
+pub async fn resolve_vta_endpoint_with_resolver_and_policy(
+    vta_did: &str,
+    did_resolver: &DIDCacheClient,
+    policy: crate::http::EndpointPolicy,
 ) -> Result<VtaEndpoint, Box<dyn std::error::Error>> {
     use crate::protocol::matching::ServiceCapabilities;
 
@@ -2196,6 +2263,7 @@ pub async fn resolve_vta_endpoint_with_resolver(
             debug!(error = %e, "DID resolution failed, falling back to URL parsing");
             let url = url_from_did(vta_did)
                 .ok_or_else(|| format!("Could not determine VTA URL from DID: {vta_did}"))?;
+            let url = vet_vta_rest_url(vta_did, &url, policy)?;
             return Ok(VtaEndpoint::Rest { url });
         }
     };
@@ -2212,7 +2280,9 @@ pub async fn resolve_vta_endpoint_with_resolver(
     let rest_url = caps
         .rest
         .as_deref()
-        .map(|u| u.trim_matches('"').trim_end_matches('/').to_string());
+        .map(|u| u.trim_matches('"').trim_end_matches('/').to_string())
+        .map(|u| vet_vta_rest_url(vta_did, &u, policy))
+        .transpose()?;
 
     // TSP and DIDComm both advertise a *mediator DID*, not a transport URL —
     // the real endpoint lives in the mediator's own document. Anything that
@@ -2253,6 +2323,7 @@ pub async fn resolve_vta_endpoint_with_resolver(
         // Last resort: parse URL from DID string
         let url = url_from_did(vta_did)
             .ok_or_else(|| format!("Could not determine VTA URL from DID: {vta_did}"))?;
+        let url = vet_vta_rest_url(vta_did, &url, policy)?;
         debug!(url = %url, "falling back to URL from DID string");
         Ok(VtaEndpoint::Rest { url })
     }
@@ -2283,53 +2354,98 @@ async fn discover_mediator_via_status(client: &crate::client::VtaClient) -> Opti
 }
 
 /// The `#vta-rest` service endpoint from the VTA's DID document, if it
-/// advertises one. `None` covers both "resolution failed" and "no REST service"
-/// — neither yields a REST URL we can stand behind.
+/// advertises one. `Ok(None)` covers both "resolution failed" and "no REST
+/// service" — neither yields a REST URL we can stand behind. An advertised URL
+/// that fails [`guard_vta_endpoint`](crate::http::guard_vta_endpoint) is an
+/// `Err`, so a caller never falls back past a refusal.
 ///
 /// Strict counterpart of [`resolve_vta_url`], which additionally guesses a URL
 /// from the DID's own domain. That guess is right for a self-hosted `did:web`
 /// VTA and wrong for a `did:webvh` whose DID lives on a hosting server, so the
 /// force-REST path uses this instead.
-async fn rest_url_from_did_doc(vta_did: &str) -> Option<String> {
-    let did_resolver = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
+async fn rest_url_from_did_doc(
+    vta_did: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let Ok(did_resolver) = DIDCacheClient::new(crate::resolver::build_did_cache_config_from_env())
         .await
         .inspect_err(|e| debug!(error = %e, "DID resolver init failed"))
-        .ok()?;
+    else {
+        return Ok(None);
+    };
+    rest_url_from_did_doc_with_resolver(
+        vta_did,
+        &did_resolver,
+        crate::http::EndpointPolicy::process_default(),
+    )
+    .await
+}
 
-    let resolved = did_resolver
+/// [`rest_url_from_did_doc`] over an existing resolver and an explicit policy.
+async fn rest_url_from_did_doc_with_resolver(
+    vta_did: &str,
+    did_resolver: &DIDCacheClient,
+    policy: crate::http::EndpointPolicy,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let Ok(resolved) = did_resolver
         .resolve(vta_did)
         .await
         .inspect_err(|e| debug!(error = %e, "DID resolution failed"))
-        .ok()?;
+    else {
+        return Ok(None);
+    };
 
-    let url = resolved
+    let Some(uri) = resolved
         .doc
-        .find_service("vta-rest")?
-        .service_endpoint
-        .get_uri()?
-        .trim_matches('"')
-        .trim_end_matches('/')
-        .to_string();
+        .find_service("vta-rest")
+        .and_then(|s| s.service_endpoint.get_uri())
+    else {
+        return Ok(None);
+    };
+    let url = uri.trim_matches('"').trim_end_matches('/');
+    let url = vet_vta_rest_url(vta_did, url, policy)?;
 
     debug!(url = %url, "found VTA URL from #vta-rest service endpoint");
-    Some(url)
+    Ok(Some(url))
+}
+
+/// Run a VTA REST URL through
+/// [`guard_vta_endpoint`](crate::http::guard_vta_endpoint). Returns the URL
+/// string unchanged, so callers keep joining paths onto the same text, or an
+/// error naming the DID that advertised it.
+fn vet_vta_rest_url(
+    vta_did: &str,
+    url: &str,
+    policy: crate::http::EndpointPolicy,
+) -> Result<String, Box<dyn std::error::Error>> {
+    crate::http::guard_vta_endpoint(url, policy)
+        .map_err(|e| format!("refusing the REST endpoint for VTA {vta_did}: {e}"))?;
+    Ok(url.to_string())
 }
 
 /// Resolve a VTA DID to discover its service URL.
 ///
 /// Resolves the DID document and looks for the `#vta-rest` service endpoint.
 /// Falls back to parsing the domain from `did:web:` or `did:webvh:` DID strings.
+///
+/// Either URL must pass [`guard_vta_endpoint`](crate::http::guard_vta_endpoint)
+/// under [`EndpointPolicy::process_default`](crate::http::EndpointPolicy::process_default);
+/// a refused URL is an error that names the opt-in.
 pub async fn resolve_vta_url(vta_did: &str) -> Result<String, Box<dyn std::error::Error>> {
     debug!(vta_did, "resolving VTA DID to discover service URL");
 
-    if let Some(url) = rest_url_from_did_doc(vta_did).await {
+    if let Some(url) = rest_url_from_did_doc(vta_did).await? {
         return Ok(url);
     }
     debug!("no #vta-rest service resolved, falling back to DID parsing");
 
     // Fallback: parse domain from did:web or did:webvh DID strings
-    url_from_did(vta_did)
-        .ok_or_else(|| format!("Could not determine VTA URL from DID: {vta_did}").into())
+    let url = url_from_did(vta_did)
+        .ok_or_else(|| format!("Could not determine VTA URL from DID: {vta_did}"))?;
+    vet_vta_rest_url(
+        vta_did,
+        &url,
+        crate::http::EndpointPolicy::process_default(),
+    )
 }
 
 /// Extract the base URL from a `did:web:` or `did:webvh:` DID string.
@@ -3489,6 +3605,7 @@ mod tests {
             vta_did: Some("did:key:z6MkVTA".into()),
             access_token: Some("tok123".into()),
             access_expires_at: Some(1700000000),
+            token_origin: Some("https://vta.example".into()),
             needs_rotation: false,
         };
         let json = serde_json::to_string(&session).unwrap();
@@ -3498,6 +3615,114 @@ mod tests {
         assert_eq!(restored.vta_did, session.vta_did);
         assert_eq!(restored.access_token, session.access_token);
         assert_eq!(restored.access_expires_at, session.access_expires_at);
+        assert_eq!(restored.token_origin, session.token_origin);
+    }
+
+    /// A session saved before tokens were origin-bound still loads; with no
+    /// origin recorded, its cached token is never reused.
+    #[test]
+    fn test_session_without_token_origin_loads() {
+        let json = r#"{
+            "client_did": "did:key:z6Mk1",
+            "private_key": "z_seed",
+            "vta_did": "did:key:z6MkVTA",
+            "access_token": "tok",
+            "access_expires_at": 4102444800
+        }"#;
+        let session: Session = serde_json::from_str(json).unwrap();
+        assert_eq!(session.access_token.as_deref(), Some("tok"));
+        assert!(session.token_origin.is_none());
+    }
+
+    #[test]
+    fn url_origin_ignores_path_and_default_port() {
+        assert_eq!(
+            url_origin("https://vta.example/v1").as_deref(),
+            Some("https://vta.example")
+        );
+        assert_eq!(
+            url_origin("https://vta.example:443"),
+            url_origin("https://vta.example")
+        );
+        assert_ne!(
+            url_origin("https://vta.example:8443"),
+            url_origin("https://vta.example")
+        );
+        assert_ne!(
+            url_origin("http://vta.example"),
+            url_origin("https://vta.example")
+        );
+        assert_eq!(url_origin("not a url"), None);
+    }
+
+    /// A resolver holding one document for `did` that advertises `#vta-rest`
+    /// at `rest` (or no service at all when `rest` is `None`).
+    async fn resolver_with_rest(did: &str, rest: Option<&str>) -> DIDCacheClient {
+        use affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder;
+        let services = match rest {
+            Some(rest) => serde_json::json!([
+                { "id": format!("{did}#vta-rest"), "type": "VTARest", "serviceEndpoint": rest }
+            ]),
+            None => serde_json::json!([]),
+        };
+        let doc = serde_json::json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": did,
+            "service": services,
+        });
+        let mut client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+        client
+            .add_did_document(did, serde_json::from_value(doc).expect("fixture document"))
+            .await;
+        client
+    }
+
+    /// The forced-REST path vets the advertised URL too.
+    #[tokio::test]
+    async fn forced_rest_url_from_did_doc_is_vetted() {
+        use crate::http::EndpointPolicy;
+        let did = "did:web:vta.example";
+
+        let r = resolver_with_rest(did, Some("http://169.254.169.254/latest/meta-data/")).await;
+        let err = rest_url_from_did_doc_with_resolver(did, &r, EndpointPolicy::private_allowed())
+            .await
+            .expect_err("a metadata endpoint is refused even with the opt-in");
+        assert!(err.to_string().contains(did), "{err}");
+
+        let r = resolver_with_rest(did, Some("https://10.0.0.5")).await;
+        let err = rest_url_from_did_doc_with_resolver(did, &r, EndpointPolicy::public_only())
+            .await
+            .expect_err("a private endpoint needs the opt-in");
+        assert!(
+            err.to_string().contains("VTA_ALLOW_PRIVATE_ENDPOINTS"),
+            "{err}"
+        );
+        assert_eq!(
+            rest_url_from_did_doc_with_resolver(did, &r, EndpointPolicy::private_allowed())
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("https://10.0.0.5")
+        );
+
+        let r = resolver_with_rest(did, Some("http://127.0.0.1:8100/")).await;
+        assert_eq!(
+            rest_url_from_did_doc_with_resolver(did, &r, EndpointPolicy::public_only())
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("http://127.0.0.1:8100")
+        );
+
+        let r = resolver_with_rest(did, None).await;
+        assert!(
+            rest_url_from_did_doc_with_resolver(did, &r, EndpointPolicy::public_only())
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// Older session blobs include a `vta_url` field. Serde silently drops
@@ -3541,6 +3766,7 @@ mod tests {
             vta_did: None,
             access_token: None,
             access_expires_at: None,
+            token_origin: None,
             needs_rotation: false,
         };
         let json = serde_json::to_string(&session).unwrap();
@@ -3740,6 +3966,7 @@ mod tests {
             vta_did: None,
             access_token: None,
             access_expires_at: None,
+            token_origin: None,
             needs_rotation: false,
         };
         let err = require_vta_did(&pending).unwrap_err();

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -26,6 +26,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
 use ed25519_dalek::SigningKey;
 use serde_json::json;
 #[cfg(not(any(
@@ -36,9 +37,12 @@ use serde_json::json;
 use tempfile::tempdir;
 use vta_sdk::credentials::CredentialBundle;
 use vta_sdk::did_key::ed25519_multibase_pubkey;
+use vta_sdk::http::EndpointPolicy;
 use vta_sdk::session::testing::InMemorySessionBackend;
 use vta_sdk::session::{
-    SessionStore, TokenStatus, VtaEndpoint, resolve_vta_endpoint, resolve_vta_url,
+    SessionStore, TokenStatus, VtaEndpoint, resolve_vta_endpoint,
+    resolve_vta_endpoint_with_resolver, resolve_vta_endpoint_with_resolver_and_policy,
+    resolve_vta_url,
 };
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -295,29 +299,61 @@ async fn login_propagates_challenge_failure() {
 
 #[tokio::test]
 async fn ensure_authenticated_returns_cached_token_if_valid() {
-    // Pre-populate a session with a token expiring far in the future.
-    // ensure_authenticated should NOT touch the network — wiremock has
-    // no /auth mocks mounted, so any HTTP attempt would fail.
+    // Pre-populate a session with a token expiring far in the future, then
+    // remove every mock. ensure_authenticated for the same origin should NOT
+    // touch the network: any HTTP attempt would now 404 and fail the call.
     let server = MockServer::start().await;
     let s = store();
     let (did, pk) = did_key_from_seed(0x10);
     let (vta_did, _) = did_key_from_seed(0x20);
 
-    // Use login to populate a valid token via wiremock, then call
-    // ensure_authenticated against a *different* (un-mocked) URL — the
-    // cache should make that a no-op.
     mount_challenge(&server).await;
     let future = now_secs() + 3600;
     mount_authenticate(&server, future).await;
     let bundle = CredentialBundle::new(&did, &pk, &vta_did);
     s.login(&bundle, &server.uri(), "k").await.unwrap();
+    server.reset().await;
 
-    // Different URL — would 404 if hit. Cached token means it isn't.
+    let token = s.ensure_authenticated(&server.uri(), "k").await.unwrap();
+    assert_eq!(token, "access-jwt");
+
+    // The binding is to the origin, not the full URL: a path on the same server
+    // (the VTC mounts its API under `/v1`) reuses the token.
     let token = s
-        .ensure_authenticated("http://127.0.0.1:1", "k")
+        .ensure_authenticated(&format!("{}/v1", server.uri()), "k")
         .await
         .unwrap();
     assert_eq!(token, "access-jwt");
+}
+
+#[tokio::test]
+async fn ensure_authenticated_does_not_reuse_a_token_for_another_origin() {
+    let issuer = MockServer::start().await;
+    mount_challenge(&issuer).await;
+    mount_authenticate(&issuer, now_secs() + 3600).await;
+
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    let bundle = CredentialBundle::new(&did, &pk, &vta_did);
+    s.login(&bundle, &issuer.uri(), "k").await.unwrap();
+
+    // A different origin (same host, different port) that refuses to
+    // authenticate. Returning the cached token would succeed without ever
+    // contacting it; re-authenticating reaches it and fails.
+    let other = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/auth/challenge"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .expect(1)
+        .mount(&other)
+        .await;
+
+    let result = s.ensure_authenticated(&other.uri(), "k").await;
+    assert!(
+        result.is_err(),
+        "a token issued for one origin must not be returned for another"
+    );
 }
 
 #[tokio::test]
@@ -706,6 +742,120 @@ async fn resolve_vta_endpoint_unparseable_did_errors() {
         Err(e) => e,
     };
     assert!(err.to_string().contains("Could not determine VTA URL"));
+}
+
+// ── Endpoint policy on DID-advertised REST URLs ─────────────────────
+
+const SEEDED_VTA: &str = "did:web:vta.example";
+
+/// A resolver holding one document for [`SEEDED_VTA`], offline.
+async fn resolver_serving(services: serde_json::Value) -> DIDCacheClient {
+    let doc = json!({
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "id": SEEDED_VTA,
+        "service": services,
+    });
+    let mut client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .expect("local DID cache");
+    client
+        .add_did_document(
+            SEEDED_VTA,
+            serde_json::from_value(doc).expect("fixture document"),
+        )
+        .await;
+    client
+}
+
+async fn rest_only(rest: &str) -> DIDCacheClient {
+    resolver_serving(json!([
+        { "id": format!("{SEEDED_VTA}#vta-rest"), "type": "VTARest", "serviceEndpoint": rest }
+    ]))
+    .await
+}
+
+fn refusal(result: Result<VtaEndpoint, Box<dyn std::error::Error>>) -> String {
+    match result {
+        Ok(_) => panic!("expected the endpoint to be refused"),
+        Err(e) => e.to_string(),
+    }
+}
+
+#[tokio::test]
+async fn resolve_vta_endpoint_refuses_a_metadata_rest_url() {
+    let r = rest_only("http://169.254.169.254/latest/meta-data/").await;
+    refusal(resolve_vta_endpoint_with_resolver(SEEDED_VTA, &r).await);
+    // Not even with private endpoints allowed.
+    refusal(
+        resolve_vta_endpoint_with_resolver_and_policy(
+            SEEDED_VTA,
+            &r,
+            EndpointPolicy::private_allowed(),
+        )
+        .await,
+    );
+}
+
+#[tokio::test]
+async fn resolve_vta_endpoint_refuses_a_userinfo_rest_url() {
+    let r = rest_only("https://user:pw@vta.example").await;
+    let msg = refusal(resolve_vta_endpoint_with_resolver(SEEDED_VTA, &r).await);
+    assert!(
+        !msg.contains("pw@"),
+        "credentials must not be echoed: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_vta_endpoint_private_rest_url_needs_the_opt_in() {
+    let r = rest_only("https://10.0.0.5").await;
+    let msg = refusal(
+        resolve_vta_endpoint_with_resolver_and_policy(
+            SEEDED_VTA,
+            &r,
+            EndpointPolicy::public_only(),
+        )
+        .await,
+    );
+    assert!(msg.contains("VTA_ALLOW_PRIVATE_ENDPOINTS"), "{msg}");
+
+    match resolve_vta_endpoint_with_resolver_and_policy(
+        SEEDED_VTA,
+        &r,
+        EndpointPolicy::private_allowed(),
+    )
+    .await
+    .expect("accepted with the opt-in")
+    {
+        VtaEndpoint::Rest { url } => assert_eq!(url, "https://10.0.0.5"),
+        _ => panic!("expected a REST endpoint"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_vta_endpoint_accepts_loopback_http() {
+    let r = rest_only("http://127.0.0.1:8100").await;
+    match resolve_vta_endpoint_with_resolver(SEEDED_VTA, &r)
+        .await
+        .expect("loopback http is accepted for local development")
+    {
+        VtaEndpoint::Rest { url } => assert_eq!(url, "http://127.0.0.1:8100"),
+        _ => panic!("expected a REST endpoint"),
+    }
+}
+
+/// The REST URL rides along in the mediator variants, so a refused one fails
+/// the whole resolution rather than being carried onward.
+#[tokio::test]
+async fn resolve_vta_endpoint_refuses_a_bad_rest_url_beside_a_mediator() {
+    let r = resolver_serving(json!([
+        { "id": format!("{SEEDED_VTA}#vta-didcomm"), "type": "DIDCommMessaging",
+          "serviceEndpoint": "did:web:mediator.example" },
+        { "id": format!("{SEEDED_VTA}#vta-rest"), "type": "VTARest",
+          "serviceEndpoint": "http://169.254.169.254/" },
+    ]))
+    .await;
+    refusal(resolve_vta_endpoint_with_resolver(SEEDED_VTA, &r).await);
 }
 
 #[tokio::test]


### PR DESCRIPTION

## Why

A VTA's REST base URL comes from the `#vta-rest` service in its DID document (or is synthesized from the DID's domain). Until now it was used as-is: any scheme, any host, with embedded credentials. Every later authenticated call went there. Separately, `SessionStore::ensure_authenticated` returned the cached access token whatever base URL it was called with. If the advertised endpoint changed, a live bearer token for the original VTA went to the new host.

While fixing that, the existing foreign-fetch guard (`vta_sdk::http::guard_public_url`, which fronts the VTC recognise/present paths and vta-vault status lists) turned out to pass IPv4-mapped IPv6 loopback, carrier-grade NAT addresses (including a cloud metadata address) and `localhost`. It also did no DNS-level check. A unit test against `main` confirmed all three literal cases.

## What changes

### `vta-sdk::http`
- **One classifier.** `classify_ip` / `classify_host` (with `IpClass` / `HostClass`) cover:
  - IPv4 private, loopback, link-local, CGNAT, `0/8`, broadcast, multicast, documentation, benchmarking and reserved space;
  - IPv6 loopback, unspecified, ULA, link-local, site-local, multicast, documentation, Teredo, discard and local-use NAT64;
  - IPv4 embedded in IPv6 (mapped, compatible, NAT64 `64:ff9b::/96`, 6to4), classified by the embedded address;
  - named cloud-metadata addresses (`fd00:ec2::254`, `100.100.100.200`);
  - local-only names (`localhost`, `*.localhost`, `*.local`, `*.internal`, `*.home.arpa`, single-label names) and metadata hostnames.

  It mirrors `affinidi-did-web`'s classifier. A comment marks it for replacement by the shared `affinidi-net-guard` crate once that is published.
- **`guard_public_url`** uses the classifier. Its signature is unchanged.
- **`foreign_fetch_client`** now installs a DNS resolver that fails closed if any answer for a name is non-public, and connects only to the vetted addresses. It also sets `no_proxy()`, so a proxy cannot resolve the name on its behalf.
- **`guard_vta_endpoint(url, EndpointPolicy)`**:
  - `https` required; `http` only to `localhost`, `127.0.0.0/8` or `::1` (the same predicate as `vta-webvh`'s webvh client).
  - Always refused: userinfo, other schemes, link-local and metadata addresses and names, unspecified, broadcast, multicast, documentation, benchmarking and reserved addresses, and IPv6 forms embedding a non-public IPv4 address.
  - RFC 1918, ULA, CGNAT and local-only names are accepted only when the private-endpoint policy is enabled. The refusal names the opt-in, and URL credentials are never echoed.
- **`EndpointPolicy::process_default()`** enables private endpoints when `VTA_ALLOW_PRIVATE_ENDPOINTS` is truthy or the binary called `set_allow_private_endpoints(true)`.
- **`rest_client()`** follows a redirect only while scheme, host and port stay the same as the original request. Otherwise the `3xx` is returned to the caller.

### `vta-sdk::session`
- Every REST URL from `resolve_vta_endpoint_with_resolver` (and so `resolve_vta_endpoint` and `provision_client::resolve_vta`), `resolve_vta_url` and the forced-REST path of `connect_with_transport` passes `guard_vta_endpoint`. That covers both the advertised `#vta-rest` and the URL synthesized from the DID.
  - A refused URL is an error, never a silent fallback. This includes a document that also advertises TSP/DIDComm, since the REST URL is carried in those variants.
- New `resolve_vta_endpoint_with_resolver_and_policy` takes an explicit policy.
- The persisted session gains `token_origin` (serde-defaulted). It is set wherever a token is stored (`login`, `ensure_authenticated`). A cached token is returned only when the requested base URL has the same origin; otherwise the session re-authenticates. Sessions saved before this change have no origin and re-authenticate once.

### CLIs
- `cnm` and `pnm` gain a global `--allow-private-endpoints` flag (also read from `VTA_ALLOW_PRIVATE_ENDPOINTS`).
- `cnm backup`, `cnm audit verify` and `pnm bootstrap connect` use `vta_sdk::http::rest_client()` instead of a bare `reqwest::Client::new()`, and read responses through `read_body_capped`:
  - backup: 64 MiB, matching the VTC's backup-import request cap;
  - audit verify and bootstrap: 1 MiB.
- `cnm-cli/clippy.toml` and `pnm-cli/clippy.toml` add a `disallowed-methods` entry for `reqwest::Client::new`. Clippy picks config up from each crate's directory, so other crates are unaffected.

## Operator-visible behaviour changes
- A VTA whose DID document advertises a private-network REST endpoint (for example `https://10.0.0.5`) is now refused by default. Pass `--allow-private-endpoints` or set `VTA_ALLOW_PRIVATE_ENDPOINTS=1`. This applies to any SDK consumer resolving VTA endpoints, not only the CLIs.
- Plain `http://` endpoints are refused unless the host is loopback. Local-dev setups using `http://localhost:…` or `http://127.0.0.1:…` keep working.
- A cached token is no longer reused against a different origin; the CLI re-authenticates instead.
- `cnm backup` and `cnm audit verify` now have the SDK's request timeouts (30 s by default, `VTA_REST_TIMEOUT_SECS` to raise).
- Foreign fetches (status lists, recognition) refuse hostnames that resolve to non-public addresses, and no longer go through `HTTP(S)_PROXY`.
- `--url` overrides are unchanged: an operator-supplied URL is not run through the endpoint guard.

## Merge note
A separate change reorders `SessionStore::login` so the session is saved only after authentication succeeds. This PR touches `login` only to add `token_origin: None` to the initial `Session` and to record `session.token_origin` next to the token. Expect a small textual conflict there; keep both.

## Tests
- `vta-sdk/src/http.rs`:
  - classifier block/allow vectors, URL canonicalisation vectors, local-name and scheme vectors;
  - stubbed DNS answers (mixed, mapped, NAT64, empty), and a real `localhost` lookup refused by the resolver;
  - `guard_vta_endpoint` accept, always-refuse and opt-in cases, and credential redaction;
  - a same-origin redirect is followed and a cross-origin redirect is not (the target sees no request).
- `vta-sdk/src/session.rs`: legacy session without `token_origin` loads; origin normalisation; forced-REST URL vetting over a seeded resolver.
- `vta-sdk/tests/session_store.rs`:
  - seeded DID documents through `resolve_vta_endpoint_with_resolver`: the metadata URL is refused even with the opt-in; a userinfo URL is refused without echoing credentials; `https://10.0.0.5` is refused unless opted in; `http://127.0.0.1:8100` is accepted; a bad REST URL beside a DIDComm mediator is refused;
  - a cached token is reused for the same origin (including a `/v1` path) but not for a different origin.
