### PR TITLE
security(sealed-transfer): check who sealed an admin credential before installing it

### DIFF
--- a/cnm-cli/README.md
+++ b/cnm-cli/README.md
@@ -149,8 +149,10 @@ tokens:
 
 ```sh
 # Apply a sealed admin credential bundle (e.g. a backup-restore handoff
-# or a sealed transfer from another operator)
-cnm auth login --credential-bundle <file>
+# or a sealed transfer from another operator). The digest comes from the
+# operator who sealed it, over a separate channel you trust; the credential
+# must be for the community's configured VTA DID.
+cnm auth login --credential-bundle <file> --expect-digest <sha256>
 
 # Check auth status
 cnm auth status

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -416,7 +416,10 @@ enum AuthCommands {
         /// Expected SHA-256 digest, communicated out-of-band by the producer.
         #[arg(long)]
         expect_digest: Option<String>,
-        /// Skip out-of-band digest verification (testing only — prints a warning).
+        /// Skip out-of-band digest verification. The bundle is then accepted
+        /// only if it is signed by the community's configured VTA DID; the
+        /// admin credentials pnm and cnm seal carry no such signature and
+        /// need --expect-digest.
         #[arg(long)]
         no_verify_digest: bool,
     },
@@ -761,31 +764,27 @@ fn print_banner() {
 /// Implementation of `cnm auth login --credential-bundle <file>`.
 ///
 /// Opens an armored sealed bundle (matching a secret persisted earlier by
-/// `cnm bootstrap request`), extracts the admin credential from the payload,
-/// and installs it via `auth::login`.
+/// `cnm bootstrap request`), verifies its producer and VTA DID against
+/// `expected_vta_did` (the community's configured DID, when there is one),
+/// and installs the admin credential via `auth::login`.
 async fn auth_login_sealed(
     client: &VtaClient,
     keyring_key: &str,
     credential_bundle: &std::path::Path,
     expect_digest: Option<&str>,
     no_verify_digest: bool,
+    expected_vta_did: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config_dir =
         config::config_dir().map_err(|e| format!("could not resolve config dir: {e}"))?;
-    if no_verify_digest {
-        vta_cli_common::sealed_consumer::warn_no_verify_digest();
-    }
-    let opened = vta_cli_common::sealed_consumer::open_armored_bundle(
+    vta_cli_common::sealed_consumer::validate_digest_flags(expect_digest, no_verify_digest)?;
+    let bundle = vta_cli_common::sealed_consumer::open_admin_credential(
         credential_bundle,
         &config_dir,
         expect_digest,
-        no_verify_digest,
+        expected_vta_did,
     )?;
-    eprintln!(
-        "Sealed bundle opened ({} — digest {}).",
-        opened.bundle_id_hex, opened.digest
-    );
-    let bundle = vta_cli_common::sealed_consumer::extract_admin_credential(opened.payload)?;
+    eprintln!("Sealed bundle opened and verified.");
     let base = client
         .rest_url()
         .ok_or("login requires a REST connection to the VTC")?;
@@ -1079,7 +1078,7 @@ async fn main() {
                 "Error: could not bootstrap session from personal VTA: {e}\n\n\
                          To fix this, either:\n  \
                          1. Import a sealed credential bundle from your VTA admin:\n     \
-                            cnm auth login --credential-bundle <bundle.armored> [--expect-digest <sha256>]\n  \
+                            cnm auth login --credential-bundle <bundle.armored> --expect-digest <sha256>\n  \
                          2. Re-run setup: cnm setup"
             );
             std::process::exit(1);
@@ -1106,12 +1105,16 @@ async fn main() {
                 expect_digest,
                 no_verify_digest,
             } => {
+                let expected_vta_did = resolve_community(cli.community.as_deref(), &cnm_config)
+                    .ok()
+                    .and_then(|(_, community)| community.vta_did.clone());
                 auth_login_sealed(
                     &client,
                     &keyring_key,
                     &credential_bundle,
                     expect_digest.as_deref(),
                     no_verify_digest,
+                    expected_vta_did.as_deref(),
                 )
                 .await
             }

--- a/cnm-cli/src/setup.rs
+++ b/cnm-cli/src/setup.rs
@@ -13,55 +13,56 @@ use vta_sdk::prelude::*;
 /// Interactively prompt for an armored sealed bundle path + expected digest,
 /// then open it via the shared consumer helper and extract the admin
 /// credential. Used by every "gimme a credential" seam in the wizard.
+///
+/// `expected_vta_did` is the DID the operator typed for this VTA; the
+/// credential must be for that VTA.
 async fn prompt_for_sealed_credential(
     label: &str,
+    expected_vta_did: &str,
 ) -> Result<CredentialBundle, Box<dyn std::error::Error>> {
     eprintln!();
     eprintln!("Before continuing, generate a bootstrap request for the {label} admin:");
     eprintln!("  cnm bootstrap request --out request.json");
     eprintln!("Hand that file to the admin, then return here with the armored sealed");
-    eprintln!("bundle they produce (and its SHA-256 digest for verification).");
+    eprintln!("bundle they produce and its SHA-256 digest. Get the digest over a channel");
+    eprintln!("you trust, separately from the bundle: it is what shows the bundle is theirs.");
     eprintln!();
     let path: String = Input::new()
         .with_prompt(format!("Path to the {label} armored sealed bundle"))
         .interact_text()?;
     let digest: String = Input::new()
         .with_prompt(format!(
-            "Expected SHA-256 digest for {label} bundle (empty = skip verification)"
+            "Expected SHA-256 digest for the {label} bundle (64 hex characters)"
         ))
-        .allow_empty(true)
+        .validate_with(|input: &String| digest_prompt_validator(input))
         .interact_text()?;
-    let (expect_digest, no_verify) = if digest.trim().is_empty() {
-        (None, true)
-    } else {
-        (Some(digest.trim().to_string()), false)
-    };
-    open_sealed_credential(Path::new(path.trim()), expect_digest.as_deref(), no_verify)
+    let digest = vta_cli_common::sealed_consumer::normalize_expected_digest(&digest)?;
+    open_sealed_credential(Path::new(path.trim()), &digest, expected_vta_did)
 }
 
-/// Open a sealed bundle file from `bundle_path` and extract a
-/// [`CredentialBundle`]. Shared by the CLI-flag path and the interactive
-/// path.
+/// Validator for the digest prompt. Empty input is rejected: without the
+/// digest, nothing shows that the bundle came from the VTA admin rather than
+/// someone else who saw the bootstrap request.
+fn digest_prompt_validator(input: &str) -> Result<(), String> {
+    vta_cli_common::sealed_consumer::normalize_expected_digest(input).map(|_| ())
+}
+
+/// Open a sealed bundle file from `bundle_path`, verify it against the
+/// digest and the expected VTA DID, and extract the [`CredentialBundle`].
 fn open_sealed_credential(
     bundle_path: &Path,
-    expect_digest: Option<&str>,
-    no_verify_digest: bool,
+    expect_digest: &str,
+    expected_vta_did: &str,
 ) -> Result<CredentialBundle, Box<dyn std::error::Error>> {
     let config_dir = config_dir()?;
-    if no_verify_digest {
-        vta_cli_common::sealed_consumer::warn_no_verify_digest();
-    }
-    let opened = vta_cli_common::sealed_consumer::open_armored_bundle(
+    let credential = vta_cli_common::sealed_consumer::open_admin_credential(
         bundle_path,
         &config_dir,
-        expect_digest,
-        no_verify_digest,
+        Some(expect_digest),
+        Some(expected_vta_did),
     )?;
-    eprintln!(
-        "Sealed bundle opened ({} — digest {}).",
-        opened.bundle_id_hex, opened.digest
-    );
-    vta_cli_common::sealed_consumer::extract_admin_credential(opened.payload)
+    eprintln!("Sealed bundle opened and verified.");
+    Ok(credential)
 }
 
 /// Derive a URL-safe slug from a community name.
@@ -118,7 +119,7 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
     // ── Personal VTA ────────────────────────────────────────────────
     let (personal_did, personal_url) = prompt_vta_did("Personal").await?;
 
-    let personal_bundle = prompt_for_sealed_credential("personal VTA").await?;
+    let personal_bundle = prompt_for_sealed_credential("personal VTA", &personal_did).await?;
 
     // Authenticate against personal VTA
     eprintln!();
@@ -151,7 +152,7 @@ pub async fn run_setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
     let context_id = match join_choice {
         // Import existing credential
         0 => {
-            let bundle = prompt_for_sealed_credential("community VTA").await?;
+            let bundle = prompt_for_sealed_credential("community VTA", &community_did).await?;
 
             let keyring_key = community_keyring_key(&community_slug);
             eprintln!();
@@ -274,7 +275,7 @@ pub async fn add_community() -> Result<(), Box<dyn std::error::Error>> {
 
     let (community_did, community_url) = prompt_vta_did("Community").await?;
 
-    let bundle = prompt_for_sealed_credential("community VTA").await?;
+    let bundle = prompt_for_sealed_credential("community VTA", &community_did).await?;
 
     let keyring_key = community_keyring_key(&community_slug);
     eprintln!();
@@ -392,5 +393,18 @@ mod tests {
     #[test]
     fn test_slugify_numbers() {
         assert_eq!(slugify("Community 42"), "community-42");
+    }
+
+    #[test]
+    fn digest_prompt_rejects_empty_input() {
+        assert!(digest_prompt_validator("").is_err());
+        assert!(digest_prompt_validator("  ").is_err());
+    }
+
+    #[test]
+    fn digest_prompt_accepts_only_a_sha256_hex_digest() {
+        assert!(digest_prompt_validator(&"0f".repeat(32)).is_ok());
+        assert!(digest_prompt_validator(&"0f".repeat(31)).is_err());
+        assert!(digest_prompt_validator(&"zz".repeat(32)).is_err());
     }
 }

--- a/pnm-cli/src/bootstrap.rs
+++ b/pnm-cli/src/bootstrap.rs
@@ -269,11 +269,18 @@ pub async fn run_open(
     }
 
     if let Some(path) = out {
-        // Rejects any payload variant that isn't an admin identity, with a
-        // per-variant message. The bundle is already spent by this point, so
-        // failing here still costs the operator a fresh request cycle — hence
-        // the up-front warning in the `--out` help text.
-        let bundle = vta_cli_common::sealed_consumer::extract_admin_credential(opened.payload)?;
+        // Writing the credential out installs it for a file-based consumer, so
+        // the bundle must be anchored first: the out-of-band digest, or a
+        // signature by `--expect-vta-did` (see `verify_admin_bundle`). This
+        // also rejects any payload variant that isn't an admin identity, with
+        // a per-variant message. The bundle is already spent by this point,
+        // so failing here still costs the operator a fresh request cycle —
+        // hence the up-front warning in the `--out` help text.
+        let bundle = vta_cli_common::sealed_consumer::verify_admin_bundle(
+            opened,
+            expect_digest.as_deref(),
+            expect_vta_did.as_deref(),
+        )?;
         write_credential_bundle(&path, &bundle)?;
         println!();
         println!("Credential written to {} (0600).", path.display());

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -594,7 +594,10 @@ pub(crate) enum BootstrapCommands {
         bundle: std::path::PathBuf,
         /// Write the extracted admin credential to this path as JSON
         /// (created 0600). Only valid for `AdminCredential` and
-        /// `ContextProvision` payloads.
+        /// `ContextProvision` payloads. The bundle must be anchored: by
+        /// `--expect-digest`, or by a signature from `--expect-vta-did`.
+        /// When `--expect-vta-did` is given, the credential must be for
+        /// that VTA.
         #[arg(long)]
         out: Option<std::path::PathBuf>,
         /// Expected SHA-256 digest, communicated out-of-band by the producer.

--- a/vta-cli-common/src/sealed_consumer.rs
+++ b/vta-cli-common/src/sealed_consumer.rs
@@ -16,9 +16,10 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 use vta_sdk::credentials::CredentialBundle;
+use vta_sdk::sealed_transfer::verify::{VerifiedAssertion, verify_producer_assertion_with_pubkey};
 use vta_sdk::sealed_transfer::{
-    BootstrapRequest, SealedPayloadV1, armor, bundle_digest, ed25519_seed_to_x25519_secret,
-    generate_ed25519_keypair, open_bundle,
+    AssertionProof, BootstrapRequest, SealedPayloadV1, armor, bundle_digest,
+    ed25519_seed_to_x25519_secret, generate_ed25519_keypair, open_bundle,
 };
 
 const SECRETS_SUBDIR: &str = "bootstrap-secrets";
@@ -179,12 +180,33 @@ pub struct OpenedArmored {
 ///
 /// Best-effort removal of the used secret file on success — the bundle id is
 /// single-use, and keeping the secret around only widens blast radius.
+///
+/// This checks the digest when one is given, but not who produced the
+/// bundle. To install an admin credential, use [`open_admin_credential`].
 pub fn open_armored_bundle(
     bundle_path: &Path,
     config_dir: &Path,
     expect_digest: Option<&str>,
     no_verify_digest: bool,
 ) -> Result<OpenedArmored, Box<dyn std::error::Error>> {
+    let (opened, secret) = open_armored_bundle_keeping_secret(
+        bundle_path,
+        config_dir,
+        expect_digest,
+        no_verify_digest,
+    )?;
+    consume_secret(&secret);
+    Ok(opened)
+}
+
+/// [`open_armored_bundle`] without the secret cleanup. Returns the secret's
+/// path so the caller can remove it once it has accepted the bundle.
+fn open_armored_bundle_keeping_secret(
+    bundle_path: &Path,
+    config_dir: &Path,
+    expect_digest: Option<&str>,
+    no_verify_digest: bool,
+) -> Result<(OpenedArmored, PathBuf), Box<dyn std::error::Error>> {
     if expect_digest.is_none() && !no_verify_digest {
         return Err(
             "--expect-digest <hex> is required (or pass --no-verify-digest to opt out)".into(),
@@ -234,25 +256,32 @@ pub fn open_armored_bundle(
     let digest = bundle_digest(bundle);
     let opened = open_bundle(&x_secret, bundle, expect_digest)?;
 
-    // Best-effort cleanup. If the caller later fails, the secret is gone —
-    // that's fine because the bundle id is single-use anyway; a retry would
-    // need a fresh request. Overwrite-then-unlink so the old bytes aren't
-    // left sitting on disk after unlink (see `zero_overwrite_and_remove`).
-    if let Err(e) = zero_overwrite_and_remove(&sp) {
+    Ok((
+        OpenedArmored {
+            payload: opened.payload,
+            producer: opened.producer,
+            bundle_id: opened.bundle_id,
+            bundle_id_hex,
+            digest,
+            client_x25519_pub,
+        },
+        sp,
+    ))
+}
+
+/// Remove a used request secret.
+///
+/// Best-effort: if a later step fails, the secret is gone, which is fine
+/// because the bundle id is single-use anyway and a retry needs a fresh
+/// request. Overwrite-then-unlink so the old bytes aren't left sitting on
+/// disk after unlink (see `zero_overwrite_and_remove`).
+fn consume_secret(path: &Path) {
+    if let Err(e) = zero_overwrite_and_remove(path) {
         eprintln!(
             "warning: could not remove used secret {}: {e}",
-            sp.display()
+            path.display()
         );
     }
-
-    Ok(OpenedArmored {
-        payload: opened.payload,
-        producer: opened.producer,
-        bundle_id: opened.bundle_id,
-        bundle_id_hex,
-        digest,
-        client_x25519_pub,
-    })
 }
 
 /// The outcome of [`create_provision_request`]: the signed VP plus the
@@ -396,6 +425,158 @@ pub fn validate_digest_flags(
                 .into(),
         ),
     }
+}
+
+/// Parse an operator-supplied SHA-256 bundle digest.
+///
+/// Accepts exactly 64 hex characters, ignoring surrounding whitespace, and
+/// returns them lower-cased: the form [`bundle_digest`] produces and
+/// `open_bundle` compares against. Empty input is an error; there is no
+/// "skip" value.
+pub fn normalize_expected_digest(input: &str) -> Result<String, String> {
+    let digest = input.trim();
+    if digest.len() != 64 || !digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(
+            "enter the 64-character hex SHA-256 digest the producer gave you out-of-band".into(),
+        );
+    }
+    Ok(digest.to_ascii_lowercase())
+}
+
+/// Open an armored admin-credential bundle and verify where it came from
+/// before anything is installed.
+///
+/// Opens the bundle like [`open_armored_bundle`], then applies
+/// [`verify_admin_bundle`]. `expect_digest` of `None` is the
+/// `--no-verify-digest` case: only a bundle `DidSigned` by
+/// `expected_vta_did` is then accepted.
+///
+/// The single-use request secret is removed only once the bundle has been
+/// accepted, so a rejected bundle does not use up the pending request.
+pub fn open_admin_credential(
+    bundle_path: &Path,
+    config_dir: &Path,
+    expect_digest: Option<&str>,
+    expected_vta_did: Option<&str>,
+) -> Result<CredentialBundle, Box<dyn std::error::Error>> {
+    let (opened, secret) = open_armored_bundle_keeping_secret(
+        bundle_path,
+        config_dir,
+        expect_digest,
+        expect_digest.is_none(),
+    )?;
+    let credential = verify_admin_bundle(opened, expect_digest, expected_vta_did)?;
+    consume_secret(&secret);
+    Ok(credential)
+}
+
+/// Check that an opened bundle is anchored to the expected producer, then
+/// extract its admin credential.
+///
+/// HPKE sealing gives confidentiality, not authenticity: anyone who has seen
+/// the consumer's bootstrap request can seal a bundle to it. A credential is
+/// only installed when something the operator trusts vouches for the bundle:
+///
+/// - `PinnedOnly`: the out-of-band digest, `expect_digest`. The admin
+///   credentials that `pnm`, `cnm` and `vta` seal today all take this form,
+///   with a throwaway producer `did:key`.
+/// - `DidSigned`: a signature by `expected_vta_did` itself. A valid signature
+///   from any other DID proves nothing, since anyone can mint a `did:key` and
+///   sign, so the producer DID must equal `expected_vta_did`, with or without
+///   a digest. Only `did:key` producers can be verified here; other methods
+///   would need DID resolution.
+/// - `Attested`: refused. Attestation quotes are verified by
+///   `pnm bootstrap connect`, not on this path.
+///
+/// When `expected_vta_did` is given, the credential's `vta_did` must also
+/// equal it, so a bundle cannot point the session at a different VTA from the
+/// one the operator named.
+pub fn verify_admin_bundle(
+    opened: OpenedArmored,
+    expect_digest: Option<&str>,
+    expected_vta_did: Option<&str>,
+) -> Result<CredentialBundle, Box<dyn std::error::Error>> {
+    if let Some(expected) = expect_digest
+        && expected != opened.digest
+    {
+        return Err(format!(
+            "bundle digest {} does not match the expected digest {expected}",
+            opened.digest
+        )
+        .into());
+    }
+
+    let producer = &opened.producer;
+    let producer_pubkey = match &producer.proof {
+        AssertionProof::DidSigned(_) => {
+            let expected = expected_vta_did.ok_or_else(|| {
+                format!(
+                    "the bundle is signed by {}, but there is no expected VTA DID to check \
+                     that against; refusing to install it",
+                    producer.producer_did
+                )
+            })?;
+            if producer.producer_did != expected {
+                return Err(format!(
+                    "the bundle is signed by {}, not by the expected VTA {expected}; refusing \
+                     to install it",
+                    producer.producer_did
+                )
+                .into());
+            }
+            let pubkey = affinidi_crypto::did_key::did_key_to_ed25519_pub(&producer.producer_did)
+                .map_err(|e| {
+                format!(
+                    "cannot verify the producer signature: {} is not an Ed25519 did:key \
+                         ({e}); use --expect-digest instead",
+                    producer.producer_did
+                )
+            })?;
+            Some(pubkey)
+        }
+        _ => None,
+    };
+
+    let verdict = verify_producer_assertion_with_pubkey(
+        producer,
+        &opened.client_x25519_pub,
+        &opened.bundle_id,
+        producer_pubkey.as_ref(),
+    )?;
+
+    // Exhaustive, so a new assertion kind has to be decided on here rather
+    // than being accepted by default.
+    match verdict {
+        VerifiedAssertion::DidSignedVerified(_) => {}
+        VerifiedAssertion::PinnedOnlyAcknowledged(_) => {
+            if expect_digest.is_none() {
+                return Err(
+                    "the bundle carries no producer signature, so only its out-of-band \
+                     SHA-256 digest can show where it came from; pass --expect-digest <hex>"
+                        .into(),
+                );
+            }
+        }
+        VerifiedAssertion::AttestedNeedsNitroCheck(_) => {
+            return Err(
+                "the bundle carries a TEE attestation, which is not verified when installing \
+                 a credential from a file; use `pnm bootstrap connect` for attested bootstrap"
+                    .into(),
+            );
+        }
+    }
+
+    let credential = extract_admin_credential(opened.payload)?;
+    if let Some(expected) = expected_vta_did
+        && credential.vta_did != expected
+    {
+        return Err(format!(
+            "the credential is for VTA {}, not the expected {expected}; refusing to install it",
+            credential.vta_did
+        )
+        .into());
+    }
+    Ok(credential)
 }
 
 #[cfg(test)]
@@ -620,5 +801,205 @@ mod tests {
         ));
         let cred = extract_admin_credential(payload).unwrap();
         assert_eq!(cred.did, "did:key:z6Mk123");
+    }
+
+    // ── open_admin_credential ──────────────────────────────────────
+
+    use vta_sdk::sealed_transfer::{
+        AttestationQuoteAssertion, DidSignedAssertion, ProducerAssertion,
+    };
+
+    const VTA_DID: &str = "did:key:z6MkVTA";
+
+    fn tmp_dir() -> PathBuf {
+        std::env::temp_dir().join(format!("vta-test-{}", rand::random::<u32>()))
+    }
+
+    fn admin_payload(vta_did: &str) -> SealedPayloadV1 {
+        SealedPayloadV1::AdminCredential(Box::new(vta_sdk::credentials::CredentialBundle::new(
+            "did:key:z6Mk123",
+            "z1234567890",
+            vta_did,
+        )))
+    }
+
+    /// Seal `payload` to `created`'s request under the given producer
+    /// assertion and write the armor into `dir`. Returns the path and digest.
+    async fn seal_to_request(
+        dir: &Path,
+        created: &CreatedRequest,
+        producer: ProducerAssertion,
+        payload: &SealedPayloadV1,
+    ) -> (PathBuf, String) {
+        let client_x = created.request.decode_client_x25519_pub().unwrap();
+        let bundle_id = created.request.decode_nonce().unwrap();
+        let store = vta_sdk::sealed_transfer::InMemoryNonceStore::new();
+        let bundle =
+            vta_sdk::sealed_transfer::seal_payload(&client_x, bundle_id, producer, payload, &store)
+                .await
+                .unwrap();
+        let path = dir.join("bundle.armor");
+        fs::write(&path, armor::encode(&bundle)).unwrap();
+        (path, bundle_digest(&bundle))
+    }
+
+    /// A correctly signed `DidSigned` assertion over `created`'s key and
+    /// nonce, made with a freshly generated key. It names `producer_did`,
+    /// which defaults to that key's own did:key. Returns the assertion and
+    /// the key's did:key.
+    fn did_signed(
+        created: &CreatedRequest,
+        producer_did: Option<&str>,
+    ) -> (ProducerAssertion, String) {
+        use base64::Engine;
+        use ed25519_dalek::Signer;
+
+        let (seed, public) = generate_ed25519_keypair();
+        let key_did = affinidi_crypto::did_key::ed25519_pub_to_did_key(&public);
+        let did = producer_did.unwrap_or(&key_did).to_string();
+
+        let mut msg = vta_sdk::sealed_transfer::verify::DID_SIGNED_DOMAIN_TAG.to_vec();
+        msg.extend_from_slice(&created.request.decode_client_x25519_pub().unwrap());
+        msg.extend_from_slice(&created.request.decode_nonce().unwrap());
+        let sig = ed25519_dalek::SigningKey::from_bytes(&seed).sign(&msg);
+
+        let assertion = ProducerAssertion {
+            producer_did: did.clone(),
+            proof: AssertionProof::DidSigned(DidSignedAssertion {
+                did: did.clone(),
+                signature_b64: base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(sig.to_bytes()),
+                verification_method: format!("{did}#key-0"),
+            }),
+        };
+        (assertion, key_did)
+    }
+
+    #[tokio::test]
+    async fn admin_credential_signed_by_an_unexpected_did_key_is_rejected() {
+        let tmp = tmp_dir();
+        let created = create_bootstrap_request(&tmp, None).unwrap();
+        // Anyone who has seen the request can mint a did:key, sign a valid
+        // assertion with it, and point the credential at a VTA of their own.
+        let (assertion, attacker_did) = did_signed(&created, None);
+        let (path, digest) =
+            seal_to_request(&tmp, &created, assertion, &admin_payload(&attacker_did)).await;
+
+        let err = open_admin_credential(&path, &tmp, None, Some("did:webvh:victim")).unwrap_err();
+        assert!(err.to_string().contains("not by the expected VTA"), "{err}");
+        // Still refused alongside a digest (which would come from the same
+        // sender), and when there is no expected VTA DID at all.
+        assert!(
+            open_admin_credential(&path, &tmp, Some(&digest), Some("did:webvh:victim")).is_err()
+        );
+        assert!(open_admin_credential(&path, &tmp, None, None).is_err());
+
+        // A rejected bundle does not use up the pending request.
+        assert!(created.secret_path.exists());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn admin_credential_signed_by_the_expected_vta_is_accepted() {
+        let tmp = tmp_dir();
+        let created = create_bootstrap_request(&tmp, None).unwrap();
+        let (assertion, vta_did) = did_signed(&created, None);
+        let (path, _) = seal_to_request(&tmp, &created, assertion, &admin_payload(&vta_did)).await;
+
+        let cred = open_admin_credential(&path, &tmp, None, Some(&vta_did)).unwrap();
+        assert_eq!(cred.vta_did, vta_did);
+        assert!(
+            !created.secret_path.exists(),
+            "an accepted bundle consumes the request secret"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn did_signed_by_another_key_in_the_vta_name_is_rejected() {
+        let tmp = tmp_dir();
+        let created = create_bootstrap_request(&tmp, None).unwrap();
+        // Names the expected VTA as the producer, but signs with another key.
+        let (_, vta_did) = did_signed(&created, None);
+        let (forged, _) = did_signed(&created, Some(&vta_did));
+        let (path, _) = seal_to_request(&tmp, &created, forged, &admin_payload(&vta_did)).await;
+
+        assert!(open_admin_credential(&path, &tmp, None, Some(&vta_did)).is_err());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn pinned_only_admin_credential_needs_the_digest() {
+        let tmp = tmp_dir();
+        let created = create_bootstrap_request(&tmp, None).unwrap();
+        let recipient =
+            SealedRecipient::from_json_str(&serde_json::to_string(&created.request).unwrap())
+                .unwrap();
+        let sealed = seal_for_recipient(&recipient, &admin_payload(VTA_DID))
+            .await
+            .unwrap();
+        let path = tmp.join("bundle.armor");
+        fs::write(&path, sealed.armored.as_bytes()).unwrap();
+
+        assert!(open_admin_credential(&path, &tmp, None, Some(VTA_DID)).is_err());
+        assert!(created.secret_path.exists());
+
+        // The digest as an operator might type it: upper-case, with whitespace.
+        let typed =
+            normalize_expected_digest(&format!(" {}\n", sealed.digest.to_uppercase())).unwrap();
+        let cred = open_admin_credential(&path, &tmp, Some(&typed), Some(VTA_DID)).unwrap();
+        assert_eq!(cred.vta_did, VTA_DID);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn admin_credential_for_a_different_vta_is_rejected() {
+        let tmp = tmp_dir();
+        let created = create_bootstrap_request(&tmp, None).unwrap();
+        let recipient =
+            SealedRecipient::from_json_str(&serde_json::to_string(&created.request).unwrap())
+                .unwrap();
+        let sealed = seal_for_recipient(&recipient, &admin_payload("did:key:z6MkOtherVTA"))
+            .await
+            .unwrap();
+        let path = tmp.join("bundle.armor");
+        fs::write(&path, sealed.armored.as_bytes()).unwrap();
+
+        let err =
+            open_admin_credential(&path, &tmp, Some(&sealed.digest), Some(VTA_DID)).unwrap_err();
+        assert!(err.to_string().contains("did:key:z6MkOtherVTA"), "{err}");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn attested_admin_credential_is_rejected() {
+        let tmp = tmp_dir();
+        let created = create_bootstrap_request(&tmp, None).unwrap();
+        let producer = ProducerAssertion {
+            producer_did: "did:key:z6MkTee".into(),
+            proof: AssertionProof::Attested(AttestationQuoteAssertion {
+                format: "aws-nitro-v1".into(),
+                quote_b64: "AAAA".into(),
+            }),
+        };
+        let (path, digest) =
+            seal_to_request(&tmp, &created, producer, &admin_payload(VTA_DID)).await;
+
+        let err = open_admin_credential(&path, &tmp, Some(&digest), Some(VTA_DID)).unwrap_err();
+        assert!(err.to_string().contains("attestation"), "{err}");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn expected_digest_must_be_64_hex_characters() {
+        assert!(normalize_expected_digest("").is_err());
+        assert!(normalize_expected_digest("   ").is_err());
+        assert!(normalize_expected_digest(&"a".repeat(63)).is_err());
+        assert!(normalize_expected_digest(&"a".repeat(65)).is_err());
+        assert!(normalize_expected_digest(&"g".repeat(64)).is_err());
+        assert_eq!(
+            normalize_expected_digest(&"AB".repeat(32)).unwrap(),
+            "ab".repeat(32)
+        );
     }
 }

--- a/vta-sdk/src/session.rs
+++ b/vta-sdk/src/session.rs
@@ -229,7 +229,12 @@ impl SessionStore {
         self.load_session(key).is_some()
     }
 
-    /// Store a credential bundle and authenticate.
+    /// Authenticate with a credential bundle, then store it as the session.
+    ///
+    /// The session is written only after challenge-response succeeds. A
+    /// bundle that does not authenticate (unreachable endpoint, unknown DID,
+    /// wrong VTA) leaves whatever is stored under `key` untouched, instead of
+    /// becoming the credential later commands use.
     ///
     /// Returns `LoginResult` on success (no printing).
     pub async fn login(
@@ -244,19 +249,6 @@ impl SessionStore {
             "login with credential bundle"
         );
 
-        let mut session = Session {
-            client_did: bundle.did.clone(),
-            private_key: bundle.private_key_multibase.clone(),
-            vta_did: Some(bundle.vta_did.clone()),
-            access_token: None,
-            access_expires_at: None,
-            token_origin: None,
-            needs_rotation: false,
-        };
-        self.save_session(key, &session)?;
-        debug!(keyring_key = key, "session saved");
-
-        // Perform authentication
         let token = challenge_response(
             base_url,
             &bundle.did,
@@ -265,10 +257,17 @@ impl SessionStore {
         )
         .await?;
 
-        session.access_token = Some(token.access_token);
-        session.access_expires_at = Some(token.access_expires_at);
-        session.token_origin = url_origin(base_url);
+        let session = Session {
+            client_did: bundle.did.clone(),
+            private_key: bundle.private_key_multibase.clone(),
+            vta_did: Some(bundle.vta_did.clone()),
+            access_token: Some(token.access_token),
+            access_expires_at: Some(token.access_expires_at),
+            token_origin: url_origin(base_url),
+            needs_rotation: false,
+        };
         self.save_session(key, &session)?;
+        debug!(keyring_key = key, "session saved");
 
         Ok(LoginResult {
             client_did: bundle.did.clone(),

--- a/vta-sdk/tests/session_store.rs
+++ b/vta-sdk/tests/session_store.rs
@@ -295,6 +295,51 @@ async fn login_propagates_challenge_failure() {
         msg.contains("challenge request failed") || msg.contains("401"),
         "expected challenge-failure surface, got: {msg}"
     );
+    assert!(
+        !s.has_session("k"),
+        "a credential that failed to authenticate must not be stored"
+    );
+}
+
+/// A bundle naming a VTA that cannot be reached must not become the stored
+/// session. Every later command resolves the session's `vta_did`, so storing
+/// it before authenticating would bind them to whatever VTA the bundle named.
+#[tokio::test]
+async fn login_against_an_unreachable_vta_persists_no_session() {
+    let s = store();
+    let (did, pk) = did_key_from_seed(0x10);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    let bundle = CredentialBundle::new(&did, &pk, &vta_did);
+
+    // Nothing listens on port 1 of loopback, so the connect fails at once.
+    let err = s
+        .login(&bundle, "http://127.0.0.1:1", "k")
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("could not connect"),
+        "expected a connection failure, got: {err}"
+    );
+    assert!(!s.has_session("k"));
+    assert!(s.loaded_session("k").is_none());
+}
+
+/// A failed login leaves an existing session under the same key as it was.
+#[tokio::test]
+async fn failed_login_keeps_the_existing_session() {
+    let s = store();
+    let (old_did, old_pk) = did_key_from_seed(0x30);
+    let (vta_did, _) = did_key_from_seed(0x20);
+    s.store_direct("k", &old_did, &old_pk, &vta_did).unwrap();
+
+    let (new_did, new_pk) = did_key_from_seed(0x10);
+    let (other_vta, _) = did_key_from_seed(0x40);
+    let bundle = CredentialBundle::new(&new_did, &new_pk, &other_vta);
+    assert!(s.login(&bundle, "http://127.0.0.1:1", "k").await.is_err());
+
+    let kept = s.loaded_session("k").expect("existing session is kept");
+    assert_eq!(kept.client_did, old_did);
+    assert_eq!(kept.vta_did.as_deref(), Some(vta_did.as_str()));
 }
 
 #[tokio::test]


### PR DESCRIPTION

## Summary

A sealed bundle is HPKE-encrypted to the consumer's request key. That keeps it
confidential, but it does not show who produced it: anyone who has seen the
bootstrap request can seal a bundle to it. Before this change, `cnm` installed an
admin credential from a bundle with no check tying it to the operator's VTA:

- the setup wizard treated an empty digest as "skip verification";
- a `DidSigned` assertion passed `open_bundle` regardless of which DID signed it,
  and no install path verified the assertion;
- the bundle's `vta_did` was never compared with the DID the operator typed;
- `SessionStore::login` stored the bundle as the session **before**
  challenge-response, so a login that failed still left that `vta_did` as the
  session later commands used.

## What producer assertion do admin credential bundles carry today?

Every path that seals an `AdminCredential` or `ContextProvision` for a consumer to
install from a file uses **`PinnedOnly` with a throwaway producer `did:key`**
(`vta_cli_common::sealed_producer::seal_for_recipient`; the private half is dropped
immediately):

| Producer | Payload | Assertion |
|---|---|---|
| `pnm auth-credential create`, `cnm auth-credential create` | `AdminCredential` | `PinnedOnly`, ephemeral did:key |
| `pnm contexts bootstrap`, `cnm contexts bootstrap` | `AdminCredential` | `PinnedOnly`, ephemeral did:key |
| `pnm contexts provision`, `pnm contexts reprovision` | `ContextProvision` | `PinnedOnly`, ephemeral did:key |
| `vta` offline context reprovision (`bootstrap_cli::run_context_reprovision`) | `ContextProvision` | `PinnedOnly`, ephemeral did:key |
| `vta bootstrap seal` (Mode C) | any payload file | `PinnedOnly`, ephemeral did:key |
| TEE `POST /bootstrap/request` | `AdminCredential` | `Attested`; consumed only by `pnm bootstrap connect`, which verifies the quote |
| provision-integration (`#sealed-transfer-0`) | `TemplateBootstrap` / `AdminRotation` | `DidSigned`, producer = VTA DID; not an admin-credential install path |

