### PR TITLE
security(backup): write backup exports readable by their owner only

### DIFF
--- a/cnm-cli/src/backup.rs
+++ b/cnm-cli/src/backup.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use serde_json::{Value, json};
 use vta_cli_common::render::{DIM, GREEN, RED, RESET};
+use vta_cli_common::secure_file;
 use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::backup_management::{MIN_BACKUP_PASSWORD_LEN, validate_backup_password};
 
@@ -68,7 +69,11 @@ pub(crate) async fn cmd_export(
     keyring_key: &str,
     include_audit: bool,
     output: Option<PathBuf>,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(path) = &output {
+        secure_file::check_export_path(path, force)?;
+    }
     let password = dialoguer::Password::new()
         .with_prompt(format!(
             "Backup password (min {MIN_BACKUP_PASSWORD_LEN} chars)"
@@ -89,10 +94,7 @@ pub(crate) async fn cmd_export(
 
     let source_did = envelope.get("sourceDid").and_then(Value::as_str);
     let path = output.unwrap_or_else(|| {
-        let slug = source_did
-            .and_then(|d| d.rsplit(':').next())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("vtc");
+        let slug = secure_file::did_filename_slug(source_did, "vtc");
         PathBuf::from(format!(
             "vtc-backup-{slug}-{}.vtcbak",
             file_stamp(&envelope)
@@ -100,7 +102,8 @@ pub(crate) async fn cmd_export(
     });
 
     let json_str = serde_json::to_string_pretty(&envelope)?;
-    std::fs::write(&path, &json_str)?;
+    // Owner-only (0600), and never silently over an existing file.
+    secure_file::write_secret_export(&path, json_str.as_bytes(), force)?;
 
     println!("{GREEN}✓{RESET} Backup saved to {}", path.display());
     println!("  Source DID:     {}", source_did.unwrap_or("(none)"));

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -316,6 +316,9 @@ enum BackupCommands {
         /// Output file path (default: `vtc-backup-<slug>-<ts>.vtcbak`).
         #[arg(short, long)]
         output: Option<std::path::PathBuf>,
+        /// Replace the output file if it already exists.
+        #[arg(long)]
+        force: bool,
     },
     /// Import the community's state from an encrypted backup file.
     Import {
@@ -1279,7 +1282,8 @@ async fn main() {
             BackupCommands::Export {
                 include_audit,
                 output,
-            } => backup::cmd_export(&client, &keyring_key, include_audit, output).await,
+                force,
+            } => backup::cmd_export(&client, &keyring_key, include_audit, output, force).await,
             BackupCommands::Import { file, preview } => {
                 backup::cmd_import(&client, &keyring_key, file, preview).await
             }

--- a/docs/03-vtc/backup-restore.md
+++ b/docs/03-vtc/backup-restore.md
@@ -43,8 +43,12 @@ keyspace overlay (its meaningful values ride in the identity snapshot above).
 ```sh
 # Prompts for the encryption password (min 15 chars), writes
 # vtc-backup-<slug>-<timestamp>.vtcbak.
-cnm backup export [--include-audit] [--output FILE]
+cnm backup export [--include-audit] [--output FILE] [--force]
 ```
+
+The file is created readable by its owner only (`0600` on Unix, an owner-only
+ACL on Windows). An existing file is never overwritten unless you pass
+`--force`.
 
 Under the hood this is `POST /v1/backup/export` (super-admin) — to script it
 directly:

--- a/pnm-cli/README.md
+++ b/pnm-cli/README.md
@@ -264,12 +264,12 @@ has unrestricted access across all contexts.
 
 ### Backup & Restore
 
-| Command                                           | Description                                   |
-| ------------------------------------------------- | --------------------------------------------- |
-| `backup export [--include-audit] [--output FILE]` | Export encrypted backup of all VTA state       |
-| `backup import <file> [--preview]`                | Import backup (preview or apply + restart VTA) |
+| Command                                                     | Description                                    |
+| ----------------------------------------------------------- | ---------------------------------------------- |
+| `backup export [--include-audit] [--output FILE] [--force]` | Export encrypted backup of all VTA state        |
+| `backup import <file> [--preview]`                          | Import backup (preview or apply + restart VTA) |
 
-Backups are encrypted with Argon2id + AES-256-GCM using a user-provided password (minimum 15 characters). The `.vtabak` file contains the seed, keys, ACL, contexts, WebVH records, and config.
+Backups are encrypted with Argon2id + AES-256-GCM using a user-provided password (minimum 15 characters). The `.vtabak` file contains the seed, keys, ACL, contexts, WebVH records, and config. It is created readable by its owner only (`0600` on Unix, an owner-only ACL on Windows), and an existing file is not overwritten unless you pass `--force`.
 
 ### VTA Management
 

--- a/pnm-cli/src/cli.rs
+++ b/pnm-cli/src/cli.rs
@@ -877,6 +877,9 @@ pub(crate) enum BackupCommands {
         /// Output file path (default: `vta-backup-<timestamp>.vtabak`)
         #[arg(short, long)]
         output: Option<std::path::PathBuf>,
+        /// Replace the output file if it already exists.
+        #[arg(long)]
+        force: bool,
         /// Fall back to the legacy inline `/backup/export` REST route
         /// instead of the descriptor-pattern trust-task flow.
         ///

--- a/pnm-cli/src/commands/backup.rs
+++ b/pnm-cli/src/commands/backup.rs
@@ -6,6 +6,7 @@
 //! committing.
 
 use vta_cli_common::render::{DIM, GREEN, RED, RESET};
+use vta_cli_common::secure_file;
 use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::backup_management::{MIN_BACKUP_PASSWORD_LEN, validate_backup_password};
 
@@ -19,12 +20,16 @@ pub(crate) async fn run(
         BackupCommands::Export {
             include_audit,
             output,
+            force,
             use_rest_legacy,
         } => {
+            if let Some(path) = &output {
+                secure_file::check_export_path(path, force)?;
+            }
             if use_rest_legacy {
-                cmd_backup_export(client, include_audit, output).await
+                cmd_backup_export(client, include_audit, output, force).await
             } else {
-                cmd_backup_export_descriptor(client, include_audit, output).await
+                cmd_backup_export_descriptor(client, include_audit, output, force).await
             }
         }
         BackupCommands::Import {
@@ -46,6 +51,7 @@ async fn cmd_backup_export(
     client: &VtaClient,
     include_audit: bool,
     output: Option<std::path::PathBuf>,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Prompt for password
     let password = dialoguer::Password::new()
@@ -62,16 +68,13 @@ async fn cmd_backup_export(
     // Determine output path
     let path = output.unwrap_or_else(|| {
         let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
-        let slug = envelope
-            .source_did
-            .as_deref()
-            .and_then(|d| d.rsplit(':').next())
-            .unwrap_or("vta");
+        let slug = secure_file::did_filename_slug(envelope.source_did.as_deref(), "vta");
         std::path::PathBuf::from(format!("vta-backup-{slug}-{ts}.vtabak"))
     });
 
     let json = serde_json::to_string_pretty(&envelope)?;
-    std::fs::write(&path, &json)?;
+    // Owner-only (0600), and never silently over an existing file.
+    secure_file::write_secret_export(&path, json.as_bytes(), force)?;
 
     println!("{GREEN}✓{RESET} Backup saved to {}", path.display());
     println!(
@@ -156,6 +159,7 @@ async fn cmd_backup_export_descriptor(
     client: &VtaClient,
     include_audit: bool,
     output: Option<std::path::PathBuf>,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let password = dialoguer::Password::new()
         .with_prompt(format!(
@@ -177,15 +181,12 @@ async fn cmd_backup_export_descriptor(
 
     let path = output.unwrap_or_else(|| {
         let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
-        let slug = envelope
-            .source_did
-            .as_deref()
-            .and_then(|d| d.rsplit(':').next())
-            .unwrap_or("vta");
+        let slug = secure_file::did_filename_slug(envelope.source_did.as_deref(), "vta");
         std::path::PathBuf::from(format!("vta-backup-{slug}-{ts}.vtabak"))
     });
 
-    std::fs::write(&path, &bytes)?;
+    // Owner-only (0600), and never silently over an existing file.
+    secure_file::write_secret_export(&path, &bytes, force)?;
 
     println!("{GREEN}✓{RESET} Backup saved to {}", path.display());
     println!(

--- a/vta-cli-common/src/secure_file.rs
+++ b/vta-cli-common/src/secure_file.rs
@@ -4,6 +4,195 @@
 //! The implementation is homed in [`vti_common::secure_file`] so it can be
 //! shared by every consumer (CLIs, services, and the `vti-secrets` crate's
 //! plaintext backend) without duplication. This module re-exports it for
-//! backwards-compatible `vta_cli_common::secure_file::*` call sites.
+//! backwards-compatible `vta_cli_common::secure_file::*` call sites, and adds
+//! the CLI-facing helpers the export commands share.
 
-pub use vti_common::secure_file::{restrict_dir_to_owner, restrict_file_to_owner};
+use std::io::ErrorKind;
+use std::path::Path;
+
+pub use vti_common::secure_file::{
+    restrict_dir_to_owner, restrict_file_to_owner, write_secret_file,
+};
+
+/// Longest slug [`did_filename_slug`] returns, so a long DID cannot push a
+/// default file name past file-system name limits.
+const MAX_SLUG_LEN: usize = 64;
+
+/// Fail early when an explicit export path already exists and `force` is not
+/// set.
+///
+/// Call this before asking the server for the export, so the operator does not
+/// enter a password and wait for an export only for the write to be refused.
+/// [`write_secret_export`] still makes the authoritative check when it creates
+/// the file.
+pub fn check_export_path(path: &Path, force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    // `symlink_metadata` so a dangling symlink counts as existing, matching
+    // what `create_new` will do.
+    if !force && std::fs::symlink_metadata(path).is_ok() {
+        return Err(already_exists(path));
+    }
+    Ok(())
+}
+
+/// Write a secret-bearing export (such as a backup envelope) to `path`, owner
+/// read/write only.
+///
+/// Wraps [`write_secret_file`], so an existing file is never silently
+/// truncated. With `force`, an existing file at `path` is removed first and a
+/// new one created in its place; without it, an existing file is an error
+/// that names `--force`.
+pub fn write_secret_export(
+    path: &Path,
+    bytes: &[u8],
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if force {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(
+                    format!("could not remove existing file {}: {e}", path.display()).into(),
+                );
+            }
+        }
+    }
+    write_secret_file(path, bytes).map_err(|e| {
+        if e.kind() == ErrorKind::AlreadyExists {
+            already_exists(path)
+        } else {
+            format!("could not write {}: {e}", path.display()).into()
+        }
+    })
+}
+
+fn already_exists(path: &Path) -> Box<dyn std::error::Error> {
+    format!(
+        "{} already exists. Choose another path with --output, or pass --force to replace it.",
+        path.display()
+    )
+    .into()
+}
+
+/// A file-name-safe slug from the last `:`-separated segment of `did`.
+///
+/// Used for default export file names. The DID comes from a server response,
+/// so it is not trusted to be a safe path component: only `[A-Za-z0-9._-]` is
+/// kept, the result is capped at 64 characters, and `fallback` is returned when
+/// nothing usable is left (no DID, an empty segment, or only dots).
+pub fn did_filename_slug(did: Option<&str>, fallback: &str) -> String {
+    let slug: String = did
+        .and_then(|d| d.rsplit(':').next())
+        .unwrap_or("")
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        .take(MAX_SLUG_LEN)
+        .collect();
+    if slug.chars().all(|c| c == '.') {
+        fallback.to_string()
+    } else {
+        slug
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("vta-test-export-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn slug_keeps_an_ordinary_did_segment() {
+        assert_eq!(
+            did_filename_slug(Some("did:webvh:QmScid:example.com"), "vtc"),
+            "example.com"
+        );
+        assert_eq!(
+            did_filename_slug(Some("did:key:z6MkAbc_1-2"), "vta"),
+            "z6MkAbc_1-2"
+        );
+    }
+
+    #[test]
+    fn slug_strips_path_separators_and_other_characters() {
+        for did in [
+            "did:web:../../x",
+            "did:web:..\\..\\x",
+            "did:web:a/b c\0d%2Fe",
+            "did:web:caf\u{e9}\n",
+        ] {
+            let slug = did_filename_slug(Some(did), "vtc");
+            assert!(
+                slug.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')),
+                "{did:?} -> {slug:?}"
+            );
+            let name = format!("vtc-backup-{slug}-20260101.vtcbak");
+            assert_eq!(
+                Path::new(&name).components().count(),
+                1,
+                "{did:?} must yield a single path component, got {name:?}"
+            );
+        }
+        assert_eq!(did_filename_slug(Some("did:web:../../x"), "vtc"), "....x");
+    }
+
+    #[test]
+    fn slug_falls_back_when_nothing_usable_is_left() {
+        assert_eq!(did_filename_slug(None, "vta"), "vta");
+        assert_eq!(did_filename_slug(Some("did:web:"), "vtc"), "vtc");
+        assert_eq!(did_filename_slug(Some("did:web:.."), "vtc"), "vtc");
+        assert_eq!(did_filename_slug(Some("did:web:/\\"), "vtc"), "vtc");
+    }
+
+    #[test]
+    fn slug_is_capped() {
+        let did = format!("did:web:{}", "a".repeat(500));
+        assert_eq!(did_filename_slug(Some(&did), "vtc").len(), MAX_SLUG_LEN);
+    }
+
+    #[test]
+    fn export_refuses_an_existing_file_without_force() {
+        let dir = tmp_dir();
+        let f = dir.join("backup.vtabak");
+        std::fs::write(&f, b"original").unwrap();
+
+        assert!(check_export_path(&f, false).is_err());
+        let err = write_secret_export(&f, b"new", false).unwrap_err();
+        assert!(err.to_string().contains("--force"), "{err}");
+        assert_eq!(std::fs::read(&f).unwrap(), b"original");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn export_replaces_an_existing_file_with_force() {
+        let dir = tmp_dir();
+        let f = dir.join("backup.vtabak");
+        std::fs::write(&f, b"original").unwrap();
+
+        check_export_path(&f, true).unwrap();
+        write_secret_export(&f, b"new", true).unwrap();
+        assert_eq!(std::fs::read(&f).unwrap(), b"new");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&f).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn export_creates_a_new_file() {
+        let dir = tmp_dir();
+        let f = dir.join("backup.vtabak");
+        check_export_path(&f, false).unwrap();
+        write_secret_export(&f, b"data", false).unwrap();
+        assert_eq!(std::fs::read(&f).unwrap(), b"data");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -130,5 +130,10 @@ tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 bytes = "1"
 
+[target.'cfg(unix)'.dev-dependencies]
+# `umask` in the secure_file tests, to prove a secret file is 0600 regardless
+# of the process file-creation mask.
+libc = { workspace = true }
+
 [lints]
 workspace = true

--- a/vti-common/src/secure_file.rs
+++ b/vti-common/src/secure_file.rs
@@ -75,6 +75,54 @@ pub fn restrict_dir_to_owner(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Write `bytes` to a new file at `path` that only the owner can read.
+///
+/// For exports that carry secret material, such as backup envelopes.
+///
+/// - The file is opened with `create_new`, so an existing path (including a
+///   symlink, dangling or not) is never truncated or followed. The call fails
+///   with [`std::io::ErrorKind::AlreadyExists`] and the caller decides whether
+///   to remove the old file first.
+/// - On Unix the file is created with mode `0600`, so it is not readable by
+///   anyone else at any point, including between create and write.
+/// - The data is flushed with `sync_all` before returning.
+/// - On Windows the owner-only DACL from [`restrict_file_to_owner`] is applied
+///   after the write.
+///
+/// Unlike the other helpers in this module, a hardening failure is an error.
+/// If any step after the file is created fails, the file is removed, so no
+/// secret is left behind with the wrong permissions and a retry is not
+/// blocked by `AlreadyExists`.
+pub fn write_secret_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    let file = opts.open(path)?;
+
+    if let Err(e) = write_and_harden(file, path, bytes) {
+        let _ = std::fs::remove_file(path);
+        return Err(e);
+    }
+    Ok(())
+}
+
+fn write_and_harden(mut file: std::fs::File, path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    drop(file);
+    #[cfg(windows)]
+    restrict_file_to_owner(path)?;
+    #[cfg(not(windows))]
+    let _ = path;
+    Ok(())
+}
+
 #[cfg(windows)]
 fn apply_windows_user_only_dacl(path: &Path) -> std::io::Result<()> {
     use std::process::Command;
@@ -166,6 +214,56 @@ mod tests {
 
         let mode = std::fs::metadata(&tmp).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o700);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A plain `std::fs::write` lands at `0644` under the common `022` umask.
+    /// The secret-file helper must not.
+    #[test]
+    fn write_secret_file_is_0600_under_a_022_umask() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = std::env::temp_dir().join(format!("vta-test-secure-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let f = tmp.join("export.vtcbak");
+
+        // SAFETY: `umask` has no memory-safety preconditions; it only swaps the
+        // process file-creation mask, which is restored straight after.
+        let previous = unsafe { libc::umask(0o022) };
+        let result = write_secret_file(&f, b"sensitive");
+        unsafe { libc::umask(previous) };
+        result.expect("write_secret_file succeeds");
+
+        let mode = std::fs::metadata(&f).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "got {:o}", mode & 0o777);
+        assert_eq!(std::fs::read(&f).unwrap(), b"sensitive");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn write_secret_file_refuses_an_existing_path() {
+        let tmp = std::env::temp_dir().join(format!("vta-test-secure-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let f = tmp.join("export.vtcbak");
+        std::fs::write(&f, b"original").unwrap();
+
+        let err = write_secret_file(&f, b"replacement").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        // The existing file is neither truncated nor removed.
+        assert_eq!(std::fs::read(&f).unwrap(), b"original");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn write_secret_file_does_not_follow_a_symlink() {
+        let tmp = std::env::temp_dir().join(format!("vta-test-secure-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let target = tmp.join("elsewhere");
+        let link = tmp.join("export.vtcbak");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = write_secret_file(&link, b"sensitive").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(!target.exists(), "the symlink target must not be created");
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }


### PR DESCRIPTION

## Summary

`cnm backup export` and both `pnm backup export` paths wrote the encrypted backup
envelope with `std::fs::write`. That creates the file at the process umask (0644
with the usual `022`), so any local user could read it. The envelope is Argon2id +
AES-256-GCM ciphertext, so exposure gives an offline password-guessing target
rather than the keys directly, but the VTA backup holds the seed and every key, and
the VTC backup holds the community signing key. The same write also silently
truncated an existing file at the path.

## Changes

### `vti-common::secure_file::write_secret_file(path, bytes)`

- `OpenOptions::create_new`: an existing path, including a symlink (dangling or
  not), is never truncated or followed. The call fails with `AlreadyExists`.
- Mode `0600` at creation on Unix, so the file is never readable by others, even
  briefly.
- `sync_all` before returning.
- On Windows, the existing owner-only DACL helper (`restrict_file_to_owner`) is
  applied after the write.
- If anything after creation fails, the file is removed: no secret left behind
  with the wrong permissions, and no stale file blocking a retry.

### `vta-cli-common::secure_file`

- Re-exports `write_secret_file`.
- `write_secret_export(path, bytes, force)`: refuses an existing file with a
  message naming `--output` and `--force`. With `force`, removes the old file and
  creates a new one.
- `check_export_path(path, force)`: the same refusal for an explicit `--output`,
  made before the password prompt and the server round-trip, so a descriptor-flow
  export isn't spent on a write that will be refused.
- `did_filename_slug(did, fallback)`: the default file name's slug comes from the
  server-supplied `sourceDid`. Only `[A-Za-z0-9._-]` is kept, the slug is capped
  at 64 characters, and it falls back to `vtc` / `vta` when nothing usable is
  left.

### Call sites

- `cnm-cli/src/backup.rs` (`cmd_export`), `pnm-cli/src/commands/backup.rs`
  (`cmd_backup_export` and `cmd_backup_export_descriptor`) use the helpers above.
- `cnm backup export` and `pnm backup export` gain `--force`.
- Docs: `docs/03-vtc/backup-restore.md` and `pnm-cli/README.md` mention the file
  mode and `--force`.

`.gitignore` is unchanged: `**.vtcbak` is already on `main` (#1435).

## Behaviour changes

- Backup files are created `0600` (owner-only ACL on Windows).
- Exporting to a path that already exists now fails unless `--force` is passed.
  Scripts that reuse a fixed `--output` name need `--force` or a fresh name.
- A default file name derived from an unusual `sourceDid` may differ from before
  (disallowed characters are dropped).

## Testing

New tests:

- `vti-common` (`#[cfg(unix)]`):
  - `write_secret_file_is_0600_under_a_022_umask`: sets `umask(0o022)`, writes,
    asserts mode `0600`, then restores the umask.
  - `write_secret_file_refuses_an_existing_path`: `ErrorKind::AlreadyExists`,
    and the original contents are untouched.
  - `write_secret_file_does_not_follow_a_symlink`: `AlreadyExists`, and the link
    target is not created.
- `vta-cli-common`:
  - slug tests for `did:web:../../x`, backslashes, spaces, NUL, `%`, non-ASCII,
    `..`, an empty segment and a 500-character segment. Each must yield a single
    path component of `[A-Za-z0-9._-]`, or the fallback.
  - export without `--force` over an existing file fails and names `--force`;
    with `--force` it replaces the file at `0600`; a new path is created.

Run locally (macOS, rustc 1.98.1):

- `cargo fmt --check`: clean.
- `cargo clippy -p vti-common -p vta-cli-common -p cnm-cli -p pnm-cli --all-targets -- -D warnings`: clean.
- `cargo test -p vti-common -p vta-cli-common -p cnm-cli -p pnm-cli`: all pass.
  Unit tests: vti-common 429, vta-cli-common 107, cnm-cli 26, pnm-cli 62. The
  vti-common integration tests also pass (1 + 14).

Not run: a Windows build. The Windows branch only adds a call to the existing
`restrict_file_to_owner`.