So for admin credentials the out-of-band digest is the only anchor that exists
today, and an expected VTA DID is enough for the `DidSigned` case. No
`--expect-producer-did` flag is added.

## Changes

### `vta-cli-common::sealed_consumer`

- `open_admin_credential(bundle_path, config_dir, expect_digest, expected_vta_did)`
  opens the bundle and calls `verify_admin_bundle`, which matches the verified
  assertion exhaustively (the same pattern as `verify_template_bundle` in
  `vta-service`):
  - `PinnedOnly`: accepted only with `expect_digest`;
  - `DidSigned`: accepted only if the producer DID equals `expected_vta_did` and
    the Ed25519 signature verifies. Any other signer is refused, with or without
    a digest. Only `did:key` producers can be verified here;
  - `Attested`: refused;
  - when `expected_vta_did` is given, `credential.vta_did` must equal it.
- The request secret is removed only after the bundle is accepted, so a rejected
  bundle does not use up the pending request. `open_armored_bundle` keeps its
  existing behaviour for inspection.
- `normalize_expected_digest`: 64 hex characters, trimmed, lower-cased.

### `cnm-cli`

- `setup` / `community add`: the digest prompt requires 64 hex characters (the
  "empty = skip" option is gone), and the credential is checked against the VTA
  DID typed in the same wizard step.
- `auth login --credential-bundle`: flags go through `validate_digest_flags`, and
  the bundle is checked against the community's configured `vta_did`.
  `--no-verify-digest` stays, but only a bundle signed by that DID is then
  accepted.
- `bootstrap open` (inspection) is unchanged, including `--no-verify-digest`.

### `pnm-cli`

- There is no `pnm auth login --credential-bundle` subcommand in the code (the
  README and `phase5-cutover.md` still mention one). The install-shaped path is
  `pnm bootstrap open --out`, which writes the credential for file-based
  consumers. It now goes through `verify_admin_bundle`, checked against
  `--expect-vta-did` when given. Without `--out`, `bootstrap open` only inspects
  and is unchanged.

### `vta-sdk`

- `SessionStore::login` runs challenge-response first and saves the session only
  on success. An existing session under the same key is left untouched by a
  failed login.

## Behaviour changes

- The `cnm` wizard no longer accepts an empty digest.
- `cnm auth login` refuses a credential whose `vta_did` differs from the
  community's configured VTA DID, and refuses `--expect-digest` combined with
  `--no-verify-digest`.
- `cnm auth login --no-verify-digest` fails for every bundle `pnm`/`cnm` produce
  today, because they are `PinnedOnly`.
- `pnm bootstrap open --out --no-verify-digest` no longer writes a credential
  file for a `PinnedOnly` bundle.
- If `cnm auth login` opens a bundle but authentication then fails (e.g. the VTA
  is unreachable), no session is stored. The request secret has already been
  used by then, so a retry needs a new bootstrap request and bundle.

## Testing

New tests in `vta-cli-common::sealed_consumer`. Each seals a real bundle to a real
bootstrap request:

- `admin_credential_signed_by_an_unexpected_did_key_is_rejected`: a correctly
  signed `DidSigned` assertion from a freshly generated did:key, with the
  credential pointing at that key's own DID. Refused against
  `did:webvh:victim` without a digest, with the bundle's own digest, and with no
  expected DID at all. The request secret is still present afterwards.
- `admin_credential_signed_by_the_expected_vta_is_accepted`: producer DID ==
  expected VTA DID, valid signature, no digest. Accepted, and the secret is
  consumed.
- `did_signed_by_another_key_in_the_vta_name_is_rejected`: the assertion names the
  expected VTA but is signed by a different key.
- `pinned_only_admin_credential_needs_the_digest`: refused without a digest (secret
  kept); accepted with the digest as an operator might type it (upper-case,
  surrounding whitespace).
- `admin_credential_for_a_different_vta_is_rejected`: valid digest, but
  `credential.vta_did` differs from the expected DID.
- `attested_admin_credential_is_rejected`.
- `expected_digest_must_be_64_hex_characters`.

`cnm-cli::setup`: `digest_prompt_rejects_empty_input`,
`digest_prompt_accepts_only_a_sha256_hex_digest`.

`vta-sdk/tests/session_store.rs`:

- `login_against_an_unreachable_vta_persists_no_session`: `login` against
  `http://127.0.0.1:1` errors, and `has_session` / `loaded_session` show nothing
  was stored.
- `failed_login_keeps_the_existing_session`: an earlier session under the same
  key survives a failed login.
- `login_propagates_challenge_failure` now also asserts no session is stored.

Run locally (macOS, rustc 1.98.1):

- `cargo fmt --check`: clean.
- `cargo clippy -p vta-sdk -p vta-cli-common -p cnm-cli -p pnm-cli --all-targets -- -D warnings`: clean.
- `cargo clippy -p vta-sdk --features session,test-support --lib --test session_store -- -D warnings`: clean.
- `cargo test -p vta-cli-common -p cnm-cli -p pnm-cli`: all pass (vta-cli-common
  107, cnm-cli 28, pnm-cli 62).
- `cargo test -p vta-sdk --features session,test-support`: 686 passed, 0 failed,
  10 ignored, including `tests/session_store.rs`.

`cargo clippy -p vta-sdk --features session,test-support --all-targets -- -D warnings`
fails with `items_after_test_module` at
`vta-sdk/src/protocols/acl_management/swap.rs:118`. This change doesn't touch that
file, and the same command fails the same way on `main` (5a6d4923).

Not exercised end to end: an interactive `cnm setup` run, and a `DidSigned` bundle
from a `did:webvh` producer. Those can't be verified without DID resolution and
are refused.
